### PR TITLE
Drain the Weblate translation backlog

### DIFF
--- a/packages/i18n/locales/ace/chrome.ftl
+++ b/packages/i18n/locales/ace/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Teungoh geupeuréksa…
 answer-submitting = Teungoh geukirém…
-
 answer-checking-status = Teungoh geupeuréksa jaweueb
 answer-submitting-status = Teungoh geukirém jaweueb
-
 answer-correct = Beutôi
 answer-incorrect = Hana beutôi
-
 answer-response-saved = Jaweueb ka geusimpan
-
 answer-percent-credit = { $percent }% kredit
 answer-percent-correct = { $percent }% beutôi
 answer-percent-short = { $percent } %
-
 max-credit-available = Kredit paléng rayeuk nyang jeuet teuhah: { $percent }%
-
 # No select: «cuba» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -45,51 +39,38 @@ attempts-remaining =
         [0] hana lé cuba nyang teungoh
        *[other] na { $count } cuba teungoh
     }
-
 validation-correct = (Beutôi)
 validation-incorrect = (Hana beutôi)
 validation-partially-correct = (Beutôi siseun bagian)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Peuleumah { $count } jaweueb keu { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komentar
-
 collapsible-click-to-open = (klik keu jeuet buka)
 collapsible-click-to-close = (klik keu jeuet tôb)
-
 collapsible-initializing = Teungoh peuphon…
-
 footnote-show = Peuleumah footnote
 footnote-hide = Som footnote
-
 description-more-information = keterangan laén
-
 
 ## Controls
 
 slider-previous = Sigohlom
 slider-next = Seulanjut
-
 keyboard-open = Buka papan tuts
 keyboard-close = Tôb papan tuts
-
 choice-input-remove-choice = Peugadôh { $choice }
-
 matrix-remove-row = Peugadôh barih
 matrix-add-row = Tamah barih
 matrix-remove-column = Peugadôh kolom
 matrix-add-column = Tamah kolom
-
 subset-add-remove-points = Tamah/Peugadôh titék
 subset-toggle-points-intervals = Tuka titék ngon interval
 subset-move-points = Peupinah titék
 subset-clear = Peugleh
-
 orbital-add-row = Tamah barih
 orbital-remove-row = Peugadôh barih
 orbital-add-box = Tamah kutak
@@ -97,13 +78,9 @@ orbital-remove-box = Peugadôh kutak
 orbital-add-up-arrow = Tamah panah u ateuh
 orbital-add-down-arrow = Tamah panah u yup
 orbital-remove-arrow = Peugadôh panah
-
 orbital-row-label = Label keu barih { $row }
-
 pretzel-answer = Jaweueb
-
 summary-statistics-caption = Ringkasan statistik { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = pratinjau ungkapan matematika
 math-input-preview = Pratinjau
 math-input-invalid-expression = Ungkapan nyang hana sah:
 
-
 ## Document status
 
 viewer-initializing = Teungoh peuphon…
 
-
 ## Errors
 
 error-heading = Salah
-
 error-found-at =
     { $span ->
         [line] Meuteumeung bak barih { $startLine }.
        *[lines] Meuteumeung bak barih { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumen nyoe na salah!
-
 diagnostic-heading-error = Salah
 diagnostic-heading-warning = Peuingat
 diagnostic-heading-information = Keterangan
 diagnostic-heading-hint = Peutunyok
-
 accessibility-heading-level-1 = Peulanggaran aksesibilitas WCAG AA
 accessibility-heading-level-2 = Peuingat keuhai aksesibilitas
-
 something-went-wrong = Na nyang hana beutôi.
-
 renderer-load-failed = na renderer nyang hana ék teumuka. Neupeuulang muat laman nyoe.
-
 core-start-failed = Peuleumah dokumen hana ék teupeuphon. Neupeuulang muat laman nyoe.

--- a/packages/i18n/locales/ace/content.ftl
+++ b/packages/i18n/locales/ace/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = unggu
     .pink = mirah muda
     .brown = coklat
-
 line-width =
     .thick = teubai
     .thin = lipéh
-
 line-style =
     .dashed = putôh-putôh
     .dotted = titék-titék
-
 # Noun phrases. Acehnese marks no plural on the noun, so «garéh» is the word for
 # one line and for many alike.
 fill-style =
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = garéh mereng meubalék
     .dots = titék
     .diamonds = beulah keutupat
-
 noun =
     .line = garéh
     .line-segment = ruweueng garéh
@@ -74,7 +70,6 @@ noun =
     .diamond = beulah keutupat
     .cross = sileuëng
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -82,10 +77,8 @@ noun-regular-polygon =
         [tail] nyang na { $numSides } sagoë
        *[head] poligon beuratura
     }
-
 # One answer for every noun: Acehnese has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -99,22 +92,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = peunoh
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ngon { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ngon { $pattern }
@@ -122,7 +111,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } ngon { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Acehnese has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «ngon» against «lom».
@@ -133,35 +121,28 @@ style-border-clause =
         [and-article] lom binèh { $border }
        *[with] ngon binèh { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = hana peunoh
-
 style-text =
     { $parts ->
         [background] { $color } ngon laté { $background }
        *[plain] { $color }
     }
-
 style-background-none = hana
-
 
 ## Boolean words
 
 boolean-true = beutôi
 boolean-false = salah
 
-
 ## Answer buttons
 
 answer-submit-label = Peuréksa buet
 answer-submit-label-no-correctness = Kirém jaweueb
-
 
 ## Sectional blocks
 
@@ -188,7 +169,6 @@ section-name =
     .solution = Peunyeulesaian
     .task = Tugaih
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -198,9 +178,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Peutunyok
-
 
 ## Tables and figures
 
@@ -211,7 +189,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Gamba { $enumeration }
@@ -220,22 +197,18 @@ figure-name =
        *[unnumbered] Gamba
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sigohlom
 paginator-next = Seulanjut
 paginator-page = Laman
-
 paginator-page-status = { $pageLabel } { $currentPage } nibak { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = atawa
 piecewise-condition-if = meunyo
 piecewise-condition-otherwise = meunyo hana
-
 
 ## Chemistry
 ##
@@ -247,6 +220,5 @@ piecewise-condition-otherwise = meunyo hana
 ## where a speaker should start rather than at the whole 118.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kimia nyang hana sah
 chemistry-invalid-ionic-compound = Sanyawa ionik nyang hana sah

--- a/packages/i18n/locales/af/chrome.ftl
+++ b/packages/i18n/locales/af/chrome.ftl
@@ -15,74 +15,55 @@
 
 answer-checking = Kontroleer tans...
 answer-submitting = Dien tans in...
-
 answer-checking-status = Kontroleer antwoord
 answer-submitting-status = Dien antwoord in
-
 answer-correct = Korrek
 answer-incorrect = Verkeerd
-
 answer-response-saved = Antwoord Gestoor
-
 answer-percent-credit = { $percent }% Krediet
 answer-percent-correct = { $percent }% Korrek
 answer-percent-short = { $percent } %
-
 max-credit-available = Maksimum krediet beskikbaar: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] geen pogings oor nie
         [one] { $count } poging oor
        *[other] { $count } pogings oor
     }
-
 validation-correct = (Korrek)
 validation-incorrect = (Verkeerd)
 validation-partially-correct = (Gedeeltelik korrek)
-
 answer-show-responses =
     { $count ->
         [one] Wys { $count } antwoord op { $answerId }
        *[other] Wys { $count } antwoorde op { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Terugvoer
-
 collapsible-click-to-open = (klik om oop te maak)
 collapsible-click-to-close = (klik om toe te maak)
-
 collapsible-initializing = Begin tans...
-
 footnote-show = Wys voetnoot
 footnote-hide = Versteek voetnoot
-
 description-more-information = meer inligting
-
 
 ## Controls
 
 slider-previous = Vorige
 slider-next = Volgende
-
 keyboard-open = Maak Sleutelbord Oop
 keyboard-close = Maak Sleutelbord Toe
-
 choice-input-remove-choice = Verwyder { $choice }
-
 matrix-remove-row = Verwyder ry
 matrix-add-row = Voeg ry by
 matrix-remove-column = Verwyder kolom
 matrix-add-column = Voeg kolom by
-
 subset-add-remove-points = Voeg punte by / verwyder punte
 subset-toggle-points-intervals = Wissel tussen punte en intervalle
 subset-move-points = Skuif Punte
 subset-clear = Maak Skoon
-
 # A `box` here is one orbital, drawn as a square: blokkie.
 orbital-add-row = Voeg Ry By
 orbital-remove-row = Verwyder Ry
@@ -91,13 +72,9 @@ orbital-remove-box = Verwyder Blokkie
 orbital-add-up-arrow = Voeg Oppyl By
 orbital-add-down-arrow = Voeg Afpyl By
 orbital-remove-arrow = Verwyder Pyl
-
 orbital-row-label = Etiket vir ry { $row }
-
 pretzel-answer = Antwoord
-
 summary-statistics-caption = Opsommende statistiek van { $column }
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = voorskou van wiskundige uitdrukking
 math-input-preview = Voorskou
 math-input-invalid-expression = Ongeldige uitdrukking:
 
-
 ## Document status
 
 viewer-initializing = Begin tans...
 
-
 ## Errors
 
 error-heading = Fout
-
 error-found-at =
     { $span ->
         [line] Gevind op reël { $startLine }.
        *[lines] Gevind op reëls { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Hierdie dokument bevat foute!
-
 diagnostic-heading-error = Fout
 diagnostic-heading-warning = Waarskuwing
 diagnostic-heading-information = Inligting
 diagnostic-heading-hint = Wenk
-
 accessibility-heading-level-1 = WCAG AA-toeganklikheidsoortreding
 accessibility-heading-level-2 = Toeganklikheidswaarskuwing
-
 something-went-wrong = Iets het verkeerd geloop.
-
 renderer-load-failed = 'n weergeër kon nie laai nie. Laai die bladsy asseblief weer.
-
 core-start-failed = Die dokumentkyker kon nie begin nie. Laai die bladsy asseblief weer.

--- a/packages/i18n/locales/af/content.ftl
+++ b/packages/i18n/locales/af/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = pers
     .pink = pienk
     .brown = bruin
-
 line-width =
     .thick = dik
     .thin = dun
-
 line-style =
     .dashed = gestreepte
     .dotted = gestippelde
-
 fill-style =
     .horizontal = horisontale lyne
     .vertical = vertikale lyne
@@ -52,7 +49,6 @@ fill-style =
     .backdiagonal = omgekeerde diagonale lyne
     .dots = kolletjies
     .diamonds = ruite
-
 noun =
     .line = lyn
     .line-segment = lynsegment
@@ -72,7 +68,6 @@ noun =
     .diamond = ruit
     .cross = kruis
     .plus = plusteken
-
 # The side count folds into the head, as English does: Afrikaans writes a
 # compound — «5-sydige reëlmatige veelhoek» — and there is nothing to put
 # after the adjectives.
@@ -81,11 +76,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides }-sydige reëlmatige veelhoek
     }
-
 # Afrikaans has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English, and unlike Dutch.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -99,21 +92,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = gevulde
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } met { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } met { $pattern }
@@ -121,7 +110,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } met { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] met 'n { $border } rand
@@ -129,35 +117,28 @@ style-border-clause =
         [and-article] en 'n { $border } rand
        *[with] met { $border } rand
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ongevuld
-
 style-text =
     { $parts ->
         [background] { $color } op 'n { $background } agtergrond
        *[plain] { $color }
     }
-
 style-background-none = geen
-
 
 ## Boolean words
 
 boolean-true = waar
 boolean-false = onwaar
 
-
 ## Answer buttons
 
 answer-submit-label = Kontroleer Werk
 answer-submit-label-no-correctness = Dien Antwoord In
-
 
 ## Sectional blocks
 
@@ -182,7 +163,6 @@ section-name =
     .solution = Oplossing
     .task = Taak
     .theorem = Stelling
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -192,9 +172,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Wenk
-
 
 ## Tables and figures
 
@@ -205,7 +183,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Figuur { $enumeration }
@@ -214,22 +191,18 @@ figure-name =
        *[unnumbered] Figuur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Vorige
 paginator-next = Volgende
 paginator-page = Bladsy
-
 paginator-page-status = { $pageLabel } { $currentPage } van { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = of
 piecewise-condition-if = as
 piecewise-condition-otherwise = andersins
-
 
 ## Chemistry
 
@@ -361,7 +334,6 @@ element-name =
     .lv = livermorium
     .ts = tennessien
     .og = oganesson
-
 element-anion-name =
     .h = hidried
     .c = karbied
@@ -375,8 +347,6 @@ element-anion-name =
     .i = jodied
     .at = astatied
     .ts = tennessied
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ongeldige Chemiese Simbool
 chemistry-invalid-ionic-compound = Ongeldige Ioniese Verbinding

--- a/packages/i18n/locales/ak/chrome.ftl
+++ b/packages/i18n/locales/ak/chrome.ftl
@@ -24,69 +24,50 @@
 
 answer-checking = Ɛrehwɛ...
 answer-submitting = Ɛrema akɔ...
-
 answer-checking-status = Ɛrehwɛ mmuaeɛ no
 answer-submitting-status = Ɛrema mmuaeɛ no akɔ
-
 answer-correct = Ɛteɛ
 answer-incorrect = Ɛnteɛ
-
 answer-response-saved = Wɔakora Mmuaeɛ No So
-
 answer-percent-credit = { $percent }% Nsɛkyerɛ
 answer-percent-correct = { $percent }% Ɛteɛ
 answer-percent-short = { $percent } %
-
 max-credit-available = Nsɛkyerɛ kɛseɛ a wobɛnya: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] mmɔdenbɔ biara nka ho
        *[other] mmɔdenbɔ { $count } na aka
     }
-
 validation-correct = (Ɛteɛ)
 validation-incorrect = (Ɛnteɛ)
 validation-partially-correct = (Ɛfã teɛ)
-
 answer-show-responses = Kyerɛ mmuaeɛ { $count } a wɔde maa { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Nsɛm a Ɛfiri Mu
-
 collapsible-click-to-open = (mia na bue)
 collapsible-click-to-close = (mia na to mu)
-
 collapsible-initializing = Ɛrefiri aseɛ...
-
 footnote-show = Kyerɛ ase nkaeɛ
 footnote-hide = Fa ase nkaeɛ sie
-
 description-more-information = nsɛm foforɔ
-
 
 ## Controls
 
 slider-previous = Akyire
 slider-next = Anim
-
 keyboard-open = Bue Kiibɔɔd
 keyboard-close = To Kiibɔɔd Mu
-
 choice-input-remove-choice = Yi { $choice } firi mu
-
 matrix-remove-row = Yi santene firi mu
 matrix-add-row = Fa santene ka ho
 matrix-remove-column = Yi adum firi mu
 matrix-add-column = Fa adum ka ho
-
 subset-add-remove-points = Fa pɔint ka ho/Yi firi mu
 subset-toggle-points-intervals = Sesa pɔint ne ntam
 subset-move-points = Twe Pɔint No
 subset-clear = Popa
-
 # A `box` here is one orbital, drawn as a square: «adaka».
 orbital-add-row = Fa Santene Ka Ho
 orbital-remove-row = Yi Santene Firi Mu
@@ -95,13 +76,9 @@ orbital-remove-box = Yi Adaka Firi Mu
 orbital-add-up-arrow = Fa Bɛmma A Ɛkyerɛ Soro Ka Ho
 orbital-add-down-arrow = Fa Bɛmma A Ɛkyerɛ Fam Ka Ho
 orbital-remove-arrow = Yi Bɛmma Firi Mu
-
 orbital-row-label = Santene { $row } din
-
 pretzel-answer = Mmuaeɛ
-
 summary-statistics-caption = { $column } ho akontabuo tiawa
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = akontabuo nkyerɛwee ho nhwɛ
 math-input-preview = Nhwɛ
 math-input-invalid-expression = Nkyerɛwee no nteɛ:
 
-
 ## Document status
 
 viewer-initializing = Ɛrefiri aseɛ...
 
-
 ## Errors
 
 error-heading = Mfomsoɔ
-
 error-found-at =
     { $span ->
         [line] Wohunuu no wɔ layin { $startLine } so.
        *[lines] Wohunuu no wɔ layin { $startLine }–{ $endLine } so.
     }
-
 document-contains-errors = Mfomsoɔ wɔ krataa yi mu!
-
 diagnostic-heading-error = Mfomsoɔ
 diagnostic-heading-warning = Kɔkɔbɔ
 diagnostic-heading-information = Nsɛm
 diagnostic-heading-hint = Akwankyerɛ
-
 accessibility-heading-level-1 = WCAG AA Nhyehyɛeɛ A Wɔabu So
 accessibility-heading-level-2 = Nkɔmu-kwan ho kɔkɔbɔ
-
 something-went-wrong = Biribi ansi yie.
-
 renderer-load-failed = ɔkyerɛfoɔ baako antumi amma. Yɛsrɛ wo, san fa kratafa no bra.
-
 core-start-failed = Krataa kyerɛfoɔ no antumi anfiri aseɛ. Yɛsrɛ wo, san fa kratafa no bra.

--- a/packages/i18n/locales/ak/content.ftl
+++ b/packages/i18n/locales/ak/content.ftl
@@ -44,17 +44,14 @@ color =
     .purple = beredum
     .pink = pinki
     .brown = dɔteɛ
-
 line-width =
     .thick = kɛseɛ
     .thin = ketewa
-
 # Written as «a ɛwɔ …» relative phrases rather than as adjectives, so that they
 # can close the description. `style-stroke` puts them last for that reason.
 line-style =
     .dashed = a ɛwɔ ntwaa
     .dotted = a ɛwɔ nsɛnkyerɛnne
-
 fill-style =
     .horizontal = nsensanee a ɛdeda hɔ
     .vertical = nsensanee a ɛgyina
@@ -62,7 +59,6 @@ fill-style =
     .backdiagonal = nsensanee a ɛkyea kɔ akyire
     .dots = nsɛnkyerɛnne
     .diamonds = daemɔn
-
 noun =
     .line = nsensanee
     .line-segment = nsensanee fã
@@ -82,7 +78,6 @@ noun =
     .diamond = daemɔn
     .cross = mmeamudua
     .plus = kabom sɛnkyerɛnne
-
 # The side count follows the adjectives, behind «a ɛwɔ», because Twi closes a
 # noun phrase with a relative rather than opening one: «ahinapii pɛpɛɛpɛ kɔkɔɔ
 # a ɛwɔ ahina 5».
@@ -91,9 +86,7 @@ noun-regular-polygon =
         [tail] a ɛwɔ ahina { $numSides }
        *[head] ahinapii pɛpɛɛpɛ
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,21 +100,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = a wɔahyɛ mu ma
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } a ɛwɔ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } a ɛwɔ { $pattern }
@@ -129,7 +118,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } a ɛwɔ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Twi has no article and joins the complement with the invariable «a ɛwɔ», so
 # all four branches read alike.
 style-border-clause =
@@ -139,35 +127,28 @@ style-border-clause =
         [and-article] a ɛwɔ ano { $border }
        *[with] a ɛwɔ ano { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = a wɔnhyɛɛ mu ma
-
 style-text =
     { $parts ->
         [background] { $color } wɔ akyire { $background } so
        *[plain] { $color }
     }
-
 style-background-none = biara nni hɔ
-
 
 ## Boolean words
 
 boolean-true = nokware
 boolean-false = atorɔ
 
-
 ## Answer buttons
 
 answer-submit-label = Hwɛ Adwuma No
 answer-submit-label-no-correctness = Fa Mmuaeɛ No Kɔ
-
 
 ## Sectional blocks
 
@@ -192,7 +173,6 @@ section-name =
     .solution = Nsɛmmuaeɛ
     .task = Adwuma
     .theorem = Teɔrɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -202,9 +182,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Akwankyerɛ
-
 
 ## Tables and figures
 
@@ -215,7 +193,6 @@ table-name =
         [unnumbered-title] Tabo{ ": " }
        *[unnumbered] Tabo
     }
-
 figure-name =
     { $parts ->
         [numbered] Mfoni { $enumeration }
@@ -224,22 +201,18 @@ figure-name =
        *[unnumbered] Mfoni
     }
 
-
 ## Paginator controls
 
 paginator-previous = Deɛ ɛdi kan
 paginator-next = Deɛ ɛdi soɔ
 paginator-page = Kratafa
-
 paginator-page-status = { $pageLabel } { $currentPage } wɔ { $numPages } mu
-
 
 ## Piecewise functions
 
 piecewise-condition-or = anaasɛ
 piecewise-condition-if = sɛ
 piecewise-condition-otherwise = sɛ ɛnte saa a
-
 
 ## Chemistry
 
@@ -249,6 +222,5 @@ piecewise-condition-otherwise = sɛ ɛnte saa a
 # English already, and the seed has no settled Twi list to reproduce. A speaker
 # adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kemikal Sɛnkyerɛnne A Ɛnteɛ
 chemistry-invalid-ionic-compound = Ayɔn Nkabom A Ɛnteɛ

--- a/packages/i18n/locales/am/chrome.ftl
+++ b/packages/i18n/locales/am/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = በማረጋገጥ ላይ...
 answer-submitting = በመላክ ላይ...
-
 answer-checking-status = መልሱ በመረጋገጥ ላይ ነው
 answer-submitting-status = መልሱ በመላክ ላይ ነው
-
 answer-correct = ትክክል
 answer-incorrect = ስህተት
-
 answer-response-saved = መልሱ ተቀምጧል
-
 answer-percent-credit = { $percent }% ነጥብ
 answer-percent-correct = { $percent }% ትክክል
 answer-percent-short = { $percent }%
-
 max-credit-available = ከፍተኛው ሊገኝ የሚችል ነጥብ፦ { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] የቀረ ሙከራ የለም
         [one] { $count } ሙከራ ቀርቷል
        *[other] { $count } ሙከራዎች ቀርተዋል
     }
-
 validation-correct = (ትክክል)
 validation-incorrect = (ስህተት)
 validation-partially-correct = (በከፊል ትክክል)
-
 answer-show-responses =
     { $count ->
         [one] የ{ $answerId } { $count } መልስ አሳይ
        *[other] የ{ $answerId } { $count } መልሶች አሳይ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = አስተያየት
-
 collapsible-click-to-open = (ለመክፈት ጠቅ ያድርጉ)
 collapsible-click-to-close = (ለመዝጋት ጠቅ ያድርጉ)
-
 collapsible-initializing = በመዘጋጀት ላይ...
-
 footnote-show = የግርጌ ማስታወሻ አሳይ
 footnote-hide = የግርጌ ማስታወሻ ደብቅ
-
 description-more-information = ተጨማሪ መረጃ
-
 
 ## Controls
 
 slider-previous = ቀዳሚ
 slider-next = ቀጣይ
-
 keyboard-open = ቁልፍ ሰሌዳ ክፈት
 keyboard-close = ቁልፍ ሰሌዳ ዝጋ
-
 choice-input-remove-choice = { $choice } አስወግድ
-
 matrix-remove-row = ረድፍ አስወግድ
 matrix-add-row = ረድፍ ጨምር
 matrix-remove-column = ዓምድ አስወግድ
 matrix-add-column = ዓምድ ጨምር
-
 subset-add-remove-points = ነጥቦች ጨምር/አስወግድ
 subset-toggle-points-intervals = በነጥቦችና በክፍተቶች መካከል ቀያይር
 subset-move-points = ነጥቦችን አንቀሳቅስ
 subset-clear = አጽዳ
-
 # A `box` here is one orbital, drawn as a square: ሳጥን.
 orbital-add-row = ረድፍ ጨምር
 orbital-remove-row = ረድፍ አስወግድ
@@ -94,13 +75,9 @@ orbital-remove-box = ሳጥን አስወግድ
 orbital-add-up-arrow = ወደ ላይ ቀስት ጨምር
 orbital-add-down-arrow = ወደ ታች ቀስት ጨምር
 orbital-remove-arrow = ቀስት አስወግድ
-
 orbital-row-label = የረድፍ { $row } መለያ
-
 pretzel-answer = መልስ
-
 summary-statistics-caption = የ{ $column } አጠቃላይ ስታቲስቲክስ
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = የሒሳብ አገላለጽ ቅድመ ዕይታ
 math-input-preview = ቅድመ ዕይታ
 math-input-invalid-expression = ልክ ያልሆነ አገላለጽ፦
 
-
 ## Document status
 
 viewer-initializing = በመዘጋጀት ላይ...
 
-
 ## Errors
 
 error-heading = ስህተት
-
 error-found-at =
     { $span ->
         [line] በመስመር { $startLine } ላይ ተገኝቷል።
        *[lines] በመስመሮች { $startLine }–{ $endLine } ላይ ተገኝቷል።
     }
-
 document-contains-errors = ይህ ሰነድ ስህተቶች አሉት።
-
 diagnostic-heading-error = ስህተት
 diagnostic-heading-warning = ማስጠንቀቂያ
 diagnostic-heading-information = መረጃ
 diagnostic-heading-hint = ፍንጭ
-
 accessibility-heading-level-1 = የWCAG AA ተደራሽነት ጥሰት
 accessibility-heading-level-2 = የተደራሽነት ማሳሰቢያ
-
 something-went-wrong = የሆነ ስህተት ተከስቷል።
-
 renderer-load-failed = አንድ አሳያ መጫን አልቻለም። እባክዎ ገጹን እንደገና ይጫኑ።
-
 core-start-failed = የሰነድ መመልከቻው ሊጀመር አልቻለም። እባክዎ ገጹን እንደገና ይጫኑ።

--- a/packages/i18n/locales/am/content.ftl
+++ b/packages/i18n/locales/am/content.ftl
@@ -32,15 +32,12 @@ color =
     .purple = ወይን ጠጅ
     .pink = ሮዝ
     .brown = ቡናማ
-
 line-width =
     .thick = ወፍራም
     .thin = ቀጭን
-
 line-style =
     .dashed = ሰረዝ ያለው
     .dotted = ነጥብ ያለው
-
 # Noun phrases: they come in front of «ያለው» and agree with nothing.
 fill-style =
     .horizontal = አግድም መስመሮች
@@ -49,7 +46,6 @@ fill-style =
     .backdiagonal = ተቃራኒ ሰያፍ መስመሮች
     .dots = ነጥቦች
     .diamonds = አልማዞች
-
 noun =
     .line = መስመር
     .line-segment = የመስመር ክፍል
@@ -69,7 +65,6 @@ noun =
     .diamond = አልማዝ
     .cross = መስቀል
     .plus = የመደመር ምልክት
-
 # Amharic keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -77,11 +72,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ጎን ያለው ወጥ ብዙ ጎን
     }
-
 # Amharic's adjectives here do not vary by gender, so every noun answers the
 # same and the answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -95,21 +88,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = የተሞላ
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } ያለው { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } ያለው { $color } { $filled } { $noun }
@@ -117,7 +106,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } ያለው { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «ያለው» carries the "with a … border" sense itself, so Amharic needs no
 # article and the `-article` branches read the same as the ones without.
 style-border-clause =
@@ -127,35 +115,28 @@ style-border-clause =
         [and-article] እና { $border } ጠርዝ ያለው
        *[with] { $border } ጠርዝ ያለው
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ያልተሞላ
-
 style-text =
     { $parts ->
         [background] { $color } በ{ $background } ዳራ ላይ
        *[plain] { $color }
     }
-
 style-background-none = የለም
-
 
 ## Boolean words
 
 boolean-true = እውነት
 boolean-false = ሐሰት
 
-
 ## Answer buttons
 
 answer-submit-label = አረጋግጥ
 answer-submit-label-no-correctness = መልስ ላክ
-
 
 ## Sectional blocks
 
@@ -180,7 +161,6 @@ section-name =
     .solution = መፍትሔ
     .task = ተግባር
     .theorem = ሒሳባዊ ሕግ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -190,9 +170,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ፍንጭ
-
 
 ## Tables and figures
 
@@ -203,7 +181,6 @@ table-name =
         [unnumbered-title] ሠንጠረዥ{ ": " }
        *[unnumbered] ሠንጠረዥ
     }
-
 figure-name =
     { $parts ->
         [numbered] ሥዕል { $enumeration }
@@ -212,15 +189,12 @@ figure-name =
        *[unnumbered] ሥዕል
     }
 
-
 ## Paginator controls
 
 paginator-previous = ቀዳሚ
 paginator-next = ቀጣይ
 paginator-page = ገጽ
-
 paginator-page-status = { $pageLabel } { $currentPage } ከ{ $numPages }
-
 
 ## Piecewise functions
 
@@ -228,8 +202,8 @@ piecewise-condition-or = ወይም
 piecewise-condition-if = ከሆነ
 piecewise-condition-otherwise = ካልሆነ
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and those
 # 130 keys fall back to English.
@@ -242,6 +216,5 @@ piecewise-condition-otherwise = ካልሆነ
 # This is the same choice Somali and Hmong Njua make, and for the same reason.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ልክ ያልሆነ የኬሚካል ምልክት
 chemistry-invalid-ionic-compound = ልክ ያልሆነ አዮኒክ ውህድ

--- a/packages/i18n/locales/ar/chrome.ftl
+++ b/packages/i18n/locales/ar/chrome.ftl
@@ -22,23 +22,17 @@
 
 answer-checking = جارٍ التحقق...
 answer-submitting = جارٍ الإرسال...
-
 answer-checking-status = جارٍ التحقق من الإجابة
 answer-submitting-status = جارٍ إرسال الإجابة
-
 answer-correct = صحيح
 answer-incorrect = غير صحيح
-
 answer-response-saved = تم حفظ الإجابة
-
 # Arabic writes no space before the percent sign, so `-short` differs from the
 # English it renders beside.
 answer-percent-credit = { $percent }% من الدرجة
 answer-percent-correct = { $percent }% صحيح
 answer-percent-short = { $percent }%
-
 max-credit-available = الحد الأقصى للدرجة المتاحة: { $percent }%
-
 attempts-remaining =
     { $count ->
         [zero] لا محاولات متبقية
@@ -48,13 +42,11 @@ attempts-remaining =
         [many] بقيت { $count } محاولة
        *[other] بقيت { $count } محاولة
     }
-
 # Named rather than adjectival: read aloud after a field's own name, «(صحيحة)»
 # alone would leave a listener to guess what agreed with it.
 validation-correct = (إجابة صحيحة)
 validation-incorrect = (إجابة غير صحيحة)
 validation-partially-correct = (إجابة صحيحة جزئيًا)
-
 answer-show-responses =
     { $count ->
         [zero] عرض الإجابات المرسلة إلى { $answerId }
@@ -65,41 +57,31 @@ answer-show-responses =
        *[other] عرض { $count } إجابة مرسلة إلى { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ملاحظات
-
 collapsible-click-to-open = (النقر للفتح)
 collapsible-click-to-close = (النقر للإغلاق)
 collapsible-initializing = جارٍ التهيئة...
-
 footnote-show = إظهار الحاشية
 footnote-hide = إخفاء الحاشية
-
 description-more-information = مزيد من المعلومات
-
 
 ## Controls
 
 slider-previous = السابق
 slider-next = التالي
-
 keyboard-open = فتح لوحة المفاتيح
 keyboard-close = إغلاق لوحة المفاتيح
-
 choice-input-remove-choice = حذف { $choice }
-
 matrix-remove-row = حذف صف
 matrix-add-row = إضافة صف
 matrix-remove-column = حذف عمود
 matrix-add-column = إضافة عمود
-
 subset-add-remove-points = إضافة/حذف نقاط
 subset-toggle-points-intervals = التبديل بين النقاط والفترات
 subset-move-points = تحريك النقاط
 subset-clear = مسح
-
 orbital-add-row = إضافة صف
 orbital-remove-row = حذف صف
 orbital-add-box = إضافة مربع
@@ -107,15 +89,11 @@ orbital-remove-box = حذف مربع
 orbital-add-up-arrow = إضافة سهم لأعلى
 orbital-add-down-arrow = إضافة سهم لأسفل
 orbital-remove-arrow = حذف سهم
-
 orbital-row-label = تسمية الصف { $row }
-
 pretzel-answer = الإجابة
-
 # «للعمود» names what `$column` is, so that the sentence does not have to
 # attach a one-letter preposition to a placeable.
 summary-statistics-caption = ملخص إحصائي للعمود { $column }
-
 
 ## Math input
 
@@ -123,37 +101,28 @@ math-input-preview-region = معاينة التعبير الرياضي
 math-input-preview = معاينة
 math-input-invalid-expression = تعبير غير صالح:
 
-
 ## Document status
 
 viewer-initializing = جارٍ التهيئة...
 
-
 ## Errors
 
 error-heading = خطأ
-
 error-found-at =
     { $span ->
         [line] وُجد في السطر { $startLine }.
        *[lines] وُجد في الأسطر من { $startLine } إلى { $endLine }.
     }
-
 document-contains-errors = يحتوي هذا المستند على أخطاء!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = خطأ
 diagnostic-heading-warning = تحذير
 diagnostic-heading-information = معلومات
 diagnostic-heading-hint = تلميح
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = مخالفة لإمكانية الوصول وفق WCAG AA
 accessibility-heading-level-2 = تنبيه بشأن إمكانية الوصول
-
 something-went-wrong = حدث خطأ ما.
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = تعذّر تحميل أحد المكوّنات. يُرجى إعادة تحميل الصفحة.
-
 core-start-failed = تعذّر بدء عارض المستند. يُرجى إعادة تحميل الصفحة.

--- a/packages/i18n/locales/ar/content.ftl
+++ b/packages/i18n/locales/ar/content.ftl
@@ -93,7 +93,6 @@ color =
             [f] بنية
            *[m] بني
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -105,7 +104,6 @@ line-width =
             [f] رفيعة
            *[m] رفيع
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -117,7 +115,6 @@ line-style =
             [f] منقطة
            *[m] منقط
         }
-
 # Fill patterns are plural nouns rather than adjectives, so they do not agree
 # with the shape and take no `$gender` branch. The colour handed in beside one
 # agrees with the head of its phrase instead, never with the pattern: the shape
@@ -130,7 +127,6 @@ fill-style =
     .backdiagonal = خطوط مائلة معاكسة
     .dots = نقاط
     .diamonds = معينات
-
 # «علامة ضرب» and «علامة زائد» name the marker by the sign it is drawn as.
 # «صليب» is the word for a cross as an object and carries a religious sense
 # that a plotted point does not.
@@ -153,7 +149,6 @@ noun =
     .diamond = معين
     .cross = علامة ضرب
     .plus = علامة زائد
-
 # The side count is a complement rather than part of the head: «مضلع منتظم»
 # takes its adjectives first and closes with «ذو 5 أضلاع», so that the
 # adjectives stay beside the noun they agree with.
@@ -175,7 +170,6 @@ noun-regular-polygon =
             }
        *[head] مضلع منتظم
     }
-
 # Besides the nouns above, `$noun` may be «regular-polygon» (مضلع منتظم, m) or
 # the head of a phrase the description never names: «border» (إطار, m), «fill»
 # (ملء, m), «text» (نص, m), «background» (خلفية, f). Only the last is feminine
@@ -195,7 +189,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # The adjectives are listed in the mirror of the English order, so that the one
@@ -211,7 +204,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «خط أحمر سميك». A noun with a
 # complement closes the phrase with it: «مضلع منتظم أحمر سميك ذو 5 أضلاع».
 style-with-noun =
@@ -219,13 +211,11 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] مملوءة
        *[m] مملوء
     }
-
 # «بنمط» — "with a pattern of" — rather than a bare preposition: Arabic
 # attaches «بـ» directly to the word after it, and a placeable cannot be
 # written against a prefix without a tatweel between them.
@@ -234,7 +224,6 @@ style-filled =
         [pattern] { $color } { $filled } بنمط { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } بنمط { $pattern }
@@ -242,7 +231,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } بنمط { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # Arabic has no indefinite article, so the two `-article` branches say exactly
 # what their plain counterparts do. They are kept apart rather than folded
 # together because the distinction is the English message's, not this one's,
@@ -255,7 +243,6 @@ style-border-clause =
         [and-article] وإطار { $border }
        *[with] بإطار { $border }
     }
-
 # «بلون» — "of the colour" — because the colour arrives agreed with «ملء»,
 # which is masculine singular, while the pattern words are feminine plurals.
 # The plain variant is the whole of what `fillColor` reports, so the gender the
@@ -266,31 +253,25 @@ style-fill =
         [pattern] { $pattern } بلون { $color }
        *[plain] { $color }
     }
-
 # Said of no particular shape — `describeFill` passes no gender — so it takes
 # the masculine, which is also what an unnamed subject takes.
 style-unfilled = غير مملوء
-
 style-text =
     { $parts ->
         [background] { $color } على خلفية { $background }
        *[plain] { $color }
     }
-
 style-background-none = لا شيء
-
 
 ## Boolean words
 
 boolean-true = صواب
 boolean-false = خطأ
 
-
 ## Answer buttons
 
 answer-submit-label = تحقق من الإجابة
 answer-submit-label-no-correctness = إرسال الإجابة
-
 
 ## Sectional blocks
 
@@ -315,7 +296,6 @@ section-name =
     .solution = حل
     .task = مهمة
     .theorem = نظرية
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -325,9 +305,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = تلميح
-
 
 ## Tables and figures
 
@@ -338,7 +316,6 @@ table-name =
         [unnumbered-title] جدول{ ": " }
        *[unnumbered] جدول
     }
-
 figure-name =
     { $parts ->
         [numbered] شكل { $enumeration }
@@ -347,24 +324,18 @@ figure-name =
        *[unnumbered] شكل
     }
 
-
 ## Paginator controls
 
 paginator-previous = السابق
 paginator-next = التالي
 paginator-page = صفحة
-
 paginator-page-status = { $pageLabel } { $currentPage } من { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = أو
-
 piecewise-condition-if = إذا كان
-
 piecewise-condition-otherwise = خلاف ذلك
-
 
 ## Chemistry
 
@@ -487,7 +458,6 @@ element-name =
     .lv = ليفرموريوم
     .ts = تينيسين
     .og = أوجانيسون
-
 element-anion-name =
     .h = هيدريد
     .c = كربيد
@@ -501,8 +471,6 @@ element-anion-name =
     .i = يوديد
     .at = أستاتيد
     .ts = تينيسيد
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = رمز كيميائي غير صالح
 chemistry-invalid-ionic-compound = مركب أيوني غير صالح

--- a/packages/i18n/locales/arn/chrome.ftl
+++ b/packages/i18n/locales/arn/chrome.ftl
@@ -25,21 +25,15 @@
 
 answer-checking = Adkintungey…
 answer-submitting = Werkülelu…
-
 answer-checking-status = Adkintungey ti llowdungun
 answer-submitting-status = Werkülelu ti llowdungun
-
 answer-correct = Rüf
 answer-incorrect = Rüfnolu
-
 answer-response-saved = Elkünungey ti llowdungun
-
 answer-percent-credit = { $percent }% falin
 answer-percent-correct = { $percent }% rüf
 answer-percent-short = { $percent } %
-
 max-credit-available = Doy fütra falin: { $percent }%
-
 # No select: «pepilun» takes no plural marker after a numeral, so both English
 # categories render the same words. The count still arrives and is still
 # formatted. `[0]` stays, because "none left" is its own sentence.
@@ -48,51 +42,38 @@ attempts-remaining =
         [0] chemnorume pepilun mülewelay
        *[other] { $count } pepilun mülewey
     }
-
 validation-correct = (Rüf)
 validation-incorrect = (Rüfnolu)
 validation-partially-correct = (Pichin rüf)
-
 # No select, for the reason given above. The answer is named with «pingelu» —
 # "the one called" — which is a whole word rather than an affix on `$answerId`.
 answer-show-responses = Pengelnge { $count } llowdungun, { $answerId } pingelu
 
-
 ## Disclosure panels
 
 feedback-heading = Wüñoldungun
-
 collapsible-click-to-open = (rütrünge nülakünuam)
 collapsible-click-to-close = (rütrünge nürükünuam)
-
 collapsible-initializing = Llitulelu…
-
 footnote-show = Pengelnge ti minche wirin
 footnote-hide = Ellkanenge ti minche wirin
-
 description-more-information = doy kimeltun
-
 
 ## Controls
 
 slider-previous = Wüne
 slider-next = Inan
-
 keyboard-open = Nülange ti wirintukupeyüm
 keyboard-close = Nürüfnge ti wirintukupeyüm
-
 choice-input-remove-choice = Nentunge { $choice }
-
 matrix-remove-row = Nentunge kiñe wirin
 matrix-add-row = Yomümnge kiñe wirin
 matrix-remove-column = Nentunge kiñe witran
 matrix-add-column = Yomümnge kiñe witran
-
 subset-add-remove-points = Yomümnge/Nentunge troy
 subset-toggle-points-intervals = Kañpüle elnge troy ka rangiñtu
 subset-move-points = Nengümnge ti troy
 subset-clear = Liftunge
-
 orbital-add-row = Yomümnge kiñe wirin
 orbital-remove-row = Nentunge kiñe wirin
 orbital-add-box = Yomümnge kiñe kaxa
@@ -100,13 +81,9 @@ orbital-remove-box = Nentunge kiñe kaxa
 orbital-add-up-arrow = Yomümnge kiñe pülki wenu
 orbital-add-down-arrow = Yomümnge kiñe pülki naq
 orbital-remove-arrow = Nentunge kiñe pülki
-
 orbital-row-label = Ti wirin { $row } üy
-
 pretzel-answer = Llowdungun
-
 summary-statistics-caption = { $column } rakin
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = rakin dungu wüne pengelün
 math-input-preview = Wüne pengelün
 math-input-invalid-expression = Weda dungu:
 
-
 ## Document status
 
 viewer-initializing = Llitulelu…
 
-
 ## Errors
 
 error-heading = Welulkan
-
 error-found-at =
     { $span ->
         [line] Peñgey ti wirin { $startLine } mew.
        *[lines] Peñgey ti wirin { $startLine }–{ $endLine } mew.
     }
-
 document-contains-errors = Tüfachi chillka niey welulkan!
-
 diagnostic-heading-error = Welulkan
 diagnostic-heading-warning = Gülamtun
 diagnostic-heading-information = Kimeltun
 diagnostic-heading-hint = Kellun
-
 accessibility-heading-level-1 = WCAG AA konpeyüm welulkan
 accessibility-heading-level-2 = Konpeyüm gülamtun
-
 something-went-wrong = Kiñe dungu rüfngelay.
-
 renderer-load-failed = kiñe pengelfe puwlay. Wüñokünunge ti chillka.
-
 core-start-failed = Ti chillka pengelfe pepi llitulay. Wüñokünunge ti chillka.

--- a/packages/i18n/locales/arn/content.ftl
+++ b/packages/i18n/locales/arn/content.ftl
@@ -54,15 +54,12 @@ color =
     .purple = kelü-kallfü
     .pink = kelü-lig
     .brown = kolü
-
 line-width =
     .thick = motrin
     .thin = trongli
-
 line-style =
     .dashed = katrüntuku
     .dotted = pichike troykülen
-
 # Noun phrases. Mapudungun marks the plural with the free word «pu» before the
 # noun rather than with a suffix, and a bare noun already reads as a kind, so
 # these carry nothing.
@@ -73,7 +70,6 @@ fill-style =
     .backdiagonal = wirin aylla wüñotun
     .dots = troykülen
     .diamonds = rombo
-
 # The geometry nouns, and the loan boundary this file's header describes. «wirin»
 # (line), «wallke» (round), «troy» (point) and «meli» / «küla» (four, three) are
 # Mapudungun; ray, vector, parabola and the rest are Spanish, because the
@@ -97,7 +93,6 @@ noun =
     .diamond = rombo
     .cross = kürus
     .plus = yomümün chillka
-
 # The side count precedes the noun, so the head holds it and the tail is empty —
 # English's shape.
 noun-regular-polygon =
@@ -105,11 +100,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } xoy poligono kiñewkülen
     }
-
 # One answer for every noun: Mapudungun has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -123,7 +116,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives precede the noun, so this is English's order. The `[noun-tail]`
 # branch is unreachable from Mapudungun's own `noun-regular-polygon`; it is kept
 # because it is what a partly-corrected catalog falls back to.
@@ -132,9 +124,7 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = apolen
-
 # «mew» is a postposition and a free word, so it follows `$pattern` without
 # touching it. Mapudungun needs none of the workarounds `locales/qu` and
 # `locales/ay` needed for this same message, and the reason is only that its
@@ -144,7 +134,6 @@ style-filled =
         [pattern] { $filled } { $color }, { $pattern } mew
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun }, { $pattern } mew
@@ -152,7 +141,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail }, { $pattern } mew
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Mapudungun has no article, so English's four branches are two distinct strings;
 # all four are written out because they are four positions and a later correction
 # to one need not be a correction to the others.
@@ -163,7 +151,6 @@ style-border-clause =
         [and-article] ka { $border } inaltu
        *[with] { $border } inaltu mew
     }
-
 # Here the pattern is the head noun — "blue diamonds" — and the colour precedes
 # it, so the phrase needs nothing at all.
 style-fill =
@@ -171,29 +158,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = apolenolu
-
 style-text =
     { $parts ->
         [background] { $color }, { $background } furi mew
        *[plain] { $color }
     }
-
 style-background-none = chemnorume
-
 
 ## Boolean words
 
 boolean-true = rüf
 boolean-false = koyla
 
-
 ## Answer buttons
 
 answer-submit-label = Adkintuge ti küdaw
 answer-submit-label-no-correctness = Werküge ti llowdungun
-
 
 ## Sectional blocks
 
@@ -221,7 +202,6 @@ section-name =
     .solution = Nornentun
     .task = Elufe küdaw
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -231,9 +211,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kellun
-
 
 ## Tables and figures
 
@@ -244,7 +222,6 @@ table-name =
         [unnumbered-title] Wirin waria{ ": " }
        *[unnumbered] Wirin waria
     }
-
 figure-name =
     { $parts ->
         [numbered] Adentun { $enumeration }
@@ -253,24 +230,20 @@ figure-name =
        *[unnumbered] Adentun
     }
 
-
 ## Paginator controls
 
 paginator-previous = Wüne
 paginator-next = Inan
 paginator-page = Chillka
-
 # «mew» follows what it governs and is a free word, so the total can stand where
 # English puts it.
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kam
 piecewise-condition-if = feyti
 piecewise-condition-otherwise = ka mew
-
 
 ## Chemistry
 ##
@@ -283,6 +256,5 @@ piecewise-condition-otherwise = ka mew
 ## that boundary is and why it is worth moving.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Weda chillka kimika
 chemistry-invalid-ionic-compound = Weda trawün ionika

--- a/packages/i18n/locales/as/chrome.ftl
+++ b/packages/i18n/locales/as/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = পৰীক্ষা কৰি থকা হৈছে...
 answer-submitting = পঠিওৱা হৈছে...
-
 answer-checking-status = উত্তৰ পৰীক্ষা কৰি থকা হৈছে
 answer-submitting-status = উত্তৰ পঠিওৱা হৈছে
-
 answer-correct = শুদ্ধ
 answer-incorrect = ভুল
-
 answer-response-saved = উত্তৰ সংৰক্ষণ কৰা হ'ল
-
 answer-percent-credit = { $percent }% নম্বৰ
 answer-percent-correct = { $percent }% শুদ্ধ
 answer-percent-short = { $percent }%
-
 max-credit-available = সৰ্বাধিক সম্ভাৱ্য নম্বৰ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] কোনো প্ৰয়াস বাকী নাই
         [one] { $count }টা প্ৰয়াস বাকী
        *[other] { $count }টা প্ৰয়াস বাকী
     }
-
 validation-correct = (শুদ্ধ)
 validation-incorrect = (ভুল)
 validation-partially-correct = (আংশিকভাৱে শুদ্ধ)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId }-ৰ { $count }টা উত্তৰ দেখুৱাওক
        *[other] { $answerId }-ৰ { $count }টা উত্তৰ দেখুৱাওক
     }
 
-
 ## Disclosure panels
 
 feedback-heading = প্ৰতিক্ৰিয়া
-
 collapsible-click-to-open = (খুলিবলৈ ক্লিক কৰক)
 collapsible-click-to-close = (বন্ধ কৰিবলৈ ক্লিক কৰক)
-
 collapsible-initializing = আৰম্ভ কৰা হৈছে...
-
 footnote-show = পাদটীকা দেখুৱাওক
 footnote-hide = পাদটীকা লুকুৱাওক
-
 description-more-information = অধিক তথ্য
-
 
 ## Controls
 
 slider-previous = পূৰ্বৱৰ্তী
 slider-next = পৰৱৰ্তী
-
 keyboard-open = কীব'ৰ্ড খোলক
 keyboard-close = কীব'ৰ্ড বন্ধ কৰক
-
 choice-input-remove-choice = { $choice } আঁতৰাওক
-
 matrix-remove-row = শাৰী আঁতৰাওক
 matrix-add-row = শাৰী যোগ কৰক
 matrix-remove-column = স্তম্ভ আঁতৰাওক
 matrix-add-column = স্তম্ভ যোগ কৰক
-
 subset-add-remove-points = বিন্দু যোগ/আঁতৰাওক
 subset-toggle-points-intervals = বিন্দু আৰু অন্তৰালৰ মাজত সলনি কৰক
 subset-move-points = বিন্দু লৰাওক
 subset-clear = পৰিষ্কাৰ কৰক
-
 # A `box` here is one orbital, drawn as a square: ঘৰ.
 orbital-add-row = শাৰী যোগ কৰক
 orbital-remove-row = শাৰী আঁতৰাওক
@@ -94,13 +75,9 @@ orbital-remove-box = ঘৰ আঁতৰাওক
 orbital-add-up-arrow = ওপৰমুৱা কাঁড় যোগ কৰক
 orbital-add-down-arrow = তলমুৱা কাঁড় যোগ কৰক
 orbital-remove-arrow = কাঁড় আঁতৰাওক
-
 orbital-row-label = { $row } নং শাৰীৰ লেবেল
-
 pretzel-answer = উত্তৰ
-
 summary-statistics-caption = { $column }-ৰ সাৰাংশ পৰিসংখ্যা
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = গাণিতিক ৰাশিৰ পূৰ্�
 math-input-preview = পূৰ্বদৃশ্য
 math-input-invalid-expression = অবৈধ ৰাশি:
 
-
 ## Document status
 
 viewer-initializing = আৰম্ভ কৰা হৈছে...
 
-
 ## Errors
 
 error-heading = ত্ৰুটি
-
 error-found-at =
     { $span ->
         [line] { $startLine } নং শাৰীত পোৱা গৈছে।
        *[lines] { $startLine }–{ $endLine } নং শাৰীত পোৱা গৈছে।
     }
-
 document-contains-errors = এই নথিত ত্ৰুটি আছে!
-
 diagnostic-heading-error = ত্ৰুটি
 diagnostic-heading-warning = সতৰ্কবাণী
 diagnostic-heading-information = তথ্য
 diagnostic-heading-hint = ইংগিত
-
 accessibility-heading-level-1 = WCAG AA প্ৰৱেশযোগ্যতা উলংঘন
 accessibility-heading-level-2 = প্ৰৱেশযোগ্যতা সতৰ্কবাণী
-
 something-went-wrong = কিবা এটা ভুল হ'ল।
-
 renderer-load-failed = এটা ৰেণ্ডাৰাৰ ল'ড কৰিব পৰা নগ'ল। অনুগ্ৰহ কৰি পৃষ্ঠাটো আকৌ ল'ড কৰক।
-
 core-start-failed = নথি প্ৰদৰ্শক আৰম্ভ কৰিব পৰা নগ'ল। অনুগ্ৰহ কৰি পৃষ্ঠাটো আকৌ ল'ড কৰক।

--- a/packages/i18n/locales/as/content.ftl
+++ b/packages/i18n/locales/as/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = বেঙুনীয়া
     .pink = গুলপীয়া
     .brown = মটীয়া
-
 line-width =
     .thick = ডাঠ
     .thin = পাতল
-
 line-style =
     .dashed = ডেচযুক্ত
     .dotted = বিন্দুযুক্ত
-
 # Noun phrases rather than adjectives: they are introduced by ৰে ("using"),
 # which takes a bare noun.
 fill-style =
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = বিপৰীত কৰ্ণ ৰেখা
     .dots = বিন্দু
     .diamonds = ৰম্বচ
-
 noun =
     .line = ৰেখা
     .line-segment = ৰেখাখণ্ড
@@ -74,7 +70,6 @@ noun =
     .diamond = ৰম্বচ
     .cross = ক্ৰছ
     .plus = যোগ চিহ্ন
-
 # বাহুবিশিষ্ট ("having sides") attaches the count to the noun that follows, so
 # the whole phrase is one head and there is no tail.
 noun-regular-polygon =
@@ -82,11 +77,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } বাহুবিশিষ্ট সুষম বহুভুজ
     }
-
 # Assamese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,15 +93,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ভৰোৱা
-
 # ৰে follows the pattern it applies to, so the clause English appends comes to
 # the front here.
 style-filled =
@@ -116,7 +106,6 @@ style-filled =
         [pattern] { $pattern }ৰে { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern }ৰে { $filled } { $color } { $noun }
@@ -124,7 +113,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern }ৰে { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # সৈতে is a postposition, so it follows প্ৰান্ত rather than preceding it as
 # English's `with` does. Assamese has no article, which leaves the `-article`
 # branches reading exactly like the ones without.
@@ -135,15 +123,12 @@ style-border-clause =
         [and-article] আৰু { $border } প্ৰান্তৰ সৈতে
        *[with] { $border } প্ৰান্তৰ সৈতে
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ভৰোৱা নহোৱা
-
 # The locative -ত marks পটভূমি, and the colour word in front of it is
 # untouched by that.
 style-text =
@@ -151,21 +136,17 @@ style-text =
         [background] { $background } পটভূমিত { $color }
        *[plain] { $color }
     }
-
 style-background-none = নাই
-
 
 ## Boolean words
 
 boolean-true = সঁচা
 boolean-false = মিছা
 
-
 ## Answer buttons
 
 answer-submit-label = পৰীক্ষা কৰক
 answer-submit-label-no-correctness = উত্তৰ দাখিল কৰক
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = সমাধান
     .task = কাম
     .theorem = উপপাদ্য
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -200,9 +180,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ইংগিত
-
 
 ## Tables and figures
 
@@ -213,7 +191,6 @@ table-name =
         [unnumbered-title] তালিকা{ ": " }
        *[unnumbered] তালিকা
     }
-
 figure-name =
     { $parts ->
         [numbered] চিত্ৰ { $enumeration }
@@ -222,28 +199,23 @@ figure-name =
        *[unnumbered] চিত্ৰ
     }
 
-
 ## Paginator controls
 
 paginator-previous = পূৰ্বৱৰ্তী
 paginator-next = পৰৱৰ্তী
 paginator-page = পৃষ্ঠা
-
 # «X-ৰ ভিতৰত Y» — "Y out of X" — puts the total first, so the two counts
 # change places.
 paginator-page-status = { $numPages }-ৰ ভিতৰত { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = বা
-
 piecewise-condition-if = যদি
-
 piecewise-condition-otherwise = অন্যথা
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and those
 # 130 keys fall back to English.
@@ -259,6 +231,5 @@ piecewise-condition-otherwise = অন্যথা
 # are two catalogs.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = অবৈধ ৰাসায়নিক চিহ্ন
 chemistry-invalid-ionic-compound = অবৈধ আয়নিক যৌগ

--- a/packages/i18n/locales/ast/chrome.ftl
+++ b/packages/i18n/locales/ast/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Comprobando…
 answer-submitting = Unviando…
-
 answer-checking-status = Comprobando la rempuesta
 answer-submitting-status = Unviando la rempuesta
-
 answer-correct = Correuto
 answer-incorrect = Incorreuto
-
 answer-response-saved = Rempuesta guardada
-
 answer-percent-credit = { $percent }% de puntos
 answer-percent-correct = { $percent }% correuto
 answer-percent-short = { $percent } %
-
 max-credit-available = Puntos másimos disponibles: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nun queden intentos
         [one] queda { $count } intentu
        *[other] queden { $count } intentos
     }
-
 validation-correct = (Correuto)
 validation-incorrect = (Incorreuto)
 validation-partially-correct = (Parcialmente correuto)
-
 answer-show-responses =
     { $count ->
         [one] Amosar { $count } rempuesta a { $answerId }
        *[other] Amosar { $count } rempuestes a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Comentariu
-
 collapsible-click-to-open = (calca p'abrir)
 collapsible-click-to-close = (calca pa zarrar)
-
 collapsible-initializing = Aniciando…
-
 footnote-show = Amosar la nota
 footnote-hide = Anubrir la nota
-
 description-more-information = más información
-
 
 ## Controls
 
 slider-previous = Anterior
 slider-next = Siguiente
-
 keyboard-open = Abrir el tecláu
 keyboard-close = Zarrar el tecláu
-
 choice-input-remove-choice = Quitar { $choice }
-
 matrix-remove-row = Quitar una filera
 matrix-add-row = Amestar una filera
 matrix-remove-column = Quitar una columna
 matrix-add-column = Amestar una columna
-
 subset-add-remove-points = Amestar/quitar puntos
 subset-toggle-points-intervals = Camudar ente puntos ya intervalos
 subset-move-points = Mover los puntos
 subset-clear = Llimpiar
-
 orbital-add-row = Amestar una filera
 orbital-remove-row = Quitar una filera
 orbital-add-box = Amestar una caxa
@@ -92,13 +73,9 @@ orbital-remove-box = Quitar una caxa
 orbital-add-up-arrow = Amestar una flecha p'arriba
 orbital-add-down-arrow = Amestar una flecha p'abaxo
 orbital-remove-arrow = Quitar una flecha
-
 orbital-row-label = Etiqueta de la filera { $row }
-
 pretzel-answer = Rempuesta
-
 summary-statistics-caption = Estadístiques resumíes de { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = vista previa de la espresión matemática
 math-input-preview = Vista previa
 math-input-invalid-expression = Espresión inválida:
 
-
 ## Document status
 
 viewer-initializing = Aniciando…
 
-
 ## Errors
 
 error-heading = Error
-
 error-found-at =
     { $span ->
         [line] Alcontráu na llinia { $startLine }.
        *[lines] Alcontráu nes llinies { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = ¡Esti documentu contién errores!
-
 diagnostic-heading-error = Error
 diagnostic-heading-warning = Alvertencia
 diagnostic-heading-information = Información
 diagnostic-heading-hint = Pista
-
 accessibility-heading-level-1 = Vulneración d'accesibilidá según WCAG AA
 accessibility-heading-level-2 = Avisu d'accesibilidá
-
 something-went-wrong = Daqué salió mal.
-
 renderer-load-failed = un módulu de representación nun se pudo cargar. Recarga la páxina.
-
 core-start-failed = El visor del documentu nun se pudo aniciar. Recarga la páxina.

--- a/packages/i18n/locales/ast/content.ftl
+++ b/packages/i18n/locales/ast/content.ftl
@@ -64,7 +64,6 @@ color =
         }
     .pink = rosa
     .brown = marrón
-
 line-width =
     .thick =
         { $gender ->
@@ -76,7 +75,6 @@ line-width =
             [f] fina
            *[m] finu
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -88,7 +86,6 @@ line-style =
             [f] puntiada
            *[m] puntiáu
         }
-
 # Plural noun phrases, which is what follows «con» in `style-filled`. They
 # agree with nothing.
 fill-style =
@@ -98,7 +95,6 @@ fill-style =
     .backdiagonal = llinies diagonales inverses
     .dots = puntos
     .diamonds = rombos
-
 noun =
     .line = recta
     .line-segment = segmentu
@@ -118,13 +114,11 @@ noun =
     .diamond = rombu
     .cross = cruz
     .plus = más
-
 noun-regular-polygon =
     { $part ->
         [tail] de { $numSides } llaos
        *[head] polígonu regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polígonu, m) or
 # the head of a phrase the description never names: `border` (borde, m), `fill`
 # (rellenu, m), `text` (testu, m), `background` (fondu, m).
@@ -141,7 +135,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -154,7 +147,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it, which is the opposite of
 # English. A noun that splits — the regular polygon — puts its complement after
 # the adjectives that agree with its head.
@@ -163,19 +155,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] rellena
        *[m] rellenu
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } con { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } con { $pattern }
@@ -183,7 +172,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } con { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «borde» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds.
 style-border-clause =
@@ -193,7 +181,6 @@ style-border-clause =
         [and-article] y un borde { $border }
        *[with] con borde { $border }
     }
-
 # The fill-pattern words are plural nouns, because their other use is the
 # «con { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «rellenu», masculine, which is the gender
@@ -203,29 +190,23 @@ style-fill =
         [pattern] rellenu { $color } con { $pattern }
        *[plain] rellenu { $color }
     }
-
 style-unfilled = ensin rellenar
-
 style-text =
     { $parts ->
         [background] { $color } sobre un fondu { $background }
        *[plain] { $color }
     }
-
 style-background-none = dengún
-
 
 ## Boolean words
 
 boolean-true = verdaderu
 boolean-false = falsu
 
-
 ## Answer buttons
 
 answer-submit-label = Comprobar
 answer-submit-label-no-correctness = Unviar la rempuesta
-
 
 ## Sectional blocks
 
@@ -250,7 +231,6 @@ section-name =
     .solution = Solución
     .task = Xera
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -260,9 +240,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pista
-
 
 ## Tables and figures
 
@@ -273,7 +251,6 @@ table-name =
         [unnumbered-title] Tabla{ ". " }
        *[unnumbered] Tabla
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -282,22 +259,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anterior
 paginator-next = Siguiente
 paginator-page = Páxina
-
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = si
 piecewise-condition-otherwise = si non
-
 
 ## Chemistry
 ##
@@ -308,6 +281,5 @@ piecewise-condition-otherwise = si non
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Símbolu químicu inválidu
 chemistry-invalid-ionic-compound = Compuestu iónicu inválidu

--- a/packages/i18n/locales/ay/chrome.ftl
+++ b/packages/i18n/locales/ay/chrome.ftl
@@ -33,21 +33,15 @@
 
 answer-checking = Uñakipaskiwa…
 answer-submitting = Apayaskiwa…
-
 answer-checking-status = Jaysäwi uñakipaskiwa
 answer-submitting-status = Jaysäwi apayaskiwa
-
 answer-correct = Askiwa
 answer-incorrect = Jan askiwa
-
 answer-response-saved = Jaysäwi imantatawa
-
 answer-percent-credit = { $percent }% chani
 answer-percent-correct = { $percent }% aski
 answer-percent-short = { $percent } %
-
 max-credit-available = Jach'a chani: { $percent }%
-
 # No select: «yant'a» takes no plural suffix after a numeral, so both English
 # categories render the same words. The count still arrives and is still
 # formatted. `[0]` stays, because "none left" is its own sentence.
@@ -56,52 +50,39 @@ attempts-remaining =
         [0] janiwa yant'a jiltkiti
        *[other] { $count } yant'a jiltiwa
     }
-
 validation-correct = (Askiwa)
 validation-incorrect = (Jan askiwa)
 validation-partially-correct = (Chikatanaki aski)
-
 # No select, for the reason given above. The answer is reached by naming it —
 # «{ $answerId } sutini jiskt'awi», "the question named X" — rather than by
 # putting a case suffix on `$answerId`.
 answer-show-responses = { $answerId } sutini jiskt'awitaki { $count } jaysäwi uñachayaña
 
-
 ## Disclosure panels
 
 feedback-heading = Kutt'awi aru
-
 collapsible-click-to-open = (jist'arañataki limt'aña)
 collapsible-click-to-close = (jist'antañataki limt'aña)
-
 collapsible-initializing = Qalltaskiwa…
-
 footnote-show = Aynachankiri qillqa uñachayaña
 footnote-hide = Aynachankiri qillqa imantaña
-
 description-more-information = juk'ampi yatiyawi
-
 
 ## Controls
 
 slider-previous = Nayra
 slider-next = Qhipa
-
 keyboard-open = Limt'aña uta jist'araña
 keyboard-close = Limt'aña uta jist'antaña
-
 choice-input-remove-choice = { $choice } apsuña
-
 matrix-remove-row = Mä siqi apsuña
 matrix-add-row = Mä siqi yapxataña
 matrix-remove-column = Mä sayt'iri apsuña
 matrix-add-column = Mä sayt'iri yapxataña
-
 subset-add-remove-points = Chimpunaka yapxataña/apsuña
 subset-toggle-points-intervals = Chimputa taypiruwa mayjt'ayaña
 subset-move-points = Chimpunaka unxtayaña
 subset-clear = Pichaña
-
 orbital-add-row = Mä siqi yapxataña
 orbital-remove-row = Mä siqi apsuña
 orbital-add-box = Mä qullqa yapxataña
@@ -109,13 +90,9 @@ orbital-remove-box = Mä qullqa apsuña
 orbital-add-up-arrow = Alaya wach'i yapxataña
 orbital-add-down-arrow = Aynacha wach'i yapxataña
 orbital-remove-arrow = Wach'i apsuña
-
 orbital-row-label = { $row } siqitaki suti
-
 pretzel-answer = Jaysäwi
-
 summary-statistics-caption = { $column } jakhuwinaka pisichata
-
 
 ## Math input
 
@@ -123,34 +100,25 @@ math-input-preview-region = jakhuwi aru nayra uñachawi
 math-input-preview = Nayra uñachawi
 math-input-invalid-expression = Jan aski aru:
 
-
 ## Document status
 
 viewer-initializing = Qalltaskiwa…
 
-
 ## Errors
 
 error-heading = Pantjawi
-
 error-found-at =
     { $span ->
         [line] { $startLine } siqina jikitawa.
        *[lines] { $startLine }–{ $endLine } siqinakana jikitawa.
     }
-
 document-contains-errors = Aka qillqana pantjawinakawa utji!
-
 diagnostic-heading-error = Pantjawi
 diagnostic-heading-warning = Amuyt'ayawi
 diagnostic-heading-information = Yatiyawi
 diagnostic-heading-hint = Yanapa
-
 accessibility-heading-level-1 = WCAG AA puriña p'akjawi
 accessibility-heading-level-2 = Puriña amuyt'ayawi
-
 something-went-wrong = Kunas jan askiwa mistuwa.
-
 renderer-load-failed = mä uñachayirisa janiwa purkiti. Mira, laphi wasitat apnaqaña.
-
 core-start-failed = Qillqa uñachayirisa janiwa qalltañ atkiti. Mira, laphi wasitat apnaqaña.

--- a/packages/i18n/locales/ay/content.ftl
+++ b/packages/i18n/locales/ay/content.ftl
@@ -46,15 +46,12 @@ color =
     .purple = kulli
     .pink = panti
     .brown = ch'umphi
-
 line-width =
     .thick = lanqu
     .thin = juch'usa
-
 line-style =
     .dashed = t'aqata
     .dotted = chhiqchhi
-
 # Noun phrases, which is what the head of `style-fill` is. «-naka» is written
 # here because nothing precedes them to say how many.
 fill-style =
@@ -64,7 +61,6 @@ fill-style =
     .backdiagonal = kutt'ata k'umu siqinaka
     .dots = chhiqchhinaka
     .diamonds = rombonaka
-
 noun =
     .line = siqi
     .line-segment = siqi t'aqa
@@ -84,7 +80,6 @@ noun =
     .diamond = rombo
     .cross = chakana
     .plus = yapa chimpu
-
 # The side count is a prenominal modifier, so it stays in the head and the tail
 # is empty. «-ni», "having", lands on «jarpha», the side, which this catalog
 # writes.
@@ -93,11 +88,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } jarphini pachpa walja k'uchu
     }
-
 # One answer for every noun: Aymara has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -111,7 +104,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives precede the noun, so this is English's order. The `[noun-tail]`
 # branch is unreachable from Aymara's own `noun-regular-polygon`; it is kept
 # because it is what a partly-corrected catalog falls back to, and dropping it
@@ -121,9 +113,7 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = phuqata
-
 # The instrumental «-mpi» cannot be welded to `$pattern`, so the pattern is named
 # rather than marked: «saltanakapa { $pattern }», "its woven figures: diamonds".
 style-filled =
@@ -131,7 +121,6 @@ style-filled =
         [pattern] { $filled } { $color }, saltanakapa { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun }, saltanakapa { $pattern }
@@ -139,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail }, saltanakapa { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «-ni», "having", lands on «jarpha» again — the same word `noun-regular-polygon`
 # counts, since Aymara's word for a polygon's side is its word for an edge — and
 # the adjectives precede it.
@@ -152,7 +140,6 @@ style-border-clause =
         [and-article] ukhamaraki { $border } jarphini
        *[with] { $border } jarphini
     }
-
 # Here the pattern is the head noun — "blue diamonds" — so it needs no suffix at
 # all and the colour simply precedes it. The same value that had to be named in
 # `style-filled` needs nothing here.
@@ -161,29 +148,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = jan phuqata
-
 style-text =
     { $parts ->
         [background] { $background } laphimpi { $color }
        *[plain] { $color }
     }
-
 style-background-none = janiwa utjkiti
-
 
 ## Boolean words
 
 boolean-true = chiqa
 boolean-false = k'ari
 
-
 ## Answer buttons
 
 answer-submit-label = Luräwi uñakipaña
 answer-submit-label-no-correctness = Jaysäwi apayaña
-
 
 ## Sectional blocks
 
@@ -208,7 +189,6 @@ section-name =
     .solution = Askichawi
     .task = Luranawi
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -218,9 +198,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Yanapa
-
 
 ## Tables and figures
 
@@ -231,7 +209,6 @@ table-name =
         [unnumbered-title] Tabla{ ": " }
        *[unnumbered] Tabla
     }
-
 figure-name =
     { $parts ->
         [numbered] Uñacha { $enumeration }
@@ -240,24 +217,20 @@ figure-name =
        *[unnumbered] Uñacha
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nayra
 paginator-next = Qhipa
 paginator-page = Laphi
-
 # The ablative «-ta» lands on «laphi», which this catalog writes, so the total
 # precedes it: "of N pages, Page 3".
 paginator-page-status = { $numPages } laphinakata { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = jan ukaxa
 piecewise-condition-if = ukhamäspa
 piecewise-condition-otherwise = jan ukhamäspa
-
 
 ## Chemistry
 ##
@@ -268,6 +241,5 @@ piecewise-condition-otherwise = jan ukhamäspa
 ## is no settled Aymara table for a seed to reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Jan aski chimpu kimiku
 chemistry-invalid-ionic-compound = Jan aski mayacha ioniku

--- a/packages/i18n/locales/az/chrome.ftl
+++ b/packages/i18n/locales/az/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Yoxlanılır…
 answer-submitting = Göndərilir…
-
 answer-checking-status = Cavab yoxlanılır
 answer-submitting-status = Cavab göndərilir
-
 answer-correct = Düzdür
 answer-incorrect = Səhvdir
-
 answer-response-saved = Cavab saxlanıldı
-
 answer-percent-credit = { $percent }% bal
 answer-percent-correct = { $percent }% düz
 answer-percent-short = { $percent } %
-
 max-credit-available = Mümkün ən yüksək bal: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] cəhd qalmayıb
         [one] { $count } cəhd qalıb
        *[other] { $count } cəhd qalıb
     }
-
 validation-correct = (Düzdür)
 validation-incorrect = (Səhvdir)
 validation-partially-correct = (Qismən düzdür)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } üçün { $count } cavabı göstər
        *[other] { $answerId } üçün { $count } cavabı göstər
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Rəy
-
 collapsible-click-to-open = (açmaq üçün klikləyin)
 collapsible-click-to-close = (bağlamaq üçün klikləyin)
-
 collapsible-initializing = Hazırlanır…
-
 footnote-show = Qeydi göstər
 footnote-hide = Qeydi gizlət
-
 description-more-information = əlavə məlumat
-
 
 ## Controls
 
 slider-previous = Əvvəlki
 slider-next = Sonrakı
-
 keyboard-open = Klaviaturanı aç
 keyboard-close = Klaviaturanı bağla
-
 choice-input-remove-choice = { $choice } seçimini sil
-
 matrix-remove-row = Sətri sil
 matrix-add-row = Sətir əlavə et
 matrix-remove-column = Sütunu sil
 matrix-add-column = Sütun əlavə et
-
 subset-add-remove-points = Nöqtə əlavə et/sil
 subset-toggle-points-intervals = Nöqtələr və intervallar arasında keç
 subset-move-points = Nöqtələri köçür
 subset-clear = Təmizlə
-
 orbital-add-row = Sətir əlavə et
 orbital-remove-row = Sətri sil
 orbital-add-box = Xana əlavə et
@@ -92,13 +73,9 @@ orbital-remove-box = Xananı sil
 orbital-add-up-arrow = Yuxarı ox əlavə et
 orbital-add-down-arrow = Aşağı ox əlavə et
 orbital-remove-arrow = Oxu sil
-
 orbital-row-label = { $row } sətrinin etiketi
-
 pretzel-answer = Cavab
-
 summary-statistics-caption = { $column } sütununun yekun statistikası
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = riyazi ifadənin ön baxışı
 math-input-preview = Ön baxış
 math-input-invalid-expression = Yanlış ifadə:
 
-
 ## Document status
 
 viewer-initializing = Hazırlanır…
 
-
 ## Errors
 
 error-heading = Xəta
-
 error-found-at =
     { $span ->
         [line] { $startLine } sətrində tapıldı.
        *[lines] { $startLine }–{ $endLine } sətirlərində tapıldı.
     }
-
 document-contains-errors = Bu sənəddə xətalar var!
-
 diagnostic-heading-error = Xəta
 diagnostic-heading-warning = Xəbərdarlıq
 diagnostic-heading-information = Məlumat
 diagnostic-heading-hint = İpucu
-
 accessibility-heading-level-1 = WCAG AA əlçatanlıq pozuntusu
 accessibility-heading-level-2 = Əlçatanlıq bildirişi
-
 something-went-wrong = Nəsə səhv getdi.
-
 renderer-load-failed = göstərici yüklənə bilmədi. Zəhmət olmasa səhifəni yeniləyin.
-
 core-start-failed = Sənəd göstəricisi işə salına bilmədi. Zəhmət olmasa səhifəni yeniləyin.

--- a/packages/i18n/locales/az/content.ftl
+++ b/packages/i18n/locales/az/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = bənövşəyi
     .pink = çəhrayı
     .brown = qəhvəyi
-
 line-width =
     .thick = qalın
     .thin = nazik
-
 line-style =
     .dashed = qırıq-qırıq
     .dotted = nöqtəli
-
 # Noun phrases: they stand in front of «naxışlı» and modify nothing.
 fill-style =
     .horizontal = üfüqi xətt
@@ -53,7 +50,6 @@ fill-style =
     .backdiagonal = əks diaqonal xətt
     .dots = nöqtə
     .diamonds = romb
-
 noun =
     .line = düz xətt
     .line-segment = parça
@@ -73,7 +69,6 @@ noun =
     .diamond = romb
     .cross = çarpaz
     .plus = plus
-
 # Azerbaijani builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -81,11 +76,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] düzgün { $numSides }-bucaqlı
     }
-
 # Azerbaijani has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -99,21 +92,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = doldurulmuş
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } naxışlı { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } naxışlı { $color } { $filled } { $noun }
@@ -121,7 +110,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } naxışlı { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «haşiyəli» — "bordered" — carries the "with a border" sense in its own suffix,
 # so neither a preposition nor an article is wanted, and all four branches read
 # alike except for the connective English needs and Azerbaijani does not.
@@ -132,35 +120,28 @@ style-border-clause =
         [and-article] və { $border } haşiyəli
        *[with] { $border } haşiyəli
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } naxışlı { $color } dolğu
        *[plain] { $color } dolğu
     }
-
 style-unfilled = doldurulmamış
-
 style-text =
     { $parts ->
         [background] { $background } fon üzərində { $color }
        *[plain] { $color }
     }
-
 style-background-none = yoxdur
-
 
 ## Boolean words
 
 boolean-true = doğru
 boolean-false = yanlış
 
-
 ## Answer buttons
 
 answer-submit-label = Yoxla
 answer-submit-label-no-correctness = Cavabı göndər
-
 
 ## Sectional blocks
 
@@ -185,7 +166,6 @@ section-name =
     .solution = Həll
     .task = Tapşırıq
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -195,9 +175,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = İpucu
-
 
 ## Tables and figures
 
@@ -208,7 +186,6 @@ table-name =
         [unnumbered-title] Cədvəl{ ": " }
        *[unnumbered] Cədvəl
     }
-
 figure-name =
     { $parts ->
         [numbered] Şəkil { $enumeration }
@@ -217,22 +194,18 @@ figure-name =
        *[unnumbered] Şəkil
     }
 
-
 ## Paginator controls
 
 paginator-previous = Əvvəlki
 paginator-next = Sonrakı
 paginator-page = Səhifə
-
 paginator-page-status = { $numPages } { $pageLabel } içərisindən { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = və ya
 piecewise-condition-if = əgər
 piecewise-condition-otherwise = əks halda
-
 
 ## Chemistry
 
@@ -355,7 +328,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennessin
     .og = Oqanesson
-
 element-anion-name =
     .h = Hidrid
     .c = Karbid
@@ -369,8 +341,6 @@ element-anion-name =
     .i = Yodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Yanlış kimyəvi simvol
 chemistry-invalid-ionic-compound = Yanlış ion birləşməsi

--- a/packages/i18n/locales/ba/chrome.ftl
+++ b/packages/i18n/locales/ba/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Тикшерелә…
 answer-submitting = Ебәрелә…
-
 answer-checking-status = Яуап тикшерелә
 answer-submitting-status = Яуап ебәрелә
-
 answer-correct = Дөрөҫ
 answer-incorrect = Яңылыш
-
 answer-response-saved = Яуап һаҡланды
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% дөрөҫ
 answer-percent-short = { $percent } %
-
 max-credit-available = Мөмкин булған иң юғары балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] омтылыш ҡалманы
         [one] { $count } омтылыш ҡалды
        *[other] { $count } омтылыш ҡалды
     }
-
 validation-correct = (Дөрөҫ)
 validation-incorrect = (Яңылыш)
 validation-partially-correct = (Өлөшләтә дөрөҫ)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } өсөн { $count } яуапты күрһәтеү
        *[other] { $answerId } өсөн { $count } яуапты күрһәтеү
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Кире бәйләнеш
-
 collapsible-click-to-open = (асыу өсөн баҫығыҙ)
 collapsible-click-to-close = (ябыу өсөн баҫығыҙ)
-
 collapsible-initializing = Әҙерләнә…
-
 footnote-show = Иҫкәрмәне күрһәтеү
 footnote-hide = Иҫкәрмәне йәшереү
-
 description-more-information = өҫтәмә мәғлүмәт
-
 
 ## Controls
 
 slider-previous = Алдағы
 slider-next = Киләһе
-
 keyboard-open = Клавиатураны асыу
 keyboard-close = Клавиатураны ябыу
-
 choice-input-remove-choice = { $choice } һайлауын алып ташлау
-
 matrix-remove-row = Юлды алып ташлау
 matrix-add-row = Юл өҫтәү
 matrix-remove-column = Бағананы алып ташлау
 matrix-add-column = Бағана өҫтәү
-
 subset-add-remove-points = Нөктә өҫтәү/алып ташлау
 subset-toggle-points-intervals = Нөктәләр менән аралыҡтарҙы алмаштырыу
 subset-move-points = Нөктәләрҙе күсереү
 subset-clear = Таҙартыу
-
 orbital-add-row = Юл өҫтәү
 orbital-remove-row = Юлды алып ташлау
 orbital-add-box = Күҙәнәк өҫтәү
@@ -92,13 +73,9 @@ orbital-remove-box = Күҙәнәкте алып ташлау
 orbital-add-up-arrow = Өҫкә уҡ өҫтәү
 orbital-add-down-arrow = Аҫҡа уҡ өҫтәү
 orbital-remove-arrow = Уҡты алып ташлау
-
 orbital-row-label = { $row } юлының билдәһе
-
 pretzel-answer = Яуап
-
 summary-statistics-caption = { $column } бағанаһының йомғаҡлау статистикаһы
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = математик аңлатманың алдан �
 math-input-preview = Алдан ҡараш
 math-input-invalid-expression = Дөрөҫ булмаған аңлатма:
 
-
 ## Document status
 
 viewer-initializing = Әҙерләнә…
 
-
 ## Errors
 
 error-heading = Хата
-
 error-found-at =
     { $span ->
         [line] Табылған юл: { $startLine }.
        *[lines] Табылған юлдар: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Был документта хаталар бар!
-
 diagnostic-heading-error = Хата
 diagnostic-heading-warning = Иҫкәртеү
 diagnostic-heading-information = Мәғлүмәт
 diagnostic-heading-hint = Кәңәш
-
 accessibility-heading-level-1 = WCAG AA ҡулайлылыҡ боҙоуы
 accessibility-heading-level-2 = Ҡулайлылыҡ хәбәре
-
 something-went-wrong = Ниҙер дөрөҫ булманы.
-
 renderer-load-failed = һүрәтләүсене йөкләп булманы. Битте яңыртығыҙ.
-
 core-start-failed = Документ ҡарағысын эшләтеп ебәреп булманы. Битте яңыртығыҙ.

--- a/packages/i18n/locales/ba/content.ftl
+++ b/packages/i18n/locales/ba/content.ftl
@@ -33,15 +33,12 @@ color =
     .purple = шәмәхә
     .pink = алһыу
     .brown = көрән
-
 line-width =
     .thick = ҡалын
     .thin = нәҙек
-
 line-style =
     .dashed = өҙөклө
     .dotted = нөктәле
-
 # Noun phrases: they stand in front of «биҙәкле» and modify nothing.
 fill-style =
     .horizontal = горизонталь һыҙыҡ
@@ -50,7 +47,6 @@ fill-style =
     .backdiagonal = кире диагональ һыҙыҡ
     .dots = нөктә
     .diamonds = ромб
-
 noun =
     .line = тура һыҙыҡ
     .line-segment = киҫек
@@ -70,7 +66,6 @@ noun =
     .diamond = ромб
     .cross = крест
     .plus = плюс
-
 # Bashkir builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -78,11 +73,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] дөрөҫ { $numSides } мөйөш
     }
-
 # Bashkir has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English, Turkish and Tatar.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -96,21 +89,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = буялған
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } биҙәкле { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } биҙәкле { $color } { $filled } { $noun }
@@ -118,7 +107,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } биҙәкле { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «ситле» — "having an edge" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted, and all four
 # branches read alike except for the connective English needs and Bashkir does
@@ -130,15 +118,12 @@ style-border-clause =
         [and-article] һәм { $border } ситле
        *[with] { $border } ситле
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } биҙәкле { $color } буяу
        *[plain] { $color } буяу
     }
-
 style-unfilled = буялмаған
-
 # «фонда» is the locative of «фон» and says "on the background" by itself, so
 # nothing stands between the two colours.
 style-text =
@@ -146,21 +131,17 @@ style-text =
         [background] { $background } фонда { $color }
        *[plain] { $color }
     }
-
 style-background-none = юҡ
-
 
 ## Boolean words
 
 boolean-true = дөрөҫ
 boolean-false = яңылыш
 
-
 ## Answer buttons
 
 answer-submit-label = Тикшереү
 answer-submit-label-no-correctness = Яуапты ебәреү
-
 
 ## Sectional blocks
 
@@ -185,7 +166,6 @@ section-name =
     .solution = Сиселеш
     .task = Бирем
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -195,9 +175,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Кәңәш
-
 
 ## Tables and figures
 
@@ -208,7 +186,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Рәсем { $enumeration }
@@ -217,22 +194,18 @@ figure-name =
        *[unnumbered] Рәсем
     }
 
-
 ## Paginator controls
 
 paginator-previous = Алдағы
 paginator-next = Киләһе
 paginator-page = Бит
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = йәки
 piecewise-condition-if = әгәр
 piecewise-condition-otherwise = юғиһә
-
 
 ## Chemistry
 ##
@@ -247,6 +220,5 @@ piecewise-condition-otherwise = юғиһә
 ## one, and nothing about the two languages predicts the difference.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Дөрөҫ булмаған химик билдә
 chemistry-invalid-ionic-compound = Дөрөҫ булмаған ион ҡушылмаһы

--- a/packages/i18n/locales/ban/chrome.ftl
+++ b/packages/i18n/locales/ban/chrome.ftl
@@ -32,21 +32,15 @@
 
 answer-checking = Ngecek…
 answer-submitting = Ngirim…
-
 answer-checking-status = Ngecek pasaut
 answer-submitting-status = Ngirim pasaut
-
 answer-correct = Beneh
 answer-incorrect = Pelih
-
 answer-response-saved = Pasautne suba kasimpen
-
 answer-percent-credit = { $percent }% kredit
 answer-percent-correct = { $percent }% beneh
 answer-percent-short = { $percent } %
-
 max-credit-available = Kredit paling gede ane bakat: { $percent }%
-
 # No select: «kesempatan» is the same word for one and for many. The `[0]`
 # branch stays, because it names none rather than counting.
 attempts-remaining =
@@ -54,51 +48,38 @@ attempts-remaining =
         [0] tusing ada kesempatan ane enu
        *[other] enu { $count } kesempatan
     }
-
 validation-correct = (Beneh)
 validation-incorrect = (Pelih)
 validation-partially-correct = (Beneh abagian)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Edengang { $count } pasaut anggon { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komentar
-
 collapsible-click-to-open = (klik apang mabukak)
 collapsible-click-to-close = (klik apang matutup)
-
 collapsible-initializing = Ngawitin…
-
 footnote-show = Edengang footnote
 footnote-hide = Engkebang footnote
-
 description-more-information = informasi ane lenan
-
 
 ## Controls
 
 slider-previous = Sadurunge
 slider-next = Salanturne
-
 keyboard-open = Ampakang papan tuts
 keyboard-close = Tekepang papan tuts
-
 choice-input-remove-choice = Kaadang { $choice }
-
 matrix-remove-row = Kaadang barisne
 matrix-add-row = Imbuhin baris
 matrix-remove-column = Kaadang kolomne
 matrix-add-column = Imbuhin kolom
-
 subset-add-remove-points = Ngimbuhin/Ngaadang titik
 subset-toggle-points-intervals = Nyilurin titik lan interval
 subset-move-points = Genahang titikne
 subset-clear = Kedasin
-
 orbital-add-row = Imbuhin baris
 orbital-remove-row = Kaadang barisne
 orbital-add-box = Imbuhin kotak
@@ -106,13 +87,9 @@ orbital-remove-box = Kaadang kotakne
 orbital-add-up-arrow = Imbuhin panah menek
 orbital-add-down-arrow = Imbuhin panah tuun
 orbital-remove-arrow = Kaadang panahne
-
 orbital-row-label = Label anggon baris { $row }
-
 pretzel-answer = Pasaut
-
 summary-statistics-caption = Ringkesan statistik { $column }
-
 
 ## Math input
 
@@ -120,34 +97,25 @@ math-input-preview-region = pratinjau ekspresi matematika
 math-input-preview = Pratinjau
 math-input-invalid-expression = Ekspresi ane tusing sah:
 
-
 ## Document status
 
 viewer-initializing = Ngawitin…
 
-
 ## Errors
 
 error-heading = Kaiwangan
-
 error-found-at =
     { $span ->
         [line] Katemu di baris { $startLine }.
        *[lines] Katemu di baris { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumen ene ngelah kaiwangan!
-
 diagnostic-heading-error = Kaiwangan
 diagnostic-heading-warning = Pinget
 diagnostic-heading-information = Informasi
 diagnostic-heading-hint = Tunjuk
-
 accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
 accessibility-heading-level-2 = Pinget indik aksesibilitas
-
 something-went-wrong = Ada ane pelih.
-
 renderer-load-failed = ada renderer ane tusing nyidang kaload. Ledang muat ulang kacane.
-
 core-start-failed = Panyingakan dokumene tusing nyidang kawitin. Ledang muat ulang kacane.

--- a/packages/i18n/locales/ban/content.ftl
+++ b/packages/i18n/locales/ban/content.ftl
@@ -42,15 +42,12 @@ color =
     .purple = ungu
     .pink = jambon
     .brown = cokelat
-
 line-width =
     .thick = tebel
     .thin = tipis
-
 line-style =
     .dashed = putus-putus
     .dotted = titik-titik
-
 # Noun phrases. Balinese marks no plural on the noun, so «garis» is the word for
 # one line and for many alike.
 fill-style =
@@ -60,7 +57,6 @@ fill-style =
     .backdiagonal = garis miring mabalik
     .dots = titik
     .diamonds = belah ketupat
-
 noun =
     .line = garis
     .line-segment = ruas garis
@@ -80,7 +76,6 @@ noun =
     .diamond = belah ketupat
     .cross = pangkah
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe — the `[noun-tail]` branch of `style-with-noun`.
 noun-regular-polygon =
@@ -88,10 +83,8 @@ noun-regular-polygon =
         [tail] ane ngelah { $numSides } sisi
        *[head] poligon beraturan
     }
-
 # One answer for every noun: Balinese has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,22 +98,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = bek
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } misi { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } misi { $pattern }
@@ -128,7 +117,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } misi { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Balinese has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «misi» against «tur».
@@ -139,35 +127,28 @@ style-border-clause =
         [and-article] tur tepi { $border }
        *[with] misi tepi { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tusing bek
-
 style-text =
     { $parts ->
         [background] { $color } misi dasar { $background }
        *[plain] { $color }
     }
-
 style-background-none = tusing ada
-
 
 ## Boolean words
 
 boolean-true = patut
 boolean-false = iwang
 
-
 ## Answer buttons
 
 answer-submit-label = Cek gaene
 answer-submit-label-no-correctness = Kirim pasaut
-
 
 ## Sectional blocks
 
@@ -194,7 +175,6 @@ section-name =
     .solution = Pamragat
     .task = Tugas
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -204,9 +184,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tunjuk
-
 
 ## Tables and figures
 
@@ -217,7 +195,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Gambar { $enumeration }
@@ -226,22 +203,18 @@ figure-name =
        *[unnumbered] Gambar
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sadurunge
 paginator-next = Salanturne
 paginator-page = Kaca
-
 paginator-page-status = { $pageLabel } { $currentPage } uli { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = utawi
 piecewise-condition-if = yen
 piecewise-condition-otherwise = yen tusing
-
 
 ## Chemistry
 ##
@@ -255,6 +228,5 @@ piecewise-condition-otherwise = yen tusing
 ## substances Balinese does name itself are the place a speaker should start.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kimia ane tusing sah
 chemistry-invalid-ionic-compound = Senyawa ionik ane tusing sah

--- a/packages/i18n/locales/bci/chrome.ftl
+++ b/packages/i18n/locales/bci/chrome.ftl
@@ -17,21 +17,15 @@
 
 answer-checking = Be nian i su...
 answer-submitting = Be fa i kɔ...
-
 answer-checking-status = Be nian tɛlɛ'n su
 answer-submitting-status = Be fa tɛlɛ'n kɔ
-
 answer-correct = I ti kpa
 answer-incorrect = I timan kpa
-
 answer-response-saved = Be fa tɛlɛ'n sieli
-
 answer-percent-credit = Nsɛkyerɛ { $percent }%
 answer-percent-correct = I ti kpa { $percent }%
 answer-percent-short = { $percent } %
-
 max-credit-available = Nzuɛn kpanngban be kwla ɲɛn i: { $percent }%
-
 # Baoulé has only `one` and `other` (see `content.ftl`), and «wafa» "attempt"
 # keeps one shape in both, so the categories collapse to a single wording; the
 # `[0]` branch stays because it is matched by exact value, not by category.
@@ -40,49 +34,36 @@ attempts-remaining =
         [0] wafa fi w'a to-man
        *[other] wafa { $count } yɛ w'a to-man ɔn
     }
-
 validation-correct = (I ti kpa)
 validation-incorrect = (I timan kpa)
 validation-partially-correct = (I ti kpa wie)
-
 answer-show-responses = Kyerɛ tɛlɛ { $count } mɔ be fali i mannin { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Ndɛ
-
 collapsible-click-to-open = (fa i bɔ i wun kle wɔ)
 collapsible-click-to-close = (fa i kata i)
-
 collapsible-initializing = Be bo i bo su...
-
 footnote-show = Kyerɛ ndɛ ng'ɔ o ase'n
 footnote-hide = Fa ndɛ ng'ɔ o ase'n sie
-
 description-more-information = ndɛ uflɛ mun
-
 
 ## Controls
 
 slider-previous = Osu
 slider-next = Ɲɛ
-
 keyboard-open = Kle mmuaeɛ-fa-kɛtɛ
 keyboard-close = Kata mmuaeɛ-fa-kɛtɛ
-
 choice-input-remove-choice = Yi { $choice } i wun
-
 matrix-remove-row = Yi layin nun
 matrix-add-row = Fa layin uflɛ gua su
 matrix-remove-column = Yi kolɔn nun
 matrix-add-column = Fa kolɔn uflɛ gua su
-
 subset-add-remove-points = Fa pwɛn gua su annzɛ yi i nun
 subset-toggle-points-intervals = Kaci pwɛn nin ndɛ-tɛtɛ
 subset-move-points = Kaci Pwɛn Be Osu
 subset-clear = Yi be kwlaa
-
 orbital-add-row = Fa layin uflɛ gua su
 orbital-remove-row = Yi layin nun
 orbital-add-box = Fa adaka uflɛ gua su
@@ -90,48 +71,35 @@ orbital-remove-box = Yi adaka nun
 orbital-add-up-arrow = Fa fanngo mɔ ɔ kɔ soro'n gua su
 orbital-add-down-arrow = Fa fanngo mɔ ɔ tɔ fam'n gua su
 orbital-remove-arrow = Yi fanngo'n i nun
-
 orbital-row-label = Layin { $row } i dunman
-
 pretzel-answer = Tɛlɛ
-
 summary-statistics-caption = { $column } i jatelɛ kunkun
 
 ## Math input
 
 math-input-preview-region = akontabuo ndɛ i yilɛ ng'ɔ o kɛ i sɔ'n
 math-input-preview = Yilɛ
-
 math-input-invalid-expression = Akontabuo ndɛ nga w'i su:
-
 
 ## Document status
 
 viewer-initializing = Be bo i bo su...
 
-
 ## Errors
 
 error-heading = Sa tɛ
-
 error-found-at =
     { $span ->
         [line] Be wunnin i layin { $startLine } su.
        *[lines] Be wunnin i layin { $startLine } lele { $endLine } su.
     }
-
 document-contains-errors = Fluwa nga sa tɛ o nun!
-
 diagnostic-heading-error = Sa tɛ
 diagnostic-heading-warning = Kɔkɔlɛ
 diagnostic-heading-information = Ndɛ
 diagnostic-heading-hint = Ndɛ ɲrɛnnɛn
-
 accessibility-heading-level-1 = WCAG AA mmara mɔ be buman i su
 accessibility-heading-level-2 = Kɔkɔlɛ mɔ ɔ fata be nyian i akunndan
-
 something-went-wrong = Sa kun timan kpa.
-
 renderer-load-failed = kyerɛfoɛ kun w'a kwlaman w'a ba. Yaci fluwa'n san kan bio.
-
 core-start-failed = Fluwa'n kyerɛlɛ dilɛ w'a kwlaman w'a bo i bo. Yaci fluwa'n san kan bio.

--- a/packages/i18n/locales/bci/content.ftl
+++ b/packages/i18n/locales/bci/content.ftl
@@ -98,15 +98,12 @@ color =
     .purple = vio
     .pink = piŋki
     .brown = ntɔlɛ
-
 line-width =
     .thick = kpanngban
     .thin = kaan
-
 line-style =
     .dashed = mɔ be pɔtɔli i nun
     .dotted = mɔ ndɛnkɛtɛ o i nun
-
 fill-style =
     .horizontal = liɲ mɔ be tɔli i nun i wia bo lɛ
     .vertical = liɲ mɔ be tɔli i nun sinlɛ lɛ
@@ -114,7 +111,6 @@ fill-style =
     .backdiagonal = liɲ mɔ be tɔli i nun kekle sin i ekun
     .dots = ndɛnkɛtɛ mun
     .diamonds = diaman mun
-
 noun =
     .line = liɲ
     .line-segment = liɲ i wafa kaan
@@ -134,7 +130,6 @@ noun =
     .diamond = diaman
     .cross = kroa
     .plus = kabo sunmanlɛ
-
 # The side count follows the adjectives, joined by «mɔ ɔ wɔ», as the border
 # clause below joins its own complement — Baoulé, like Twi, closes the noun
 # phrase with a relative rather than opening one.
@@ -143,9 +138,7 @@ noun-regular-polygon =
         [tail] mɔ ɔ wɔ nzo { $numSides }
        *[head] wafa mɔ ɔ ti kpokpo kpa
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -159,21 +152,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = mɔ be yili i nun ma
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } mɔ { $pattern } o i nun
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } mɔ { $pattern } o i nun
@@ -181,7 +170,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } mɔ { $pattern } o i nun
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Baoulé has no article and joins the complement with the invariable «mɔ ɔ wɔ
 # i su», so all four branches read alike.
 style-border-clause =
@@ -191,21 +179,17 @@ style-border-clause =
         [and-article] mɔ ɔ wɔ i su { $border }
        *[with] mɔ ɔ wɔ i su { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = mɔ be yiman i nun ma
-
 style-text =
     { $parts ->
         [background] { $color } mɔ akyi { $background } o
        *[plain] { $color }
     }
-
 style-background-none = fii
 
 ## Boolean words
@@ -241,7 +225,6 @@ section-name =
     .solution = Tɛlɛ ng'ɔ kle sa'n
     .task = Junman
     .theorem = Nglɛlɛ dan
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -251,7 +234,6 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ndɛ ɲrɛnnɛn
 
 ## Tables and figures
@@ -263,7 +245,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Fɔto { $enumeration }
@@ -277,7 +258,6 @@ figure-name =
 paginator-previous = Osu
 paginator-next = Ɲɛ
 paginator-page = Bue
-
 paginator-page-status = { $pageLabel } { $currentPage } (bue { $numPages } nun)
 
 ## Piecewise functions
@@ -292,6 +272,5 @@ piecewise-condition-otherwise = sɛ i sɔ timan sa'n
 ## header's chemistry paragraph.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simii Nzuɛn Nzɛnzɛ Mɔ I Ti Timan Kpa
 chemistry-invalid-ionic-compound = Ayɔn Nkabo Mɔ I Ti Timan Kpa

--- a/packages/i18n/locales/be/chrome.ftl
+++ b/packages/i18n/locales/be/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Праверка…
 answer-submitting = Адпраўка…
-
 answer-checking-status = Праверка адказу
 answer-submitting-status = Адпраўка адказу
-
 answer-correct = Правільна
 answer-incorrect = Няправільна
-
 answer-response-saved = Адказ захаваны
-
 answer-percent-credit = { $percent }% балаў
 answer-percent-correct = { $percent }% правільна
 answer-percent-short = { $percent } %
-
 max-credit-available = Найбольшая магчымая колькасць балаў: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] спроб не засталося
@@ -46,11 +40,9 @@ attempts-remaining =
         [many] засталося { $count } спроб
        *[other] засталося { $count } спробы
     }
-
 validation-correct = (Правільна)
 validation-incorrect = (Няправільна)
 validation-partially-correct = (Часткова правільна)
-
 answer-show-responses =
     { $count ->
         [one] Паказаць { $count } адказ на { $answerId }
@@ -59,42 +51,31 @@ answer-show-responses =
        *[other] Паказаць { $count } адказы на { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Зваротная сувязь
-
 collapsible-click-to-open = (націсніце, каб адкрыць)
 collapsible-click-to-close = (націсніце, каб закрыць)
-
 collapsible-initializing = Ініцыялізацыя…
-
 footnote-show = Паказаць зноску
 footnote-hide = Схаваць зноску
-
 description-more-information = больш звестак
-
 
 ## Controls
 
 slider-previous = Назад
 slider-next = Наперад
-
 keyboard-open = Адкрыць клавіятуру
 keyboard-close = Закрыць клавіятуру
-
 choice-input-remove-choice = Выдаліць { $choice }
-
 matrix-remove-row = Выдаліць радок
 matrix-add-row = Дадаць радок
 matrix-remove-column = Выдаліць слупок
 matrix-add-column = Дадаць слупок
-
 subset-add-remove-points = Дадаць/выдаліць пункты
 subset-toggle-points-intervals = Пераключыць паміж пунктамі і інтэрваламі
 subset-move-points = Перамясціць пункты
 subset-clear = Ачысціць
-
 orbital-add-row = Дадаць радок
 orbital-remove-row = Выдаліць радок
 orbital-add-box = Дадаць ячэйку
@@ -102,13 +83,9 @@ orbital-remove-box = Выдаліць ячэйку
 orbital-add-up-arrow = Дадаць стрэлку ўверх
 orbital-add-down-arrow = Дадаць стрэлку ўніз
 orbital-remove-arrow = Выдаліць стрэлку
-
 orbital-row-label = Подпіс для радка { $row }
-
 pretzel-answer = Адказ
-
 summary-statistics-caption = Зводная статыстыка па { $column }
-
 
 ## Math input
 
@@ -116,34 +93,25 @@ math-input-preview-region = папярэдні прагляд матэматыч
 math-input-preview = Прагляд
 math-input-invalid-expression = Няправільны выраз:
 
-
 ## Document status
 
 viewer-initializing = Ініцыялізацыя…
 
-
 ## Errors
 
 error-heading = Памылка
-
 error-found-at =
     { $span ->
         [line] Знойдзена ў радку { $startLine }.
        *[lines] Знойдзена ў радках { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Гэты дакумент змяшчае памылкі!
-
 diagnostic-heading-error = Памылка
 diagnostic-heading-warning = Папярэджанне
 diagnostic-heading-information = Звесткі
 diagnostic-heading-hint = Падказка
-
 accessibility-heading-level-1 = Парушэнне даступнасці паводле WCAG AA
 accessibility-heading-level-2 = Паведамленне пра даступнасць
-
 something-went-wrong = Нешта пайшло не так.
-
 renderer-load-failed = не ўдалося загрузіць модуль адлюстравання. Перазагрузіце старонку.
-
 core-start-failed = Не ўдалося запусціць прагляднік дакумента. Перазагрузіце старонку.

--- a/packages/i18n/locales/be/content.ftl
+++ b/packages/i18n/locales/be/content.ftl
@@ -170,7 +170,6 @@ color =
                    *[m] карычневы
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -196,7 +195,6 @@ line-width =
                    *[m] тонкі
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -222,7 +220,6 @@ line-style =
                    *[m] пункцірны
                 }
         }
-
 # Noun phrases in the instrumental, which is the case «з» takes. They agree
 # with nothing.
 fill-style =
@@ -232,7 +229,6 @@ fill-style =
     .backdiagonal = адваротнымі дыяганальнымі лініямі
     .dots = кропкамі
     .diamonds = ромбамі
-
 noun =
     .line = прамая
     .line-segment = адрэзак
@@ -252,7 +248,6 @@ noun =
     .diamond = ромб
     .cross = крыж
     .plus = плюс
-
 # Belarusian keeps the side count in front of the noun, so the whole of it is
 # one head and there is no tail.
 noun-regular-polygon =
@@ -260,7 +255,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] правільны { $numSides }-вугольнік
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (мнагавугольнік, m)
 # or the head of a phrase the description never names: `border` (рамка, f),
 # `fill` (заліўка, f), `text` (тэкст, m), `background` (фон, m).
@@ -279,7 +273,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -292,13 +285,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -307,13 +298,11 @@ style-filled-word =
         [n] зафарбаванае
        *[m] зафарбаваны
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } з { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } з { $pattern }
@@ -321,7 +310,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } з { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «рамка» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Belarusian has no article, so the two `-article`
 # branches read like the two without.
@@ -332,7 +320,6 @@ style-border-clause =
         [and-article] і { $border } рамкай
        *[with] з { $border } рамкай
     }
-
 # The fill-pattern words are instrumental plurals, because their other use is
 # the «з { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «заліўка», feminine, which is the gender `noun-gender`
@@ -342,29 +329,23 @@ style-fill =
         [pattern] { $color } заліўка з { $pattern }
        *[plain] { $color } заліўка
     }
-
 style-unfilled = незафарбаваны
-
 style-text =
     { $parts ->
         [background] { $color } на { $background } фоне
        *[plain] { $color }
     }
-
 style-background-none = няма
-
 
 ## Boolean words
 
 boolean-true = праўда
 boolean-false = няпраўда
 
-
 ## Answer buttons
 
 answer-submit-label = Праверыць
 answer-submit-label-no-correctness = Адправіць адказ
-
 
 ## Sectional blocks
 
@@ -389,7 +370,6 @@ section-name =
     .solution = Рашэнне
     .task = Задача
     .theorem = Тэарэма
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -399,9 +379,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Падказка
-
 
 ## Tables and figures
 
@@ -412,7 +390,6 @@ table-name =
         [unnumbered-title] Табліца{ ". " }
        *[unnumbered] Табліца
     }
-
 figure-name =
     { $parts ->
         [numbered] Малюнак { $enumeration }
@@ -421,22 +398,18 @@ figure-name =
        *[unnumbered] Малюнак
     }
 
-
 ## Paginator controls
 
 paginator-previous = Назад
 paginator-next = Наперад
 paginator-page = Старонка
-
 paginator-page-status = { $pageLabel } { $currentPage } з { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = або
 piecewise-condition-if = калі
 piecewise-condition-otherwise = інакш
-
 
 ## Chemistry
 
@@ -559,7 +532,6 @@ element-name =
     .lv = Лівермарый
     .ts = Тэнесін
     .og = Аганесон
-
 element-anion-name =
     .h = Гідрыд
     .c = Карбід
@@ -573,8 +545,6 @@ element-anion-name =
     .i = Ёдыд
     .at = Астатыд
     .ts = Тэнесід
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Няправільны хімічны сімвал
 chemistry-invalid-ionic-compound = Няправільнае іоннае злучэнне

--- a/packages/i18n/locales/bem/chrome.ftl
+++ b/packages/i18n/locales/bem/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Kuleceeceta…
 answer-submitting = Kuletuma…
-
 answer-checking-status = Icasuko cileceecetwa
 answer-submitting-status = Icasuko cileletumwa
-
 answer-correct = Calungama
 answer-incorrect = Tacalungeme
-
 answer-response-saved = Icasuko Casungwa
-
 answer-percent-credit = { $percent }% ya Mapoyinti
 answer-percent-correct = { $percent }% Calungama
 answer-percent-short = { $percent } %
-
 max-credit-available = Amapoyinti ayengi ayaba: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] takwaba ukwesha ukwashala
         [one] kwashala ukwesha { $count }
        *[other] kwashala ukwesha { $count }
     }
-
 validation-correct = (Calungama)
 validation-incorrect = (Tacalungeme)
 validation-partially-correct = (Calungama pa lubali)
-
 answer-show-responses =
     { $count ->
         [one] Langa icasuko { $count } kuli { $answerId }
        *[other] Langa amasuko { $count } kuli { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ukwasuka
-
 collapsible-click-to-open = (tinya ukwisula)
 collapsible-click-to-close = (tinya ukwisala)
-
 collapsible-initializing = Kuletendeka…
-
 footnote-show = Langa icalembwa ca panshi
 footnote-hide = Fisa icalembwa ca panshi
-
 description-more-information = ilyashi limbi
-
 
 ## Controls
 
 slider-previous = Icapitapo
 slider-next = Icakonkapo
-
 keyboard-open = Isula Kibodi
 keyboard-close = Isala Kibodi
-
 choice-input-remove-choice = Fumya { $choice }
-
 matrix-remove-row = Fumya umutalale
 matrix-add-row = Lundapo umutalale
 matrix-remove-column = Fumya ulukolomu
 matrix-add-column = Lundapo ulukolomu
-
 subset-add-remove-points = Lundapo/Fumya amapoyinti
 subset-toggle-points-intervals = Aluka amapoyinti ne nshita
 subset-move-points = Kunkusha Amapoyinti
 subset-clear = Fumyapo
-
 orbital-add-row = Lundapo Umutalale
 orbital-remove-row = Fumya Umutalale
 orbital-add-box = Lundapo Ibokoshi
@@ -86,13 +67,9 @@ orbital-remove-box = Fumya Ibokoshi
 orbital-add-up-arrow = Lundapo Umufwi wa Kuulu
 orbital-add-down-arrow = Lundapo Umufwi wa Panshi
 orbital-remove-arrow = Fumya Umufwi
-
 orbital-row-label = Ishina lya mutalale { $row }
-
 pretzel-answer = Icasuko
-
 summary-statistics-caption = Ukwipifya kwa mibalo ya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ukumona kwa numbala pa ntanshi
 math-input-preview = Ukumona pa ntanshi
 math-input-invalid-expression = Ukulanda ukwabipa:
 
-
 ## Document status
 
 viewer-initializing = Kuletendeka…
 
-
 ## Errors
 
 error-heading = Ubulubo
-
 error-found-at =
     { $span ->
         [line] Bwasangwa pa mutalale { $startLine }.
        *[lines] Bwasangwa pa mitalale { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ici cipepala cakwata amalubo!
-
 diagnostic-heading-error = Ubulubo
 diagnostic-heading-warning = Ukusoka
 diagnostic-heading-information = Ilyashi
 diagnostic-heading-hint = Akalangililo
-
 accessibility-heading-level-1 = Ukupula kwa WCAG AA kwa Kufikako
 accessibility-heading-level-2 = Ukusoka kwa kufikako
-
 something-went-wrong = Kwaliba icishalungeme.
-
 renderer-load-failed = kalanga tafikile. Napapata pilibula ibula.
-
 core-start-failed = Kalanga wa cipepala tatendeke. Napapata pilibula ibula.

--- a/packages/i18n/locales/bem/content.ftl
+++ b/packages/i18n/locales/bem/content.ftl
@@ -73,7 +73,6 @@ color =
     .purple = papulo
     .pink = pingi
     .brown = burauni
-
 line-width =
     .thick =
         { $gender ->
@@ -87,13 +86,11 @@ line-width =
             [c7] icinono
            *[c9] innono
         }
-
 # Written as an invariable «na …» phrase, so that it agrees with nothing and
 # can close the phrase. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = na tuputule
     .dotted = na tundoti
-
 fill-style =
     .horizontal = imitalale iyalaala
     .vertical = imitalale iyaiminina
@@ -101,7 +98,6 @@ fill-style =
     .backdiagonal = imitalale iyaselemuka ku lubali lumbi
     .dots = tundoti
     .diamonds = tudayamondi
-
 noun =
     .line = umutalale
     .line-segment = icipande ca mutalale
@@ -121,7 +117,6 @@ noun =
     .diamond = dayamondi
     .cross = umusalaba
     .plus = icishibilo ca kulundapo
-
 # The side count is a relative complement and closes the noun phrase behind the
 # describing words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -129,7 +124,6 @@ noun-regular-polygon =
         [tail] icakwata amabali { $numSides }
        *[head] icimo icalingana
     }
-
 # The noun class. `c9` is the default and the class of every loanword.
 noun-gender =
     { $noun ->
@@ -152,7 +146,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «na …» phrase and closes the description, so it moves
@@ -167,26 +160,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] uwaisula
         [c7] icaisula
        *[c9] iyaisula
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -194,7 +183,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «umupaka» is class 3 and leads its own describing words, so the border's
 # words agree with it rather than with the shape it surrounds. Bemba has no
 # article and joins this clause with the invariable «na», so all four branches
@@ -206,35 +194,28 @@ style-border-clause =
         [and-article] na umupaka { $border }
        *[with] na umupaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tacaisula
-
 style-text =
     { $parts ->
         [background] { $color } pa cishinte { $background }
        *[plain] { $color }
     }
-
 style-background-none = takuli cintu
-
 
 ## Boolean words
 
 boolean-true = cine
 boolean-false = bufi
 
-
 ## Answer buttons
 
 answer-submit-label = Ceeceta Incito
 answer-submit-label-no-correctness = Tuma Icasuko
-
 
 ## Sectional blocks
 
@@ -259,7 +240,6 @@ section-name =
     .solution = Ukupwisha
     .task = Incito
     .theorem = Tiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -269,9 +249,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Akalangililo
-
 
 ## Tables and figures
 
@@ -282,7 +260,6 @@ table-name =
         [unnumbered-title] Itebulo{ ": " }
        *[unnumbered] Itebulo
     }
-
 figure-name =
     { $parts ->
         [numbered] Icikope { $enumeration }
@@ -291,24 +268,18 @@ figure-name =
        *[unnumbered] Icikope
     }
 
-
 ## Paginator controls
 
 paginator-previous = Icapitapo
 paginator-next = Icakonkapo
 paginator-page = Ibula
-
 paginator-page-status = { $pageLabel } { $currentPage } muli { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = nangu
-
 piecewise-condition-if = nga
-
 piecewise-condition-otherwise = nga te fyo
-
 
 ## Chemistry
 ##
@@ -320,6 +291,5 @@ piecewise-condition-otherwise = nga te fyo
 ## curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Icishibilo ca Kemikolo Icabipa
 chemistry-invalid-ionic-compound = Ukusakanya kwa Ayoni Ukwabipa

--- a/packages/i18n/locales/bg/chrome.ftl
+++ b/packages/i18n/locales/bg/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Проверка…
 answer-submitting = Изпращане…
-
 answer-checking-status = Проверка на отговора
 answer-submitting-status = Изпращане на отговора
-
 answer-correct = Вярно
 answer-incorrect = Грешно
-
 answer-response-saved = Отговорът е запазен
-
 answer-percent-credit = { $percent }% от точките
 answer-percent-correct = { $percent }% вярно
 answer-percent-short = { $percent } %
-
 max-credit-available = Максимални възможни точки: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] не остават опити
         [one] остава { $count } опит
        *[other] остават { $count } опита
     }
-
 validation-correct = (Вярно)
 validation-incorrect = (Грешно)
 validation-partially-correct = (Частично вярно)
-
 answer-show-responses =
     { $count ->
         [one] Показване на { $count } отговор на { $answerId }
        *[other] Показване на { $count } отговора на { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Обратна връзка
-
 collapsible-click-to-open = (щракнете, за да отворите)
 collapsible-click-to-close = (щракнете, за да затворите)
-
 collapsible-initializing = Инициализиране…
-
 footnote-show = Показване на бележката
 footnote-hide = Скриване на бележката
-
 description-more-information = повече информация
-
 
 ## Controls
 
 slider-previous = Назад
 slider-next = Напред
-
 keyboard-open = Отваряне на клавиатурата
 keyboard-close = Затваряне на клавиатурата
-
 choice-input-remove-choice = Премахване на { $choice }
-
 matrix-remove-row = Премахване на ред
 matrix-add-row = Добавяне на ред
 matrix-remove-column = Премахване на стълб
 matrix-add-column = Добавяне на стълб
-
 subset-add-remove-points = Добавяне/премахване на точки
 subset-toggle-points-intervals = Превключване между точки и интервали
 subset-move-points = Местене на точки
 subset-clear = Изчистване
-
 orbital-add-row = Добавяне на ред
 orbital-remove-row = Премахване на ред
 orbital-add-box = Добавяне на клетка
@@ -95,13 +76,9 @@ orbital-remove-box = Премахване на клетка
 orbital-add-up-arrow = Добавяне на стрелка нагоре
 orbital-add-down-arrow = Добавяне на стрелка надолу
 orbital-remove-arrow = Премахване на стрелка
-
 orbital-row-label = Надпис за ред { $row }
-
 pretzel-answer = Отговор
-
 summary-statistics-caption = Обобщени статистики за { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = преглед на математическия и�
 math-input-preview = Преглед
 math-input-invalid-expression = Невалиден израз:
 
-
 ## Document status
 
 viewer-initializing = Инициализиране…
 
-
 ## Errors
 
 error-heading = Грешка
-
 error-found-at =
     { $span ->
         [line] Намерена на ред { $startLine }.
        *[lines] Намерена на редове { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Този документ съдържа грешки!
-
 diagnostic-heading-error = Грешка
 diagnostic-heading-warning = Предупреждение
 diagnostic-heading-information = Информация
 diagnostic-heading-hint = Подсказка
-
 accessibility-heading-level-1 = Нарушение на достъпността по WCAG AA
 accessibility-heading-level-2 = Сигнал за достъпност
-
 something-went-wrong = Нещо се обърка.
-
 renderer-load-failed = не успя да се зареди модул за изобразяване. Презаредете страницата.
-
 core-start-failed = Визуализаторът на документа не можа да бъде стартиран. Презаредете страницата.

--- a/packages/i18n/locales/bg/content.ftl
+++ b/packages/i18n/locales/bg/content.ftl
@@ -93,7 +93,6 @@ color =
             [n] кафяво
            *[m] кафяв
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -107,7 +106,6 @@ line-width =
             [n] тънко
            *[m] тънък
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -121,7 +119,6 @@ line-style =
             [n] пунктирано
            *[m] пунктиран
         }
-
 # Bare plural noun phrases. They follow «с» in `style-filled`, and Bulgarian
 # puts nothing on a noun after a preposition, so the same words stand alone in
 # `style-fill`.
@@ -132,7 +129,6 @@ fill-style =
     .backdiagonal = обратни диагонални линии
     .dots = точки
     .diamonds = ромбове
-
 noun =
     .line = линия
     .line-segment = отсечка
@@ -152,7 +148,6 @@ noun =
     .diamond = ромб
     .cross = кръст
     .plus = плюс
-
 # Bulgarian keeps the side count in front of the noun, so the whole of it is
 # one head and there is no tail.
 noun-regular-polygon =
@@ -160,7 +155,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] правилен { $numSides }-ъгълник
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (многоъгълник, m)
 # or the head of a phrase the description never names: `border` (граница, f),
 # `fill` (запълване, n), `text` (текст, m), `background` (фон, m).
@@ -180,7 +174,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -193,26 +186,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [f] запълнена
         [n] запълнено
        *[m] запълнен
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } с { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } с { $pattern }
@@ -220,7 +209,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } с { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «граница» is feminine, so the border's adjectives agree with it rather than
 # with the shape it surrounds. Bulgarian has an article but attaches it as a
 # suffix and does not use it here, so the two `-article` branches read like the
@@ -232,7 +220,6 @@ style-border-clause =
         [and-article] и { $border } граница
        *[with] с { $border } граница
     }
-
 # The fill-pattern words need a noun to hang off when they stand on their own,
 # so this supplies «запълване» — neuter, which is the gender `noun-gender`
 # already answers for `fill`, so the colour agrees with it in both variants.
@@ -241,9 +228,7 @@ style-fill =
         [pattern] { $color } запълване с { $pattern }
        *[plain] { $color } запълване
     }
-
 style-unfilled = незапълнен
-
 # «текст» and «фон» are both masculine, and neither moves behind «на», so both
 # colours here are the plain masculine `noun-gender` supplies.
 style-text =
@@ -251,21 +236,17 @@ style-text =
         [background] { $color } на { $background } фон
        *[plain] { $color }
     }
-
 style-background-none = няма
-
 
 ## Boolean words
 
 boolean-true = истина
 boolean-false = лъжа
 
-
 ## Answer buttons
 
 answer-submit-label = Провери
 answer-submit-label-no-correctness = Изпрати отговора
-
 
 ## Sectional blocks
 
@@ -290,7 +271,6 @@ section-name =
     .solution = Решение
     .task = Задача
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -300,9 +280,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Подсказка
-
 
 ## Tables and figures
 
@@ -313,7 +291,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Фигура { $enumeration }
@@ -322,22 +299,18 @@ figure-name =
        *[unnumbered] Фигура
     }
 
-
 ## Paginator controls
 
 paginator-previous = Назад
 paginator-next = Напред
 paginator-page = Страница
-
 paginator-page-status = { $pageLabel } { $currentPage } от { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = или
 piecewise-condition-if = ако
 piecewise-condition-otherwise = иначе
-
 
 ## Chemistry
 
@@ -460,7 +433,6 @@ element-name =
     .lv = Ливерморий
     .ts = Тенесин
     .og = Оганесон
-
 element-anion-name =
     .h = Хидрид
     .c = Карбид
@@ -474,8 +446,6 @@ element-anion-name =
     .i = Йодид
     .at = Астатид
     .ts = Тенесид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Невалиден химичен символ
 chemistry-invalid-ionic-compound = Невалидно йонно съединение

--- a/packages/i18n/locales/bho/chrome.ftl
+++ b/packages/i18n/locales/bho/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = जाँच होखत बा…
 answer-submitting = भेजल जात बा…
-
 answer-checking-status = जवाब के जाँच होखत बा
 answer-submitting-status = जवाब भेजल जात बा
-
 answer-correct = सही
 answer-incorrect = गलत
-
 answer-response-saved = जवाब सहेजल गइल
-
 answer-percent-credit = { $percent }% अंक
 answer-percent-correct = { $percent }% सही
 answer-percent-short = { $percent } %
-
 max-credit-available = ज्यादा से ज्यादा मिलल अंक: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] कवनो कोशिश ना बचल
         [one] { $count } कोशिश बाकी
        *[other] { $count } कोशिश बाकी
     }
-
 validation-correct = (सही)
 validation-incorrect = (गलत)
 validation-partially-correct = (कुछ हद तक सही)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } खातिर { $count } जवाब देखाईं
        *[other] { $answerId } खातिर { $count } जवाब देखाईं
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिपुष्टि
-
 collapsible-click-to-open = (खोले खातिर क्लिक करीं)
 collapsible-click-to-close = (बंद करे खातिर क्लिक करीं)
-
 collapsible-initializing = शुरू होखत बा…
-
 footnote-show = पादटीप देखाईं
 footnote-hide = पादटीप छिपाईं
-
 description-more-information = अउरी जानकारी
-
 
 ## Controls
 
 slider-previous = पहिले वाला
 slider-next = अगिला
-
 keyboard-open = कुंजीपटल खोलीं
 keyboard-close = कुंजीपटल बंद करीं
-
 choice-input-remove-choice = { $choice } हटाईं
-
 matrix-remove-row = पाँती हटाईं
 matrix-add-row = पाँती जोड़ीं
 matrix-remove-column = स्तंभ हटाईं
 matrix-add-column = स्तंभ जोड़ीं
-
 subset-add-remove-points = बिंदु जोड़ीं/हटाईं
 subset-toggle-points-intervals = बिंदु आ अंतराल बदलीं
 subset-move-points = बिंदु सरकाईं
 subset-clear = मिटाईं
-
 orbital-add-row = पाँती जोड़ीं
 orbital-remove-row = पाँती हटाईं
 orbital-add-box = बक्सा जोड़ीं
@@ -87,13 +68,9 @@ orbital-remove-box = बक्सा हटाईं
 orbital-add-up-arrow = ऊपर वाला तीर जोड़ीं
 orbital-add-down-arrow = नीचे वाला तीर जोड़ीं
 orbital-remove-arrow = तीर हटाईं
-
 orbital-row-label = पाँती { $row } के लेबल
-
 pretzel-answer = जवाब
-
 summary-statistics-caption = { $column } के सांख्यिकी सार
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = गणित के व्यंजन के झल
 math-input-preview = झलक
 math-input-invalid-expression = अमान्य व्यंजन:
 
-
 ## Document status
 
 viewer-initializing = शुरू होखत बा…
 
-
 ## Errors
 
 error-heading = गलती
-
 error-found-at =
     { $span ->
         [line] पाँती { $startLine } पर मिलल।
        *[lines] पाँती { $startLine }–{ $endLine } पर मिलल।
     }
-
 document-contains-errors = ई दस्तावेज में गलती बा!
-
 diagnostic-heading-error = गलती
 diagnostic-heading-warning = चेतावनी
 diagnostic-heading-information = जानकारी
 diagnostic-heading-hint = संकेत
-
 accessibility-heading-level-1 = WCAG AA सुगम्यता के उल्लंघन
 accessibility-heading-level-2 = सुगम्यता के सूचना
-
 something-went-wrong = कुछ गड़बड़ हो गइल।
-
 renderer-load-failed = एगो प्रदर्शक लोड ना हो सकल। कृपया पन्ना फेर से लोड करीं।
-
 core-start-failed = दस्तावेज दर्शक शुरू ना हो सकल। कृपया पन्ना फेर से लोड करीं।

--- a/packages/i18n/locales/bho/content.ftl
+++ b/packages/i18n/locales/bho/content.ftl
@@ -47,15 +47,12 @@ color =
     .purple = बैंगनी
     .pink = गुलाबी
     .brown = खैरा
-
 line-width =
     .thick = मोट
     .thin = पातर
-
 line-style =
     .dashed = टूटल
     .dotted = बिंदुदार
-
 fill-style =
     .horizontal = आड़ी रेखा
     .vertical = खड़ी रेखा
@@ -63,7 +60,6 @@ fill-style =
     .backdiagonal = उलटी तिरछी रेखा
     .dots = बिंदु
     .diamonds = समचतुर्भुज
-
 noun =
     .line = रेखा
     .line-segment = रेखाखंड
@@ -83,7 +79,6 @@ noun =
     .diamond = समचतुर्भुज
     .cross = गुना के चिन्ह
     .plus = जोड़ के चिन्ह
-
 # «-भुजा वाला» takes the count and stands in front of the noun, so nothing
 # follows the adjectives and the tail is empty.
 noun-regular-polygon =
@@ -91,9 +86,7 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides }-भुजा वाला समबहुभुज
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,15 +100,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = भरल
-
 # «से» is a postposition and follows what it governs, so the pattern moves to
 # the front of the phrase where English appends it.
 style-filled =
@@ -123,7 +113,6 @@ style-filled =
         [pattern] { $pattern } से { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } से { $filled } { $color } { $noun }
@@ -131,7 +120,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } से { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Bhojpuri has no article, so the two `-article` branches read like their
 # neighbours.
 style-border-clause =
@@ -141,35 +129,28 @@ style-border-clause =
         [and-article] आ { $border } किनारी सहित
        *[with] { $border } किनारी सहित
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } से { $color } भराई
        *[plain] { $color } भराई
     }
-
 style-unfilled = बिना भरल
-
 style-text =
     { $parts ->
         [background] { $background } पृष्ठभूमि पर { $color }
        *[plain] { $color }
     }
-
 style-background-none = कुछ ना
-
 
 ## Boolean words
 
 boolean-true = सही
 boolean-false = गलत
 
-
 ## Answer buttons
 
 answer-submit-label = जाँचीं
 answer-submit-label-no-correctness = जवाब भेजीं
-
 
 ## Sectional blocks
 
@@ -194,7 +175,6 @@ section-name =
     .solution = हल
     .task = काम
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -204,9 +184,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = संकेत
-
 
 ## Tables and figures
 
@@ -217,7 +195,6 @@ table-name =
         [unnumbered-title] सारणी{ ": " }
        *[unnumbered] सारणी
     }
-
 figure-name =
     { $parts ->
         [numbered] चित्र { $enumeration }
@@ -226,26 +203,20 @@ figure-name =
        *[unnumbered] चित्र
     }
 
-
 ## Paginator controls
 
 paginator-previous = पहिले वाला
 paginator-next = अगिला
 paginator-page = पन्ना
-
 # «X में से Y» — "Y out of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } में से { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = भा
-
 piecewise-condition-if = अगर
-
 piecewise-condition-otherwise = ना त
-
 
 ## Chemistry
 ##
@@ -261,6 +232,5 @@ piecewise-condition-otherwise = ना त
 ## instance of it in this batch: nothing about the language is in question.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अमान्य रासायनिक चिन्ह
 chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक

--- a/packages/i18n/locales/bik/chrome.ftl
+++ b/packages/i18n/locales/bik/chrome.ftl
@@ -29,21 +29,15 @@
 
 answer-checking = Sinisiyasat…
 answer-submitting = Ipinapadara…
-
 answer-checking-status = Sinisiyasat an simbag
 answer-submitting-status = Ipinapadara an simbag
-
 answer-correct = Tama
 answer-incorrect = Bakong tama
-
 answer-response-saved = Natago an simbag
-
 answer-percent-credit = { $percent }% na kredito
 answer-percent-correct = { $percent }% na tama
 answer-percent-short = { $percent } %
-
 max-credit-available = Pinakahalangkaw na kreditong makukua: { $percent }%
-
 # No select: «purbar» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -51,51 +45,38 @@ attempts-remaining =
         [0] mayo nang natadang purbar
        *[other] { $count } na purbar an natada
     }
-
 validation-correct = (Tama)
 validation-incorrect = (Bakong tama)
 validation-partially-correct = (Tama sa kabtang)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Ipahiling an { $count } na simbag para sa { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komento
-
 collapsible-click-to-open = (i-klik tanganing mabuksan)
 collapsible-click-to-close = (i-klik tanganing masarahan)
-
 collapsible-initializing = Nagpopoon…
-
 footnote-show = Ipahiling an footnote
 footnote-hide = Itago an footnote
-
 description-more-information = dagdag na impormasyon
-
 
 ## Controls
 
 slider-previous = Nakaagi
 slider-next = Sunod
-
 keyboard-open = Buksan an teklado
 keyboard-close = Sarahan an teklado
-
 choice-input-remove-choice = Halion an { $choice }
-
 matrix-remove-row = Halion an linya
 matrix-add-row = Dagdagan nin linya
 matrix-remove-column = Halion an kolum
 matrix-add-column = Dagdagan nin kolum
-
 subset-add-remove-points = Pagdagdag/Paghali nin mga punto
 subset-toggle-points-intervals = Pagsalyo nin mga punto asin interbalo
 subset-move-points = Ibalyo an mga punto
 subset-clear = Linigan
-
 orbital-add-row = Dagdagan nin linya
 orbital-remove-row = Halion an linya
 orbital-add-box = Dagdagan nin kahon
@@ -103,13 +84,9 @@ orbital-remove-box = Halion an kahon
 orbital-add-up-arrow = Dagdagan nin panang pasiring sa itaas
 orbital-add-down-arrow = Dagdagan nin panang pasiring sa ibaba
 orbital-remove-arrow = Halion an pana
-
 orbital-row-label = Etiketa para sa linya { $row }
-
 pretzel-answer = Simbag
-
 summary-statistics-caption = Buod na estadistika kan { $column }
-
 
 ## Math input
 
@@ -117,34 +94,25 @@ math-input-preview-region = enot na pagheling sa ekspresyon na matematika
 math-input-preview = Enot na pagheling
 math-input-invalid-expression = Bakong balidong ekspresyon:
 
-
 ## Document status
 
 viewer-initializing = Nagpopoon…
 
-
 ## Errors
 
 error-heading = Sala
-
 error-found-at =
     { $span ->
         [line] Nakua sa linya { $startLine }.
        *[lines] Nakua sa mga linya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Igwang sala ining dokumento!
-
 diagnostic-heading-error = Sala
 diagnostic-heading-warning = Patanid
 diagnostic-heading-information = Impormasyon
 diagnostic-heading-hint = Giya
-
 accessibility-heading-level-1 = Paglapas sa aksesibilidad na WCAG AA
 accessibility-heading-level-2 = Patanid manongod sa aksesibilidad
-
 something-went-wrong = Igwang nagkasala.
-
 renderer-load-failed = igwang renderer na dai na-load. Pakiulit i-load an pahina.
-
 core-start-failed = Dai nagpoon an pagheling kan dokumento. Pakiulit i-load an pahina.

--- a/packages/i18n/locales/bik/content.ftl
+++ b/packages/i18n/locales/bik/content.ftl
@@ -45,15 +45,12 @@ color =
     .purple = lila
     .pink = rosas
     .brown = kape
-
 line-width =
     .thick = makapal
     .thin = manipis
-
 line-style =
     .dashed = putol-putol
     .dotted = tuldok-tuldok
-
 # Noun phrases. Bikol marks no plural on the noun, so «linya» is the word for
 # one line and for many alike.
 fill-style =
@@ -63,7 +60,6 @@ fill-style =
     .backdiagonal = baliktad na pahilig na linya
     .dots = tuldok
     .diamonds = diyamante
-
 noun =
     .line = linya
     .line-segment = segmento
@@ -83,16 +79,13 @@ noun =
     .diamond = diyamante
     .cross = krus
     .plus = plus
-
 noun-regular-polygon =
     { $part ->
         [tail] na may { $numSides } na gilid
        *[head] regular na poligono
     }
-
 # One answer for every noun: Bikol has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,21 +100,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } na { $noun } { $nounTail }
        *[noun] { $description } na { $noun }
     }
-
 style-filled-word = pano
-
 style-filled =
     { $parts ->
         [pattern] { $filled } na { $color } na may { $pattern }
        *[plain] { $filled } na { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } na { $color } na { $noun } na may { $pattern }
@@ -129,7 +118,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } na { $color } na { $noun } { $nounTail } na may { $pattern }
        *[plain] { $filled } na { $color } na { $noun }
     }
-
 # Bikol has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «na may» against «asin».
@@ -140,35 +128,28 @@ style-border-clause =
         [and-article] asin { $border } na gilid
        *[with] na may { $border } na gilid
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } na { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = bakong pano
-
 style-text =
     { $parts ->
         [background] { $color } na may { $background } na background
        *[plain] { $color }
     }
-
 style-background-none = mayo
-
 
 ## Boolean words
 
 boolean-true = totoo
 boolean-false = bakong totoo
 
-
 ## Answer buttons
 
 answer-submit-label = Siyasaton an simbag
 answer-submit-label-no-correctness = Ipadara an simbag
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = Solusyon
     .task = Gibuhon
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Giya
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] Talaan{ ": " }
        *[unnumbered] Talaan
     }
-
 figure-name =
     { $parts ->
         [numbered] Pigura { $enumeration }
@@ -228,22 +205,18 @@ figure-name =
        *[unnumbered] Pigura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nakaagi
 paginator-next = Sunod
 paginator-page = Pahina
-
 paginator-page-status = { $pageLabel } { $currentPage } sa { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = kun
 piecewise-condition-otherwise = kun bako
-
 
 ## Chemistry
 ##
@@ -253,6 +226,5 @@ piecewise-condition-otherwise = kun bako
 ## one — the same reason `locales/fil` and `locales/ceb` leave these keys out.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Bakong balidong simbolong kemikal
 chemistry-invalid-ionic-compound = Bakong balidong kompuwestong ioniko

--- a/packages/i18n/locales/bin/chrome.ftl
+++ b/packages/i18n/locales/bin/chrome.ftl
@@ -39,75 +39,56 @@
 
 answer-checking = A gha miẹn ọre...
 answer-submitting = A gha rhie ọre...
-
 answer-checking-status = A gha miẹn ọre
 answer-submitting-status = A gha rhie ọre
-
 answer-correct = Ọ maan
 answer-incorrect = Ọ i maan
-
 answer-response-saved = A rhie ọre ye efe
-
 answer-percent-credit = Kirediti { $percent }%
 answer-percent-correct = { $percent }% Ọ maan
 answer-percent-short = { $percent } %
-
 max-credit-available = Kirediti nọ khẹke sẹ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ighiẹnrhan i ke rre
         [one] ighiẹnrhan { $count } keghi rre
        *[other] ighiẹnrhan { $count } keghi rre
     }
-
 validation-correct = (Ọ maan)
 validation-incorrect = (Ọ i maan)
 validation-partially-correct = (Ọ maan vbe ọkpa fua)
-
 answer-show-responses =
     { $count ->
         [one] Rhie ọre { $count } ne { $answerId } miẹn
        *[other] Rhie ọre { $count } ne { $answerId } miẹn
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Erhuanren
-
 collapsible-click-to-open = (kie ne u wa a)
 collapsible-click-to-close = (kie ne u mudia a)
-
 collapsible-initializing = A gha ghi hia...
-
 footnote-show = Rhie ẹkpotọ nkoko miẹn
 footnote-hide = Fian ẹkpotọ nkoko
-
 description-more-information = ikuẹdẹ eso ke odaro
-
 
 ## Controls
 
 slider-previous = Ọni
 slider-next = Ọvbehe
-
 keyboard-open = Wa Kiboọdi
 keyboard-close = Mudia Kiboọdi
-
 # `$choice` — the choice's own text — is not translated.
 choice-input-remove-choice = Fian { $choice }
-
 matrix-remove-row = Fian ẹfẹ
 matrix-add-row = Gie ẹfẹ
 matrix-remove-column = Fian ọwagbe
 matrix-add-column = Gie ọwagbe
-
 subset-add-remove-points = Gie/Fian akoto
 subset-toggle-points-intervals = Ghee vbe akoto kevbe ẹvba
 subset-move-points = Gele akoto
 subset-clear = Fian hia
-
 orbital-add-row = Gie Ẹfẹ
 orbital-remove-row = Fian Ẹfẹ
 orbital-add-box = Gie Ẹkpẹtin
@@ -115,13 +96,9 @@ orbital-remove-box = Fian Ẹkpẹtin
 orbital-add-up-arrow = Gie Ọfa Ye Odukhunmwu
 orbital-add-down-arrow = Gie Ọfa Ye Otọ
 orbital-remove-arrow = Fian Ọfa
-
 orbital-row-label = Uni ne ẹfẹ { $row }
-
 pretzel-answer = Ọre
-
 summary-statistics-caption = Igbe ekhọe ti { $column }
-
 
 ## Math input
 
@@ -129,34 +106,25 @@ math-input-preview-region = uhunmwu ẹdẹ ọfoworhọ
 math-input-preview = Uhunmwu
 math-input-invalid-expression = Ọfoworhọ nọ i maan:
 
-
 ## Document status
 
 viewer-initializing = A gha ghi hia...
 
-
 ## Errors
 
 error-heading = Efian
-
 error-found-at =
     { $span ->
         [line] A miẹn ẹre vbe ẹfẹ { $startLine }.
        *[lines] A miẹn ẹre vbe efe { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ekhọe rre vbe akọsile nan!
-
 diagnostic-heading-error = Efian
 diagnostic-heading-warning = Ivbieka
 diagnostic-heading-information = Ikuẹdẹ
 diagnostic-heading-hint = Ọtọ
-
 accessibility-heading-level-1 = Efian WCAG AA vbe abọ nọ khẹke
 accessibility-heading-level-2 = Ivbieka vbe abọ nọ khẹke
-
 something-went-wrong = Emwin ọkpa i rre vbe odẹ.
-
 renderer-load-failed = ọkpa ke ihe ọfoworhọ i rre. Gie ọdẹ mudia ọni ọwagbe.
-
 core-start-failed = Ihe akọsile i sẹtin ghi. Gie ọdẹ mudia ọni ọwagbe.

--- a/packages/i18n/locales/bin/content.ftl
+++ b/packages/i18n/locales/bin/content.ftl
@@ -62,15 +62,12 @@ color =
     .purple = papulu
     .pink = pinki
     .brown = braun
-
 line-width =
     .thick = gbanhọn
     .thin = fiofio
-
 line-style =
     .dashed = ni ẹmiẹmi
     .dotted = ni akoto akoto
-
 # Noun phrases: they follow the shape being described and modify nothing.
 fill-style =
     .horizontal = efe nọ dẹbeghe
@@ -79,7 +76,6 @@ fill-style =
     .backdiagonal = efe nọ gbayie fiegbe
     .dots = akoto
     .diamonds = ayamọni
-
 noun =
     .line = ẹfẹ
     .line-segment = ọya ẹfẹ
@@ -99,7 +95,6 @@ noun =
     .diamond = ayamọni
     .cross = ekpogho
     .plus = ọfa ẹkọ
-
 # The side count follows in the tail, behind the description, as Yoruba does:
 # «ọtọ ọbọkiọkiọ dọgbanhi ọtọ 5», keeping «ọtọ» beside the numeral counting it
 # rather than separating them to hold a fixed English word order.
@@ -108,11 +103,9 @@ noun-regular-polygon =
         [tail] ọtọ { $numSides }
        *[head] ọtọ ọbọkiọkiọ dọgbanhi
     }
-
 # Edo has no grammatical gender, so every noun answers the same way and the
 # answer goes unused — as in English and Yoruba.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -126,22 +119,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its description follows: «ẹfẹ gbanhọn ni ẹmiẹmi ọbara».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = nọ vbe ẹgua
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kevbe { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } kevbe { $pattern }
@@ -149,7 +138,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } kevbe { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «kevbe ọya ẹfẹ ọbara nọ gbanhọn» — "and a thick red border".
 style-border-clause =
     { $parts ->
@@ -158,35 +146,28 @@ style-border-clause =
         [and-article] kevbe ọya ẹfẹ { $border }
        *[with] kevbe ọya ẹfẹ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = nọ i vbe ẹgua
-
 style-text =
     { $parts ->
         [background] { $color } vbe ugbo { $background }
        *[plain] { $color }
     }
-
 style-background-none = i rre
-
 
 ## Boolean words
 
 boolean-true = true
 boolean-false = false
 
-
 ## Answer buttons
 
 answer-submit-label = Miẹn Ọsẹ
 answer-submit-label-no-correctness = Rhie Ọre
-
 
 ## Sectional blocks
 
@@ -211,7 +192,6 @@ section-name =
     .solution = Ọre nọ Gbaroko
     .task = Ọsẹ
     .theorem = Emwẹ nọ Gbaroko
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -221,9 +201,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ọtọ
-
 
 ## Tables and figures
 
@@ -234,7 +212,6 @@ table-name =
         [unnumbered-title] Tebulu{ ": " }
        *[unnumbered] Tebulu
     }
-
 figure-name =
     { $parts ->
         [numbered] Owanrẹn { $enumeration }
@@ -243,15 +220,12 @@ figure-name =
        *[unnumbered] Owanrẹn
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ọni
 paginator-next = Ọvbehe
 paginator-page = Ọwagbe
-
 paginator-page-status = { $pageLabel } { $currentPage } vbe { $numPages }
-
 
 ## Piecewise functions
 
@@ -259,14 +233,14 @@ piecewise-condition-or = yana
 piecewise-condition-if = deghẹ
 piecewise-condition-otherwise = deghẹ ọvbehe
 
-
 ## Chemistry
+
+
 #
 # Bini leaves `element-name` and `element-anion-name` out, following the same
 # Nigerian-education reasoning `locales/ha` and `locales/yo` document: see this
 # file's header.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Uni Kemisiti nọ i maan
 chemistry-invalid-ionic-compound = Emwin Ayọni nọ i maan

--- a/packages/i18n/locales/bm/chrome.ftl
+++ b/packages/i18n/locales/bm/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = A bɛ sɛgɛsɛgɛ...
 answer-submitting = A bɛ ci...
-
 answer-checking-status = Jaabi bɛ sɛgɛsɛgɛ
 answer-submitting-status = Jaabi bɛ ci
-
 answer-correct = A bɛnna
 answer-incorrect = A ma bɛn
-
 answer-response-saved = Jaabi Marala
-
 answer-percent-credit = Nɔgɔya { $percent }%
 answer-percent-correct = { $percent }% Bɛnnen
 answer-percent-short = { $percent } %
-
 max-credit-available = Nɔgɔya belebele min bɛ sɔrɔ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] cɛsiri si tɛ yen tugun
        *[other] cɛsiri { $count } tora
     }
-
 validation-correct = (A bɛnna)
 validation-incorrect = (A ma bɛn)
 validation-partially-correct = (A bɛnna dɔɔni)
-
 answer-show-responses = { $answerId } ka jaabi { $count } jira
-
 
 ## Disclosure panels
 
 feedback-heading = Kɔsegin
-
 collapsible-click-to-open = (digi walasa k'a da wuli)
 collapsible-click-to-close = (digi walasa k'a datugu)
-
 collapsible-initializing = A bɛ daminɛ...
-
 footnote-show = Duguma-sɛbɛnni jira
 footnote-hide = Duguma-sɛbɛnni dogo
-
 description-more-information = kunnafoni wɛrɛw
-
 
 ## Controls
 
 slider-previous = Kɔfɛta
 slider-next = Nata
-
 keyboard-open = Kilabɔri Da Wuli
 keyboard-close = Kilabɔri Datugu
-
 choice-input-remove-choice = { $choice } bɔ
-
 matrix-remove-row = Layini bɔ
 matrix-add-row = Layini fara
 matrix-remove-column = Kolɔni bɔ
 matrix-add-column = Kolɔni fara
-
 subset-add-remove-points = Pɔnw fara/bɔ
 subset-toggle-points-intervals = Pɔnw ni ɛntɛrɛvaliw falen-falen
 subset-move-points = Pɔnw Yɛlɛma
 subset-clear = Jɔsi
-
 # A `box` here is one orbital, drawn as a square: «kɛsu».
 orbital-add-row = Layini Fara
 orbital-remove-row = Layini Bɔ
@@ -91,13 +72,9 @@ orbital-remove-box = Kɛsu Bɔ
 orbital-add-up-arrow = Sanfɛ-Bina Fara
 orbital-add-down-arrow = Dugumafɛ-Bina Fara
 orbital-remove-arrow = Bina Bɔ
-
 orbital-row-label = Layini { $row } tɔgɔ
-
 pretzel-answer = Jaabi
-
 summary-statistics-caption = { $column } ka jatebɔ surunman
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = matematiki fɔcogo ɲɛfɔli
 math-input-preview = Ɲɛfɔli
 math-input-invalid-expression = Fɔcogo tɛ ɲɛ:
 
-
 ## Document status
 
 viewer-initializing = A bɛ daminɛ...
 
-
 ## Errors
 
 error-heading = Fili
-
 error-found-at =
     { $span ->
         [line] A sɔrɔla liɲi { $startLine } kan.
        *[lines] A sɔrɔla liɲi { $startLine }–{ $endLine } kan.
     }
-
 document-contains-errors = Filiw bɛ nin sɛbɛn kɔnɔ!
-
 diagnostic-heading-error = Fili
 diagnostic-heading-warning = Lasɔmini
 diagnostic-heading-information = Kunnafoni
 diagnostic-heading-hint = Ladilikan
-
 accessibility-heading-level-1 = WCAG AA Sɔrɔliya Tiɲɛni
 accessibility-heading-level-2 = Sɔrɔliya lasɔmini
-
 something-went-wrong = Fɛn dɔ ma taa a cogo la.
-
 renderer-load-failed = jirali fɛn kelen ma se ka don. Aw ka sɛbɛnnisɛn lasegin.
-
 core-start-failed = Sɛbɛn jirala ma se ka daminɛ. Aw ka sɛbɛnnisɛn lasegin.

--- a/packages/i18n/locales/bm/content.ftl
+++ b/packages/i18n/locales/bm/content.ftl
@@ -42,17 +42,14 @@ color =
     .purple = wulenfinman
     .pink = wulenɲɛman
     .brown = bɔgɔlama
-
 line-width =
     .thick = bonman
     .thin = misɛnman
-
 # Written as «ni …» phrases rather than as qualifiers, so that they take no
 # `-man` and can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = ni tirɛw ye
     .dotted = ni pɔnw ye
-
 fill-style =
     .horizontal = liɲi dalenw
     .vertical = liɲi jɔlenw
@@ -60,7 +57,6 @@ fill-style =
     .backdiagonal = liɲi jɛngɛlen kɔfɛtaw
     .dots = pɔnw
     .diamonds = losanziw
-
 noun =
     .line = liɲi
     .line-segment = liɲi tilayɔrɔ
@@ -80,7 +76,6 @@ noun =
     .diamond = losanzi
     .cross = kuruwa
     .plus = fara-taamasere
-
 # The side count follows the qualifiers, behind «min kɛrɛ … ye», because
 # Bambara closes a noun phrase with a relative rather than opening one.
 noun-regular-polygon =
@@ -88,9 +83,7 @@ noun-regular-polygon =
         [tail] min kɛrɛ { $numSides } ye
        *[head] poligɔni bɛnnen
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,21 +97,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = falen
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ni { $pattern } ye
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ni { $pattern } ye
@@ -126,7 +115,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ni { $pattern } ye
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Bambara has no article and joins the complement with the invariable «ni …
 # ye», so all four branches read alike.
 style-border-clause =
@@ -136,35 +124,28 @@ style-border-clause =
         [and-article] ni dancɛ { $border } ye
        *[with] ni dancɛ { $border } ye
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = falenbali
-
 style-text =
     { $parts ->
         [background] { $color } kɔkanna { $background } kan
        *[plain] { $color }
     }
-
 style-background-none = foyi tɛ
-
 
 ## Boolean words
 
 boolean-true = tiɲɛ
 boolean-false = galon
 
-
 ## Answer buttons
 
 answer-submit-label = Baara Sɛgɛsɛgɛ
 answer-submit-label-no-correctness = Jaabi Ci
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = Ɲɛnabɔli
     .task = Baara
     .theorem = Teyorɛmu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ladilikan
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] Tabali{ ": " }
        *[unnumbered] Tabali
     }
-
 figure-name =
     { $parts ->
         [numbered] Ja { $enumeration }
@@ -221,22 +198,18 @@ figure-name =
        *[unnumbered] Ja
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kɔfɛta
 paginator-next = Nata
 paginator-page = Sɛbɛnnisɛn
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = walima
 piecewise-condition-if = ni
 piecewise-condition-otherwise = n'o tɛ
-
 
 ## Chemistry
 
@@ -246,6 +219,5 @@ piecewise-condition-otherwise = n'o tɛ
 # language already — and the seed has no settled Bambara list to reproduce. A
 # speaker adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simi Taamasere Tɛ Ɲɛ
 chemistry-invalid-ionic-compound = Iyɔn Fɛn-Fara Tɛ Ɲɛ

--- a/packages/i18n/locales/bn/chrome.ftl
+++ b/packages/i18n/locales/bn/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = যাচাই করা হচ্ছে...
 answer-submitting = পাঠানো হচ্ছে...
-
 answer-checking-status = উত্তর যাচাই করা হচ্ছে
 answer-submitting-status = উত্তর পাঠানো হচ্ছে
-
 answer-correct = সঠিক
 answer-incorrect = ভুল
-
 answer-response-saved = উত্তর সংরক্ষিত হয়েছে
-
 answer-percent-credit = { $percent }% নম্বর
 answer-percent-correct = { $percent }% সঠিক
 answer-percent-short = { $percent }%
-
 max-credit-available = সর্বোচ্চ সম্ভাব্য নম্বর: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] কোনো প্রচেষ্টা বাকি নেই
         [one] { $count }টি প্রচেষ্টা বাকি
        *[other] { $count }টি প্রচেষ্টা বাকি
     }
-
 validation-correct = (সঠিক)
 validation-incorrect = (ভুল)
 validation-partially-correct = (আংশিক সঠিক)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId }-এর { $count }টি উত্তর দেখান
        *[other] { $answerId }-এর { $count }টি উত্তর দেখান
     }
 
-
 ## Disclosure panels
 
 feedback-heading = প্রতিক্রিয়া
-
 collapsible-click-to-open = (খুলতে ক্লিক করুন)
 collapsible-click-to-close = (বন্ধ করতে ক্লিক করুন)
-
 collapsible-initializing = শুরু করা হচ্ছে...
-
 footnote-show = পাদটীকা দেখান
 footnote-hide = পাদটীকা লুকান
-
 description-more-information = আরও তথ্য
-
 
 ## Controls
 
 slider-previous = পূর্ববর্তী
 slider-next = পরবর্তী
-
 keyboard-open = কীবোর্ড খুলুন
 keyboard-close = কীবোর্ড বন্ধ করুন
-
 choice-input-remove-choice = { $choice } সরান
-
 matrix-remove-row = সারি সরান
 matrix-add-row = সারি যোগ করুন
 matrix-remove-column = কলাম সরান
 matrix-add-column = কলাম যোগ করুন
-
 subset-add-remove-points = বিন্দু যোগ/অপসারণ
 subset-toggle-points-intervals = বিন্দু ও ব্যবধির মধ্যে পাল্টান
 subset-move-points = বিন্দু সরান
 subset-clear = পরিষ্কার করুন
-
 # A `box` here is one orbital, drawn as a square: ঘর.
 orbital-add-row = সারি যোগ করুন
 orbital-remove-row = সারি সরান
@@ -94,13 +75,9 @@ orbital-remove-box = ঘর সরান
 orbital-add-up-arrow = ঊর্ধ্বমুখী তির যোগ করুন
 orbital-add-down-arrow = নিম্নমুখী তির যোগ করুন
 orbital-remove-arrow = তির সরান
-
 orbital-row-label = { $row } নং সারির লেবেল
-
 pretzel-answer = উত্তর
-
 summary-statistics-caption = { $column }-এর সারসংক্ষেপ পরিসংখ্যান
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = গাণিতিক রাশির পূর্�
 math-input-preview = পূর্বরূপ
 math-input-invalid-expression = অবৈধ রাশি:
 
-
 ## Document status
 
 viewer-initializing = শুরু করা হচ্ছে...
 
-
 ## Errors
 
 error-heading = ত্রুটি
-
 error-found-at =
     { $span ->
         [line] { $startLine } নং লাইনে পাওয়া গেছে।
        *[lines] { $startLine }–{ $endLine } নং লাইনে পাওয়া গেছে।
     }
-
 document-contains-errors = এই নথিতে ত্রুটি রয়েছে!
-
 diagnostic-heading-error = ত্রুটি
 diagnostic-heading-warning = সতর্কতা
 diagnostic-heading-information = তথ্য
 diagnostic-heading-hint = ইঙ্গিত
-
 accessibility-heading-level-1 = WCAG AA প্রবেশযোগ্যতা লঙ্ঘন
 accessibility-heading-level-2 = প্রবেশযোগ্যতা সতর্কতা
-
 something-went-wrong = কিছু একটা ভুল হয়েছে।
-
 renderer-load-failed = একটি রেন্ডারার লোড করা যায়নি। অনুগ্রহ করে পৃষ্ঠাটি আবার লোড করুন।
-
 core-start-failed = নথি প্রদর্শক চালু করা যায়নি। অনুগ্রহ করে পৃষ্ঠাটি আবার লোড করুন।

--- a/packages/i18n/locales/bn/content.ftl
+++ b/packages/i18n/locales/bn/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = বেগুনি
     .pink = গোলাপি
     .brown = বাদামি
-
 line-width =
     .thick = মোটা
     .thin = সরু
-
 line-style =
     .dashed = ড্যাশযুক্ত
     .dotted = বিন্দুযুক্ত
-
 # Noun phrases rather than adjectives: they are introduced by দিয়ে ("using"),
 # which takes a bare noun, so each one stands on its own below.
 fill-style =
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = বিপরীত কর্ণ রেখা
     .dots = বিন্দু
     .diamonds = রম্বস
-
 noun =
     .line = রেখা
     .line-segment = রেখাংশ
@@ -74,7 +70,6 @@ noun =
     .diamond = রম্বস
     .cross = ক্রস
     .plus = যোগ চিহ্ন
-
 # বাহুবিশিষ্ট ("having sides") attaches the count to the noun that follows, so
 # the whole phrase is one head and there is no tail.
 noun-regular-polygon =
@@ -82,11 +77,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } বাহুবিশিষ্ট সুষম বহুভুজ
     }
-
 # Bangla has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,15 +93,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ভরাট
-
 # দিয়ে follows the pattern it applies to, so the clause English appends comes
 # to the front here.
 style-filled =
@@ -116,7 +106,6 @@ style-filled =
         [pattern] { $pattern } দিয়ে { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } দিয়ে { $filled } { $color } { $noun }
@@ -124,7 +113,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } দিয়ে { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # সহ is a postposition, so it follows সীমানা rather than preceding it as
 # English's `with` does. Bangla has no article, which leaves the `-article`
 # branches reading exactly like the ones without.
@@ -135,15 +123,12 @@ style-border-clause =
         [and-article] এবং { $border } সীমানা সহ
        *[with] { $border } সীমানা সহ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ভরাটহীন
-
 # The locative -তে marks পটভূমি, and the colour word in front of it is
 # untouched by that.
 style-text =
@@ -151,21 +136,17 @@ style-text =
         [background] { $background } পটভূমিতে { $color }
        *[plain] { $color }
     }
-
 style-background-none = নেই
-
 
 ## Boolean words
 
 boolean-true = সত্য
 boolean-false = মিথ্যা
 
-
 ## Answer buttons
 
 answer-submit-label = যাচাই করুন
 answer-submit-label-no-correctness = উত্তর জমা দিন
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = সমাধান
     .task = কাজ
     .theorem = উপপাদ্য
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -200,9 +180,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ইঙ্গিত
-
 
 ## Tables and figures
 
@@ -213,7 +191,6 @@ table-name =
         [unnumbered-title] সারণি{ ": " }
        *[unnumbered] সারণি
     }
-
 figure-name =
     { $parts ->
         [numbered] চিত্র { $enumeration }
@@ -222,26 +199,20 @@ figure-name =
        *[unnumbered] চিত্র
     }
 
-
 ## Paginator controls
 
 paginator-previous = পূর্ববর্তী
 paginator-next = পরবর্তী
 paginator-page = পৃষ্ঠা
-
 # «X-এর মধ্যে Y» — "Y out of X" — puts the total first, so the two counts
 # change places.
 paginator-page-status = { $numPages }-এর মধ্যে { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = অথবা
-
 piecewise-condition-if = যদি
-
 piecewise-condition-otherwise = অন্যথায়
-
 
 ## Chemistry
 ##
@@ -369,7 +340,6 @@ element-name =
     .lv = লিভারমোরিয়াম
     .ts = টেনেসিন
     .og = ওগানেসন
-
 element-anion-name =
     .h = হাইড্রাইড
     .c = কার্বাইড
@@ -383,8 +353,6 @@ element-anion-name =
     .i = আয়োডাইড
     .at = অ্যাস্টাটাইড
     .ts = টেনেসাইড
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = অবৈধ রাসায়নিক প্রতীক
 chemistry-invalid-ionic-compound = অবৈধ আয়নিক যৌগ

--- a/packages/i18n/locales/bo/chrome.ftl
+++ b/packages/i18n/locales/bo/chrome.ftl
@@ -18,69 +18,50 @@
 
 answer-checking = ཞིབ་བཤེར་བྱེད་བཞིན་པ།
 answer-submitting = སྐུར་བཞིན་པ།
-
 answer-checking-status = ལན་ལ་ཞིབ་བཤེར་བྱེད་བཞིན་པ
 answer-submitting-status = ལན་སྐུར་བཞིན་པ
-
 answer-correct = ཡང་དག
 answer-incorrect = ནོར་འཁྲུལ
-
 answer-response-saved = ལན་ཉར་ཚགས་བྱས་ཟིན
-
 answer-percent-credit = { $percent }% སྐར་གྲངས
 answer-percent-correct = { $percent }% ཡང་དག
 answer-percent-short = { $percent } %
-
 max-credit-available = ཐོབ་ཐུབ་པའི་སྐར་གྲངས་མཐོ་ཤོས། { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] འབད་བརྩོན་ལྷག་མ་མེད
        *[other] འབད་བརྩོན་ { $count } ལྷག་ཡོད
     }
-
 validation-correct = (ཡང་དག)
 validation-incorrect = (ནོར་འཁྲུལ)
 validation-partially-correct = (ཕྱོགས་གཅིག་ཡང་དག)
-
 answer-show-responses = { $answerId } ལ་ལན་ { $count } སྟོན
-
 
 ## Disclosure panels
 
 feedback-heading = ལན་འདེབས
-
 collapsible-click-to-open = (ཕྱེ་བར་ནོན)
 collapsible-click-to-close = (སྒོ་རྒྱག་པར་ནོན)
-
 collapsible-initializing = འགོ་འཛུགས་བཞིན་པ།
-
 footnote-show = མཇུག་མཆན་སྟོན
 footnote-hide = མཇུག་མཆན་སྦེད
-
 description-more-information = གནས་ཚུལ་མང་བ
-
 
 ## Controls
 
 slider-previous = སྔོན་མ
 slider-next = རྗེས་མ
-
 keyboard-open = མཐེབ་གཞོང་ཕྱེ
 keyboard-close = མཐེབ་གཞོང་སྒོ་རྒྱོབ
-
 choice-input-remove-choice = { $choice } ཕྱིར་འདོན
-
 matrix-remove-row = ཕྲེང་ཕྱིར་འདོན
 matrix-add-row = ཕྲེང་སྣོན
 matrix-remove-column = སྟར་ཕྱིར་འདོན
 matrix-add-column = སྟར་སྣོན
-
 subset-add-remove-points = ཚེག་སྣོན་དང་ཕྱིར་འདོན
 subset-toggle-points-intervals = ཚེག་དང་བར་མཚམས་བརྗེ
 subset-move-points = ཚེག་སྤོ
 subset-clear = གཙང་སེལ
-
 orbital-add-row = ཕྲེང་སྣོན
 orbital-remove-row = ཕྲེང་ཕྱིར་འདོན
 orbital-add-box = སྒམ་སྣོན
@@ -88,13 +69,9 @@ orbital-remove-box = སྒམ་ཕྱིར་འདོན
 orbital-add-up-arrow = ཡར་མདའ་སྣོན
 orbital-add-down-arrow = མར་མདའ་སྣོན
 orbital-remove-arrow = མདའ་ཕྱིར་འདོན
-
 orbital-row-label = ཕྲེང་ { $row } གི་མིང་བྱང
-
 pretzel-answer = ལན
-
 summary-statistics-caption = { $column } གི་གྲངས་ཐོའི་བསྡུས་དོན
-
 
 ## Math input
 
@@ -102,34 +79,25 @@ math-input-preview-region = རྩིས་བརྗོད་ཀྱི་སྔ�
 math-input-preview = སྔོན་ལྟ
 math-input-invalid-expression = བརྗོད་པ་ནོར་བ།
 
-
 ## Document status
 
 viewer-initializing = འགོ་འཛུགས་བཞིན་པ།
 
-
 ## Errors
 
 error-heading = ནོར་འཁྲུལ
-
 error-found-at =
     { $span ->
         [line] ཐིག་ཕྲེང་ { $startLine } ལ་རྙེད་བྱུང་།
        *[lines] ཐིག་ཕྲེང་ { $startLine }–{ $endLine } ལ་རྙེད་བྱུང་།
     }
-
 document-contains-errors = ཡིག་ཆ་འདིའི་ནང་ནོར་འཁྲུལ་ཡོད།
-
 diagnostic-heading-error = ནོར་འཁྲུལ
 diagnostic-heading-warning = ཉེན་བརྡ
 diagnostic-heading-information = གནས་ཚུལ
 diagnostic-heading-hint = བརྡ་སྟོན
-
 accessibility-heading-level-1 = WCAG AA བདེ་སྤྱོད་འགལ་བ
 accessibility-heading-level-2 = བདེ་སྤྱོད་ཉེན་བརྡ
-
 something-went-wrong = ཅི་ཞིག་ནོར་སོང་།
-
 renderer-load-failed = སྟོན་བྱེད་ཅིག་སྣོན་མ་ཐུབ། ཤོག་ངོས་སླར་ཡང་སྣོན་རོགས།
-
 core-start-failed = ཡིག་ཆ་སྟོན་བྱེད་འགོ་འཛུགས་མ་ཐུབ། ཤོག་ངོས་སླར་ཡང་སྣོན་རོགས།

--- a/packages/i18n/locales/bo/content.ftl
+++ b/packages/i18n/locales/bo/content.ftl
@@ -57,15 +57,12 @@ color =
     .purple = རྒྱ་སྨུག
     .pink = ཟིང་སྐྱ
     .brown = སྨུག་པོ
-
 line-width =
     .thick = མཐུག་པོ
     .thin = སྲབ་མོ
-
 line-style =
     .dashed = ཆད་ལྷུག
     .dotted = ཚེག་ཅན
-
 fill-style =
     .horizontal = འཕྲེད་ཐིག
     .vertical = གཞུང་ཐིག
@@ -73,7 +70,6 @@ fill-style =
     .backdiagonal = ལྡོག་ཟུར་ཐིག
     .dots = ཚེག
     .diamonds = ཕ་ལམ་དབྱིབས
-
 noun =
     .line = ཐིག
     .line-segment = ཐིག་དུམ
@@ -93,7 +89,6 @@ noun =
     .diamond = ཕ་ལམ་དབྱིབས
     .cross = བསྒྱུར་རྟགས
     .plus = སྣོན་རྟགས
-
 # The count is a complement that follows the whole phrase, so the head carries
 # the noun alone and the tail carries the count. Tibetan reaches `[noun-tail]`
 # for the same reason `locales/mni` does — a count is a modifier and modifiers
@@ -103,10 +98,8 @@ noun-regular-polygon =
         [tail] ཟུར་ { $numSides } ཅན
        *[head] ཆ་སྙོམས་ཟུར་མང
     }
-
 # Nothing selects on it: Tibetan has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -120,7 +113,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives follow the noun, so the two halves change places against
 # English, and a noun with a complement puts it last.
 style-with-noun =
@@ -128,9 +120,7 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = བཀང་བ
-
 # «དང་» is invariant whatever precedes it, which is why the pattern can stand
 # beside a placeable here; see the header.
 style-filled =
@@ -138,7 +128,6 @@ style-filled =
         [pattern] { $filled } { $color } { $pattern } དང་བཅས་པ
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } { $pattern } དང་བཅས་པ
@@ -146,7 +135,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } { $pattern } དང་བཅས་པ
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «མཐའ་» is the border and stands in front of its own adjective, so «དང་བཅས་པ»
 # closes the clause. Tibetan has no article, so the `-article` branches read
 # like their neighbours.
@@ -157,36 +145,29 @@ style-border-clause =
         [and-article] དེ་བཞིན་མཐའ་ { $border } དང་བཅས་པ
        *[with] མཐའ་ { $border } དང་བཅས་པ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = མ་བཀང་བ
-
 # «ལ་» is invariant too, so the background can carry it beside a value.
 style-text =
     { $parts ->
         [background] རྒྱབ་ལྗོངས་ { $background } ལ་ { $color }
        *[plain] { $color }
     }
-
 style-background-none = གང་ཡང་མེད
-
 
 ## Boolean words
 
 boolean-true = བདེན་པ
 boolean-false = རྫུན་པ
 
-
 ## Answer buttons
 
 answer-submit-label = ཞིབ་བཤེར
 answer-submit-label-no-correctness = ལན་སྐུར
-
 
 ## Sectional blocks
 
@@ -211,7 +192,6 @@ section-name =
     .solution = ལན་ཐབས
     .task = ལས་འགན
     .theorem = གཏན་ཚིག
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -221,9 +201,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = བརྡ་སྟོན
-
 
 ## Tables and figures
 
@@ -234,7 +212,6 @@ table-name =
         [unnumbered-title] རེའུ་མིག{ ": " }
        *[unnumbered] རེའུ་མིག
     }
-
 figure-name =
     { $parts ->
         [numbered] རི་མོ { $enumeration }
@@ -243,26 +220,20 @@ figure-name =
        *[unnumbered] རི་མོ
     }
 
-
 ## Paginator controls
 
 paginator-previous = སྔོན་མ
 paginator-next = རྗེས་མ
 paginator-page = ཤོག་ངོས
-
 # «X ནང་གི Y» — "Y of X" — puts the total first, so the two counts change
 # places. «ནང་» is invariant.
 paginator-page-status = { $numPages } ནང་ { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = ཡང་ན
-
 piecewise-condition-if = གལ་ཏེ
-
 piecewise-condition-otherwise = དེ་མིན
-
 
 ## Chemistry
 ##
@@ -282,6 +253,5 @@ piecewise-condition-otherwise = དེ་མིན
 ## catalog.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ནུས་རྫས་རྟགས་ནོར་བ
 chemistry-invalid-ionic-compound = རླུང་རྡུལ་འདུས་རྫས་ནོར་བ

--- a/packages/i18n/locales/br/chrome.ftl
+++ b/packages/i18n/locales/br/chrome.ftl
@@ -14,25 +14,20 @@
 # 3 of those mutates, so that branch keeps the base form. `many` is the branch
 # for multiples of a million, which is why it reads with «a» and a plural.
 
+
 ## Answer submission
 
 answer-checking = O wiriañ…
 answer-submitting = O kas…
-
 answer-checking-status = O wiriañ ar respont
 answer-submitting-status = O kas ar respont
-
 answer-correct = Reizh
 answer-incorrect = Direizh
-
 answer-response-saved = Respont enrollet
-
 answer-percent-credit = { $percent }% eus ar poentoù
 answer-percent-correct = { $percent }% reizh
 answer-percent-short = { $percent } %
-
 max-credit-available = Poentoù uhelañ hegerz: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] taol ebet a chom
@@ -42,11 +37,9 @@ attempts-remaining =
         [many] { $count } a daolioù a chom
        *[other] { $count } taol a chom
     }
-
 validation-correct = (Reizh)
 validation-incorrect = (Direizh)
 validation-partially-correct = (Reizh en un doare)
-
 answer-show-responses =
     { $count ->
         [one] Diskouez { $count } respont da { $answerId }
@@ -56,42 +49,31 @@ answer-show-responses =
        *[other] Diskouez { $count } respont da { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Evezhiadennoù
-
 collapsible-click-to-open = (klikit evit digeriñ)
 collapsible-click-to-close = (klikit evit serriñ)
-
 collapsible-initializing = O kregiñ…
-
 footnote-show = Diskouez an notenn traoñ-pajenn
 footnote-hide = Kuzhat an notenn traoñ-pajenn
-
 description-more-information = muioc'h a ditouroù
-
 
 ## Controls
 
 slider-previous = A-raok
 slider-next = War-lerc'h
-
 keyboard-open = Digeriñ ar c'hlavier
 keyboard-close = Serriñ ar c'hlavier
-
 choice-input-remove-choice = Lemel { $choice }
-
 matrix-remove-row = Lemel ul linenn
 matrix-add-row = Ouzhpennañ ul linenn
 matrix-remove-column = Lemel ur bann
 matrix-add-column = Ouzhpennañ ur bann
-
 subset-add-remove-points = Ouzhpennañ/lemel poentoù
 subset-toggle-points-intervals = Tremen etre poentoù ha spasoù
 subset-move-points = Dilec'hiañ ar poentoù
 subset-clear = Skarzhañ
-
 orbital-add-row = Ouzhpennañ ul linenn
 orbital-remove-row = Lemel ul linenn
 orbital-add-box = Ouzhpennañ ur voest
@@ -99,13 +81,9 @@ orbital-remove-box = Lemel ur voest
 orbital-add-up-arrow = Ouzhpennañ ur bir war-grec'h
 orbital-add-down-arrow = Ouzhpennañ ur bir war-zu an traoñ
 orbital-remove-arrow = Lemel ur bir
-
 orbital-row-label = Tikedenn evit al linenn { $row }
-
 pretzel-answer = Respont
-
 summary-statistics-caption = Stadegoù berr eus { $column }
-
 
 ## Math input
 
@@ -113,34 +91,25 @@ math-input-preview-region = rakwel eus ar frazenn jedoniel
 math-input-preview = Rakwel
 math-input-invalid-expression = Frazenn direizh:
 
-
 ## Document status
 
 viewer-initializing = O kregiñ…
 
-
 ## Errors
 
 error-heading = Fazi
-
 error-found-at =
     { $span ->
         [line] Kavet war al linenn { $startLine }.
        *[lines] Kavet war al linennoù { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Fazioù zo en teul-mañ!
-
 diagnostic-heading-error = Fazi
 diagnostic-heading-warning = Diwall
 diagnostic-heading-information = Titour
 diagnostic-heading-hint = Kuzul
-
 accessibility-heading-level-1 = Torr-reizh haezadusted WCAG AA
 accessibility-heading-level-2 = Kemenn haezadusted
-
 something-went-wrong = Un dra bennak a zo aet a-dreuz.
-
 renderer-load-failed = un treser n'en deus ket gallet kargañ. Adkargit ar bajenn.
-
 core-start-failed = N'eus ket bet gallet kregiñ gant gweler an teul. Adkargit ar bajenn.

--- a/packages/i18n/locales/br/content.ftl
+++ b/packages/i18n/locales/br/content.ftl
@@ -67,7 +67,6 @@ color =
             [f] vrun
            *[m] brun
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -79,7 +78,6 @@ line-width =
             [f] voan
            *[m] moan
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -91,7 +89,6 @@ line-style =
             [f] bikennaouet
            *[m] pikennaouet
         }
-
 # Noun phrases standing behind «gant». They modify nothing and take no gender.
 fill-style =
     .horizontal = linennoù a-blaen
@@ -100,7 +97,6 @@ fill-style =
     .backdiagonal = linennoù a-veskell eus an tu all
     .dots = pikennoù
     .diamonds = diamantoù
-
 noun =
     .line = linenn
     .line-segment = tamm linenn
@@ -120,7 +116,6 @@ noun =
     .diamond = diamant
     .cross = kroaz
     .plus = plus
-
 # The side count follows the style adjectives, so the head and the tail split
 # around them.
 noun-regular-polygon =
@@ -128,7 +123,6 @@ noun-regular-polygon =
         [tail] gant { $numSides } tu
        *[head] liestueg reoliek
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (liestueg, m) or
 # the head of a phrase the description never names: `border` (bevenn, f),
 # `fill` (leunadur, m), `text` (testenn, f), `background` (drekleur, m).
@@ -143,7 +137,6 @@ noun-gender =
         [text] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -162,22 +155,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 # A past participle, invariable in Breton, so it needs no branch.
 style-filled-word = leuniet
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } gant { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } gant { $pattern }
@@ -185,7 +174,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } gant { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «bevenn» is feminine, so its own adjectives soften after it — and «bevenn»
 # itself softens to «vevenn» after the article «ur», which is a mutation of the
 # noun rather than of anything the description supplies. Breton always writes
@@ -197,35 +185,28 @@ style-border-clause =
         [and-article] hag ur vevenn { $border }
        *[with] gant ur vevenn { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] leunadur { $color } gant { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = goullo
-
 style-text =
     { $parts ->
         [background] { $color } gant un drekleur { $background }
        *[plain] { $color }
     }
-
 style-background-none = hini ebet
-
 
 ## Boolean words
 
 boolean-true = gwir
 boolean-false = faos
 
-
 ## Answer buttons
 
 answer-submit-label = Gwiriañ
 answer-submit-label-no-correctness = Kas ar respont
-
 
 ## Sectional blocks
 
@@ -250,7 +231,6 @@ section-name =
     .solution = Diskoulm
     .task = Trevell
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -260,9 +240,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kuzul
-
 
 ## Tables and figures
 
@@ -273,7 +251,6 @@ table-name =
         [unnumbered-title] Taolenn{ ": " }
        *[unnumbered] Taolenn
     }
-
 figure-name =
     { $parts ->
         [numbered] Skeudenn { $enumeration }
@@ -282,22 +259,18 @@ figure-name =
        *[unnumbered] Skeudenn
     }
 
-
 ## Paginator controls
 
 paginator-previous = A-raok
 paginator-next = War-lerc'h
 paginator-page = Pajenn
-
 paginator-page-status = { $pageLabel } { $currentPage } war { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = pe
 piecewise-condition-if = ma
 piecewise-condition-otherwise = a-hend-all
-
 
 ## Chemistry
 
@@ -420,7 +393,6 @@ element-name =
     .lv = Livermoriom
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrur
     .c = Karbur
@@ -434,8 +406,6 @@ element-anion-name =
     .i = Iodur
     .at = Astatur
     .ts = Tenesur
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Arouez kimiek direizh
 chemistry-invalid-ionic-compound = Kevreadenn ionek direizh

--- a/packages/i18n/locales/brx/chrome.ftl
+++ b/packages/i18n/locales/brx/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = आनजाद खालामगासिनो दं…
 answer-submitting = दैथायगासिनो दं…
-
 answer-checking-status = फिनखौ आनजाद खालामगासिनो दं
 answer-submitting-status = फिनखौ दैथायगासिनो दं
-
 answer-correct = थार
 answer-incorrect = गोरोन्थि
-
 answer-response-saved = फिनखौ थिना दोनबाय
-
 answer-percent-credit = { $percent }% नम्बर
 answer-percent-correct = { $percent }% थार
 answer-percent-short = { $percent } %
-
 max-credit-available = मोनथाव गोबाव नम्बर: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] जेबो नाजाथाय गैया
         [one] { $count } नाजाथाय दंफैदं
        *[other] { $count } नाजाथाय दंफैदं
     }
-
 validation-correct = (थार)
 validation-incorrect = (गोरोन्थि)
 validation-partially-correct = (बाहागोजों थार)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId }नि थाखाय { $count } फिन दिन्थि
        *[other] { $answerId }नि थाखाय { $count } फिन दिन्थि
     }
 
-
 ## Disclosure panels
 
 feedback-heading = फिननाय
-
 collapsible-click-to-open = (खेवनो क्लिक खालाम)
 collapsible-click-to-close = (बन्द खालामनो क्लिक खालाम)
-
 collapsible-initializing = जागायगासिनो दं…
-
 footnote-show = आथिं टिप्पनी दिन्थि
 footnote-hide = आथिं टिप्पनी एरसुं
-
 description-more-information = गोबाव फोरमायथिहोग्रा
-
 
 ## Controls
 
 slider-previous = आगोलनि
 slider-next = उननि
-
 keyboard-open = कि-बोर्ड खेव
 keyboard-close = कि-बोर्ड बन्द खालाम
-
 choice-input-remove-choice = { $choice } बोखार
-
 matrix-remove-row = सारि बोखार
 matrix-add-row = सारि दाजाब
 matrix-remove-column = खाम्फा बोखार
 matrix-add-column = खाम्फा दाजाब
-
 subset-add-remove-points = बिन्दु दाजाब/बोखार
 subset-toggle-points-intervals = बिन्दु आरो अन्तराल सोलाय
 subset-move-points = बिन्दु सोलाय दिहुन
 subset-clear = हुखुमार
-
 orbital-add-row = सारि दाजाब
 orbital-remove-row = सारि बोखार
 orbital-add-box = बाक्सा दाजाब
@@ -86,13 +67,9 @@ orbital-remove-box = बाक्सा बोखार
 orbital-add-up-arrow = गोजौथिं थिर दाजाब
 orbital-add-down-arrow = गाहायथिं थिर दाजाब
 orbital-remove-arrow = थिर बोखार
-
 orbital-row-label = सारि { $row }नि लेबेल
-
 pretzel-answer = फिन
-
 summary-statistics-caption = { $column }नि साङ्ख्यिक सारसा
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = गणित बाथ्रानि सिगा�
 math-input-preview = सिगांथिं नुथाय
 math-input-invalid-expression = गोरोन्थि बाथ्रा:
 
-
 ## Document status
 
 viewer-initializing = जागायगासिनो दं…
 
-
 ## Errors
 
 error-heading = गोरोन्थि
-
 error-found-at =
     { $span ->
         [line] सारि { $startLine }आव मोनखांबाय।
        *[lines] सारि { $startLine }–{ $endLine }आव मोनखांबाय।
     }
-
 document-contains-errors = बे दस्ताबेजआव गोरोन्थि दं!
-
 diagnostic-heading-error = गोरोन्थि
 diagnostic-heading-warning = सांग्रांथि
 diagnostic-heading-information = फोरमायथिहोग्रा
 diagnostic-heading-hint = सिनायथि
-
 accessibility-heading-level-1 = WCAG AA मोनथाव जायगानि गोरोन्थि
 accessibility-heading-level-2 = मोनथाव जायगानि सांग्रांथि
-
 something-went-wrong = माबा गोरोन्थि जाबाय।
-
 renderer-load-failed = मोनसे दिन्थिग्रा लोड जाया। अननानै बिलाइखौ फिन लोड खालाम।
-
 core-start-failed = दस्ताबेज नुग्रा जागायनो हाया। अननानै बिलाइखौ फिन लोड खालाम।

--- a/packages/i18n/locales/brx/content.ftl
+++ b/packages/i18n/locales/brx/content.ftl
@@ -43,16 +43,13 @@ color =
     .purple = बेगुनि
     .pink = गुलापि
     .brown = खैरा
-
 # Bodo names a stroke's width with its ordinary words for large and small.
 line-width =
     .thick = गिदिर
     .thin = फिसा
-
 line-style =
     .dashed = बोखावनाय
     .dotted = बिन्दुजों
-
 fill-style =
     .horizontal = आथिं सारि
     .vertical = गोजौ सारि
@@ -60,7 +57,6 @@ fill-style =
     .backdiagonal = उल्था खारसा सारि
     .dots = बिन्दु
     .diamonds = समचतुर्भुज
-
 noun =
     .line = सारि
     .line-segment = सारि खण्ड
@@ -80,7 +76,6 @@ noun =
     .diamond = समचतुर्भुज
     .cross = गुणन सिन
     .plus = जोड़ सिन
-
 # «-भुजनि» takes the count and stands in front of the noun, so nothing follows
 # the adjectives and the tail is empty. The ending has one shape whatever
 # number lands before it.
@@ -89,10 +84,8 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides }-भुजनि समबहुभुज
     }
-
 # Nothing selects on it: Bodo has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -106,15 +99,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = आबुं
-
 # «-जों» is the instrumental postposition and follows what it governs, so the
 # pattern moves to the front of the phrase where English appends it. It has one
 # shape whatever precedes it, so welding it onto a placeable is sound.
@@ -123,7 +113,6 @@ style-filled =
         [pattern] { $pattern }जों { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern }जों { $filled } { $color } { $noun }
@@ -131,7 +120,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern }जों { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Bodo has no article, so the two `-article` branches read like their
 # neighbours; «आरो» is the conjunction and stands in front.
 style-border-clause =
@@ -141,36 +129,29 @@ style-border-clause =
         [and-article] आरो { $border } किनारजों
        *[with] { $border } किनारजों
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern }जों { $color } आबुंनाय
        *[plain] { $color } आबुंनाय
     }
-
 style-unfilled = आबुंआ
-
 # «-आव» is the locative postposition, and has one shape too.
 style-text =
     { $parts ->
         [background] { $background } फाइलआव { $color }
        *[plain] { $color }
     }
-
 style-background-none = जेबो गैया
-
 
 ## Boolean words
 
 boolean-true = थार
 boolean-false = फोसाब
 
-
 ## Answer buttons
 
 answer-submit-label = आनजाद खालाम
 answer-submit-label-no-correctness = फिन दैथाय
-
 
 ## Sectional blocks
 
@@ -195,7 +176,6 @@ section-name =
     .solution = सुस्रांथि
     .task = खामानि
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -205,9 +185,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = सिनायथि
-
 
 ## Tables and figures
 
@@ -218,7 +196,6 @@ table-name =
         [unnumbered-title] सारनी{ ": " }
        *[unnumbered] सारनी
     }
-
 figure-name =
     { $parts ->
         [numbered] मुसुखा { $enumeration }
@@ -227,26 +204,20 @@ figure-name =
        *[unnumbered] मुसुखा
     }
 
-
 ## Paginator controls
 
 paginator-previous = आगोलनि
 paginator-next = उननि
 paginator-page = बिलाइ
-
 # «X-निफ्राय Y» — "Y out of X" — puts the total first, so the two counts change
 # places. The ablative «-निफ्राय» has one shape whatever precedes it.
 paginator-page-status = { $numPages }-निफ्राय { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = एबा
-
 piecewise-condition-if = जुदि
-
 piecewise-condition-otherwise = एबा नङाब्ला
-
 
 ## Chemistry
 ##
@@ -263,6 +234,5 @@ piecewise-condition-otherwise = एबा नङाब्ला
 ## parallel text for whoever fills this in.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = गोरोन्थि रासायनिक सिन
 chemistry-invalid-ionic-compound = गोरोन्थि आयनिक यौगिक

--- a/packages/i18n/locales/bs/chrome.ftl
+++ b/packages/i18n/locales/bs/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Provjera…
 answer-submitting = Slanje…
-
 answer-checking-status = Provjera odgovora
 answer-submitting-status = Slanje odgovora
-
 answer-correct = Tačno
 answer-incorrect = Netačno
-
 answer-response-saved = Odgovor je sačuvan
-
 answer-percent-credit = { $percent }% bodova
 answer-percent-correct = { $percent }% tačno
 answer-percent-short = { $percent } %
-
 max-credit-available = Najviše mogućih bodova: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nema više pokušaja
@@ -45,11 +39,9 @@ attempts-remaining =
         [few] preostaju { $count } pokušaja
        *[other] preostaje { $count } pokušaja
     }
-
 validation-correct = (Tačno)
 validation-incorrect = (Netačno)
 validation-partially-correct = (Djelimično tačno)
-
 answer-show-responses =
     { $count ->
         [one] Prikaži { $count } odgovor na { $answerId }
@@ -57,42 +49,31 @@ answer-show-responses =
        *[other] Prikaži { $count } odgovora na { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Povratna informacija
-
 collapsible-click-to-open = (kliknite za otvaranje)
 collapsible-click-to-close = (kliknite za zatvaranje)
-
 collapsible-initializing = Pokretanje…
-
 footnote-show = Prikaži fusnotu
 footnote-hide = Sakrij fusnotu
-
 description-more-information = više informacija
-
 
 ## Controls
 
 slider-previous = Nazad
 slider-next = Naprijed
-
 keyboard-open = Otvori tastaturu
 keyboard-close = Zatvori tastaturu
-
 choice-input-remove-choice = Ukloni { $choice }
-
 matrix-remove-row = Ukloni red
 matrix-add-row = Dodaj red
 matrix-remove-column = Ukloni kolonu
 matrix-add-column = Dodaj kolonu
-
 subset-add-remove-points = Dodaj/ukloni tačke
 subset-toggle-points-intervals = Prebaci između tačaka i intervala
 subset-move-points = Pomjeri tačke
 subset-clear = Očisti
-
 orbital-add-row = Dodaj red
 orbital-remove-row = Ukloni red
 orbital-add-box = Dodaj okvir
@@ -100,13 +81,9 @@ orbital-remove-box = Ukloni okvir
 orbital-add-up-arrow = Dodaj strelicu nagore
 orbital-add-down-arrow = Dodaj strelicu nadolje
 orbital-remove-arrow = Ukloni strelicu
-
 orbital-row-label = Oznaka za red { $row }
-
 pretzel-answer = Odgovor
-
 summary-statistics-caption = Sažete statistike za { $column }
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = pregled matematičkog izraza
 math-input-preview = Pregled
 math-input-invalid-expression = Neispravan izraz:
 
-
 ## Document status
 
 viewer-initializing = Pokretanje…
 
-
 ## Errors
 
 error-heading = Greška
-
 error-found-at =
     { $span ->
         [line] Pronađena u redu { $startLine }.
        *[lines] Pronađena u redovima { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ovaj dokument sadrži greške!
-
 diagnostic-heading-error = Greška
 diagnostic-heading-warning = Upozorenje
 diagnostic-heading-information = Informacija
 diagnostic-heading-hint = Savjet
-
 accessibility-heading-level-1 = Kršenje pristupačnosti prema WCAG AA
 accessibility-heading-level-2 = Upozorenje o pristupačnosti
-
 something-went-wrong = Nešto je pošlo po zlu.
-
 renderer-load-failed = modul za prikaz nije se uspio učitati. Ponovo učitajte stranicu.
-
 core-start-failed = Pregledač dokumenta nije se mogao pokrenuti. Ponovo učitajte stranicu.

--- a/packages/i18n/locales/bs/content.ftl
+++ b/packages/i18n/locales/bs/content.ftl
@@ -168,7 +168,6 @@ color =
                    *[m] smeđ
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -192,7 +191,6 @@ line-width =
                    *[m] tanak
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -216,7 +214,6 @@ line-style =
                    *[m] tačkast
                 }
         }
-
 # Noun phrases in the instrumental, which is the case «sa» takes. They agree
 # with nothing.
 fill-style =
@@ -226,7 +223,6 @@ fill-style =
     .backdiagonal = obrnutim dijagonalnim linijama
     .dots = tačkama
     .diamonds = rombovima
-
 noun =
     .line = prava
     .line-segment = duž
@@ -246,7 +242,6 @@ noun =
     .diamond = romb
     .cross = križ
     .plus = plus
-
 # Bosnian keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -254,7 +249,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] pravilni { $numSides }-ougao
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (mnogougao, m) or
 # the head of a phrase the description never names: `border` (ivica, f), `fill`
 # (ispuna, f), `text` (tekst, m), `background` (pozadina, f).
@@ -279,7 +273,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -292,13 +285,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -306,13 +297,11 @@ style-filled-word =
         [f] ispunjena
        *[m] ispunjen
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } sa { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } sa { $pattern }
@@ -320,7 +309,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } sa { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ivica» is feminine, so the border's adjectives agree with it and not with the
 # shape it surrounds — and they are in the instrumental, which «sa» governs.
 # Bosnian has no article, so the two `-article` branches read like the two
@@ -332,7 +320,6 @@ style-border-clause =
         [and-article] i { $border } ivicom
        *[with] sa { $border } ivicom
     }
-
 # The fill-pattern words are instrumental plurals, because their other use is
 # the «sa { $pattern }» clause in `style-filled`. So this message supplies a
 # noun for them to hang off — «ispuna», feminine, which is the gender
@@ -343,17 +330,13 @@ style-fill =
         [pattern] { $color } ispuna sa { $pattern }
        *[plain] { $color } ispuna
     }
-
 style-unfilled = neispunjen
-
 style-text =
     { $parts ->
         [background] { $color } na { $background } pozadini
        *[plain] { $color }
     }
-
 style-background-none = nema
-
 
 ## Boolean words
 ##
@@ -365,12 +348,10 @@ style-background-none = nema
 boolean-true = tačno
 boolean-false = netačno
 
-
 ## Answer buttons
 
 answer-submit-label = Provjeri
 answer-submit-label-no-correctness = Pošalji odgovor
-
 
 ## Sectional blocks
 
@@ -395,7 +376,6 @@ section-name =
     .solution = Rješenje
     .task = Zadatak
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -405,9 +385,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Savjet
-
 
 ## Tables and figures
 
@@ -418,7 +396,6 @@ table-name =
         [unnumbered-title] Tabela{ ". " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Slika { $enumeration }
@@ -427,22 +404,18 @@ figure-name =
        *[unnumbered] Slika
     }
 
-
 ## Paginator controls
 
 paginator-previous = Prethodna
 paginator-next = Sljedeća
 paginator-page = Stranica
-
 paginator-page-status = { $pageLabel } { $currentPage } od { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ili
 piecewise-condition-if = ako
 piecewise-condition-otherwise = inače
-
 
 ## Chemistry
 ##
@@ -572,7 +545,6 @@ element-name =
     .lv = Livermorij
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrid
     .c = Karbid
@@ -586,8 +558,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tenesid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Neispravan hemijski simbol
 chemistry-invalid-ionic-compound = Neispravan jonski spoj

--- a/packages/i18n/locales/bua/chrome.ftl
+++ b/packages/i18n/locales/bua/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Шалгагдажа байна…
 answer-submitting = Эльгээгдэжэ байна…
-
 answer-checking-status = Харюу шалгагдажа байна
 answer-submitting-status = Харюу эльгээгдэжэ байна
-
 answer-correct = Зүб
 answer-incorrect = Буруу
-
 answer-response-saved = Харюу хадагалагдаба
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% зүб
 answer-percent-short = { $percent } %
-
 max-credit-available = Абажа болохо эгээ ехэ балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] оролдолго үлэбэгүй
         [one] { $count } оролдолго үлэбэ
        *[other] { $count } оролдолго үлэбэ
     }
-
 validation-correct = (Зүб)
 validation-incorrect = (Буруу)
 validation-partially-correct = (Хубиингаа зүб)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } дээрэ { $count } харюу харуулха
        *[other] { $answerId } дээрэ { $count } харюу харуулха
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Хариу дуулгалга
-
 collapsible-click-to-open = (нээхын тулада дарагты)
 collapsible-click-to-close = (хаахын тулада дарагты)
-
 collapsible-initializing = Бэлдэгдэжэ байна…
-
 footnote-show = Тэмдэглэл харуулха
 footnote-hide = Тэмдэглэл нюуха
-
 description-more-information = нэмэлтэ мэдээсэл
-
 
 ## Controls
 
 slider-previous = Урдахи
 slider-next = Дараахи
-
 keyboard-open = Хабтагай нээхэ
 keyboard-close = Хабтагай хааха
-
 choice-input-remove-choice = { $choice } шэлэлгые усадхаха
-
 matrix-remove-row = Мүр усадхаха
 matrix-add-row = Мүр нэмэхэ
 matrix-remove-column = Багана усадхаха
 matrix-add-column = Багана нэмэхэ
-
 subset-add-remove-points = Сэг нэмэхэ/усадхаха
 subset-toggle-points-intervals = Сэгүүд ба забһарнуудые һэлгэхэ
 subset-move-points = Сэгүүдые зөөхэ
 subset-clear = Арилгаха
-
 orbital-add-row = Мүр нэмэхэ
 orbital-remove-row = Мүр усадхаха
 orbital-add-box = Нүхэн нэмэхэ
@@ -91,13 +72,9 @@ orbital-remove-box = Нүхэн усадхаха
 orbital-add-up-arrow = Дээшээ һомо нэмэхэ
 orbital-add-down-arrow = Доошоо һомо нэмэхэ
 orbital-remove-arrow = Һомо усадхаха
-
 orbital-row-label = { $row } мүрэй тэмдэг
-
 pretzel-answer = Харюу
-
 summary-statistics-caption = { $column } баганын дүнгэй статистика
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = математическа илэрхэйлэлгы�
 math-input-preview = Урьдшалан харалга
 math-input-invalid-expression = Буруу илэрхэйлэлгэ:
 
-
 ## Document status
 
 viewer-initializing = Бэлдэгдэжэ байна…
 
-
 ## Errors
 
 error-heading = Алдуу
-
 error-found-at =
     { $span ->
         [line] Олдоһон мүр: { $startLine }.
        *[lines] Олдоһон мүрнүүд: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Энэ бэшэг соо алдуунууд бии!
-
 diagnostic-heading-error = Алдуу
 diagnostic-heading-warning = Һэргылэмжэ
 diagnostic-heading-information = Мэдээсэл
 diagnostic-heading-hint = Заабари
-
 accessibility-heading-level-1 = WCAG AA хүрэхэ аргын эбдэлгэ
 accessibility-heading-level-2 = Хүрэхэ аргын тухай мэдээсэл
-
 something-went-wrong = Юуншьеб буруу болобо.
-
 renderer-load-failed = зурагшые ашаалжа шадабагүй. Нюур шэнэлэгты.
-
 core-start-failed = Бэшэг харагшые эхилжэ шадабагүй. Нюур шэнэлэгты.

--- a/packages/i18n/locales/bua/content.ftl
+++ b/packages/i18n/locales/bua/content.ftl
@@ -38,15 +38,12 @@ color =
     .purple = нил ягаан
     .pink = ягаан
     .brown = хүрин
-
 line-width =
     .thick = бүдүүн
     .thin = нимгэн
-
 line-style =
     .dashed = таһаршаһан
     .dotted = сэгтэй
-
 # Noun phrases: they stand in front of «хээтэй» and modify nothing.
 fill-style =
     .horizontal = хэбтээ зурлаа
@@ -55,7 +52,6 @@ fill-style =
     .backdiagonal = харша диагональ зурлаа
     .dots = сэг
     .diamonds = ромб
-
 noun =
     .line = сэхэ зурлаа
     .line-segment = хэрчим
@@ -75,7 +71,6 @@ noun =
     .diamond = ромб
     .cross = хэрээһэн
     .plus = плюс
-
 # Buryat builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -83,11 +78,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] тэгшэ { $numSides } талата
     }
-
 # Buryat has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -101,21 +94,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = будагдаһан
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } хээтэй { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } хээтэй { $color } { $filled } { $noun }
@@ -123,7 +112,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } хээтэй { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «хизаартай» — "having an edge" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
@@ -133,15 +121,12 @@ style-border-clause =
         [and-article] ба { $border } хизаартай
        *[with] { $border } хизаартай
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } хээтэй { $color } будаг
        *[plain] { $color } будаг
     }
-
 style-unfilled = будагдаагүй
-
 # «дээрэ» — "on top of" — is a postposition and follows the background colour,
 # so nothing stands between the two words.
 style-text =
@@ -149,21 +134,17 @@ style-text =
         [background] { $background } дэбисхэр дээрэ { $color }
        *[plain] { $color }
     }
-
 style-background-none = үгы
-
 
 ## Boolean words
 
 boolean-true = үнэн
 boolean-false = худал
 
-
 ## Answer buttons
 
 answer-submit-label = Шалгаха
 answer-submit-label-no-correctness = Харюу эльгээхэ
-
 
 ## Sectional blocks
 
@@ -188,7 +169,6 @@ section-name =
     .solution = Шиидхэбэри
     .task = Даабари
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -198,9 +178,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Заабари
-
 
 ## Tables and figures
 
@@ -211,7 +189,6 @@ table-name =
         [unnumbered-title] Хүснэгтэ{ ". " }
        *[unnumbered] Хүснэгтэ
     }
-
 figure-name =
     { $parts ->
         [numbered] Зураг { $enumeration }
@@ -220,15 +197,12 @@ figure-name =
        *[unnumbered] Зураг
     }
 
-
 ## Paginator controls
 
 paginator-previous = Урдахи
 paginator-next = Дараахи
 paginator-page = Нюур
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -241,7 +215,6 @@ piecewise-condition-or = али
 piecewise-condition-if = хэрбээ
 piecewise-condition-otherwise = үгы һаа
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -250,6 +223,5 @@ piecewise-condition-otherwise = үгы һаа
 ## ones — the school-system case this batch shares throughout.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Буруу химическэ тэмдэг
 chemistry-invalid-ionic-compound = Буруу ионой холбоо

--- a/packages/i18n/locales/bum/chrome.ftl
+++ b/packages/i18n/locales/bum/chrome.ftl
@@ -13,73 +13,55 @@
 
 answer-checking = A ke yene nkobo...
 answer-submitting = A ke lômane nkobo...
-
 answer-checking-status = Nkobo wu ke yenban
 answer-submitting-status = Nkobo wu ke lômban
-
 answer-correct = Mvaé
 answer-incorrect = Abé
-
 answer-response-saved = Nkobo Wu Along
-
 answer-percent-credit = { $percent }% a Mapwan
 answer-percent-correct = { $percent }% Mvaé
 answer-percent-short = { $percent } %
-
 max-credit-available = Mapwan me ne fe abui: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] a nga bo mekeñ me ne fe te
         [one] mekeñ me ne fe { $count } m'a tôbô
        *[other] mekeñ me ne fe { $count } m'a tôbô
     }
-
 validation-correct = (Mvaé)
 validation-incorrect = (Abé)
 validation-partially-correct = (Mvaé asu ntôtôlô)
-
 answer-show-responses =
     { $count ->
         [one] Yene nkobo { $count } w'a { $answerId }
        *[other] Yene nkobo { $count } w'a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Njô
-
 collapsible-click-to-open = (bo klik asu na o kuli)
 collapsible-click-to-close = (bo klik asu na o kale)
-
 collapsible-initializing = A ke tebe...
-
 footnote-show = Yene ntili w'ase
 footnote-hide = Kasé ntili w'ase
-
 description-more-information = melu me bibsimilane
 
 ## Controls
 
 slider-previous = Avan
 slider-next = Apre
-
 keyboard-open = Kuli Klavye
 keyboard-close = Kale Klavye
-
 choice-input-remove-choice = Lôs { $choice }
-
 matrix-remove-row = Lôs ndamba
 matrix-add-row = Tôbô ndamba
 matrix-remove-column = Lôs kolonu
 matrix-add-column = Tôbô kolonu
-
 subset-add-remove-points = Tôbô/Lôs bipwɛ̃
 subset-toggle-points-intervals = Kelege bipwɛ̃ ai mintɛrval
 subset-move-points = Yenane Bipwɛ̃
 subset-clear = Wôé mese
-
 orbital-add-row = Tôbô Ndamba
 orbital-remove-row = Lôs Ndamba
 orbital-add-box = Tôbô Bwat
@@ -87,13 +69,9 @@ orbital-remove-box = Lôs Bwat
 orbital-add-up-arrow = Tôbô Flèsh Ya Ke Étam
 orbital-add-down-arrow = Tôbô Flèsh Ya Ke Asi
 orbital-remove-arrow = Lôs Flèsh
-
 orbital-row-label = Jôé a ndamba { $row }
-
 pretzel-answer = Nkobo
-
 summary-statistics-caption = Ntôtôlô statistik w'a { $column }
-
 
 ## Math input
 
@@ -101,34 +79,25 @@ math-input-preview-region = ntôtôlô a nônga ya mibalo
 math-input-preview = Nônga
 math-input-invalid-expression = Nônga é si mvaé ki:
 
-
 ## Document status
 
 viewer-initializing = A ke tebe...
 
-
 ## Errors
 
 error-heading = Abé
-
 error-found-at =
     { $span ->
         [line] A yiane ke ndamba { $startLine }.
        *[lines] A yiane ke ndamba { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Kalate nyi a ne bibé!
-
 diagnostic-heading-error = Abé
 diagnostic-heading-warning = Ayɔŋ
 diagnostic-heading-information = Melu
 diagnostic-heading-hint = Ajô
-
 accessibility-heading-level-1 = Ntyeñ WCAG AA w'akusa
 accessibility-heading-level-2 = Ayɔŋ w'akusa
-
 something-went-wrong = Jôm éziñ é nga bo abé.
-
 renderer-load-failed = ntolan é si kuli ki. Kobo pilibule ibumu.
-
 core-start-failed = Kalanga a kalate a si tebe ki. Kobo pilibule ibumu.

--- a/packages/i18n/locales/bum/content.ftl
+++ b/packages/i18n/locales/bum/content.ftl
@@ -90,7 +90,6 @@ color =
     .purple = violɛ
     .pink = rozɛ
     .brown = marɔ̃
-
 line-width =
     .thick =
         { $gender ->
@@ -102,13 +101,11 @@ line-width =
             [c1] môkekele
            *[c7] ékekele
         }
-
 # Written as an invariable «a bo …» phrase, so that it agrees with nothing
 # and can close the phrase. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = a bo tirɛ
     .dotted = a bo pwɛ̃
-
 fill-style =
     .horizontal = melal ma ne mimbaman
     .vertical = melal ma ne miyembane
@@ -116,7 +113,6 @@ fill-style =
     .backdiagonal = melal ma ne melogolo m'ényiñ
     .dots = bipwɛ̃
     .diamonds = bidiyaman
-
 noun =
     .line = liñ
     .line-segment = morso liñ
@@ -136,7 +132,6 @@ noun =
     .diamond = diyaman
     .cross = kwa
     .plus = plis
-
 # The side count is a relative complement and closes the noun phrase, so it
 # goes in the tail, following `locales/bem`'s shape for the same reason.
 noun-regular-polygon =
@@ -144,7 +139,6 @@ noun-regular-polygon =
         [tail] a ne bibalabala { $numSides }
        *[head] poligon é ne mvegan
     }
-
 # The noun class. `c7` is the default and the class of every loanword.
 noun-gender =
     { $noun ->
@@ -156,7 +150,6 @@ noun-gender =
         [border] c1
        *[other] c7
     }
-
 
 ## Style composition
 
@@ -170,25 +163,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c1] môlôné
        *[c7] élôné
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } a bo { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } a bo { $pattern }
@@ -196,7 +185,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } a bo { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «bɔr» is a loanword and takes no concord, so its describing words agree
 # with nothing and all four branches read alike, on `locales/bem`'s pattern
 # for its invariable «na».
@@ -207,35 +195,28 @@ style-border-clause =
         [and-article] a bo bɔr { $border }
        *[with] a bo bɔr { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = a si lôné ki
-
 style-text =
     { $parts ->
         [background] { $color } a bo fɔ̃ { $background }
        *[plain] { $color }
     }
-
 style-background-none = jôm éziñ te
-
 
 ## Boolean words
 
 boolean-true = mvaé
 boolean-false = abé
 
-
 ## Answer buttons
 
 answer-submit-label = Yene Nkobo
 answer-submit-label-no-correctness = Lôm Nkobo
-
 
 ## Sectional blocks
 
@@ -260,7 +241,6 @@ section-name =
     .solution = Sɔlisiɔ̃
     .task = Ésaé
     .theorem = Téyorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -270,7 +250,6 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ajô
 
 ## Tables and figures
@@ -282,7 +261,6 @@ table-name =
         [unnumbered-title] Tab{ ": " }
        *[unnumbered] Tab
     }
-
 figure-name =
     { $parts ->
         [numbered] Figɛr { $enumeration }
@@ -291,23 +269,18 @@ figure-name =
        *[unnumbered] Figɛr
     }
 
-
 ## Paginator controls
 
 paginator-previous = Avan
 paginator-next = Apre
 paginator-page = Ibumu
-
 paginator-page-status = { $pageLabel } { $currentPage } asu { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = nge
 piecewise-condition-if = nge
-
 piecewise-condition-otherwise = nge te fe
-
 
 ## Chemistry
 ##
@@ -320,6 +293,5 @@ piecewise-condition-otherwise = nge te fe
 ## table there and the fallback *is* the curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ébwaé a Kemi É Si Mvaé Ki
 chemistry-invalid-ionic-compound = Nkobo w'Ayɔ̃ Wu Si Mvaé Ki

--- a/packages/i18n/locales/ca/chrome.ftl
+++ b/packages/i18n/locales/ca/chrome.ftl
@@ -11,78 +11,60 @@
 # the compact millions, which nothing below counts to. So every
 # `{ $count -> … }` keeps the two branches the English source has.
 
+
 ## Answer submission
 
 answer-checking = S'està comprovant…
 answer-submitting = S'està enviant…
-
 answer-checking-status = S'està comprovant la resposta
 answer-submitting-status = S'està enviant la resposta
-
 answer-correct = Correcte
 answer-incorrect = Incorrecte
-
 answer-response-saved = Resposta desada
-
 answer-percent-credit = { $percent }% de la puntuació
 answer-percent-correct = { $percent }% correcte
 answer-percent-short = { $percent } %
-
 max-credit-available = Puntuació màxima disponible: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] no queda cap intent
         [one] queda { $count } intent
        *[other] queden { $count } intents
     }
-
 validation-correct = (Correcte)
 validation-incorrect = (Incorrecte)
 validation-partially-correct = (Parcialment correcte)
-
 answer-show-responses =
     { $count ->
         [one] Mostra { $count } resposta a { $answerId }
        *[other] Mostra { $count } respostes a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Comentaris
-
 collapsible-click-to-open = (feu clic per obrir)
 collapsible-click-to-close = (feu clic per tancar)
-
 collapsible-initializing = S'està inicialitzant…
-
 footnote-show = Mostra la nota al peu
 footnote-hide = Amaga la nota al peu
-
 description-more-information = més informació
-
 
 ## Controls
 
 slider-previous = Anterior
 slider-next = Següent
-
 keyboard-open = Obre el teclat
 keyboard-close = Tanca el teclat
-
 choice-input-remove-choice = Elimina { $choice }
-
 matrix-remove-row = Elimina una fila
 matrix-add-row = Afegeix una fila
 matrix-remove-column = Elimina una columna
 matrix-add-column = Afegeix una columna
-
 subset-add-remove-points = Afegeix/elimina punts
 subset-toggle-points-intervals = Alterna entre punts i intervals
 subset-move-points = Mou els punts
 subset-clear = Neteja
-
 orbital-add-row = Afegeix una fila
 orbital-remove-row = Elimina una fila
 orbital-add-box = Afegeix una casella
@@ -90,13 +72,9 @@ orbital-remove-box = Elimina una casella
 orbital-add-up-arrow = Afegeix una fletxa amunt
 orbital-add-down-arrow = Afegeix una fletxa avall
 orbital-remove-arrow = Elimina una fletxa
-
 orbital-row-label = Etiqueta de la fila { $row }
-
 pretzel-answer = Resposta
-
 summary-statistics-caption = Estadístiques resum de { $column }
-
 
 ## Math input
 
@@ -104,34 +82,25 @@ math-input-preview-region = previsualització de l'expressió matemàtica
 math-input-preview = Previsualització
 math-input-invalid-expression = Expressió no vàlida:
 
-
 ## Document status
 
 viewer-initializing = S'està inicialitzant…
 
-
 ## Errors
 
 error-heading = Error
-
 error-found-at =
     { $span ->
         [line] Trobat a la línia { $startLine }.
        *[lines] Trobat a les línies { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Aquest document conté errors!
-
 diagnostic-heading-error = Error
 diagnostic-heading-warning = Advertiment
 diagnostic-heading-information = Informació
 diagnostic-heading-hint = Suggeriment
-
 accessibility-heading-level-1 = Incompliment d'accessibilitat WCAG AA
 accessibility-heading-level-2 = Avís d'accessibilitat
-
 something-went-wrong = Alguna cosa ha anat malament.
-
 renderer-load-failed = un renderitzador no s'ha pogut carregar. Torneu a carregar la pàgina.
-
 core-start-failed = No s'ha pogut iniciar el visualitzador del document. Torneu a carregar la pàgina.

--- a/packages/i18n/locales/ca/content.ftl
+++ b/packages/i18n/locales/ca/content.ftl
@@ -58,7 +58,6 @@ color =
     .purple = porpra
     .pink = rosa
     .brown = marró
-
 line-width =
     .thick =
         { $gender ->
@@ -70,7 +69,6 @@ line-width =
             [f] prima
            *[m] prim
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -82,7 +80,6 @@ line-style =
             [f] puntejada
            *[m] puntejat
         }
-
 # Noun phrases standing behind «amb». They modify nothing and take no gender.
 fill-style =
     .horizontal = línies horitzontals
@@ -91,7 +88,6 @@ fill-style =
     .backdiagonal = línies diagonals inverses
     .dots = punts
     .diamonds = rombes
-
 noun =
     .line = línia
     .line-segment = segment
@@ -111,7 +107,6 @@ noun =
     .diamond = rombe
     .cross = creu
     .plus = signe més
-
 # The side count follows the style adjectives so that they stay beside the noun
 # they agree with, which is the split `noun-regular-polygon` exists for.
 noun-regular-polygon =
@@ -119,7 +114,6 @@ noun-regular-polygon =
         [tail] de { $numSides } costats
        *[head] polígon regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polígon, m) or the
 # head of a phrase the description never names: `border` (vora, f), `fill`
 # (emplenat, m), `text` (text, m), `background` (fons, m).
@@ -137,7 +131,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # The adjectives follow their noun, and the colour closes the run: «línia
@@ -152,25 +145,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] plena
        *[m] ple
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } amb { $pattern }
        *[plain] { $color } { $filled }
     }
-
 # The complement sits against the noun rather than at the end, unlike
 # `style-with-noun`: «ple de …» reads as «full of …», so «ple de 5 costats»
 # would say something else. «Polígon regular de 5 costats blau ple».
@@ -181,7 +170,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } amb { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «vora» is feminine, so the border's adjectives agree with it and not with the
 # shape it surrounds. Catalan does have an indefinite article, so the two
 # `-article` branches are the two that write «una».
@@ -192,7 +180,6 @@ style-border-clause =
         [and-article] i una vora { $border }
        *[with] amb vora { $border }
     }
-
 # «de color» avoids having to agree the colour with a plural pattern noun
 # («línies horitzontals de color vermell»).
 style-fill =
@@ -200,29 +187,23 @@ style-fill =
         [pattern] { $pattern } de color { $color }
        *[plain] { $color }
     }
-
 style-unfilled = sense emplenar
-
 style-text =
     { $parts ->
         [background] { $color } amb un fons { $background }
        *[plain] { $color }
     }
-
 style-background-none = cap
-
 
 ## Boolean words
 
 boolean-true = cert
 boolean-false = fals
 
-
 ## Answer buttons
 
 answer-submit-label = Comprova
 answer-submit-label-no-correctness = Envia la resposta
-
 
 ## Sectional blocks
 
@@ -247,7 +228,6 @@ section-name =
     .solution = Solució
     .task = Tasca
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -257,9 +237,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pista
-
 
 ## Tables and figures
 
@@ -270,7 +248,6 @@ table-name =
         [unnumbered-title] Taula{ ": " }
        *[unnumbered] Taula
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -279,22 +256,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anterior
 paginator-next = Següent
 paginator-page = Pàgina
-
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = si
 piecewise-condition-otherwise = altrament
-
 
 ## Chemistry
 
@@ -417,7 +390,6 @@ element-name =
     .lv = Livermori
     .ts = Tennes
     .og = Oganessó
-
 element-anion-name =
     .h = Hidrur
     .c = Carbur
@@ -431,8 +403,6 @@ element-anion-name =
     .i = Iodur
     .at = Astatur
     .ts = Tennesur
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Símbol químic no vàlid
 chemistry-invalid-ionic-compound = Compost iònic no vàlid

--- a/packages/i18n/locales/ce/chrome.ftl
+++ b/packages/i18n/locales/ce/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Талло…
 answer-submitting = ДӀадоьхуьйту…
-
 answer-checking-status = Жоп талло
 answer-submitting-status = Жоп дӀадоьхуьйту
-
 answer-correct = Нийса
 answer-incorrect = Нийса дац
-
 answer-response-saved = Жоп Ӏалашдина
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% нийса
 answer-percent-short = { $percent } %
-
 max-credit-available = Схьаэца тарлун сов баккхий балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] гӀорт йисина яц
         [one] { $count } гӀорт йисина
        *[other] { $count } гӀорт йисина
     }
-
 validation-correct = (Нийса)
 validation-incorrect = (Нийса дац)
 validation-partially-correct = (Дакъош нийса)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } тӀе { $count } жоп гайта
        *[other] { $answerId } тӀе { $count } жоп гайта
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ЮхаӀаткъам
-
 collapsible-click-to-open = (даста тӀетаӀае)
 collapsible-click-to-close = (дӀакъовла тӀетаӀае)
-
 collapsible-initializing = Кечдо…
-
 footnote-show = Билгалдар гайта
 footnote-hide = Билгалдар къайладаккха
-
 description-more-information = тӀетоьхна хаам
-
 
 ## Controls
 
 slider-previous = Хьалха
 slider-next = ТӀаьхьа
-
 keyboard-open = Клавиатура даста
 keyboard-close = Клавиатура дӀакъовла
-
 choice-input-remove-choice = { $choice } харжам дӀабаккха
-
 matrix-remove-row = МогӀа дӀабаккха
 matrix-add-row = МогӀа тӀетоха
 matrix-remove-column = Багана дӀаяккха
 matrix-add-column = Багана тӀетоха
-
 subset-add-remove-points = ТӀадам тӀетоха/дӀабаккха
 subset-toggle-points-intervals = ТӀадамаш а, юкъамаш а хийца
 subset-move-points = ТӀадамаш дӀадаха
 subset-clear = ЦӀандан
-
 orbital-add-row = МогӀа тӀетоха
 orbital-remove-row = МогӀа дӀабаккха
 orbital-add-box = Клетка тӀетоха
@@ -95,13 +76,9 @@ orbital-remove-box = Клетка дӀаяккха
 orbital-add-up-arrow = Лакхарчу тӀам тӀетоха
 orbital-add-down-arrow = Лахарчу тӀам тӀетоха
 orbital-remove-arrow = ТӀам дӀабаккха
-
 orbital-row-label = { $row } могӀанан хьаьрк
-
 pretzel-answer = Жоп
-
 summary-statistics-caption = { $column } баганин жамӀан статистика
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = математически билгалдаккха�
 math-input-preview = Хьалхара хьажар
 math-input-invalid-expression = Нийса доцу билгалдаккхар:
 
-
 ## Document status
 
 viewer-initializing = Кечдо…
 
-
 ## Errors
 
 error-heading = ГӀалат
-
 error-found-at =
     { $span ->
         [line] Каро могӀа: { $startLine }.
        *[lines] Каро могӀанаш: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = ХӀокху документехь гӀалаташ ду!
-
 diagnostic-heading-error = ГӀалат
 diagnostic-heading-warning = Тергамча
 diagnostic-heading-information = Хаам
 diagnostic-heading-hint = Хьехам
-
 accessibility-heading-level-1 = WCAG AA кхачаран дохор
 accessibility-heading-level-2 = Кхачаран хьокъехь хаам
-
 something-went-wrong = ХӀума нийса ца хилла.
-
 renderer-load-failed = сурт диллархо чуялийта ца делира. АгӀо керлаян.
-
 core-start-failed = Документан хьажархо болийта ца делира. АгӀо керлаян.

--- a/packages/i18n/locales/ce/content.ftl
+++ b/packages/i18n/locales/ce/content.ftl
@@ -63,15 +63,12 @@ color =
     .purple = сийна-цӀен
     .pink = цӀен-кӀайн
     .brown = мора
-
 line-width =
     .thick = дуькъа
     .thin = дораха
-
 line-style =
     .dashed = кагйина
     .dotted = тӀадамашца
-
 # Noun phrases: they stand in front of «сурташца» and modify nothing.
 fill-style =
     .horizontal = горизонталан сиз
@@ -80,7 +77,6 @@ fill-style =
     .backdiagonal = дуьхьал диагоналан сиз
     .dots = тӀадам
     .diamonds = ромб
-
 noun =
     .line = нийса сиз
     .line-segment = сизан дакъа
@@ -100,7 +96,6 @@ noun =
     .diamond = ромб
     .cross = жӀар
     .plus = плюс
-
 # Chechen builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -108,7 +103,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] нийса { $numSides } сонера
     }
-
 # The class of the noun being described, handed to every word that agrees with
 # it. See the note at the top of this file: only the entries this seed could
 # check are written out, and everything else falls to `d`.
@@ -128,7 +122,6 @@ noun-gender =
        *[other] d
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -141,13 +134,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # The one word in this catalog that carries a class prefix, and the reason
 # `$gender` exists here at all.
 style-filled-word =
@@ -157,13 +148,11 @@ style-filled-word =
         [v] вуьзна
        *[d] дуьзна
     }
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } сурташца { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } сурташца { $color } { $filled } { $noun }
@@ -171,7 +160,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } сурташца { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «йистеца» — "with an edge" — is a case form of a noun this catalog writes, so
 # nothing is welded to a placeable and no article is wanted.
 style-border-clause =
@@ -181,20 +169,17 @@ style-border-clause =
         [and-article] а { $border } йистеца
        *[with] { $border } йистеца
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } сурташца { $color } бос
        *[plain] { $color } бос
     }
-
 # The negated participle agrees in the language exactly as the positive one
 # does — «буьзна боцу», «юьзна йоцу», «вуьзна воцу» — but this message
 # describes a fill standing on its own, with no noun and therefore no
 # `$gender` reaching it. So the д-class form is written flat, and a fork here
 # would only ever render its default branch.
 style-unfilled = дуьзна доцу
-
 # «тӀехь» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.
 style-text =
@@ -202,21 +187,17 @@ style-text =
         [background] { $background } фон тӀехь { $color }
        *[plain] { $color }
     }
-
 style-background-none = дац
-
 
 ## Boolean words
 
 boolean-true = бакъ
 boolean-false = харц
 
-
 ## Answer buttons
 
 answer-submit-label = Таллар
 answer-submit-label-no-correctness = Жоп дӀадахьийта
-
 
 ## Sectional blocks
 
@@ -241,7 +222,6 @@ section-name =
     .solution = Сацам
     .task = Дехар
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -251,9 +231,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Хьехам
-
 
 ## Tables and figures
 
@@ -264,7 +242,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Сурт { $enumeration }
@@ -273,15 +250,12 @@ figure-name =
        *[unnumbered] Сурт
     }
 
-
 ## Paginator controls
 
 paginator-previous = Хьалха
 paginator-next = ТӀаьхьа
 paginator-page = АгӀо
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -294,7 +268,6 @@ piecewise-condition-or = я
 piecewise-condition-if = нагахь санна
 piecewise-condition-otherwise = кхечу агӀор
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -303,6 +276,5 @@ piecewise-condition-otherwise = кхечу агӀор
 ## ones — the school-system case this batch shares throughout.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Нийса доцу химин хьаьрк
 chemistry-invalid-ionic-compound = Нийса доцу ионан цхьаьнакхетар

--- a/packages/i18n/locales/ceb/chrome.ftl
+++ b/packages/i18n/locales/ceb/chrome.ftl
@@ -26,69 +26,50 @@
 
 answer-checking = Gisusi...
 answer-submitting = Gipadala...
-
 answer-checking-status = Gisusi ang tubag
 answer-submitting-status = Gipadala ang tubag
-
 answer-correct = Husto
 answer-incorrect = Sayop
-
 answer-response-saved = Natipigan ang Tubag
-
 answer-percent-credit = { $percent }% nga puntos
 answer-percent-correct = { $percent }% husto
 answer-percent-short = { $percent }%
-
 max-credit-available = Kinatas-ang puntos nga makuha: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] wala nay nahibiling higayon
        *[other] nahibilin nga { $count } ka higayon
     }
-
 validation-correct = (Husto)
 validation-incorrect = (Sayop)
 validation-partially-correct = (Husto ang pipila)
-
 answer-show-responses = Ipakita ang { $count } ka tubag ngadto sa { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Puna
-
 collapsible-click-to-open = (i-klik aron ablihan)
 collapsible-click-to-close = (i-klik aron sirad-an)
-
 collapsible-initializing = Nagsugod...
-
 footnote-show = Ipakita ang nota sa tiilan
 footnote-hide = Itago ang nota sa tiilan
-
 description-more-information = dugang impormasyon
-
 
 ## Controls
 
 slider-previous = Miagi
 slider-next = Sunod
-
 keyboard-open = Ablihi ang keyboard
 keyboard-close = Sirad-i ang keyboard
-
 choice-input-remove-choice = Kuhaa ang { $choice }
-
 matrix-remove-row = Kuhaa ang laray
 matrix-add-row = Pagdugang ug laray
 matrix-remove-column = Kuhaa ang kolum
 matrix-add-column = Pagdugang ug kolum
-
 subset-add-remove-points = Pagdugang/Pagkuha ug mga punto
 subset-toggle-points-intervals = Ilisan ang mga punto ug interbalo
 subset-move-points = Ibalhin ang mga Punto
 subset-clear = Hawani
-
 orbital-add-row = Pagdugang ug Laray
 orbital-remove-row = Kuhaa ang Laray
 orbital-add-box = Pagdugang ug Kahon
@@ -96,13 +77,9 @@ orbital-remove-box = Kuhaa ang Kahon
 orbital-add-up-arrow = Pagdugang ug Pana Pataas
 orbital-add-down-arrow = Pagdugang ug Pana Paubos
 orbital-remove-arrow = Kuhaa ang Pana
-
 orbital-row-label = Label sa laray { $row }
-
 pretzel-answer = Tubag
-
 summary-statistics-caption = Lagom nga estadistika sa { $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = pasiuna nga panan-aw sa ekspresyon sa matematika
 math-input-preview = Pasiuna nga panan-aw
 math-input-invalid-expression = Dili balido nga ekspresyon:
 
-
 ## Document status
 
 viewer-initializing = Nagsugod...
 
-
 ## Errors
 
 error-heading = Sayop
-
 error-found-at =
     { $span ->
         [line] Nakit-an sa linya { $startLine }.
        *[lines] Nakit-an sa mga linya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Kini nga dokumento adunay mga sayop!
-
 diagnostic-heading-error = Sayop
 diagnostic-heading-warning = Pasidaan
 diagnostic-heading-information = Impormasyon
 diagnostic-heading-hint = Timailhan
-
 accessibility-heading-level-1 = Paglapas sa aksesibilidad nga WCAG AA
 accessibility-heading-level-2 = Pahimangno sa aksesibilidad
-
 something-went-wrong = Adunay nasayop.
-
 renderer-load-failed = adunay renderer nga wala makarga. Palihog i-reload ang panid.
-
 core-start-failed = Wala masugdan ang tigtan-aw sa dokumento. Palihog i-reload ang panid.

--- a/packages/i18n/locales/ceb/content.ftl
+++ b/packages/i18n/locales/ceb/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = purpura
     .pink = rosas
     .brown = tabunon
-
 line-width =
     .thick = baga
     .thin = nipis
-
 line-style =
     .dashed = putol-putol
     .dotted = tuldok-tuldok
-
 # Noun phrases: they follow «uban ang» and modify nothing, so they take no
 # linker.
 fill-style =
@@ -55,7 +52,6 @@ fill-style =
     .backdiagonal = mga linya nga pahilis pabalik
     .dots = mga tuldok
     .diamonds = mga diyamante
-
 noun =
     .line = linya
     .line-segment = bahin sa linya
@@ -75,7 +71,6 @@ noun =
     .diamond = diyamante
     .cross = krus
     .plus = timaan sa dugang
-
 # The side count follows the noun with «nga» and «ka», the numeral linker, and
 # precedes the adjectives, so it folds into the head and there is no tail:
 # «regular nga poligono nga { $numSides } ka kilid».
@@ -84,11 +79,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regular nga poligono nga { $numSides } ka kilid
     }
-
 # Cebuano has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,7 +97,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and the linker introduces its adjectives: «linya nga baga nga
 # putol-putol nga pula».
 style-with-noun =
@@ -112,15 +104,12 @@ style-with-noun =
         [noun-tail] { $noun } nga { $description } { $nounTail }
        *[noun] { $noun } nga { $description }
     }
-
 style-filled-word = puno
-
 style-filled =
     { $parts ->
         [pattern] { $filled } nga { $color } uban ang { $pattern }
        *[plain] { $filled } nga { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } nga { $filled } nga { $color } uban ang { $pattern }
@@ -128,7 +117,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } nga { $filled } nga { $color } uban ang { $pattern }
        *[plain] { $noun } nga { $filled } nga { $color }
     }
-
 # Cebuano needs no article, so the `-article` branches read like the ones
 # without.
 style-border-clause =
@@ -138,36 +126,29 @@ style-border-clause =
         [and-article] ug utlanan nga { $border }
        *[with] uban ang utlanan nga { $border }
     }
-
 # The pattern is a noun and the colour follows it with the linker.
 style-fill =
     { $parts ->
         [pattern] { $pattern } nga { $color }
        *[plain] { $color }
     }
-
 style-unfilled = walay sulod
-
 style-text =
     { $parts ->
         [background] { $color } uban ang luyo nga { $background }
        *[plain] { $color }
     }
-
 style-background-none = wala
-
 
 ## Boolean words
 
 boolean-true = tinuod
 boolean-false = bakak
 
-
 ## Answer buttons
 
 answer-submit-label = Susiha ang Buhat
 answer-submit-label-no-correctness = Ipadala ang Tubag
-
 
 ## Sectional blocks
 
@@ -192,7 +173,6 @@ section-name =
     .solution = Solusyon
     .task = Buluhaton
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -202,9 +182,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Timailhan
-
 
 ## Tables and figures
 
@@ -217,7 +195,6 @@ table-name =
         [unnumbered-title] Talaan{ ": " }
        *[unnumbered] Talaan
     }
-
 figure-name =
     { $parts ->
         [numbered] Hulagway { $enumeration }
@@ -226,22 +203,18 @@ figure-name =
        *[unnumbered] Hulagway
     }
 
-
 ## Paginator controls
 
 paginator-previous = Miagi
 paginator-next = Sunod
 paginator-page = Panid
-
 paginator-page-status = { $pageLabel } { $currentPage } sa { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = kon
 piecewise-condition-otherwise = kon dili
-
 
 ## Chemistry
 ##
@@ -253,6 +226,5 @@ piecewise-condition-otherwise = kon dili
 ## and for the same school system rather than for two different reasons.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Dili Balido nga Simbolo sa Kemikal
 chemistry-invalid-ionic-compound = Dili Balido nga Ionic nga Compound

--- a/packages/i18n/locales/ch/chrome.ftl
+++ b/packages/i18n/locales/ch/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Machecheki…
 answer-submitting = Manmanenå'i…
-
 answer-checking-status = Machecheki i ineppe'
 answer-submitting-status = Manmanenå'i i ineppe'
-
 answer-correct = Korekto
 answer-incorrect = Ti korekto
-
 answer-response-saved = Masåtba i ineppe'
-
 answer-percent-credit = { $percent }% na kredito
 answer-percent-correct = { $percent }% korekto
 answer-percent-short = { $percent } %
-
 max-credit-available = I mås takhilo' na kredito ni siña masodda': { $percent }%
-
 # No select: «chinagi» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -45,51 +39,38 @@ attempts-remaining =
         [0] taya' mås chinagi ni sesetbe
        *[other] { $count } na chinagi sesetbe ha'
     }
-
 validation-correct = (Korekto)
 validation-incorrect = (Ti korekto)
 validation-partially-correct = (Korekto gi patte)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Na'annok { $count } na ineppe' para i { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Kumentåyu
-
 collapsible-click-to-open = (klek para u mababa)
 collapsible-click-to-close = (klek para u mahuchom)
-
 collapsible-initializing = Matutuhon…
-
 footnote-show = Na'annok i footnote
 footnote-hide = Na'atok i footnote
-
 description-more-information = mås infotmasion
-
 
 ## Controls
 
 slider-previous = Antes
 slider-next = Sigiente
-
 keyboard-open = Baba i tekladu
 keyboard-close = Huchom i tekladu
-
 choice-input-remove-choice = Na'suha i { $choice }
-
 matrix-remove-row = Na'suha i liña
 matrix-add-row = Na'saga un liña
 matrix-remove-column = Na'suha i kolumna
 matrix-add-column = Na'saga un kolumna
-
 subset-add-remove-points = Na'saga/Na'suha puntos
 subset-toggle-points-intervals = Tulaika puntos yan intetbalu
 subset-move-points = Na'mudda i puntos
 subset-clear = Na'gasgas
-
 orbital-add-row = Na'saga un liña
 orbital-remove-row = Na'suha i liña
 orbital-add-box = Na'saga un kahon
@@ -97,13 +78,9 @@ orbital-remove-box = Na'suha i kahon
 orbital-add-up-arrow = Na'saga un flecha hulo'
 orbital-add-down-arrow = Na'saga un flecha papa'
 orbital-remove-arrow = Na'suha i flecha
-
 orbital-row-label = Etiketa para i liña { $row }
-
 pretzel-answer = Ineppe'
-
 summary-statistics-caption = Kabåles na estadistika i { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = fine'nana na atan i ekspresion matemåtika
 math-input-preview = Fine'nana na atan
 math-input-invalid-expression = Ti maolek na ekspresion:
 
-
 ## Document status
 
 viewer-initializing = Matutuhon…
 
-
 ## Errors
 
 error-heading = Linachi
-
 error-found-at =
     { $span ->
         [line] Masodda' gi liña { $startLine }.
        *[lines] Masodda' gi liña { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Guaha linachi este na dokumento!
-
 diagnostic-heading-error = Linachi
 diagnostic-heading-warning = Adbertensia
 diagnostic-heading-information = Infotmasion
 diagnostic-heading-hint = Hinasso
-
 accessibility-heading-level-1 = Kinentra i akseso WCAG AA
 accessibility-heading-level-2 = Adbertensia put i akseso
-
 something-went-wrong = Guaha ti maolek.
-
 renderer-load-failed = guaha renderer ni ti masetbe. Pot fabot na'nuebu i påhina.
-
 core-start-failed = Ti siña matutuhon i atan i dokumento. Pot fabot na'nuebu i påhina.

--- a/packages/i18n/locales/ch/content.ftl
+++ b/packages/i18n/locales/ch/content.ftl
@@ -38,15 +38,12 @@ color =
     .purple = lila
     .pink = rosåda
     .brown = kulot chukulåti
-
 line-width =
     .thick = damo'
     .thin = dilikåo
-
 line-style =
     .dashed = ma'ipe'-ipe'
     .dotted = tuntos-tuntos
-
 # Noun phrases. Chamorro marks no plural on the noun, so «liña» is the word for
 # one line and for many alike.
 fill-style =
@@ -56,7 +53,6 @@ fill-style =
     .backdiagonal = liña diagonåt ma'atrasa
     .dots = tuntos
     .diamonds = diamånti
-
 noun =
     .line = liña
     .line-segment = pidåson liña
@@ -76,7 +72,6 @@ noun =
     .diamond = diamånti
     .cross = kilu'us
     .plus = mås
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -84,11 +79,9 @@ noun-regular-polygon =
         [tail] ni guaha { $numSides } na kanton
        *[head] poligono regulåt
     }
-
 # One answer for every noun: Chamorro has no grammatical gender, and its Spanish
 # loans do not carry Spanish agreement either.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -102,22 +95,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = bula
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } yan { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } yan { $pattern }
@@ -125,7 +114,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } yan { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Chamorro's «i» is the definite article and is not what English's "a" is doing
 # here, so all four branches read alike but for the connective: «yan» opens the
 # first clause and «yan lokkue'» a further one.
@@ -136,35 +124,28 @@ style-border-clause =
         [and-article] yan lokkue' kanton { $border }
        *[with] yan kanton { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ti bula
-
 style-text =
     { $parts ->
         [background] { $color } yan i tatte { $background }
        *[plain] { $color }
     }
-
 style-background-none = taya'
-
 
 ## Boolean words
 
 boolean-true = magåhet
 boolean-false = dinagi
 
-
 ## Answer buttons
 
 answer-submit-label = Cheki i che'cho'
 answer-submit-label-no-correctness = Na'hålom i ineppe'
-
 
 ## Sectional blocks
 
@@ -191,7 +172,6 @@ section-name =
     .solution = Solusion
     .task = Cho'cho'
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -201,9 +181,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Hinasso
-
 
 ## Tables and figures
 
@@ -214,7 +192,6 @@ table-name =
         [unnumbered-title] Låmasa{ ": " }
        *[unnumbered] Låmasa
     }
-
 figure-name =
     { $parts ->
         [numbered] Litråtu { $enumeration }
@@ -223,22 +200,18 @@ figure-name =
        *[unnumbered] Litråtu
     }
 
-
 ## Paginator controls
 
 paginator-previous = Antes
 paginator-next = Sigiente
 paginator-page = Påhina
-
 paginator-page-status = { $pageLabel } { $currentPage } gi { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = pat
 piecewise-condition-if = yanggen
 piecewise-condition-otherwise = yanggen ti
-
 
 ## Chemistry
 ##
@@ -250,6 +223,5 @@ piecewise-condition-otherwise = yanggen ti
 ## there is neither a Chamorro table nor a Spanish one behind it.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ti maolek na simbolon kimika
 chemistry-invalid-ionic-compound = Ti maolek na kompuesto ioniko

--- a/packages/i18n/locales/chm/chrome.ftl
+++ b/packages/i18n/locales/chm/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Тергалтеш…
 answer-submitting = Колталтеш…
-
 answer-checking-status = Вашмут тергалтеш
 answer-submitting-status = Вашмут колталтеш
-
 answer-correct = Чын
 answer-incorrect = Чын огыл
-
 answer-response-saved = Вашмут аралалте
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% чын
 answer-percent-short = { $percent } %
-
 max-credit-available = Налаш лийше эн кугу балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] тӧчымаш кодын огыл
         [one] { $count } тӧчымаш кодын
        *[other] { $count } тӧчымаш кодын
     }
-
 validation-correct = (Чын)
 validation-incorrect = (Чын огыл)
 validation-partially-correct = (Ужашын чын)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } ӱмбак { $count } вашмутым ончыкташ
        *[other] { $answerId } ӱмбак { $count } вашмутым ончыкташ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Мӧҥгеш каласымаш
-
 collapsible-click-to-open = (почаш темдал)
 collapsible-click-to-close = (петыраш темдал)
-
 collapsible-initializing = Ямдылалтеш…
-
 footnote-show = Палемдымашым ончыкташ
 footnote-hide = Палемдымашым шылташ
-
 description-more-information = ешартыш увер
-
 
 ## Controls
 
 slider-previous = Ончычсо
 slider-next = Вес
-
 keyboard-open = Клавиатурым почаш
 keyboard-close = Клавиатурым петыраш
-
 choice-input-remove-choice = { $choice } ойырымашым кораҥдаш
-
 matrix-remove-row = Радамым кораҥдаш
 matrix-add-row = Радамым ешараш
 matrix-remove-column = Меҥгым кораҥдаш
 matrix-add-column = Меҥгым ешараш
-
 subset-add-remove-points = Точкым ешараш/кораҥдаш
 subset-toggle-points-intervals = Точко ден кокласым вашталташ
 subset-move-points = Точко-влакым кусараш
 subset-clear = Эрыкташ
-
 orbital-add-row = Радамым ешараш
 orbital-remove-row = Радамым кораҥдаш
 orbital-add-box = Клеткым ешараш
@@ -91,13 +72,9 @@ orbital-remove-box = Клеткым кораҥдаш
 orbital-add-up-arrow = Кӱшкӧ пикшым ешараш
 orbital-add-down-arrow = Ӱлыкӧ пикшым ешараш
 orbital-remove-arrow = Пикшым кораҥдаш
-
 orbital-row-label = { $row } радамын палыже
-
 pretzel-answer = Вашмут
-
 summary-statistics-caption = { $column } меҥгын иктешлыме статистикыже
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = математический ойлымашын он
 math-input-preview = Ончылгоч ончымаш
 math-input-invalid-expression = Чын огыл ойлымаш:
 
-
 ## Document status
 
 viewer-initializing = Ямдылалтеш…
 
-
 ## Errors
 
 error-heading = Йоҥылыш
-
 error-found-at =
     { $span ->
         [line] Муымо радам: { $startLine }.
        *[lines] Муымо радам-влак: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Тиде документыште йоҥылыш-влак улыт!
-
 diagnostic-heading-error = Йоҥылыш
 diagnostic-heading-warning = Шижтарымаш
 diagnostic-heading-information = Увер
 diagnostic-heading-hint = Ой
-
 accessibility-heading-level-1 = WCAG AA шуын кертмашын пудыртымашыже
 accessibility-heading-level-2 = Шуын кертмаш нерген увер
-
 something-went-wrong = Ала-мо чын огыл лие.
-
 renderer-load-failed = сӱретызым налаш ыш лий. Лаштыкым уэмде.
-
 core-start-failed = Документым ончышым чӱкташ ыш лий. Лаштыкым уэмде.

--- a/packages/i18n/locales/chm/content.ftl
+++ b/packages/i18n/locales/chm/content.ftl
@@ -38,15 +38,12 @@ color =
     .purple = фиолетовый
     .pink = роза тӱсан
     .brown = кӱрен
-
 line-width =
     .thick = кӱжгӧ
     .thin = вичкыж
-
 line-style =
     .dashed = кӱрылтшӧ
     .dotted = точкан
-
 # Noun phrases: they stand in front of «сӱретан» and modify nothing.
 fill-style =
     .horizontal = горизонтальный линий
@@ -55,7 +52,6 @@ fill-style =
     .backdiagonal = ваштареш диагональный линий
     .dots = точко
     .diamonds = ромб
-
 noun =
     .line = вияш линий
     .line-segment = ужаш
@@ -75,7 +71,6 @@ noun =
     .diamond = ромб
     .cross = вашкыл
     .plus = плюс
-
 # Mari builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -83,11 +78,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] тӧр { $numSides } лукан
     }
-
 # Mari has no grammatical gender, so every noun answers the same and the answer
 # goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -101,21 +94,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = чиялтыме
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } сӱретан { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } сӱретан { $color } { $filled } { $noun }
@@ -123,7 +112,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } сӱретан { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «тӱран» — "having an edge" — carries the whole of "with a border" in its own
 # suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
@@ -133,15 +121,12 @@ style-border-clause =
         [and-article] да { $border } тӱран
        *[with] { $border } тӱран
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } сӱретан { $color } чия
        *[plain] { $color } чия
     }
-
 style-unfilled = чиялтыдыме
-
 # «ӱмбалне» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.
 style-text =
@@ -149,21 +134,17 @@ style-text =
         [background] { $background } фон ӱмбалне { $color }
        *[plain] { $color }
     }
-
 style-background-none = уке
-
 
 ## Boolean words
 
 boolean-true = чын
 boolean-false = чын огыл
 
-
 ## Answer buttons
 
 answer-submit-label = Тергаш
 answer-submit-label-no-correctness = Вашмутым колташ
-
 
 ## Sectional blocks
 
@@ -188,7 +169,6 @@ section-name =
     .solution = Решений
     .task = Пашаж
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -198,9 +178,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ой
-
 
 ## Tables and figures
 
@@ -211,7 +189,6 @@ table-name =
         [unnumbered-title] Таблице{ ". " }
        *[unnumbered] Таблице
     }
-
 figure-name =
     { $parts ->
         [numbered] Сӱрет { $enumeration }
@@ -220,15 +197,12 @@ figure-name =
        *[unnumbered] Сӱрет
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ончычсо
 paginator-next = Вес
 paginator-page = Лаштык
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -242,7 +216,6 @@ piecewise-condition-or = але
 piecewise-condition-if = гын
 piecewise-condition-otherwise = вес семын
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -251,6 +224,5 @@ piecewise-condition-otherwise = вес семын
 ## ones — the school-system case this batch shares throughout.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Чын огыл химический пале
 chemistry-invalid-ionic-compound = Чын огыл ион ушымаш

--- a/packages/i18n/locales/co/chrome.ftl
+++ b/packages/i18n/locales/co/chrome.ftl
@@ -15,74 +15,55 @@
 
 answer-checking = Verificazione…
 answer-submitting = Mandata…
-
 answer-checking-status = Verificazione di a risposta
 answer-submitting-status = Mandata di a risposta
-
 answer-correct = Ghjustu
 answer-incorrect = Sbagliatu
-
 answer-response-saved = Risposta arregistrata
-
 answer-percent-credit = { $percent }% di punti
 answer-percent-correct = { $percent }% ghjustu
 answer-percent-short = { $percent } %
-
 max-credit-available = Punti massimi pussibuli: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ùn ci sò più prove
         [one] ferma { $count } prova
        *[other] fermanu { $count } prove
     }
-
 validation-correct = (Ghjustu)
 validation-incorrect = (Sbagliatu)
 validation-partially-correct = (In parte ghjustu)
-
 answer-show-responses =
     { $count ->
         [one] Mustrà { $count } risposta à { $answerId }
        *[other] Mustrà { $count } risposte à { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Cummentu
-
 collapsible-click-to-open = (cliccà per apre)
 collapsible-click-to-close = (cliccà per chjude)
-
 collapsible-initializing = Avviu…
-
 footnote-show = Mustrà a nota
 footnote-hide = Piattà a nota
-
 description-more-information = più infurmazione
-
 
 ## Controls
 
 slider-previous = Precedente
 slider-next = Seguente
-
 keyboard-open = Apre a tastera
 keyboard-close = Chjude a tastera
-
 choice-input-remove-choice = Toglie { $choice }
-
 matrix-remove-row = Toglie una fila
 matrix-add-row = Aghjunghje una fila
 matrix-remove-column = Toglie una culonna
 matrix-add-column = Aghjunghje una culonna
-
 subset-add-remove-points = Aghjunghje/toglie punti
 subset-toggle-points-intervals = Cambià trà punti è intervalli
 subset-move-points = Spustà i punti
 subset-clear = Nettà
-
 orbital-add-row = Aghjunghje una fila
 orbital-remove-row = Toglie una fila
 orbital-add-box = Aghjunghje una casella
@@ -90,13 +71,9 @@ orbital-remove-box = Toglie una casella
 orbital-add-up-arrow = Aghjunghje una freccia in sù
 orbital-add-down-arrow = Aghjunghje una freccia in ghjù
 orbital-remove-arrow = Toglie una freccia
-
 orbital-row-label = Etichetta di a fila { $row }
-
 pretzel-answer = Risposta
-
 summary-statistics-caption = Statistiche riassuntive di { $column }
-
 
 ## Math input
 
@@ -104,34 +81,25 @@ math-input-preview-region = anteprima di l'espressione matematica
 math-input-preview = Anteprima
 math-input-invalid-expression = Espressione invalida:
 
-
 ## Document status
 
 viewer-initializing = Avviu…
 
-
 ## Errors
 
 error-heading = Errore
-
 error-found-at =
     { $span ->
         [line] Trovu à a linea { $startLine }.
        *[lines] Trovu à e linee { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Stu documentu cuntene errori!
-
 diagnostic-heading-error = Errore
 diagnostic-heading-warning = Avvertimentu
 diagnostic-heading-information = Infurmazione
 diagnostic-heading-hint = Indiziu
-
 accessibility-heading-level-1 = Viulazione di l'accessibilità secondu WCAG AA
 accessibility-heading-level-2 = Avvisu d'accessibilità
-
 something-went-wrong = Qualcosa hè andata male.
-
 renderer-load-failed = un modulu di visualizazione ùn s'hè caricatu. Ricarica a pagina.
-
 core-start-failed = U visualizatore di u documentu ùn s'hè pussutu avvià. Ricarica a pagina.

--- a/packages/i18n/locales/co/content.ftl
+++ b/packages/i18n/locales/co/content.ftl
@@ -57,7 +57,6 @@ color =
     .purple = viola
     .pink = rosa
     .brown = marrone
-
 line-width =
     .thick =
         { $gender ->
@@ -65,7 +64,6 @@ line-width =
            *[m] grossu
         }
     .thin = sottile
-
 line-style =
     .dashed =
         { $gender ->
@@ -77,7 +75,6 @@ line-style =
             [f] puntighjata
            *[m] puntighjatu
         }
-
 # Plural noun phrases, which is what follows «cù» in `style-filled`. They agree
 # with nothing.
 fill-style =
@@ -87,7 +84,6 @@ fill-style =
     .backdiagonal = linee diagunali inverse
     .dots = punti
     .diamonds = rombi
-
 noun =
     .line = retta
     .line-segment = segmentu
@@ -107,13 +103,11 @@ noun =
     .diamond = rombu
     .cross = croce
     .plus = più
-
 noun-regular-polygon =
     { $part ->
         [tail] di { $numSides } lati
        *[head] puligonu regulare
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (puligonu, m) or
 # the head of a phrase the description never names: `border` (orlu, m), `fill`
 # (riempimentu, m), `text` (testu, m), `background` (fondu, m).
@@ -130,7 +124,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -143,7 +136,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it, which is the opposite of
 # English. A noun that splits — the regular polygon — puts its complement after
 # the adjectives that agree with its head.
@@ -152,19 +144,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] piena
        *[m] pienu
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } cù { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } cù { $pattern }
@@ -172,7 +161,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } cù { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «orlu» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds.
 style-border-clause =
@@ -182,7 +170,6 @@ style-border-clause =
         [and-article] è un orlu { $border }
        *[with] cù orlu { $border }
     }
-
 # The fill-pattern words are plural nouns, because their other use is the
 # «cù { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «riempimentu», masculine, which is the gender
@@ -192,29 +179,23 @@ style-fill =
         [pattern] riempimentu { $color } cù { $pattern }
        *[plain] riempimentu { $color }
     }
-
 style-unfilled = micca pienu
-
 style-text =
     { $parts ->
         [background] { $color } nantu à un fondu { $background }
        *[plain] { $color }
     }
-
 style-background-none = nunda
-
 
 ## Boolean words
 
 boolean-true = veru
 boolean-false = falsu
 
-
 ## Answer buttons
 
 answer-submit-label = Verificà
 answer-submit-label-no-correctness = Mandà a risposta
-
 
 ## Sectional blocks
 
@@ -239,7 +220,6 @@ section-name =
     .solution = Suluzione
     .task = Cumpitu
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -249,9 +229,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Indiziu
-
 
 ## Tables and figures
 
@@ -262,7 +240,6 @@ table-name =
         [unnumbered-title] Tavula{ ". " }
        *[unnumbered] Tavula
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -271,22 +248,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Precedente
 paginator-next = Seguente
 paginator-page = Pagina
-
 paginator-page-status = { $pageLabel } { $currentPage } di { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = sè
 piecewise-condition-otherwise = altrimenti
-
 
 ## Chemistry
 ##
@@ -297,6 +270,5 @@ piecewise-condition-otherwise = altrimenti
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbulu chimicu invalidu
 chemistry-invalid-ionic-compound = Cumpostu ionicu invalidu

--- a/packages/i18n/locales/cs/chrome.ftl
+++ b/packages/i18n/locales/cs/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Probíhá kontrola…
 answer-submitting = Probíhá odesílání…
-
 answer-checking-status = Kontrola odpovědi
 answer-submitting-status = Odesílání odpovědi
-
 answer-correct = Správně
 answer-incorrect = Nesprávně
-
 answer-response-saved = Odpověď uložena
-
 answer-percent-credit = { $percent } % hodnocení
 answer-percent-correct = { $percent } % správně
 answer-percent-short = { $percent } %
-
 max-credit-available = Maximální možné hodnocení: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] nezbývají žádné pokusy
@@ -45,11 +39,9 @@ attempts-remaining =
         [few] zbývají { $count } pokusy
        *[other] zbývá { $count } pokusů
     }
-
 validation-correct = (Správně)
 validation-incorrect = (Nesprávně)
 validation-partially-correct = (Částečně správně)
-
 answer-show-responses =
     { $count ->
         [one] Zobrazit { $count } odpověď k { $answerId }
@@ -57,42 +49,31 @@ answer-show-responses =
        *[other] Zobrazit { $count } odpovědí k { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Zpětná vazba
-
 collapsible-click-to-open = (kliknutím otevřít)
 collapsible-click-to-close = (kliknutím zavřít)
-
 collapsible-initializing = Inicializace…
-
 footnote-show = Zobrazit poznámku pod čarou
 footnote-hide = Skrýt poznámku pod čarou
-
 description-more-information = více informací
-
 
 ## Controls
 
 slider-previous = Zpět
 slider-next = Další
-
 keyboard-open = Otevřít klávesnici
 keyboard-close = Zavřít klávesnici
-
 choice-input-remove-choice = Odebrat { $choice }
-
 matrix-remove-row = Odebrat řádek
 matrix-add-row = Přidat řádek
 matrix-remove-column = Odebrat sloupec
 matrix-add-column = Přidat sloupec
-
 subset-add-remove-points = Přidat/odebrat body
 subset-toggle-points-intervals = Přepnout body a intervaly
 subset-move-points = Přesunout body
 subset-clear = Vymazat
-
 orbital-add-row = Přidat řádek
 orbital-remove-row = Odebrat řádek
 orbital-add-box = Přidat rámeček
@@ -100,13 +81,9 @@ orbital-remove-box = Odebrat rámeček
 orbital-add-up-arrow = Přidat šipku nahoru
 orbital-add-down-arrow = Přidat šipku dolů
 orbital-remove-arrow = Odebrat šipku
-
 orbital-row-label = Popisek řádku { $row }
-
 pretzel-answer = Odpověď
-
 summary-statistics-caption = Souhrnné statistiky pro { $column }
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = náhled matematického výrazu
 math-input-preview = Náhled
 math-input-invalid-expression = Neplatný výraz:
 
-
 ## Document status
 
 viewer-initializing = Inicializace…
 
-
 ## Errors
 
 error-heading = Chyba
-
 error-found-at =
     { $span ->
         [line] Nalezeno na řádku { $startLine }.
        *[lines] Nalezeno na řádcích { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tento dokument obsahuje chyby!
-
 diagnostic-heading-error = Chyba
 diagnostic-heading-warning = Varování
 diagnostic-heading-information = Informace
 diagnostic-heading-hint = Nápověda
-
 accessibility-heading-level-1 = Porušení přístupnosti WCAG AA
 accessibility-heading-level-2 = Upozornění na přístupnost
-
 something-went-wrong = Něco se pokazilo.
-
 renderer-load-failed = vykreslovací modul se nepodařilo načíst. Je třeba znovu načíst stránku.
-
 core-start-failed = Prohlížeč dokumentu se nepodařilo spustit. Je třeba znovu načíst stránku.

--- a/packages/i18n/locales/cs/content.ftl
+++ b/packages/i18n/locales/cs/content.ftl
@@ -175,7 +175,6 @@ color =
                    *[m] hnědý
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -201,7 +200,6 @@ line-width =
                    *[m] tenký
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -227,7 +225,6 @@ line-style =
                    *[m] tečkovaný
                 }
         }
-
 # Noun phrases in the accusative plural, which is the case «v» takes when it
 # names a pattern — «v kostky», «v puntíky», the way Czech describes patterned
 # cloth. The accusative plural of an inanimate noun is spelled like the
@@ -239,7 +236,6 @@ fill-style =
     .backdiagonal = opačně šikmé čáry
     .dots = tečky
     .diamonds = kosočtverce
-
 noun =
     .line = přímka
     .line-segment = úsečka
@@ -259,7 +255,6 @@ noun =
     .diamond = kosočtverec
     .cross = křížek
     .plus = plus
-
 # Czech counts the sides after the noun, so the count closes the phrase behind
 # the adjectives: «tlustý červený pravidelný mnohoúhelník o 5 stranách». «o»
 # and the locative rather than «s» and the instrumental, so the phrase does not
@@ -269,7 +264,6 @@ noun-regular-polygon =
         [tail] o { $numSides } stranách
        *[head] pravidelný mnohoúhelník
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (mnohoúhelník, m)
 # or the head of a phrase the description never names: `border` (okraj, m),
 # `fill` (výplň, f), `text` (text, m), `background` (pozadí, n).
@@ -290,7 +284,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -303,13 +296,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -318,13 +309,11 @@ style-filled-word =
         [n] vyplněné
        *[m] vyplněný
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } v { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } v { $pattern }
@@ -332,7 +321,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } v { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «s» governs the instrumental, which the `border-clause` branch of every
 # adjective supplies. Czech has no article, so the `-article` branches read the
 # same as the ones without.
@@ -347,15 +335,12 @@ style-border-clause =
         [and-article] a s { $border } okrajem
        *[with] s { $border } okrajem
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = nevyplněný
-
 # «na» governs the locative, which is what the `background-clause` branch of
 # every adjective supplies — «na černém pozadí».
 style-text =
@@ -363,21 +348,17 @@ style-text =
         [background] { $color } na { $background } pozadí
        *[plain] { $color }
     }
-
 style-background-none = žádné
-
 
 ## Boolean words
 
 boolean-true = pravda
 boolean-false = nepravda
 
-
 ## Answer buttons
 
 answer-submit-label = Zkontrolovat
 answer-submit-label-no-correctness = Odeslat odpověď
-
 
 ## Sectional blocks
 
@@ -402,7 +383,6 @@ section-name =
     .solution = Řešení
     .task = Úkol
     .theorem = Věta
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -412,9 +392,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Nápověda
-
 
 ## Tables and figures
 
@@ -425,7 +403,6 @@ table-name =
         [unnumbered-title] Tabulka{ ": " }
        *[unnumbered] Tabulka
     }
-
 figure-name =
     { $parts ->
         [numbered] Obrázek { $enumeration }
@@ -434,22 +411,18 @@ figure-name =
        *[unnumbered] Obrázek
     }
 
-
 ## Paginator controls
 
 paginator-previous = Předchozí
 paginator-next = Další
 paginator-page = Stránka
-
 paginator-page-status = { $pageLabel } { $currentPage } z { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = nebo
 piecewise-condition-if = pokud
 piecewise-condition-otherwise = jinak
-
 
 ## Chemistry
 
@@ -572,7 +545,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennessin
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Karbid
@@ -586,8 +558,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Neplatná chemická značka
 chemistry-invalid-ionic-compound = Neplatná iontová sloučenina

--- a/packages/i18n/locales/cv/chrome.ftl
+++ b/packages/i18n/locales/cv/chrome.ftl
@@ -27,32 +27,24 @@
 
 answer-checking = Тӗрӗслет…
 answer-submitting = Ярать…
-
 answer-checking-status = Хурава тӗрӗслет
 answer-submitting-status = Хурава ярать
-
 answer-correct = Тӗрӗс
 answer-incorrect = Йӑнӑш
-
 answer-response-saved = Хурав упранчӗ
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% тӗрӗс
 answer-percent-short = { $percent } %
-
 max-credit-available = Пулма пултаракан чи пысӑк балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] хӑтланса пӑхмалли юлмарӗ
         [one] { $count } хут хӑтланса пӑхма юлчӗ
        *[other] { $count } хут хӑтланса пӑхма юлчӗ
     }
-
 validation-correct = (Тӗрӗс)
 validation-incorrect = (Йӑнӑш)
 validation-partially-correct = (Пайӑн-пайӑн тӗрӗс)
-
 answer-show-responses =
     { $count ->
         [zero] { $answerId } валли хурав ҫук
@@ -60,42 +52,31 @@ answer-show-responses =
        *[other] { $answerId } валли { $count } хурав кӑтартас
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Хирӗҫ калани
-
 collapsible-click-to-open = (уҫма пусӑр)
 collapsible-click-to-close = (хупма пусӑр)
-
 collapsible-initializing = Хатӗрленет…
-
 footnote-show = Асӑрхаттарӑва кӑтартас
 footnote-hide = Асӑрхаттарӑва пытарас
-
 description-more-information = хушма информаци
-
 
 ## Controls
 
 slider-previous = Малтанхи
 slider-next = Тепӗр
-
 keyboard-open = Клавиатурӑна уҫас
 keyboard-close = Клавиатурӑна хупас
-
 choice-input-remove-choice = { $choice } суйлавне кӑларас
-
 matrix-remove-row = Йӗркене кӑларас
 matrix-add-row = Йӗрке хушас
 matrix-remove-column = Юпана кӑларас
 matrix-add-column = Юпа хушас
-
 subset-add-remove-points = Пӑнчӑ хушас/кӑларас
 subset-toggle-points-intervals = Пӑнчӑсемпе хушӑксене улӑштарас
 subset-move-points = Пӑнчӑсене куҫарас
 subset-clear = Тасатас
-
 orbital-add-row = Йӗрке хушас
 orbital-remove-row = Йӗркене кӑларас
 orbital-add-box = Куҫӑ хушас
@@ -103,13 +84,9 @@ orbital-remove-box = Куҫӑ кӑларас
 orbital-add-up-arrow = Ҫӳлелле йӗппи хушас
 orbital-add-down-arrow = Аялалла йӗппи хушас
 orbital-remove-arrow = Йӗппе кӑларас
-
 orbital-row-label = { $row } йӗркин палли
-
 pretzel-answer = Хурав
-
 summary-statistics-caption = { $column } юпин пӗтӗмлетӳ статистики
-
 
 ## Math input
 
@@ -117,34 +94,25 @@ math-input-preview-region = математика палӑртӑвне малта
 math-input-preview = Малтан пӑхни
 math-input-invalid-expression = Тӗрӗс мар палӑрту:
 
-
 ## Document status
 
 viewer-initializing = Хатӗрленет…
 
-
 ## Errors
 
 error-heading = Йӑнӑш
-
 error-found-at =
     { $span ->
         [line] Тупнӑ йӗрке: { $startLine }.
        *[lines] Тупнӑ йӗркесем: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ку документра йӑнӑшсем пур!
-
 diagnostic-heading-error = Йӑнӑш
 diagnostic-heading-warning = Асӑрхаттару
 diagnostic-heading-information = Информаци
 diagnostic-heading-hint = Канаш
-
 accessibility-heading-level-1 = WCAG AA майлӑх пӑсӑлӑвӗ
 accessibility-heading-level-2 = Майлӑх пирки хыпар
-
 something-went-wrong = Темӗн йӑнӑш пулса тухрӗ.
-
 renderer-load-failed = ӳкерекеннине тиеме пулмарӗ. Страницӑна ҫӗнетӗр.
-
 core-start-failed = Документ пӑхмалли хатӗре ӗҫлеттерсе яма пулмарӗ. Страницӑна ҫӗнетӗр.

--- a/packages/i18n/locales/cv/content.ftl
+++ b/packages/i18n/locales/cv/content.ftl
@@ -41,15 +41,12 @@ color =
     .purple = хӗрхӗлтӗм
     .pink = шупка хӗрлӗ
     .brown = хӑмӑр
-
 line-width =
     .thick = хулӑн
     .thin = ҫӳхе
-
 line-style =
     .dashed = татӑклӑ
     .dotted = пӑнчӑллӑ
-
 # Noun phrases: they stand in front of «эрешлӗ» and modify nothing.
 fill-style =
     .horizontal = горизонталь йӗр
@@ -58,7 +55,6 @@ fill-style =
     .backdiagonal = хирӗҫ диагональ йӗр
     .dots = пӑнчӑ
     .diamonds = ромб
-
 noun =
     .line = тӳрӗ йӗр
     .line-segment = касӑк
@@ -78,7 +74,6 @@ noun =
     .diamond = ромб
     .cross = хӗрес
     .plus = плюс
-
 # Chuvash builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -86,11 +81,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] тӗрӗс { $numSides } кӗтеслӗх
     }
-
 # Chuvash has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,21 +97,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = сӑрланӑ
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } эрешлӗ { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } эрешлӗ { $color } { $filled } { $noun }
@@ -126,7 +115,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } эрешлӗ { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «хӗрриллӗ» — "having an edge" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
@@ -136,15 +124,12 @@ style-border-clause =
         [and-article] тата { $border } хӗрриллӗ
        *[with] { $border } хӗрриллӗ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } эрешлӗ { $color } сӑр
        *[plain] { $color } сӑр
     }
-
 style-unfilled = сӑрламан
-
 # «ҫинче» — "on" — is a postposition, so it follows the background colour
 # rather than standing between the two words the way English's "with a" does.
 style-text =
@@ -152,21 +137,17 @@ style-text =
         [background] { $background } фон ҫинче { $color }
        *[plain] { $color }
     }
-
 style-background-none = ҫук
-
 
 ## Boolean words
 
 boolean-true = тӗрӗс
 boolean-false = йӑнӑш
 
-
 ## Answer buttons
 
 answer-submit-label = Тӗрӗслесе пӑхас
 answer-submit-label-no-correctness = Хурава ярас
-
 
 ## Sectional blocks
 
@@ -191,7 +172,6 @@ section-name =
     .solution = Татӑлӑхӗ
     .task = Ӗҫ хушни
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -201,9 +181,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Канаш
-
 
 ## Tables and figures
 
@@ -214,7 +192,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Ӳкерчӗк { $enumeration }
@@ -223,22 +200,18 @@ figure-name =
        *[unnumbered] Ӳкерчӗк
     }
 
-
 ## Paginator controls
 
 paginator-previous = Малтанхи
 paginator-next = Тепӗр
 paginator-page = Страница
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = е
 piecewise-condition-if = енчен
 piecewise-condition-otherwise = урӑх чухне
-
 
 ## Chemistry
 ##
@@ -252,6 +225,5 @@ piecewise-condition-otherwise = урӑх чухне
 ## fact about a curriculum rather than about a language.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Тӗрӗс мар хими палли
 chemistry-invalid-ionic-compound = Тӗрӗс мар ион пӗрлешӗвӗ

--- a/packages/i18n/locales/cy/chrome.ftl
+++ b/packages/i18n/locales/cy/chrome.ftl
@@ -14,25 +14,20 @@
 # word and not in its ending. A noun that begins with a vowel cannot mutate, so
 # all six branches would read alike and the select is dropped instead.
 
+
 ## Answer submission
 
 answer-checking = Yn gwirio…
 answer-submitting = Yn cyflwyno…
-
 answer-checking-status = Yn gwirio'r ateb
 answer-submitting-status = Yn cyflwyno'r ateb
-
 answer-correct = Cywir
 answer-incorrect = Anghywir
-
 answer-response-saved = Ymateb wedi'i gadw
-
 answer-percent-credit = { $percent }% o'r marciau
 answer-percent-correct = { $percent }% yn gywir
 answer-percent-short = { $percent } %
-
 max-credit-available = Uchafswm y marciau sydd ar gael: { $percent }%
-
 # The numeral decides the mutation on «cynnig»: «dau gynnig», «tri chynnig»,
 # «chwe chynnig», and the radical everywhere else. `[0]` catches none by
 # number, as the English does, so the `zero` category it would otherwise
@@ -46,51 +41,38 @@ attempts-remaining =
         [many] { $count } chynnig ar ôl
        *[other] { $count } cynnig ar ôl
     }
-
 validation-correct = (Cywir)
 validation-incorrect = (Anghywir)
 validation-partially-correct = (Yn rhannol gywir)
-
 # «ar gyfer» rather than «i»: `i` softens the word after it, and the word
 # after it here is an authored name the catalog never sees.
 answer-show-responses = Dangos { $count } ymateb ar gyfer { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Adborth
-
 collapsible-click-to-open = (cliciwch i agor)
 collapsible-click-to-close = (cliciwch i gau)
-
 collapsible-initializing = Yn cychwyn…
-
 footnote-show = Dangos y troednodyn
 footnote-hide = Cuddio'r troednodyn
-
 description-more-information = rhagor o wybodaeth
-
 
 ## Controls
 
 slider-previous = Blaenorol
 slider-next = Nesaf
-
 keyboard-open = Agor y bysellfwrdd
 keyboard-close = Cau'r bysellfwrdd
-
 choice-input-remove-choice = Tynnu { $choice }
-
 matrix-remove-row = Tynnu rhes
 matrix-add-row = Ychwanegu rhes
 matrix-remove-column = Tynnu colofn
 matrix-add-column = Ychwanegu colofn
-
 subset-add-remove-points = Ychwanegu/tynnu pwyntiau
 subset-toggle-points-intervals = Newid rhwng pwyntiau a chyfyngau
 subset-move-points = Symud y pwyntiau
 subset-clear = Clirio
-
 orbital-add-row = Ychwanegu rhes
 orbital-remove-row = Tynnu rhes
 orbital-add-box = Ychwanegu blwch
@@ -98,14 +80,10 @@ orbital-remove-box = Tynnu blwch
 orbital-add-up-arrow = Ychwanegu saeth i fyny
 orbital-add-down-arrow = Ychwanegu saeth i lawr
 orbital-remove-arrow = Tynnu saeth
-
 orbital-row-label = Label ar gyfer rhes { $row }
-
 pretzel-answer = Ateb
-
 # «ar gyfer» again, for the same reason: «o» would soften the column's name.
 summary-statistics-caption = Ystadegau crynodeb ar gyfer { $column }
-
 
 ## Math input
 
@@ -113,34 +91,25 @@ math-input-preview-region = rhagolwg o'r mynegiad mathemategol
 math-input-preview = Rhagolwg
 math-input-invalid-expression = Mynegiad annilys:
 
-
 ## Document status
 
 viewer-initializing = Yn cychwyn…
 
-
 ## Errors
 
 error-heading = Gwall
-
 error-found-at =
     { $span ->
         [line] Wedi'i ganfod ar linell { $startLine }.
        *[lines] Wedi'i ganfod ar linellau { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Mae gwallau yn y ddogfen hon!
-
 diagnostic-heading-error = Gwall
 diagnostic-heading-warning = Rhybudd
 diagnostic-heading-information = Gwybodaeth
 diagnostic-heading-hint = Awgrym
-
 accessibility-heading-level-1 = Tramgwydd hygyrchedd WCAG AA
 accessibility-heading-level-2 = Rhybudd hygyrchedd
-
 something-went-wrong = Aeth rhywbeth o'i le.
-
 renderer-load-failed = methodd rendrwr â llwytho. Ail-lwythwch y dudalen.
-
 core-start-failed = Nid oedd modd cychwyn gwyliwr y ddogfen. Ail-lwythwch y dudalen.

--- a/packages/i18n/locales/cy/content.ftl
+++ b/packages/i18n/locales/cy/content.ftl
@@ -79,7 +79,6 @@ color =
             [f] frown
            *[m] brown
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -91,7 +90,6 @@ line-width =
             [f] denau
            *[m] tenau
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -103,7 +101,6 @@ line-style =
             [f] ddotiog
            *[m] dotiog
         }
-
 # Noun phrases standing behind «â», which takes the aspirate mutation. None of
 # these words begins with `c`, `p` or `t`, so none of them shows it.
 fill-style =
@@ -113,7 +110,6 @@ fill-style =
     .backdiagonal = llinellau croeslinol gwrthdro
     .dots = dotiau
     .diamonds = diemwntau
-
 noun =
     .line = llinell
     .line-segment = segment llinell
@@ -133,7 +129,6 @@ noun =
     .diamond = diemwnt
     .cross = croes
     .plus = plws
-
 # The side count follows the style adjectives, so the head and the tail split
 # around them.
 #
@@ -146,7 +141,6 @@ noun-regular-polygon =
         [tail] { $numSides } ochr
        *[head] polygon rheolaidd
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polygon, m) or the
 # head of a phrase the description never names: `border` (ffin, f), `fill`
 # (llenwad, m), `text` (testun, m), `background` (cefndir, m).
@@ -159,7 +153,6 @@ noun-gender =
         [border] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -181,13 +174,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 # The infixed pronoun in this phrase agrees with what is filled: the masculine
 # «ei» softens «llenwi» to «lenwi» and the feminine leaves it alone. So this
 # selects on `$gender` like the adjectives, even though it is a
@@ -197,13 +188,11 @@ style-filled-word =
         [f] wedi'i llenwi
        *[m] wedi'i lenwi
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } â { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } â { $pattern }
@@ -211,7 +200,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } â { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «ffin» is feminine, so the border's adjectives soften after it whatever the
 # shape around it is. Welsh has no indefinite article, so the two `-article`
 # branches read like the two without; what changes between the pairs is the
@@ -224,19 +212,16 @@ style-border-clause =
         [and-article] ac â ffin { $border }
        *[with] â ffin { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] llenwad { $color } â { $pattern }
        *[plain] { $color }
     }
-
 # This one is given no `$gender`, so it cannot agree with the shape it
 # describes. «heb lenwad» — "without a fill" — reads the same whatever that
 # shape turns out to be, where «heb ei lenwi» would have committed to a
 # masculine pronoun.
 style-unfilled = heb lenwad
-
 # «â» takes the aspirate mutation, and «cefndir» begins with `c`, so it is
 # «â chefndir» here and «cefndir» anywhere else. The colour after it is
 # masculine and unmutated.
@@ -245,21 +230,17 @@ style-text =
         [background] { $color } â chefndir { $background }
        *[plain] { $color }
     }
-
 style-background-none = dim
-
 
 ## Boolean words
 
 boolean-true = gwir
 boolean-false = gau
 
-
 ## Answer buttons
 
 answer-submit-label = Gwirio
 answer-submit-label-no-correctness = Cyflwyno'r ymateb
-
 
 ## Sectional blocks
 
@@ -284,7 +265,6 @@ section-name =
     .solution = Datrysiad
     .task = Tasg
     .theorem = Theorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -294,9 +274,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Awgrym
-
 
 ## Tables and figures
 
@@ -307,7 +285,6 @@ table-name =
         [unnumbered-title] Tabl{ ": " }
        *[unnumbered] Tabl
     }
-
 figure-name =
     { $parts ->
         [numbered] Ffigur { $enumeration }
@@ -316,22 +293,18 @@ figure-name =
        *[unnumbered] Ffigur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Blaenorol
 paginator-next = Nesaf
 paginator-page = Tudalen
-
 paginator-page-status = { $pageLabel } { $currentPage } o { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = neu
 piecewise-condition-if = os
 piecewise-condition-otherwise = fel arall
-
 
 ## Chemistry
 
@@ -454,7 +427,6 @@ element-name =
     .lv = Livermoriwm
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hydrid
     .c = Carbid
@@ -468,8 +440,6 @@ element-anion-name =
     .i = Ïodid
     .at = Astatid
     .ts = Tenesid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Symbol cemegol annilys
 chemistry-invalid-ionic-compound = Cyfansoddyn ïonig annilys

--- a/packages/i18n/locales/da/chrome.ftl
+++ b/packages/i18n/locales/da/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Kontrollerer…
 answer-submitting = Sender…
-
 answer-checking-status = Kontrollerer svar
 answer-submitting-status = Sender svar
-
 answer-correct = Rigtigt
 answer-incorrect = Forkert
-
 answer-response-saved = Svar gemt
-
 answer-percent-credit = { $percent } % point
 answer-percent-correct = { $percent } % rigtigt
 answer-percent-short = { $percent } %
-
 max-credit-available = Højeste mulige point: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] ingen forsøg tilbage
        *[other] { $count } forsøg tilbage
     }
-
 validation-correct = (Rigtigt)
 validation-incorrect = (Forkert)
 validation-partially-correct = (Delvist rigtigt)
-
 answer-show-responses = Vis { $count } svar til { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Feedback
-
 collapsible-click-to-open = (klik for at åbne)
 collapsible-click-to-close = (klik for at lukke)
-
 collapsible-initializing = Initialiserer…
-
 footnote-show = Vis fodnote
 footnote-hide = Skjul fodnote
-
 description-more-information = flere oplysninger
-
 
 ## Controls
 
 slider-previous = Forrige
 slider-next = Næste
-
 keyboard-open = Åbn tastaturet
 keyboard-close = Luk tastaturet
-
 choice-input-remove-choice = Fjern { $choice }
-
 matrix-remove-row = Fjern række
 matrix-add-row = Tilføj række
 matrix-remove-column = Fjern kolonne
 matrix-add-column = Tilføj kolonne
-
 subset-add-remove-points = Tilføj/fjern punkter
 subset-toggle-points-intervals = Skift mellem punkter og intervaller
 subset-move-points = Flyt punkter
 subset-clear = Ryd
-
 orbital-add-row = Tilføj række
 orbital-remove-row = Fjern række
 orbital-add-box = Tilføj felt
@@ -90,13 +71,9 @@ orbital-remove-box = Fjern felt
 orbital-add-up-arrow = Tilføj pil opad
 orbital-add-down-arrow = Tilføj pil nedad
 orbital-remove-arrow = Fjern pil
-
 orbital-row-label = Mærkat til række { $row }
-
 pretzel-answer = Svar
-
 summary-statistics-caption = Opsummerende statistik for { $column }
-
 
 ## Math input
 
@@ -104,34 +81,25 @@ math-input-preview-region = forhåndsvisning af matematisk udtryk
 math-input-preview = Forhåndsvisning
 math-input-invalid-expression = Ugyldigt udtryk:
 
-
 ## Document status
 
 viewer-initializing = Initialiserer…
 
-
 ## Errors
 
 error-heading = Fejl
-
 error-found-at =
     { $span ->
         [line] Fundet på linje { $startLine }.
        *[lines] Fundet på linjerne { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dette dokument indeholder fejl!
-
 diagnostic-heading-error = Fejl
 diagnostic-heading-warning = Advarsel
 diagnostic-heading-information = Information
 diagnostic-heading-hint = Tip
-
 accessibility-heading-level-1 = Tilgængelighedsbrud efter WCAG AA
 accessibility-heading-level-2 = Tilgængelighedsbemærkning
-
 something-went-wrong = Noget gik galt.
-
 renderer-load-failed = et gengivelsesmodul kunne ikke indlæses. Genindlæs siden.
-
 core-start-failed = Dokumentfremviseren kunne ikke startes. Genindlæs siden.

--- a/packages/i18n/locales/da/content.ftl
+++ b/packages/i18n/locales/da/content.ftl
@@ -71,7 +71,6 @@ color =
             [neuter] brunt
            *[common] brun
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -83,11 +82,9 @@ line-width =
             [neuter] tyndt
            *[common] tynd
         }
-
 line-style =
     .dashed = stiplet
     .dotted = prikket
-
 fill-style =
     .horizontal = vandrette linjer
     .vertical = lodrette linjer
@@ -95,7 +92,6 @@ fill-style =
     .backdiagonal = omvendte diagonale linjer
     .dots = prikker
     .diamonds = romber
-
 noun =
     .line = linje
     .line-segment = linjestykke
@@ -115,7 +111,6 @@ noun =
     .diamond = rombe
     .cross = kryds
     .plus = plus
-
 # Danish names a regular polygon by its side count in one word — «regelmæssig
 # 5-kant» — so the count stays in the head and there is no tail. «-kant» is
 # common, like «trekant».
@@ -124,7 +119,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelmæssig { $numSides }-kant
     }
-
 # `$noun` can also be `regular-polygon` (kant, common) or a head the
 # description never names: `border` (kant, common), `fill` (udfyldning,
 # common), `text` (tekst, common), `background` (baggrund, common).
@@ -140,7 +134,6 @@ noun-gender =
        *[other] common
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -153,23 +146,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «udfyldt» already ends in `-t`, so it does not inflect and takes no
 # `$gender` branch.
 style-filled-word = udfyldt
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } med { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } med { $pattern }
@@ -177,7 +166,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } med { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «kant» is common, so the indefinite article is «en» — a word of its own,
 # which is why the distinction English draws between the `-article` branches
 # and the others survives here.
@@ -188,35 +176,28 @@ style-border-clause =
         [and-article] og en { $border } kant
        *[with] med { $border } kant
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = uudfyldt
-
 style-text =
     { $parts ->
         [background] { $color } på { $background } baggrund
        *[plain] { $color }
     }
-
 style-background-none = ingen
-
 
 ## Boolean words
 
 boolean-true = sand
 boolean-false = falsk
 
-
 ## Answer buttons
 
 answer-submit-label = Kontrollér
 answer-submit-label-no-correctness = Indsend svar
-
 
 ## Sectional blocks
 
@@ -241,7 +222,6 @@ section-name =
     .solution = Løsning
     .task = Arbejdsopgave
     .theorem = Sætning
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -251,9 +231,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Hint
-
 
 ## Tables and figures
 
@@ -264,7 +242,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Figur { $enumeration }
@@ -273,22 +250,18 @@ figure-name =
        *[unnumbered] Figur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Forrige
 paginator-next = Næste
 paginator-page = Side
-
 paginator-page-status = { $pageLabel } { $currentPage } af { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = eller
 piecewise-condition-if = hvis
 piecewise-condition-otherwise = ellers
-
 
 ## Chemistry
 
@@ -411,7 +384,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenness
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Carbid
@@ -425,8 +397,6 @@ element-anion-name =
     .i = Iodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ugyldigt kemisk symbol
 chemistry-invalid-ionic-compound = Ugyldig ionforbindelse

--- a/packages/i18n/locales/dag/chrome.ftl
+++ b/packages/i18n/locales/dag/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Yuligu…
 answer-submitting = Timbu…
-
 answer-checking-status = Bɛ yuli lahabali maa
 answer-submitting-status = Bɛ tim lahabali maa
-
 answer-correct = Di viɛla
 answer-incorrect = Di bi viɛla
-
 answer-response-saved = Bɛ gbibi lahabali maa
-
 answer-percent-credit = { $percent }% pɔyintnima
 answer-percent-correct = { $percent }% viɛla
 answer-percent-short = { $percent } %
-
 max-credit-available = Pɔyint pam din be: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] dihibu shɛli bi kpalim
         [one] dihibu { $count } n-kpalim
        *[other] dihibu { $count } n-kpalim
     }
-
 validation-correct = (Di viɛla)
 validation-incorrect = (Di bi viɛla)
 validation-partially-correct = (Di viɛla pirigili)
-
 answer-show-responses =
     { $count ->
         [one] Wuhi lahabali { $count } din chaŋ { $answerId }
        *[other] Wuhi lahabali { $count } din chaŋ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Labsibu
-
 collapsible-click-to-open = (nyɛbi ka yooi)
 collapsible-click-to-close = (nyɛbi ka yɔhi)
-
 collapsible-initializing = Piligu…
-
 footnote-show = Wuhi tiŋgbani gbaabu
 footnote-hide = Sɔɣi tiŋgbani gbaabu
-
 description-more-information = lahabali shɛŋa
-
 
 ## Controls
 
 slider-previous = Din daŋ
 slider-next = Din pahi
-
 keyboard-open = Yooi Kiiboodi
 keyboard-close = Yɔhi Kiiboodi
-
 choice-input-remove-choice = Yihi { $choice }
-
 matrix-remove-row = Yihi layin
 matrix-add-row = Pahi layin
 matrix-remove-column = Yihi kɔlum
 matrix-add-column = Pahi kɔlum
-
 subset-add-remove-points = Pahi/Yihi pɔyintnima
 subset-toggle-points-intervals = Taɣi pɔyintnima ni pirigilinima
 subset-move-points = Vuui Pɔyintnima
 subset-clear = Yihi zaa
-
 orbital-add-row = Pahi Layin
 orbital-remove-row = Yihi Layin
 orbital-add-box = Pahi Adaka
@@ -87,13 +68,9 @@ orbital-remove-box = Yihi Adaka
 orbital-add-up-arrow = Pahi Pima Din Chaŋ Zuɣu
 orbital-add-down-arrow = Pahi Pima Din Chaŋ Tiŋgbani
 orbital-remove-arrow = Yihi Pima
-
 orbital-row-label = Layin { $row } yuli
-
 pretzel-answer = Lahabali
-
 summary-statistics-caption = { $column } kalinli ŋmaabu
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = kalinli yɛtɔɣa nyabu pɔi
 math-input-preview = Nyabu pɔi
 math-input-invalid-expression = Yɛtɔɣa din bi tuhi:
 
-
 ## Document status
 
 viewer-initializing = Piligu…
 
-
 ## Errors
 
 error-heading = Taali
-
 error-found-at =
     { $span ->
         [line] Bɛ nya li layin { $startLine } zuɣu.
        *[lines] Bɛ nya li layinnima { $startLine }–{ $endLine } zuɣu.
     }
-
 document-contains-errors = Gbaŋ ŋɔ mali taya!
-
 diagnostic-heading-error = Taali
 diagnostic-heading-warning = Kpahimbu
 diagnostic-heading-information = Lahabali
 diagnostic-heading-hint = Maka
-
 accessibility-heading-level-1 = WCAG AA paabu taali
 accessibility-heading-level-2 = Paabu kpahimbu
-
 something-went-wrong = Shɛli bi niŋ viɛnyɛla.
-
 renderer-load-failed = wuhira bi kana. Din niŋ suhudoo, labsim peji maa.
-
 core-start-failed = Gbaŋ wuhira bi pili. Din niŋ suhudoo, labsim peji maa.

--- a/packages/i18n/locales/dag/content.ftl
+++ b/packages/i18n/locales/dag/content.ftl
@@ -72,7 +72,6 @@ color =
     .purple = pɔpul
     .pink = piŋk
     .brown = braun
-
 line-width =
     .thick =
         { $gender ->
@@ -86,7 +85,6 @@ line-width =
             [c3] bilim
            *[c1] billi
         }
-
 # Written as an invariable «ni …» phrase, so that it agrees with nothing and
 # can close the description; `style-stroke` puts it last for that reason. That
 # is also what keeps the class suffix off the end of the phrase, where a
@@ -94,7 +92,6 @@ line-width =
 line-style =
     .dashed = ni dasɛs
     .dotted = ni dɔts
-
 fill-style =
     .horizontal = layinnima din doya
     .vertical = layinnima din ʒe
@@ -102,7 +99,6 @@ fill-style =
     .backdiagonal = layinnima din gbaai luɣ' shɛli
     .dots = dɔts
     .diamonds = dayamɔnnima
-
 noun =
     .line = layin
     .line-segment = layin sɛgmɛnti
@@ -122,7 +118,6 @@ noun =
     .diamond = dayamɔn
     .cross = daantalli
     .plus = pahibu maka
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -130,7 +125,6 @@ noun-regular-polygon =
         [tail] din mali kpaŋa { $numSides }
        *[head] poligɔn din kpaŋa nyɛla yim
     }
-
 # The noun class. A Dagbani noun's class is usually legible in its own suffix —
 # «gilli» and «luɣili» are `-li`, so `c1` — but the class is a fact about the
 # noun rather than about its ending: «daantalli» is `c2` despite `-li`. The
@@ -153,7 +147,6 @@ noun-gender =
        *[other] c1
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ni …» phrase and closes the description, so it moves
@@ -168,26 +161,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c2] palliga
         [c3] pallim
        *[c1] palli
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ni { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ni { $pattern }
@@ -195,7 +184,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ni { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «nɔli» is the border and leads its own describing words, so they agree with
 # it rather than with the shape it surrounds. Dagbani has no article and joins
 # this clause with the invariable «ni», so all four branches read alike.
@@ -206,35 +194,28 @@ style-border-clause =
         [and-article] ni nɔli { $border }
        *[with] ni nɔli { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = bi palli
-
 style-text =
     { $parts ->
         [background] { $color } nyaaŋa { $background }
        *[plain] { $color }
     }
-
 style-background-none = shɛli ka nyaaŋa
-
 
 ## Boolean words
 
 boolean-true = yɛlimaŋli
 boolean-false = ʒiri
 
-
 ## Answer buttons
 
 answer-submit-label = Yuli Tuma
 answer-submit-label-no-correctness = Tim Lahabali
-
 
 ## Sectional blocks
 
@@ -259,7 +240,6 @@ section-name =
     .solution = Ŋmaabu
     .task = Tuma
     .theorem = Tiyorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -269,9 +249,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Maka
-
 
 ## Tables and figures
 
@@ -282,7 +260,6 @@ table-name =
         [unnumbered-title] Teebul{ ": " }
        *[unnumbered] Teebul
     }
-
 figure-name =
     { $parts ->
         [numbered] Ŋmahiŋga { $enumeration }
@@ -291,24 +268,18 @@ figure-name =
        *[unnumbered] Ŋmahiŋga
     }
 
-
 ## Paginator controls
 
 paginator-previous = Din daŋ
 paginator-next = Din pahi
 paginator-page = Peji
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = bee
-
 piecewise-condition-if = di yi niŋ
-
 piecewise-condition-otherwise = luɣ' shɛŋa kam
-
 
 ## Chemistry
 ##
@@ -322,6 +293,5 @@ piecewise-condition-otherwise = luɣ' shɛŋa kam
 ## one border away.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kɛmistiri Maka Din Bi Tuhi
 chemistry-invalid-ionic-compound = Ayɔn Laɣimbu Din Bi Tuhi

--- a/packages/i18n/locales/de/chrome.ftl
+++ b/packages/i18n/locales/de/chrome.ftl
@@ -18,32 +18,24 @@
 
 answer-checking = Wird geprüft …
 answer-submitting = Wird gesendet …
-
 answer-checking-status = Antwort wird geprüft
 answer-submitting-status = Antwort wird gesendet
-
 answer-correct = Richtig
 answer-incorrect = Falsch
-
 answer-response-saved = Antwort gespeichert
-
 answer-percent-credit = { $percent } % Anrechnung
 answer-percent-correct = { $percent } % richtig
 answer-percent-short = { $percent } %
-
 max-credit-available = Höchstens erreichbar: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] keine Versuche übrig
         [one] noch { $count } Versuch
        *[other] noch { $count } Versuche
     }
-
 validation-correct = (Richtig)
 validation-incorrect = (Falsch)
 validation-partially-correct = (Teilweise richtig)
-
 # `Anzeigen` is the infinitive, per the register note above.
 answer-show-responses =
     { $count ->
@@ -51,42 +43,31 @@ answer-show-responses =
        *[other] { $count } Antworten auf { $answerId } anzeigen
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Rückmeldung
-
 collapsible-click-to-open = (zum Öffnen klicken)
 collapsible-click-to-close = (zum Schließen klicken)
-
 collapsible-initializing = Wird initialisiert …
-
 footnote-show = Fußnote anzeigen
 footnote-hide = Fußnote ausblenden
-
 description-more-information = weitere Informationen
-
 
 ## Controls
 
 slider-previous = Zurück
 slider-next = Weiter
-
 keyboard-open = Tastatur öffnen
 keyboard-close = Tastatur schließen
-
 choice-input-remove-choice = { $choice } entfernen
-
 matrix-remove-row = Zeile entfernen
 matrix-add-row = Zeile hinzufügen
 matrix-remove-column = Spalte entfernen
 matrix-add-column = Spalte hinzufügen
-
 subset-add-remove-points = Punkte hinzufügen/entfernen
 subset-toggle-points-intervals = Zwischen Punkten und Intervallen wechseln
 subset-move-points = Punkte verschieben
 subset-clear = Leeren
-
 # A `box` here is one orbital, drawn as a square: `Kästchen`.
 orbital-add-row = Zeile hinzufügen
 orbital-remove-row = Zeile entfernen
@@ -95,13 +76,9 @@ orbital-remove-box = Kästchen entfernen
 orbital-add-up-arrow = Pfeil nach oben hinzufügen
 orbital-add-down-arrow = Pfeil nach unten hinzufügen
 orbital-remove-arrow = Pfeil entfernen
-
 orbital-row-label = Beschriftung für Zeile { $row }
-
 pretzel-answer = Antwort
-
 summary-statistics-caption = Kennzahlen von { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = Vorschau des mathematischen Ausdrucks
 math-input-preview = Vorschau
 math-input-invalid-expression = Ungültiger Ausdruck:
 
-
 ## Document status
 
 viewer-initializing = Wird initialisiert …
 
-
 ## Errors
 
 error-heading = Fehler
-
 error-found-at =
     { $span ->
         [line] Gefunden in Zeile { $startLine }.
        *[lines] Gefunden in den Zeilen { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dieses Dokument enthält Fehler!
-
 diagnostic-heading-error = Fehler
 diagnostic-heading-warning = Warnung
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Hinweis
-
 accessibility-heading-level-1 = Verstoß gegen WCAG AA (Barrierefreiheit)
 accessibility-heading-level-2 = Hinweis zur Barrierefreiheit
-
 something-went-wrong = Etwas ist schiefgelaufen.
-
 renderer-load-failed = eine Anzeigekomponente konnte nicht geladen werden. Bitte die Seite neu laden.
-
 core-start-failed = Die Dokumentanzeige konnte nicht gestartet werden. Bitte die Seite neu laden.

--- a/packages/i18n/locales/de/content.ftl
+++ b/packages/i18n/locales/de/content.ftl
@@ -175,7 +175,6 @@ color =
                    *[m] brauner
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -201,7 +200,6 @@ line-width =
                    *[m] dünner
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -227,7 +225,6 @@ line-style =
                    *[m] gepunkteter
                 }
         }
-
 # Noun phrases: they follow `mit` and agree with nothing.
 fill-style =
     .horizontal = waagerechten Linien
@@ -236,7 +233,6 @@ fill-style =
     .backdiagonal = gegenläufigen diagonalen Linien
     .dots = Punkten
     .diamonds = Rauten
-
 noun =
     .line = Linie
     .line-segment = Strecke
@@ -256,7 +252,6 @@ noun =
     .diamond = Raute
     .cross = Kreuz
     .plus = Pluszeichen
-
 # German keeps the side count in front of the noun, as a compound, so the whole
 # thing is one head and there is no tail.
 noun-regular-polygon =
@@ -264,7 +259,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelmäßiges { $numSides }-Eck
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (which is
 # `{ $numSides }-Eck`, neuter) or the head of a phrase the description never
 # names: `border` (der Rand, m), `fill` (die Füllung, f), `text` (der Text, m),
@@ -298,7 +292,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -311,7 +304,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives lead and the noun closes the phrase, which is the reverse of
 # Spanish and the same as English: „dicke rote Linie“.
 style-with-noun =
@@ -319,7 +311,6 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every
 # description and takes no `$role` branch.
 style-filled-word =
@@ -328,13 +319,11 @@ style-filled-word =
         [n] gefülltes
        *[m] gefüllter
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } mit { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } mit { $pattern }
@@ -342,7 +331,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } mit { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # „Rand“ is masculine, so the border's adjectives agree with it and not with
 # the shape it surrounds. `mit` and `und einem` govern the dative, which is
 # what the `border-clause` branch of every adjective supplies.
@@ -360,7 +348,6 @@ style-border-clause =
         [and-article] und einem { $border } Rand
        *[with] mit einem { $border } Rand
     }
-
 # The fill-pattern words are dative plurals, because their other use is the
 # „mit { $pattern }“ clause in `style-filled`. So this message supplies a noun
 # for them to hang off — „Füllung“, feminine, which is the gender `noun-gender`
@@ -370,9 +357,7 @@ style-fill =
         [pattern] { $color } Füllung mit { $pattern }
        *[plain] { $color } Füllung
     }
-
 style-unfilled = ungefüllt
-
 # „auf“ with no article governs the strong dative, which is the
 # `background-clause` ending; the text colour beside it is predicative, which
 # in German is the bare stem. So this reads „rot auf gelbem Hintergrund“, where
@@ -383,21 +368,17 @@ style-text =
         [background] { $color } auf { $background } Hintergrund
        *[plain] { $color }
     }
-
 style-background-none = keiner
-
 
 ## Boolean words
 
 boolean-true = wahr
 boolean-false = falsch
 
-
 ## Answer buttons
 
 answer-submit-label = Prüfen
 answer-submit-label-no-correctness = Antwort senden
-
 
 ## Sectional blocks
 
@@ -422,7 +403,6 @@ section-name =
     .solution = Lösung
     .task = Aufgabe
     .theorem = Satz
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -432,9 +412,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tipp
-
 
 ## Tables and figures
 
@@ -445,7 +423,6 @@ table-name =
         [unnumbered-title] Tabelle{ ": " }
        *[unnumbered] Tabelle
     }
-
 figure-name =
     { $parts ->
         [numbered] Abbildung { $enumeration }
@@ -454,22 +431,18 @@ figure-name =
        *[unnumbered] Abbildung
     }
 
-
 ## Paginator controls
 
 paginator-previous = Zurück
 paginator-next = Weiter
 paginator-page = Seite
-
 paginator-page-status = { $pageLabel } { $currentPage } von { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = oder
 piecewise-condition-if = falls
 piecewise-condition-otherwise = sonst
-
 
 ## Chemistry
 
@@ -592,7 +565,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenness
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Carbid
@@ -606,8 +578,6 @@ element-anion-name =
     .i = Iodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ungültiges chemisches Symbol
 chemistry-invalid-ionic-compound = Ungültige Ionenverbindung

--- a/packages/i18n/locales/dje/chrome.ftl
+++ b/packages/i18n/locales/dje/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Goo ma guna…
 answer-submitting = Goo ma samba…
-
 answer-checking-status = I goo ga tuuruyaŋo guna
 answer-submitting-status = I goo ga tuuruyaŋo samba
-
 answer-correct = A ga cimi
 answer-incorrect = A si cimi
-
 answer-response-saved = Tuuruyaŋo Gaay
-
 answer-percent-credit = { $percent }% Nooru
 answer-percent-correct = { $percent }% Cimi
 answer-percent-short = { $percent } %
-
 max-credit-available = Nooru beeri kaŋ ni ga du: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] dooni kulu si cindi
         [one] dooni { $count } cindi
        *[other] dooni { $count } cindi
     }
-
 validation-correct = (A ga cimi)
 validation-incorrect = (A si cimi)
 validation-partially-correct = (A ga cimi kayna)
-
 answer-show-responses =
     { $count ->
         [one] Cabe tuuruyaŋ { $count } { $answerId } se
        *[other] Cabe tuuruyaŋ { $count } { $answerId } se
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Tuuruyaŋ
-
 collapsible-click-to-open = (kar zama a ma feeri)
 collapsible-click-to-close = (kar zama a ma daabu)
-
 collapsible-initializing = Goo ma sintin…
-
 footnote-show = Cabe ganda hantumo
 footnote-hide = Tugu ganda hantumo
-
 description-more-information = bayrandi fo
-
 
 ## Controls
 
 slider-previous = Kaŋ bisa
 slider-next = Kaŋ ga kaa
-
 keyboard-open = Feeri Klaviye
 keyboard-close = Daabu Klaviye
-
 choice-input-remove-choice = Kaa { $choice }
-
 matrix-remove-row = Kaa kar
 matrix-add-row = Tonton kar
 matrix-remove-column = Kaa kolon
 matrix-add-column = Tonton kolon
-
 subset-add-remove-points = Tonton/Kaa alaama-yaŋ
 subset-toggle-points-intervals = Barmay alaama-yaŋ nda alwaati-yaŋ
 subset-move-points = Ganandi Alaama-yaŋ
 subset-clear = Tuusu
-
 orbital-add-row = Tonton Kar
 orbital-remove-row = Kaa Kar
 orbital-add-box = Tonton Sanduku
@@ -87,13 +68,9 @@ orbital-remove-box = Kaa Sanduku
 orbital-add-up-arrow = Tonton Beene Hangaw
 orbital-add-down-arrow = Tonton Ganda Hangaw
 orbital-remove-arrow = Kaa Hangaw
-
 orbital-row-label = Kar { $row } maa
-
 pretzel-answer = Tuuruyaŋ
-
 summary-statistics-caption = { $column } lasaabu feerijandi
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = lasaabu sanni jina guna
 math-input-preview = Guna jina
 math-input-invalid-expression = Sanni kaŋ si boori:
 
-
 ## Document status
 
 viewer-initializing = Goo ma sintin…
 
-
 ## Errors
 
 error-heading = Taali
-
 error-found-at =
     { $span ->
         [line] I du a kar { $startLine } ga.
        *[lines] I du a kar { $startLine }–{ $endLine } ga.
     }
-
 document-contains-errors = Tira woo gonda taali-yaŋ!
-
 diagnostic-heading-error = Taali
 diagnostic-heading-warning = Yaamar
 diagnostic-heading-information = Bayrandi
 diagnostic-heading-hint = Faada
-
 accessibility-heading-level-1 = WCAG AA Duyaŋ Sanno Ŋwaarey
 accessibility-heading-level-2 = Duyaŋ yaamar
-
 something-went-wrong = Hay fo mana boori.
-
 renderer-load-failed = cabeko fo mana kaa. Ay ga ni ŋwaaray, ye moo ga zumandi.
-
 core-start-failed = Tira cabeko mana hin ka sintin. Ay ga ni ŋwaaray, ye moo ga zumandi.

--- a/packages/i18n/locales/dje/content.ftl
+++ b/packages/i18n/locales/dje/content.ftl
@@ -67,17 +67,14 @@ color =
     .purple = violee
     .pink = roozu
     .brown = maroŋ
-
 line-width =
     .thick = beeri
     .thin = kayna
-
 # Written as «nda …» phrases rather than as bare qualifiers, so that they close
 # the description. `style-stroke` puts them last.
 line-style =
     .dashed = nda dumbu-dumbu
     .dotted = nda alaama-alaama
-
 fill-style =
     .horizontal = kar-yaŋ kaŋ ga kani
     .vertical = kar-yaŋ kaŋ ga kay
@@ -85,7 +82,6 @@ fill-style =
     .backdiagonal = kar-yaŋ kaŋ ga daŋ banda kambu fo ra
     .dots = alaama-yaŋ
     .diamonds = diyaman-yaŋ
-
 noun =
     .line = kar
     .line-segment = kar dumbu
@@ -105,7 +101,6 @@ noun =
     .diamond = diyaman
     .cross = gurumey
     .plus = tontoni alaama
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words, so it goes in the tail.
 noun-regular-polygon =
@@ -113,12 +108,10 @@ noun-regular-polygon =
         [tail] kaŋ gonda kambu { $numSides }
        *[head] poligon saawa
     }
-
 # Zarma has no noun class and no gender, so every noun answers the same and the
 # answer goes unused — the shape `locales/en`, `locales/men` and `locales/pcm`
 # have.
 noun-gender = afo
-
 
 ## Style composition
 
@@ -134,21 +127,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = toonante
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } nda { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } nda { $pattern }
@@ -156,7 +145,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nda { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «hirri» is the border and leads its own describing words. Zarma has no
 # article and joins this clause with the invariable «nda», so all four branches
 # read alike.
@@ -167,35 +155,28 @@ style-border-clause =
         [and-article] nda hirri { $border }
        *[with] nda hirri { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = mana too
-
 style-text =
     { $parts ->
         [background] { $color } nda banda { $background }
        *[plain] { $color }
     }
-
 style-background-none = hay kulu si
-
 
 ## Boolean words
 
 boolean-true = cimi
 boolean-false = tangari
 
-
 ## Answer buttons
 
 answer-submit-label = Guna Goyo
 answer-submit-label-no-correctness = Samba Tuuruyaŋ
-
 
 ## Sectional blocks
 
@@ -220,7 +201,6 @@ section-name =
     .solution = Feeriji
     .task = Goy
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -230,9 +210,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Faada
-
 
 ## Tables and figures
 
@@ -243,7 +221,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Biiyaŋ { $enumeration }
@@ -252,25 +229,18 @@ figure-name =
        *[unnumbered] Biiyaŋ
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kaŋ bisa
 paginator-next = Kaŋ ga kaa
-
 paginator-page = Moo
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = wala
-
 piecewise-condition-if = da
-
 piecewise-condition-otherwise = hari fo kulu ra
-
 
 ## Chemistry
 ##
@@ -283,6 +253,5 @@ piecewise-condition-otherwise = hari fo kulu ra
 ## ministry, and `locales/kg`, `locales/fon` and `locales/kbp` from theirs.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simi Alaama Kaŋ Si Boori
 chemistry-invalid-ionic-compound = Iyon Margayaŋ Kaŋ Si Boori

--- a/packages/i18n/locales/doi/chrome.ftl
+++ b/packages/i18n/locales/doi/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = जाँच होआ‌ करदी ऐ…
 answer-submitting = भेजेआ जा करदा ऐ…
-
 answer-checking-status = जवाब दी जाँच होआ करदी ऐ
 answer-submitting-status = जवाब भेजेआ जा करदा ऐ
-
 answer-correct = ठीक
 answer-incorrect = गलत
-
 answer-response-saved = जवाब सांभेआ गेआ
-
 answer-percent-credit = { $percent }% अंक
 answer-percent-correct = { $percent }% ठीक
 answer-percent-short = { $percent } %
-
 max-credit-available = बद्धोबद्ध मिलने आले अंक: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] कोई कोशश नेईं बची
         [one] { $count } कोशश बाकी
        *[other] { $count } कोशशां बाकी
     }
-
 validation-correct = (ठीक)
 validation-incorrect = (गलत)
 validation-partially-correct = (कुछ हद तगर ठीक)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } आस्तै { $count } जवाब दस्सो
        *[other] { $answerId } आस्तै { $count } जवाब दस्सो
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिक्रिया
-
 collapsible-click-to-open = (खोह्लने आस्तै क्लिक करो)
 collapsible-click-to-close = (बंद करने आस्तै क्लिक करो)
-
 collapsible-initializing = शुरू होआ करदा ऐ…
-
 footnote-show = पादटिप्पणी दस्सो
 footnote-hide = पादटिप्पणी लकाओ
-
 description-more-information = होर जानकारी
-
 
 ## Controls
 
 slider-previous = पिछला
 slider-next = अगला
-
 keyboard-open = कुंजीपटल खोह्लो
 keyboard-close = कुंजीपटल बंद करो
-
 choice-input-remove-choice = { $choice } हटाओ
-
 matrix-remove-row = पंगत हटाओ
 matrix-add-row = पंगत जोड़ो
 matrix-remove-column = स्तंभ हटाओ
 matrix-add-column = स्तंभ जोड़ो
-
 subset-add-remove-points = बिंदू जोड़ो/हटाओ
 subset-toggle-points-intervals = बिंदू ते अंतराल बदलो
 subset-move-points = बिंदू सरकाओ
 subset-clear = मटाओ
-
 orbital-add-row = पंगत जोड़ो
 orbital-remove-row = पंगत हटाओ
 orbital-add-box = डिब्बा जोड़ो
@@ -86,13 +67,9 @@ orbital-remove-box = डिब्बा हटाओ
 orbital-add-up-arrow = उप्पर आला तीर जोड़ो
 orbital-add-down-arrow = थल्ले आला तीर जोड़ो
 orbital-remove-arrow = तीर हटाओ
-
 orbital-row-label = पंगत { $row } दा लेबल
-
 pretzel-answer = जवाब
-
 summary-statistics-caption = { $column } दा सांख्यिकी सार
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = गणित दे व्यंजन दी झल
 math-input-preview = झलक
 math-input-invalid-expression = गलत व्यंजन:
 
-
 ## Document status
 
 viewer-initializing = शुरू होआ करदा ऐ…
 
-
 ## Errors
 
 error-heading = गलती
-
 error-found-at =
     { $span ->
         [line] पंगत { $startLine } पर मिली।
        *[lines] पंगत { $startLine }–{ $endLine } पर मिली।
     }
-
 document-contains-errors = इस दस्तावेज च गलतियां न!
-
 diagnostic-heading-error = गलती
 diagnostic-heading-warning = चेतावनी
 diagnostic-heading-information = जानकारी
 diagnostic-heading-hint = इशारा
-
 accessibility-heading-level-1 = WCAG AA सुगमता दा उल्लंघन
 accessibility-heading-level-2 = सुगमता दी सूचना
-
 something-went-wrong = कुछ गड़बड़ होई गेई।
-
 renderer-load-failed = इक प्रदर्शक लोड नेईं होई सकेआ। कृपा करियै सफा फ्ही लोड करो।
-
 core-start-failed = दस्तावेज दर्शक शुरू नेईं होई सकेआ। कृपा करियै सफा फ्ही लोड करो।

--- a/packages/i18n/locales/doi/content.ftl
+++ b/packages/i18n/locales/doi/content.ftl
@@ -74,7 +74,6 @@ color =
             [f] भूरी
            *[m] भूरा
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -86,12 +85,10 @@ line-width =
             [f] पतली
            *[m] पतला
         }
-
 # Neither ends in -आ, so neither changes.
 line-style =
     .dashed = टुकड़ेदार
     .dotted = बिंदुदार
-
 # Plural nouns rather than adjectives, so they carry their own agreement and
 # «कन्नै» takes them bare.
 fill-style =
@@ -101,7 +98,6 @@ fill-style =
     .backdiagonal = उल्टियां तिरछियां लकीरां
     .dots = बिंदू
     .diamonds = समचतुर्भुज
-
 noun =
     .line = रेखा
     .line-segment = रेखाखंड
@@ -121,7 +117,6 @@ noun =
     .diamond = समचतुर्भुज
     .cross = गुणा दा निशान
     .plus = जोड़ दा निशान
-
 # «भुजाएं आला» takes the count and stands in front of the noun, so nothing
 # follows the adjectives and the tail is empty.
 noun-regular-polygon =
@@ -129,7 +124,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } भुजाएं आला समबहुभुज
     }
-
 # Besides the nouns above, `$noun` may be «regular-polygon» (बहुभुज, m) or the
 # head of a phrase the description does not name: «border» (किनारी, f), «fill»
 # (भराई, f), «text» (पाठ, m), «background» (पृष्ठभूमि, f).
@@ -144,7 +138,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -157,19 +150,16 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [f] भरेई
        *[m] भरेआ
     }
-
 # «कन्नै» ("with") is a postposition and follows what it governs, so the
 # pattern moves to the front of the phrase where English appends it.
 style-filled =
@@ -177,7 +167,6 @@ style-filled =
         [pattern] { $pattern } कन्नै { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } कन्नै { $filled } { $color } { $noun }
@@ -185,7 +174,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } कन्नै { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Dogri has no article, so the two `-article` branches read like their
 # neighbours; «ते» is the conjunction and stands in front.
 style-border-clause =
@@ -195,35 +183,28 @@ style-border-clause =
         [and-article] ते { $border } किनारी कन्नै
        *[with] { $border } किनारी कन्नै
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } कन्नै { $color } भराई
        *[plain] { $color } भराई
     }
-
 style-unfilled = बिन भरेआ
-
 style-text =
     { $parts ->
         [background] { $background } पृष्ठभूमि पर { $color }
        *[plain] { $color }
     }
-
 style-background-none = कुसै किस्म दा नेईं
-
 
 ## Boolean words
 
 boolean-true = सच्च
 boolean-false = झूठ
 
-
 ## Answer buttons
 
 answer-submit-label = जाँचो
 answer-submit-label-no-correctness = जवाब भेजो
-
 
 ## Sectional blocks
 
@@ -248,7 +229,6 @@ section-name =
     .solution = हल
     .task = कम्म
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -258,9 +238,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = इशारा
-
 
 ## Tables and figures
 
@@ -271,7 +249,6 @@ table-name =
         [unnumbered-title] सारणी{ ": " }
        *[unnumbered] सारणी
     }
-
 figure-name =
     { $parts ->
         [numbered] चित्र { $enumeration }
@@ -280,25 +257,19 @@ figure-name =
        *[unnumbered] चित्र
     }
 
-
 ## Paginator controls
 
 paginator-previous = पिछला
 paginator-next = अगला
 paginator-page = सफा
-
 # «X चा Y» — "Y of X" — puts the total first, so the two counts change places.
 paginator-page-status = { $numPages } चा { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = जां
-
 piecewise-condition-if = जेकर
-
 piecewise-condition-otherwise = नैं ते
-
 
 ## Chemistry
 ##
@@ -313,6 +284,5 @@ piecewise-condition-otherwise = नैं ते
 ## and `kok` record — four languages, four education systems, one sentence.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = गलत रसायनिक निशान
 chemistry-invalid-ionic-compound = गलत आयनिक यौगिक

--- a/packages/i18n/locales/dv/chrome.ftl
+++ b/packages/i18n/locales/dv/chrome.ftl
@@ -10,74 +10,55 @@
 
 answer-checking = ބަލަނީ…
 answer-submitting = ފޮނުވަނީ…
-
 answer-checking-status = ޖަވާބު ބަލަނީ
 answer-submitting-status = ޖަވާބު ފޮނުވަނީ
-
 answer-correct = ރަނގަޅު
 answer-incorrect = ނުބައި
-
 answer-response-saved = ޖަވާބު ރައްކާކުރެވިއްޖެ
-
 answer-percent-credit = { $percent }% މާކްސް
 answer-percent-correct = { $percent }% ރަނގަޅު
 answer-percent-short = { $percent } %
-
 max-credit-available = ލިބެންހުރި އެންމެ ގިނަ މާކްސް: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] އެއްވެސް ފުރުސަތެއް ނެތް
         [one] { $count } ފުރުސަތު ބާކީ
        *[other] { $count } ފުރުސަތު ބާކީ
     }
-
 validation-correct = (ރަނގަޅު)
 validation-incorrect = (ނުބައި)
 validation-partially-correct = (އެއްބައި ރަނގަޅު)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } އަށް { $count } ޖަވާބު ދައްކާ
        *[other] { $answerId } އަށް { $count } ޖަވާބު ދައްކާ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ފީޑްބެކް
-
 collapsible-click-to-open = (ހުޅުވަން ކްލިކްކުރައްވާ)
 collapsible-click-to-close = (ބަންދުކުރަން ކްލިކްކުރައްވާ)
-
 collapsible-initializing = ފަށަނީ…
-
 footnote-show = ފުޓްނޯޓު ދައްކާ
 footnote-hide = ފުޓްނޯޓު ފޮރުވާ
-
 description-more-information = އިތުރު މައުލޫމާތު
-
 
 ## Controls
 
 slider-previous = ކުރީގެ
 slider-next = ދެން
-
 keyboard-open = ކީބޯޑު ހުޅުވާ
 keyboard-close = ކީބޯޑު ބަންދުކުރޭ
-
 choice-input-remove-choice = { $choice } ނަގާ
-
 matrix-remove-row = ރޯ ނަގާ
 matrix-add-row = ރޯ އިތުރުކުރޭ
 matrix-remove-column = ކޮލަމް ނަގާ
 matrix-add-column = ކޮލަމް އިތުރުކުރޭ
-
 subset-add-remove-points = ނުކުތާ އިތުރުކުރޭ/ނަގާ
 subset-toggle-points-intervals = ނުކުތާއާއި ފަށަލަ ބަދަލުކުރޭ
 subset-move-points = ނުކުތާ ގެންދޭ
 subset-clear = ސާފުކުރޭ
-
 orbital-add-row = ރޯ އިތުރުކުރޭ
 orbital-remove-row = ރޯ ނަގާ
 orbital-add-box = ފޮށި އިތުރުކުރޭ
@@ -85,13 +66,9 @@ orbital-remove-box = ފޮށި ނަގާ
 orbital-add-up-arrow = މައްޗަށް އަމާޒު އިތުރުކުރޭ
 orbital-add-down-arrow = ތިރިއަށް އަމާޒު އިތުރުކުރޭ
 orbital-remove-arrow = އަމާޒު ނަގާ
-
 orbital-row-label = ރޯ { $row } ގެ ލޭބަލް
-
 pretzel-answer = ޖަވާބު
-
 summary-statistics-caption = { $column } ގެ ތަފާސް ހިސާބުގެ ޚުލާސާ
-
 
 ## Math input
 
@@ -99,34 +76,25 @@ math-input-preview-region = ހިސާބުގެ އިބާރާތުގެ ކުރީގެ �
 math-input-preview = ކުރީގެ ނަޒަރު
 math-input-invalid-expression = ސައްހަނޫން އިބާރާތެއް:
 
-
 ## Document status
 
 viewer-initializing = ފަށަނީ…
 
-
 ## Errors
 
 error-heading = ކުށް
-
 error-found-at =
     { $span ->
         [line] ފޮޅުވަތް { $startLine } ން ފެނުނު.
        *[lines] ފޮޅުވަތް { $startLine }–{ $endLine } ން ފެނުނު.
     }
-
 document-contains-errors = މި ލިޔުމުގައި ކުށް އެބަހުރި!
-
 diagnostic-heading-error = ކުށް
 diagnostic-heading-warning = އިންޒާރު
 diagnostic-heading-information = މައުލޫމާތު
 diagnostic-heading-hint = އިޝާރާތް
-
 accessibility-heading-level-1 = WCAG AA ވާސިލުވުމުގެ ޚިލާފުވުން
 accessibility-heading-level-2 = ވާސިލުވުމުގެ އިންޒާރު
-
 something-went-wrong = ކޮންމެވެސް ކަމެއް ގޯސްވެއްޖެ.
-
 renderer-load-failed = ދައްކާ އެއް ބައި ލޯޑެއް ނުވި. ސަފުހާ އަލުން ލޯޑުކުރައްވާ.
-
 core-start-failed = ލިޔުން ދައްކާ ބައި ފެށޭގޮތެއް ނުވި. ސަފުހާ އަލުން ލޯޑުކުރައްވާ.

--- a/packages/i18n/locales/dv/content.ftl
+++ b/packages/i18n/locales/dv/content.ftl
@@ -46,15 +46,12 @@ color =
     .purple = ދަނބު
     .pink = ފިޔާތޮށި
     .brown = މުށި
-
 line-width =
     .thick = ބޯ
     .thin = ތުނި
-
 line-style =
     .dashed = ކެނޑިކެނޑިގެން
     .dotted = ތިކިޖެހި
-
 fill-style =
     .horizontal = އަރިމަތީ ރޮނގު
     .vertical = ސީދާ ރޮނގު
@@ -62,7 +59,6 @@ fill-style =
     .backdiagonal = ވާތު ބުރި ރޮނގު
     .dots = ތިކި
     .diamonds = މުއްބަރު
-
 noun =
     .line = ރޮނގު
     .line-segment = ރޮނގުކޮޅު
@@ -82,7 +78,6 @@ noun =
     .diamond = މުއްބަރު
     .cross = ގުނަކުރުމުގެ ނިޝާން
     .plus = އެއްކުރުމުގެ ނިޝާން
-
 # «-ކަން ހުރި» takes the count and stands in front of the noun, so nothing
 # follows the adjectives and the tail is empty.
 noun-regular-polygon =
@@ -90,10 +85,8 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ކަން ހުރި ހަމަހަމަ ގިނަކަން
     }
-
 # Nothing selects on it: Dhivehi has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,15 +100,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ފުރިފައިވާ
-
 # «އިން» ("with, by means of") follows what it governs, so the pattern moves to
 # the front of the phrase where English appends it. It has one shape whatever
 # precedes it.
@@ -124,7 +114,6 @@ style-filled =
         [pattern] { $pattern } އިން { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } އިން { $filled } { $color } { $noun }
@@ -132,7 +121,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } އިން { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Dhivehi has no article, so the two `-article` branches read like their
 # neighbours; «އަދި» is the conjunction and stands in front.
 style-border-clause =
@@ -142,36 +130,29 @@ style-border-clause =
         [and-article] އަދި { $border } އަރިމަތްޗާއެކު
        *[with] { $border } އަރިމަތްޗާއެކު
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } އިން { $color } ފުރުން
        *[plain] { $color } ފުރުން
     }
-
 style-unfilled = ނުފުރޭ
-
 # «-ގައި» is the locative and has one shape too.
 style-text =
     { $parts ->
         [background] { $background } ބެކްގްރައުންޑުގައި { $color }
        *[plain] { $color }
     }
-
 style-background-none = އެއްވެސް އެއްޗެއް ނެތް
-
 
 ## Boolean words
 
 boolean-true = ތެދު
 boolean-false = ދޮގު
 
-
 ## Answer buttons
 
 answer-submit-label = ބައްލަވާ
 answer-submit-label-no-correctness = ޖަވާބު ފޮނުވާ
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = ހައްލު
     .task = މަސައްކަތް
     .theorem = ނަޒަރިއްޔާ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = އިޝާރާތް
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] ތާވަލު{ ": " }
        *[unnumbered] ތާވަލު
     }
-
 figure-name =
     { $parts ->
         [numbered] ތަސްވީރު { $enumeration }
@@ -228,28 +205,22 @@ figure-name =
        *[unnumbered] ތަސްވީރު
     }
 
-
 ## Paginator controls
 
 paginator-previous = ކުރީގެ
 paginator-next = ދެން
 paginator-page = ސަފުހާ
-
 # «X ން Y» — "Y out of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } ން { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = ނުވަތަ
-
 # Clause-final in Dhivehi and placed before the mathematics by the renderer;
 # see the header. The word is right and its position is not.
 piecewise-condition-if = ނަމަ
-
 piecewise-condition-otherwise = އެހެންނޫންނަމަ
-
 
 ## Chemistry
 ##
@@ -265,6 +236,5 @@ piecewise-condition-otherwise = އެހެންނޫންނަމަ
 ## and no table waiting behind it.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ސައްހަނޫން ކެމިކަލް ނިޝާން
 chemistry-invalid-ionic-compound = ސައްހަނޫން އަޔޮނިކް މުރައްކަބު

--- a/packages/i18n/locales/dyo/chrome.ftl
+++ b/packages/i18n/locales/dyo/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Ka juut...
 answer-submitting = Ka lel...
-
 answer-checking-status = Ka juut kalipi
 answer-submitting-status = Ka lel kalipi
-
 answer-correct = Katofo
 answer-incorrect = Katofo arus
-
 answer-response-saved = Kalipi Ma Sit
-
 answer-percent-credit = { $percent }% Kabay
 answer-percent-correct = { $percent }% Katofo
 answer-percent-short = { $percent } %
-
 max-credit-available = Kabay kaboor ka mu am: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] katampa arus
         [one] katampa { $count } ka sipeŋ
        *[other] sitampa { $count } si sipeŋ
     }
-
 validation-correct = (Katofo)
 validation-incorrect = (Katofo arus)
 validation-partially-correct = (Katofo kapat)
-
 answer-show-responses =
     { $count ->
         [one] Won kalipi { $count } ku { $answerId }
        *[other] Won silipi { $count } si ku { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Silipi si kasandi
-
 collapsible-click-to-open = (toot buka tulen)
 collapsible-click-to-close = (toot buka kant)
-
 collapsible-initializing = Ka tam...
-
 footnote-show = Won kasandi ka katep
 footnote-hide = Cim kasandi ka katep
-
 description-more-information = sikeer sixaley
-
 
 ## Controls
 
 slider-previous = Ka paa
 slider-next = Ka taŋ
-
 keyboard-open = Tulen Kibɔd
 keyboard-close = Kant Kibɔd
-
 choice-input-remove-choice = Cim { $choice }
-
 matrix-remove-row = Cim karoo
 matrix-add-row = Lomb karoo
 matrix-remove-column = Cim kakolom
 matrix-add-column = Lomb kakolom
-
 subset-add-remove-points = Lomb/Cim situt
 subset-toggle-points-intervals = Yeen situt ase siyintaval
 subset-move-points = Baŋ Situt
 subset-clear = Lëf
-
 orbital-add-row = Lomb Karoo
 orbital-remove-row = Cim Karoo
 orbital-add-box = Lomb Kabɔks
@@ -87,13 +68,9 @@ orbital-remove-box = Cim Kabɔks
 orbital-add-up-arrow = Lomb Kaaro ka Katoŋ
 orbital-add-down-arrow = Lomb Kaaro ka Katep
 orbital-remove-arrow = Cim Kaaro
-
 orbital-row-label = Funoor ka karoo { $row }
-
 pretzel-answer = Kalipi
-
 summary-statistics-caption = Kabat si sinoome si { $column }
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = won funkeer ka mat paa
 math-input-preview = Won paa
 math-input-invalid-expression = Funkeer ka yem arus:
 
-
 ## Document status
 
 viewer-initializing = Ka tam...
 
-
 ## Errors
 
 error-heading = Kakaañ
-
 error-found-at =
     { $span ->
         [line] Ma siit ku kalay { $startLine }.
        *[lines] Ma siit ku silay { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Kabuk kanɛ ka na sikaañ!
-
 diagnostic-heading-error = Kakaañ
 diagnostic-heading-warning = Kafur
 diagnostic-heading-information = Funkeer
 diagnostic-heading-hint = Kasandi
-
 accessibility-heading-level-1 = WCAG AA Kakaañ ka Kasoot
 accessibility-heading-level-2 = Kafur ka kasoot
-
 something-went-wrong = Kajaŋ ka yem arus.
-
 renderer-load-failed = kayiraŋ kajaŋ ka lel arus. Yeen kapej.
-
 core-start-failed = Kayiraŋ ka kabuk ka tam arus. Yeen kapej.

--- a/packages/i18n/locales/dyo/content.ftl
+++ b/packages/i18n/locales/dyo/content.ftl
@@ -114,7 +114,6 @@ color =
     .purple = mov
     .pink = roz
     .brown = maron
-
 line-width =
     .thick =
         { $gender ->
@@ -130,14 +129,12 @@ line-width =
             [fu] fukenkeen
            *[ka] kakenkeen
         }
-
 # Written as «ku …» phrases rather than as class-marked qualifiers, so that
 # they take no concord and can close the description. `style-stroke` puts
 # them last.
 line-style =
     .dashed = ku sipatpati
     .dotted = ku sitoni
-
 fill-style =
     .horizontal = silay si lëmp
     .vertical = silay si tell
@@ -145,7 +142,6 @@ fill-style =
     .backdiagonal = silay si jeeñ ku situp
     .dots = sitoni
     .diamonds = sidiyamɔn
-
 # Every noun below carries its class prefix in writing, so `noun-gender`'s
 # table can be read straight off this message. That is the property the
 # header describes.
@@ -168,7 +164,6 @@ noun =
     .diamond = fulosas
     .cross = fukurwa
     .plus = fumandarga plus
-
 # The side count is a relative and closes the noun phrase behind the
 # describing words, so it goes in the tail — mirroring the shape
 # `noun-regular-polygon`'s own comment in `locales/en` asks for.
@@ -177,7 +172,6 @@ noun-regular-polygon =
         [tail] bu am { $numSides } wet
        *[head] bupoligɔn bu yem
     }
-
 # The noun class. Read it against `noun` above: each entry naming one of
 # `noun`'s attributes takes the class that attribute's own written prefix
 # carries, and `regular-polygon` takes `bu` because `noun-regular-polygon`'s
@@ -206,7 +200,6 @@ noun-gender =
        *[other] ka
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ku …» phrase and closes the description, so it
@@ -221,13 +214,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [si] sifees
@@ -235,13 +226,11 @@ style-filled-word =
         [fu] fufees
        *[ka] kafees
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ku { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ku { $pattern }
@@ -249,7 +238,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ku { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «funbaŋ» is the border and leads its own describing words, so they agree
 # with it rather than with the shape it surrounds — which is why `border`
 # answers `fu` in `noun-gender`, matching that word's own `fu-`. Jola-Fonyi
@@ -262,35 +250,28 @@ style-border-clause =
         [and-article] ku funbaŋ { $border }
        *[with] ku funbaŋ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = fees arus
-
 style-text =
     { $parts ->
         [background] { $color } ku kabaka { $background }
        *[plain] { $color }
     }
-
 style-background-none = lëf
-
 
 ## Boolean words
 
 boolean-true = yem
 boolean-false = arus
 
-
 ## Answer buttons
 
 answer-submit-label = Juut Lil
 answer-submit-label-no-correctness = Lel Kalipi
-
 
 ## Sectional blocks
 
@@ -315,7 +296,6 @@ section-name =
     .solution = Solisiyɔŋ
     .task = Lil
     .theorem = Tiyorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -325,9 +305,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kasandi
-
 
 ## Tables and figures
 
@@ -338,7 +316,6 @@ table-name =
         [unnumbered-title] Tabal{ ": " }
        *[unnumbered] Tabal
     }
-
 figure-name =
     { $parts ->
         [numbered] Kamisal { $enumeration }
@@ -347,22 +324,18 @@ figure-name =
        *[unnumbered] Kamisal
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ka paa
 paginator-next = Ka taŋ
 paginator-page = Kapej
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = mba
 piecewise-condition-if = te
 piecewise-condition-otherwise = ku sipeŋ
-
 
 ## Chemistry
 ##
@@ -372,6 +345,5 @@ piecewise-condition-otherwise = ku sipeŋ
 ## elsewhere, is taught in French.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kamark ka Kimi ka Yem Arus
 chemistry-invalid-ionic-compound = Katofi ka Ayɔn ka Yem Arus

--- a/packages/i18n/locales/dyu/chrome.ftl
+++ b/packages/i18n/locales/dyu/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Lajɛli bɛ kɛ…
 answer-submitting = Cili bɛ kɛ…
-
 answer-checking-status = Jaabi bɛ lajɛ
 answer-submitting-status = Jaabi bɛ ci
-
 answer-correct = A ka ɲi
 answer-incorrect = A man ɲi
-
 answer-response-saved = Jaabi maralen don
-
 answer-percent-credit = { $percent }% pɔnw
 answer-percent-correct = { $percent }% ka ɲi
 answer-percent-short = { $percent } %
-
 max-credit-available = Pɔn caman minnu bɛ sɔrɔ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kɛcogo si ma to
         [one] kɛcogo { $count } tora
        *[other] kɛcogo { $count } tora
     }
-
 validation-correct = (A ka ɲi)
 validation-incorrect = (A man ɲi)
 validation-partially-correct = (A ka ɲi yɔrɔ dɔ la)
-
 answer-show-responses =
     { $count ->
         [one] Jaabi { $count } jira { $answerId } kan
        *[other] Jaabi { $count } jira { $answerId } kan
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ladilikan
-
 collapsible-click-to-open = (a digi walisa ka a da wuli)
 collapsible-click-to-close = (a digi walisa ka a datugu)
-
 collapsible-initializing = Damina bɛ kɛ…
-
 footnote-show = Duguma sɛbɛnni jira
 footnote-hide = Duguma sɛbɛnni dogo
-
 description-more-information = kunnafoni wɛrɛw
-
 
 ## Controls
 
 slider-previous = Tɛmɛnen
 slider-next = Nata
-
 keyboard-open = Klaviye Da Wuli
 keyboard-close = Klaviye Datugu
-
 choice-input-remove-choice = { $choice } bɔ
-
 matrix-remove-row = Layini bɔ
 matrix-add-row = Layini fara
 matrix-remove-column = Kolɔni bɔ
 matrix-add-column = Kolɔni fara
-
 subset-add-remove-points = Pɔnw fara/bɔ
 subset-toggle-points-intervals = Pɔnw ni tilayɔrɔw falen
 subset-move-points = Pɔnw Lamaga
 subset-clear = Bɛɛ bɔ
-
 orbital-add-row = Layini Fara
 orbital-remove-row = Layini Bɔ
 orbital-add-box = Kɛsu Fara
@@ -86,13 +67,9 @@ orbital-remove-box = Kɛsu Bɔ
 orbital-add-up-arrow = Sanfɛ Bin Fara
 orbital-add-down-arrow = Dugumafɛ Bin Fara
 orbital-remove-arrow = Bin Bɔ
-
 orbital-row-label = Layini { $row } tɔgɔ
-
 pretzel-answer = Jaabi
-
 summary-statistics-caption = { $column } jatew kunkurunni
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = jatebɔ kuma ɲɛfɔli
 math-input-preview = Ɲɛfɔli
 math-input-invalid-expression = Kuma jugu:
 
-
 ## Document status
 
 viewer-initializing = Damina bɛ kɛ…
 
-
 ## Errors
 
 error-heading = Fili
-
 error-found-at =
     { $span ->
         [line] A sɔrɔla layini { $startLine } kan.
        *[lines] A sɔrɔla layini { $startLine }–{ $endLine } kan.
     }
-
 document-contains-errors = Sɛbɛn in filiw bɛ a la!
-
 diagnostic-heading-error = Fili
 diagnostic-heading-warning = Lasɔmini
 diagnostic-heading-information = Kunnafoni
 diagnostic-heading-hint = Nɔnabɔli
-
 accessibility-heading-level-1 = WCAG AA sekokɔrɔ tɛmɛ
 accessibility-heading-level-2 = Sekokɔrɔ lasɔmini
-
 something-went-wrong = Fɛn dɔ ma ɲɛ.
-
 renderer-load-failed = jirala ma se. Aw ye ɲɛ in segin.
-
 core-start-failed = Sɛbɛn jirala ma damina. Aw ye ɲɛ in segin.

--- a/packages/i18n/locales/dyu/content.ftl
+++ b/packages/i18n/locales/dyu/content.ftl
@@ -53,17 +53,14 @@ color =
     .purple = wulenfinman
     .pink = wulenɲɛman
     .brown = bɔgɔman
-
 line-width =
     .thick = bonman
     .thin = misɛnman
-
 # Written as «ni …» phrases rather than as qualifiers, so that they take no
 # `-man` and can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = ni tirɛw ye
     .dotted = ni pɔnw ye
-
 fill-style =
     .horizontal = layini dalenw
     .vertical = layini lɔlenw
@@ -71,7 +68,6 @@ fill-style =
     .backdiagonal = layini jɛngɛlen kɔfɛtaw
     .dots = pɔnw
     .diamonds = losanziw
-
 noun =
     .line = layini
     .line-segment = layini tilayɔrɔ
@@ -91,7 +87,6 @@ noun =
     .diamond = losanzi
     .cross = kuruwa
     .plus = fara-taamasere
-
 # The side count follows the qualifiers, behind «min kɛrɛ … ye», because Dyula
 # closes a noun phrase with a relative rather than opening one.
 noun-regular-polygon =
@@ -99,11 +94,9 @@ noun-regular-polygon =
         [tail] min kɛrɛ { $numSides } ye
        *[head] poligɔni bɛnnen
     }
-
 # No grammatical gender, so this answers one token for every noun and the
 # answer goes unused — the shape `locales/en` has.
 noun-gender = kelen
-
 
 ## Style composition
 
@@ -117,21 +110,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = falenman
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ni { $pattern } ye
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ni { $pattern } ye
@@ -139,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ni { $pattern } ye
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Dyula has no article, and joins this clause with «ni … ye» whatever came
 # before it, so all four branches read alike.
 style-border-clause =
@@ -149,35 +137,28 @@ style-border-clause =
         [and-article] ni dankan { $border } ye
        *[with] ni dankan { $border } ye
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = falenbali
-
 style-text =
     { $parts ->
         [background] { $color } ni kɔfɛla { $background } ye
        *[plain] { $color }
     }
-
 style-background-none = foyi tɛ yen
-
 
 ## Boolean words
 
 boolean-true = tiɲɛ
 boolean-false = nkalon
 
-
 ## Answer buttons
 
 answer-submit-label = Baara Lajɛ
 answer-submit-label-no-correctness = Jaabi Ci
-
 
 ## Sectional blocks
 
@@ -202,7 +183,6 @@ section-name =
     .solution = Fura
     .task = Baara
     .theorem = Teyorɛmu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -212,9 +192,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Nɔnabɔli
-
 
 ## Tables and figures
 
@@ -225,7 +203,6 @@ table-name =
         [unnumbered-title] Tabalo{ ": " }
        *[unnumbered] Tabalo
     }
-
 figure-name =
     { $parts ->
         [numbered] Ja { $enumeration }
@@ -234,24 +211,18 @@ figure-name =
        *[unnumbered] Ja
     }
 
-
 ## Paginator controls
 
 paginator-previous = Tɛmɛnen
 paginator-next = Nata
 paginator-page = Ɲɛ
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = walima
-
 piecewise-condition-if = ni
-
 piecewise-condition-otherwise = yɔrɔ tɔw bɛɛ la
-
 
 ## Chemistry
 ##
@@ -264,6 +235,5 @@ piecewise-condition-otherwise = yɔrɔ tɔw bɛɛ la
 ## border away and `locales/mos` gives inside one of the same two countries.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simi Taamasere Jugu
 chemistry-invalid-ionic-compound = Ayɔn Ɲagaminen Jugu

--- a/packages/i18n/locales/dz/chrome.ftl
+++ b/packages/i18n/locales/dz/chrome.ftl
@@ -15,69 +15,50 @@
 
 answer-checking = ཞིབ་དཔྱད་འབད་དོ།
 answer-submitting = བཏང་དོ།
-
 answer-checking-status = ལན་ལུ་ཞིབ་དཔྱད་འབད་དོ
 answer-submitting-status = ལན་བཏང་དོ
-
 answer-correct = ངོ་མ
 answer-incorrect = འཛོལ་བ
-
 answer-response-saved = ལན་བསྲུངས་ཡི
-
 answer-percent-credit = { $percent }% སྐུགས
 answer-percent-correct = { $percent }% ངོ་མ
 answer-percent-short = { $percent } %
-
 max-credit-available = ཐོབ་ཚུགས་པའི་སྐུགས་མང་ཤོས། { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] འབད་རྩོལ་ལྷག་ལུས་མེད
        *[other] འབད་རྩོལ་ { $count } ལྷག་ལུས་ཡོད
     }
-
 validation-correct = (ངོ་མ)
 validation-incorrect = (འཛོལ་བ)
 validation-partially-correct = (ཕྱོགས་གཅིག་ངོ་མ)
-
 answer-show-responses = { $answerId } ལུ་ལན་ { $count } སྟོན
-
 
 ## Disclosure panels
 
 feedback-heading = བསམ་ལན
-
 collapsible-click-to-open = (ཁ་ཕྱེ་ནི་ལུ་ཨེབ)
 collapsible-click-to-close = (ཁ་བསྡམ་ནི་ལུ་ཨེབ)
-
 collapsible-initializing = འགོ་བཙུགས་དོ།
-
 footnote-show = མཇུག་གི་དྲན་གསོ་སྟོན
 footnote-hide = མཇུག་གི་དྲན་གསོ་སྦས
-
 description-more-information = བརྡ་དོན་ཧེང་བཀལ
-
 
 ## Controls
 
 slider-previous = ཧེ་མམ
 slider-next = ཤུལ་མམ
-
 keyboard-open = ལྡེ་སྒྲོམ་ཁ་ཕྱེ
 keyboard-close = ལྡེ་སྒྲོམ་ཁ་བསྡམ
-
 choice-input-remove-choice = { $choice } རྩ་བསྐྲད
-
 matrix-remove-row = གྲལ་ཐིག་རྩ་བསྐྲད
 matrix-add-row = གྲལ་ཐིག་ཁ་སྐོང
 matrix-remove-column = ཀེར་ཐིག་རྩ་བསྐྲད
 matrix-add-column = ཀེར་ཐིག་ཁ་སྐོང
-
 subset-add-remove-points = ཚག་ཁ་སྐོང་དང་རྩ་བསྐྲད
 subset-toggle-points-intervals = ཚག་དང་བར་མཚམས་སོར
 subset-move-points = ཚག་སྤོ
 subset-clear = བསལ
-
 orbital-add-row = གྲལ་ཐིག་ཁ་སྐོང
 orbital-remove-row = གྲལ་ཐིག་རྩ་བསྐྲད
 orbital-add-box = སྒྲོམ་ཁ་སྐོང
@@ -85,13 +66,9 @@ orbital-remove-box = སྒྲོམ་རྩ་བསྐྲད
 orbital-add-up-arrow = ཡར་མདའ་ཁ་སྐོང
 orbital-add-down-arrow = མར་མདའ་ཁ་སྐོང
 orbital-remove-arrow = མདའ་རྩ་བསྐྲད
-
 orbital-row-label = གྲལ་ཐིག་ { $row } གི་ཁ་ཡིག
-
 pretzel-answer = ལན
-
 summary-statistics-caption = { $column } གི་གྲངས་ཐོའི་བསྡུས་དོན
-
 
 ## Math input
 
@@ -99,34 +76,25 @@ math-input-preview-region = ཨང་རྩིས་བརྗོད་པའི�
 math-input-preview = སྔོན་ལྟ
 math-input-invalid-expression = བརྗོད་པ་ནོར་བ།
 
-
 ## Document status
 
 viewer-initializing = འགོ་བཙུགས་དོ།
 
-
 ## Errors
 
 error-heading = འཛོལ་བ
-
 error-found-at =
     { $span ->
         [line] གྲལ་ཐིག་ { $startLine } ལུ་ཐོབ་ཅི།
        *[lines] གྲལ་ཐིག་ { $startLine }–{ $endLine } ལུ་ཐོབ་ཅི།
     }
-
 document-contains-errors = ཡིག་ཆ་འདི་ནང་འཛོལ་བ་འདུག
-
 diagnostic-heading-error = འཛོལ་བ
 diagnostic-heading-warning = ཉེན་བརྡ
 diagnostic-heading-information = བརྡ་དོན
 diagnostic-heading-hint = བརྡ་མཚོན
-
 accessibility-heading-level-1 = WCAG AA འཛུལ་སྤྱོད་འགལ་བ
 accessibility-heading-level-2 = འཛུལ་སྤྱོད་ཉེན་བརྡ
-
 something-went-wrong = ག་ཅི་ཞིག་འཛོལ་སོ་ནུག
-
 renderer-load-failed = སྟོན་བྱེད་ཅིག་མངོན་གསལ་འབད་མ་ཚུགས། ཤོག་ལེབ་ལོག་མངོན་གསལ་འབད་གནང་།
-
 core-start-failed = ཡིག་ཆ་སྟོན་བྱེད་འགོ་བཙུགས་མ་ཚུགས། ཤོག་ལེབ་ལོག་མངོན་གསལ་འབད་གནང་།

--- a/packages/i18n/locales/dz/content.ftl
+++ b/packages/i18n/locales/dz/content.ftl
@@ -46,15 +46,12 @@ color =
     .purple = རྒྱ་སྨུག
     .pink = ཟིང་སྐྱ
     .brown = སྨུག་པོ
-
 line-width =
     .thick = སྦོམ
     .thin = ཕྲམ
-
 line-style =
     .dashed = ཆད་ལྷུག
     .dotted = ཚེག་ཅན
-
 fill-style =
     .horizontal = འཕྲང་ཐིག
     .vertical = ཐད་ཐིག
@@ -62,7 +59,6 @@ fill-style =
     .backdiagonal = ལོག་ཟུར་ཐིག
     .dots = ཚེག
     .diamonds = ཕ་ལམ་གཟུགས
-
 noun =
     .line = གྲལ་ཐིག
     .line-segment = ཐིག་དུམ
@@ -82,7 +78,6 @@ noun =
     .diamond = ཕ་ལམ་གཟུགས
     .cross = བསྒྱུར་རྟགས
     .plus = ཁ་སྐོང་རྟགས
-
 # The count is a complement that follows the whole phrase, so the head carries
 # the noun alone and the tail carries the count.
 noun-regular-polygon =
@@ -90,10 +85,8 @@ noun-regular-polygon =
         [tail] ཟུར་ { $numSides } ཡོདཔ
        *[head] ཚད་མཉམ་ཟུར་མང
     }
-
 # Nothing selects on it: Dzongkha has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,22 +100,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = བཀངམ
-
 # «དང་» is invariant whatever precedes it.
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } དང་བཅསཔ
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } { $pattern } དང་བཅསཔ
@@ -130,7 +119,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } { $pattern } དང་བཅསཔ
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Dzongkha has no article, so the `-article` branches read like their
 # neighbours.
 style-border-clause =
@@ -140,36 +128,29 @@ style-border-clause =
         [and-article] ད་རུང་མཐའ་ { $border } དང་བཅསཔ
        *[with] མཐའ་ { $border } དང་བཅསཔ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = མ་བཀངམ
-
 # «ལུ་», the Dzongkha dative, is invariant too.
 style-text =
     { $parts ->
         [background] རྒྱབ་གཞི་ { $background } ལུ་ { $color }
        *[plain] { $color }
     }
-
 style-background-none = ག་ནི་ཡང་མེད
-
 
 ## Boolean words
 
 boolean-true = བདེན་པ
 boolean-false = རྫུན་པ
 
-
 ## Answer buttons
 
 answer-submit-label = ཞིབ་དཔྱད
 answer-submit-label-no-correctness = ལན་བཏང
-
 
 ## Sectional blocks
 
@@ -194,7 +175,6 @@ section-name =
     .solution = ཐབས་ལམ
     .task = ལཱ
     .theorem = གཏན་ཚིག
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -204,9 +184,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = བརྡ་མཚོན
-
 
 ## Tables and figures
 
@@ -217,7 +195,6 @@ table-name =
         [unnumbered-title] ཐིག་ཁྲམ{ ": " }
        *[unnumbered] ཐིག་ཁྲམ
     }
-
 figure-name =
     { $parts ->
         [numbered] པར་རིས { $enumeration }
@@ -226,25 +203,19 @@ figure-name =
        *[unnumbered] པར་རིས
     }
 
-
 ## Paginator controls
 
 paginator-previous = ཧེ་མམ
 paginator-next = ཤུལ་མམ
 paginator-page = ཤོག་ལེབ
-
 # «X ནང་ Y» — "Y of X" — puts the total first; «ནང་» is invariant.
 paginator-page-status = { $numPages } ནང་ { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ཡང་ན
-
 piecewise-condition-if = པ་ཅིན
-
 piecewise-condition-otherwise = དེ་མིན
-
 
 ## Chemistry
 ##
@@ -261,6 +232,5 @@ piecewise-condition-otherwise = དེ་མིན
 ## Two catalogs in one script, two different reasons for the same gap.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ནུས་རྫས་ཀྱི་བརྡ་རྟགས་ནོར་བ
 chemistry-invalid-ionic-compound = རླུང་རྡུལ་འདུས་རྫས་ནོར་བ

--- a/packages/i18n/locales/ee/chrome.ftl
+++ b/packages/i18n/locales/ee/chrome.ftl
@@ -23,69 +23,50 @@
 
 answer-checking = Ele kpɔkpɔm...
 answer-submitting = Ele ɖoɖom ɖa...
-
 answer-checking-status = Ele ŋuɖoɖoa kpɔm
 answer-submitting-status = Ele ŋuɖoɖoa ɖom ɖa
-
 answer-correct = Esɔ
 answer-incorrect = Mesɔ o
-
 answer-response-saved = Woɖo Ŋuɖoɖoa Ɖi
-
 answer-percent-credit = Dzesi { $percent }%
 answer-percent-correct = { $percent }% Sɔ
 answer-percent-short = { $percent } %
-
 max-credit-available = Dzesi gãtɔ si woate ŋu axɔ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] agbagbadzedze aɖeke mesusɔ o
        *[other] agbagbadzedze { $count } susɔ
     }
-
 validation-correct = (Esɔ)
 validation-incorrect = (Mesɔ o)
 validation-partially-correct = (Esɔ le akpa aɖe me)
-
 answer-show-responses = Fia ŋuɖoɖo { $count } si woɖo ɖe { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Nyaŋuɖoɖo
-
 collapsible-click-to-open = (zi edzi be nàʋui)
 collapsible-click-to-close = (zi edzi be nàtui)
-
 collapsible-initializing = Ele gɔmedzedzem...
-
 footnote-show = Fia afɔnuŋɔŋlɔ
 footnote-hide = Ɣla afɔnuŋɔŋlɔ
-
 description-more-information = nyatakaka bubuwo
-
 
 ## Controls
 
 slider-previous = Megbe
 slider-next = Ŋgɔ
-
 keyboard-open = Ʋu Fɛŋlɔdzesiawo
 keyboard-close = Tu Fɛŋlɔdzesiawo
-
 choice-input-remove-choice = Ɖe { $choice } ɖa
-
 matrix-remove-row = Ɖe fli ɖa
 matrix-add-row = Tsɔ fli kpe ɖe eŋu
 matrix-remove-column = Ɖe sɔti ɖa
 matrix-add-column = Tsɔ sɔti kpe ɖe eŋu
-
 subset-add-remove-points = Tsɔ nɔƒe kpe ɖe eŋu/Ɖe wo ɖa
 subset-toggle-points-intervals = Trɔ le nɔƒewo kple dometsotsowo dome
 subset-move-points = Ʋu Nɔƒeawo
 subset-clear = Tutu
-
 # A `box` here is one orbital, drawn as a square: «aɖaka».
 orbital-add-row = Tsɔ Fli Kpe Ɖe Eŋu
 orbital-remove-row = Ɖe Fli Ɖa
@@ -94,13 +75,9 @@ orbital-remove-box = Ɖe Aɖaka Ɖa
 orbital-add-up-arrow = Tsɔ Aŋutrɔ Dziyimetɔ Kpe Ɖe Eŋu
 orbital-add-down-arrow = Tsɔ Aŋutrɔ Anyiyimetɔ Kpe Ɖe Eŋu
 orbital-remove-arrow = Ɖe Aŋutrɔ Ɖa
-
 orbital-row-label = Fli { $row } ƒe ŋkɔ
-
 pretzel-answer = Ŋuɖoɖo
-
 summary-statistics-caption = { $column } ƒe akɔntabubu kpuiwo
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = akɔntabubu nyagbe ƒe ŋgɔdokpɔ
 math-input-preview = Ŋgɔdokpɔ
 math-input-invalid-expression = Nyagbea mesɔ o:
 
-
 ## Document status
 
 viewer-initializing = Ele gɔmedzedzem...
 
-
 ## Errors
 
 error-heading = Vodada
-
 error-found-at =
     { $span ->
         [line] Wokpɔe le fli { $startLine } dzi.
        *[lines] Wokpɔe le fli { $startLine }–{ $endLine } dzi.
     }
-
 document-contains-errors = Vodadawo le agbalẽ sia me!
-
 diagnostic-heading-error = Vodada
 diagnostic-heading-warning = Nuxlɔ̃ame
 diagnostic-heading-information = Nyatakaka
 diagnostic-heading-hint = Mɔfiame
-
 accessibility-heading-level-1 = WCAG AA Sedzimawɔmawɔ le Ŋudɔwɔwɔ Ŋu
 accessibility-heading-level-2 = Ŋudɔwɔwɔ ŋuti nuxlɔ̃ame
-
 something-went-wrong = Nane meyi edzi nyuie o.
-
 renderer-load-failed = nufiala ɖeka mete ŋu va o. Taflatse gaʋu axaa.
-
 core-start-failed = Agbalẽ kpɔla la mete ŋu dze egɔme o. Taflatse gaʋu axaa.

--- a/packages/i18n/locales/ee/content.ftl
+++ b/packages/i18n/locales/ee/content.ftl
@@ -42,17 +42,14 @@ color =
     .purple = pɔpul
     .pink = piŋk
     .brown = anyigbatɔ
-
 line-width =
     .thick = lolo
     .thin = sue
-
 # Written as «kple …» phrases rather than as adjectives, so that they can close
 # the description. `style-stroke` puts them last for that reason.
 line-style =
     .dashed = kple fli kakɛwo
     .dotted = kple dzesi sueawo
-
 fill-style =
     .horizontal = fli mlɔamlɔwo
     .vertical = fli tsitrewo
@@ -60,7 +57,6 @@ fill-style =
     .backdiagonal = fli dzeŋgɔ megbetɔwo
     .dots = dzesi sueawo
     .diamonds = adzagbawo
-
 noun =
     .line = fli
     .line-segment = fli akpa
@@ -80,7 +76,6 @@ noun =
     .diamond = adzagba
     .cross = atitsoga
     .plus = tsɔkpe dzesi
-
 # The side count follows the adjectives, behind «si le», because Ewe closes a
 # noun phrase with a relative rather than opening one: «axa geɖe sɔsɔ dzĩ si le
 # axa 5».
@@ -89,9 +84,7 @@ noun-regular-polygon =
         [tail] si le axa { $numSides }
        *[head] axa geɖe sɔsɔ
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,21 +98,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = si me yɔ
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kple { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kple { $pattern }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kple { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Ewe has no article and joins the complement with the invariable «kple», so
 # all four branches read alike.
 style-border-clause =
@@ -137,35 +125,28 @@ style-border-clause =
         [and-article] kple liƒo { $border }
        *[with] kple liƒo { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = si me meyɔ o
-
 style-text =
     { $parts ->
         [background] { $color } le megbenu { $background } dzi
        *[plain] { $color }
     }
-
 style-background-none = ɖeke meli o
-
 
 ## Boolean words
 
 boolean-true = nyateƒe
 boolean-false = alakpa
 
-
 ## Answer buttons
 
 answer-submit-label = Do Dɔa Kpɔ
 answer-submit-label-no-correctness = Ɖo Ŋuɖoɖoa Ɖa
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = Kuxikakaɖeŋu
     .task = Dɔ
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -200,9 +180,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Mɔfiame
-
 
 ## Tables and figures
 
@@ -213,7 +191,6 @@ table-name =
         [unnumbered-title] Kplɔ̃{ ": " }
        *[unnumbered] Kplɔ̃
     }
-
 figure-name =
     { $parts ->
         [numbered] Nɔnɔmetata { $enumeration }
@@ -222,22 +199,18 @@ figure-name =
        *[unnumbered] Nɔnɔmetata
     }
 
-
 ## Paginator controls
 
 paginator-previous = Do ŋgɔ
 paginator-next = Emegbetɔ
 paginator-page = Axa
-
 paginator-page-status = { $pageLabel } { $currentPage } le { $numPages } dome
-
 
 ## Piecewise functions
 
 piecewise-condition-or = alo
 piecewise-condition-if = ne
 piecewise-condition-otherwise = ne menye nenema o
-
 
 ## Chemistry
 
@@ -248,6 +221,5 @@ piecewise-condition-otherwise = ne menye nenema o
 # seed that guessed would have to guess twice, once for each school system. A
 # speaker adding a list should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kemikal Dzesi Si Mesɔ O
 chemistry-invalid-ionic-compound = Ion Nutsotso Si Mesɔ O

--- a/packages/i18n/locales/efi/chrome.ftl
+++ b/packages/i18n/locales/efi/chrome.ftl
@@ -24,51 +24,38 @@
 
 answer-checking = Ke ndise…
 answer-submitting = Ke ndinọ…
-
 answer-checking-status = Ke ndise ibọrọ
 answer-submitting-status = Ke ndinọ ibọrọ
-
 answer-correct = Nen
 answer-incorrect = Inenke
-
 answer-response-saved = Ẹkpọn̄ Ibọrọ
-
 answer-percent-credit = { $percent }% Ntak
 answer-percent-correct = { $percent }% Nen
 answer-percent-short = { $percent } %
-
 max-credit-available = Ata ntak oro ẹkemede ndinọ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] mîdụhe ndomo efen
         [one] ndomo { $count } efen odụhe
        *[other] ndomo { $count } efen ẹdụhe
     }
-
 validation-correct = (Nen)
 validation-incorrect = (Inenke)
 validation-partially-correct = (Enen ke ubak ubak)
-
 answer-show-responses =
     { $count ->
         [one] Wụt ibọrọ { $count } oro ẹnọde { $answerId }
        *[other] Wụt mme ibọrọ { $count } oro ẹnọde { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ikọ Ntịn̄
-
 collapsible-click-to-open = (mia man ọberede)
 collapsible-click-to-close = (mia man ọfịk)
-
 collapsible-initializing = Ke ntọn̄ọ…
-
 footnote-show = Wụt n̄wed idak
 footnote-hide = Dịbe n̄wed idak
-
 description-more-information = adian ibat
 
 # Placeholder inside a panel that has been opened before its contents have
@@ -79,22 +66,17 @@ description-more-information = adian ibat
 
 slider-previous = Mbemiso
 slider-next = N̄kaha
-
 keyboard-open = Beere Keyboard
 keyboard-close = Fịk Keyboard
-
 choice-input-remove-choice = Sio { $choice }
-
 matrix-remove-row = Sio ubọk
 matrix-add-row = Dian ubọk
 matrix-remove-column = Sio ọtọn̄ọ
 matrix-add-column = Dian ọtọn̄ọ
-
 subset-add-remove-points = Dian/Sio mme ntọt
 subset-toggle-points-intervals = Kpụhọde mme ntọt ye mme ufan̄
 subset-move-points = Domo Mme Ntọt
 subset-clear = Nyat Kpụhọde
-
 orbital-add-row = Dian Ubọk
 orbital-remove-row = Sio Ubọk
 orbital-add-box = Dian Ekpat
@@ -102,13 +84,9 @@ orbital-remove-box = Sio Ekpat
 orbital-add-up-arrow = Dian Ọfịọn̄ Ke Enyọn̄
 orbital-add-down-arrow = Dian Ọfịọn̄ Ke Idem
 orbital-remove-arrow = Sio Ọfịọn̄
-
 orbital-row-label = Enyịn̄ ubọk { $row }
-
 pretzel-answer = Ibọrọ
-
 summary-statistics-caption = Ibat ekikere ntamban̄a { $column }
-
 
 ## Math input
 
@@ -116,34 +94,25 @@ math-input-preview-region = ndise n̄kpọ ekikere mbemiso
 math-input-preview = Ndise Mbemiso
 math-input-invalid-expression = Ikọ ekikere emi enyeneke uduak:
 
-
 ## Document status
 
 viewer-initializing = Ke ntọn̄ọ…
 
-
 ## Errors
 
 error-heading = Ndudue
-
 error-found-at =
     { $span ->
         [line] Ẹkụt ke lain { $startLine }.
        *[lines] Ẹkụt ke lain { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = N̄wed emi enyene ndudue!
-
 diagnostic-heading-error = Ndudue
 diagnostic-heading-warning = Utọt
 diagnostic-heading-information = Ntọn̄ọ
 diagnostic-heading-hint = Ibuot
-
 accessibility-heading-level-1 = Ndudue WCAG AA Ntak Ekemede Ndinọ Kpukpru Owo
 accessibility-heading-level-2 = Ntọt Ntak Ekemede Ndinọ Kpukpru Owo
-
 something-went-wrong = N̄kpọ ẹkenam ke usụn̄ oro mîdotke.
-
 renderer-load-failed = n̄kpọ oro ẹdide ẹwụt n̄wed ikọdọhọ ndụk. Buọlọ page emi.
-
 core-start-failed = N̄wed emi mîkemeke ndịtọn̄ọ. Buọlọ page emi.

--- a/packages/i18n/locales/efi/content.ftl
+++ b/packages/i18n/locales/efi/content.ftl
@@ -71,15 +71,12 @@ color =
     .purple = ntong-ọbara
     .pink = ntong-ndịdiọn̄
     .brown = itiat
-
 line-width =
     .thick = akwa
     .thin = nsịn
-
 line-style =
     .dashed = eke ẹkpade ẹkpade
     .dotted = eke mme ntọt
-
 fill-style =
     .horizontal = mme ọfụhọ eke ẹnyụn̄de
     .vertical = mme ọfụhọ eke ẹdarade
@@ -87,7 +84,6 @@ fill-style =
     .backdiagonal = mme ọfụhọ eke ẹdarade ke ọkpọkpọ efep
     .dots = mme ntọt
     .diamonds = mme diamon
-
 noun =
     .line = ọfụhọ
     .line-segment = ubak ọfụhọ
@@ -107,17 +103,14 @@ noun =
     .diamond = diamon
     .cross = ekpri-ubọk
     .plus = idian
-
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] n̄kanika eke enyenede { $numSides } n̄kịk emi ekemde kiet
     }
-
 # No grammatical gender, so this answers one token for every noun and the
 # answer goes unused — the shape `locales/en` has.
 noun-gender = kiet
-
 
 ## Style composition
 
@@ -131,21 +124,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = eke ẹyọhọde
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ye { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } ye { $pattern }
@@ -153,7 +142,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } ye { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] ye ọkpọkpọ { $border }
@@ -161,35 +149,28 @@ style-border-clause =
         [and-article] ye ọkpọkpọ { $border }
        *[with] ye ọkpọkpọ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = eke mîyọhọke
-
 style-text =
     { $parts ->
         [background] { $color } ye ọkpọkpọ efep { $background }
        *[plain] { $color }
     }
-
 style-background-none = idụhe n̄kpọ
-
 
 ## Boolean words
 
 boolean-true = true
 boolean-false = false
 
-
 ## Answer buttons
 
 answer-submit-label = Nse Utom
 answer-submit-label-no-correctness = Nọ Ibọrọ
-
 
 ## Sectional blocks
 
@@ -214,7 +195,6 @@ section-name =
     .solution = Ibiere
     .task = Utom
     .theorem = Eti Ikọ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -224,7 +204,6 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ibuot
 
 ## Tables and figures
@@ -236,7 +215,6 @@ table-name =
         [unnumbered-title] Tebụl{ ": " }
        *[unnumbered] Tebụl
     }
-
 figure-name =
     { $parts ->
         [numbered] Ndise { $enumeration }
@@ -245,15 +223,12 @@ figure-name =
        *[unnumbered] Ndise
     }
 
-
 ## Paginator controls
 
 paginator-previous = Mbemiso
 paginator-next = N̄kaha
 paginator-page = Page
-
 paginator-page-status = { $pageLabel } { $currentPage } eke { $numPages }
-
 
 ## Piecewise functions
 
@@ -261,13 +236,11 @@ piecewise-condition-or = m̀mê
 piecewise-condition-if = edieke
 piecewise-condition-otherwise = ke n̄kpọ efen
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately absent — see the
 ## header above.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ndamban̄a Kemistri Emi Mîdotke
 chemistry-invalid-ionic-compound = N̄kpọ Ionic Emi Mîdotke

--- a/packages/i18n/locales/el/chrome.ftl
+++ b/packages/i18n/locales/el/chrome.ftl
@@ -22,74 +22,55 @@
 
 answer-checking = Έλεγχος…
 answer-submitting = Υποβολή…
-
 answer-checking-status = Έλεγχος απάντησης
 answer-submitting-status = Υποβολή απάντησης
-
 answer-correct = Σωστό
 answer-incorrect = Λάθος
-
 answer-response-saved = Η απάντηση αποθηκεύτηκε
-
 answer-percent-credit = { $percent }% βαθμολογία
 answer-percent-correct = { $percent }% σωστό
 answer-percent-short = { $percent } %
-
 max-credit-available = Μέγιστη διαθέσιμη βαθμολογία: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] δεν απομένουν προσπάθειες
         [one] απομένει { $count } προσπάθεια
        *[other] απομένουν { $count } προσπάθειες
     }
-
 validation-correct = (Σωστό)
 validation-incorrect = (Λάθος)
 validation-partially-correct = (Εν μέρει σωστό)
-
 answer-show-responses =
     { $count ->
         [one] Εμφάνιση { $count } απάντησης στο { $answerId }
        *[other] Εμφάνιση { $count } απαντήσεων στο { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ανατροφοδότηση
-
 collapsible-click-to-open = (κάντε κλικ για άνοιγμα)
 collapsible-click-to-close = (κάντε κλικ για κλείσιμο)
-
 collapsible-initializing = Αρχικοποίηση…
-
 footnote-show = Εμφάνιση υποσημείωσης
 footnote-hide = Απόκρυψη υποσημείωσης
-
 description-more-information = περισσότερες πληροφορίες
-
 
 ## Controls
 
 slider-previous = Προηγ.
 slider-next = Επόμ.
-
 keyboard-open = Άνοιγμα πληκτρολογίου
 keyboard-close = Κλείσιμο πληκτρολογίου
-
 choice-input-remove-choice = Αφαίρεση { $choice }
-
 matrix-remove-row = Αφαίρεση γραμμής
 matrix-add-row = Προσθήκη γραμμής
 matrix-remove-column = Αφαίρεση στήλης
 matrix-add-column = Προσθήκη στήλης
-
 subset-add-remove-points = Προσθήκη/αφαίρεση σημείων
 subset-toggle-points-intervals = Εναλλαγή σημείων και διαστημάτων
 subset-move-points = Μετακίνηση σημείων
 subset-clear = Καθαρισμός
-
 orbital-add-row = Προσθήκη γραμμής
 orbital-remove-row = Αφαίρεση γραμμής
 orbital-add-box = Προσθήκη πλαισίου
@@ -97,13 +78,9 @@ orbital-remove-box = Αφαίρεση πλαισίου
 orbital-add-up-arrow = Προσθήκη βέλους προς τα πάνω
 orbital-add-down-arrow = Προσθήκη βέλους προς τα κάτω
 orbital-remove-arrow = Αφαίρεση βέλους
-
 orbital-row-label = Ετικέτα για τη γραμμή { $row }
-
 pretzel-answer = Απάντηση
-
 summary-statistics-caption = Συνοπτικά στατιστικά του { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = προεπισκόπηση μαθηματικής π
 math-input-preview = Προεπισκόπηση
 math-input-invalid-expression = Μη έγκυρη παράσταση:
 
-
 ## Document status
 
 viewer-initializing = Αρχικοποίηση…
 
-
 ## Errors
 
 error-heading = Σφάλμα
-
 error-found-at =
     { $span ->
         [line] Βρέθηκε στη γραμμή { $startLine }.
        *[lines] Βρέθηκε στις γραμμές { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Αυτό το έγγραφο περιέχει σφάλματα!
-
 diagnostic-heading-error = Σφάλμα
 diagnostic-heading-warning = Προειδοποίηση
 diagnostic-heading-information = Πληροφορίες
 diagnostic-heading-hint = Υπόδειξη
-
 accessibility-heading-level-1 = Παραβίαση προσβασιμότητας WCAG AA
 accessibility-heading-level-2 = Ειδοποίηση προσβασιμότητας
-
 something-went-wrong = Κάτι πήγε στραβά.
-
 renderer-load-failed = απέτυχε η φόρτωση ενός προγράμματος απόδοσης. Φορτώστε ξανά τη σελίδα.
-
 core-start-failed = Δεν ήταν δυνατή η εκκίνηση του προγράμματος προβολής εγγράφων. Φορτώστε ξανά τη σελίδα.

--- a/packages/i18n/locales/el/content.ftl
+++ b/packages/i18n/locales/el/content.ftl
@@ -111,7 +111,6 @@ color =
     .purple = μοβ
     .pink = ροζ
     .brown = καφέ
-
 line-width =
     .thick =
         { $role ->
@@ -137,7 +136,6 @@ line-width =
                    *[m] λεπτός
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -163,7 +161,6 @@ line-style =
                    *[m] διάστικτος
                 }
         }
-
 # These stand on their own in `style-fill` and follow «με» in `style-filled`,
 # which governs the accusative — so every one of them is a feminine or neuter
 # plural, where Greek spells the accusative like the nominative. That is why
@@ -176,7 +173,6 @@ fill-style =
     .backdiagonal = αντίστροφες διαγώνιες γραμμές
     .dots = κουκκίδες
     .diamonds = σχήματα ρόμβου
-
 noun =
     .line = ευθεία
     .line-segment = ευθύγραμμο τμήμα
@@ -196,7 +192,6 @@ noun =
     .diamond = ρόμβος
     .cross = σταυρός
     .plus = συν
-
 # Greek counts the sides after the noun and in the genitive, which keeps the
 # phrase clear of «με» — the preposition the border clause already uses:
 # «χοντρό κόκκινο κανονικό πολύγωνο 5 πλευρών».
@@ -205,7 +200,6 @@ noun-regular-polygon =
         [tail] { $numSides } πλευρών
        *[head] κανονικό πολύγωνο
     }
-
 # Neuter is the default because most of these shapes are neuter, including all
 # four heads a description names without listing: `border` (περίγραμμα),
 # `fill` (γέμισμα), `text` (κείμενο), `background` (φόντο), and
@@ -225,7 +219,6 @@ noun-gender =
        *[other] n
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -238,13 +231,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -253,13 +244,11 @@ style-filled-word =
         [n] γεμάτο
        *[m] γεμάτος
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } με { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } με { $pattern }
@@ -267,7 +256,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } με { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Greek drops the indefinite article, so all four branches read alike apart
 # from the conjunction.
 style-border-clause =
@@ -277,37 +265,30 @@ style-border-clause =
         [and-article] και { $border } περίγραμμα
        *[with] με { $border } περίγραμμα
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 # A phrase rather than an adjective, so that it agrees with nothing: the shape
 # it is said of can be any of the three genders.
 style-unfilled = χωρίς γέμισμα
-
 style-text =
     { $parts ->
         [background] { $color } σε { $background } φόντο
        *[plain] { $color }
     }
-
 style-background-none = κανένα
-
 
 ## Boolean words
 
 boolean-true = αληθές
 boolean-false = ψευδές
 
-
 ## Answer buttons
 
 answer-submit-label = Έλεγχος
 answer-submit-label-no-correctness = Υποβολή απάντησης
-
 
 ## Sectional blocks
 
@@ -332,7 +313,6 @@ section-name =
     .solution = Λύση
     .task = Εργασία
     .theorem = Θεώρημα
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -342,9 +322,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Υπόδειξη
-
 
 ## Tables and figures
 
@@ -355,7 +333,6 @@ table-name =
         [unnumbered-title] Πίνακας{ ": " }
        *[unnumbered] Πίνακας
     }
-
 figure-name =
     { $parts ->
         [numbered] Σχήμα { $enumeration }
@@ -364,22 +341,18 @@ figure-name =
        *[unnumbered] Σχήμα
     }
 
-
 ## Paginator controls
 
 paginator-previous = Προηγούμενη
 paginator-next = Επόμενη
 paginator-page = Σελίδα
-
 paginator-page-status = { $pageLabel } { $currentPage } από { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ή
 piecewise-condition-if = αν
 piecewise-condition-otherwise = αλλιώς
-
 
 ## Chemistry
 
@@ -502,7 +475,6 @@ element-name =
     .lv = Λιβερμόριο
     .ts = Τενέσιο
     .og = Ογκανέσιο
-
 element-anion-name =
     .h = Υδρίδιο
     .c = Καρβίδιο
@@ -516,8 +488,6 @@ element-anion-name =
     .i = Ιωδίδιο
     .at = Αστατίδιο
     .ts = Τενεσίδιο
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Μη έγκυρο χημικό σύμβολο
 chemistry-invalid-ionic-compound = Μη έγκυρη ιοντική ένωση

--- a/packages/i18n/locales/es/chrome.ftl
+++ b/packages/i18n/locales/es/chrome.ftl
@@ -16,33 +16,25 @@
 
 answer-checking = Comprobando...
 answer-submitting = Enviando...
-
 answer-checking-status = Comprobando la respuesta
 answer-submitting-status = Enviando la respuesta
-
 answer-correct = Correcto
 answer-incorrect = Incorrecto
-
 answer-response-saved = Respuesta guardada
-
 # Spanish typographic convention puts a space before the percent sign.
 answer-percent-credit = { $percent } % de crédito
 answer-percent-correct = { $percent } % correcto
 answer-percent-short = { $percent } %
-
 max-credit-available = Crédito máximo disponible: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] no quedan intentos
         [one] queda { $count } intento
        *[other] quedan { $count } intentos
     }
-
 validation-correct = (Correcto)
 validation-incorrect = (Incorrecto)
 validation-partially-correct = (Parcialmente correcto)
-
 # `Mostrar` is the infinitive, per the register note above.
 answer-show-responses =
     { $count ->
@@ -50,41 +42,31 @@ answer-show-responses =
        *[other] Mostrar { $count } respuestas a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Comentarios
-
 collapsible-click-to-open = (clic para abrir)
 collapsible-click-to-close = (clic para cerrar)
 collapsible-initializing = Inicializando...
-
 footnote-show = Mostrar la nota al pie
 footnote-hide = Ocultar la nota al pie
-
 description-more-information = más información
-
 
 ## Controls
 
 slider-previous = Anterior
 slider-next = Siguiente
-
 keyboard-open = Abrir el teclado
 keyboard-close = Cerrar el teclado
-
 choice-input-remove-choice = Eliminar { $choice }
-
 matrix-remove-row = Eliminar fila
 matrix-add-row = Añadir fila
 matrix-remove-column = Eliminar columna
 matrix-add-column = Añadir columna
-
 subset-add-remove-points = Añadir/Eliminar puntos
 subset-toggle-points-intervals = Alternar puntos e intervalos
 subset-move-points = Mover puntos
 subset-clear = Borrar
-
 orbital-add-row = Añadir fila
 orbital-remove-row = Eliminar fila
 orbital-add-box = Añadir casilla
@@ -92,13 +74,9 @@ orbital-remove-box = Eliminar casilla
 orbital-add-up-arrow = Añadir flecha hacia arriba
 orbital-add-down-arrow = Añadir flecha hacia abajo
 orbital-remove-arrow = Eliminar flecha
-
 orbital-row-label = Etiqueta de la fila { $row }
-
 pretzel-answer = Respuesta
-
 summary-statistics-caption = Resumen estadístico de { $column }
-
 
 ## Math input
 
@@ -106,16 +84,13 @@ math-input-preview-region = vista previa de la expresión matemática
 math-input-preview = Vista previa
 math-input-invalid-expression = Expresión no válida:
 
-
 ## Document status
 
 viewer-initializing = Inicializando...
 
-
 ## Errors
 
 error-heading = Error
-
 # $startLine and $endLine are line numbers, and arrive as text rather than as
 # numbers so that line 1234 is not grouped as "1.234".
 error-found-at =
@@ -123,23 +98,17 @@ error-found-at =
         [line] Encontrado en la línea { $startLine }.
        *[lines] Encontrado en las líneas { $startLine } a { $endLine }.
     }
-
 document-contains-errors = ¡Este documento contiene errores!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = Error
 diagnostic-heading-warning = Advertencia
 diagnostic-heading-information = Información
 diagnostic-heading-hint = Sugerencia
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = Incumplimiento de accesibilidad WCAG AA
 accessibility-heading-level-2 = Aviso de accesibilidad
-
 something-went-wrong = Algo salió mal.
-
 # Follows `error-heading` and a colon, so it begins in lower case, as in
 # English. The instruction is an infinitive, per the register note above.
 renderer-load-failed = no se pudo cargar un componente. Recargar la página.
-
 core-start-failed = No se pudo iniciar el visor del documento. Recargar la página.

--- a/packages/i18n/locales/es/content.ftl
+++ b/packages/i18n/locales/es/content.ftl
@@ -46,7 +46,6 @@ color =
         }
     .pink = rosa
     .brown = marrón
-
 line-width =
     .thick =
         { $gender ->
@@ -58,7 +57,6 @@ line-width =
             [f] delgada
            *[m] delgado
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -70,7 +68,6 @@ line-style =
             [f] punteada
            *[m] punteado
         }
-
 # Noun phrases: they follow «con» and agree with nothing.
 fill-style =
     .horizontal = líneas horizontales
@@ -79,7 +76,6 @@ fill-style =
     .backdiagonal = líneas diagonales inversas
     .dots = puntos
     .diamonds = rombos
-
 noun =
     .line = línea
     .line-segment = segmento
@@ -99,7 +95,6 @@ noun =
     .diamond = rombo
     .cross = cruz
     .plus = signo más
-
 # The noun splits: «polígono regular» takes the adjectives and «de 5 lados»
 # closes the phrase behind them. Were the complement to come first, the
 # adjectives would be stranded away from the noun they agree with («polígono
@@ -109,7 +104,6 @@ noun-regular-polygon =
         [tail] de { $numSides } lados
        *[head] polígono regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (the noun
 # `noun-regular-polygon` composes) or the head of a phrase the description
 # never names: `border`, `fill`, `text`, `background`. All of those are
@@ -128,7 +122,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -141,7 +134,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it: «línea discontinua gruesa
 # roja». The noun's complement, where there is one, closes the phrase:
 # «polígono regular grueso rojo de 5 lados».
@@ -150,19 +142,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] rellena
        *[m] relleno
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } con { $pattern }
        *[plain] { $color } { $filled }
     }
-
 # Here the complement sits against the noun rather than at the end, as it does
 # in `style-with-noun`: «relleno de …» reads as «lleno de …», so «relleno de 5
 # lados» would say something else. «Polígono regular de 5 lados azul relleno».
@@ -173,7 +162,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } con { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «borde» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds.
 style-border-clause =
@@ -183,24 +171,19 @@ style-border-clause =
         [and-article] y un borde { $border }
        *[with] con borde { $border }
     }
-
 # «de color» avoids having to agree the color with a plural pattern.
 style-fill =
     { $parts ->
         [pattern] { $pattern } de color { $color }
        *[plain] { $color }
     }
-
 style-unfilled = sin relleno
-
 style-text =
     { $parts ->
         [background] { $color } con un fondo { $background }
        *[plain] { $color }
     }
-
 style-background-none = ninguno
-
 
 ## Boolean words
 ##
@@ -210,12 +193,10 @@ style-background-none = ninguno
 boolean-true = verdadero
 boolean-false = falso
 
-
 ## Answer buttons
 
 answer-submit-label = Revisar
 answer-submit-label-no-correctness = Enviar respuesta
-
 
 ## Sectional blocks
 
@@ -240,7 +221,6 @@ section-name =
     .solution = Solución
     .task = Tarea
     .theorem = Teorema
-
 # Spanish separates the title with a period after a bare number, as English
 # does, and with a colon when the word leads.
 section-title-prefix =
@@ -252,9 +232,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pista
-
 
 ## Tables and figures
 
@@ -265,7 +243,6 @@ table-name =
         [unnumbered-title] Tabla{ ": " }
        *[unnumbered] Tabla
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -274,22 +251,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anterior
 paginator-next = Siguiente
 paginator-page = Página
-
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = si
 piecewise-condition-otherwise = en otro caso
-
 
 ## Chemistry
 ##
@@ -415,7 +388,6 @@ element-name =
     .lv = Livermorio
     .ts = Teneso
     .og = Oganesón
-
 element-anion-name =
     .h = Hidruro
     .c = Carburo
@@ -429,8 +401,6 @@ element-anion-name =
     .i = Yoduro
     .at = Astaturo
     .ts = Tenesuro
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Símbolo químico no válido
 chemistry-invalid-ionic-compound = Compuesto iónico no válido

--- a/packages/i18n/locales/et/chrome.ftl
+++ b/packages/i18n/locales/et/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = Kontrollin…
 answer-submitting = Saadan…
-
 answer-checking-status = Vastuse kontrollimine
 answer-submitting-status = Vastuse saatmine
-
 answer-correct = Õige
 answer-incorrect = Vale
-
 answer-response-saved = Vastus salvestatud
-
 answer-percent-credit = { $percent }% punktidest
 answer-percent-correct = { $percent }% õige
 answer-percent-short = { $percent } %
-
 max-credit-available = Suurim võimalik punktisumma: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] katseid pole enam
         [one] jäänud { $count } katse
        *[other] jäänud { $count } katset
     }
-
 validation-correct = (Õige)
 validation-incorrect = (Vale)
 validation-partially-correct = (Osaliselt õige)
-
 answer-show-responses =
     { $count ->
         [one] Näita { $count } vastust küsimusele { $answerId }
        *[other] Näita { $count } vastust küsimusele { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Tagasiside
-
 collapsible-click-to-open = (klõpsake avamiseks)
 collapsible-click-to-close = (klõpsake sulgemiseks)
-
 collapsible-initializing = Käivitan…
-
 footnote-show = Näita allmärkust
 footnote-hide = Peida allmärkus
-
 description-more-information = lisateave
-
 
 ## Controls
 
 slider-previous = Tagasi
 slider-next = Edasi
-
 keyboard-open = Ava klaviatuur
 keyboard-close = Sulge klaviatuur
-
 choice-input-remove-choice = Eemalda { $choice }
-
 matrix-remove-row = Eemalda rida
 matrix-add-row = Lisa rida
 matrix-remove-column = Eemalda veerg
 matrix-add-column = Lisa veerg
-
 subset-add-remove-points = Lisa/eemalda punkte
 subset-toggle-points-intervals = Lülita punktide ja vahemike vahel
 subset-move-points = Liiguta punkte
 subset-clear = Tühjenda
-
 orbital-add-row = Lisa rida
 orbital-remove-row = Eemalda rida
 orbital-add-box = Lisa kast
@@ -94,13 +75,9 @@ orbital-remove-box = Eemalda kast
 orbital-add-up-arrow = Lisa nool üles
 orbital-add-down-arrow = Lisa nool alla
 orbital-remove-arrow = Eemalda nool
-
 orbital-row-label = Rea { $row } silt
-
 pretzel-answer = Vastus
-
 summary-statistics-caption = Veeru { $column } koondstatistika
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = matemaatilise avaldise eelvaade
 math-input-preview = Eelvaade
 math-input-invalid-expression = Vigane avaldis:
 
-
 ## Document status
 
 viewer-initializing = Käivitan…
 
-
 ## Errors
 
 error-heading = Viga
-
 error-found-at =
     { $span ->
         [line] Leitud real { $startLine }.
        *[lines] Leitud ridadel { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = See dokument sisaldab vigu!
-
 diagnostic-heading-error = Viga
 diagnostic-heading-warning = Hoiatus
 diagnostic-heading-information = Teave
 diagnostic-heading-hint = Vihje
-
 accessibility-heading-level-1 = WCAG AA ligipääsetavuse rikkumine
 accessibility-heading-level-2 = Ligipääsetavuse teade
-
 something-went-wrong = Midagi läks valesti.
-
 renderer-load-failed = kuvamismoodulit ei õnnestunud laadida. Laadige leht uuesti.
-
 core-start-failed = Dokumendivaaturit ei õnnestunud käivitada. Laadige leht uuesti.

--- a/packages/i18n/locales/et/content.ftl
+++ b/packages/i18n/locales/et/content.ftl
@@ -97,7 +97,6 @@ color =
             [background-clause] pruunil
            *[standalone] pruun
         }
-
 line-width =
     .thick =
         { $role ->
@@ -111,7 +110,6 @@ line-width =
             [background-clause] peenikesel
            *[standalone] peenike
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -125,7 +123,6 @@ line-style =
             [background-clause] punktiirilisel
            *[standalone] punktiiriline
         }
-
 # Comitative plurals — the case that renders as "with" in English. The ending
 # carries the sense, so nothing is written in front of them where they are
 # placed.
@@ -136,7 +133,6 @@ fill-style =
     .backdiagonal = vastupidiste diagonaaljoontega
     .dots = punktidega
     .diamonds = rombidega
-
 noun =
     .line = sirge
     .line-segment = lõik
@@ -156,7 +152,6 @@ noun =
     .diamond = romb
     .cross = rist
     .plus = pluss
-
 # Estonian keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -164,13 +159,11 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] korrapärane { $numSides }-nurk
     }
-
 # Estonian has no grammatical gender, so every noun answers the same and the
 # answer goes unused — the same thing `locales/en` does, and for the same
 # reason, down to the constant it answers, which every genderless catalog here
 # spells `neuter`. What this catalog agrees for is case, which `$role` carries.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -184,23 +177,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # A participle, which does not decline here, so it needs neither argument.
 style-filled-word = täidetud
-
 # `{ $pattern }` is already comitative, so no connective is written.
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern }
@@ -208,7 +197,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «äärisega» is the comitative of «ääris», and it is the ending rather than a
 # preposition that says "with" — so the clause opens on the border's own
 # adjectives. Estonian has no article, so the two `-article` branches read like
@@ -220,7 +208,6 @@ style-border-clause =
         [and-article] ja { $border } äärisega
        *[with] { $border } äärisega
     }
-
 # The fill-pattern words are comitatives, so this message supplies «täide» for
 # the colour to stand with; the pattern follows it already inflected.
 style-fill =
@@ -228,9 +215,7 @@ style-fill =
         [pattern] { $color } täide { $pattern }
        *[plain] { $color } täide
     }
-
 style-unfilled = täitmata
-
 # «taustal» is the adessive of «taust», and the colour in front of it is
 # adessive too. Nothing stands between the two colours.
 style-text =
@@ -238,21 +223,17 @@ style-text =
         [background] { $color } { $background } taustal
        *[plain] { $color }
     }
-
 style-background-none = puudub
-
 
 ## Boolean words
 
 boolean-true = tõene
 boolean-false = väär
 
-
 ## Answer buttons
 
 answer-submit-label = Kontrolli
 answer-submit-label-no-correctness = Saada vastus
-
 
 ## Sectional blocks
 
@@ -277,7 +258,6 @@ section-name =
     .solution = Lahendus
     .task = Ülesanne
     .theorem = Teoreem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -287,9 +267,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Vihje
-
 
 ## Tables and figures
 
@@ -300,7 +278,6 @@ table-name =
         [unnumbered-title] Tabel{ ". " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Joonis { $enumeration }
@@ -309,22 +286,18 @@ figure-name =
        *[unnumbered] Joonis
     }
 
-
 ## Paginator controls
 
 paginator-previous = Eelmine
 paginator-next = Järgmine
 paginator-page = Lehekülg
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = või
 piecewise-condition-if = kui
 piecewise-condition-otherwise = muul juhul
-
 
 ## Chemistry
 
@@ -447,7 +420,6 @@ element-name =
     .lv = Livermoorium
     .ts = Tennessiin
     .og = Oganesson
-
 element-anion-name =
     .h = Hüdriid
     .c = Karbiid
@@ -461,8 +433,6 @@ element-anion-name =
     .i = Jodiid
     .at = Astatiid
     .ts = Tennessiid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Vigane keemiline sümbol
 chemistry-invalid-ionic-compound = Vigane ioonne ühend

--- a/packages/i18n/locales/eu/chrome.ftl
+++ b/packages/i18n/locales/eu/chrome.ftl
@@ -13,77 +13,59 @@
 # «geratzen dira», and `answer-show-responses`, which has no verb after the
 # count, needs none.
 
+
 ## Answer submission
 
 answer-checking = Egiaztatzen…
 answer-submitting = Bidaltzen…
-
 answer-checking-status = Erantzuna egiaztatzen
 answer-submitting-status = Erantzuna bidaltzen
-
 answer-correct = Zuzena
 answer-incorrect = Okerra
-
 answer-response-saved = Erantzuna gordeta
-
 answer-percent-credit = % { $percent } puntu
 answer-percent-correct = % { $percent } zuzen
 answer-percent-short = % { $percent }
-
 max-credit-available = Eskuragarri dagoen gehieneko puntuazioa: % { $percent }
-
 attempts-remaining =
     { $count ->
         [0] ez da saiakerarik geratzen
         [one] { $count } saiakera geratzen da
        *[other] { $count } saiakera geratzen dira
     }
-
 validation-correct = (Zuzena)
 validation-incorrect = (Okerra)
 validation-partially-correct = (Partzialki zuzena)
-
 # The genitive lands on «izeneko erantzunaren», words this catalog writes, so
 # nothing is welded to `$answerId`. The noun stays singular after the numeral
 # and no verb follows it, so the count needs no branch.
 answer-show-responses = Erakutsi { $answerId } izeneko erantzunaren { $count } erantzun
 
-
 ## Disclosure panels
 
 feedback-heading = Iruzkina
-
 collapsible-click-to-open = (egin klik irekitzeko)
 collapsible-click-to-close = (egin klik ixteko)
-
 collapsible-initializing = Hasieratzen…
-
 footnote-show = Erakutsi oin-oharra
 footnote-hide = Ezkutatu oin-oharra
-
 description-more-information = informazio gehiago
-
 
 ## Controls
 
 slider-previous = Aurrekoa
 slider-next = Hurrengoa
-
 keyboard-open = Ireki teklatua
 keyboard-close = Itxi teklatua
-
 choice-input-remove-choice = Kendu { $choice }
-
 matrix-remove-row = Kendu errenkada
 matrix-add-row = Gehitu errenkada
 matrix-remove-column = Kendu zutabea
 matrix-add-column = Gehitu zutabea
-
 subset-add-remove-points = Gehitu/kendu puntuak
 subset-toggle-points-intervals = Txandakatu puntuak eta tarteak
 subset-move-points = Mugitu puntuak
 subset-clear = Garbitu
-
 orbital-add-row = Gehitu errenkada
 orbital-remove-row = Kendu errenkada
 orbital-add-box = Gehitu laukia
@@ -91,13 +73,9 @@ orbital-remove-box = Kendu laukia
 orbital-add-up-arrow = Gehitu gorako gezia
 orbital-add-down-arrow = Gehitu beherako gezia
 orbital-remove-arrow = Kendu gezia
-
 orbital-row-label = { $row }. errenkadaren etiketa
-
 pretzel-answer = Erantzuna
-
 summary-statistics-caption = { $column } zutabearen laburpen-estatistikak
-
 
 ## Math input
 
@@ -105,34 +83,25 @@ math-input-preview-region = adierazpen matematikoaren aurrebista
 math-input-preview = Aurrebista
 math-input-invalid-expression = Adierazpen baliogabea:
 
-
 ## Document status
 
 viewer-initializing = Hasieratzen…
 
-
 ## Errors
 
 error-heading = Errorea
-
 error-found-at =
     { $span ->
         [line] { $startLine }. lerroan aurkitua.
        *[lines] { $startLine }–{ $endLine } lerroetan aurkitua.
     }
-
 document-contains-errors = Dokumentu honek erroreak ditu!
-
 diagnostic-heading-error = Errorea
 diagnostic-heading-warning = Abisua
 diagnostic-heading-information = Informazioa
 diagnostic-heading-hint = Iradokizuna
-
 accessibility-heading-level-1 = WCAG AA irisgarritasun-urraketa
 accessibility-heading-level-2 = Irisgarritasun-oharra
-
 something-went-wrong = Zerbait gaizki joan da.
-
 renderer-load-failed = errendatzaile bat ezin izan da kargatu. Kargatu orria berriro.
-
 core-start-failed = Ezin izan da dokumentuaren ikustailea abiarazi. Kargatu orria berriro.

--- a/packages/i18n/locales/eu/content.ftl
+++ b/packages/i18n/locales/eu/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = more
     .pink = arrosa
     .brown = marroi
-
 line-width =
     .thick = lodi
     .thin = mehe
-
 line-style =
     .dashed = eten
     .dotted = puntukatu
-
 # Noun phrases already in the comitative, which is the case the composition
 # messages put them in. They agree with nothing.
 fill-style =
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = alderantzizko marra diagonalekin
     .dots = puntuekin
     .diamonds = erronboekin
-
 noun =
     .line = marra
     .line-segment = segmentu
@@ -74,7 +70,6 @@ noun =
     .diamond = erronbo
     .cross = gurutze
     .plus = plus
-
 # Basque puts a «-ko» modifier phrase *before* the noun — «5 aldeko poligono
 # erregular» — so the tail is the side count and the composing messages place
 # it ahead of the head rather than after the adjectives.
@@ -83,11 +78,9 @@ noun-regular-polygon =
         [tail] { $numSides } aldeko
        *[head] poligono erregular
     }
-
 # Basque has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English, Turkish and Finnish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,21 +98,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $nounTail } { $noun } { $description }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = beteta
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } { $pattern }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $nounTail } { $noun } { $color } { $filled } { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # The comitative `-ekin` lands on «bat», the indefinite article word, which
 # closes the phrase after the adjectives — so nothing is welded to a placeable
 # here. Basque has no article to distinguish, so the two `-article` branches
@@ -139,15 +127,12 @@ style-border-clause =
         [and-article] eta ertz { $border } batekin
        *[with] ertz { $border } batekin
     }
-
 style-fill =
     { $parts ->
         [pattern] betegarri { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = bete gabe
-
 # The comitative closes on «planoarekin», another word this catalog writes.
 # The colour reaches it through «koloreko» — "of the colour" — rather than
 # taking the ending itself, which is what keeps the suffix off the placeable.
@@ -156,21 +141,17 @@ style-text =
         [background] { $color }, { $background } koloreko atzeko planoarekin
        *[plain] { $color }
     }
-
 style-background-none = bat ere ez
-
 
 ## Boolean words
 
 boolean-true = egia
 boolean-false = gezurra
 
-
 ## Answer buttons
 
 answer-submit-label = Egiaztatu
 answer-submit-label-no-correctness = Bidali erantzuna
-
 
 ## Sectional blocks
 
@@ -195,7 +176,6 @@ section-name =
     .solution = Ebazpena
     .task = Zeregina
     .theorem = Teorema
-
 # Basque counts a numbered heading the way `table-name` and `figure-name`
 # already do: the ordinal comes first and the word follows it, «1.3. Atala»
 # rather than «Atala 1.3».
@@ -208,9 +188,7 @@ section-title-prefix =
         [name-number-title] { $sectionNumber }. { $sectionName }{ ": " }
        *[name-number] { $sectionNumber }. { $sectionName }
     }
-
 hint-title = Laguntza
-
 
 ## Tables and figures
 
@@ -221,7 +199,6 @@ table-name =
         [unnumbered-title] Taula{ ": " }
        *[unnumbered] Taula
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration }. irudia
@@ -230,22 +207,18 @@ figure-name =
        *[unnumbered] Irudia
     }
 
-
 ## Paginator controls
 
 paginator-previous = Aurrekoa
 paginator-next = Hurrengoa
 paginator-page = Orrialdea
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = edo
 piecewise-condition-if = baldin
 piecewise-condition-otherwise = bestela
-
 
 ## Chemistry
 
@@ -368,7 +341,6 @@ element-name =
     .lv = Livermorioa
     .ts = Tenesoa
     .og = Oganesoa
-
 element-anion-name =
     .h = Hidruroa
     .c = Karburoa
@@ -382,8 +354,6 @@ element-anion-name =
     .i = Ioduroa
     .at = Astaturoa
     .ts = Tenesuroa
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ikur kimiko baliogabea
 chemistry-invalid-ionic-compound = Konposatu ioniko baliogabea

--- a/packages/i18n/locales/ewo/chrome.ftl
+++ b/packages/i18n/locales/ewo/chrome.ftl
@@ -13,73 +13,54 @@
 
 answer-checking = A ke lɛk...
 answer-submitting = A ke lɔɔt...
-
 answer-checking-status = Ajapkɔb a ke lɛk
 answer-submitting-status = Ajapkɔb a ke lɔɔt
-
 answer-correct = Mvɛ̃
 answer-incorrect = Abé
-
 answer-response-saved = Ajapkɔb da bí
-
 answer-percent-credit = { $percent }% ya mfaŋ
 answer-percent-correct = { $percent }% mvɛ̃
 answer-percent-short = { $percent } %
-
 max-credit-available = Mfaŋ ô ne mbɛnge : { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] a bɔŋ ke lat étam éziŋ
        *[other] a bɔŋ ke lat étam { $count }
     }
-
 validation-correct = (Mvɛ̃)
 validation-incorrect = (Abé)
 validation-partially-correct = (Mvɛ̃ mbílé)
-
 answer-show-responses =
     { $count ->
         [one] Yen ajapkɔb { $count } dama { $answerId }
        *[other] Yen ajapkɔb { $count } dama { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ayoŋ
-
 collapsible-click-to-open = (kaba na o fúlé)
 collapsible-click-to-close = (kaba na o kɔŋ)
-
 collapsible-initializing = A ke tébege...
-
 footnote-show = Yen ntílán
 footnote-hide = Kɔŋ ntílán
-
 description-more-information = mam mefe
-
 
 ## Controls
 
 slider-previous = Osú
 slider-next = Ényiñ
-
 keyboard-open = Fúlé Kavye
 keyboard-close = Kɔŋ Kavye
-
 choice-input-remove-choice = Kɔt { $choice }
-
 matrix-remove-row = Kɔt elɔŋ
 matrix-add-row = Tob elɔŋ
 matrix-remove-column = Kɔt kolɔn
 matrix-add-column = Tob kolɔn
-
 subset-add-remove-points = Tob/Kɔt bipwɛ̃
 subset-toggle-points-intervals = Bulane bipwɛ̃ a bibaŋ
 subset-move-points = Ke a bipwɛ̃
 subset-clear = Vɔmɛ
-
 orbital-add-row = Tob Elɔŋ
 orbital-remove-row = Kɔt Elɔŋ
 orbital-add-box = Tob Ekat
@@ -87,13 +68,9 @@ orbital-remove-box = Kɔt Ekat
 orbital-add-up-arrow = Tob Nsom wa Zu
 orbital-add-down-arrow = Tob Nsom wa Si
 orbital-remove-arrow = Kɔt Nsom
-
 orbital-row-label = Dzina ya elɔŋ { $row }
-
 pretzel-answer = Ajapkɔb
-
 summary-statistics-caption = Statistik ya kolɔn { $column }
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = mben ya ntili wa matematik
 math-input-preview = Ntili
 math-input-invalid-expression = Ntili a si mvɛ̃ te :
 
-
 ## Document status
 
 viewer-initializing = A ke tébege...
 
-
 ## Errors
 
 error-heading = Abé
-
 error-found-at =
     { $span ->
         [line] A yén nyo si elɔŋ { $startLine }.
        *[lines] A yén nyo si melɔŋ { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ayôs di ne abé!
-
 diagnostic-heading-error = Abé
 diagnostic-heading-warning = Ayɛgɛlɛ
 diagnostic-heading-information = Foɔn
 diagnostic-heading-hint = Ntílán
-
 accessibility-heading-level-1 = Abé ya WCAG AA
 accessibility-heading-level-2 = Ayɛgɛlɛ ya ndoŋ
-
 something-went-wrong = Jôm éziŋ a si mvɛ̃ te.
-
 renderer-load-failed = elát éziŋ a si fúlé te. Bulane page te, o kaba.
-
 core-start-failed = Ndoŋ ya ayôs a si tébege te. Bulane page te, o kaba.

--- a/packages/i18n/locales/ewo/content.ftl
+++ b/packages/i18n/locales/ewo/content.ftl
@@ -61,15 +61,12 @@ color =
     .purple = vyolɛ
     .pink = rɔzi
     .brown = maroŋ
-
 line-width =
     .thick = abibí
     .thin = afefele
-
 line-style =
     .dashed = a mimbaŋ
     .dotted = a mimpwɛ̃
-
 fill-style =
     .horizontal = milɔn mi orizɔntal
     .vertical = milɔn mi vertikal
@@ -77,7 +74,6 @@ fill-style =
     .backdiagonal = milɔn mi diagonal, nkíli
     .dots = mimpwɛ̃
     .diamonds = milozãzi
-
 noun =
     .line = liɲi
     .line-segment = segimã a liɲi
@@ -97,15 +93,12 @@ noun =
     .diamond = lozãzi
     .cross = krwa
     .plus = plisi
-
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] poligɔn a kɔte { $numSides }, a regilie
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -119,21 +112,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } a { $noun } { $nounTail }
        *[noun] { $description } a { $noun }
     }
-
 style-filled-word = tôbé
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } a { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } a { $noun } a { $pattern }
@@ -141,7 +130,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } a { $noun } { $nounTail } a { $pattern }
        *[plain] { $filled } { $color } a { $noun }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] a mfeg { $border }
@@ -149,35 +137,28 @@ style-border-clause =
         [and-article] a mfeg { $border }
        *[with] a mfeg { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = te tôbé
-
 style-text =
     { $parts ->
         [background] { $color }, a ndoŋ { $background }
        *[plain] { $color }
     }
-
 style-background-none = éziŋ
-
 
 ## Boolean words
 
 boolean-true = true
 boolean-false = false
 
-
 ## Answer buttons
 
 answer-submit-label = Lɛk Nkɔbɔ
 answer-submit-label-no-correctness = Lɔɔt Ajapkɔb
-
 
 ## Sectional blocks
 
@@ -202,7 +183,6 @@ section-name =
     .solution = Ajapkɔb
     .task = Nkɔbɔ
     .theorem = Teorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -212,9 +192,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ntílán
-
 
 ## Tables and figures
 
@@ -225,7 +203,6 @@ table-name =
         [unnumbered-title] Tabló{ ": " }
        *[unnumbered] Tabló
     }
-
 figure-name =
     { $parts ->
         [numbered] Figír { $enumeration }
@@ -234,24 +211,18 @@ figure-name =
        *[unnumbered] Figír
     }
 
-
 ## Paginator controls
 
 paginator-previous = Osú
 paginator-next = Ényiñ
 paginator-page = Pázi
-
 paginator-page-status = { $pageLabel } { $currentPage } dama { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = to
-
 piecewise-condition-if = nge
-
 piecewise-condition-otherwise = ényiñ éziŋ
-
 
 ## Chemistry
 ##
@@ -260,6 +231,5 @@ piecewise-condition-otherwise = ényiñ éziŋ
 ## secondary science in Ewondo-speaking Cameroon is taught in French.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Symbole Chimique a si mvɛ̃ te
 chemistry-invalid-ionic-compound = Compound Ionique a si mvɛ̃ te

--- a/packages/i18n/locales/fa/chrome.ftl
+++ b/packages/i18n/locales/fa/chrome.ftl
@@ -23,68 +23,50 @@
 
 answer-checking = در حال بررسی...
 answer-submitting = در حال ارسال...
-
 answer-checking-status = در حال بررسی پاسخ
 answer-submitting-status = در حال ارسال پاسخ
-
 answer-correct = درست
 answer-incorrect = نادرست
-
 answer-response-saved = پاسخ ذخیره شد
-
 answer-percent-credit = { $percent }% از نمره
 answer-percent-correct = { $percent }% درست
 answer-percent-short = { $percent }%
-
 max-credit-available = بیشترین نمرهٔ ممکن: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] تلاشی باقی نمانده است
        *[other] { $count } تلاش باقی مانده است
     }
-
 validation-correct = (پاسخ درست)
 validation-incorrect = (پاسخ نادرست)
 validation-partially-correct = (پاسخ تا حدی درست)
-
 answer-show-responses = نمایش { $count } پاسخ ارسال‌شده به { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = بازخورد
-
 collapsible-click-to-open = (برای باز کردن کلیک کنید)
 collapsible-click-to-close = (برای بستن کلیک کنید)
 collapsible-initializing = در حال آماده‌سازی...
-
 footnote-show = نمایش پانویس
 footnote-hide = پنهان کردن پانویس
-
 description-more-information = اطلاعات بیشتر
-
 
 ## Controls
 
 slider-previous = قبلی
 slider-next = بعدی
-
 keyboard-open = باز کردن صفحه‌کلید
 keyboard-close = بستن صفحه‌کلید
-
 choice-input-remove-choice = حذف { $choice }
-
 matrix-remove-row = حذف سطر
 matrix-add-row = افزودن سطر
 matrix-remove-column = حذف ستون
 matrix-add-column = افزودن ستون
-
 subset-add-remove-points = افزودن/حذف نقطه
 subset-toggle-points-intervals = تغییر میان نقطه‌ها و بازه‌ها
 subset-move-points = جابه‌جایی نقطه‌ها
 subset-clear = پاک کردن
-
 orbital-add-row = افزودن سطر
 orbital-remove-row = حذف سطر
 orbital-add-box = افزودن خانه
@@ -92,15 +74,11 @@ orbital-remove-box = حذف خانه
 orbital-add-up-arrow = افزودن پیکان رو به بالا
 orbital-add-down-arrow = افزودن پیکان رو به پایین
 orbital-remove-arrow = حذف پیکان
-
 orbital-row-label = برچسب سطر { $row }
-
 pretzel-answer = پاسخ
-
 # «ستون» names what `$column` is, so that the ezāfe joining the phrase to it
 # does not have to be written onto a placeable.
 summary-statistics-caption = خلاصهٔ آماری ستون { $column }
-
 
 ## Math input
 
@@ -108,37 +86,28 @@ math-input-preview-region = پیش‌نمایش عبارت ریاضی
 math-input-preview = پیش‌نمایش
 math-input-invalid-expression = عبارت نامعتبر:
 
-
 ## Document status
 
 viewer-initializing = در حال آماده‌سازی...
 
-
 ## Errors
 
 error-heading = خطا
-
 error-found-at =
     { $span ->
         [line] در سطر { $startLine } یافت شد.
        *[lines] در سطرهای { $startLine } تا { $endLine } یافت شد.
     }
-
 document-contains-errors = این سند خطا دارد!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = خطا
 diagnostic-heading-warning = هشدار
 diagnostic-heading-information = اطلاعات
 diagnostic-heading-hint = راهنمایی
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = نقض دسترس‌پذیری بر پایهٔ WCAG AA
 accessibility-heading-level-2 = هشدار دسترس‌پذیری
-
 something-went-wrong = مشکلی پیش آمد.
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = بارگذاری یکی از مؤلفه‌ها ناموفق بود. لطفاً صفحه را دوباره بارگذاری کنید.
-
 core-start-failed = راه‌اندازی نمایشگر سند ناموفق بود. لطفاً صفحه را دوباره بارگذاری کنید.

--- a/packages/i18n/locales/fa/content.ftl
+++ b/packages/i18n/locales/fa/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = بنفش
     .pink = صورتی
     .brown = قهوه‌ای
-
 line-width =
     .thick = ضخیم
     .thin = نازک
-
 line-style =
     .dashed = خط‌چین
     .dotted = نقطه‌چین
-
 fill-style =
     .horizontal = خطوط افقی
     .vertical = خطوط عمودی
@@ -53,7 +50,6 @@ fill-style =
     .backdiagonal = خطوط مورب معکوس
     .dots = نقطه‌ها
     .diamonds = لوزی‌ها
-
 noun =
     .line = خط
     .line-segment = پاره‌خط
@@ -73,7 +69,6 @@ noun =
     .diamond = لوزی
     .cross = ضربدر
     .plus = به‌علاوه
-
 # The side count follows the adjectives rather than preceding the noun, so that
 # the adjectives stay against the word they describe: «چندضلعی منتظم قرمز ضخیم
 # با 5 ضلع». Persian counts with a singular noun, so there is nothing here for
@@ -83,12 +78,10 @@ noun-regular-polygon =
         [tail] با { $numSides } ضلع
        *[head] چندضلعی منتظم
     }
-
 # Persian has no grammatical gender. The token is defined anyway rather than
 # left to fall back, so that this catalog says so on purpose and none of the
 # adjectives above has to carry a branch nothing reads.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,23 +98,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 # «توپر» — solid — against «توخالی» below, which is how Persian says a shape is
 # filled rather than hollow.
 style-filled-word = توپر
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } با نقش { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } با نقش { $pattern }
@@ -129,7 +118,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } با نقش { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # Persian has no indefinite article, so the two `-article` branches say what
 # their plain counterparts do. They are kept apart because the distinction
 # belongs to the English message rather than to this one.
@@ -140,7 +128,6 @@ style-border-clause =
         [and-article] و حاشیهٔ { $border }
        *[with] با حاشیهٔ { $border }
     }
-
 # «به رنگ» — "in the color of" — rather than an adjective against the pattern:
 # the ezāfe linking a plural noun to its adjective is written, and it cannot be
 # written onto a placeable.
@@ -149,29 +136,23 @@ style-fill =
         [pattern] { $pattern } به رنگ { $color }
        *[plain] { $color }
     }
-
 style-unfilled = توخالی
-
 style-text =
     { $parts ->
         [background] { $color } با پس‌زمینهٔ { $background }
        *[plain] { $color }
     }
-
 style-background-none = هیچ
-
 
 ## Boolean words
 
 boolean-true = درست
 boolean-false = نادرست
 
-
 ## Answer buttons
 
 answer-submit-label = بررسی پاسخ
 answer-submit-label-no-correctness = ارسال پاسخ
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = راه‌حل
     .task = تکلیف
     .theorem = قضیه
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = راهنمایی
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] جدول{ ": " }
        *[unnumbered] جدول
     }
-
 figure-name =
     { $parts ->
         [numbered] شکل { $enumeration }
@@ -228,24 +205,18 @@ figure-name =
        *[unnumbered] شکل
     }
 
-
 ## Paginator controls
 
 paginator-previous = قبلی
 paginator-next = بعدی
 paginator-page = صفحه
-
 paginator-page-status = { $pageLabel } { $currentPage } از { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = یا
-
 piecewise-condition-if = اگر
-
 piecewise-condition-otherwise = در غیر این صورت
-
 
 ## Chemistry
 
@@ -368,7 +339,6 @@ element-name =
     .lv = لیورموریم
     .ts = تنسین
     .og = اوگانسون
-
 element-anion-name =
     .h = هیدرید
     .c = کربید
@@ -382,8 +352,6 @@ element-anion-name =
     .i = یدید
     .at = آستاتید
     .ts = تنسید
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = نماد شیمیایی نامعتبر
 chemistry-invalid-ionic-compound = ترکیب یونی نامعتبر

--- a/packages/i18n/locales/ff/chrome.ftl
+++ b/packages/i18n/locales/ff/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Ina ƴeewtee…
 answer-submitting = Ina neldee…
-
 answer-checking-status = Jaabawol ngol ina ƴeewtee
 answer-submitting-status = Jaabawol ngol ina neldee
-
 answer-correct = Ko goonga
 answer-incorrect = Wonaa goonga
-
 answer-response-saved = Jaabawol Danndaama
-
 answer-percent-credit = { $percent }% e Nataaji
 answer-percent-correct = { $percent }% Goonga
 answer-percent-short = { $percent } %
-
 max-credit-available = Nataaji ɓurɗi heewde: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] alaa etagol heddiingol
         [one] etagol { $count } heddiima
        *[other] etagol { $count } heddiima
     }
-
 validation-correct = (Ko goonga)
 validation-incorrect = (Wonaa goonga)
 validation-partially-correct = (Ko goonga e geɗal)
-
 answer-show-responses =
     { $count ->
         [one] Hollu jaabawol { $count } e { $answerId }
        *[other] Hollu jaabawuuji { $count } e { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Miijooji
-
 collapsible-click-to-open = (ñoƴƴu ngam udditde)
 collapsible-click-to-close = (ñoƴƴu ngam uddude)
-
 collapsible-initializing = Ina fuɗɗoo…
-
 footnote-show = Hollu bindol ley
 footnote-hide = Suuɗu bindol ley
-
 description-more-information = humpito goɗɗo
-
 
 ## Controls
 
 slider-previous = Ɓennungo
 slider-next = Garowo
-
 keyboard-open = Uddit Klawiyee
 keyboard-close = Uddu Klawiyee
-
 choice-input-remove-choice = Ittu { $choice }
-
 matrix-remove-row = Ittu diidol
 matrix-add-row = Ɓeydu diidol
 matrix-remove-column = Ittu kolom
 matrix-add-column = Ɓeydu kolom
-
 subset-add-remove-points = Ɓeydu/Ittu toɓɓe
 subset-toggle-points-intervals = Waylu toɓɓe e sahaaji
 subset-move-points = Dirtin Toɓɓe
 subset-clear = Momtu
-
 orbital-add-row = Ɓeydu Diidol
 orbital-remove-row = Ittu Diidol
 orbital-add-box = Ɓeydu Buwat
@@ -86,13 +67,9 @@ orbital-remove-box = Ittu Buwat
 orbital-add-up-arrow = Ɓeydu Kure Dow
 orbital-add-down-arrow = Ɓeydu Kure Ley
 orbital-remove-arrow = Ittu Kure
-
 orbital-row-label = Innde diidol { $row }
-
 pretzel-answer = Jaabawol
-
 summary-statistics-caption = Dental limooje { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ƴeewgol adiingol e konngol limtorgal
 math-input-preview = Ƴeewgol adiingol
 math-input-invalid-expression = Konngol moƴƴaani:
 
-
 ## Document status
 
 viewer-initializing = Ina fuɗɗoo…
 
-
 ## Errors
 
 error-heading = Juumre
-
 error-found-at =
     { $span ->
         [line] Yiyaama e diidol { $startLine }.
        *[lines] Yiyaama e diide { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ndee ɗeri ina jogii juumreeji!
-
 diagnostic-heading-error = Juumre
 diagnostic-heading-warning = Reentino
 diagnostic-heading-information = Humpito
 diagnostic-heading-hint = Tinndinoore
-
 accessibility-heading-level-1 = Firtugol WCAG AA e Yettagol
 accessibility-heading-level-2 = Reentino yettagol
-
 something-went-wrong = Woodi ko yahaani no haani.
-
 renderer-load-failed = kollirgal waawaa loowde. Tiiɗno loow hello ngoo kadi.
-
 core-start-failed = Kollirgal ɗeri waawaa fuɗɗaade. Tiiɗno loow hello ngoo kadi.

--- a/packages/i18n/locales/ff/content.ftl
+++ b/packages/i18n/locales/ff/content.ftl
@@ -82,7 +82,6 @@ color =
     .purple = purpul
     .pink = roos
     .brown = mbaroodi
-
 line-width =
     .thick =
         { $gender ->
@@ -98,13 +97,11 @@ line-width =
             [ngal] famɗungal
            *[nde] famɗunde
         }
-
 # Written as an invariable «e …» phrase, so that it agrees with nothing and can
 # close the phrase. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = e taƴe
     .dotted = e toɓɓe
-
 fill-style =
     .horizontal = diide lelinde
     .vertical = diide dariinde
@@ -112,7 +109,6 @@ fill-style =
     .backdiagonal = diide ooñiinde e banŋe goɗɗo
     .dots = toɓɓe
     .diamonds = damaa
-
 noun =
     .line = diidol
     .line-segment = taƴre diidol
@@ -132,14 +128,12 @@ noun =
     .diamond = damaa
     .cross = kuruwaa
     .plus = maandeeji ɓeydugol
-
 # The side count follows the whole phrase, so it goes in the tail.
 noun-regular-polygon =
     { $part ->
         [tail] mo banŋeeji { $numSides }
        *[head] poligoŋ fotduɗo
     }
-
 # The noun class, which is what a concording suffix agrees with. `nde` is the
 # default and the class of every loanword.
 noun-gender =
@@ -159,7 +153,6 @@ noun-gender =
        *[other] nde
     }
 
-
 ## Style composition
 
 # The dash pattern is an «e …» phrase and closes the description, so it moves
@@ -174,13 +167,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [ngol] heewngol
@@ -188,13 +179,11 @@ style-filled-word =
         [ngal] heewngal
        *[nde] heewnde
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } e { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } e { $pattern }
@@ -202,7 +191,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } e { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «keerol» is an `ngol` noun and leads its own adjectives, so the border's
 # words agree with it rather than with the shape it surrounds. Fula has no
 # article and joins this clause with the invariable «e», so all four branches
@@ -214,35 +202,28 @@ style-border-clause =
         [and-article] e keerol { $border }
        *[with] e keerol { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = heewaani
-
 style-text =
     { $parts ->
         [background] { $color } e dow ɓaawo { $background }
        *[plain] { $color }
     }
-
 style-background-none = alaa
-
 
 ## Boolean words
 
 boolean-true = goonga
 boolean-false = fenaande
 
-
 ## Answer buttons
 
 answer-submit-label = Ƴeewto Golle
 answer-submit-label-no-correctness = Neldu Jaabawol
-
 
 ## Sectional blocks
 
@@ -267,7 +248,6 @@ section-name =
     .solution = Ndimaagu
     .task = Golle
     .theorem = Teyoreem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -277,9 +257,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tinndinoore
-
 
 ## Tables and figures
 
@@ -290,7 +268,6 @@ table-name =
         [unnumbered-title] Tabal{ ": " }
        *[unnumbered] Tabal
     }
-
 figure-name =
     { $parts ->
         [numbered] Natal { $enumeration }
@@ -299,24 +276,18 @@ figure-name =
        *[unnumbered] Natal
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ɓennungo
 paginator-next = Garowo
 paginator-page = Hello
-
 paginator-page-status = { $pageLabel } { $currentPage } e { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = walla
-
 piecewise-condition-if = si
-
 piecewise-condition-otherwise = si wonaa noon
-
 
 ## Chemistry
 ##
@@ -330,6 +301,5 @@ piecewise-condition-otherwise = si wonaa noon
 ## those two and the fallback *is* the curriculum wherever they are.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Maandeeji Kimi Moƴƴaani
 chemistry-invalid-ionic-compound = Denndaangal Iyoŋ Moƴƴaani

--- a/packages/i18n/locales/fi/chrome.ftl
+++ b/packages/i18n/locales/fi/chrome.ftl
@@ -19,32 +19,24 @@
 
 answer-checking = Tarkistetaan…
 answer-submitting = Lähetetään…
-
 answer-checking-status = Vastausta tarkistetaan
 answer-submitting-status = Vastausta lähetetään
-
 answer-correct = Oikein
 answer-incorrect = Väärin
-
 answer-response-saved = Vastaus tallennettu
-
 answer-percent-credit = { $percent } % pisteistä
 answer-percent-correct = { $percent } % oikein
 answer-percent-short = { $percent } %
-
 max-credit-available = Suurin saatavilla oleva pistemäärä: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] ei yrityksiä jäljellä
         [one] { $count } yritys jäljellä
        *[other] { $count } yritystä jäljellä
     }
-
 validation-correct = (Oikein)
 validation-incorrect = (Väärin)
 validation-partially-correct = (Osittain oikein)
-
 # «kohteeseen» rather than a case ending on the answer's name: the illative
 # harmonizes with the word it attaches to, and that word is an argument.
 answer-show-responses =
@@ -53,42 +45,31 @@ answer-show-responses =
        *[other] Näytä { $count } vastausta kohteeseen { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Palaute
-
 collapsible-click-to-open = (avaa napsauttamalla)
 collapsible-click-to-close = (sulje napsauttamalla)
-
 collapsible-initializing = Alustetaan…
-
 footnote-show = Näytä alaviite
 footnote-hide = Piilota alaviite
-
 description-more-information = lisätietoja
-
 
 ## Controls
 
 slider-previous = Edell.
 slider-next = Seur.
-
 keyboard-open = Avaa näppäimistö
 keyboard-close = Sulje näppäimistö
-
 choice-input-remove-choice = Poista { $choice }
-
 matrix-remove-row = Poista rivi
 matrix-add-row = Lisää rivi
 matrix-remove-column = Poista sarake
 matrix-add-column = Lisää sarake
-
 subset-add-remove-points = Lisää/poista pisteitä
 subset-toggle-points-intervals = Vaihda pisteiden ja välien välillä
 subset-move-points = Siirrä pisteitä
 subset-clear = Tyhjennä
-
 orbital-add-row = Lisää rivi
 orbital-remove-row = Poista rivi
 orbital-add-box = Lisää ruutu
@@ -96,13 +77,9 @@ orbital-remove-box = Poista ruutu
 orbital-add-up-arrow = Lisää ylöspäin osoittava nuoli
 orbital-add-down-arrow = Lisää alaspäin osoittava nuoli
 orbital-remove-arrow = Poista nuoli
-
 orbital-row-label = Rivin { $row } nimike
-
 pretzel-answer = Vastaus
-
 summary-statistics-caption = Yhteenvetotunnusluvut: { $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = matemaattisen lausekkeen esikatselu
 math-input-preview = Esikatselu
 math-input-invalid-expression = Virheellinen lauseke:
 
-
 ## Document status
 
 viewer-initializing = Alustetaan…
 
-
 ## Errors
 
 error-heading = Virhe
-
 error-found-at =
     { $span ->
         [line] Löytyi riviltä { $startLine }.
        *[lines] Löytyi riveiltä { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tässä asiakirjassa on virheitä!
-
 diagnostic-heading-error = Virhe
 diagnostic-heading-warning = Varoitus
 diagnostic-heading-information = Tieto
 diagnostic-heading-hint = Vihje
-
 accessibility-heading-level-1 = WCAG AA -saavutettavuusrikkomus
 accessibility-heading-level-2 = Saavutettavuushuomautus
-
 something-went-wrong = Jokin meni pieleen.
-
 renderer-load-failed = piirtomoduulin lataus epäonnistui. Lataa sivu uudelleen.
-
 core-start-failed = Asiakirjan katselinta ei voitu käynnistää. Lataa sivu uudelleen.

--- a/packages/i18n/locales/fi/content.ftl
+++ b/packages/i18n/locales/fi/content.ftl
@@ -105,7 +105,6 @@ color =
             [background-clause] ruskealla
            *[standalone] ruskea
         }
-
 line-width =
     .thick =
         { $role ->
@@ -119,7 +118,6 @@ line-width =
             [background-clause] ohuella
            *[standalone] ohut
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -133,7 +131,6 @@ line-style =
             [background-clause] pisteviivaisella
            *[standalone] pisteviivainen
         }
-
 # Partitive plural, which is what «jossa on» governs — see the note at the top
 # of this file.
 fill-style =
@@ -143,7 +140,6 @@ fill-style =
     .backdiagonal = vastakkaisia vinoviivoja
     .dots = pisteitä
     .diamonds = vinoneliöitä
-
 noun =
     .line = suora
     .line-segment = jana
@@ -163,7 +159,6 @@ noun =
     .diamond = vinoneliö
     .cross = risti
     .plus = plus
-
 # «5-kulmio» — Finnish writes a numeral-headed compound with a hyphen, and the
 # word after it is the same whatever the numeral, so the whole phrase is a head
 # and there is no tail.
@@ -172,12 +167,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] säännöllinen { $numSides }-kulmio
     }
-
 # Finnish has no grammatical gender, so this answer goes unused. It is here
 # because the source catalog defines the key and a missing key would fall back
 # to English rather than to nothing.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -191,21 +184,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = täytetty
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color }, jossa on { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun }, jossa on { $pattern }
@@ -213,7 +202,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail }, jossa on { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «reuna» takes the adessive, which the `border-clause` branch of every
 # adjective agrees with. Finnish has no article, so the `-article` branches
 # read the same as the ones without.
@@ -224,15 +212,12 @@ style-border-clause =
         [and-article] ja { $border } reunalla
        *[with] { $border } reunalla
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } täyttö, jossa on { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = täyttämätön
-
 # «tausta» takes the adessive too, so the colour in front of it agrees with it
 # the same way the border's does.
 style-text =
@@ -240,21 +225,17 @@ style-text =
         [background] { $color } { $background } taustalla
        *[plain] { $color }
     }
-
 style-background-none = ei mitään
-
 
 ## Boolean words
 
 boolean-true = tosi
 boolean-false = epätosi
 
-
 ## Answer buttons
 
 answer-submit-label = Tarkista
 answer-submit-label-no-correctness = Lähetä vastaus
-
 
 ## Sectional blocks
 
@@ -279,7 +260,6 @@ section-name =
     .solution = Ratkaisu
     .task = Tehtävänanto
     .theorem = Lause
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -289,9 +269,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Vihje
-
 
 ## Tables and figures
 
@@ -302,7 +280,6 @@ table-name =
         [unnumbered-title] Taulukko{ ": " }
        *[unnumbered] Taulukko
     }
-
 figure-name =
     { $parts ->
         [numbered] Kuva { $enumeration }
@@ -311,24 +288,20 @@ figure-name =
        *[unnumbered] Kuva
     }
 
-
 ## Paginator controls
 
 paginator-previous = Edellinen
 paginator-next = Seuraava
 paginator-page = Sivu
-
 # A slash rather than «-sta/-stä»: the elative harmonizes with how the numeral
 # is read, which the catalog cannot see.
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = tai
 piecewise-condition-if = jos
 piecewise-condition-otherwise = muutoin
-
 
 ## Chemistry
 
@@ -451,7 +424,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennessiini
     .og = Oganesson
-
 element-anion-name =
     .h = Hydridi
     .c = Karbidi
@@ -465,8 +437,6 @@ element-anion-name =
     .i = Jodidi
     .at = Astatidi
     .ts = Tennessidi
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Virheellinen kemiallinen merkki
 chemistry-invalid-ionic-compound = Virheellinen ioniyhdiste

--- a/packages/i18n/locales/fil/chrome.ftl
+++ b/packages/i18n/locales/fil/chrome.ftl
@@ -27,21 +27,15 @@
 
 answer-checking = Sinusuri...
 answer-submitting = Ipinapasa...
-
 answer-checking-status = Sinusuri ang sagot
 answer-submitting-status = Ipinapasa ang sagot
-
 answer-correct = Tama
 answer-incorrect = Mali
-
 answer-response-saved = Nai-save ang Sagot
-
 answer-percent-credit = { $percent }% na Puntos
 answer-percent-correct = { $percent }% Tama
 answer-percent-short = { $percent }%
-
 max-credit-available = Pinakamataas na puntos na maaaring makuha: { $percent }%
-
 # The noun stays as it is whatever the count; the two branches differ only in
 # the linker the numeral takes, as `answer-show-responses` below does. `[0]` is
 # written by number rather than by category, exactly as the English is.
@@ -51,53 +45,40 @@ attempts-remaining =
         [one] { $count } pagsubok na lang ang natitira
        *[other] { $count } na pagsubok na lang ang natitira
     }
-
 validation-correct = (Tama)
 validation-incorrect = (Mali)
 validation-partially-correct = (Bahagyang tama)
-
 answer-show-responses =
     { $count ->
         [one] Ipakita ang { $count } sagot sa { $answerId }
        *[other] Ipakita ang { $count } na sagot sa { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Puna
-
 collapsible-click-to-open = (i-click para buksan)
 collapsible-click-to-close = (i-click para isara)
-
 collapsible-initializing = Sinisimulan...
-
 footnote-show = Ipakita ang talababa
 footnote-hide = Itago ang talababa
-
 description-more-information = higit pang impormasyon
-
 
 ## Controls
 
 slider-previous = Nakaraan
 slider-next = Susunod
-
 keyboard-open = Buksan ang Keyboard
 keyboard-close = Isara ang Keyboard
-
 choice-input-remove-choice = Alisin ang { $choice }
-
 matrix-remove-row = Alisin ang hanay
 matrix-add-row = Magdagdag ng hanay
 matrix-remove-column = Alisin ang kolum
 matrix-add-column = Magdagdag ng kolum
-
 subset-add-remove-points = Magdagdag/Mag-alis ng mga punto
 subset-toggle-points-intervals = Magpalit sa pagitan ng mga punto at agwat
 subset-move-points = Ilipat ang mga Punto
 subset-clear = Burahin
-
 # A `box` here is one orbital, drawn as a square: kahon.
 orbital-add-row = Magdagdag ng Hanay
 orbital-remove-row = Alisin ang Hanay
@@ -106,13 +87,9 @@ orbital-remove-box = Alisin ang Kahon
 orbital-add-up-arrow = Magdagdag ng Pataas na Arrow
 orbital-add-down-arrow = Magdagdag ng Pababang Arrow
 orbital-remove-arrow = Alisin ang Arrow
-
 orbital-row-label = Label para sa hanay { $row }
-
 pretzel-answer = Sagot
-
 summary-statistics-caption = Buod na istatistika ng { $column }
-
 
 ## Math input
 
@@ -120,34 +97,25 @@ math-input-preview-region = preview ng ekspresyong matematikal
 math-input-preview = Preview
 math-input-invalid-expression = Di-wastong ekspresyon:
 
-
 ## Document status
 
 viewer-initializing = Sinisimulan...
 
-
 ## Errors
 
 error-heading = Error
-
 error-found-at =
     { $span ->
         [line] Natagpuan sa linya { $startLine }.
        *[lines] Natagpuan sa mga linya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = May mga error ang dokumentong ito!
-
 diagnostic-heading-error = Error
 diagnostic-heading-warning = Babala
 diagnostic-heading-information = Impormasyon
 diagnostic-heading-hint = Pahiwatig
-
 accessibility-heading-level-1 = Paglabag sa Accessibility ng WCAG AA
 accessibility-heading-level-2 = Babala sa accessibility
-
 something-went-wrong = May nagkamali.
-
 renderer-load-failed = may renderer na hindi na-load. Mangyaring i-reload ang pahina.
-
 core-start-failed = Hindi masimulan ang tagatanaw ng dokumento. Mangyaring i-reload ang pahina.

--- a/packages/i18n/locales/fil/content.ftl
+++ b/packages/i18n/locales/fil/content.ftl
@@ -48,15 +48,12 @@ color =
     .purple = lila
     .pink = rosas
     .brown = kayumanggi
-
 line-width =
     .thick = makapal
     .thin = manipis
-
 line-style =
     .dashed = putol-putol
     .dotted = tuldok-tuldok
-
 # Noun phrases: they follow «may» and modify nothing.
 fill-style =
     .horizontal = pahigang mga guhit
@@ -65,7 +62,6 @@ fill-style =
     .backdiagonal = kabaligtarang pahilis na mga guhit
     .dots = mga tuldok
     .diamonds = mga rombo
-
 noun =
     .line = guhit
     .line-segment = segment ng guhit
@@ -85,23 +81,21 @@ noun =
     .diamond = rombo
     .cross = ekis
     .plus = tandang plus
-
 # The side count is carried by a `may` phrase that belongs to the noun, so it
 # folds into the head and there is no tail. Putting it after the adjectives
 # would separate «gilid» from the number counting it.
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
-       *[head] regular na polygon na may { $numSides ->
-            [one] { $numSides } gilid
-           *[other] { $numSides } na gilid
-        }
+       *[head]
+            regular na polygon na may { $numSides ->
+                [one] { $numSides } gilid
+               *[other] { $numSides } na gilid
+            }
     }
-
 # Filipino has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -115,22 +109,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The linker joins the whole description to the noun it describes.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } na { $noun } { $nounTail }
        *[noun] { $description } na { $noun }
     }
-
 style-filled-word = puno
-
 style-filled =
     { $parts ->
         [pattern] { $filled } na { $color } na may { $pattern }
        *[plain] { $filled } na { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } na { $color } na { $noun } na may { $pattern }
@@ -138,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } na { $color } na { $noun } { $nounTail } na may { $pattern }
        *[plain] { $filled } na { $color } na { $noun }
     }
-
 # «may» is what Filipino uses where English uses "with a", so the two
 # `-article` branches read like the ones without.
 style-border-clause =
@@ -148,35 +137,28 @@ style-border-clause =
         [and-article] at { $border } na hangganan
        *[with] na may { $border } na hangganan
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } na { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = hindi puno
-
 style-text =
     { $parts ->
         [background] { $color } na may { $background } na bakgrawnd
        *[plain] { $color }
     }
-
 style-background-none = wala
-
 
 ## Boolean words
 
 boolean-true = totoo
 boolean-false = mali
 
-
 ## Answer buttons
 
 answer-submit-label = Suriin
 answer-submit-label-no-correctness = Ipasa ang Sagot
-
 
 ## Sectional blocks
 
@@ -201,7 +183,6 @@ section-name =
     .solution = Solusyon
     .task = Tungkulin
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -211,9 +192,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pahiwatig
-
 
 ## Tables and figures
 
@@ -224,7 +203,6 @@ table-name =
         [unnumbered-title] Talahanayan{ ": " }
        *[unnumbered] Talahanayan
     }
-
 figure-name =
     { $parts ->
         [numbered] Larawan { $enumeration }
@@ -233,15 +211,12 @@ figure-name =
        *[unnumbered] Larawan
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nakaraan
 paginator-next = Susunod
 paginator-page = Pahina
-
 paginator-page-status = { $pageLabel } { $currentPage } ng { $numPages }
-
 
 ## Piecewise functions
 
@@ -249,8 +224,8 @@ piecewise-condition-or = o
 piecewise-condition-if = kung
 piecewise-condition-otherwise = kung hindi
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and the 130
 # keys fall back to English.
@@ -265,6 +240,5 @@ piecewise-condition-otherwise = kung hindi
 # already carries, arrived at from the other direction.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Di-wastong Simbolong Kemikal
 chemistry-invalid-ionic-compound = Di-wastong Ionic Compound

--- a/packages/i18n/locales/fj/chrome.ftl
+++ b/packages/i18n/locales/fj/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Sa vakadikevi tiko…
 answer-submitting = Sa vakau tiko…
-
 answer-checking-status = Sa vakadikevi tiko na isau
 answer-submitting-status = Sa vakau tiko na isau
-
 answer-correct = Dodonu
 answer-incorrect = Sega ni dodonu
-
 answer-response-saved = Sa maroroi na isau
-
 answer-percent-credit = { $percent }% na ivotavota
 answer-percent-correct = { $percent }% dodonu
 answer-percent-short = { $percent } %
-
 max-credit-available = Ivotavota levu duadua e rawati: { $percent }%
-
 # No select: «itovo ni saga» is the same phrase for one and for many. The `[0]`
 # branch stays, because it names none rather than counting.
 attempts-remaining =
@@ -45,51 +39,38 @@ attempts-remaining =
         [0] sa sega na isaga e vo
        *[other] e vo tiko e { $count } na isaga
     }
-
 validation-correct = (Dodonu)
 validation-incorrect = (Sega ni dodonu)
 validation-partially-correct = (Dodonu ena dua na tikina)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Vakaraitaka e { $count } na isau me baleta na { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Ivakamacala
-
 collapsible-click-to-open = (kilika me dolavi)
 collapsible-click-to-close = (kilika me sogoti)
-
 collapsible-initializing = Sa tekivu tiko…
-
 footnote-show = Vakaraitaka na footnote
 footnote-hide = Vunitaka na footnote
-
 description-more-information = itukutuku tale
-
 
 ## Controls
 
 slider-previous = Liu
 slider-next = Tarava
-
 keyboard-open = Dolava na kipodi
 keyboard-close = Sogota na kipodi
-
 choice-input-remove-choice = Kau tani na { $choice }
-
 matrix-remove-row = Kau tani na rowa
 matrix-add-row = Kuria e dua na rowa
 matrix-remove-column = Kau tani na duru
 matrix-add-column = Kuria e dua na duru
-
 subset-add-remove-points = Kuria/Kau tani na poini
 subset-toggle-points-intervals = Veisautaka na poini kei na kalawa
 subset-move-points = Toso na poini
 subset-clear = Vakasavasavataka
-
 orbital-add-row = Kuria e dua na rowa
 orbital-remove-row = Kau tani na rowa
 orbital-add-box = Kuria e dua na kato
@@ -97,13 +78,9 @@ orbital-remove-box = Kau tani na kato
 orbital-add-up-arrow = Kuria e dua na iviri cake
 orbital-add-down-arrow = Kuria e dua na iviri sobu
 orbital-remove-arrow = Kau tani na iviri
-
 orbital-row-label = Iyacana ni rowa { $row }
-
 pretzel-answer = Isau
-
 summary-statistics-caption = Ilairai vakaiwiliwili ni { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = irairai taumada ni ivakamacala vakaiwiliwili
 math-input-preview = Irairai taumada
 math-input-invalid-expression = Ivakamacala e sega ni dodonu:
 
-
 ## Document status
 
 viewer-initializing = Sa tekivu tiko…
 
-
 ## Errors
 
 error-heading = Cala
-
 error-found-at =
     { $span ->
         [line] E kune ena laini { $startLine }.
        *[lines] E kune ena laini { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = E tiko e so na cala ena ivola oqo!
-
 diagnostic-heading-error = Cala
 diagnostic-heading-warning = Ivakasalasala
 diagnostic-heading-information = Itukutuku
 diagnostic-heading-hint = Idusidusi
-
 accessibility-heading-level-1 = Beitaki ni ivakatagedegede ni rawarawa WCAG AA
 accessibility-heading-level-2 = Ivakasalasala me baleta na rawarawa
-
 something-went-wrong = E dua na ka e cala.
-
 renderer-load-failed = e dua na renderer e sega ni laveti rawa. Yalovinaka lomani tale na tabana.
-
 core-start-failed = Sa sega ni tekivu rawa na irairai ni ivola. Yalovinaka lomani tale na tabana.

--- a/packages/i18n/locales/fj/content.ftl
+++ b/packages/i18n/locales/fj/content.ftl
@@ -43,15 +43,12 @@ color =
     .purple = vaiolete
     .pink = pingi
     .brown = buraunu
-
 line-width =
     .thick = levu
     .thin = lailai
-
 line-style =
     .dashed = musumusu
     .dotted = tokitoki
-
 # Noun phrases. Fijian marks no plural on the noun, so «laini» is the word for
 # one line and for many alike.
 fill-style =
@@ -61,7 +58,6 @@ fill-style =
     .backdiagonal = laini sivia vakasosomi
     .dots = toki
     .diamonds = daimani
-
 noun =
     .line = laini
     .line-segment = iwase ni laini
@@ -81,7 +77,6 @@ noun =
     .diamond = daimani
     .cross = kurusi
     .plus = purasi
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -89,10 +84,8 @@ noun-regular-polygon =
         [tail] e { $numSides } na yasana
        *[head] poligani veitautauvata
     }
-
 # One answer for every noun: Fijian has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -106,22 +99,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = sinai
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kei na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kei na { $pattern }
@@ -129,7 +118,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } kei na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Fijian's «na» is the common article and is not what English's "a" is doing
 # here, so all four branches read alike but for the connective: «kei na» opens
 # the first clause and «kei na tale ga» a further one.
@@ -140,35 +128,28 @@ style-border-clause =
         [and-article] kei na tale ga na bati { $border }
        *[with] kei na bati { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = sega ni sinai
-
 style-text =
     { $parts ->
         [background] { $color } kei na tuvaki { $background }
        *[plain] { $color }
     }
-
 style-background-none = sega
-
 
 ## Boolean words
 
 boolean-true = dina
 boolean-false = lasu
 
-
 ## Answer buttons
 
 answer-submit-label = Vakadikeva na cakacaka
 answer-submit-label-no-correctness = Vakauta na isau
-
 
 ## Sectional blocks
 
@@ -195,7 +176,6 @@ section-name =
     .solution = Isolisoli ni leqa
     .task = Itavi
     .theorem = Tioreme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -205,9 +185,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Idusidusi
-
 
 ## Tables and figures
 
@@ -218,7 +196,6 @@ table-name =
         [unnumbered-title] Teveli{ ": " }
        *[unnumbered] Teveli
     }
-
 figure-name =
     { $parts ->
         [numbered] Iyaloyalo { $enumeration }
@@ -227,22 +204,18 @@ figure-name =
        *[unnumbered] Iyaloyalo
     }
 
-
 ## Paginator controls
 
 paginator-previous = Liu
 paginator-next = Tarava
 paginator-page = Tabana
-
 paginator-page-status = { $pageLabel } { $currentPage } mai na { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = se
 piecewise-condition-if = kevaka
 piecewise-condition-otherwise = kevaka e sega
-
 
 ## Chemistry
 ##
@@ -252,6 +225,5 @@ piecewise-condition-otherwise = kevaka e sega
 ## the same reason.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ivakatakilakila ni kemikali e sega ni dodonu
 chemistry-invalid-ionic-compound = Iwiliwili ni aioni e sega ni dodonu

--- a/packages/i18n/locales/fo/chrome.ftl
+++ b/packages/i18n/locales/fo/chrome.ftl
@@ -10,78 +10,60 @@
 # Faroese counts in the same two plural categories English does, so every
 # `{ $count -> … }` below keeps the shape it had.
 
+
 ## Answer submission
 
 answer-checking = Kannar…
 answer-submitting = Sendir…
-
 answer-checking-status = Kannar svarið
 answer-submitting-status = Sendir svarið
-
 answer-correct = Rætt
 answer-incorrect = Skeivt
-
 answer-response-saved = Svarið er goymt
-
 answer-percent-credit = { $percent }% av stigunum
 answer-percent-correct = { $percent }% rætt
 answer-percent-short = { $percent } %
-
 max-credit-available = Hægst møguligt stig: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] eingin roynd eftir
         [one] { $count } roynd eftir
        *[other] { $count } royndir eftir
     }
-
 validation-correct = (Rætt)
 validation-incorrect = (Skeivt)
 validation-partially-correct = (Partvíst rætt)
-
 answer-show-responses =
     { $count ->
         [one] Vís { $count } svar til { $answerId }
        *[other] Vís { $count } svør til { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Afturmelding
-
 collapsible-click-to-open = (trýst fyri at lata upp)
 collapsible-click-to-close = (trýst fyri at lata aftur)
-
 collapsible-initializing = Byrjar…
-
 footnote-show = Vís fótnotu
 footnote-hide = Fjal fótnotu
-
 description-more-information = meiri kunning
-
 
 ## Controls
 
 slider-previous = Fyrra
 slider-next = Næsta
-
 keyboard-open = Lat upp knappaborðið
 keyboard-close = Lat knappaborðið aftur
-
 choice-input-remove-choice = Tak { $choice } burtur
-
 matrix-remove-row = Tak rað burtur
 matrix-add-row = Legg rað afturat
 matrix-remove-column = Tak dálk burtur
 matrix-add-column = Legg dálk afturat
-
 subset-add-remove-points = Legg punkt afturat / tak punkt burtur
 subset-toggle-points-intervals = Skift millum punkt og millumbil
 subset-move-points = Flyt punktini
 subset-clear = Rudda
-
 orbital-add-row = Legg rað afturat
 orbital-remove-row = Tak rað burtur
 orbital-add-box = Legg kassa afturat
@@ -89,13 +71,9 @@ orbital-remove-box = Tak kassa burtur
 orbital-add-up-arrow = Legg píl upp afturat
 orbital-add-down-arrow = Legg píl niður afturat
 orbital-remove-arrow = Tak píl burtur
-
 orbital-row-label = Merki fyri rað { $row }
-
 pretzel-answer = Svar
-
 summary-statistics-caption = Samandráttarhagtøl fyri { $column }
-
 
 ## Math input
 
@@ -103,34 +81,25 @@ math-input-preview-region = forsýning av støddfrøðiliga úttrykkinum
 math-input-preview = Forsýning
 math-input-invalid-expression = Ógildugt úttrykk:
 
-
 ## Document status
 
 viewer-initializing = Byrjar…
 
-
 ## Errors
 
 error-heading = Villa
-
 error-found-at =
     { $span ->
         [line] Funnið á linju { $startLine }.
        *[lines] Funnið á linjum { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Hetta skjalið hevur villur í sær!
-
 diagnostic-heading-error = Villa
 diagnostic-heading-warning = Ávaring
 diagnostic-heading-information = Kunning
 diagnostic-heading-hint = Vísbending
-
 accessibility-heading-level-1 = Brot á WCAG AA atkomukrøv
 accessibility-heading-level-2 = Atkomuávaring
-
 something-went-wrong = Okkurt fór skeivt.
-
 renderer-load-failed = ein teknari kundi ikki lastast. Endurles síðuna.
-
 core-start-failed = Skjalavísarin kundi ikki byrja. Endurles síðuna.

--- a/packages/i18n/locales/fo/content.ftl
+++ b/packages/i18n/locales/fo/content.ftl
@@ -160,7 +160,6 @@ color =
                    *[m] brúnur
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -186,7 +185,6 @@ line-width =
                    *[m] tunnur
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -212,7 +210,6 @@ line-style =
                    *[m] punktaður
                 }
         }
-
 # Noun phrases in the dative plural, which is the case «við» takes. They agree
 # with nothing.
 fill-style =
@@ -222,7 +219,6 @@ fill-style =
     .backdiagonal = øvutum skálinjum
     .dots = punktum
     .diamonds = rutum
-
 noun =
     .line = linja
     .line-segment = linjustykki
@@ -242,7 +238,6 @@ noun =
     .diamond = ruta
     .cross = kross
     .plus = plus
-
 # Faroese builds the side count into the noun in front of it, so the whole of
 # it is one head and there is no tail.
 noun-regular-polygon =
@@ -250,7 +245,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regluligur { $numSides }-hyrningur
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon`, whose head is
 # «-hyrningur» and so masculine, or the head of a phrase the description never
 # names: `border` (kantur, m), `fill` (fylling, f), `text` (tekstur, m),
@@ -271,7 +265,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -284,13 +277,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -299,13 +290,11 @@ style-filled-word =
         [n] fylt
        *[m] fyltur
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } við { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } við { $pattern }
@@ -313,7 +302,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } við { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «kantur» is masculine and stands in the dative after «við», so the border's
 # adjectives agree with it and not with the shape it surrounds. Faroese has no
 # indefinite article, so the two `-article` branches read like the two without.
@@ -324,7 +312,6 @@ style-border-clause =
         [and-article] og { $border } kanti
        *[with] við { $border } kanti
     }
-
 # The fill-pattern words are dative plurals, because their other use is the
 # «við { $pattern }» clause above. So this message supplies a noun for them to
 # hang off — «fylling», feminine, which is the gender `noun-gender` already
@@ -334,29 +321,23 @@ style-fill =
         [pattern] { $color } fylling við { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ófylt
-
 style-text =
     { $parts ->
         [background] { $color } á { $background } bakgrund
        *[plain] { $color }
     }
-
 style-background-none = eingin
-
 
 ## Boolean words
 
 boolean-true = satt
 boolean-false = ósatt
 
-
 ## Answer buttons
 
 answer-submit-label = Kanna
 answer-submit-label-no-correctness = Send svar
-
 
 ## Sectional blocks
 
@@ -381,7 +362,6 @@ section-name =
     .solution = Loysn
     .task = Uppgáva
     .theorem = Setningur
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -391,9 +371,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Vísbending
-
 
 ## Tables and figures
 
@@ -404,7 +382,6 @@ table-name =
         [unnumbered-title] Talva{ ": " }
        *[unnumbered] Talva
     }
-
 figure-name =
     { $parts ->
         [numbered] Mynd { $enumeration }
@@ -413,22 +390,18 @@ figure-name =
        *[unnumbered] Mynd
     }
 
-
 ## Paginator controls
 
 paginator-previous = Fyrra
 paginator-next = Næsta
 paginator-page = Síða
-
 paginator-page-status = { $pageLabel } { $currentPage } av { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ella
 piecewise-condition-if = um
 piecewise-condition-otherwise = annars
-
 
 ## Chemistry
 
@@ -551,7 +524,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennessin
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Karbid
@@ -565,8 +537,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ógildugt evnafrøðiligt tekn
 chemistry-invalid-ionic-compound = Ógildugt iónsamband

--- a/packages/i18n/locales/fon/chrome.ftl
+++ b/packages/i18n/locales/fon/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Ðò kpɔ́n wɛ…
 answer-submitting = Ðò sɛ́dó wɛ…
-
 answer-checking-status = È ɖò xósin ɔ́ kpɔ́n wɛ
 answer-submitting-status = È ɖò xósin ɔ́ sɛ́dó wɛ
-
 answer-correct = É sɔgbe
 answer-incorrect = É má sɔgbe ǎ
-
 answer-response-saved = È Bɛ́ Xósin Ɔ́ Dó
-
 answer-percent-credit = { $percent }% Kɛ́ndɛ́
 answer-percent-correct = { $percent }% Sɔgbe
 answer-percent-short = { $percent } %
-
 max-credit-available = Kɛ́ndɛ́ ɖaxó e è sixú mɔ é: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tɛnkpɔ́n ɖé kpò ǎ
         [one] tɛnkpɔ́n { $count } kpò
        *[other] tɛnkpɔ́n { $count } kpò
     }
-
 validation-correct = (É sɔgbe)
 validation-incorrect = (É má sɔgbe ǎ)
 validation-partially-correct = (É sɔgbe ɖé)
-
 answer-show-responses =
     { $count ->
         [one] Ðè xósin { $count } tɔ̀n { $answerId } tɔ̀n xlɛ́
        *[other] Ðè xósin { $count } tɔ̀n { $answerId } tɔ̀n xlɛ́
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Xósin
-
 collapsible-click-to-open = (zin bo hun)
 collapsible-click-to-close = (zin bo sú)
-
 collapsible-initializing = Ðò bɛ́ wɛ…
-
 footnote-show = Ðè wema dò tɔ̀n xlɛ́
 footnote-hide = Hwlá wema dò tɔ̀n
-
 description-more-information = nǔmɔnú ɖěvo lɛ́
-
 
 ## Controls
 
 slider-previous = Yɛ̌yǐ
 slider-next = Bɔ̌dó
-
 keyboard-open = Hun Klavier
 keyboard-close = Sú Klavier
-
 choice-input-remove-choice = Ðè { $choice } sín mɛ
-
 matrix-remove-row = Ðè línu sín mɛ
 matrix-add-row = Sɔ́ línu dó
 matrix-remove-column = Ðè kɔ́ sín mɛ
 matrix-add-column = Sɔ́ kɔ́ dó
-
 subset-add-remove-points = Sɔ́ tɛ́n dó/Ðè tɛ́n sín mɛ
 subset-toggle-points-intervals = Ðyɔ́ tɛ́n kpó intervalle kpó
 subset-move-points = Sɛ Tɛ́n Lɛ́ Dó
 subset-clear = Súnsún
-
 orbital-add-row = Sɔ́ Línu Dó
 orbital-remove-row = Ðè Línu Sín Mɛ
 orbital-add-box = Sɔ́ Gbà Dó
@@ -87,13 +68,9 @@ orbital-remove-box = Ðè Gbà Sín Mɛ
 orbital-add-up-arrow = Sɔ́ Gǎ Yiaji Tɔ̀n Dó
 orbital-add-down-arrow = Sɔ́ Gǎ Yidó Tɔ̀n Dó
 orbital-remove-arrow = Ðè Gǎ Sín Mɛ
-
 orbital-row-label = Nyikɔ́ línu { $row } tɔ̀n
-
 pretzel-answer = Xósin
-
 summary-statistics-caption = Kplékplé xayi { $column } tɔ̀n
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = nùnywɛ́xó kpɔ́n jɛ nukɔ́n
 math-input-preview = Kpɔ́n jɛ nukɔ́n
 math-input-invalid-expression = Nǔnywɛ́xó e má sɔgbe ǎ é:
 
-
 ## Document status
 
 viewer-initializing = Ðò bɛ́ wɛ…
 
-
 ## Errors
 
 error-heading = Nùwaɖókpɔ́
-
 error-found-at =
     { $span ->
         [line] È mɔ ɖò línu { $startLine } jí.
        *[lines] È mɔ ɖò línu { $startLine }–{ $endLine } jí.
     }
-
 document-contains-errors = Wema élɔ́ ɖó nùwaɖókpɔ́ lɛ́!
-
 diagnostic-heading-error = Nùwaɖókpɔ́
 diagnostic-heading-warning = Gbeɖiɖe
 diagnostic-heading-information = Nǔmɔnú
 diagnostic-heading-hint = Alɔdo
-
 accessibility-heading-level-1 = Gbigbà WCAG AA tɔ̀n ɖò Sisɛkpɔ́ mɛ
 accessibility-heading-level-2 = Gbeɖiɖe sisɛkpɔ́ tɔ̀n
-
 something-went-wrong = Nǔɖé má sɔgbe ǎ.
-
 renderer-load-failed = ɖiɖexlɛ́tɔ́ ɔ́ má wá ǎ. Kú dó nú mì, lɛ́ hun wexwɛ ɔ́.
-
 core-start-failed = Wemakpɔ́ntɔ́ ɔ́ má sixú bɛ́ ǎ. Kú dó nú mì, lɛ́ hun wexwɛ ɔ́.

--- a/packages/i18n/locales/fon/content.ftl
+++ b/packages/i18n/locales/fon/content.ftl
@@ -61,20 +61,17 @@ color =
     .purple = violet
     .pink = rose
     .brown = marron
-
 # Both are Fon statives, but only one reduplicates: «gaga» doubles «gá» to be
 # big, while «kléwún» is derived from «klé» to be slender without doubling it.
 # That is why the table in the header gives it a row of its own.
 line-width =
     .thick = gaga
     .thin = kléwún
-
 # Written as «kpó …» phrases rather than as statives, so that they close the
 # description rather than sitting inside it. `style-stroke` puts them last.
 line-style =
     .dashed = kpó dlɛ̌n kpɛví lɛ́
     .dotted = kpó tɛ́n lɛ́
-
 fill-style =
     .horizontal = dlɛ̌n dòdó lɛ́
     .vertical = dlɛ̌n sítɛ́ lɛ́
@@ -82,7 +79,6 @@ fill-style =
     .backdiagonal = dlɛ̌n gbɔn ɖò alɔ ɖèvo lɛ́
     .dots = tɛ́n lɛ́
     .diamonds = diamant lɛ́
-
 noun =
     .line = dlɛ̌n
     .line-segment = dlɛ̌n kpɛví
@@ -102,7 +98,6 @@ noun =
     .diamond = diamant
     .cross = akluzu
     .plus = wlɛ́n plus
-
 # The side count follows the describing words and closes the noun phrase, so it
 # goes in the tail — the position Fon's own determiner would occupy.
 noun-regular-polygon =
@@ -110,11 +105,9 @@ noun-regular-polygon =
         [tail] kpó akpá { $numSides }
        *[head] polygone jɛ́jɛ́
     }
-
 # Fon has no noun class and no gender, so every noun answers the same and the
 # answer goes unused — the shape `locales/en` and `locales/ktu` have.
 noun-gender = ɖokpo
-
 
 ## Style composition
 
@@ -130,21 +123,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = gɔ́
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kpó { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kpó { $pattern }
@@ -152,7 +141,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kpó { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «dogbó» is the border. Fon has no indefinite article and joins this clause
 # with the invariable «kpó», so all four branches read alike.
 style-border-clause =
@@ -162,35 +150,28 @@ style-border-clause =
         [and-article] kpó dogbó { $border }
        *[with] kpó dogbó { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = mǎ gɔ́ ǎ
-
 style-text =
     { $parts ->
         [background] { $color } kpó gudo { $background }
        *[plain] { $color }
     }
-
 style-background-none = nǔ ɖé ǎ
-
 
 ## Boolean words
 
 boolean-true = nugbó
 boolean-false = adingban
 
-
 ## Answer buttons
 
 answer-submit-label = Kpɔ́n Azɔ̌
 answer-submit-label-no-correctness = Sɛ́ Xósin Dó
-
 
 ## Sectional blocks
 
@@ -215,7 +196,6 @@ section-name =
     .solution = Ali
     .task = Azɔ̌
     .theorem = Théorème
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -225,9 +205,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Alɔdo
-
 
 ## Tables and figures
 
@@ -238,7 +216,6 @@ table-name =
         [unnumbered-title] Tableau{ ": " }
        *[unnumbered] Tableau
     }
-
 figure-name =
     { $parts ->
         [numbered] Ðiɖe { $enumeration }
@@ -247,25 +224,18 @@ figure-name =
        *[unnumbered] Ðiɖe
     }
 
-
 ## Paginator controls
 
 paginator-previous = Yɛ̌yǐ
 paginator-next = Bɔ̌dó
-
 paginator-page = Wexwɛ
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = alǒ
-
 piecewise-condition-if = énɛ́ ɔ́
-
 piecewise-condition-otherwise = ɖò ninɔmɛ ɖě lɛ́ bǐ mɛ
-
 
 ## Chemistry
 ##
@@ -279,6 +249,5 @@ piecewise-condition-otherwise = ɖò ninɔmɛ ɖě lɛ́ bǐ mɛ
 ## the Ghanaian and Togolese ministries.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Wlɛ́n Chimie Tɔ̀n E Má Nyɔ́ Ǎ
 chemistry-invalid-ionic-compound = Kplékplé Ion Tɔ̀n E Má Nyɔ́ Ǎ

--- a/packages/i18n/locales/fr/chrome.ftl
+++ b/packages/i18n/locales/fr/chrome.ftl
@@ -20,32 +20,24 @@
 
 answer-checking = Vérification…
 answer-submitting = Envoi…
-
 answer-checking-status = Vérification de la réponse
 answer-submitting-status = Envoi de la réponse
-
 answer-correct = Correct
 answer-incorrect = Incorrect
-
 answer-response-saved = Réponse enregistrée
-
 answer-percent-credit = { $percent } % de crédit
 answer-percent-correct = { $percent } % correct
 answer-percent-short = { $percent } %
-
 max-credit-available = Crédit maximal disponible : { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] aucune tentative restante
         [one] { $count } tentative restante
        *[other] { $count } tentatives restantes
     }
-
 validation-correct = (Correct)
 validation-incorrect = (Incorrect)
 validation-partially-correct = (Partiellement correct)
-
 # `Afficher` is the infinitive, per the register note above.
 answer-show-responses =
     { $count ->
@@ -53,42 +45,31 @@ answer-show-responses =
        *[other] Afficher { $count } réponses à { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Commentaires
-
 collapsible-click-to-open = (cliquer pour ouvrir)
 collapsible-click-to-close = (cliquer pour fermer)
-
 collapsible-initializing = Initialisation…
-
 footnote-show = Afficher la note
 footnote-hide = Masquer la note
-
 description-more-information = plus d’informations
-
 
 ## Controls
 
 slider-previous = Préc.
 slider-next = Suiv.
-
 keyboard-open = Ouvrir le clavier
 keyboard-close = Fermer le clavier
-
 choice-input-remove-choice = Supprimer { $choice }
-
 matrix-remove-row = Supprimer une ligne
 matrix-add-row = Ajouter une ligne
 matrix-remove-column = Supprimer une colonne
 matrix-add-column = Ajouter une colonne
-
 subset-add-remove-points = Ajouter/supprimer des points
 subset-toggle-points-intervals = Basculer entre points et intervalles
 subset-move-points = Déplacer les points
 subset-clear = Effacer
-
 # A `box` here is one orbital, drawn as a square; `case` is the word for a
 # square on a grid, which is what the reader sees.
 orbital-add-row = Ajouter une ligne
@@ -98,13 +79,9 @@ orbital-remove-box = Supprimer une case
 orbital-add-up-arrow = Ajouter une flèche vers le haut
 orbital-add-down-arrow = Ajouter une flèche vers le bas
 orbital-remove-arrow = Supprimer une flèche
-
 orbital-row-label = Étiquette de la ligne { $row }
-
 pretzel-answer = Réponse
-
 summary-statistics-caption = Statistiques descriptives de { $column }
-
 
 ## Math input
 
@@ -112,35 +89,26 @@ math-input-preview-region = aperçu de l’expression mathématique
 math-input-preview = Aperçu
 math-input-invalid-expression = Expression invalide :
 
-
 ## Document status
 
 viewer-initializing = Initialisation…
 
-
 ## Errors
 
 error-heading = Erreur
-
 # `Trouvée` agrees with `erreur`, which is what this sentence follows.
 error-found-at =
     { $span ->
         [line] Trouvée à la ligne { $startLine }.
        *[lines] Trouvée aux lignes { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ce document contient des erreurs !
-
 diagnostic-heading-error = Erreur
 diagnostic-heading-warning = Avertissement
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Suggestion
-
 accessibility-heading-level-1 = Violation d’accessibilité WCAG AA
 accessibility-heading-level-2 = Alerte d’accessibilité
-
 something-went-wrong = Une erreur s’est produite.
-
 renderer-load-failed = un composant d’affichage n’a pas pu être chargé. Veuillez recharger la page.
-
 core-start-failed = Le lecteur de document n’a pas pu démarrer. Veuillez recharger la page.

--- a/packages/i18n/locales/fr/content.ftl
+++ b/packages/i18n/locales/fr/content.ftl
@@ -50,7 +50,6 @@ color =
         }
     .pink = rose
     .brown = marron
-
 line-width =
     .thick =
         { $gender ->
@@ -62,7 +61,6 @@ line-width =
             [f] fine
            *[m] fin
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -74,7 +72,6 @@ line-style =
             [f] pointillée
            *[m] pointillé
         }
-
 # Noun phrases: they follow «avec des» and agree with nothing. All six are
 # plural, which is what lets one article cover them all.
 fill-style =
@@ -84,7 +81,6 @@ fill-style =
     .backdiagonal = lignes diagonales inverses
     .dots = points
     .diamonds = losanges
-
 noun =
     .line = ligne
     .line-segment = segment
@@ -104,7 +100,6 @@ noun =
     .diamond = losange
     .cross = croix
     .plus = signe plus
-
 # The noun is split: «polygone régulier» carries the agreement and
 # «à 5 côtés» closes the phrase, so the complement stays beside its own head
 # rather than being stranded after the adjectives.
@@ -113,7 +108,6 @@ noun-regular-polygon =
         [tail] à { $numSides } côtés
        *[head] polygone régulier
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (the shape
 # `noun-regular-polygon` names) or the head of a phrase the description never
 # names: `border`, `fill`, `text`, `background`. Of those only «bordure» is
@@ -133,7 +127,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -146,7 +139,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «ligne épaisse rouge». A noun with
 # a complement keeps it: «polygone régulier à 5 côtés épais rouge».
 style-with-noun =
@@ -154,19 +146,16 @@ style-with-noun =
         [noun-tail] { $noun } { $nounTail } { $description }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] remplie
        *[m] rempli
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } avec des { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } avec des { $pattern }
@@ -174,7 +163,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } avec des { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «bordure» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. French wants the article in every branch, so only the
 # conjunction distinguishes them.
@@ -185,7 +173,6 @@ style-border-clause =
         [and-article] et une bordure { $border }
        *[with] avec une bordure { $border }
     }
-
 # The gender this message is handed is the one `noun-gender` answers for
 # `fill` — masculine, for «remplissage» — so it names that noun and the colour
 # agrees with it in both variants. The pattern follows in the «avec des»
@@ -195,29 +182,23 @@ style-fill =
         [pattern] remplissage { $color } avec des { $pattern }
        *[plain] remplissage { $color }
     }
-
 style-unfilled = non rempli
-
 style-text =
     { $parts ->
         [background] { $color } sur un fond { $background }
        *[plain] { $color }
     }
-
 style-background-none = aucun
-
 
 ## Boolean words
 
 boolean-true = vrai
 boolean-false = faux
 
-
 ## Answer buttons
 
 answer-submit-label = Vérifier
 answer-submit-label-no-correctness = Envoyer la réponse
-
 
 ## Sectional blocks
 
@@ -242,7 +223,6 @@ section-name =
     .solution = Solution
     .task = Tâche
     .theorem = Théorème
-
 # French puts a space before a colon, which is why the separator differs from
 # the English one rather than being reused.
 section-title-prefix =
@@ -254,9 +234,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ " : " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Indice
-
 
 ## Tables and figures
 
@@ -267,7 +245,6 @@ table-name =
         [unnumbered-title] Tableau{ " : " }
        *[unnumbered] Tableau
     }
-
 figure-name =
     { $parts ->
         [numbered] Figure { $enumeration }
@@ -276,22 +253,18 @@ figure-name =
        *[unnumbered] Figure
     }
 
-
 ## Paginator controls
 
 paginator-previous = Précédent
 paginator-next = Suivant
 paginator-page = Page
-
 paginator-page-status = { $pageLabel } { $currentPage } sur { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ou
 piecewise-condition-if = si
 piecewise-condition-otherwise = sinon
-
 
 ## Chemistry
 
@@ -414,7 +387,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennesse
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrure
     .c = Carbure
@@ -428,8 +400,6 @@ element-anion-name =
     .i = Iodure
     .at = Astature
     .ts = Tennessure
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Symbole chimique invalide
 chemistry-invalid-ionic-compound = Composé ionique invalide

--- a/packages/i18n/locales/fy/chrome.ftl
+++ b/packages/i18n/locales/fy/chrome.ftl
@@ -15,21 +15,15 @@
 
 answer-checking = Kontrolearje…
 answer-submitting = Ynstjoere…
-
 answer-checking-status = Antwurd wurdt kontrolearre
 answer-submitting-status = Antwurd wurdt ynstjoerd
-
 answer-correct = Goed
 answer-incorrect = Ferkeard
-
 answer-response-saved = Antwurd bewarre
-
 answer-percent-credit = { $percent }% punten
 answer-percent-correct = { $percent }% goed
 answer-percent-short = { $percent } %
-
 max-credit-available = Maksimaal helbere punten: { $percent }%
-
 # Counted as "may still try N times" rather than "N attempts remain", so that
 # the count sits beside «kear», which does not change after a numeral. That
 # leaves `one` and `other` identical, so only the wording for none is branched.
@@ -38,53 +32,40 @@ attempts-remaining =
         [0] gjin besykjen mear oer
        *[other] noch { $count } kear besykje
     }
-
 validation-correct = (Goed)
 validation-incorrect = (Ferkeard)
 validation-partially-correct = (Foar in part goed)
-
 answer-show-responses =
     { $count ->
         [one] { $count } antwurd op { $answerId } sjen litte
        *[other] { $count } antwurden op { $answerId } sjen litte
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Weromkeppeling
-
 collapsible-click-to-open = (klik om iepen te dwaan)
 collapsible-click-to-close = (klik om ticht te dwaan)
-
 collapsible-initializing = Opstarte…
-
 footnote-show = Fuotnoat sjen litte
 footnote-hide = Fuotnoat ferstopje
-
 description-more-information = mear ynformaasje
-
 
 ## Controls
 
 slider-previous = Foarige
 slider-next = Folgjende
-
 keyboard-open = Toetseboerd iepenje
 keyboard-close = Toetseboerd slute
-
 choice-input-remove-choice = { $choice } fuortsmite
-
 matrix-remove-row = Rige fuortsmite
 matrix-add-row = Rige tafoegje
 matrix-remove-column = Kolom fuortsmite
 matrix-add-column = Kolom tafoegje
-
 subset-add-remove-points = Punten tafoegje/fuortsmite
 subset-toggle-points-intervals = Wikselje tusken punten en yntervallen
 subset-move-points = Punten ferskowe
 subset-clear = Leechmeitsje
-
 orbital-add-row = Rige tafoegje
 orbital-remove-row = Rige fuortsmite
 orbital-add-box = Fakje tafoegje
@@ -92,13 +73,9 @@ orbital-remove-box = Fakje fuortsmite
 orbital-add-up-arrow = Piel omheech tafoegje
 orbital-add-down-arrow = Piel omleech tafoegje
 orbital-remove-arrow = Piel fuortsmite
-
 orbital-row-label = Namme foar rige { $row }
-
 pretzel-answer = Antwurd
-
 summary-statistics-caption = Gearfetsjende statistiken fan { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = foarbyld fan 'e wiskundige útdrukking
 math-input-preview = Foarbyld
 math-input-invalid-expression = Unjildige útdrukking:
 
-
 ## Document status
 
 viewer-initializing = Opstarte…
 
-
 ## Errors
 
 error-heading = Flater
-
 error-found-at =
     { $span ->
         [line] Fûn op rigel { $startLine }.
        *[lines] Fûn op rigels { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dit dokumint befettet flaters!
-
 diagnostic-heading-error = Flater
 diagnostic-heading-warning = Warskôging
 diagnostic-heading-information = Ynfo
 diagnostic-heading-hint = Oanwizing
-
 accessibility-heading-level-1 = Skeining fan 'e tagonklikens neffens WCAG AA
 accessibility-heading-level-2 = Warskôging oer tagonklikens
-
 something-went-wrong = Der is wat misgien.
-
 renderer-load-failed = in module foar it werjaan koe net laden wurde. Laad de side opnij.
-
 core-start-failed = De dokumintwerjefte koe net start wurde. Laad de side opnij.

--- a/packages/i18n/locales/fy/content.ftl
+++ b/packages/i18n/locales/fy/content.ftl
@@ -79,7 +79,6 @@ color =
             [n] brún
            *[c] brune
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -91,7 +90,6 @@ line-width =
             [n] tin
            *[c] tinne
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -99,7 +97,6 @@ line-style =
            *[c] streepte
         }
     .dotted = stippele
-
 # Plural noun phrases, which is what follows «mei» in `style-filled`. A plural
 # adjective always takes `-e`, so these agree with nothing.
 fill-style =
@@ -109,7 +106,6 @@ fill-style =
     .backdiagonal = omkearde diagonale linen
     .dots = stippen
     .diamonds = ruten
-
 noun =
     .line = line
     .line-segment = linestik
@@ -129,13 +125,11 @@ noun =
     .diamond = ruut
     .cross = krús
     .plus = plus
-
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] regelmjittige { $numSides }-hoek
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (which is
 # `{ $numSides }-hoek`, common) or the head of a phrase the description never
 # names: `border` (râne, common), `fill` (folling, common), `text` (tekst,
@@ -150,7 +144,6 @@ noun-gender =
        *[other] c
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -163,25 +156,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [n] follet
        *[c] follete
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } mei { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } mei { $pattern }
@@ -189,7 +178,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } mei { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «râne» is common, so the border's adjectives agree with it rather than with
 # the shape it surrounds. Frisian has an indefinite article, «in», so the two
 # `-article` branches really do differ from the two without.
@@ -200,35 +188,28 @@ style-border-clause =
         [and-article] en in { $border } râne
        *[with] mei { $border } râne
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } folling mei { $pattern }
        *[plain] { $color } folling
     }
-
 style-unfilled = net follet
-
 style-text =
     { $parts ->
         [background] { $color } op in { $background } eftergrûn
        *[plain] { $color }
     }
-
 style-background-none = gjin
-
 
 ## Boolean words
 
 boolean-true = wier
 boolean-false = falsk
 
-
 ## Answer buttons
 
 answer-submit-label = Kontrolearje
 answer-submit-label-no-correctness = Antwurd ynstjoere
-
 
 ## Sectional blocks
 
@@ -253,7 +234,6 @@ section-name =
     .solution = Oplossing
     .task = Taak
     .theorem = Stelling
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -263,9 +243,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Oanwizing
-
 
 ## Tables and figures
 
@@ -276,7 +254,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Figuer { $enumeration }
@@ -285,22 +262,18 @@ figure-name =
        *[unnumbered] Figuer
     }
 
-
 ## Paginator controls
 
 paginator-previous = Foarige
 paginator-next = Folgjende
 paginator-page = Side
-
 paginator-page-status = { $pageLabel } { $currentPage } fan { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = of
 piecewise-condition-if = as
 piecewise-condition-otherwise = oars
-
 
 ## Chemistry
 ##
@@ -311,6 +284,5 @@ piecewise-condition-otherwise = oars
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Unjildich chemysk symboal
 chemistry-invalid-ionic-compound = Unjildige ioanyske ferbining

--- a/packages/i18n/locales/ga/chrome.ftl
+++ b/packages/i18n/locales/ga/chrome.ftl
@@ -15,25 +15,20 @@
 # the `many` branch. «iarracht» begins with a vowel, so only the eclipsis shows
 # on it, as `n-`; «freagra» shows both, as «fhreagra» and «bhfreagra».
 
+
 ## Answer submission
 
 answer-checking = Á sheiceáil…
 answer-submitting = Á sheoladh…
-
 answer-checking-status = An freagra á sheiceáil
 answer-submitting-status = An freagra á sheoladh
-
 answer-correct = Ceart
 answer-incorrect = Mícheart
-
 answer-response-saved = Freagra sábháilte
-
 answer-percent-credit = { $percent }% creidiúna
 answer-percent-correct = { $percent }% ceart
 answer-percent-short = { $percent } %
-
 max-credit-available = Uaschreidiúint atá ar fáil: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] níl aon iarracht fágtha
@@ -43,11 +38,9 @@ attempts-remaining =
         [many] { $count } n-iarracht fágtha
        *[other] { $count } iarracht fágtha
     }
-
 validation-correct = (Ceart)
 validation-incorrect = (Mícheart)
 validation-partially-correct = (Ceart go páirteach)
-
 answer-show-responses =
     { $count ->
         [one] Taispeáin { $count } freagra ar { $answerId }
@@ -57,42 +50,31 @@ answer-show-responses =
        *[other] Taispeáin { $count } freagra ar { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Aiseolas
-
 collapsible-click-to-open = (cliceáil chun oscailt)
 collapsible-click-to-close = (cliceáil chun dúnadh)
-
 collapsible-initializing = Á thúsú…
-
 footnote-show = Taispeáin an fonóta
 footnote-hide = Folaigh an fonóta
-
 description-more-information = tuilleadh eolais
-
 
 ## Controls
 
 slider-previous = Siar
 slider-next = Ar aghaidh
-
 keyboard-open = Oscail an méarchlár
 keyboard-close = Dún an méarchlár
-
 choice-input-remove-choice = Bain { $choice }
-
 matrix-remove-row = Bain ró
 matrix-add-row = Cuir ró leis
 matrix-remove-column = Bain colún
 matrix-add-column = Cuir colún leis
-
 subset-add-remove-points = Cuir pointí leis / bain pointí
 subset-toggle-points-intervals = Scoránaigh idir pointí agus eatraimh
 subset-move-points = Bog na pointí
 subset-clear = Glan
-
 orbital-add-row = Cuir ró leis
 orbital-remove-row = Bain ró
 orbital-add-box = Cuir bosca leis
@@ -100,13 +82,9 @@ orbital-remove-box = Bain bosca
 orbital-add-up-arrow = Cuir saighead suas leis
 orbital-add-down-arrow = Cuir saighead síos leis
 orbital-remove-arrow = Bain saighead
-
 orbital-row-label = Lipéad don ró { $row }
-
 pretzel-answer = Freagra
-
 summary-statistics-caption = Staitisticí achoimre { $column }
-
 
 ## Math input
 
@@ -114,34 +92,25 @@ math-input-preview-region = réamhamharc ar an slonn matamaitice
 math-input-preview = Réamhamharc
 math-input-invalid-expression = Slonn neamhbhailí:
 
-
 ## Document status
 
 viewer-initializing = Á thúsú…
 
-
 ## Errors
 
 error-heading = Earráid
-
 error-found-at =
     { $span ->
         [line] Aimsíodh ar líne { $startLine } é.
        *[lines] Aimsíodh ar línte { $startLine }–{ $endLine } é.
     }
-
 document-contains-errors = Tá earráidí sa cháipéis seo!
-
 diagnostic-heading-error = Earráid
 diagnostic-heading-warning = Rabhadh
 diagnostic-heading-information = Eolas
 diagnostic-heading-hint = Leid
-
 accessibility-heading-level-1 = Sárú inrochtaineachta WCAG AA
 accessibility-heading-level-2 = Foláireamh inrochtaineachta
-
 something-went-wrong = Chuaigh rud éigin amú.
-
 renderer-load-failed = theip ar rindreálaí a lódáil. Athlódáil an leathanach, le do thoil.
-
 core-start-failed = Níorbh fhéidir amharcán na cáipéise a thosú. Athlódáil an leathanach, le do thoil.

--- a/packages/i18n/locales/ga/content.ftl
+++ b/packages/i18n/locales/ga/content.ftl
@@ -83,7 +83,6 @@ color =
             [f] dhonn
            *[m] donn
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -95,7 +94,6 @@ line-width =
             [f] thanaí
            *[m] tanaí
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -107,7 +105,6 @@ line-style =
             [f] phoncaithe
            *[m] poncaithe
         }
-
 # Noun phrases standing behind «le», which is where the composition messages
 # put them. They modify nothing and so take no gender.
 fill-style =
@@ -117,7 +114,6 @@ fill-style =
     .backdiagonal = línte trasnánacha droim ar ais
     .dots = poncanna
     .diamonds = muileataí
-
 noun =
     .line = líne
     .line-segment = mírlíne
@@ -137,7 +133,6 @@ noun =
     .diamond = muileata
     .cross = cros
     .plus = plus
-
 # «polagán rialta» is the noun and its own adjective; the side count follows
 # the style adjectives as a prepositional phrase, so the head and the tail
 # split around them the way Spanish's does.
@@ -151,7 +146,6 @@ noun-regular-polygon =
         [tail] le { $numSides } taobh
        *[head] polagán rialta
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polagán, m) or the
 # head of a phrase the description never names: `border` (imlíne, f), `fill`
 # (líonadh, m), `text` (téacs, m), `background` (cúlra, m).
@@ -169,7 +163,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # The adjectives follow their noun rather than preceding it, and among
@@ -185,7 +178,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and the adjectives follow it, which is the reverse of English
 # and the reason this message exists rather than a concatenation.
 style-with-noun =
@@ -193,17 +185,14 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 # «líonta» begins with `l`, which has no lenited form, so it reads the same
 # after a feminine noun as after a masculine one and needs no branch.
 style-filled-word = líonta
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } le { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } le { $pattern }
@@ -211,7 +200,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } le { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «imlíne» is feminine, so the border's adjectives lenite after it whatever the
 # shape around it is. It also begins with a vowel, and «le» prefixes h- to a
 # vowel while «agus» does not — so the same noun is «le himlíne» in one pair of
@@ -224,7 +212,6 @@ style-border-clause =
         [and-article] agus imlíne { $border }
        *[with] le himlíne { $border }
     }
-
 # The pattern words are plural nouns, so this supplies «líonadh» — masculine,
 # the gender `noun-gender` already answers for `fill` — for the colour to
 # follow, and hangs the pattern off it with «le».
@@ -233,9 +220,7 @@ style-fill =
         [pattern] líonadh { $color } le { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = gan líonadh
-
 # «cúlra» is masculine, so the background colour does not lenite, and «le»
 # leaves a consonant alone.
 style-text =
@@ -243,21 +228,17 @@ style-text =
         [background] { $color } le cúlra { $background }
        *[plain] { $color }
     }
-
 style-background-none = gan aon cheann
-
 
 ## Boolean words
 
 boolean-true = fíor
 boolean-false = bréagach
 
-
 ## Answer buttons
 
 answer-submit-label = Seiceáil an obair
 answer-submit-label-no-correctness = Seol an freagra
-
 
 ## Sectional blocks
 
@@ -282,7 +263,6 @@ section-name =
     .solution = Réiteach
     .task = Tasc
     .theorem = Teoirim
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -292,9 +272,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Leid
-
 
 ## Tables and figures
 
@@ -305,7 +283,6 @@ table-name =
         [unnumbered-title] Tábla{ ": " }
        *[unnumbered] Tábla
     }
-
 figure-name =
     { $parts ->
         [numbered] Fíor { $enumeration }
@@ -314,22 +291,18 @@ figure-name =
        *[unnumbered] Fíor
     }
 
-
 ## Paginator controls
 
 paginator-previous = Roimhe seo
 paginator-next = Ar aghaidh
 paginator-page = Leathanach
-
 paginator-page-status = { $pageLabel } { $currentPage } as { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = nó
 piecewise-condition-if = má
 piecewise-condition-otherwise = ar shlí eile
-
 
 ## Chemistry
 
@@ -452,7 +425,6 @@ element-name =
     .lv = Livearmóiriam
     .ts = Teinisein
     .og = Oganasan
-
 element-anion-name =
     .h = Hidríd
     .c = Cairbíd
@@ -466,8 +438,6 @@ element-anion-name =
     .i = Iaidíd
     .at = Astaitíd
     .ts = Teiniséid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Siombail cheimiceach neamhbhailí
 chemistry-invalid-ionic-compound = Comhdhúil ianach neamhbhailí

--- a/packages/i18n/locales/gaa/chrome.ftl
+++ b/packages/i18n/locales/gaa/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Miikwɛ…
 answer-submitting = Miimaje…
-
 answer-checking-status = Akwɛɔ hetoo lɛ
 answer-submitting-status = Amajeɔ hetoo lɛ
-
 answer-correct = Eja
 answer-incorrect = Ejaaa
-
 answer-response-saved = Ato Hetoo Lɛ
-
 answer-percent-credit = { $percent }% pɔintsii
 answer-percent-correct = { $percent }% eja
 answer-percent-short = { $percent } %
-
 max-credit-available = Pɔintsii babaoo ni yɔɔ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kasemɔ ko eshwɛɛɛ
         [one] kasemɔ { $count } eshwɛ
        *[other] kasemɔi { $count } eshwɛ
     }
-
 validation-correct = (Eja)
 validation-incorrect = (Ejaaa)
 validation-partially-correct = (Eja yɛ fã ko nɔ)
-
 answer-show-responses =
     { $count ->
         [one] Tsɔɔmɔ hetoo { $count } ni kɔɔ { $answerId } he
        *[other] Tsɔɔmɔ hetooi { $count } ni kɔɔ { $answerId } he
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Hesaamɔ
-
 collapsible-click-to-open = (nyɛmɔ ni ogbele)
 collapsible-click-to-close = (nyɛmɔ ni oŋa)
-
 collapsible-initializing = Miije shishi…
-
 footnote-show = Tsɔɔmɔ shishi kadimɔ
 footnote-hide = Teemɔ shishi kadimɔ
-
 description-more-information = saji krokomɛi
-
 
 ## Controls
 
 slider-previous = Nɔ ni tsɔ hiɛ
 slider-next = Nɔ ni nyiɛ sɛɛ
-
 keyboard-open = Gbele Kiibɔd
 keyboard-close = Ŋa Kiibɔd
-
 choice-input-remove-choice = Jie { $choice }
-
 matrix-remove-row = Jie laiŋi
 matrix-add-row = Fata laiŋi he
 matrix-remove-column = Jie kɔlom
 matrix-add-column = Fata kɔlom he
-
 subset-add-remove-points = Fata/Jie pɔintsii
 subset-toggle-points-intervals = Tsake pɔintsii kɛ fãi
 subset-move-points = Hiɛɛ Pɔintsii
 subset-clear = Jie fɛɛ
-
 orbital-add-row = Fata Laiŋi He
 orbital-remove-row = Jie Laiŋi
 orbital-add-box = Fata Adeka He
@@ -86,13 +67,9 @@ orbital-remove-box = Jie Adeka
 orbital-add-up-arrow = Fata Gãŋ ni Kwɔ He
 orbital-add-down-arrow = Fata Gãŋ ni Shi He
 orbital-remove-arrow = Jie Gãŋ
-
 orbital-row-label = Laiŋi { $row } gbɛi
-
 pretzel-answer = Hetoo
-
 summary-statistics-caption = { $column } yibɔi amuu
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = yibɔi wiemɔ hiɛkwɛmɔ
 math-input-preview = Hiɛkwɛmɔ
 math-input-invalid-expression = Wiemɔ ni ejaaa:
 
-
 ## Document status
 
 viewer-initializing = Miije shishi…
 
-
 ## Errors
 
 error-heading = Tɔmɔ
-
 error-found-at =
     { $span ->
         [line] Ana yɛ laiŋi { $startLine } nɔ.
        *[lines] Ana yɛ laiŋi { $startLine }–{ $endLine } nɔ.
     }
-
 document-contains-errors = Wolo nɛɛ yɔɔ tɔmɔi!
-
 diagnostic-heading-error = Tɔmɔ
 diagnostic-heading-warning = Kɔkɔbɔɔ
 diagnostic-heading-information = Sane
 diagnostic-heading-hint = Hiɛtsɔɔmɔ
-
 accessibility-heading-level-1 = WCAG AA shɛmɔ he tɔmɔ
 accessibility-heading-level-2 = Shɛmɔ he kɔkɔbɔɔ
-
 something-went-wrong = Nɔ ko efeee jogbaŋŋ.
-
 renderer-load-failed = tsɔɔlɔ lɛ shɛɛɛ. Ofainɛ, tsɔɔ baafa lɛ ekoŋŋ.
-
 core-start-failed = Wolo lɛ tsɔɔlɔ ejeee shishi. Ofainɛ, tsɔɔ baafa lɛ ekoŋŋ.

--- a/packages/i18n/locales/gaa/content.ftl
+++ b/packages/i18n/locales/gaa/content.ftl
@@ -44,17 +44,14 @@ color =
     .purple = paapul
     .pink = piŋk
     .brown = braun
-
 line-width =
     .thick = agbo
     .thin = bibioo
-
 # Written as invariable «kɛ …» phrases rather than as qualifiers, so that they
 # can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = kɛ dashii
     .dotted = kɛ dɔtsii
-
 fill-style =
     .horizontal = laiŋi ni ekã shi
     .vertical = laiŋi ni edamɔ shi
@@ -62,7 +59,6 @@ fill-style =
     .backdiagonal = laiŋi ni ekpe yɛ gbɛ kroko nɔ
     .dots = dɔtsii
     .diamonds = diamondii
-
 noun =
     .line = laiŋi
     .line-segment = laiŋi fã
@@ -82,7 +78,6 @@ noun =
     .diamond = diamond
     .cross = sɛŋɛ
     .plus = kɛfataa okadi
-
 # The side count follows the qualifiers, behind «ni yɔɔ», because Ga closes a
 # noun phrase with a relative rather than opening one.
 noun-regular-polygon =
@@ -90,11 +85,9 @@ noun-regular-polygon =
         [tail] ni yɔɔ tsɔɔmɔ { $numSides }
        *[head] poligɔn ni damɔ pɛpɛɛpɛ
     }
-
 # No grammatical gender, so this answers one token for every noun and the
 # answer goes unused — the shape `locales/en` has.
 noun-gender = ekome
-
 
 ## Style composition
 
@@ -108,21 +101,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ni eyi obɔ
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kɛ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kɛ { $pattern }
@@ -130,7 +119,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kɛ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Ga has no article, and joins this clause with the invariable «kɛ» whatever
 # came before it, so all four branches read alike.
 style-border-clause =
@@ -140,35 +128,28 @@ style-border-clause =
         [and-article] kɛ kɛnkɛn { $border }
        *[with] kɛ kɛnkɛn { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ni eyiii obɔ
-
 style-text =
     { $parts ->
         [background] { $color } kɛ sɛɛgbɛ { $background }
        *[plain] { $color }
     }
-
 style-background-none = nɔ ko bɛ jɛi
-
 
 ## Boolean words
 
 boolean-true = anɔkwale
 boolean-false = amale
 
-
 ## Answer buttons
 
 answer-submit-label = Kwɛmɔ Nitsumɔ
 answer-submit-label-no-correctness = Maje Hetoo
-
 
 ## Sectional blocks
 
@@ -193,7 +174,6 @@ section-name =
     .solution = Tsabaa
     .task = Nitsumɔ
     .theorem = Tiorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -203,9 +183,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Hiɛtsɔɔmɔ
-
 
 ## Tables and figures
 
@@ -216,7 +194,6 @@ table-name =
         [unnumbered-title] Okpɔlɔ{ ": " }
        *[unnumbered] Okpɔlɔ
     }
-
 figure-name =
     { $parts ->
         [numbered] Mfoniri { $enumeration }
@@ -225,24 +202,18 @@ figure-name =
        *[unnumbered] Mfoniri
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nɔ ni tsɔ hiɛ
 paginator-next = Nɔ ni nyiɛ sɛɛ
 paginator-page = Baafa
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = loo
-
 piecewise-condition-if = kɛji
-
 piecewise-condition-otherwise = hei krokomɛi fɛɛ
-
 
 ## Chemistry
 ##
@@ -255,6 +226,5 @@ piecewise-condition-otherwise = hei krokomɛi fɛɛ
 ## same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kɛmistri Okadi ni Ejaaa
 chemistry-invalid-ionic-compound = Ayɔn Fatamɔ ni Ejaaa

--- a/packages/i18n/locales/gd/chrome.ftl
+++ b/packages/i18n/locales/gd/chrome.ftl
@@ -13,25 +13,20 @@
 # noun singular and lenites it, exactly as «aon» does — so the `two` branch
 # reads like `one` rather than like `few`, and only `few` takes a plural noun.
 
+
 ## Answer submission
 
 answer-checking = Ga dhearbhadh…
 answer-submitting = Ga chur…
-
 answer-checking-status = A' dearbhadh na freagairte
 answer-submitting-status = A' cur na freagairte
-
 answer-correct = Ceart
 answer-incorrect = Ceàrr
-
 answer-response-saved = Chaidh an fhreagairt a shàbhaladh
-
 answer-percent-credit = { $percent }% de chreideas
 answer-percent-correct = { $percent }% ceart
 answer-percent-short = { $percent } %
-
 max-credit-available = An creideas as motha a tha ri fhaighinn: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] chan eil oidhirp air fhàgail
@@ -40,11 +35,9 @@ attempts-remaining =
         [few] { $count } oidhirpean air fhàgail
        *[other] { $count } oidhirp air fhàgail
     }
-
 validation-correct = (Ceart)
 validation-incorrect = (Ceàrr)
 validation-partially-correct = (Ceart gu ìre)
-
 answer-show-responses =
     { $count ->
         [one] Seall { $count } fhreagairt air { $answerId }
@@ -53,42 +46,31 @@ answer-show-responses =
        *[other] Seall { $count } freagairt air { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Beachdan
-
 collapsible-click-to-open = (briog gus a fhosgladh)
 collapsible-click-to-close = (briog gus a dhùnadh)
-
 collapsible-initializing = Ga thòiseachadh…
-
 footnote-show = Seall am bun-nòta
 footnote-hide = Falaich am bun-nòta
-
 description-more-information = barrachd fiosrachaidh
-
 
 ## Controls
 
 slider-previous = Air ais
 slider-next = Air adhart
-
 keyboard-open = Fosgail am meur-chlàr
 keyboard-close = Dùin am meur-chlàr
-
 choice-input-remove-choice = Thoir { $choice } air falbh
-
 matrix-remove-row = Thoir sreath air falbh
 matrix-add-row = Cuir sreath ris
 matrix-remove-column = Thoir colbh air falbh
 matrix-add-column = Cuir colbh ris
-
 subset-add-remove-points = Cuir puingean ris / thoir air falbh
 subset-toggle-points-intervals = Toglaich eadar puingean is eadaramhan
 subset-move-points = Gluais na puingean
 subset-clear = Falamhaich
-
 orbital-add-row = Cuir sreath ris
 orbital-remove-row = Thoir sreath air falbh
 orbital-add-box = Cuir bogsa ris
@@ -96,13 +78,9 @@ orbital-remove-box = Thoir bogsa air falbh
 orbital-add-up-arrow = Cuir saighead-suas ris
 orbital-add-down-arrow = Cuir saighead-sìos ris
 orbital-remove-arrow = Thoir saighead air falbh
-
 orbital-row-label = Leubail airson sreath { $row }
-
 pretzel-answer = Freagairt
-
 summary-statistics-caption = Geàrr-shuimean staitistigeach airson { $column }
-
 
 ## Math input
 
@@ -110,34 +88,25 @@ math-input-preview-region = ro-shealladh air an abairt mhatamataigeach
 math-input-preview = Ro-shealladh
 math-input-invalid-expression = Abairt mhì-dhligheach:
 
-
 ## Document status
 
 viewer-initializing = Ga thòiseachadh…
 
-
 ## Errors
 
 error-heading = Mearachd
-
 error-found-at =
     { $span ->
         [line] Chaidh a lorg air loidhne { $startLine }.
        *[lines] Chaidh a lorg air loidhnichean { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tha mearachdan san sgrìobhainn seo!
-
 diagnostic-heading-error = Mearachd
 diagnostic-heading-warning = Rabhadh
 diagnostic-heading-information = Fiosrachadh
 diagnostic-heading-hint = Sanas
-
 accessibility-heading-level-1 = Briseadh so-ruigsinneachd WCAG AA
 accessibility-heading-level-2 = Rabhadh so-ruigsinneachd
-
 something-went-wrong = Chaidh rudeigin ceàrr.
-
 renderer-load-failed = dh'fhàillig le reandaraiche a luchdachadh. Ath-luchdaich an duilleag.
-
 core-start-failed = Cha b' urrainnear sealladair na sgrìobhainn a thòiseachadh. Ath-luchdaich an duilleag.

--- a/packages/i18n/locales/gd/content.ftl
+++ b/packages/i18n/locales/gd/content.ftl
@@ -76,7 +76,6 @@ color =
             [f] dhonn
            *[m] donn
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -88,7 +87,6 @@ line-width =
             [f] chaol
            *[m] caol
         }
-
 line-style =
     .dashed = strìochagach
     .dotted =
@@ -96,7 +94,6 @@ line-style =
             [f] dhotagach
            *[m] dotagach
         }
-
 # Noun phrases standing behind «le». They modify nothing and take no gender.
 fill-style =
     .horizontal = loidhnichean còmhnard
@@ -105,7 +102,6 @@ fill-style =
     .backdiagonal = loidhnichean trastanach cùil
     .dots = dotagan
     .diamonds = daoimeanan
-
 noun =
     .line = loidhne
     .line-segment = earrann-loidhne
@@ -125,19 +121,18 @@ noun =
     .diamond = daoimean
     .cross = crois
     .plus = plus
-
 # The side count follows the style adjectives, so the head and the tail split
 # around them. Three to ten take a plural noun in Gaelic and every other count
 # leaves it singular, so the tail branches on `few` alone.
 noun-regular-polygon =
     { $part ->
-        [tail] le { $numSides } { $numSides ->
-            [few] taobhan
-           *[other] taobh
-        }
+        [tail]
+            le { $numSides } { $numSides ->
+                [few] taobhan
+               *[other] taobh
+            }
        *[head] ioma-cheàrnach riaghailteach
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (ioma-cheàrnach, m) or
 # the head of a phrase the description never names: `border` (iomall, m),
 # `fill` (lìonadh, m), `text` (teacsa, m), `background` (cùlaibh, m).
@@ -155,7 +150,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # The adjectives follow their noun, and among themselves Gaelic keeps the
@@ -172,23 +166,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 # «lìonta» begins with `l`, which has no lenited form, so it reads the same
 # after either gender.
 style-filled-word = lìonta
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } le { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } le { $pattern }
@@ -196,7 +186,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } le { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «iomall» is masculine, so the border's adjectives are unlenited after it
 # whatever the shape around it is. Gaelic prefixes nothing to it after «le»,
 # and has no indefinite article, so all four branches differ only in the
@@ -208,35 +197,28 @@ style-border-clause =
         [and-article] agus iomall { $border }
        *[with] le iomall { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] lìonadh { $color } le { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = gun lìonadh
-
 style-text =
     { $parts ->
         [background] { $color } le cùlaibh { $background }
        *[plain] { $color }
     }
-
 style-background-none = chan eil gin
-
 
 ## Boolean words
 
 boolean-true = fìor
 boolean-false = breugach
 
-
 ## Answer buttons
 
 answer-submit-label = Dearbh an obair
 answer-submit-label-no-correctness = Cuir a-steach an fhreagairt
-
 
 ## Sectional blocks
 
@@ -261,7 +243,6 @@ section-name =
     .solution = Fuasgladh
     .task = Obair
     .theorem = Teòirim
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -271,9 +252,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Sanas
-
 
 ## Tables and figures
 
@@ -284,7 +263,6 @@ table-name =
         [unnumbered-title] Clàr{ ": " }
        *[unnumbered] Clàr
     }
-
 figure-name =
     { $parts ->
         [numbered] Dealbh { $enumeration }
@@ -293,22 +271,18 @@ figure-name =
        *[unnumbered] Dealbh
     }
 
-
 ## Paginator controls
 
 paginator-previous = Air ais
 paginator-next = Air adhart
 paginator-page = Duilleag
-
 paginator-page-status = { $pageLabel } { $currentPage } à { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = no
 piecewise-condition-if = ma
 piecewise-condition-otherwise = air neo
-
 
 ## Chemistry
 
@@ -431,7 +405,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenneisin
     .og = Oganeson
-
 element-anion-name =
     .h = Haidrid
     .c = Carbaid
@@ -445,8 +418,6 @@ element-anion-name =
     .i = Iodaid
     .at = Astataid
     .ts = Tenneisid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Samhla ceimigeach mì-dhligheach
 chemistry-invalid-ionic-compound = Todhar ianach mì-dhligheach

--- a/packages/i18n/locales/gl/chrome.ftl
+++ b/packages/i18n/locales/gl/chrome.ftl
@@ -10,78 +10,60 @@
 # Galician counts in the same two plural categories English does, so every
 # `{ $count -> … }` below keeps the shape it had.
 
+
 ## Answer submission
 
 answer-checking = Comprobando…
 answer-submitting = Enviando…
-
 answer-checking-status = Comprobando a resposta
 answer-submitting-status = Enviando a resposta
-
 answer-correct = Correcto
 answer-incorrect = Incorrecto
-
 answer-response-saved = Resposta gardada
-
 answer-percent-credit = { $percent }% da puntuación
 answer-percent-correct = { $percent }% correcto
 answer-percent-short = { $percent } %
-
 max-credit-available = Puntuación máxima dispoñible: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] non queda ningún intento
         [one] queda { $count } intento
        *[other] quedan { $count } intentos
     }
-
 validation-correct = (Correcto)
 validation-incorrect = (Incorrecto)
 validation-partially-correct = (Parcialmente correcto)
-
 answer-show-responses =
     { $count ->
         [one] Amosar { $count } resposta a { $answerId }
        *[other] Amosar { $count } respostas a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Comentarios
-
 collapsible-click-to-open = (prema para abrir)
 collapsible-click-to-close = (prema para pechar)
-
 collapsible-initializing = Inicializando…
-
 footnote-show = Amosar a nota ao pé
 footnote-hide = Agochar a nota ao pé
-
 description-more-information = máis información
-
 
 ## Controls
 
 slider-previous = Anterior
 slider-next = Seguinte
-
 keyboard-open = Abrir o teclado
 keyboard-close = Pechar o teclado
-
 choice-input-remove-choice = Quitar { $choice }
-
 matrix-remove-row = Quitar unha fila
 matrix-add-row = Engadir unha fila
 matrix-remove-column = Quitar unha columna
 matrix-add-column = Engadir unha columna
-
 subset-add-remove-points = Engadir/quitar puntos
 subset-toggle-points-intervals = Alternar entre puntos e intervalos
 subset-move-points = Mover os puntos
 subset-clear = Limpar
-
 orbital-add-row = Engadir unha fila
 orbital-remove-row = Quitar unha fila
 orbital-add-box = Engadir unha caixa
@@ -89,13 +71,9 @@ orbital-remove-box = Quitar unha caixa
 orbital-add-up-arrow = Engadir unha frecha cara arriba
 orbital-add-down-arrow = Engadir unha frecha cara abaixo
 orbital-remove-arrow = Quitar unha frecha
-
 orbital-row-label = Etiqueta da fila { $row }
-
 pretzel-answer = Resposta
-
 summary-statistics-caption = Resumo estatístico de { $column }
-
 
 ## Math input
 
@@ -103,34 +81,25 @@ math-input-preview-region = vista previa da expresión matemática
 math-input-preview = Vista previa
 math-input-invalid-expression = Expresión non válida:
 
-
 ## Document status
 
 viewer-initializing = Inicializando…
 
-
 ## Errors
 
 error-heading = Erro
-
 error-found-at =
     { $span ->
         [line] Atopado na liña { $startLine }.
        *[lines] Atopado nas liñas { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Este documento contén erros!
-
 diagnostic-heading-error = Erro
 diagnostic-heading-warning = Aviso
 diagnostic-heading-information = Información
 diagnostic-heading-hint = Suxestión
-
 accessibility-heading-level-1 = Incumprimento de accesibilidade WCAG AA
 accessibility-heading-level-2 = Alerta de accesibilidade
-
 something-went-wrong = Algo foi mal.
-
 renderer-load-failed = non se puido cargar un renderizador. Recargue a páxina.
-
 core-start-failed = Non se puido iniciar o visualizador do documento. Recargue a páxina.

--- a/packages/i18n/locales/gl/content.ftl
+++ b/packages/i18n/locales/gl/content.ftl
@@ -53,7 +53,6 @@ color =
         }
     .pink = rosa
     .brown = marrón
-
 line-width =
     .thick =
         { $gender ->
@@ -65,7 +64,6 @@ line-width =
             [f] fina
            *[m] fino
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -77,7 +75,6 @@ line-style =
             [f] punteada
            *[m] punteado
         }
-
 # Noun phrases standing behind «con». They modify nothing and take no gender.
 fill-style =
     .horizontal = liñas horizontais
@@ -86,7 +83,6 @@ fill-style =
     .backdiagonal = liñas diagonais inversas
     .dots = puntos
     .diamonds = rombos
-
 noun =
     .line = liña
     .line-segment = segmento
@@ -106,7 +102,6 @@ noun =
     .diamond = rombo
     .cross = cruz
     .plus = máis
-
 # The side count follows the style adjectives so that they stay beside the noun
 # they agree with.
 noun-regular-polygon =
@@ -114,7 +109,6 @@ noun-regular-polygon =
         [tail] de { $numSides } lados
        *[head] polígono regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polígono, m) or
 # the head of a phrase the description never names: `border` (bordo, m), `fill`
 # (recheo, m), `text` (texto, m), `background` (fondo, m).
@@ -130,7 +124,6 @@ noun-gender =
         [cross] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -149,25 +142,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] chea
        *[m] cheo
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } con { $pattern }
        *[plain] { $color } { $filled }
     }
-
 # The complement stays beside its own noun rather than at the end: «cheo de 5
 # lados» would read as «full of 5 sides». «Polígono regular de 5 lados azul
 # cheo».
@@ -178,7 +167,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } con { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «bordo» is masculine, so the border's adjectives agree with it and not with
 # the shape it surrounds.
 style-border-clause =
@@ -188,7 +176,6 @@ style-border-clause =
         [and-article] e un bordo { $border }
        *[with] con bordo { $border }
     }
-
 # Naming «recheo» keeps the colour agreeing with a masculine singular noun the
 # catalog writes, instead of with the plural pattern word beside it: «recheo
 # azul con rombos» rather than «rombos azuis».
@@ -197,29 +184,23 @@ style-fill =
         [pattern] recheo { $color } con { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = sen recheo
-
 style-text =
     { $parts ->
         [background] { $color } cun fondo { $background }
        *[plain] { $color }
     }
-
 style-background-none = ningún
-
 
 ## Boolean words
 
 boolean-true = verdadeiro
 boolean-false = falso
 
-
 ## Answer buttons
 
 answer-submit-label = Comprobar
 answer-submit-label-no-correctness = Enviar a resposta
-
 
 ## Sectional blocks
 
@@ -244,7 +225,6 @@ section-name =
     .solution = Solución
     .task = Tarefa
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -254,9 +234,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pista
-
 
 ## Tables and figures
 
@@ -267,7 +245,6 @@ table-name =
         [unnumbered-title] Táboa{ ": " }
        *[unnumbered] Táboa
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -276,22 +253,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anterior
 paginator-next = Seguinte
 paginator-page = Páxina
-
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ou
 piecewise-condition-if = se
 piecewise-condition-otherwise = noutro caso
-
 
 ## Chemistry
 
@@ -414,7 +387,6 @@ element-name =
     .lv = Livermorio
     .ts = Teneso
     .og = Oganesón
-
 element-anion-name =
     .h = Hidruro
     .c = Carburo
@@ -428,8 +400,6 @@ element-anion-name =
     .i = Ioduro
     .at = Astaturo
     .ts = Tenesuro
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Símbolo químico non válido
 chemistry-invalid-ionic-compound = Composto iónico non válido

--- a/packages/i18n/locales/gn/chrome.ftl
+++ b/packages/i18n/locales/gn/chrome.ftl
@@ -34,21 +34,15 @@
 
 answer-checking = Ohechajeýma…
 answer-submitting = Omondóma…
-
 answer-checking-status = Ohechajey pe mbohovái
 answer-submitting-status = Omondo pe mbohovái
-
 answer-correct = Oĩ porã
 answer-incorrect = Naiporãi
-
 answer-response-saved = Mbohovái ñongatupyre
-
 answer-percent-credit = { $percent }% tepy
 answer-percent-correct = { $percent }% oĩ porã
 answer-percent-short = { $percent } %
-
 max-credit-available = Tepy tuichavéva: { $percent }%
-
 # No select: «ñeha'ã» takes no plural suffix after a numeral, so both English
 # categories render the same words. The count still arrives and is still
 # formatted. `[0]` stays, because "none left" is its own sentence.
@@ -57,55 +51,42 @@ attempts-remaining =
         [0] ndaipóri véima ñeha'ã
        *[other] opyta { $count } ñeha'ã
     }
-
 validation-correct = (Oĩ porã)
 validation-incorrect = (Naiporãi)
 validation-partially-correct = (Oĩ porã mbytemi)
-
 # No select, for the reason given above. The answer is reached by naming it —
 # «{ $answerId } hérava», "the one named X" — rather than by putting the dative
 # on `$answerId`, whose shape nasal harmony would decide from a word this
 # catalog never sees.
 answer-show-responses = Ehecha { $count } mbohovái, { $answerId } hérava pyendápe
 
-
 ## Disclosure panels
 
 feedback-heading = Ñe'ẽ jevy
-
 collapsible-click-to-open = (eikutu ojepe'a haguã)
 collapsible-click-to-close = (eikutu oñembotý haguã)
-
 collapsible-initializing = Oñepyrũma…
-
 footnote-show = Ehecha yvypegua jehaipy
 footnote-hide = Emokañy yvypegua jehaipy
-
 description-more-information = marandu hetave
-
 
 ## Controls
 
 slider-previous = Mboyve
 slider-next = Upéi
-
 keyboard-open = Embojera pe teclado
 keyboard-close = Emboty pe teclado
-
 choice-input-remove-choice = Emboguete { $choice }
-
 matrix-remove-row = Emboguete peteĩ tysỹi
 matrix-add-row = Embojoapy peteĩ tysỹi
 # «tysỹi» is the row; the column is the Spanish loan, which is what the register
 # this catalog is written in uses. Guarani has no inherited term for it.
 matrix-remove-column = Emboguete peteĩ kolúmna
 matrix-add-column = Embojoapy peteĩ kolúmna
-
 subset-add-remove-points = Embojoapy/Emboguete kyta
 subset-toggle-points-intervals = Embojopyrũ kyta ha pa'ũ
 subset-move-points = Emongu'e kyta
 subset-clear = Emboguete
-
 orbital-add-row = Embojoapy peteĩ tysỹi
 orbital-remove-row = Emboguete peteĩ tysỹi
 orbital-add-box = Embojoapy peteĩ karameguã
@@ -113,13 +94,9 @@ orbital-remove-box = Emboguete peteĩ karameguã
 orbital-add-up-arrow = Embojoapy peteĩ hu'y yvate gotyo
 orbital-add-down-arrow = Embojoapy peteĩ hu'y yvy gotyo
 orbital-remove-arrow = Emboguete peteĩ hu'y
-
 orbital-row-label = Tysỹi { $row } réra
-
 pretzel-answer = Mbohovái
-
 summary-statistics-caption = { $column } papapy mombykypyre
-
 
 ## Math input
 
@@ -127,34 +104,25 @@ math-input-preview-region = papapy ñe'ẽ jehecha mboyve
 math-input-preview = Jehecha mboyve
 math-input-invalid-expression = Ñe'ẽ naiporãiva:
 
-
 ## Document status
 
 viewer-initializing = Oñepyrũma…
 
-
 ## Errors
 
 error-heading = Javy
-
 error-found-at =
     { $span ->
         [line] Ojejuhu tysỹi { $startLine } rehe.
        *[lines] Ojejuhu tysỹi { $startLine }–{ $endLine } rehe.
     }
-
 document-contains-errors = Ko kuatia oguereko javy!
-
 diagnostic-heading-error = Javy
 diagnostic-heading-warning = Ñemomarandu
 diagnostic-heading-information = Marandu
 diagnostic-heading-hint = Ñepytyvõ
-
 accessibility-heading-level-1 = WCAG AA jeikeha ñembyai
 accessibility-heading-level-2 = Jeikeha ñemomarandu
-
 something-went-wrong = Oĩ mba'e naiporãiva.
-
 renderer-load-failed = peteĩ mba'erechaha ndoúi. Ikatúpa embojevy pe rogue.
-
 core-start-failed = Kuatia rechaha ndaikatúi oñepyrũ. Ikatúpa embojevy pe rogue.

--- a/packages/i18n/locales/gn/content.ftl
+++ b/packages/i18n/locales/gn/content.ftl
@@ -48,15 +48,12 @@ color =
     .purple = violéta
     .pink = pytãngy
     .brown = marrõ
-
 line-width =
     .thick = anambusu
     .thin = po'i
-
 line-style =
     .dashed = kytĩmby
     .dotted = kytã'i
-
 # Noun phrases, which is what the head of `style-fill` is. Guarani drops the
 # plural suffix here because nothing precedes them to say how many, and a bare
 # noun already reads as a kind rather than as one thing.
@@ -67,7 +64,6 @@ fill-style =
     .backdiagonal = tairũ karẽ jeguerujey
     .dots = kytã'i
     .diamonds = rombo
-
 noun =
     .line = tairũ
     .line-segment = tairũ pehẽ
@@ -87,17 +83,14 @@ noun =
     .diamond = rombo
     .cross = kurusu
     .plus = ñembojoapy ta'ãnga
-
 noun-regular-polygon =
     { $part ->
         [tail] { $numSides } hakuáva
        *[head] heta hakua joja
     }
-
 # One answer for every noun: Guarani has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -111,7 +104,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives after it, which is the opposite of English.
 # The regular polygon's relative clause follows both.
 style-with-noun =
@@ -119,9 +111,7 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = mbojehe'apyre
-
 # «ndive», "with", is a free postposition and follows what it governs, so the
 # pattern precedes it and no suffix lands on `$pattern`. That is the whole reason
 # this catalog needs none of `locales/qu`'s workaround for the same message.
@@ -130,7 +120,6 @@ style-filled =
         [pattern] { $filled } { $color }, { $pattern } ndive
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color }, { $pattern } ndive
@@ -138,7 +127,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail }, { $pattern } ndive
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Guarani has no article, so English's four branches are two distinct strings.
 # All four are written out because they are four positions and a later correction
 # to one need not be a correction to the others.
@@ -149,7 +137,6 @@ style-border-clause =
         [and-article] ha ijyva { $border }
        *[with] ijyva { $border } ndive
     }
-
 # Here the pattern is the head noun — "blue diamonds" — and the colour follows
 # it, so nothing marks the relation at all.
 style-fill =
@@ -157,29 +144,23 @@ style-fill =
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = mbojehe'apy'ỹ
-
 style-text =
     { $parts ->
         [background] { $color }, { $background } tugua ári
        *[plain] { $color }
     }
-
 style-background-none = mavave
-
 
 ## Boolean words
 
 boolean-true = añete
 boolean-false = japu
 
-
 ## Answer buttons
 
 answer-submit-label = Ehecha pe tembiapo
 answer-submit-label-no-correctness = Emondo pe mbohovái
-
 
 ## Sectional blocks
 
@@ -206,7 +187,6 @@ section-name =
     .solution = Ñeñandu
     .task = Tembiaporã
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -216,9 +196,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ñepytyvõ
-
 
 ## Tables and figures
 
@@ -229,7 +207,6 @@ table-name =
         [unnumbered-title] Tabla{ ": " }
        *[unnumbered] Tabla
     }
-
 figure-name =
     { $parts ->
         [numbered] Ta'ãnga { $enumeration }
@@ -238,24 +215,20 @@ figure-name =
        *[unnumbered] Ta'ãnga
     }
 
-
 ## Paginator controls
 
 paginator-previous = Mboyve
 paginator-next = Upéi
 paginator-page = Rogue
-
 # The ablative «-gui» lands on «rogue», which this catalog writes, so the total
 # precedes it: "of N pages, Page 3".
 paginator-page-status = { $numPages } roguégui { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = térã
 piecewise-condition-if = ramo
 piecewise-condition-otherwise = ambue jave
-
 
 ## Chemistry
 ##
@@ -267,6 +240,5 @@ piecewise-condition-otherwise = ambue jave
 ## There is no settled Guarani table for a seed to reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ta'ãnga kimiko naiporãiva
 chemistry-invalid-ionic-compound = Ñembojoaju ioniko naiporãiva

--- a/packages/i18n/locales/gu/chrome.ftl
+++ b/packages/i18n/locales/gu/chrome.ftl
@@ -21,74 +21,55 @@
 
 answer-checking = તપાસી રહ્યાં છીએ...
 answer-submitting = મોકલી રહ્યાં છીએ...
-
 answer-checking-status = જવાબ તપાસાઈ રહ્યો છે
 answer-submitting-status = જવાબ મોકલાઈ રહ્યો છે
-
 answer-correct = સાચું
 answer-incorrect = ખોટું
-
 answer-response-saved = જવાબ સાચવ્યો
-
 answer-percent-credit = { $percent }% ગુણ
 answer-percent-correct = { $percent }% સાચું
 answer-percent-short = { $percent }%
-
 max-credit-available = ઉપલબ્ધ મહત્તમ ગુણ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] એકેય પ્રયાસ બાકી નથી
         [one] { $count } પ્રયાસ બાકી
        *[other] { $count } પ્રયાસો બાકી
     }
-
 validation-correct = (સાચું)
 validation-incorrect = (ખોટું)
 validation-partially-correct = (અંશતઃ સાચું)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } નો { $count } જવાબ બતાવો
        *[other] { $answerId } ના { $count } જવાબો બતાવો
     }
 
-
 ## Disclosure panels
 
 feedback-heading = પ્રતિભાવ
-
 collapsible-click-to-open = (ખોલવા ક્લિક કરો)
 collapsible-click-to-close = (બંધ કરવા ક્લિક કરો)
-
 collapsible-initializing = શરૂ થઈ રહ્યું છે...
-
 footnote-show = પાદનોંધ બતાવો
 footnote-hide = પાદનોંધ છુપાવો
-
 description-more-information = વધુ માહિતી
-
 
 ## Controls
 
 slider-previous = પાછલું
 slider-next = આગલું
-
 keyboard-open = કીબોર્ડ ખોલો
 keyboard-close = કીબોર્ડ બંધ કરો
-
 choice-input-remove-choice = { $choice } દૂર કરો
-
 matrix-remove-row = હરોળ દૂર કરો
 matrix-add-row = હરોળ ઉમેરો
 matrix-remove-column = સ્તંભ દૂર કરો
 matrix-add-column = સ્તંભ ઉમેરો
-
 subset-add-remove-points = બિંદુઓ ઉમેરો/દૂર કરો
 subset-toggle-points-intervals = બિંદુઓ અને અંતરાલો વચ્ચે બદલો
 subset-move-points = બિંદુઓ ખસેડો
 subset-clear = ભૂંસો
-
 # A `box` here is one orbital, drawn as a square: ખાનું.
 orbital-add-row = હરોળ ઉમેરો
 orbital-remove-row = હરોળ દૂર કરો
@@ -97,13 +78,9 @@ orbital-remove-box = ખાનું દૂર કરો
 orbital-add-up-arrow = ઉપરનું તીર ઉમેરો
 orbital-add-down-arrow = નીચેનું તીર ઉમેરો
 orbital-remove-arrow = તીર દૂર કરો
-
 orbital-row-label = હરોળ { $row } નું લેબલ
-
 pretzel-answer = જવાબ
-
 summary-statistics-caption = { $column } નાં સારાંશ આંકડા
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = ગાણિતિક પદાવલિની ઝ�
 math-input-preview = ઝલક
 math-input-invalid-expression = અમાન્ય પદાવલિ:
 
-
 ## Document status
 
 viewer-initializing = શરૂ થઈ રહ્યું છે...
 
-
 ## Errors
 
 error-heading = ભૂલ
-
 error-found-at =
     { $span ->
         [line] લીટી { $startLine } પર મળી.
        *[lines] લીટી { $startLine }–{ $endLine } પર મળી.
     }
-
 document-contains-errors = આ દસ્તાવેજમાં ભૂલો છે!
-
 diagnostic-heading-error = ભૂલ
 diagnostic-heading-warning = ચેતવણી
 diagnostic-heading-information = માહિતી
 diagnostic-heading-hint = સંકેત
-
 accessibility-heading-level-1 = WCAG AA સુગમતા ઉલ્લંઘન
 accessibility-heading-level-2 = સુગમતા ચેતવણી
-
 something-went-wrong = કંઈક ખોટું થયું.
-
 renderer-load-failed = એક રેન્ડરર લોડ થઈ શક્યું નહીં. કૃપા કરી પાનું ફરી લોડ કરો.
-
 core-start-failed = દસ્તાવેજ દર્શક શરૂ થઈ શક્યું નહીં. કૃપા કરી પાનું ફરી લોડ કરો.

--- a/packages/i18n/locales/gu/content.ftl
+++ b/packages/i18n/locales/gu/content.ftl
@@ -62,7 +62,6 @@ color =
     .purple = જાંબલી
     .pink = ગુલાબી
     .brown = કથ્થઈ
-
 line-width =
     .thick =
         { $gender ->
@@ -76,7 +75,6 @@ line-width =
             [n] પાતળું
            *[m] પાતળો
         }
-
 # તૂટક ends in a consonant and never changes; ટપકાંવાળો does.
 line-style =
     .dashed = તૂટક
@@ -86,7 +84,6 @@ line-style =
             [n] ટપકાંવાળું
            *[m] ટપકાંવાળો
         }
-
 # Noun phrases: they stand in front of the «સાથે» the composition messages
 # supply, or in front of the «વાળી» in `style-fill`, and agree with nothing
 # themselves.
@@ -97,7 +94,6 @@ fill-style =
     .backdiagonal = સામી ત્રાંસી લીટીઓ
     .dots = ટપકાં
     .diamonds = હીરા
-
 noun =
     .line = રેખા
     .line-segment = રેખાખંડ
@@ -117,7 +113,6 @@ noun =
     .diamond = હીરો
     .cross = ચોકડી
     .plus = સરવાળાનું ચિહ્ન
-
 # The side count precedes the noun, as every modifier in Gujarati does, so it
 # folds into the head and there is no tail.
 noun-regular-polygon =
@@ -125,7 +120,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } બાજુવાળો નિયમિત બહુકોણ
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (બહુકોણ, m) or the
 # head of a phrase: `border` (કિનારી, f), `fill` (ભરણી, f), `text` (લખાણ, n),
 # `background` (પૃષ્ઠભૂમિ, f). English leaves all four unnamed; the composition
@@ -148,7 +142,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -161,13 +154,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Said only of the shape itself, so it agrees with the noun described.
 style-filled-word =
     { $gender ->
@@ -175,13 +166,11 @@ style-filled-word =
         [n] ભરેલું
        *[m] ભરેલો
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } સાથે
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } સાથે
@@ -189,7 +178,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } સાથે
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «કિનારી» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Gujarati has no article, so the two `-article`
 # branches read like the ones without.
@@ -200,7 +188,6 @@ style-border-clause =
         [and-article] અને { $border } કિનારી સાથે
        *[with] { $border } કિનારી સાથે
     }
-
 # The colour arrives agreeing with `fill`, which `noun-gender` answers feminine
 # — but the pattern words are plural nouns of their own gender (હીરા m, ટપકાં
 # n), so putting the colour straight in front of one would disagree with it.
@@ -211,12 +198,10 @@ style-fill =
         [pattern] { $pattern } વાળી { $color } ભરણી
        *[plain] { $color } ભરણી
     }
-
 # The other answer the same variable gives, and it takes no `$gender`, so it
 # names the noun rather than inflecting an adjective for a gender it was not
 # told — as «बिना भराव» does in `hi`.
 style-unfilled = ભરણી વગર
-
 # «પૃષ્ઠભૂમિ» takes the postposition «પર», so the background leads and the text
 # colour follows it.
 style-text =
@@ -224,21 +209,17 @@ style-text =
         [background] { $background } પૃષ્ઠભૂમિ પર { $color }
        *[plain] { $color }
     }
-
 style-background-none = કંઈ નહીં
-
 
 ## Boolean words
 
 boolean-true = સાચું
 boolean-false = ખોટું
 
-
 ## Answer buttons
 
 answer-submit-label = તપાસો
 answer-submit-label-no-correctness = જવાબ મોકલો
-
 
 ## Sectional blocks
 
@@ -263,7 +244,6 @@ section-name =
     .solution = ઉકેલ
     .task = કાર્ય
     .theorem = પ્રમેય
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -273,9 +253,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = સંકેત
-
 
 ## Tables and figures
 
@@ -286,7 +264,6 @@ table-name =
         [unnumbered-title] કોષ્ટક{ ": " }
        *[unnumbered] કોષ્ટક
     }
-
 figure-name =
     { $parts ->
         [numbered] આકૃતિ { $enumeration }
@@ -295,23 +272,19 @@ figure-name =
        *[unnumbered] આકૃતિ
     }
 
-
 ## Paginator controls
 
 paginator-previous = પાછલું
 paginator-next = આગલું
 paginator-page = પાનું
-
 # The total leads, marked with «માંથી», which is how Gujarati says "3 of 5".
 paginator-page-status = { $numPages } માંથી { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = અથવા
 piecewise-condition-if = જો
 piecewise-condition-otherwise = અન્યથા
-
 
 ## Chemistry
 
@@ -438,7 +411,6 @@ element-name =
     .lv = લિવરમોરિયમ
     .ts = ટેનેસિન
     .og = ઓગેનેસન
-
 element-anion-name =
     .h = હાઇડ્રાઇડ
     .c = કાર્બાઇડ
@@ -452,8 +424,6 @@ element-anion-name =
     .i = આયોડાઇડ
     .at = એસ્ટેટાઇડ
     .ts = ટેનેસાઇડ
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = અમાન્ય રાસાયણિક સંજ્ઞા
 chemistry-invalid-ionic-compound = અમાન્ય આયનીય સંયોજન

--- a/packages/i18n/locales/ha/chrome.ftl
+++ b/packages/i18n/locales/ha/chrome.ftl
@@ -19,69 +19,50 @@
 
 answer-checking = Ana dubawa...
 answer-submitting = Ana aikawa...
-
 answer-checking-status = Ana duba amsa
 answer-submitting-status = Ana aika amsa
-
 answer-correct = Daidai
 answer-incorrect = Ba daidai ba
-
 answer-response-saved = An Ajiye Amsa
-
 answer-percent-credit = Maki { $percent }%
 answer-percent-correct = { $percent }% Daidai
 answer-percent-short = { $percent }%
-
 max-credit-available = Mafi girman maki da ake iya samu: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] babu sauran yunƙuri
        *[other] sauran yunƙuri { $count }
     }
-
 validation-correct = (Daidai)
 validation-incorrect = (Ba daidai ba)
 validation-partially-correct = (Daidai a wani ɓangare)
-
 answer-show-responses = Nuna amsa { $count } ga { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Ra'ayi
-
 collapsible-click-to-open = (danna don buɗewa)
 collapsible-click-to-close = (danna don rufewa)
-
 collapsible-initializing = Ana farawa...
-
 footnote-show = Nuna bayanin ƙasa
 footnote-hide = Ɓoye bayanin ƙasa
-
 description-more-information = ƙarin bayani
-
 
 ## Controls
 
 slider-previous = Baya
 slider-next = Gaba
-
 keyboard-open = Buɗe Madannai
 keyboard-close = Rufe Madannai
-
 choice-input-remove-choice = Cire { $choice }
-
 matrix-remove-row = Cire jeri
 matrix-add-row = Ƙara jeri
 matrix-remove-column = Cire ginshiƙi
 matrix-add-column = Ƙara ginshiƙi
-
 subset-add-remove-points = Ƙara/Cire digo
 subset-toggle-points-intervals = Sauya tsakanin digo da tazara
 subset-move-points = Motsa Digo
 subset-clear = Share
-
 # A `box` here is one orbital, drawn as a square: akwati.
 orbital-add-row = Ƙara Jeri
 orbital-remove-row = Cire Jeri
@@ -90,13 +71,9 @@ orbital-remove-box = Cire Akwati
 orbital-add-up-arrow = Ƙara Kibiya Sama
 orbital-add-down-arrow = Ƙara Kibiya Ƙasa
 orbital-remove-arrow = Cire Kibiya
-
 orbital-row-label = Lakabin jeri { $row }
-
 pretzel-answer = Amsa
-
 summary-statistics-caption = Taƙaitaccen ƙididdigar { $column }
-
 
 ## Math input
 
@@ -104,34 +81,25 @@ math-input-preview-region = duban bayanin lissafi
 math-input-preview = Dubawa
 math-input-invalid-expression = Bayani mara inganci:
 
-
 ## Document status
 
 viewer-initializing = Ana farawa...
 
-
 ## Errors
 
 error-heading = Kuskure
-
 error-found-at =
     { $span ->
         [line] An same shi a layi { $startLine }.
        *[lines] An same shi a layuka { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Wannan takarda tana da kurakurai!
-
 diagnostic-heading-error = Kuskure
 diagnostic-heading-warning = Gargaɗi
 diagnostic-heading-information = Bayani
 diagnostic-heading-hint = Alama
-
 accessibility-heading-level-1 = Take Haƙƙin Samun Damar WCAG AA
 accessibility-heading-level-2 = Gargaɗin samun dama
-
 something-went-wrong = Wani abu bai tafi daidai ba.
-
 renderer-load-failed = wani mai nunawa bai ɗauku ba. Da fatan za a sake ɗora shafin.
-
 core-start-failed = Ba a iya fara mai nuna takardar ba. Da fatan za a sake ɗora shafin.

--- a/packages/i18n/locales/ha/content.ftl
+++ b/packages/i18n/locales/ha/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = mai launin shunayya
     .pink = mai launin ruwan hoda
     .brown = mai launin ruwan ƙasa
-
 line-width =
     .thick = mai kauri
     .thin = mai sirara
-
 line-style =
     .dashed = mai gutsattsari
     .dotted = mai ɗigogi
-
 # Noun phrases: they follow «da» and modify nothing.
 fill-style =
     .horizontal = layukan kwance
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = layukan karkata ta wancan gefe
     .dots = ɗigogi
     .diamonds = lu'ulu'ai
-
 noun =
     .line = layi
     .line-segment = gutsuren layi
@@ -77,7 +73,6 @@ noun =
     .diamond = lu'ulu'u
     .cross = giciye
     .plus = alamar tarawa
-
 # The side count goes in the tail, behind the describing words, because «mai
 # gefuna 5» is one more «mai …» phrase and Hausa strings them after the noun
 # rather than folding one into it.
@@ -86,7 +81,6 @@ noun-regular-polygon =
         [tail] mai gefuna { $numSides }
        *[head] siffa daidaitacciya
     }
-
 # Real genders, and nothing here reads them. See the header.
 noun-gender =
     { $noun ->
@@ -101,7 +95,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -114,7 +107,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its «mai …» phrases follow, with the noun's own
 # complement closing the phrase: «siffa daidaitacciya mai launin ja mai gefuna
 # 5».
@@ -123,15 +115,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = cike
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } da { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } da { $pattern }
@@ -139,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } da { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Hausa has no article, and it joins a complement with the invariable «da», so
 # all four branches read alike.
 style-border-clause =
@@ -149,35 +137,28 @@ style-border-clause =
         [and-article] da iyaka { $border }
        *[with] da iyaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ba a cika ba
-
 style-text =
     { $parts ->
         [background] { $color } a bango { $background }
        *[plain] { $color }
     }
-
 style-background-none = babu
-
 
 ## Boolean words
 
 boolean-true = gaskiya
 boolean-false = ƙarya
 
-
 ## Answer buttons
 
 answer-submit-label = Duba Aiki
 answer-submit-label-no-correctness = Aika Amsa
-
 
 ## Sectional blocks
 
@@ -202,7 +183,6 @@ section-name =
     .solution = Mafita
     .task = Aiki
     .theorem = Ka'ida
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -212,9 +192,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Alama
-
 
 ## Tables and figures
 
@@ -225,7 +203,6 @@ table-name =
         [unnumbered-title] Tebur{ ": " }
        *[unnumbered] Tebur
     }
-
 figure-name =
     { $parts ->
         [numbered] Hoto { $enumeration }
@@ -234,15 +211,12 @@ figure-name =
        *[unnumbered] Hoto
     }
 
-
 ## Paginator controls
 
 paginator-previous = Baya
 paginator-next = Gaba
 paginator-page = Shafi
-
 paginator-page-status = { $pageLabel } { $currentPage } daga cikin { $numPages }
-
 
 ## Piecewise functions
 
@@ -250,8 +224,8 @@ piecewise-condition-or = ko
 piecewise-condition-if = idan
 piecewise-condition-otherwise = in ba haka ba
 
-
 ## Chemistry
+
 
 # Hausa is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. Nigerian
@@ -261,6 +235,5 @@ piecewise-condition-otherwise = in ba haka ba
 # rather than a translation.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Alamar Sinadari Mara Inganci
 chemistry-invalid-ionic-compound = Haɗin Ayon Mara Inganci

--- a/packages/i18n/locales/haw/chrome.ftl
+++ b/packages/i18n/locales/haw/chrome.ftl
@@ -24,71 +24,52 @@
 
 answer-checking = Ke nānā nei...
 answer-submitting = Ke hoʻouna nei...
-
 answer-checking-status = Ke nānā nei i ka pane
 answer-submitting-status = Ke hoʻouna nei i ka pane
-
 answer-correct = Pololei
 answer-incorrect = Hewa
-
 answer-response-saved = Ua mālama ʻia ka pane
-
 answer-percent-credit = { $percent }% o ka helu
 answer-percent-correct = { $percent }% pololei
 answer-percent-short = { $percent }%
-
 max-credit-available = Ka helu kiʻekiʻe loa e loaʻa ai: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ʻaʻohe hoʻāʻo i koe
        *[other] koe { $count } hoʻāʻo
     }
-
 validation-correct = (Pololei)
 validation-incorrect = (Hewa)
 validation-partially-correct = (Pololei ma kekahi hapa)
-
 answer-show-responses = E hōʻike i { $count } pane iā { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Manaʻo hoʻi
-
 collapsible-click-to-open = (kaomi e wehe)
 collapsible-click-to-close = (kaomi e pani)
-
 collapsible-initializing = Ke hoʻomaka nei...
-
 footnote-show = E hōʻike i ka memo wāwae
 footnote-hide = E hūnā i ka memo wāwae
-
 # «ʻike», knowledge, rather than «ʻikepili», which is this catalog's word for
 # data and would read as "more data" on an affordance that reveals prose.
 description-more-information = ʻike hou aku
-
 
 ## Controls
 
 slider-previous = Mua
 slider-next = Aʻe
-
 keyboard-open = E wehe i ka papapihi
 keyboard-close = E pani i ka papapihi
-
 choice-input-remove-choice = E wehe iā { $choice }
-
 matrix-remove-row = E wehe i ka lālani
 matrix-add-row = E hoʻohui i lālani
 matrix-remove-column = E wehe i ke kolamu
 matrix-add-column = E hoʻohui i kolamu
-
 subset-add-remove-points = E hoʻohui/wehe i nā kiko
 subset-toggle-points-intervals = E hoʻololi i nā kiko a me nā kaʻawale
 subset-move-points = E hoʻoneʻe i nā kiko
 subset-clear = E holoi
-
 orbital-add-row = E hoʻohui i lālani
 orbital-remove-row = E wehe i ka lālani
 orbital-add-box = E hoʻohui i pahu
@@ -96,13 +77,9 @@ orbital-remove-box = E wehe i ka pahu
 orbital-add-up-arrow = E hoʻohui i pua i luna
 orbital-add-down-arrow = E hoʻohui i pua i lalo
 orbital-remove-arrow = E wehe i ka pua
-
 orbital-row-label = Inoa no ka lālani { $row }
-
 pretzel-answer = Pane
-
 summary-statistics-caption = Helu hōʻuluʻulu o { $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = nānā mua o ka hōʻike makemakika
 math-input-preview = Nānā mua
 math-input-invalid-expression = Hōʻike kūpono ʻole:
 
-
 ## Document status
 
 viewer-initializing = Ke hoʻomaka nei...
 
-
 ## Errors
 
 error-heading = Hewa
-
 error-found-at =
     { $span ->
         [line] Ua loaʻa ma ka lālani { $startLine }.
        *[lines] Ua loaʻa ma nā lālani { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Aia nā hewa i loko o kēia palapala!
-
 diagnostic-heading-error = Hewa
 diagnostic-heading-warning = Ao
 diagnostic-heading-information = ʻIke
 diagnostic-heading-hint = Kuhikuhi
-
 accessibility-heading-level-1 = Kūʻē i ka hiki ke komo WCAG AA
 accessibility-heading-level-2 = Ao no ka hiki ke komo
-
 something-went-wrong = Ua hewa kekahi mea.
-
 renderer-load-failed = ʻaʻole i hoʻouka ʻia kekahi mea hōʻike. E ʻoluʻolu, e hoʻouka hou i ka ʻaoʻao.
-
 core-start-failed = ʻAʻole hiki ke hoʻomaka i ka mea nānā palapala. E ʻoluʻolu, e hoʻouka hou i ka ʻaoʻao.

--- a/packages/i18n/locales/haw/content.ftl
+++ b/packages/i18n/locales/haw/content.ftl
@@ -41,15 +41,12 @@ color =
     .purple = poni
     .pink = ʻākala
     .brown = palaunu
-
 line-width =
     .thick = mānoanoa
     .thin = lahilahi
-
 line-style =
     .dashed = mokumoku
     .dotted = kikokiko
-
 # Noun phrases: they follow «me» and modify nothing.
 fill-style =
     .horizontal = laina moe
@@ -58,7 +55,6 @@ fill-style =
     .backdiagonal = laina hio huli
     .dots = kiko
     .diamonds = kaimana
-
 noun =
     .line = laina
     .line-segment = ʻāpana laina
@@ -78,7 +74,6 @@ noun =
     .diamond = kaimana
     .cross = keʻa
     .plus = hōʻailona hoʻohui
-
 # The side count follows the noun and precedes its adjectives, so it folds into
 # the head and there is no tail: «huinalehulehu like { $numSides } ʻaoʻao».
 noun-regular-polygon =
@@ -86,11 +81,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] huinalehulehu like { $numSides } ʻaoʻao
     }
-
 # Hawaiian has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,22 +97,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «laina mānoanoa mokumoku ʻulaʻula».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = piha
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } me { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } me { $pattern }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } me { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] me ka palena { $border }
@@ -135,36 +123,29 @@ style-border-clause =
         [and-article] a me ka palena { $border }
        *[with] me ka palena { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = piha ʻole
-
 style-text =
     { $parts ->
         [background] { $color } ma luna o ke kua { $background }
        *[plain] { $color }
     }
-
 style-background-none = ʻaʻohe
-
 
 ## Boolean words
 
 boolean-true = ʻoiaʻiʻo
 boolean-false = wahaheʻe
 
-
 ## Answer buttons
 
 answer-submit-label = E nānā i ka hana
 answer-submit-label-no-correctness = E hoʻouna i ka pane
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = Hopena
     .task = Hana
     .theorem = Kumumanaʻo
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kuhikuhi
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] Papa{ ": " }
        *[unnumbered] Papa
     }
-
 figure-name =
     { $parts ->
         [numbered] Kiʻi { $enumeration }
@@ -221,22 +198,18 @@ figure-name =
        *[unnumbered] Kiʻi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Mua
 paginator-next = Aʻe
 paginator-page = ʻAoʻao
-
 paginator-page-status = { $pageLabel } { $currentPage } o { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = a i ʻole
 piecewise-condition-if = inā
 piecewise-condition-otherwise = a i ʻole kēlā
-
 
 ## Chemistry
 ##
@@ -250,6 +223,5 @@ piecewise-condition-otherwise = a i ʻole kēlā
 ## a speaker should add here.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Hōʻailona kemikala kūpono ʻole
 chemistry-invalid-ionic-compound = Huikau ionika kūpono ʻole

--- a/packages/i18n/locales/he/chrome.ftl
+++ b/packages/i18n/locales/he/chrome.ftl
@@ -21,21 +21,15 @@
 
 answer-checking = בודק...
 answer-submitting = שולח...
-
 answer-checking-status = בודק את התשובה
 answer-submitting-status = שולח את התשובה
-
 answer-correct = נכון
 answer-incorrect = לא נכון
-
 answer-response-saved = התשובה נשמרה
-
 answer-percent-credit = { $percent }% מהניקוד
 answer-percent-correct = { $percent }% נכון
 answer-percent-short = { $percent }%
-
 max-credit-available = הניקוד המרבי האפשרי: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] לא נותרו ניסיונות
@@ -43,13 +37,11 @@ attempts-remaining =
         [two] נותרו שני ניסיונות
        *[other] נותרו { $count } ניסיונות
     }
-
 # Named rather than adjectival: read aloud after a field's own name, a bare
 # «(נכונה)» would leave a listener to guess what it agreed with.
 validation-correct = (תשובה נכונה)
 validation-incorrect = (תשובה לא נכונה)
 validation-partially-correct = (תשובה נכונה חלקית)
-
 answer-show-responses =
     { $count ->
         [one] הצגת תשובה אחת שנשלחה אל { $answerId }
@@ -57,41 +49,31 @@ answer-show-responses =
        *[other] הצגת { $count } תשובות שנשלחו אל { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = משוב
-
 collapsible-click-to-open = (לחיצה לפתיחה)
 collapsible-click-to-close = (לחיצה לסגירה)
 collapsible-initializing = מאתחל...
-
 footnote-show = הצגת הערת השוליים
 footnote-hide = הסתרת הערת השוליים
-
 description-more-information = מידע נוסף
-
 
 ## Controls
 
 slider-previous = הקודם
 slider-next = הבא
-
 keyboard-open = פתיחת המקלדת
 keyboard-close = סגירת המקלדת
-
 choice-input-remove-choice = הסרת { $choice }
-
 matrix-remove-row = הסרת שורה
 matrix-add-row = הוספת שורה
 matrix-remove-column = הסרת עמודה
 matrix-add-column = הוספת עמודה
-
 subset-add-remove-points = הוספת/הסרת נקודות
 subset-toggle-points-intervals = מעבר בין נקודות לקטעים
 subset-move-points = הזזת נקודות
 subset-clear = ניקוי
-
 orbital-add-row = הוספת שורה
 orbital-remove-row = הסרת שורה
 orbital-add-box = הוספת תא
@@ -99,13 +81,9 @@ orbital-remove-box = הסרת תא
 orbital-add-up-arrow = הוספת חץ למעלה
 orbital-add-down-arrow = הוספת חץ למטה
 orbital-remove-arrow = הסרת חץ
-
 orbital-row-label = תווית לשורה { $row }
-
 pretzel-answer = תשובה
-
 summary-statistics-caption = סטטיסטיקה מסכמת של העמודה { $column }
-
 
 ## Math input
 
@@ -113,37 +91,28 @@ math-input-preview-region = תצוגה מקדימה של הביטוי המתמט
 math-input-preview = תצוגה מקדימה
 math-input-invalid-expression = ביטוי לא תקין:
 
-
 ## Document status
 
 viewer-initializing = מאתחל...
 
-
 ## Errors
 
 error-heading = שגיאה
-
 error-found-at =
     { $span ->
         [line] נמצאה בשורה { $startLine }.
        *[lines] נמצאה בשורות { $startLine } עד { $endLine }.
     }
-
 document-contains-errors = במסמך הזה יש שגיאות!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = שגיאה
 diagnostic-heading-warning = אזהרה
 diagnostic-heading-information = מידע
 diagnostic-heading-hint = רמז
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = הפרת נגישות לפי WCAG AA
 accessibility-heading-level-2 = התראת נגישות
-
 something-went-wrong = משהו השתבש.
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = טעינת אחד הרכיבים נכשלה. יש לטעון מחדש את העמוד.
-
 core-start-failed = הפעלת מציג המסמך נכשלה. יש לטעון מחדש את העמוד.

--- a/packages/i18n/locales/he/content.ftl
+++ b/packages/i18n/locales/he/content.ftl
@@ -79,7 +79,6 @@ color =
             [f] חומה
            *[m] חום
         }
-
 # «עבה» is spelled the same in both genders once the vowels are left out, which
 # they are, so it takes no branch.
 line-width =
@@ -89,7 +88,6 @@ line-width =
             [f] דקה
            *[m] דק
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -101,7 +99,6 @@ line-style =
             [f] מנוקדת
            *[m] מנוקד
         }
-
 # Fill patterns are plural nouns rather than adjectives and take no gender
 # branch; `style-fill` names their colour with «בצבע» instead of agreeing an
 # adjective with them.
@@ -112,7 +109,6 @@ fill-style =
     .backdiagonal = קווים אלכסוניים הפוכים
     .dots = נקודות
     .diamonds = מעוינים
-
 # «איקס» names the marker by the sign it is drawn as; «צלב» is the word for a
 # cross as an object and carries a sense a plotted point does not.
 noun =
@@ -134,7 +130,6 @@ noun =
     .diamond = מעוין
     .cross = איקס
     .plus = פלוס
-
 # The side count is a complement closing the phrase, after the adjectives, so
 # that they stay beside the noun they agree with: «מצולע משוכלל אדום עבה בעל 5
 # צלעות».
@@ -143,7 +138,6 @@ noun-regular-polygon =
         [tail] בעל { $numSides } צלעות
        *[head] מצולע משוכלל
     }
-
 # Besides the nouns above, `$noun` may be «regular-polygon» (מצולע משוכלל, m) or
 # the head of a phrase the description never names: «border» (מסגרת, f), «fill»
 # (מילוי, m), «text» (טקסט, m), «background» (רקע, m). Only the first of those
@@ -161,7 +155,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # The mirror of the English order, so the adjective English puts nearest the
@@ -177,25 +170,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] מלאה
        *[m] מלא
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } עם { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } עם { $pattern }
@@ -203,7 +192,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $color } { $filled } { $nounTail } עם { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # Hebrew has no indefinite article, so the two `-article` branches say what
 # their plain counterparts do. «מסגרת» is feminine, so the border's adjectives
 # agree with it rather than with the shape around it.
@@ -214,7 +202,6 @@ style-border-clause =
         [and-article] ומסגרת { $border }
        *[with] עם מסגרת { $border }
     }
-
 # «בצבע» — "in the colour of" — because the pattern is a plural noun and the
 # colour arrives agreed with «מילוי», which is masculine singular.
 style-fill =
@@ -222,31 +209,25 @@ style-fill =
         [pattern] { $pattern } בצבע { $color }
        *[plain] { $color }
     }
-
 # Said of no particular shape — `describeFill` passes no gender — so it is put
 # as a phrase that does not inflect at all.
 style-unfilled = ללא מילוי
-
 style-text =
     { $parts ->
         [background] { $color } על רקע { $background }
        *[plain] { $color }
     }
-
 style-background-none = ללא
-
 
 ## Boolean words
 
 boolean-true = אמת
 boolean-false = שקר
 
-
 ## Answer buttons
 
 answer-submit-label = בדיקת התשובה
 answer-submit-label-no-correctness = שליחת התשובה
-
 
 ## Sectional blocks
 
@@ -271,7 +252,6 @@ section-name =
     .solution = פתרון
     .task = משימה
     .theorem = משפט
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -281,9 +261,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = רמז
-
 
 ## Tables and figures
 
@@ -294,7 +272,6 @@ table-name =
         [unnumbered-title] טבלה{ ": " }
        *[unnumbered] טבלה
     }
-
 figure-name =
     { $parts ->
         [numbered] איור { $enumeration }
@@ -303,24 +280,18 @@ figure-name =
        *[unnumbered] איור
     }
 
-
 ## Paginator controls
 
 paginator-previous = הקודם
 paginator-next = הבא
 paginator-page = עמוד
-
 paginator-page-status = { $pageLabel } { $currentPage } מתוך { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = או
-
 piecewise-condition-if = אם
-
 piecewise-condition-otherwise = אחרת
-
 
 ## Chemistry
 
@@ -443,7 +414,6 @@ element-name =
     .lv = ליברמוריום
     .ts = טנסין
     .og = אוגנסון
-
 element-anion-name =
     .h = הידריד
     .c = קרביד
@@ -457,8 +427,6 @@ element-anion-name =
     .i = יודיד
     .at = אסטטיד
     .ts = טנסיד
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = סמל כימי לא תקין
 chemistry-invalid-ionic-compound = תרכובת יונית לא תקינה

--- a/packages/i18n/locales/hi/chrome.ftl
+++ b/packages/i18n/locales/hi/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = जाँचा जा रहा है...
 answer-submitting = भेजा जा रहा है...
-
 answer-checking-status = उत्तर जाँचा जा रहा है
 answer-submitting-status = उत्तर भेजा जा रहा है
-
 answer-correct = सही
 answer-incorrect = ग़लत
-
 answer-response-saved = उत्तर सहेजा गया
-
 answer-percent-credit = { $percent }% अंक
 answer-percent-correct = { $percent }% सही
 answer-percent-short = { $percent }%
-
 max-credit-available = अधिकतम संभव अंक: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] कोई प्रयास शेष नहीं
         [one] { $count } प्रयास शेष
        *[other] { $count } प्रयास शेष
     }
-
 validation-correct = (सही)
 validation-incorrect = (ग़लत)
 validation-partially-correct = (आंशिक रूप से सही)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } का { $count } उत्तर दिखाएँ
        *[other] { $answerId } के { $count } उत्तर दिखाएँ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिक्रिया
-
 collapsible-click-to-open = (खोलने के लिए क्लिक करें)
 collapsible-click-to-close = (बंद करने के लिए क्लिक करें)
-
 collapsible-initializing = आरंभ किया जा रहा है...
-
 footnote-show = पादटिप्पणी दिखाएँ
 footnote-hide = पादटिप्पणी छिपाएँ
-
 description-more-information = अधिक जानकारी
-
 
 ## Controls
 
 slider-previous = पिछला
 slider-next = अगला
-
 keyboard-open = कीबोर्ड खोलें
 keyboard-close = कीबोर्ड बंद करें
-
 choice-input-remove-choice = { $choice } हटाएँ
-
 matrix-remove-row = पंक्ति हटाएँ
 matrix-add-row = पंक्ति जोड़ें
 matrix-remove-column = स्तंभ हटाएँ
 matrix-add-column = स्तंभ जोड़ें
-
 subset-add-remove-points = बिंदु जोड़ें/हटाएँ
 subset-toggle-points-intervals = बिंदुओं और अंतरालों के बीच बदलें
 subset-move-points = बिंदु खिसकाएँ
 subset-clear = साफ़ करें
-
 # A `box` here is one orbital, drawn as a square: खाँचा. Not खाना, whose first
 # reading is "food".
 orbital-add-row = पंक्ति जोड़ें
@@ -97,13 +78,9 @@ orbital-remove-box = खाँचा हटाएँ
 orbital-add-up-arrow = ऊपर का तीर जोड़ें
 orbital-add-down-arrow = नीचे का तीर जोड़ें
 orbital-remove-arrow = तीर हटाएँ
-
 orbital-row-label = पंक्ति { $row } का लेबल
-
 pretzel-answer = उत्तर
-
 summary-statistics-caption = { $column } के वर्णनात्मक सांख्यिकी
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = गणितीय व्यंजक का पू�
 math-input-preview = पूर्वावलोकन
 math-input-invalid-expression = अमान्य व्यंजक:
 
-
 ## Document status
 
 viewer-initializing = आरंभ किया जा रहा है...
 
-
 ## Errors
 
 error-heading = त्रुटि
-
 error-found-at =
     { $span ->
         [line] पंक्ति { $startLine } में मिली।
        *[lines] पंक्तियों { $startLine }–{ $endLine } में मिली।
     }
-
 document-contains-errors = इस दस्तावेज़ में त्रुटियाँ हैं!
-
 diagnostic-heading-error = त्रुटि
 diagnostic-heading-warning = चेतावनी
 diagnostic-heading-information = जानकारी
 diagnostic-heading-hint = संकेत
-
 accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
 accessibility-heading-level-2 = सुगम्यता चेतावनी
-
 something-went-wrong = कुछ ग़लत हो गया।
-
 renderer-load-failed = एक रेंडरर लोड नहीं हो सका। कृपया पृष्ठ फिर से लोड करें।
-
 core-start-failed = दस्तावेज़ दर्शक शुरू नहीं किया जा सका। कृपया पृष्ठ फिर से लोड करें।

--- a/packages/i18n/locales/hi/content.ftl
+++ b/packages/i18n/locales/hi/content.ftl
@@ -91,7 +91,6 @@ color =
                    *[m] भूरा
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -115,12 +114,10 @@ line-width =
                    *[m] पतला
                 }
         }
-
 # Both are unmarked, so neither inflects.
 line-style =
     .dashed = खंडित
     .dotted = बिंदुदार
-
 # Noun phrases in the oblique plural, because their other use is in front of
 # «वाला» — a postposition that governs the oblique and inflects like a marked
 # adjective itself. They agree with nothing, so `style-fill` has to give them
@@ -133,7 +130,6 @@ fill-style =
     .backdiagonal = विपरीत विकर्ण रेखाओं
     .dots = बिंदुओं
     .diamonds = समचतुर्भुजों
-
 noun =
     .line = रेखा
     .line-segment = रेखाखंड
@@ -153,7 +149,6 @@ noun =
     .diamond = समचतुर्भुज
     .cross = क्रॉस
     .plus = धन चिह्न
-
 # Hindi keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -161,7 +156,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } भुजाओं वाला सम बहुभुज
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (बहुभुज, m) or the
 # head of a phrase the description never names: `border` (किनारा, m), `fill`
 # (भराव, m), `text` (पाठ, m), `background` (पृष्ठभूमि, f).
@@ -173,7 +167,6 @@ noun-gender =
         [background] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -187,14 +180,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every
 # description and takes no `$role` branch.
 style-filled-word =
@@ -202,7 +193,6 @@ style-filled-word =
         [f] भरी हुई
        *[m] भरा हुआ
     }
-
 # «वाला» is a marked adjective itself, and it agrees with the shape rather than
 # with the pattern in front of it: «बिंदुओं वाली रेखा», «बिंदुओं वाला वर्ग». It
 # is always said of the shape, so the direct form is the only one needed here —
@@ -210,27 +200,28 @@ style-filled-word =
 # there is «भराव», which is always masculine.
 style-filled =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] वाली
-           *[m] वाला
-        } { $color } { $filled }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] वाली
+               *[m] वाला
+            } { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] वाली
-           *[m] वाला
-        } { $color } { $filled } { $noun }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] वाली
+               *[m] वाला
+            } { $color } { $filled } { $noun }
         [plain-tail] { $color } { $filled } { $noun } { $nounTail }
-        [pattern-tail] { $pattern } { $gender ->
-            [f] वाली
-           *[m] वाला
-        } { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail]
+            { $pattern } { $gender ->
+                [f] वाली
+               *[m] वाला
+            } { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «के साथ» is a postposition, so «किनारा» takes the oblique «किनारे» and so do
 # its adjectives — which is what the `border-clause` branch supplies. Hindi has
 # no article, so the `-article` branches read the same as the ones without.
@@ -241,7 +232,6 @@ style-border-clause =
         [and-article] और { $border } किनारे के साथ
        *[with] { $border } किनारे के साथ
     }
-
 # The fill-pattern words are oblique plurals, because their other use is the
 # «{ $pattern } वाला» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «भराव», masculine, which is the gender `noun-gender`
@@ -251,9 +241,7 @@ style-fill =
         [pattern] { $pattern } वाला { $color } भराव
        *[plain] { $color } भराव
     }
-
 style-unfilled = बिना भराव
-
 # «पर» is a postposition too, but «पृष्ठभूमि» is feminine, and a marked
 # adjective spells its feminine the same in the direct and the oblique — so the
 # `background-clause` branch coincides with the standalone feminine.
@@ -262,21 +250,17 @@ style-text =
         [background] { $background } पृष्ठभूमि पर { $color }
        *[plain] { $color }
     }
-
 style-background-none = कोई नहीं
-
 
 ## Boolean words
 
 boolean-true = सत्य
 boolean-false = असत्य
 
-
 ## Answer buttons
 
 answer-submit-label = जाँचें
 answer-submit-label-no-correctness = उत्तर भेजें
-
 
 ## Sectional blocks
 
@@ -301,7 +285,6 @@ section-name =
     .solution = हल
     .task = कार्य
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -311,9 +294,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = संकेत
-
 
 ## Tables and figures
 
@@ -324,7 +305,6 @@ table-name =
         [unnumbered-title] सारणी{ ": " }
        *[unnumbered] सारणी
     }
-
 figure-name =
     { $parts ->
         [numbered] चित्र { $enumeration }
@@ -333,22 +313,18 @@ figure-name =
        *[unnumbered] चित्र
     }
 
-
 ## Paginator controls
 
 paginator-previous = पिछला
 paginator-next = अगला
 paginator-page = पृष्ठ
-
 paginator-page-status = { $numPages } में से { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = या
 piecewise-condition-if = यदि
 piecewise-condition-otherwise = अन्यथा
-
 
 ## Chemistry
 
@@ -471,7 +447,6 @@ element-name =
     .lv = लिवरमोरियम
     .ts = टेनेसीन
     .og = ओगेनेसन
-
 element-anion-name =
     .h = हाइड्राइड
     .c = कार्बाइड
@@ -485,8 +460,6 @@ element-anion-name =
     .i = आयोडाइड
     .at = ऐस्टैटाइड
     .ts = टेनेसाइड
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अमान्य रासायनिक संकेत
 chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक

--- a/packages/i18n/locales/hil/chrome.ftl
+++ b/packages/i18n/locales/hil/chrome.ftl
@@ -26,21 +26,15 @@
 
 answer-checking = Ginausisa…
 answer-submitting = Ginapadala…
-
 answer-checking-status = Ginausisa ang sabat
 answer-submitting-status = Ginapadala ang sabat
-
 answer-correct = Husto
 answer-incorrect = Indi husto
-
 answer-response-saved = Natipigan ang sabat
-
 answer-percent-credit = { $percent }% nga kredito
 answer-percent-correct = { $percent }% nga husto
 answer-percent-short = { $percent } %
-
 max-credit-available = Pinakamataas nga kredito nga mabaton: { $percent }%
-
 # No select: «tilaw» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -48,51 +42,38 @@ attempts-remaining =
         [0] wala na sing nabilin nga tilaw
        *[other] { $count } nga tilaw ang nabilin
     }
-
 validation-correct = (Husto)
 validation-incorrect = (Indi husto)
 validation-partially-correct = (Husto sa bahin)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Ipakita ang { $count } nga sabat para sa { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komento
-
 collapsible-click-to-open = (i-klik agod mabuksan)
 collapsible-click-to-close = (i-klik agod matakpan)
-
 collapsible-initializing = Ginasugdan…
-
 footnote-show = Ipakita ang footnote
 footnote-hide = Itago ang footnote
-
 description-more-information = dugang nga impormasyon
-
 
 ## Controls
 
 slider-previous = Nagligad
 slider-next = Sunod
-
 keyboard-open = Buksi ang teklado
 keyboard-close = Takpi ang teklado
-
 choice-input-remove-choice = Kuhaa ang { $choice }
-
 matrix-remove-row = Kuhaa ang lakan
 matrix-add-row = Dugangi sing lakan
 matrix-remove-column = Kuhaa ang kolum
 matrix-add-column = Dugangi sing kolum
-
 subset-add-remove-points = Pagdugang/Pagkuha sing mga punto
 subset-toggle-points-intervals = Pagbaylo sing mga punto kag interbalo
 subset-move-points = Ibalhin ang mga punto
 subset-clear = Limpyuhi
-
 orbital-add-row = Dugangi sing lakan
 orbital-remove-row = Kuhaa ang lakan
 orbital-add-box = Dugangi sing kahon
@@ -100,13 +81,9 @@ orbital-remove-box = Kuhaa ang kahon
 orbital-add-up-arrow = Dugangi sing pana nga pasaka
 orbital-add-down-arrow = Dugangi sing pana nga padulhog
 orbital-remove-arrow = Kuhaa ang pana
-
 orbital-row-label = Etiketa para sa lakan { $row }
-
 pretzel-answer = Sabat
-
 summary-statistics-caption = Sumaryo nga estadistika sang { $column }
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = pahiuna nga pagtan-aw sang ekspresyon nga matematika
 math-input-preview = Pahiuna nga pagtan-aw
 math-input-invalid-expression = Indi balido nga ekspresyon:
 
-
 ## Document status
 
 viewer-initializing = Ginasugdan…
 
-
 ## Errors
 
 error-heading = Sayop
-
 error-found-at =
     { $span ->
         [line] Nakita sa linya { $startLine }.
        *[lines] Nakita sa mga linya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = May sayop ini nga dokumento!
-
 diagnostic-heading-error = Sayop
 diagnostic-heading-warning = Paandam
 diagnostic-heading-information = Impormasyon
 diagnostic-heading-hint = Giya
-
 accessibility-heading-level-1 = Paglapas sa aksesibilidad nga WCAG AA
 accessibility-heading-level-2 = Paandam parte sa aksesibilidad
-
 something-went-wrong = May nagsayop.
-
 renderer-load-failed = may renderer nga wala na-load. Palihog i-reload ang pahina.
-
 core-start-failed = Wala nagsugod ang pagtan-aw sang dokumento. Palihog i-reload ang pahina.

--- a/packages/i18n/locales/hil/content.ftl
+++ b/packages/i18n/locales/hil/content.ftl
@@ -39,15 +39,12 @@ color =
     .purple = lila
     .pink = rosas
     .brown = kape
-
 line-width =
     .thick = madamol
     .thin = manipis
-
 line-style =
     .dashed = putol-putol
     .dotted = tuldok-tuldok
-
 # Noun phrases. Hiligaynon marks no plural on the noun, so «linya» is the word
 # for one line and for many alike.
 fill-style =
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = balikwaot nga halihad nga linya
     .dots = tuldok
     .diamonds = diyamante
-
 noun =
     .line = linya
     .line-segment = segmento
@@ -77,16 +73,13 @@ noun =
     .diamond = diyamante
     .cross = krus
     .plus = plus
-
 noun-regular-polygon =
     { $part ->
         [tail] nga may { $numSides } nga kilid
        *[head] regular nga poligono
     }
-
 # One answer for every noun: Hiligaynon has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,21 +93,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } nga { $noun } { $nounTail }
        *[noun] { $description } nga { $noun }
     }
-
 style-filled-word = puno
-
 style-filled =
     { $parts ->
         [pattern] { $filled } nga { $color } nga may { $pattern }
        *[plain] { $filled } nga { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } nga { $color } nga { $noun } nga may { $pattern }
@@ -122,7 +111,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } nga { $color } nga { $noun } { $nounTail } nga may { $pattern }
        *[plain] { $filled } nga { $color } nga { $noun }
     }
-
 # Hiligaynon has no article, so the two `-article` branches say what the other
 # two say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «nga may» against «kag».
@@ -133,35 +121,28 @@ style-border-clause =
         [and-article] kag { $border } nga ligid
        *[with] nga may { $border } nga ligid
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } nga { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = indi puno
-
 style-text =
     { $parts ->
         [background] { $color } nga may { $background } nga background
        *[plain] { $color }
     }
-
 style-background-none = wala
-
 
 ## Boolean words
 
 boolean-true = matuod
 boolean-false = butig
 
-
 ## Answer buttons
 
 answer-submit-label = Usisaa ang sabat
 answer-submit-label-no-correctness = Ipadala ang sabat
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = Solusyon
     .task = Buluhaton
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Giya
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] Talaan{ ": " }
        *[unnumbered] Talaan
     }
-
 figure-name =
     { $parts ->
         [numbered] Pigura { $enumeration }
@@ -221,22 +198,18 @@ figure-name =
        *[unnumbered] Pigura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nagligad
 paginator-next = Sunod
 paginator-page = Pahina
-
 paginator-page-status = { $pageLabel } { $currentPage } sa { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ukon
 piecewise-condition-if = kon
 piecewise-condition-otherwise = kon indi
-
 
 ## Chemistry
 ##
@@ -247,6 +220,5 @@ piecewise-condition-otherwise = kon indi
 ## keys out.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Indi balido nga simbolo nga kemikal
 chemistry-invalid-ionic-compound = Indi balido nga kompuwesto nga ioniko

--- a/packages/i18n/locales/hnj/chrome.ftl
+++ b/packages/i18n/locales/hnj/chrome.ftl
@@ -26,69 +26,50 @@
 
 answer-checking = Tab tom kuaj...
 answer-submitting = Tab tom xa...
-
 answer-checking-status = Tab tom kuaj cov lus teb
 answer-submitting-status = Tab tom xa cov lus teb
-
 answer-correct = Yog
 answer-incorrect = Tsis yog
-
 answer-response-saved = Cov lus teb khaws cia lawm
-
 answer-percent-credit = { $percent }% ntawm cov ntsiab
 answer-percent-correct = { $percent }% yog
 answer-percent-short = { $percent } %
-
 max-credit-available = Cov ntsiab siab tshaj plaws: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tsis tshuav sij hawm sim
        *[other] tshuav { $count } zaug sim
     }
-
 validation-correct = (Yog)
 validation-incorrect = (Tsis yog)
 validation-partially-correct = (Yog ib nrab)
-
 answer-show-responses = Qhia { $count } cov lus teb rau { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Lus qhia rov qab
-
 collapsible-click-to-open = (nias los qhib)
 collapsible-click-to-close = (nias los kaw)
-
 collapsible-initializing = Tab tom pib...
-
 footnote-show = Qhia cov lus nyob hauv qab
 footnote-hide = Zais cov lus nyob hauv qab
-
 description-more-information = ntxiv lus qhia
-
 
 ## Controls
 
 slider-previous = Yav tas
 slider-next = Tom ntej
-
 keyboard-open = Qhib lub keyboard
 keyboard-close = Kaw lub keyboard
-
 choice-input-remove-choice = Tshem kem { $choice }
-
 matrix-remove-row = Tshem kem kab
 matrix-add-row = Ntxiv kem kab
 matrix-remove-column = Tshem kem ncaj
 matrix-add-column = Ntxiv kem ncaj
-
 subset-add-remove-points = Ntxiv/tshem cov taw
 subset-toggle-points-intervals = Hloov ntawm cov taw thiab cov ntu
 subset-move-points = Txav cov taw
 subset-clear = Ntxuav
-
 # A `box` here is one orbital, drawn as a square.
 orbital-add-row = Ntxiv kem kab
 orbital-remove-row = Tshem kem kab
@@ -97,13 +78,9 @@ orbital-remove-box = Tshem lub thawv
 orbital-add-up-arrow = Ntxiv tus xub taw rau saum
 orbital-add-down-arrow = Ntxiv tus xub taw rau hauv
 orbital-remove-arrow = Tshem tus xub
-
 orbital-row-label = Lub npe rau kem kab { $row }
-
 pretzel-answer = Lus teb
-
 summary-statistics-caption = Cov txheeb xyuas ntawm { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = saib ua ntej cov lej
 math-input-preview = Saib ua ntej
 math-input-invalid-expression = Cov lej tsis raug:
 
-
 ## Document status
 
 viewer-initializing = Tab tom pib...
 
-
 ## Errors
 
 error-heading = Yuam kev
-
 error-found-at =
     { $span ->
         [line] Pom nyob rau kab { $startLine }.
        *[lines] Pom nyob rau cov kab { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Daim ntawv no muaj kev yuam kev!
-
 diagnostic-heading-error = Yuam kev
 diagnostic-heading-warning = Ceeb toom
 diagnostic-heading-information = Lus qhia
 diagnostic-heading-hint = Lus taw qhia
-
 accessibility-heading-level-1 = Ua txhaum WCAG AA txog kev nkag tau
 accessibility-heading-level-2 = Ceeb toom txog kev nkag tau
-
 something-went-wrong = Muaj ib yam ua tsis tau zoo.
-
 renderer-load-failed = ib feem ntawm cov duab tsis tau thauj tau. Thov rov qab thauj nplooj no dua.
-
 core-start-failed = Tsis tau pib tau tus saib ntaub ntawv. Thov rov qab thauj nplooj no dua.

--- a/packages/i18n/locales/hnj/content.ftl
+++ b/packages/i18n/locales/hnj/content.ftl
@@ -30,15 +30,12 @@ color =
     .purple = paj yeeb
     .pink = liab qab zib
     .brown = av
-
 line-width =
     .thick = tuab
     .thin = nyias
-
 line-style =
     .dashed = tu ntu
     .dotted = ua teev
-
 # Noun phrases: they follow `nrog` and modify nothing.
 fill-style =
     .horizontal = kab pheej
@@ -47,7 +44,6 @@ fill-style =
     .backdiagonal = kab txiav rov qab
     .dots = teev
     .diamonds = lub duab plaub ceg
-
 noun =
     .line = kab
     .line-segment = ib ntu kab
@@ -67,7 +63,6 @@ noun =
     .diamond = duab plaub ceg tig
     .cross = duab ntoo cuam
     .plus = lub cim ntxiv
-
 # The noun is split: the head carries the adjectives and the complement closes
 # the phrase behind them.
 noun-regular-polygon =
@@ -75,9 +70,7 @@ noun-regular-polygon =
         [tail] uas muaj { $numSides } sab
        *[head] duab ntau ceg sib npaug
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -91,22 +84,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $nounTail } { $description }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ntim puv
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } nrog { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } nrog { $pattern }
@@ -114,7 +103,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } nrog { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] nrog ib npoo { $border }
@@ -122,35 +110,28 @@ style-border-clause =
         [and-article] thiab ib npoo { $border }
        *[with] nrog npoo { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } xim { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tsis tau ntim
-
 style-text =
     { $parts ->
         [background] { $color } saum keeb { $background }
        *[plain] { $color }
     }
-
 style-background-none = tsis muaj
-
 
 ## Boolean words
 
 boolean-true = tseeb
 boolean-false = tsis tseeb
 
-
 ## Answer buttons
 
 answer-submit-label = Kuaj
 answer-submit-label-no-correctness = Xa cov lus teb
-
 
 ## Sectional blocks
 
@@ -175,7 +156,6 @@ section-name =
     .solution = Kev daws
     .task = Hauj lwm
     .theorem = Txoj cai lej
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -185,9 +165,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Lus taw qhia
-
 
 ## Tables and figures
 
@@ -198,7 +176,6 @@ table-name =
         [unnumbered-title] Rooj{ ": " }
        *[unnumbered] Rooj
     }
-
 figure-name =
     { $parts ->
         [numbered] Duab { $enumeration }
@@ -207,15 +184,12 @@ figure-name =
        *[unnumbered] Duab
     }
 
-
 ## Paginator controls
 
 paginator-previous = Yav tas
 paginator-next = Tom ntej
 paginator-page = Nplooj
-
 paginator-page-status = { $pageLabel } { $currentPage } ntawm { $numPages }
-
 
 ## Piecewise functions
 
@@ -223,10 +197,8 @@ piecewise-condition-or = los yog
 piecewise-condition-if = yog tias
 piecewise-condition-otherwise = yog tsis li
 
-
 ## Chemistry
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Lub cim tshuaj tsis raug
 chemistry-invalid-ionic-compound = Cov tshuaj ion tsis raug

--- a/packages/i18n/locales/hr/chrome.ftl
+++ b/packages/i18n/locales/hr/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Provjera…
 answer-submitting = Slanje…
-
 answer-checking-status = Provjera odgovora
 answer-submitting-status = Slanje odgovora
-
 answer-correct = Točno
 answer-incorrect = Netočno
-
 answer-response-saved = Odgovor je spremljen
-
 answer-percent-credit = { $percent }% bodova
 answer-percent-correct = { $percent }% točno
 answer-percent-short = { $percent } %
-
 max-credit-available = Najviše mogućih bodova: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nema više pokušaja
@@ -45,11 +39,9 @@ attempts-remaining =
         [few] preostaju { $count } pokušaja
        *[other] preostaje { $count } pokušaja
     }
-
 validation-correct = (Točno)
 validation-incorrect = (Netočno)
 validation-partially-correct = (Djelomično točno)
-
 answer-show-responses =
     { $count ->
         [one] Prikaži { $count } odgovor na { $answerId }
@@ -57,42 +49,31 @@ answer-show-responses =
        *[other] Prikaži { $count } odgovora na { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Povratna informacija
-
 collapsible-click-to-open = (kliknite za otvaranje)
 collapsible-click-to-close = (kliknite za zatvaranje)
-
 collapsible-initializing = Pokretanje…
-
 footnote-show = Prikaži bilješku
 footnote-hide = Sakrij bilješku
-
 description-more-information = više informacija
-
 
 ## Controls
 
 slider-previous = Natrag
 slider-next = Naprijed
-
 keyboard-open = Otvori tipkovnicu
 keyboard-close = Zatvori tipkovnicu
-
 choice-input-remove-choice = Ukloni { $choice }
-
 matrix-remove-row = Ukloni redak
 matrix-add-row = Dodaj redak
 matrix-remove-column = Ukloni stupac
 matrix-add-column = Dodaj stupac
-
 subset-add-remove-points = Dodaj/ukloni točke
 subset-toggle-points-intervals = Prebaci između točaka i intervala
 subset-move-points = Pomakni točke
 subset-clear = Očisti
-
 orbital-add-row = Dodaj redak
 orbital-remove-row = Ukloni redak
 orbital-add-box = Dodaj okvir
@@ -100,13 +81,9 @@ orbital-remove-box = Ukloni okvir
 orbital-add-up-arrow = Dodaj strelicu prema gore
 orbital-add-down-arrow = Dodaj strelicu prema dolje
 orbital-remove-arrow = Ukloni strelicu
-
 orbital-row-label = Oznaka za redak { $row }
-
 pretzel-answer = Odgovor
-
 summary-statistics-caption = Sažete statistike za { $column }
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = pregled matematičkog izraza
 math-input-preview = Pregled
 math-input-invalid-expression = Neispravan izraz:
 
-
 ## Document status
 
 viewer-initializing = Pokretanje…
 
-
 ## Errors
 
 error-heading = Pogreška
-
 error-found-at =
     { $span ->
         [line] Pronađena u retku { $startLine }.
        *[lines] Pronađena u recima { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ovaj dokument sadrži pogreške!
-
 diagnostic-heading-error = Pogreška
 diagnostic-heading-warning = Upozorenje
 diagnostic-heading-information = Informacija
 diagnostic-heading-hint = Savjet
-
 accessibility-heading-level-1 = Kršenje pristupačnosti prema WCAG AA
 accessibility-heading-level-2 = Upozorenje o pristupačnosti
-
 something-went-wrong = Nešto je pošlo po zlu.
-
 renderer-load-failed = modul za prikaz nije se uspio učitati. Ponovno učitajte stranicu.
-
 core-start-failed = Preglednik dokumenta nije se mogao pokrenuti. Ponovno učitajte stranicu.

--- a/packages/i18n/locales/hr/content.ftl
+++ b/packages/i18n/locales/hr/content.ftl
@@ -168,7 +168,6 @@ color =
                    *[m] smeđ
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -194,7 +193,6 @@ line-width =
                    *[m] tanak
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -220,7 +218,6 @@ line-style =
                    *[m] točkast
                 }
         }
-
 # Noun phrases in the instrumental, which is the case «s» takes. They agree
 # with nothing.
 fill-style =
@@ -230,7 +227,6 @@ fill-style =
     .backdiagonal = obrnutim dijagonalnim crtama
     .dots = točkama
     .diamonds = rombovima
-
 noun =
     .line = pravac
     .line-segment = dužina
@@ -250,7 +246,6 @@ noun =
     .diamond = romb
     .cross = križ
     .plus = plus
-
 # Croatian keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -258,7 +253,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] pravilni { $numSides }-erokut
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (mnogokut, m) or
 # the head of a phrase the description never names: `border` (rub, m), `fill`
 # (ispuna, f), `text` (tekst, m), `background` (pozadina, f).
@@ -277,7 +271,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -290,13 +283,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -305,13 +296,11 @@ style-filled-word =
         [n] ispunjeno
        *[m] ispunjen
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } s { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } s { $pattern }
@@ -319,7 +308,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } s { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «rub» is masculine, so the border's adjectives agree with it and not with the
 # shape it surrounds. Croatian has no article, so the two `-article` branches
 # read like the two without.
@@ -330,7 +318,6 @@ style-border-clause =
         [and-article] i { $border } rubom
        *[with] s { $border } rubom
     }
-
 # The fill-pattern words are instrumental plurals, because their other use is
 # the «s { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «ispuna», feminine, which is the gender `noun-gender`
@@ -340,29 +327,23 @@ style-fill =
         [pattern] { $color } ispuna s { $pattern }
        *[plain] { $color } ispuna
     }
-
 style-unfilled = neispunjen
-
 style-text =
     { $parts ->
         [background] { $color } na { $background } pozadini
        *[plain] { $color }
     }
-
 style-background-none = nema
-
 
 ## Boolean words
 
 boolean-true = istina
 boolean-false = laž
 
-
 ## Answer buttons
 
 answer-submit-label = Provjeri
 answer-submit-label-no-correctness = Pošalji odgovor
-
 
 ## Sectional blocks
 
@@ -387,7 +368,6 @@ section-name =
     .solution = Rješenje
     .task = Zadatak
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -397,9 +377,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Savjet
-
 
 ## Tables and figures
 
@@ -410,7 +388,6 @@ table-name =
         [unnumbered-title] Tablica{ ". " }
        *[unnumbered] Tablica
     }
-
 figure-name =
     { $parts ->
         [numbered] Slika { $enumeration }
@@ -419,22 +396,18 @@ figure-name =
        *[unnumbered] Slika
     }
 
-
 ## Paginator controls
 
 paginator-previous = Prethodna
 paginator-next = Sljedeća
 paginator-page = Stranica
-
 paginator-page-status = { $pageLabel } { $currentPage } od { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ili
 piecewise-condition-if = ako
 piecewise-condition-otherwise = inače
-
 
 ## Chemistry
 
@@ -557,7 +530,6 @@ element-name =
     .lv = Livermorij
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrid
     .c = Karbid
@@ -571,8 +543,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tenesid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Neispravan kemijski simbol
 chemistry-invalid-ionic-compound = Neispravan ionski spoj

--- a/packages/i18n/locales/ht/chrome.ftl
+++ b/packages/i18n/locales/ht/chrome.ftl
@@ -27,21 +27,15 @@
 
 answer-checking = Ap tcheke…
 answer-submitting = Ap voye…
-
 answer-checking-status = Ap tcheke repons la
 answer-submitting-status = Ap voye repons la
-
 answer-correct = Kòrèk
 answer-incorrect = Pa kòrèk
-
 answer-response-saved = Repons la anrejistre
-
 answer-percent-credit = { $percent }% kredi
 answer-percent-correct = { $percent }% kòrèk
 answer-percent-short = { $percent } %
-
 max-credit-available = Kredi maksimòm disponib: { $percent }%
-
 # No select: «esè» is the same word for one and for many, so both categories
 # would render the same string. The count still arrives and is still formatted;
 # only the branching is gone. `[0]` stays, because "none left" is its own
@@ -51,50 +45,37 @@ attempts-remaining =
         [0] pa gen esè ki rete
        *[other] { $count } esè ki rete
     }
-
 validation-correct = (Kòrèk)
 validation-incorrect = (Pa kòrèk)
 validation-partially-correct = (Kòrèk an pati)
-
 # No select, for the reason given above.
 answer-show-responses = Montre { $count } repons pou { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Fidbak
-
 collapsible-click-to-open = (klike pou ouvri)
 collapsible-click-to-close = (klike pou fèmen)
-
 collapsible-initializing = Ap inisyalize…
-
 footnote-show = Montre nòt anba paj la
 footnote-hide = Kache nòt anba paj la
-
 description-more-information = plis enfòmasyon
-
 
 ## Controls
 
 slider-previous = Anvan
 slider-next = Apre
-
 keyboard-open = Ouvri klavye a
 keyboard-close = Fèmen klavye a
-
 choice-input-remove-choice = Retire { $choice }
-
 matrix-remove-row = Retire yon ranje
 matrix-add-row = Ajoute yon ranje
 matrix-remove-column = Retire yon kolòn
 matrix-add-column = Ajoute yon kolòn
-
 subset-add-remove-points = Ajoute/Retire pwen
 subset-toggle-points-intervals = Chanje ant pwen ak entèval
 subset-move-points = Deplase pwen
 subset-clear = Efase
-
 orbital-add-row = Ajoute yon ranje
 orbital-remove-row = Retire yon ranje
 orbital-add-box = Ajoute yon bwat
@@ -102,13 +83,9 @@ orbital-remove-box = Retire yon bwat
 orbital-add-up-arrow = Ajoute yon flèch anwo
 orbital-add-down-arrow = Ajoute yon flèch anba
 orbital-remove-arrow = Retire yon flèch
-
 orbital-row-label = Etikèt pou ranje { $row }
-
 pretzel-answer = Repons
-
 summary-statistics-caption = Estatistik rezime pou { $column }
-
 
 ## Math input
 
@@ -116,34 +93,25 @@ math-input-preview-region = apèsi ekspresyon matematik la
 math-input-preview = Apèsi
 math-input-invalid-expression = Ekspresyon ki pa valab:
 
-
 ## Document status
 
 viewer-initializing = Ap inisyalize…
 
-
 ## Errors
 
 error-heading = Erè
-
 error-found-at =
     { $span ->
         [line] Yo jwenn li nan liy { $startLine }.
        *[lines] Yo jwenn li nan liy { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokiman sa a gen erè ladan l!
-
 diagnostic-heading-error = Erè
 diagnostic-heading-warning = Avètisman
 diagnostic-heading-information = Enfo
 diagnostic-heading-hint = Endikasyon
-
 accessibility-heading-level-1 = Vyolasyon aksesibilite WCAG AA
 accessibility-heading-level-2 = Alèt aksesibilite
-
 something-went-wrong = Gen yon bagay ki pa mache.
-
 renderer-load-failed = yon randè pa t rive chaje. Tanpri rechaje paj la.
-
 core-start-failed = Vizyonè dokiman an pa t kapab demare. Tanpri rechaje paj la.

--- a/packages/i18n/locales/ht/content.ftl
+++ b/packages/i18n/locales/ht/content.ftl
@@ -42,15 +42,12 @@ color =
     .purple = vyolèt
     .pink = woz
     .brown = mawon
-
 line-width =
     .thick = epè
     .thin = fen
-
 line-style =
     .dashed = an tirè
     .dotted = an pwentiye
-
 # Noun phrases. «liy» is the same word for one line and for many, so these are
 # not plurals of anything — they are what the language says in both places.
 fill-style =
@@ -60,7 +57,6 @@ fill-style =
     .backdiagonal = liy dyagonal envès
     .dots = pwen
     .diamonds = dyaman
-
 noun =
     .line = liy
     .line-segment = segman
@@ -80,17 +76,14 @@ noun =
     .diamond = dyaman
     .cross = kwa
     .plus = plis
-
 noun-regular-polygon =
     { $part ->
         [tail] ki gen { $numSides } kote
        *[head] poligòn regilye
     }
-
 # One answer for every noun: Creole has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,7 +97,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives after it, which is the opposite of English.
 # The regular polygon's complement follows both.
 style-with-noun =
@@ -112,15 +104,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ranpli
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ak { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ak { $pattern }
@@ -128,7 +117,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } ak { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] ak yon bòdi { $border }
@@ -136,7 +124,6 @@ style-border-clause =
         [and-article] epi yon bòdi { $border }
        *[with] ak bòdi { $border }
     }
-
 # The pattern words are postposed straight onto the colour — «dyaman ble» —
 # because there is no agreement for a head noun to carry. That is the one place
 # this catalog is shorter than a Romance one rather than merely different.
@@ -145,29 +132,23 @@ style-fill =
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = san ranpli
-
 style-text =
     { $parts ->
         [background] { $color } ak yon fon { $background }
        *[plain] { $color }
     }
-
 style-background-none = anyen
-
 
 ## Boolean words
 
 boolean-true = vre
 boolean-false = fo
 
-
 ## Answer buttons
 
 answer-submit-label = Tcheke travay la
 answer-submit-label-no-correctness = Voye repons la
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = Solisyon
     .task = Travay
     .theorem = Teyorèm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Endikasyon
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Figi { $enumeration }
@@ -228,22 +205,18 @@ figure-name =
        *[unnumbered] Figi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anvan
 paginator-next = Apre
 paginator-page = Paj
-
 paginator-page-status = { $pageLabel } { $currentPage } sou { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = oswa
 piecewise-condition-if = si
 piecewise-condition-otherwise = sinon
-
 
 ## Chemistry
 ##
@@ -255,6 +228,5 @@ piecewise-condition-otherwise = sinon
 ## Creole table for a seed to reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Senbòl chimik ki pa valab
 chemistry-invalid-ionic-compound = Konpoze yonik ki pa valab

--- a/packages/i18n/locales/hu/chrome.ftl
+++ b/packages/i18n/locales/hu/chrome.ftl
@@ -26,71 +26,52 @@
 
 answer-checking = Ellenőrzés…
 answer-submitting = Beküldés…
-
 answer-checking-status = Válasz ellenőrzése
 answer-submitting-status = Válasz beküldése
-
 answer-correct = Helyes
 answer-incorrect = Helytelen
-
 answer-response-saved = Válasz mentve
-
 answer-percent-credit = { $percent }% pont
 answer-percent-correct = { $percent }% helyes
 answer-percent-short = { $percent } %
-
 max-credit-available = Elérhető maximális pont: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nincs több próbálkozás
        *[other] { $count } próbálkozás maradt
     }
-
 validation-correct = (Helyes)
 validation-incorrect = (Helytelen)
 validation-partially-correct = (Részben helyes)
-
 # «ehhez:» rather than a case suffix on the answer's name: «-hoz/-hez/-höz»
 # harmonizes with the word it attaches to, and that word is an argument.
 answer-show-responses = { $count } válasz megjelenítése ehhez: { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Visszajelzés
-
 collapsible-click-to-open = (kattintson a megnyitáshoz)
 collapsible-click-to-close = (kattintson a bezáráshoz)
-
 collapsible-initializing = Inicializálás…
-
 footnote-show = Lábjegyzet megjelenítése
 footnote-hide = Lábjegyzet elrejtése
-
 description-more-information = további információ
-
 
 ## Controls
 
 slider-previous = Előző
 slider-next = Következő
-
 keyboard-open = Billentyűzet megnyitása
 keyboard-close = Billentyűzet bezárása
-
 choice-input-remove-choice = { $choice } eltávolítása
-
 matrix-remove-row = Sor eltávolítása
 matrix-add-row = Sor hozzáadása
 matrix-remove-column = Oszlop eltávolítása
 matrix-add-column = Oszlop hozzáadása
-
 subset-add-remove-points = Pontok hozzáadása/eltávolítása
 subset-toggle-points-intervals = Pontok és intervallumok váltása
 subset-move-points = Pontok mozgatása
 subset-clear = Törlés
-
 orbital-add-row = Sor hozzáadása
 orbital-remove-row = Sor eltávolítása
 orbital-add-box = Doboz hozzáadása
@@ -98,13 +79,9 @@ orbital-remove-box = Doboz eltávolítása
 orbital-add-up-arrow = Felfelé mutató nyíl hozzáadása
 orbital-add-down-arrow = Lefelé mutató nyíl hozzáadása
 orbital-remove-arrow = Nyíl eltávolítása
-
 orbital-row-label = A(z) { $row }. sor címkéje
-
 pretzel-answer = Válasz
-
 summary-statistics-caption = A(z) { $column } összesítő statisztikái
-
 
 ## Math input
 
@@ -112,34 +89,25 @@ math-input-preview-region = matematikai kifejezés előnézete
 math-input-preview = Előnézet
 math-input-invalid-expression = Érvénytelen kifejezés:
 
-
 ## Document status
 
 viewer-initializing = Inicializálás…
 
-
 ## Errors
 
 error-heading = Hiba
-
 error-found-at =
     { $span ->
         [line] A(z) { $startLine }. sorban található.
        *[lines] A(z) { $startLine }–{ $endLine }. sorban található.
     }
-
 document-contains-errors = Ez a dokumentum hibákat tartalmaz!
-
 diagnostic-heading-error = Hiba
 diagnostic-heading-warning = Figyelmeztetés
 diagnostic-heading-information = Információ
 diagnostic-heading-hint = Tipp
-
 accessibility-heading-level-1 = WCAG AA akadálymentességi szabálysértés
 accessibility-heading-level-2 = Akadálymentességi figyelmeztetés
-
 something-went-wrong = Valami hiba történt.
-
 renderer-load-failed = egy megjelenítőmodult nem sikerült betölteni. Töltse újra az oldalt.
-
 core-start-failed = A dokumentummegjelenítőt nem sikerült elindítani. Töltse újra az oldalt.

--- a/packages/i18n/locales/hu/content.ftl
+++ b/packages/i18n/locales/hu/content.ftl
@@ -42,15 +42,12 @@ color =
     .purple = lila
     .pink = rózsaszín
     .brown = barna
-
 line-width =
     .thick = vastag
     .thin = vékony
-
 line-style =
     .dashed = szaggatott
     .dotted = pontozott
-
 # Bare singular nouns, because they are used as compound modifiers of «minta»
 # rather than as nouns of their own: «rombusz mintával», «pont mintával». That
 # is what lets the instrumental suffix stay on a word this catalog writes.
@@ -61,7 +58,6 @@ fill-style =
     .backdiagonal = fordított átlós vonal
     .dots = pont
     .diamonds = rombusz
-
 noun =
     .line = egyenes
     .line-segment = szakasz
@@ -81,7 +77,6 @@ noun =
     .diamond = rombusz
     .cross = kereszt
     .plus = plusz
-
 # «5 oldalú sokszög» — the count and the word for "sided" are separate words in
 # front of the noun, so the whole phrase is a head and there is no tail.
 noun-regular-polygon =
@@ -89,12 +84,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] szabályos { $numSides } oldalú sokszög
     }
-
 # Hungarian has no grammatical gender, so this answer goes unused. It is here
 # because the source catalog defines the key and a missing key would fall back
 # to English rather than to nothing.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -108,15 +101,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = kitöltött
-
 # The pattern clause moves to the front, because «mintával kitöltött» is a
 # participle phrase and everything modifying the noun stands before it.
 style-filled =
@@ -124,7 +114,6 @@ style-filled =
         [pattern] { $pattern } mintával { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } mintával { $filled } { $color } { $noun }
@@ -132,7 +121,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } mintával { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «keret» is written here, so it carries the instrumental itself. Hungarian
 # has no indefinite article in this position, so the `-article` branches read
 # the same as the ones without.
@@ -143,36 +131,29 @@ style-border-clause =
         [and-article] és { $border } kerettel
        *[with] { $border } kerettel
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern } minta
        *[plain] { $color }
     }
-
 style-unfilled = kitöltetlen
-
 # «háttér» takes the superessive, and it is written here: «háttéren».
 style-text =
     { $parts ->
         [background] { $color } { $background } háttéren
        *[plain] { $color }
     }
-
 style-background-none = nincs
-
 
 ## Boolean words
 
 boolean-true = igaz
 boolean-false = hamis
 
-
 ## Answer buttons
 
 answer-submit-label = Ellenőrzés
 answer-submit-label-no-correctness = Válasz beküldése
-
 
 ## Sectional blocks
 
@@ -197,7 +178,6 @@ section-name =
     .solution = Megoldás
     .task = Teendő
     .theorem = Tétel
-
 # Hungarian puts the number in front of the word it counts, with an ordinal
 # period: «2. példa», not «Példa 2».
 section-title-prefix =
@@ -209,9 +189,7 @@ section-title-prefix =
         [name-number-title] { $sectionNumber }. { $sectionName }{ ": " }
        *[name-number] { $sectionNumber }. { $sectionName }
     }
-
 hint-title = Segítség
-
 
 ## Tables and figures
 ##
@@ -224,7 +202,6 @@ table-name =
         [unnumbered-title] Táblázat{ ": " }
        *[unnumbered] Táblázat
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration }. ábra
@@ -233,24 +210,20 @@ figure-name =
        *[unnumbered] Ábra
     }
 
-
 ## Paginator controls
 
 paginator-previous = Előző
 paginator-next = Következő
 paginator-page = Oldal
-
 # A slash rather than «-ból/-ből»: the elative harmonizes with how the numeral
 # is read, which the catalog cannot see.
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = vagy
 piecewise-condition-if = ha
 piecewise-condition-otherwise = egyébként
-
 
 ## Chemistry
 
@@ -373,7 +346,6 @@ element-name =
     .lv = Livermórium
     .ts = Tenesszin
     .og = Oganesszon
-
 element-anion-name =
     .h = Hidrid
     .c = Karbid
@@ -387,8 +359,6 @@ element-anion-name =
     .i = Jodid
     .at = Asztatid
     .ts = Tenesszid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Érvénytelen vegyjel
 chemistry-invalid-ionic-compound = Érvénytelen ionvegyület

--- a/packages/i18n/locales/hy/chrome.ftl
+++ b/packages/i18n/locales/hy/chrome.ftl
@@ -27,74 +27,55 @@
 
 answer-checking = Ստուգվում է…
 answer-submitting = Ուղարկվում է…
-
 answer-checking-status = Պատասխանի ստուգում
 answer-submitting-status = Պատասխանի ուղարկում
-
 answer-correct = Ճիշտ է
 answer-incorrect = Սխալ է
-
 answer-response-saved = Պատասխանը պահպանվեց
-
 answer-percent-credit = { $percent }% միավոր
 answer-percent-correct = { $percent }% ճիշտ
 answer-percent-short = { $percent } %
-
 max-credit-available = Առավելագույն հնարավոր միավորը՝ { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] փորձեր չեն մնացել
         [one] մնացել է { $count } փորձ
        *[other] մնացել է { $count } փորձ
     }
-
 validation-correct = (Ճիշտ է)
 validation-incorrect = (Սխալ է)
 validation-partially-correct = (Մասամբ ճիշտ է)
-
 answer-show-responses =
     { $count ->
         [one] Ցույց տալ { $answerId }-ի { $count } պատասխանը
        *[other] Ցույց տալ { $answerId }-ի { $count } պատասխանը
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Արձագանք
-
 collapsible-click-to-open = (սեղմեք բացելու համար)
 collapsible-click-to-close = (սեղմեք փակելու համար)
-
 collapsible-initializing = Նախապատրաստվում է…
-
 footnote-show = Ցույց տալ ծանոթագրությունը
 footnote-hide = Թաքցնել ծանոթագրությունը
-
 description-more-information = լրացուցիչ տեղեկություն
-
 
 ## Controls
 
 slider-previous = Նախորդը
 slider-next = Հաջորդը
-
 keyboard-open = Բացել ստեղնաշարը
 keyboard-close = Փակել ստեղնաշարը
-
 choice-input-remove-choice = Հեռացնել { $choice }
-
 matrix-remove-row = Հեռացնել տողը
 matrix-add-row = Ավելացնել տող
 matrix-remove-column = Հեռացնել սյունը
 matrix-add-column = Ավելացնել սյուն
-
 subset-add-remove-points = Ավելացնել/հեռացնել կետեր
 subset-toggle-points-intervals = Փոխարկել կետերի և միջակայքերի միջև
 subset-move-points = Տեղափոխել կետերը
 subset-clear = Մաքրել
-
 orbital-add-row = Ավելացնել տող
 orbital-remove-row = Հեռացնել տողը
 orbital-add-box = Ավելացնել վանդակ
@@ -102,13 +83,9 @@ orbital-remove-box = Հեռացնել վանդակը
 orbital-add-up-arrow = Ավելացնել վերև սլաք
 orbital-add-down-arrow = Ավելացնել ներքև սլաք
 orbital-remove-arrow = Հեռացնել սլաքը
-
 orbital-row-label = { $row } տողի պիտակը
-
 pretzel-answer = Պատասխան
-
 summary-statistics-caption = { $column } սյան ամփոփ վիճակագրությունը
-
 
 ## Math input
 
@@ -116,34 +93,25 @@ math-input-preview-region = մաթեմատիկական արտահայտությ�
 math-input-preview = Նախադիտում
 math-input-invalid-expression = Անվավեր արտահայտություն՝
 
-
 ## Document status
 
 viewer-initializing = Նախապատրաստվում է…
 
-
 ## Errors
 
 error-heading = Սխալ
-
 error-found-at =
     { $span ->
         [line] Հայտնաբերվել է { $startLine } տողում։
        *[lines] Հայտնաբերվել է { $startLine }–{ $endLine } տողերում։
     }
-
 document-contains-errors = Այս փաստաթուղթը սխալներ է պարունակում։
-
 diagnostic-heading-error = Սխալ
 diagnostic-heading-warning = Զգուշացում
 diagnostic-heading-information = Տեղեկություն
 diagnostic-heading-hint = Հուշում
-
 accessibility-heading-level-1 = WCAG AA մատչելիության խախտում
 accessibility-heading-level-2 = Մատչելիության ծանուցում
-
 something-went-wrong = Ինչ-որ բան սխալ գնաց։
-
 renderer-load-failed = պատկերիչը չհաջողվեց բեռնել։ Թարմացրեք էջը։
-
 core-start-failed = Փաստաթղթի դիտիչը չհաջողվեց գործարկել։ Թարմացրեք էջը։

--- a/packages/i18n/locales/hy/content.ftl
+++ b/packages/i18n/locales/hy/content.ftl
@@ -32,15 +32,12 @@ color =
     .purple = մանուշակագույն
     .pink = վարդագույն
     .brown = շագանակագույն
-
 line-width =
     .thick = հաստ
     .thin = բարակ
-
 line-style =
     .dashed = գծիկավոր
     .dotted = կետավոր
-
 fill-style =
     .horizontal = հորիզոնական գծերի
     .vertical = ուղղահայաց գծերի
@@ -48,7 +45,6 @@ fill-style =
     .backdiagonal = հակառակ անկյունագծային գծերի
     .dots = կետերի
     .diamonds = շեղանկյունների
-
 noun =
     .line = ուղիղ
     .line-segment = հատված
@@ -68,7 +64,6 @@ noun =
     .diamond = շեղանկյուն
     .cross = խաչ
     .plus = գումարած
-
 # Armenian builds the word from the side count itself, in front of the noun, so
 # the whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -76,12 +71,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] կանոնավոր { $numSides }-անկյուն
     }
-
 # Armenian has no grammatical gender, so every noun answers the same and the
 # answer goes unused — the same thing `locales/en` and `locales/tr` do. Nor is
 # there a case fork underneath it: the adjectives never move.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -95,15 +88,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = լցված
-
 # «զարդանախշով» — "with a pattern" — is instrumental, and the pattern word in
 # front of it is genitive, governed by «զարդանախշով» — which is why the
 # `fill-style` patterns are written in the genitive plural. Nothing is welded
@@ -113,7 +103,6 @@ style-filled =
         [pattern] { $pattern } զարդանախշով { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } զարդանախշով { $color } { $filled } { $noun }
@@ -121,7 +110,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } զարդանախշով { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «եզրագծով» is the instrumental of «եզրագիծ» and carries the "with" in its own
 # ending, so the clause opens on the border's adjectives. Armenian has no
 # indefinite article, so the two `-article` branches read like the two without.
@@ -132,15 +120,12 @@ style-border-clause =
         [and-article] և { $border } եզրագծով
        *[with] { $border } եզրագծով
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } զարդանախշով { $color } լցվածք
        *[plain] { $color } լցվածք
     }
-
 style-unfilled = չլցված
-
 # «ֆոնի վրա» — genitive plus postposition — and the colour in front of it does
 # not move, so the same word stands here and on its own.
 style-text =
@@ -148,21 +133,17 @@ style-text =
         [background] { $background } ֆոնի վրա { $color }
        *[plain] { $color }
     }
-
 style-background-none = չկա
-
 
 ## Boolean words
 
 boolean-true = ճշմարիտ
 boolean-false = կեղծ
 
-
 ## Answer buttons
 
 answer-submit-label = Ստուգել
 answer-submit-label-no-correctness = Ուղարկել պատասխանը
-
 
 ## Sectional blocks
 
@@ -187,7 +168,6 @@ section-name =
     .solution = Լուծում
     .task = Առաջադրանք
     .theorem = Թեորեմ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -197,9 +177,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Հուշում
-
 
 ## Tables and figures
 
@@ -210,7 +188,6 @@ table-name =
         [unnumbered-title] Աղյուսակ{ ". " }
        *[unnumbered] Աղյուսակ
     }
-
 figure-name =
     { $parts ->
         [numbered] Նկար { $enumeration }
@@ -219,22 +196,18 @@ figure-name =
        *[unnumbered] Նկար
     }
 
-
 ## Paginator controls
 
 paginator-previous = Նախորդը
 paginator-next = Հաջորդը
 paginator-page = Էջ
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = կամ
 piecewise-condition-if = եթե
 piecewise-condition-otherwise = հակառակ դեպքում
-
 
 ## Chemistry
 
@@ -357,7 +330,6 @@ element-name =
     .lv = Լիվերմորիում
     .ts = Թենեսին
     .og = Օգանեսոն
-
 element-anion-name =
     .h = Հիդրիդ
     .c = Կարբիդ
@@ -371,8 +343,6 @@ element-anion-name =
     .i = Յոդիդ
     .at = Աստատիդ
     .ts = Թենեսիդ
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Անվավեր քիմիական նշան
 chemistry-invalid-ionic-compound = Անվավեր իոնային միացություն

--- a/packages/i18n/locales/id/chrome.ftl
+++ b/packages/i18n/locales/id/chrome.ftl
@@ -21,69 +21,50 @@
 
 answer-checking = Memeriksa...
 answer-submitting = Mengirim...
-
 answer-checking-status = Memeriksa jawaban
 answer-submitting-status = Mengirim jawaban
-
 answer-correct = Benar
 answer-incorrect = Salah
-
 answer-response-saved = Jawaban tersimpan
-
 answer-percent-credit = Nilai { $percent }%
 answer-percent-correct = { $percent }% benar
 answer-percent-short = { $percent }%
-
 max-credit-available = Nilai maksimum yang tersedia: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tidak ada percobaan tersisa
        *[other] tersisa { $count } percobaan
     }
-
 validation-correct = (Benar)
 validation-incorrect = (Salah)
 validation-partially-correct = (Sebagian benar)
-
 answer-show-responses = Tampilkan { $count } jawaban untuk { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Umpan balik
-
 collapsible-click-to-open = (klik untuk membuka)
 collapsible-click-to-close = (klik untuk menutup)
-
 collapsible-initializing = Menyiapkan...
-
 footnote-show = Tampilkan catatan kaki
 footnote-hide = Sembunyikan catatan kaki
-
 description-more-information = informasi lebih lanjut
-
 
 ## Controls
 
 slider-previous = Sebelumnya
 slider-next = Berikutnya
-
 keyboard-open = Buka papan ketik
 keyboard-close = Tutup papan ketik
-
 choice-input-remove-choice = Hapus { $choice }
-
 matrix-remove-row = Hapus baris
 matrix-add-row = Tambah baris
 matrix-remove-column = Hapus kolom
 matrix-add-column = Tambah kolom
-
 subset-add-remove-points = Tambah/Hapus titik
 subset-toggle-points-intervals = Alihkan titik dan selang
 subset-move-points = Pindahkan titik
 subset-clear = Bersihkan
-
 # A `box` here is one orbital, drawn as a square: kotak.
 orbital-add-row = Tambah baris
 orbital-remove-row = Hapus baris
@@ -92,13 +73,9 @@ orbital-remove-box = Hapus kotak
 orbital-add-up-arrow = Tambah panah atas
 orbital-add-down-arrow = Tambah panah bawah
 orbital-remove-arrow = Hapus panah
-
 orbital-row-label = Label untuk baris { $row }
-
 pretzel-answer = Jawaban
-
 summary-statistics-caption = Statistik ringkasan dari { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = pratinjau ekspresi matematika
 math-input-preview = Pratinjau
 math-input-invalid-expression = Ekspresi tidak valid:
 
-
 ## Document status
 
 viewer-initializing = Menyiapkan...
 
-
 ## Errors
 
 error-heading = Kesalahan
-
 error-found-at =
     { $span ->
         [line] Ditemukan pada baris { $startLine }.
        *[lines] Ditemukan pada baris { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumen ini mengandung kesalahan!
-
 diagnostic-heading-error = Kesalahan
 diagnostic-heading-warning = Peringatan
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Petunjuk
-
 accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
 accessibility-heading-level-2 = Peringatan aksesibilitas
-
 something-went-wrong = Terjadi kesalahan.
-
 renderer-load-failed = sebuah perender gagal dimuat. Silakan muat ulang halaman.
-
 core-start-failed = Penampil dokumen tidak dapat dijalankan. Silakan muat ulang halaman.

--- a/packages/i18n/locales/id/content.ftl
+++ b/packages/i18n/locales/id/content.ftl
@@ -26,15 +26,12 @@ color =
     .purple = ungu
     .pink = merah muda
     .brown = cokelat
-
 line-width =
     .thick = tebal
     .thin = tipis
-
 line-style =
     .dashed = putus-putus
     .dotted = titik-titik
-
 # Noun phrases: they follow "dengan" and modify nothing.
 fill-style =
     .horizontal = garis mendatar
@@ -43,7 +40,6 @@ fill-style =
     .backdiagonal = garis diagonal terbalik
     .dots = titik
     .diamonds = belah ketupat
-
 noun =
     .line = garis
     .line-segment = ruas garis
@@ -63,7 +59,6 @@ noun =
     .diamond = belah ketupat
     .cross = silang
     .plus = tanda tambah
-
 # `bersisi 5` binds to the noun rather than to the adjectives, so it folds into
 # the head and there is no tail. Placing it after the adjectives would read as
 # though the colour, not the polygon, had five sides.
@@ -72,11 +67,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] poligon beraturan bersisi { $numSides }
     }
-
 # Indonesian has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -90,22 +83,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: "garis tebal putus-putus merah".
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = terisi
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } dengan { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } dengan { $pattern }
@@ -113,7 +102,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } dengan { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # Indonesian needs no article, so the `-article` branches read the same as the
 # ones without.
 style-border-clause =
@@ -123,36 +111,29 @@ style-border-clause =
         [and-article] dan batas { $border }
        *[with] dengan batas { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tidak terisi
-
 style-text =
     { $parts ->
         [background] { $color } dengan latar { $background }
        *[plain] { $color }
     }
-
 style-background-none = tidak ada
-
 
 ## Boolean words
 
 boolean-true = benar
 boolean-false = salah
 
-
 ## Answer buttons
 
 answer-submit-label = Periksa
 answer-submit-label-no-correctness = Kirim jawaban
-
 
 ## Sectional blocks
 
@@ -177,7 +158,6 @@ section-name =
     .solution = Penyelesaian
     .task = Tugas
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -187,9 +167,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Petunjuk
-
 
 ## Tables and figures
 
@@ -200,7 +178,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Gambar { $enumeration }
@@ -209,22 +186,18 @@ figure-name =
        *[unnumbered] Gambar
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sebelumnya
 paginator-next = Berikutnya
 paginator-page = Halaman
-
 paginator-page-status = { $pageLabel } { $currentPage } dari { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = atau
 piecewise-condition-if = jika
 piecewise-condition-otherwise = selainnya
-
 
 ## Chemistry
 
@@ -347,7 +320,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrida
     .c = Karbida
@@ -361,8 +333,6 @@ element-anion-name =
     .i = Iodida
     .at = Astatida
     .ts = Tenesida
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kimia tidak valid
 chemistry-invalid-ionic-compound = Senyawa ion tidak valid

--- a/packages/i18n/locales/ig/chrome.ftl
+++ b/packages/i18n/locales/ig/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Na-elele...
 answer-submitting = Na-ezipu...
-
 answer-checking-status = Na-elele azịza
 answer-submitting-status = Na-ezipu azịza
-
 answer-correct = Ọ ziri ezi
 answer-incorrect = Ọ ezighi ezi
-
 answer-response-saved = E chekwaala Azịza
-
 answer-percent-credit = Akara { $percent }%
 answer-percent-correct = { $percent }% Ziri ezi
 answer-percent-short = { $percent }%
-
 max-credit-available = Akara kachasị elu dị: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ọ dịghị mgbalị fọdụrụ
        *[other] mgbalị { $count } fọdụrụ
     }
-
 validation-correct = (Ọ ziri ezi)
 validation-incorrect = (Ọ ezighi ezi)
 validation-partially-correct = (Ọ ziri ezi n'akụkụ)
-
 answer-show-responses = Gosi azịza { $count } nye { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Nzaghachi
-
 collapsible-click-to-open = (pịa iji mepee)
 collapsible-click-to-close = (pịa iji mechie)
-
 collapsible-initializing = Na-amalite...
-
 footnote-show = Gosi ihe ncheta ala
 footnote-hide = Zoo ihe ncheta ala
-
 description-more-information = ozi ndị ọzọ
-
 
 ## Controls
 
 slider-previous = Azụ
 slider-next = Ihu
-
 keyboard-open = Mepee Ahụ Ihe Odide
 keyboard-close = Mechie Ahụ Ihe Odide
-
 choice-input-remove-choice = Wepụ { $choice }
-
 matrix-remove-row = Wepụ ahịrị
 matrix-add-row = Tinye ahịrị
 matrix-remove-column = Wepụ ogidi
 matrix-add-column = Tinye ogidi
-
 subset-add-remove-points = Tinye/Wepụ ntụpọ
 subset-toggle-points-intervals = Gbanwee n'etiti ntụpọ na oghere
 subset-move-points = Kpụga Ntụpọ
 subset-clear = Hichaa
-
 # A `box` here is one orbital, drawn as a square: igbe.
 orbital-add-row = Tinye Ahịrị
 orbital-remove-row = Wepụ Ahịrị
@@ -91,13 +72,9 @@ orbital-remove-box = Wepụ Igbe
 orbital-add-up-arrow = Tinye Àkụ Elu
 orbital-add-down-arrow = Tinye Àkụ Ala
 orbital-remove-arrow = Wepụ Àkụ
-
 orbital-row-label = Akara ahịrị { $row }
-
 pretzel-answer = Azịza
-
 summary-statistics-caption = Nchịkọta ọnụọgụgụ nke { $column }
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = nlele okwu mgbakọ na mwepụ
 math-input-preview = Nlele
 math-input-invalid-expression = Okwu na-ezighị ezi:
 
-
 ## Document status
 
 viewer-initializing = Na-amalite...
 
-
 ## Errors
 
 error-heading = Njehie
-
 error-found-at =
     { $span ->
         [line] Achọtara ya n'ahịrị { $startLine }.
        *[lines] Achọtara ya n'ahịrị { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Akwụkwọ a nwere njehie!
-
 diagnostic-heading-error = Njehie
 diagnostic-heading-warning = Ịdọ aka ná ntị
 diagnostic-heading-information = Ozi
 diagnostic-heading-hint = Ndụmọdụ
-
 accessibility-heading-level-1 = Mmebi Nnweta WCAG AA
 accessibility-heading-level-2 = Ịdọ aka ná ntị nke nnweta
-
 something-went-wrong = Ihe ụfọdụ agaghị nke ọma.
-
 renderer-load-failed = otu ngosi adaghị ibudata. Biko budataghachi ibe a.
-
 core-start-failed = Ngosi akwụkwọ enweghị ike ịmalite. Biko budataghachi ibe a.

--- a/packages/i18n/locales/ig/content.ftl
+++ b/packages/i18n/locales/ig/content.ftl
@@ -34,15 +34,12 @@ color =
     .purple = odo anụnụ
     .pink = pinki
     .brown = aja aja
-
 line-width =
     .thick = ọkpụrụkpụ
     .thin = gịrịgịrị
-
 line-style =
     .dashed = nwere nkejị
     .dotted = nwere ntụpọ
-
 # Noun phrases: they follow «na» and modify nothing.
 fill-style =
     .horizontal = ahịrị ndina
@@ -51,7 +48,6 @@ fill-style =
     .backdiagonal = ahịrị nkwụgharị azụ
     .dots = ntụpọ
     .diamonds = daịmọnd
-
 noun =
     .line = ahịrị
     .line-segment = akụkụ ahịrị
@@ -71,7 +67,6 @@ noun =
     .diamond = daịmọnd
     .cross = obe
     .plus = akara mgbakwunye
-
 # The side count goes in the tail, behind the describing words: «ọdịdị nhata
 # uhie nwere akụkụ 5».
 noun-regular-polygon =
@@ -79,11 +74,9 @@ noun-regular-polygon =
         [tail] nwere akụkụ { $numSides }
        *[head] ọdịdị nhata
     }
-
 # Igbo has no grammatical gender, so every noun answers the same and the answer
 # goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -97,21 +90,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = juputara
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -119,7 +108,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «oke» leads its own describing words, the same way every noun here does.
 style-border-clause =
     { $parts ->
@@ -128,35 +116,28 @@ style-border-clause =
         [and-article] na oke { $border }
        *[with] na oke { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ejupụtaghị
-
 style-text =
     { $parts ->
         [background] { $color } n'okpuru { $background }
        *[plain] { $color }
     }
-
 style-background-none = ọ dịghị
-
 
 ## Boolean words
 
 boolean-true = eziokwu
 boolean-false = ụgha
 
-
 ## Answer buttons
 
 answer-submit-label = Lelee Ọrụ
 answer-submit-label-no-correctness = Zipu Azịza
-
 
 ## Sectional blocks
 
@@ -181,7 +162,6 @@ section-name =
     .solution = Ngwọta
     .task = Ọrụ
     .theorem = Ụkpụrụ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -191,9 +171,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ndụmọdụ
-
 
 ## Tables and figures
 
@@ -204,7 +182,6 @@ table-name =
         [unnumbered-title] Tebụl{ ": " }
        *[unnumbered] Tebụl
     }
-
 figure-name =
     { $parts ->
         [numbered] Eserese { $enumeration }
@@ -213,15 +190,12 @@ figure-name =
        *[unnumbered] Eserese
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nke gara aga
 paginator-next = Nke ọzọ
 paginator-page = Peeji
-
 paginator-page-status = { $pageLabel } { $currentPage } n'ime { $numPages }
-
 
 ## Piecewise functions
 
@@ -229,8 +203,8 @@ piecewise-condition-or = ma ọ bụ
 piecewise-condition-if = ọ bụrụ na
 piecewise-condition-otherwise = ma ọ bụghị ya
 
-
 ## Chemistry
+
 
 # Igbo is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. Nigerian
@@ -238,6 +212,5 @@ piecewise-condition-otherwise = ma ọ bụghị ya
 # has reached a classroom to seed from.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Akara Kemịkal Na-ezighị Ezi
 chemistry-invalid-ionic-compound = Ngwakọta Ayọn Na-ezighị Ezi

--- a/packages/i18n/locales/ilo/chrome.ftl
+++ b/packages/i18n/locales/ilo/chrome.ftl
@@ -31,21 +31,15 @@
 
 answer-checking = Sursukimaten…
 answer-submitting = Ipatpatulod…
-
 answer-checking-status = Sursukimaten ti sungbat
 answer-submitting-status = Ipatpatulod ti sungbat
-
 answer-correct = Husto
 answer-incorrect = Saan a husto
-
 answer-response-saved = Naidulin ti sungbat
-
 answer-percent-credit = { $percent }% a kredito
 answer-percent-correct = { $percent }% a husto
 answer-percent-short = { $percent } %
-
 max-credit-available = Kangatuan a kredito a magun-od: { $percent }%
-
 # No select: «padas» is the same word for one and for many — the number in front
 # of it does the work — so both English categories render one string here. The
 # `[0]` branch stays, because it names none rather than counting.
@@ -54,54 +48,41 @@ attempts-remaining =
         [0] awanen ti nabati a padas
        *[other] { $count } ti nabati a padas
     }
-
 validation-correct = (Husto)
 validation-incorrect = (Saan a husto)
 validation-partially-correct = (Husto iti paset)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated, so the sentence reaches it through «iti»
 # rather than through a linker whose shape that name would decide.
 answer-show-responses = Ipakita ti { $count } a sungbat iti { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komento
-
 collapsible-click-to-open = (pinduten tapno maluktan)
 collapsible-click-to-close = (pinduten tapno mairikep)
-
 collapsible-initializing = Mangrugrugi…
-
 footnote-show = Ipakita ti footnote
 footnote-hide = Ilemmeng ti footnote
-
 description-more-information = ad-adu pay nga impormasion
-
 
 ## Controls
 
 slider-previous = Napalabas
 slider-next = Sumaruno
-
 keyboard-open = Luktan ti teklado
 keyboard-close = Irikep ti teklado
-
 # `$choice` is the choice's own text and is never translated. It follows «ti»,
 # so no linker has to agree with a word this catalog has not seen.
 choice-input-remove-choice = Ikkaten ti { $choice }
-
 matrix-remove-row = Ikkaten ti intar
 matrix-add-row = Mangnayon iti intar
 matrix-remove-column = Ikkaten ti adigi
 matrix-add-column = Mangnayon iti adigi
-
 subset-add-remove-points = Mangnayon/Mangikkat kadagiti punto
 subset-toggle-points-intervals = Agbaliw kadagiti punto ken interbalo
 subset-move-points = Iyalis dagiti punto
 subset-clear = Dalusan
-
 orbital-add-row = Mangnayon iti intar
 orbital-remove-row = Ikkaten ti intar
 orbital-add-box = Mangnayon iti kahon
@@ -109,13 +90,9 @@ orbital-remove-box = Ikkaten ti kahon
 orbital-add-up-arrow = Mangnayon iti pana nga agpangato
 orbital-add-down-arrow = Mangnayon iti pana nga agpababa
 orbital-remove-arrow = Ikkaten ti pana
-
 orbital-row-label = Etiketa para iti intar { $row }
-
 pretzel-answer = Sungbat
-
 summary-statistics-caption = Pakabuklan a estadistika ti { $column }
-
 
 ## Math input
 
@@ -123,35 +100,26 @@ math-input-preview-region = pagsakbayan ti ekspresion a matematika
 math-input-preview = Pagsakbayan
 math-input-invalid-expression = Imbalido nga ekspresion:
 
-
 ## Document status
 
 viewer-initializing = Mangrugrugi…
 
-
 ## Errors
 
 error-heading = Biddut
-
 # `$startLine` and `$endLine` are line numbers and arrive as text.
 error-found-at =
     { $span ->
         [line] Nasarakan iti linia { $startLine }.
        *[lines] Nasarakan kadagiti linia { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Adda biddut daytoy a dokumento!
-
 diagnostic-heading-error = Biddut
 diagnostic-heading-warning = Ballaag
 diagnostic-heading-information = Impormasion
 diagnostic-heading-hint = Palagip
-
 accessibility-heading-level-1 = Panaglabsing iti aksesibilidad a WCAG AA
 accessibility-heading-level-2 = Ballaag maipapan iti aksesibilidad
-
 something-went-wrong = Adda saan a nasayaat a napasamak.
-
 renderer-load-failed = adda renderer a saan a naikarga. Pangngaasi ta i-reload ti panid.
-
 core-start-failed = Saan a nairugi ti pagbuyaan ti dokumento. Pangngaasi ta i-reload ti panid.

--- a/packages/i18n/locales/ilo/content.ftl
+++ b/packages/i18n/locales/ilo/content.ftl
@@ -49,15 +49,12 @@ color =
     .purple = lila
     .pink = rosas
     .brown = kapé
-
 line-width =
     .thick = napuskol
     .thin = nanipis
-
 line-style =
     .dashed = naguris-guris
     .dotted = natuldek-tuldek
-
 # Noun phrases. Ilocano marks no plural on the noun, so «guris» is the word for
 # one line and for many alike; these are not plurals of anything.
 fill-style =
@@ -67,7 +64,6 @@ fill-style =
     .backdiagonal = supadi a kilo a guris
     .dots = tuldek
     .diamonds = diamante
-
 noun =
     .line = linia
     .line-segment = segmento
@@ -87,7 +83,6 @@ noun =
     .diamond = diamante
     .cross = krus
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe. «nga» here is correct and fixed: «addaan» is
 # vowel-initial and is this catalog's own word.
@@ -96,11 +91,9 @@ noun-regular-polygon =
         [tail] nga addaan iti { $numSides } a sikigan
        *[head] regular a poligono
     }
-
 # One answer for every noun: Ilocano has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -115,21 +108,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } a { $noun } { $nounTail }
        *[noun] { $description } a { $noun }
     }
-
 style-filled-word = napunno
-
 style-filled =
     { $parts ->
         [pattern] { $filled } a { $color } nga addaan iti { $pattern }
        *[plain] { $filled } a { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } a { $color } a { $noun } nga addaan iti { $pattern }
@@ -137,7 +126,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } a { $color } a { $noun } { $nounTail } nga addaan iti { $pattern }
        *[plain] { $filled } a { $color } a { $noun }
     }
-
 # Ilocano has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «nga addaan iti» against
@@ -150,35 +138,28 @@ style-border-clause =
         [and-article] ken { $border } nga igid
        *[with] nga addaan iti { $border } nga igid
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } a { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = saan a napunno
-
 style-text =
     { $parts ->
         [background] { $color } nga addaan iti { $background } a likudan
        *[plain] { $color }
     }
-
 style-background-none = awan
-
 
 ## Boolean words
 
 boolean-true = pudno
 boolean-false = saan a pudno
 
-
 ## Answer buttons
 
 answer-submit-label = Sukimaten ti sungbat
 answer-submit-label-no-correctness = Ipatulod ti sungbat
-
 
 ## Sectional blocks
 
@@ -207,7 +188,6 @@ section-name =
     .solution = Solusion
     .task = Trabaho
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -217,9 +197,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Palagip
-
 
 ## Tables and figures
 
@@ -230,7 +208,6 @@ table-name =
         [unnumbered-title] Tabla{ ": " }
        *[unnumbered] Tabla
     }
-
 figure-name =
     { $parts ->
         [numbered] Pigura { $enumeration }
@@ -239,22 +216,18 @@ figure-name =
        *[unnumbered] Pigura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Napalabas
 paginator-next = Sumaruno
 paginator-page = Panid
-
 paginator-page-status = { $pageLabel } { $currentPage } iti { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = wenno
 piecewise-condition-if = no
 piecewise-condition-otherwise = no saan
-
 
 ## Chemistry
 ##
@@ -266,6 +239,5 @@ piecewise-condition-otherwise = no saan
 ## Philippine languages the roster now carries.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Imbalido a simbolo a kemikal
 chemistry-invalid-ionic-compound = Imbalido a kompuesto nga ioniko

--- a/packages/i18n/locales/is/chrome.ftl
+++ b/packages/i18n/locales/is/chrome.ftl
@@ -13,78 +13,60 @@
 # and 111 do not. That is CLDR's rule and Fluent applies it; the branches only
 # have to be written.
 
+
 ## Answer submission
 
 answer-checking = Athuga…
 answer-submitting = Sendi…
-
 answer-checking-status = Athuga svar
 answer-submitting-status = Sendi svar
-
 answer-correct = Rétt
 answer-incorrect = Rangt
-
 answer-response-saved = Svar vistað
-
 answer-percent-credit = { $percent }% einkunn
 answer-percent-correct = { $percent }% rétt
 answer-percent-short = { $percent } %
-
 max-credit-available = Hámarkseinkunn í boði: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] engar tilraunir eftir
         [one] { $count } tilraun eftir
        *[other] { $count } tilraunir eftir
     }
-
 validation-correct = (Rétt)
 validation-incorrect = (Rangt)
 validation-partially-correct = (Að hluta rétt)
-
 answer-show-responses =
     { $count ->
         [one] Sýna { $count } svar við { $answerId }
        *[other] Sýna { $count } svör við { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Endurgjöf
-
 collapsible-click-to-open = (smelltu til að opna)
 collapsible-click-to-close = (smelltu til að loka)
-
 collapsible-initializing = Ræsi…
-
 footnote-show = Sýna neðanmálsgrein
 footnote-hide = Fela neðanmálsgrein
-
 description-more-information = nánari upplýsingar
-
 
 ## Controls
 
 slider-previous = Fyrri
 slider-next = Næsta
-
 keyboard-open = Opna lyklaborð
 keyboard-close = Loka lyklaborði
-
 choice-input-remove-choice = Fjarlægja { $choice }
-
 matrix-remove-row = Fjarlægja röð
 matrix-add-row = Bæta við röð
 matrix-remove-column = Fjarlægja dálk
 matrix-add-column = Bæta við dálki
-
 subset-add-remove-points = Bæta við/fjarlægja punkta
 subset-toggle-points-intervals = Skipta milli punkta og bila
 subset-move-points = Færa punkta
 subset-clear = Hreinsa
-
 orbital-add-row = Bæta við röð
 orbital-remove-row = Fjarlægja röð
 orbital-add-box = Bæta við reit
@@ -92,13 +74,9 @@ orbital-remove-box = Fjarlægja reit
 orbital-add-up-arrow = Bæta við ör upp
 orbital-add-down-arrow = Bæta við ör niður
 orbital-remove-arrow = Fjarlægja ör
-
 orbital-row-label = Merki fyrir röð { $row }
-
 pretzel-answer = Svar
-
 summary-statistics-caption = Tölfræðileg samantekt fyrir { $column }
-
 
 ## Math input
 
@@ -106,34 +84,25 @@ math-input-preview-region = forskoðun stærðfræðisegðar
 math-input-preview = Forskoðun
 math-input-invalid-expression = Ógild segð:
 
-
 ## Document status
 
 viewer-initializing = Ræsi…
 
-
 ## Errors
 
 error-heading = Villa
-
 error-found-at =
     { $span ->
         [line] Fannst í línu { $startLine }.
        *[lines] Fannst í línum { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Þetta skjal inniheldur villur!
-
 diagnostic-heading-error = Villa
 diagnostic-heading-warning = Aðvörun
 diagnostic-heading-information = Upplýsingar
 diagnostic-heading-hint = Ábending
-
 accessibility-heading-level-1 = Brot á WCAG AA aðgengiskröfum
 accessibility-heading-level-2 = Aðgengisviðvörun
-
 something-went-wrong = Eitthvað fór úrskeiðis.
-
 renderer-load-failed = teiknari hlóðst ekki. Endurhlaððu síðuna.
-
 core-start-failed = Ekki tókst að ræsa skjalaskoðarann. Endurhlaððu síðuna.

--- a/packages/i18n/locales/is/content.ftl
+++ b/packages/i18n/locales/is/content.ftl
@@ -168,7 +168,6 @@ color =
                    *[m] brúnn
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -190,7 +189,6 @@ line-width =
                    *[m] þunnur
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -212,7 +210,6 @@ line-style =
                    *[m] punktaður
                 }
         }
-
 # Noun phrases in the dative plural, which is the case «með» takes. They agree
 # with nothing.
 fill-style =
@@ -222,7 +219,6 @@ fill-style =
     .backdiagonal = öfugum skálínum
     .dots = punktum
     .diamonds = tíglum
-
 noun =
     .line = lína
     .line-segment = línustrik
@@ -242,7 +238,6 @@ noun =
     .diamond = tígull
     .cross = kross
     .plus = plús
-
 # Icelandic builds the side count into the noun in front of it, so the whole of
 # it is one head and there is no tail.
 noun-regular-polygon =
@@ -250,7 +245,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] reglulegur { $numSides }-hyrningur
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (marghyrningur, m)
 # or the head of a phrase the description never names: `border` (jaðar, m),
 # `fill` (fylling, f), `text` (texti, m), `background` (bakgrunnur, m).
@@ -265,7 +259,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -278,13 +271,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -293,13 +284,11 @@ style-filled-word =
         [n] fyllt
        *[m] fylltur
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } með { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } með { $pattern }
@@ -307,7 +296,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } með { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «jaðar» is masculine and stands in the dative after «með», so the border's
 # adjectives agree with it and not with the shape it surrounds. Icelandic has
 # no indefinite article, so the two `-article` branches read like the two
@@ -319,7 +307,6 @@ style-border-clause =
         [and-article] og { $border } jaðri
        *[with] með { $border } jaðri
     }
-
 # The fill-pattern words are dative plurals, because their other use is the
 # «með { $pattern }» clause above. So this message supplies a noun for them to
 # hang off — «fylling», feminine, which is the gender `noun-gender` already
@@ -329,29 +316,23 @@ style-fill =
         [pattern] { $color } fylling með { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ófyllt
-
 style-text =
     { $parts ->
         [background] { $color } á { $background } bakgrunni
        *[plain] { $color }
     }
-
 style-background-none = enginn
-
 
 ## Boolean words
 
 boolean-true = satt
 boolean-false = ósatt
 
-
 ## Answer buttons
 
 answer-submit-label = Athuga svar
 answer-submit-label-no-correctness = Senda svar
-
 
 ## Sectional blocks
 
@@ -380,7 +361,6 @@ section-name =
     .solution = Lausn
     .task = Viðfangsefni
     .theorem = Setning
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -390,9 +370,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Vísbending
-
 
 ## Tables and figures
 
@@ -403,7 +381,6 @@ table-name =
         [unnumbered-title] Tafla{ ": " }
        *[unnumbered] Tafla
     }
-
 figure-name =
     { $parts ->
         [numbered] Mynd { $enumeration }
@@ -412,22 +389,18 @@ figure-name =
        *[unnumbered] Mynd
     }
 
-
 ## Paginator controls
 
 paginator-previous = Fyrri
 paginator-next = Næsta
 paginator-page = Síða
-
 paginator-page-status = { $pageLabel } { $currentPage } af { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = eða
 piecewise-condition-if = ef
 piecewise-condition-otherwise = annars
-
 
 ## Chemistry
 
@@ -550,7 +523,6 @@ element-name =
     .lv = Livermorín
     .ts = Tenness
     .og = Óganesson
-
 element-anion-name =
     .h = Hýdríð
     .c = Karbíð
@@ -564,8 +536,6 @@ element-anion-name =
     .i = Joðíð
     .at = Astatíð
     .ts = Tennessíð
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ógilt efnatákn
 chemistry-invalid-ionic-compound = Ógilt jónaefnasamband

--- a/packages/i18n/locales/it/chrome.ftl
+++ b/packages/i18n/locales/it/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = Verifica in corso...
 answer-submitting = Invio in corso...
-
 answer-checking-status = Verifica della risposta
 answer-submitting-status = Invio della risposta
-
 answer-correct = Corretto
 answer-incorrect = Errato
-
 answer-response-saved = Risposta salvata
-
 answer-percent-credit = { $percent }% di credito
 answer-percent-correct = { $percent }% corretto
 answer-percent-short = { $percent } %
-
 max-credit-available = Credito massimo disponibile: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nessun tentativo rimasto
         [one] { $count } tentativo rimasto
        *[other] { $count } tentativi rimasti
     }
-
 validation-correct = (Corretto)
 validation-incorrect = (Errato)
 validation-partially-correct = (Parzialmente corretto)
-
 answer-show-responses =
     { $count ->
         [one] Mostra { $count } risposta a { $answerId }
        *[other] Mostra { $count } risposte a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Riscontro
-
 collapsible-click-to-open = (clicca per aprire)
 collapsible-click-to-close = (clicca per chiudere)
-
 collapsible-initializing = Inizializzazione...
-
 footnote-show = Mostra la nota
 footnote-hide = Nascondi la nota
-
 description-more-information = maggiori informazioni
-
 
 ## Controls
 
 slider-previous = Prec.
 slider-next = Succ.
-
 keyboard-open = Apri la tastiera
 keyboard-close = Chiudi la tastiera
-
 choice-input-remove-choice = Rimuovi { $choice }
-
 matrix-remove-row = Rimuovi riga
 matrix-add-row = Aggiungi riga
 matrix-remove-column = Rimuovi colonna
 matrix-add-column = Aggiungi colonna
-
 subset-add-remove-points = Aggiungi/rimuovi punti
 subset-toggle-points-intervals = Alterna punti e intervalli
 subset-move-points = Sposta i punti
 subset-clear = Cancella
-
 # A `box` here is one orbital, drawn as a square: `casella`.
 orbital-add-row = Aggiungi riga
 orbital-remove-row = Rimuovi riga
@@ -94,13 +75,9 @@ orbital-remove-box = Rimuovi casella
 orbital-add-up-arrow = Aggiungi freccia in su
 orbital-add-down-arrow = Aggiungi freccia in giù
 orbital-remove-arrow = Rimuovi freccia
-
 orbital-row-label = Etichetta per la riga { $row }
-
 pretzel-answer = Risposta
-
 summary-statistics-caption = Statistiche descrittive di { $column }
-
 
 ## Math input
 
@@ -108,35 +85,26 @@ math-input-preview-region = anteprima dell’espressione matematica
 math-input-preview = Anteprima
 math-input-invalid-expression = Espressione non valida:
 
-
 ## Document status
 
 viewer-initializing = Inizializzazione...
 
-
 ## Errors
 
 error-heading = Errore
-
 # `Trovato` agrees with `errore`, which is what this sentence follows.
 error-found-at =
     { $span ->
         [line] Trovato alla riga { $startLine }.
        *[lines] Trovato alle righe { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Questo documento contiene errori!
-
 diagnostic-heading-error = Errore
 diagnostic-heading-warning = Avviso
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Suggerimento
-
 accessibility-heading-level-1 = Violazione di accessibilità WCAG AA
 accessibility-heading-level-2 = Avviso di accessibilità
-
 something-went-wrong = Qualcosa è andato storto.
-
 renderer-load-failed = non è stato possibile caricare un componente di visualizzazione. Ricarica la pagina.
-
 core-start-failed = Non è stato possibile avviare il visualizzatore del documento. Ricarica la pagina.

--- a/packages/i18n/locales/it/content.ftl
+++ b/packages/i18n/locales/it/content.ftl
@@ -44,7 +44,6 @@ color =
     .purple = viola
     .pink = rosa
     .brown = marrone
-
 line-width =
     .thick =
         { $gender ->
@@ -52,7 +51,6 @@ line-width =
            *[m] spesso
         }
     .thin = sottile
-
 line-style =
     .dashed =
         { $gender ->
@@ -64,7 +62,6 @@ line-style =
             [f] punteggiata
            *[m] punteggiato
         }
-
 # Noun phrases: they follow «con» and agree with nothing.
 fill-style =
     .horizontal = linee orizzontali
@@ -73,7 +70,6 @@ fill-style =
     .backdiagonal = linee diagonali inverse
     .dots = punti
     .diamonds = rombi
-
 noun =
     .line = linea
     .line-segment = segmento
@@ -93,7 +89,6 @@ noun =
     .diamond = rombo
     .cross = croce
     .plus = segno più
-
 # The noun is split: «poligono regolare» carries the agreement and
 # «con 5 lati» closes the phrase behind the adjectives.
 noun-regular-polygon =
@@ -101,7 +96,6 @@ noun-regular-polygon =
         [tail] con { $numSides } lati
        *[head] poligono regolare
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` or the head of a
 # phrase the description never names: `border` (bordo), `fill` (riempimento),
 # `text` (testo), `background` (sfondo). All four are masculine and fall to the
@@ -120,7 +114,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -133,7 +126,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «linea spessa rossa». A noun with a
 # complement keeps it beside itself.
 style-with-noun =
@@ -141,19 +133,16 @@ style-with-noun =
         [noun-tail] { $noun } { $nounTail } { $description }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] riempita
        *[m] riempito
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } con { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } con { $pattern }
@@ -161,7 +150,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } con { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «bordo» is masculine, so the border's adjectives agree with it and not with
 # the shape it surrounds.
 style-border-clause =
@@ -171,36 +159,29 @@ style-border-clause =
         [and-article] e un bordo { $border }
        *[with] con bordo { $border }
     }
-
 # «di colore» avoids having to agree the colour with a plural pattern noun.
 style-fill =
     { $parts ->
         [pattern] { $pattern } di colore { $color }
        *[plain] { $color }
     }
-
 style-unfilled = non riempito
-
 style-text =
     { $parts ->
         [background] { $color } su sfondo { $background }
        *[plain] { $color }
     }
-
 style-background-none = nessuno
-
 
 ## Boolean words
 
 boolean-true = vero
 boolean-false = falso
 
-
 ## Answer buttons
 
 answer-submit-label = Verifica
 answer-submit-label-no-correctness = Invia la risposta
-
 
 ## Sectional blocks
 
@@ -225,7 +206,6 @@ section-name =
     .solution = Soluzione
     .task = Compito
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -235,9 +215,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Suggerimento
-
 
 ## Tables and figures
 
@@ -248,7 +226,6 @@ table-name =
         [unnumbered-title] Tabella{ ": " }
        *[unnumbered] Tabella
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -257,22 +234,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Precedente
 paginator-next = Successivo
 paginator-page = Pagina
-
 paginator-page-status = { $pageLabel } { $currentPage } di { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = oppure
 piecewise-condition-if = se
 piecewise-condition-otherwise = altrimenti
-
 
 ## Chemistry
 
@@ -395,7 +368,6 @@ element-name =
     .lv = Livermorio
     .ts = Tennesso
     .og = Oganesson
-
 element-anion-name =
     .h = Idruro
     .c = Carburo
@@ -409,8 +381,6 @@ element-anion-name =
     .i = Ioduro
     .at = Astaturo
     .ts = Tennessuro
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbolo chimico non valido
 chemistry-invalid-ionic-compound = Composto ionico non valido

--- a/packages/i18n/locales/ja/chrome.ftl
+++ b/packages/i18n/locales/ja/chrome.ftl
@@ -28,69 +28,50 @@
 
 answer-checking = 確認中...
 answer-submitting = 送信中...
-
 answer-checking-status = 解答を確認しています
 answer-submitting-status = 解答を送信しています
-
 answer-correct = 正解
 answer-incorrect = 不正解
-
 answer-response-saved = 解答を保存しました
-
 answer-percent-credit = { $percent }% の得点
 answer-percent-correct = { $percent }% 正解
 answer-percent-short = { $percent }%
-
 max-credit-available = 獲得可能な最高得点: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] 残りの試行回数はありません
        *[other] 残り { $count } 回
     }
-
 validation-correct = （正解）
 validation-incorrect = （不正解）
 validation-partially-correct = （部分正解）
-
 answer-show-responses = { $answerId } の解答 { $count } 件を表示
-
 
 ## Disclosure panels
 
 feedback-heading = フィードバック
-
 collapsible-click-to-open = （クリックで開く）
 collapsible-click-to-close = （クリックで閉じる）
-
 collapsible-initializing = 初期化中...
-
 footnote-show = 脚注を表示
 footnote-hide = 脚注を非表示
-
 description-more-information = 詳細情報
-
 
 ## Controls
 
 slider-previous = 前へ
 slider-next = 次へ
-
 keyboard-open = キーボードを開く
 keyboard-close = キーボードを閉じる
-
 choice-input-remove-choice = { $choice } を削除
-
 matrix-remove-row = 行を削除
 matrix-add-row = 行を追加
 matrix-remove-column = 列を削除
 matrix-add-column = 列を追加
-
 subset-add-remove-points = 点の追加・削除
 subset-toggle-points-intervals = 点と区間を切り替え
 subset-move-points = 点を移動
 subset-clear = クリア
-
 # A `box` here is one orbital, drawn as a square: ボックス.
 orbital-add-row = 行を追加
 orbital-remove-row = 行を削除
@@ -99,13 +80,9 @@ orbital-remove-box = ボックスを削除
 orbital-add-up-arrow = 上向き矢印を追加
 orbital-add-down-arrow = 下向き矢印を追加
 orbital-remove-arrow = 矢印を削除
-
 orbital-row-label = { $row } 行目のラベル
-
 pretzel-answer = 解答
-
 summary-statistics-caption = { $column } の要約統計量
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = 数式のプレビュー
 math-input-preview = プレビュー
 math-input-invalid-expression = 無効な数式:
 
-
 ## Document status
 
 viewer-initializing = 初期化中...
 
-
 ## Errors
 
 error-heading = エラー
-
 error-found-at =
     { $span ->
         [line] { $startLine } 行目で見つかりました。
        *[lines] { $startLine }–{ $endLine } 行目で見つかりました。
     }
-
 document-contains-errors = この文書にはエラーがあります。
-
 diagnostic-heading-error = エラー
 diagnostic-heading-warning = 警告
 diagnostic-heading-information = 情報
 diagnostic-heading-hint = ヒント
-
 accessibility-heading-level-1 = WCAG AA アクセシビリティ違反
 accessibility-heading-level-2 = アクセシビリティに関する注意
-
 something-went-wrong = 問題が発生しました。
-
 renderer-load-failed = 描画コンポーネントの読み込みに失敗しました。ページを再読み込みしてください。
-
 core-start-failed = 文書ビューアーを起動できませんでした。ページを再読み込みしてください。

--- a/packages/i18n/locales/ja/content.ftl
+++ b/packages/i18n/locales/ja/content.ftl
@@ -35,15 +35,12 @@ color =
     .purple = 紫色
     .pink = ピンク色
     .brown = 茶色
-
 line-width =
     .thick = 太め
     .thin = 細め
-
 line-style =
     .dashed = 破線
     .dotted = 点線
-
 # Noun phrases: they precede 入り and modify nothing.
 fill-style =
     .horizontal = 横線
@@ -52,7 +49,6 @@ fill-style =
     .backdiagonal = 逆斜線
     .dots = ドット
     .diamonds = ひし形
-
 noun =
     .line = 直線
     .line-segment = 線分
@@ -72,7 +68,6 @@ noun =
     .diamond = ひし形
     .cross = 十字
     .plus = プラス記号
-
 # Japanese puts the side count inside the noun itself — 正 5 角形 — so the
 # whole thing is one head and there is no tail.
 noun-regular-polygon =
@@ -80,11 +75,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] 正 { $numSides } 角形
     }
-
 # Japanese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -98,22 +91,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The modifier precedes the noun and is joined to it with の.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description }の{ $noun }{ $nounTail }
        *[noun] { $description }の{ $noun }
     }
-
 style-filled-word = 塗りつぶし
-
 style-filled =
     { $parts ->
         [pattern] { $pattern }入りの{ $color }の{ $filled }
        *[plain] { $color }の{ $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern }入りの{ $color }の{ $filled }の{ $noun }
@@ -121,7 +110,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern }入りの{ $color }の{ $filled }の{ $noun }{ $nounTail }
        *[plain] { $color }の{ $filled }の{ $noun }
     }
-
 # Japanese needs no article, so the `-article` branches read the same as the
 # ones without.
 style-border-clause =
@@ -131,35 +119,28 @@ style-border-clause =
         [and-article] と{ $border }の枠線
        *[with] { $border }の枠線付き
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color }の{ $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = 塗りつぶしなし
-
 style-text =
     { $parts ->
         [background] { $color }（背景は{ $background }）
        *[plain] { $color }
     }
-
 style-background-none = なし
-
 
 ## Boolean words
 
 boolean-true = 真
 boolean-false = 偽
 
-
 ## Answer buttons
 
 answer-submit-label = 解答を確認
 answer-submit-label-no-correctness = 解答を送信
-
 
 ## Sectional blocks
 
@@ -184,7 +165,6 @@ section-name =
     .solution = 解答
     .task = 課題
     .theorem = 定理
-
 # A space separates the word from its number, because the number is Latin
 # digits. A title follows the full-width colon Japanese punctuates with, which
 # carries its own trailing space. A bare number keeps the ASCII period, which
@@ -198,9 +178,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ "：" }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ヒント
-
 
 ## Tables and figures
 
@@ -211,7 +189,6 @@ table-name =
         [unnumbered-title] 表{ "：" }
        *[unnumbered] 表
     }
-
 figure-name =
     { $parts ->
         [numbered] 図 { $enumeration }
@@ -220,17 +197,14 @@ figure-name =
        *[unnumbered] 図
     }
 
-
 ## Paginator controls
 
 paginator-previous = 前へ
 paginator-next = 次へ
 paginator-page = ページ
-
 # `$pageLabel` is the `pageLabel` attribute, which an author may have written
 # themselves, so it leads and the counts follow it.
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
@@ -239,7 +213,6 @@ piecewise-condition-or = または
 # that can come first — もし rather than the clause-final のとき.
 piecewise-condition-if = もし
 piecewise-condition-otherwise = それ以外
-
 
 ## Chemistry
 
@@ -362,7 +335,6 @@ element-name =
     .lv = リバモリウム
     .ts = テネシン
     .og = オガネソン
-
 element-anion-name =
     .h = 水素化物
     .c = 炭化物
@@ -376,8 +348,6 @@ element-anion-name =
     .i = ヨウ化物
     .at = アスタチン化物
     .ts = テネシン化物
-
 ion-name-oxidation-state = { $name }（{ $numeral }）
-
 chemistry-invalid-symbol = 無効な化学記号
 chemistry-invalid-ionic-compound = 無効なイオン化合物

--- a/packages/i18n/locales/jv/chrome.ftl
+++ b/packages/i18n/locales/jv/chrome.ftl
@@ -31,69 +31,50 @@
 
 answer-checking = Mriksa...
 answer-submitting = Ngirim...
-
 answer-checking-status = Mriksa wangsulan
 answer-submitting-status = Ngirim wangsulan
-
 answer-correct = Bener
 answer-incorrect = Salah
-
 answer-response-saved = Wangsulan Disimpen
-
 answer-percent-credit = Biji { $percent }%
 answer-percent-correct = Bener { $percent }%
 answer-percent-short = { $percent }%
-
 max-credit-available = Biji paling dhuwur sing bisa diolèh: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ora ana kesempatan sing kèri
        *[other] kèri { $count } kesempatan
     }
-
 validation-correct = (Bener)
 validation-incorrect = (Salah)
 validation-partially-correct = (Bener sabagéan)
-
 answer-show-responses = Tampilaké { $count } wangsulan kanggo { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Tanggapan
-
 collapsible-click-to-open = (klik kanggo mbukak)
 collapsible-click-to-close = (klik kanggo nutup)
-
 collapsible-initializing = Miwiti...
-
 footnote-show = Tampilaké cathetan sikil
 footnote-hide = Ndhelikaké cathetan sikil
-
 description-more-information = katrangan liyané
-
 
 ## Controls
 
 slider-previous = Sadurungé
 slider-next = Sabanjuré
-
 keyboard-open = Bukak Papan Tuts
 keyboard-close = Tutup Papan Tuts
-
 choice-input-remove-choice = Busak { $choice }
-
 matrix-remove-row = Busak larik
 matrix-add-row = Tambah larik
 matrix-remove-column = Busak kolom
 matrix-add-column = Tambah kolom
-
 subset-add-remove-points = Tambah/Busak titik
 subset-toggle-points-intervals = Ganti titik lan interval
 subset-move-points = Pindhah Titik
 subset-clear = Resiki
-
 orbital-add-row = Tambah Larik
 orbital-remove-row = Busak Larik
 orbital-add-box = Tambah Kothak
@@ -101,13 +82,9 @@ orbital-remove-box = Busak Kothak
 orbital-add-up-arrow = Tambah Panah Munggah
 orbital-add-down-arrow = Tambah Panah Mudhun
 orbital-remove-arrow = Busak Panah
-
 orbital-row-label = Label kanggo larik { $row }
-
 pretzel-answer = Wangsulan
-
 summary-statistics-caption = Statistik ringkesan saka { $column }
-
 
 ## Math input
 
@@ -115,34 +92,25 @@ math-input-preview-region = pratayang èkspresi matématika
 math-input-preview = Pratayang
 math-input-invalid-expression = Èkspresi ora bener:
 
-
 ## Document status
 
 viewer-initializing = Miwiti...
 
-
 ## Errors
 
 error-heading = Kaluputan
-
 error-found-at =
     { $span ->
         [line] Ketemu ing larik { $startLine }.
        *[lines] Ketemu ing larik { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumèn iki ngandhut kaluputan!
-
 diagnostic-heading-error = Kaluputan
 diagnostic-heading-warning = Pènget
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Pituduh
-
 accessibility-heading-level-1 = Pelanggaran Aksesibilitas WCAG AA
 accessibility-heading-level-2 = Pènget aksesibilitas
-
 something-went-wrong = Ana sing salah.
-
 renderer-load-failed = ana perènder sing gagal dimuat. Muat ulanga kaca iki.
-
 core-start-failed = Panampil dokumèn ora bisa diwiwiti. Muat ulanga kaca iki.

--- a/packages/i18n/locales/jv/content.ftl
+++ b/packages/i18n/locales/jv/content.ftl
@@ -32,15 +32,12 @@ color =
     .purple = ungu
     .pink = jambon
     .brown = soklat
-
 line-width =
     .thick = kandel
     .thin = tipis
-
 line-style =
     .dashed = pedhot-pedhot
     .dotted = titik-titik
-
 # Noun phrases: they follow «karo» and modify nothing.
 fill-style =
     .horizontal = garis mendhatar
@@ -49,7 +46,6 @@ fill-style =
     .backdiagonal = garis miring walikan
     .dots = titik
     .diamonds = wajik
-
 noun =
     .line = garis
     .line-segment = ruas garis
@@ -69,7 +65,6 @@ noun =
     .diamond = wajik
     .cross = tandha silang
     .plus = tandha tambah
-
 # The side count follows the noun and precedes its adjectives, so it folds into
 # the head and there is no tail.
 noun-regular-polygon =
@@ -77,11 +72,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] poligon ajeg sisi { $numSides }
     }
-
 # Javanese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -95,22 +88,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «garis kandel pedhot-pedhot abang».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = kebak
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } karo { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } karo { $pattern }
@@ -118,7 +107,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } karo { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # Javanese needs no article, so the `-article` branches read like the ones
 # without.
 style-border-clause =
@@ -128,36 +116,29 @@ style-border-clause =
         [and-article] lan pinggiran { $border }
        *[with] karo pinggiran { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ora kebak
-
 style-text =
     { $parts ->
         [background] { $color } karo latar { $background }
        *[plain] { $color }
     }
-
 style-background-none = ora ana
-
 
 ## Boolean words
 
 boolean-true = bener
 boolean-false = salah
 
-
 ## Answer buttons
 
 answer-submit-label = Priksa Garapan
 answer-submit-label-no-correctness = Kirim Wangsulan
-
 
 ## Sectional blocks
 
@@ -182,7 +163,6 @@ section-name =
     .solution = Pamecahan
     .task = Tugas
     .theorem = Tèoréma
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -192,9 +172,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pituduh
-
 
 ## Tables and figures
 
@@ -205,7 +183,6 @@ table-name =
         [unnumbered-title] Tabèl{ ": " }
        *[unnumbered] Tabèl
     }
-
 figure-name =
     { $parts ->
         [numbered] Gambar { $enumeration }
@@ -214,22 +191,18 @@ figure-name =
        *[unnumbered] Gambar
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sadurungé
 paginator-next = Sabanjuré
 paginator-page = Kaca
-
 paginator-page-status = { $pageLabel } { $currentPage } saka { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = utawa
 piecewise-condition-if = yèn
 piecewise-condition-otherwise = liyané
-
 
 ## Chemistry
 ##
@@ -363,7 +336,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrida
     .c = Karbida
@@ -377,8 +349,6 @@ element-anion-name =
     .i = Iodida
     .at = Astatida
     .ts = Tenesida
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol Kimia Ora Bener
 chemistry-invalid-ionic-compound = Senyawa Ionik Ora Bener

--- a/packages/i18n/locales/ka/chrome.ftl
+++ b/packages/i18n/locales/ka/chrome.ftl
@@ -27,74 +27,55 @@
 
 answer-checking = მოწმდება…
 answer-submitting = იგზავნება…
-
 answer-checking-status = პასუხის შემოწმება
 answer-submitting-status = პასუხის გაგზავნა
-
 answer-correct = სწორია
 answer-incorrect = არასწორია
-
 answer-response-saved = პასუხი შენახულია
-
 answer-percent-credit = { $percent }% ქულა
 answer-percent-correct = { $percent }% სწორია
 answer-percent-short = { $percent } %
-
 max-credit-available = მაქსიმალური შესაძლო ქულა: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] მცდელობა აღარ დარჩა
         [one] დარჩა { $count } მცდელობა
        *[other] დარჩა { $count } მცდელობა
     }
-
 validation-correct = (სწორია)
 validation-incorrect = (არასწორია)
 validation-partially-correct = (ნაწილობრივ სწორია)
-
 answer-show-responses =
     { $count ->
         [one] { $count } პასუხის ჩვენება { $answerId }-ზე
        *[other] { $count } პასუხის ჩვენება { $answerId }-ზე
     }
 
-
 ## Disclosure panels
 
 feedback-heading = უკუკავშირი
-
 collapsible-click-to-open = (დააწკაპუნეთ გასახსნელად)
 collapsible-click-to-close = (დააწკაპუნეთ დასახურად)
-
 collapsible-initializing = ემზადება…
-
 footnote-show = სქოლიოს ჩვენება
 footnote-hide = სქოლიოს დამალვა
-
 description-more-information = დამატებითი ინფორმაცია
-
 
 ## Controls
 
 slider-previous = წინა
 slider-next = შემდეგი
-
 keyboard-open = კლავიატურის გახსნა
 keyboard-close = კლავიატურის დახურვა
-
 choice-input-remove-choice = { $choice } არჩევანის წაშლა
-
 matrix-remove-row = სტრიქონის წაშლა
 matrix-add-row = სტრიქონის დამატება
 matrix-remove-column = სვეტის წაშლა
 matrix-add-column = სვეტის დამატება
-
 subset-add-remove-points = წერტილების დამატება/წაშლა
 subset-toggle-points-intervals = წერტილებსა და შუალედებს შორის გადართვა
 subset-move-points = წერტილების გადატანა
 subset-clear = გასუფთავება
-
 orbital-add-row = სტრიქონის დამატება
 orbital-remove-row = სტრიქონის წაშლა
 orbital-add-box = უჯრის დამატება
@@ -102,13 +83,9 @@ orbital-remove-box = უჯრის წაშლა
 orbital-add-up-arrow = ზემოთ ისრის დამატება
 orbital-add-down-arrow = ქვემოთ ისრის დამატება
 orbital-remove-arrow = ისრის წაშლა
-
 orbital-row-label = { $row } სტრიქონის წარწერა
-
 pretzel-answer = პასუხი
-
 summary-statistics-caption = { $column } სვეტის შემაჯამებელი სტატისტიკა
-
 
 ## Math input
 
@@ -116,34 +93,25 @@ math-input-preview-region = მათემატიკური გამოს
 math-input-preview = წინასწარი ხედი
 math-input-invalid-expression = არასწორი გამოსახულება:
 
-
 ## Document status
 
 viewer-initializing = ემზადება…
 
-
 ## Errors
 
 error-heading = შეცდომა
-
 error-found-at =
     { $span ->
         [line] ნაპოვნია { $startLine } სტრიქონში.
        *[lines] ნაპოვნია { $startLine }–{ $endLine } სტრიქონებში.
     }
-
 document-contains-errors = ეს დოკუმენტი შეიცავს შეცდომებს!
-
 diagnostic-heading-error = შეცდომა
 diagnostic-heading-warning = გაფრთხილება
 diagnostic-heading-information = ინფორმაცია
 diagnostic-heading-hint = მინიშნება
-
 accessibility-heading-level-1 = WCAG AA ხელმისაწვდომობის დარღვევა
 accessibility-heading-level-2 = ხელმისაწვდომობის შეტყობინება
-
 something-went-wrong = რაღაც შეცდომა მოხდა.
-
 renderer-load-failed = გამომსახველის ჩატვირთვა ვერ მოხერხდა. გთხოვთ, განაახლოთ გვერდი.
-
 core-start-failed = დოკუმენტის დამთვალიერებლის გაშვება ვერ მოხერხდა. გთხოვთ, განაახლოთ გვერდი.

--- a/packages/i18n/locales/ka/content.ftl
+++ b/packages/i18n/locales/ka/content.ftl
@@ -90,7 +90,6 @@ color =
             [background-clause] ყავისფერ
            *[standalone] ყავისფერი
         }
-
 # Only a colour is ever looked up in `background-clause`, so a width and a dash
 # pattern reach just the nominative and the instrumental, where they read alike.
 # No select is written here: the dative form these words would take there is
@@ -98,11 +97,9 @@ color =
 line-width =
     .thick = სქელი
     .thin = თხელი
-
 line-style =
     .dashed = წყვეტილი
     .dotted = წერტილოვანი
-
 # Instrumental plurals — the case that renders as "with" in English. The ending
 # carries the sense, so nothing is written in front of them where they are
 # placed.
@@ -113,7 +110,6 @@ fill-style =
     .backdiagonal = უკუდიაგონალური ხაზებით
     .dots = წერტილებით
     .diamonds = რომბებით
-
 noun =
     .line = წრფე
     .line-segment = მონაკვეთი
@@ -133,7 +129,6 @@ noun =
     .diamond = რომბი
     .cross = ჯვარი
     .plus = პლუსი
-
 # Georgian builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -141,12 +136,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] წესიერი { $numSides }-კუთხედი
     }
-
 # Georgian has no grammatical gender, so every noun answers the same and the
 # answer goes unused. What this catalog agrees for is case, which `$role`
 # carries.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -160,23 +153,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # A participle, which stands here in the nominative and takes neither argument.
 style-filled-word = შევსებული
-
 # `{ $pattern }` is already instrumental, so no connective is written.
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $color } { $filled } { $noun } { $pattern }
@@ -184,7 +173,6 @@ style-filled-with-noun =
         [pattern-tail] { $color } { $filled } { $noun } { $nounTail } { $pattern }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «ჩარჩოთი» is the instrumental of «ჩარჩო», and it is the ending rather than a
 # preposition that says "with" — so the clause opens on the border's own
 # adjectives, which the instrumental leaves in their nominative shape. Georgian
@@ -196,15 +184,12 @@ style-border-clause =
         [and-article] და { $border } ჩარჩოთი
        *[with] { $border } ჩარჩოთი
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } შევსება { $pattern }
        *[plain] { $color } შევსება
     }
-
 style-unfilled = შეუვსებელი
-
 # «ფონზე» is the dative of «ფონი» plus the postposition -ზე, and it is the
 # dative that truncates the colour in front of it. The text colour beside it is
 # nominative, agreeing with «ტექსტი».
@@ -213,21 +198,17 @@ style-text =
         [background] { $background } ფონზე { $color }
        *[plain] { $color }
     }
-
 style-background-none = არ არის
-
 
 ## Boolean words
 
 boolean-true = ჭეშმარიტი
 boolean-false = მცდარი
 
-
 ## Answer buttons
 
 answer-submit-label = შემოწმება
 answer-submit-label-no-correctness = პასუხის გაგზავნა
-
 
 ## Sectional blocks
 
@@ -252,7 +233,6 @@ section-name =
     .solution = ამოხსნა
     .task = დავალება
     .theorem = თეორემა
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -262,9 +242,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = მინიშნება
-
 
 ## Tables and figures
 
@@ -275,7 +253,6 @@ table-name =
         [unnumbered-title] ცხრილი{ ". " }
        *[unnumbered] ცხრილი
     }
-
 figure-name =
     { $parts ->
         [numbered] ნახაზი { $enumeration }
@@ -284,22 +261,18 @@ figure-name =
        *[unnumbered] ნახაზი
     }
 
-
 ## Paginator controls
 
 paginator-previous = წინა
 paginator-next = შემდეგი
 paginator-page = გვერდი
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ან
 piecewise-condition-if = თუ
 piecewise-condition-otherwise = წინააღმდეგ შემთხვევაში
-
 
 ## Chemistry
 
@@ -422,7 +395,6 @@ element-name =
     .lv = ლივერმორიუმი
     .ts = ტენესინი
     .og = ოგანესონი
-
 element-anion-name =
     .h = ჰიდრიდი
     .c = კარბიდი
@@ -436,8 +408,6 @@ element-anion-name =
     .i = იოდიდი
     .at = ასტატიდი
     .ts = ტენესიდი
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = არასწორი ქიმიური სიმბოლო
 chemistry-invalid-ionic-compound = არასწორი იონური ნაერთი

--- a/packages/i18n/locales/kab/chrome.ftl
+++ b/packages/i18n/locales/kab/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Asenqed…
 answer-submitting = Tuzna…
-
 answer-checking-status = Tiririt tettwasenqad
 answer-submitting-status = Tiririt tettwazen
-
 answer-correct = D ṣṣeḥ
 answer-incorrect = Mačči d ṣṣeḥ
-
 answer-response-saved = Tiririt tettwasekles
-
 answer-percent-credit = { $percent }% n tenqiḍin
 answer-percent-correct = { $percent }% d ṣṣeḥ
 answer-percent-short = { $percent } %
-
 max-credit-available = Tanqiḍin ugar i yellan: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ulac aɛraḍ i d-yeqqimen
         [one] yeqqim-d { $count } n uɛraḍ
        *[other] qqimen-d { $count } n yiɛraḍen
     }
-
 validation-correct = (D ṣṣeḥ)
 validation-incorrect = (Mačči d ṣṣeḥ)
 validation-partially-correct = (D ṣṣeḥ s uḥric)
-
 answer-show-responses =
     { $count ->
         [one] Sken { $count } n tririt i { $answerId }
        *[other] Sken { $count } n tririyin i { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Iwenniten
-
 collapsible-click-to-open = (sit akken ad t-teldiḍ)
 collapsible-click-to-close = (sit akken ad t-tmedleḍ)
-
 collapsible-initializing = Asenker…
-
 footnote-show = Sken tazmilt n wadda
 footnote-hide = Ffer tazmilt n wadda
-
 description-more-information = ugar n telɣut
-
 
 ## Controls
 
 slider-previous = Uzwir
 slider-next = Uḍfir
-
 keyboard-open = Ldi anasiw
 keyboard-close = Mdel anasiw
-
 choice-input-remove-choice = Kkes { $choice }
-
 matrix-remove-row = Kkes izirig
 matrix-add-row = Rnu izirig
 matrix-remove-column = Kkes tagejdit
 matrix-add-column = Rnu tagejdit
-
 subset-add-remove-points = Rnu/Kkes tinqiḍin
 subset-toggle-points-intervals = Beddel tinqiḍin d wakuden
 subset-move-points = Smutti tinqiḍin
 subset-clear = Sfeḍ
-
 orbital-add-row = Rnu izirig
 orbital-remove-row = Kkes izirig
 orbital-add-box = Rnu tanaka
@@ -86,13 +67,9 @@ orbital-remove-box = Kkes tanaka
 orbital-add-up-arrow = Rnu taneccabt s ufella
 orbital-add-down-arrow = Rnu taneccabt s wadda
 orbital-remove-arrow = Kkes taneccabt
-
 orbital-row-label = Tabzimt n yizirig { $row }
-
 pretzel-answer = Tiririt
-
 summary-statistics-caption = Agzul n tsiḍa n { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = tamuɣli tazwarant n tenfalit tusnakt
 math-input-preview = Tamuɣli tazwarant
 math-input-invalid-expression = Tanfalit tarameɣtut:
 
-
 ## Document status
 
 viewer-initializing = Asenker…
 
-
 ## Errors
 
 error-heading = Tuccḍa
-
 error-found-at =
     { $span ->
         [line] Tettwaf deg yizirig { $startLine }.
        *[lines] Tettwaf deg yizirigen { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Isemli-agi yesɛa tuccḍiwin!
-
 diagnostic-heading-error = Tuccḍa
 diagnostic-heading-warning = Alɣu
 diagnostic-heading-information = Talɣut
 diagnostic-heading-hint = Taneɣruft
-
 accessibility-heading-level-1 = Azgar WCAG AA n wanekcum
 accessibility-heading-level-2 = Alɣu n wanekcum
-
 something-went-wrong = Yella wayen ur nteddu ara akken iwata.
-
 renderer-load-failed = amsken ur yezmir ara ad d-yali. Ttxil-k ales asali n usebter.
-
 core-start-failed = Amsken n usemli ur yezmir ara ad yekker. Ttxil-k ales asali n usebter.

--- a/packages/i18n/locales/kab/content.ftl
+++ b/packages/i18n/locales/kab/content.ftl
@@ -91,7 +91,6 @@ color =
     .purple = purpuri
     .pink = wardi
     .brown = qahwi
-
 line-width =
     .thick =
         { $gender ->
@@ -103,14 +102,12 @@ line-width =
             [f] tarqaqt
            *[m] arqaq
         }
-
 # Prepositional phrases rather than adjectives, so that they agree with nothing
 # and can close the description. The nouns inside them are already in the
 # annexed state «s» governs.
 line-style =
     .dashed = s tegzumin
     .dotted = s tenqiḍin
-
 # Written in the annexed state, because every place these words are placed puts
 # them behind «s»; see this file's header.
 fill-style =
@@ -120,7 +117,6 @@ fill-style =
     .backdiagonal = yizirigen izgen s tama nniḍen
     .dots = tenqiḍin
     .diamonds = telmasin
-
 noun =
     .line = izirig
     .line-segment = agzum n yizirig
@@ -140,7 +136,6 @@ noun =
     .diamond = talmast
     .cross = amgrid
     .plus = azamul n urnu
-
 # The side count is a complement introduced by «s», so it follows the whole
 # phrase rather than opening it, and the noun inside it is annexed.
 #
@@ -152,7 +147,6 @@ noun-regular-polygon =
         [tail] s { $numSides } n yidisan
        *[head] ameggetsdis amectu
     }
-
 # The grammatical gender of the noun being described. Masculine is the default
 # and the gender a loanword takes, which is what an author's own
 # `markerStyleWord` is as far as this catalog is concerned.
@@ -168,7 +162,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # The dash pattern is an «s …» phrase and closes the description, so it moves
@@ -183,19 +176,16 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] teččuṛ
        *[m] iččuṛ
     }
-
 # Every branch that places `$pattern` puts it behind «s», which is what lets
 # `fill-style` write one annexed form apiece.
 style-filled =
@@ -203,7 +193,6 @@ style-filled =
         [pattern] { $filled } { $color } s { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } s { $pattern }
@@ -211,7 +200,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } s { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «tama» is feminine, so the border's adjectives agree with it rather than with
 # the shape it surrounds, and it stands here in the annexed state «s» governs.
 # Kabyle has no indefinite article, so the two `-article` branches read like
@@ -223,36 +211,29 @@ style-border-clause =
         [and-article] d tema { $border }
        *[with] s tema { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } s { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ur yeččuṛ ara
-
 # «ugilal» is «agilal» in the annexed state, which «ɣef» governs.
 style-text =
     { $parts ->
         [background] { $color } ɣef ugilal { $background }
        *[plain] { $color }
     }
-
 style-background-none = ulac
-
 
 ## Boolean words
 
 boolean-true = tidet
 boolean-false = lekdeb
 
-
 ## Answer buttons
 
 answer-submit-label = Senqed Ammud
 answer-submit-label-no-correctness = Azen Tiririt
-
 
 ## Sectional blocks
 
@@ -277,7 +258,6 @@ section-name =
     .solution = Tifrat
     .task = Ammud
     .theorem = Aḥric usnan
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -287,9 +267,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Talɣut
-
 
 ## Tables and figures
 
@@ -300,7 +278,6 @@ table-name =
         [unnumbered-title] Tafelwit{ ": " }
        *[unnumbered] Tafelwit
     }
-
 figure-name =
     { $parts ->
         [numbered] Tugna { $enumeration }
@@ -309,24 +286,18 @@ figure-name =
        *[unnumbered] Tugna
     }
 
-
 ## Paginator controls
 
 paginator-previous = Uzwir
 paginator-next = Uḍfir
 paginator-page = Asebter
-
 paginator-page-status = { $pageLabel } { $currentPage } seg { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = neɣ
-
 piecewise-condition-if = ma yella
-
 piecewise-condition-otherwise = neɣ mulac
-
 
 ## Chemistry
 ##
@@ -341,6 +312,5 @@ piecewise-condition-otherwise = neɣ mulac
 ## school system that answers the same way.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Azamul akimyan arameɣtu
 chemistry-invalid-ionic-compound = Asdukkel ayunan arameɣtu

--- a/packages/i18n/locales/kbp/chrome.ftl
+++ b/packages/i18n/locales/kbp/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Pɩmaɣzɩɣ…
 answer-submitting = Pɩtiyiɣ…
-
 answer-checking-status = Pɛwɛɛ pamaɣzɩɣ cosuu
 answer-submitting-status = Pɛwɛɛ patiyiɣ cosuu
-
 answer-correct = Pɩtʋʋ fɛyɩ
 answer-incorrect = Pɩtɩtʋʋzɩ
-
 answer-response-saved = Pasɩɣ Cosuu
-
 answer-percent-credit = { $percent }% Kɩɖɛʋ
 answer-percent-correct = { $percent }% Pɩtʋʋ fɛyɩ
 answer-percent-short = { $percent } %
-
 max-credit-available = Kɩɖɛʋ sɔsɔʋ ŋgʋ ŋpɩzɩɣ ŋhiɣ yɔ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] maɣzʋʋ natʋyʋ tɩkazɩ
         [one] maɣzʋʋ { $count } kazɩ
        *[other] maɣzʋʋ { $count } kazɩ
     }
-
 validation-correct = (Pɩtʋʋ fɛyɩ)
 validation-incorrect = (Pɩtɩtʋʋzɩ)
 validation-partially-correct = (Pɩtʋʋ fɛyɩ pazɩ)
-
 answer-show-responses =
     { $count ->
         [one] Wɩlɩ cosuu { $count } ŋgʋ kɩwɛ { $answerId } taa yɔ
        *[other] Wɩlɩ cosuu { $count } weyi ɩwɛ { $answerId } taa yɔ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Cosuu
-
 collapsible-click-to-open = (mabɩ nɛ kɩtʋlɩ)
 collapsible-click-to-close = (mabɩ nɛ kɩtɔlɩ)
-
 collapsible-initializing = Pɩpaɣzɩɣ…
-
 footnote-show = Wɩlɩ tɛɛ takayaɣ
 footnote-hide = Mɛsɩ tɛɛ takayaɣ
-
 description-more-information = tɔm lɛɛtʋ
-
 
 ## Controls
 
 slider-previous = Ŋgʋ kɩɖɛwa yɔ
 slider-next = Ŋgʋ kɩkɔŋ yɔ
-
 keyboard-open = Tʋlɩ Klaviye
 keyboard-close = Tɔlɩ Klaviye
-
 choice-input-remove-choice = Lɩzɩ { $choice }
-
 matrix-remove-row = Lɩzɩ ñɔʋ
 matrix-add-row = Sʋsɩ ñɔʋ
 matrix-remove-column = Lɩzɩ kolonjɩ
 matrix-add-column = Sʋsɩ kolonjɩ
-
 subset-add-remove-points = Sʋsɩ/Lɩzɩ yʋsasɩ
 subset-toggle-points-intervals = Lɛɣzɩ yʋsasɩ nɛ alɩwaatɩŋ
 subset-move-points = Ñɔɔzɩ Yʋsasɩ
 subset-clear = Hɩzɩ
-
 orbital-add-row = Sʋsɩ Ñɔʋ
 orbital-remove-row = Lɩzɩ Ñɔʋ
 orbital-add-box = Sʋsɩ Aɖakaɣ
@@ -87,13 +68,9 @@ orbital-remove-box = Lɩzɩ Aɖakaɣ
 orbital-add-up-arrow = Sʋsɩ Yʋsaɣ Ŋga Kɩwɛɛ Ɖoo Yɔ
 orbital-add-down-arrow = Sʋsɩ Yʋsaɣ Ŋga Kɩwɛɛ Tɛɛ Yɔ
 orbital-remove-arrow = Lɩzɩ Yʋsaɣ
-
 orbital-row-label = Ñɔʋ { $row } hɩɖɛ
-
 pretzel-answer = Cosuu
-
 summary-statistics-caption = { $column } ñʋʋ taa kɩɖaŋ
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = maɣzɩm tɔm kɩcalʋʋ naʋ
 math-input-preview = Naʋ kɩcalʋʋ
 math-input-invalid-expression = Tɔm kɩdɛkɛdɩtʋ:
 
-
 ## Document status
 
 viewer-initializing = Pɩpaɣzɩɣ…
 
-
 ## Errors
 
 error-heading = Kɩwɛɛkɩm
-
 error-found-at =
     { $span ->
         [line] Panawa ñɔʋ { $startLine } yɔɔ.
        *[lines] Panawa ñɔŋ { $startLine }–{ $endLine } yɔɔ.
     }
-
 document-contains-errors = Takayaɣ kanɛ kɛwɛnɩ kɩwɛɛkɩm!
-
 diagnostic-heading-error = Kɩwɛɛkɩm
 diagnostic-heading-warning = Paɣtʋ
 diagnostic-heading-information = Tɔm
 diagnostic-heading-hint = Sɩnʋʋ
-
 accessibility-heading-level-1 = WCAG AA Talʋʋ Paɣtʋ Yɔɔ Maʋ
 accessibility-heading-level-2 = Talʋʋ paɣtʋ
-
 something-went-wrong = Nabʋyʋ tɩɖɔ camɩyɛ.
-
 renderer-load-failed = wɩlɩyʋ nɔɔyʋ tɩkɔɔ. Ɖɩwakɩ-ŋ nɛ ŋtasɩ hɔɔlʋʋ ñʋʋ tʋlʋʋ.
-
 core-start-failed = Takayaɣ wɩlɩyʋ tɩpɩzɩ nɛ ɛpaɣzɩ. Ɖɩwakɩ-ŋ nɛ ŋtasɩ hɔɔlʋʋ ñʋʋ tʋlʋʋ.

--- a/packages/i18n/locales/kbp/content.ftl
+++ b/packages/i18n/locales/kbp/content.ftl
@@ -94,7 +94,6 @@ color =
     .purple = violɛɛ
     .pink = rozɩ
     .brown = maroŋ
-
 line-width =
     .thick =
         { $gender ->
@@ -112,14 +111,12 @@ line-width =
             [c5] pɩŋɩm
            *[c1] pɩŋʋ
         }
-
 # Written as «nɛ …» phrases rather than as class-marked qualifiers, so that
 # they take no suffix and can close the description. `style-stroke` puts them
 # last.
 line-style =
     .dashed = nɛ hɔɔlɩŋ cikpeŋ
     .dotted = nɛ yʋsasɩ
-
 fill-style =
     .horizontal = ñɔsɩ nzɩ sɩhɩnɩ yɔ
     .vertical = ñɔsɩ nzɩ sɩsɩŋ yɔ
@@ -127,7 +124,6 @@ fill-style =
     .backdiagonal = ñɔsɩ nzɩ sɩlɩɣ hɔɔlʋʋ lɛɛkʋ yɔ
     .dots = yʋsasɩ
     .diamonds = diyamaanɩwaa
-
 noun =
     .line = ñɔʋ
     .line-segment = ñɔʋ hɔɔlʋʋ
@@ -147,7 +143,6 @@ noun =
     .diamond = diyamaanɩ
     .cross = sɩŋgɩyɛ
     .plus = plisɩ yʋsaɣ
-
 # The side count is a relative clause and closes the noun phrase behind the
 # describing words, so it goes in the tail — which is also what keeps a class
 # suffix from ever needing to land on `{ $numSides }`.
@@ -156,7 +151,6 @@ noun-regular-polygon =
         [tail] ŋgʋ kɩwɛnɩ hɔɔlɩŋ { $numSides } yɔ
        *[head] poligɔnɩ kɩmaɣzaɣ
     }
-
 # The noun class. `c1` is the default and the class a French loan joins, which
 # is what an author's own `markerStyleWord` is as far as this catalog is
 # concerned. `border` is listed explicitly even though it answers the default,
@@ -182,7 +176,6 @@ noun-gender =
        *[other] c1
     }
 
-
 ## Style composition
 
 # The dash pattern is a «nɛ …» phrase and closes the description, so it moves
@@ -197,13 +190,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c2] sʋʋtʋ
@@ -212,13 +203,11 @@ style-filled-word =
         [c5] sʋʋm
        *[c1] sʋʋʋ
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } nɛ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } nɛ { $pattern }
@@ -226,7 +215,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nɛ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «kamaɣ» is the border and leads its own describing words, so they agree with
 # it rather than with the shape it surrounds — which is why `border` answers
 # `c1` in `noun-gender`. Kabiyè has no article and joins this clause with the
@@ -238,35 +226,28 @@ style-border-clause =
         [and-article] nɛ kamaɣ { $border }
        *[with] nɛ kamaɣ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ɛtɩsʋʋ
-
 style-text =
     { $parts ->
         [background] { $color } nɛ wayɩ { $background }
        *[plain] { $color }
     }
-
 style-background-none = pʋyʋ nabʋyʋ fɛyɩ
-
 
 ## Boolean words
 
 boolean-true = toovenim
 boolean-false = cɛtɩm
 
-
 ## Answer buttons
 
 answer-submit-label = Maɣzɩ Tʋmɩyɛ
 answer-submit-label-no-correctness = Tiyi Cosuu
-
 
 ## Sectional blocks
 
@@ -291,7 +272,6 @@ section-name =
     .solution = Nʋmɔʋ kɩbaŋʋ
     .task = Tʋmɩyɛ
     .theorem = Teyorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -301,9 +281,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Sɩnʋʋ
-
 
 ## Tables and figures
 
@@ -314,7 +292,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Kɩlɛmʋʋ { $enumeration }
@@ -323,25 +300,18 @@ figure-name =
        *[unnumbered] Kɩlɛmʋʋ
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ŋgʋ kɩɖɛwa yɔ
 paginator-next = Ŋgʋ kɩkɔŋ yɔ
-
 paginator-page = Hɔɔlʋʋ
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = yaa
-
 piecewise-condition-if = ye
-
 piecewise-condition-otherwise = alɩwaatʋ lɛɛtʋ tɩŋa taa
-
 
 ## Chemistry
 ##
@@ -354,6 +324,5 @@ piecewise-condition-otherwise = alɩwaatʋ lɛɛtʋ tɩŋa taa
 ## same reason.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Siimii Yʋsaɣ Kɩdɛkɛdɩɣ
 chemistry-invalid-ionic-compound = Iyɔŋ Kpɛndʋʋ Kɩdɛkɛdɩɣ

--- a/packages/i18n/locales/kg/chrome.ftl
+++ b/packages/i18n/locales/kg/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Kufyongunuka…
 answer-submitting = Kutinda…
-
 answer-checking-status = Mvutu yifyongunukwanga
 answer-submitting-status = Mvutu yitindwanga
-
 answer-correct = Ya kyedika
 answer-incorrect = Ya luvunu
-
 answer-response-saved = Mvutu Yibumbulu
-
 answer-percent-credit = { $percent }% ya Ntalu
 answer-percent-correct = { $percent }% Ya kyedika
 answer-percent-short = { $percent } %
-
 max-credit-available = Ntalu yanene yilenda baka: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kuna ntonta ve
         [one] ntonta { $count } yasyala
        *[other] bintonta { $count } byasyala
     }
-
 validation-correct = (Ya kyedika)
 validation-incorrect = (Ya luvunu)
 validation-partially-correct = (Ya kyedika mu ndambu)
-
 answer-show-responses =
     { $count ->
         [one] Songa mvutu { $count } ya { $answerId }
        *[other] Songa mivutu { $count } ya { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Mvutu ya Kisalu
-
 collapsible-click-to-open = (buta sambu na kuzibula)
 collapsible-click-to-close = (buta sambu na kukanga)
-
 collapsible-initializing = Kuyantika…
-
 footnote-show = Songa nsonokono ya nsi
 footnote-hide = Swekisa nsonokono ya nsi
-
 description-more-information = nsangu zankaka
-
 
 ## Controls
 
 slider-previous = Yavita
 slider-next = Yalanda
-
 keyboard-open = Zibula Klavye
 keyboard-close = Kanga Klavye
-
 choice-input-remove-choice = Katula { $choice }
-
 matrix-remove-row = Katula nkonso
 matrix-add-row = Yika nkonso
 matrix-remove-column = Katula ntandu
 matrix-add-column = Yika ntandu
-
 subset-add-remove-points = Yika/Katula matona
 subset-toggle-points-intervals = Soba matona ye bintangu
 subset-move-points = Nikisa Matona
 subset-clear = Katula byonso
-
 orbital-add-row = Yika Nkonso
 orbital-remove-row = Katula Nkonso
 orbital-add-box = Yika Sanduku
@@ -86,13 +67,9 @@ orbital-remove-box = Katula Sanduku
 orbital-add-up-arrow = Yika Nsonga ya Ntandu
 orbital-add-down-arrow = Yika Nsonga ya Nsi
 orbital-remove-arrow = Katula Nsonga
-
 orbital-row-label = Nkumbu ya nkonso { $row }
-
 pretzel-answer = Mvutu
-
 summary-statistics-caption = Nkanda wa mitangu mya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = mona ntete mvovo wa mitangu
 math-input-preview = Mona ntete
 math-input-invalid-expression = Mvovo wambi:
 
-
 ## Document status
 
 viewer-initializing = Kuyantika…
 
-
 ## Errors
 
 error-heading = Mbi
-
 error-found-at =
     { $span ->
         [line] Yamonana va nsinga { $startLine }.
        *[lines] Yamonana va nsinga { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Mukanda wawu wina ye mambi!
-
 diagnostic-heading-error = Mbi
 diagnostic-heading-warning = Nlubuka
 diagnostic-heading-information = Nsangu
 diagnostic-heading-hint = Lusadisu
-
 accessibility-heading-level-1 = Mbundamusu ya WCAG AA mu Nswalu
 accessibility-heading-level-2 = Nlubuka wa nswalu
-
 something-went-wrong = Kima kyankaka kyabwa.
-
 renderer-load-failed = nsongi kalendi kwiza ko. Vutukisa lukaya.
-
 core-start-failed = Nsongi wa mukanda kalendi yantika ko. Vutukisa lukaya.

--- a/packages/i18n/locales/kg/content.ftl
+++ b/packages/i18n/locales/kg/content.ftl
@@ -133,7 +133,6 @@ color =
             [c11] lwa ntoto
            *[c9] ya ntoto
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -149,7 +148,6 @@ line-width =
             [c11] lwa fyoti
            *[c9] ya fyoti
         }
-
 # Written as «ya + noun» phrases with their own frozen class-9 linker, the way
 # Kituba writes everything: these describe a manner rather than a quality, and
 # a speaker does not agree them with the shape. They therefore take no
@@ -157,7 +155,6 @@ line-width =
 line-style =
     .dashed = ya bitini bitini
     .dotted = ya tona tona
-
 fill-style =
     .horizontal = nsinga miayalumuka
     .vertical = nsinga miatelama
@@ -165,7 +162,6 @@ fill-style =
     .backdiagonal = nsinga miasengoloka ku ndambu yankaka
     .dots = tona
     .diamonds = madiama
-
 noun =
     .line = nsinga
     .line-segment = kitini kya nsinga
@@ -185,7 +181,6 @@ noun =
     .diamond = diama
     .cross = kuluse
     .plus = sinsu kya kuvukisa
-
 # The side count is a counted complement and closes the noun phrase behind the
 # describing words, so it goes in the tail. «-a» agrees here too, but the head
 # noun is always the same word, so the form is fixed and needs no fork.
@@ -194,7 +189,6 @@ noun-regular-polygon =
         [tail] ya makonso { $numSides }
        *[head] poligone yafwanana
     }
-
 # The noun class. `c9` is the default and the class a French loan joins, which
 # is what an author's own `markerStyleWord` is as far as this catalog is
 # concerned — and it is also the row Kituba kept. So «kare» and «kuluse» are
@@ -214,7 +208,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ya …» phrase and closes the description, so it moves
@@ -231,13 +224,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c5] dyazala
@@ -245,13 +236,11 @@ style-filled-word =
         [c11] lwazala
        *[c9] yazala
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ye { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ye { $pattern }
@@ -259,7 +248,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ye { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «lubaku» is the border and leads its own describing words, so they agree with
 # it rather than with the shape it surrounds — which is why `border` answers
 # `c11` in `noun-gender`, matching «lubaku»'s own «lu-». Kongo has no
@@ -272,35 +260,28 @@ style-border-clause =
         [and-article] ye lubaku { $border }
        *[with] ye lubaku { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = kyazala ve
-
 style-text =
     { $parts ->
         [background] { $color } ye nima { $background }
        *[plain] { $color }
     }
-
 style-background-none = ata kima ve
-
 
 ## Boolean words
 
 boolean-true = kyedika
 boolean-false = luvunu
 
-
 ## Answer buttons
 
 answer-submit-label = Fyongunuka Kisalu
 answer-submit-label-no-correctness = Tinda Mvutu
-
 
 ## Sectional blocks
 
@@ -325,7 +306,6 @@ section-name =
     .solution = Nsukulu
     .task = Mfunu
     .theorem = Tewoleme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -335,9 +315,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Lusadisu
-
 
 ## Tables and figures
 
@@ -348,7 +326,6 @@ table-name =
         [unnumbered-title] Tabele{ ": " }
        *[unnumbered] Tabele
     }
-
 figure-name =
     { $parts ->
         [numbered] Kifwani { $enumeration }
@@ -357,25 +334,18 @@ figure-name =
        *[unnumbered] Kifwani
     }
 
-
 ## Paginator controls
 
 paginator-previous = Yavita
 paginator-next = Yalanda
-
 paginator-page = Lukaya
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = to
-
 piecewise-condition-if = kana
-
 piecewise-condition-otherwise = mu mambu mankaka mawonso
-
 
 ## Chemistry
 ##
@@ -389,6 +359,5 @@ piecewise-condition-otherwise = mu mambu mankaka mawonso
 ## leave the same gap for the same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Sinsu kya Simi Kyambi
 chemistry-invalid-ionic-compound = Kivukanu kya Ioni Kyambi

--- a/packages/i18n/locales/ki/chrome.ftl
+++ b/packages/i18n/locales/ki/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Nĩgũkũrorwo…
 answer-submitting = Nĩgũgũtũmwo…
-
 answer-checking-status = Macookio nĩmararorwo
 answer-submitting-status = Macookio nĩmaratũmwo
-
 answer-correct = Nĩ ma
 answer-incorrect = Ti ma
-
 answer-response-saved = Macookio Nĩmaigĩtwo
-
 answer-percent-credit = { $percent }% cia Mabatho
 answer-percent-correct = { $percent }% Nĩ ma
 answer-percent-short = { $percent } %
-
 max-credit-available = Mabatho maingĩ marĩa moimanaga: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] gũtirĩ kũgeria gũtigarĩte
         [one] nĩgũtigarĩte kũgeria { $count }
        *[other] nĩgũtigarĩte kũgeria { $count }
     }
-
 validation-correct = (Nĩ ma)
 validation-incorrect = (Ti ma)
 validation-partially-correct = (Nĩ ma kũrĩ gĩcunjĩ)
-
 answer-show-responses =
     { $count ->
         [one] Onania macookio { $count } harĩ { $answerId }
        *[other] Onania macookio { $count } harĩ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Mataaro
-
 collapsible-click-to-open = (ringa nĩguo ũhingũre)
 collapsible-click-to-close = (ringa nĩguo ũhinge)
-
 collapsible-initializing = Nĩgũkwambĩrĩria…
-
 footnote-show = Onania kĩandĩko kĩa thĩ
 footnote-hide = Hitha kĩandĩko kĩa thĩ
-
 description-more-information = ũhoro ũngĩ
-
 
 ## Controls
 
 slider-previous = Ĩrĩa ĩhĩtũkĩte
 slider-next = Ĩrĩa ĩrũmĩrĩire
-
 keyboard-open = Hingũra Kĩboodi
 keyboard-close = Hinga Kĩboodi
-
 choice-input-remove-choice = Eheria { $choice }
-
 matrix-remove-row = Eheria mũhari
 matrix-add-row = Ongerera mũhari
 matrix-remove-column = Eheria gĩtugĩ
 matrix-add-column = Ongerera gĩtugĩ
-
 subset-add-remove-points = Ongerera/Eheria ndoti
 subset-toggle-points-intervals = Garũra ndoti na ihinda
 subset-move-points = Thaamia Ndoti
 subset-clear = Thambia
-
 orbital-add-row = Ongerera Mũhari
 orbital-remove-row = Eheria Mũhari
 orbital-add-box = Ongerera Ithandũkũ
@@ -86,13 +67,9 @@ orbital-remove-box = Eheria Ithandũkũ
 orbital-add-up-arrow = Ongerera Mũguĩ wa Igũrũ
 orbital-add-down-arrow = Ongerera Mũguĩ wa Thĩ
 orbital-remove-arrow = Eheria Mũguĩ
-
 orbital-row-label = Rĩĩtwa rĩa mũhari { $row }
-
 pretzel-answer = Macookio
-
 summary-statistics-caption = Ũhũthio wa mĩigana ya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = kwĩrorera kwa mũhianĩre wa mĩigana
 math-input-preview = Kwĩrorera
 math-input-invalid-expression = Mũhianĩre ũtarĩ mwega:
 
-
 ## Document status
 
 viewer-initializing = Nĩgũkwambĩrĩria…
 
-
 ## Errors
 
 error-heading = Ihĩtia
-
 error-found-at =
     { $span ->
         [line] Nĩrĩoneka mũhari-inĩ wa { $startLine }.
        *[lines] Nĩrĩoneka mĩhari-inĩ ya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ĩbuku rĩrĩ rĩrĩ na mahĩtia!
-
 diagnostic-heading-error = Ihĩtia
 diagnostic-heading-warning = Mũkaana
 diagnostic-heading-information = Ũhoro
 diagnostic-heading-hint = Ũtaaro
-
 accessibility-heading-level-1 = Kũagarara WCAG AA kwa Ũkinyĩrĩri
 accessibility-heading-level-2 = Mũkaana wa ũkinyĩrĩri
-
 something-went-wrong = Nĩ harĩ ũndũ ũtathiĩte wega.
-
 renderer-load-failed = mũonania nĩ waremirwo nĩ gũkuua. Ndagũthaitha ũcokererie karatathi.
-
 core-start-failed = Mũonania wa ĩbuku nĩ waremirwo nĩ kwambĩrĩria. Ndagũthaitha ũcokererie karatathi.

--- a/packages/i18n/locales/ki/content.ftl
+++ b/packages/i18n/locales/ki/content.ftl
@@ -75,7 +75,6 @@ color =
     .purple = ndathi
     .pink = pingi
     .brown = ngoikoni ya thĩ
-
 line-width =
     .thick =
         { $gender ->
@@ -89,13 +88,11 @@ line-width =
             [c7] kĩnini
            *[c9] nini
         }
-
 # Written as an invariable «na …» phrase, so that it agrees with nothing and
 # can close the phrase. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = na icunjĩ
     .dotted = na tũdoti
-
 fill-style =
     .horizontal = mĩhari ĩkomete
     .vertical = mĩhari ĩrũngiĩ
@@ -103,7 +100,6 @@ fill-style =
     .backdiagonal = mĩhari ĩinamĩte na mwena ũngĩ
     .dots = tũdoti
     .diamonds = daimondi
-
 noun =
     .line = mũhari
     .line-segment = gĩcunjĩ kĩa mũhari
@@ -123,7 +119,6 @@ noun =
     .diamond = daimondi
     .cross = mũtharaba
     .plus = kĩmenyithia kĩa kuongerera
-
 # The side count is a relative complement and closes the noun phrase behind the
 # describing words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -131,7 +126,6 @@ noun-regular-polygon =
         [tail] ũrĩ na mĩena { $numSides }
        *[head] mũhianĩre mũiganu
     }
-
 # The noun class. `c9` is the default and the class of every loanword.
 noun-gender =
     { $noun ->
@@ -154,7 +148,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «na …» phrase and closes the description, so it moves
@@ -169,26 +162,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] mũiyũre
         [c7] kĩiyũre
        *[c9] njiyũre
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -196,7 +185,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «mũhaka» is class 3 and leads its own describing words, so the border's words
 # agree with it rather than with the shape it surrounds. Gĩkũyũ has no article
 # and joins this clause with the invariable «na», so all four branches read
@@ -208,35 +196,28 @@ style-border-clause =
         [and-article] na mũhaka { $border }
        *[with] na mũhaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ndĩiyũre
-
 style-text =
     { $parts ->
         [background] { $color } igũrũ rĩa kĩhumo { $background }
        *[plain] { $color }
     }
-
 style-background-none = gũtirĩ kĩndũ
-
 
 ## Boolean words
 
 boolean-true = ma
 boolean-false = maheeni
 
-
 ## Answer buttons
 
 answer-submit-label = Rora Wĩra
 answer-submit-label-no-correctness = Tũma Macookio
-
 
 ## Sectional blocks
 
@@ -261,7 +242,6 @@ section-name =
     .solution = Ũtaũri
     .task = Wĩra
     .theorem = Thioremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -271,9 +251,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kĩrĩkanĩro
-
 
 ## Tables and figures
 
@@ -284,7 +262,6 @@ table-name =
         [unnumbered-title] Metha{ ": " }
        *[unnumbered] Metha
     }
-
 figure-name =
     { $parts ->
         [numbered] Mũhianano { $enumeration }
@@ -293,24 +270,18 @@ figure-name =
        *[unnumbered] Mũhianano
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ĩrĩa ĩhĩtũkĩte
 paginator-next = Ĩrĩa ĩrũmĩrĩire
 paginator-page = Karatathi
-
 paginator-page-status = { $pageLabel } { $currentPage } harĩ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kana
-
 piecewise-condition-if = angĩkorwo
-
 piecewise-condition-otherwise = angĩkorwo tiguo
-
 
 ## Chemistry
 ##
@@ -325,6 +296,5 @@ piecewise-condition-otherwise = angĩkorwo tiguo
 ## education system, two different answers.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kĩmenyithia kĩa Kemikaru Gĩtarĩ kĩega
 chemistry-invalid-ionic-compound = Mũtukanio wa Ayoni Ũtarĩ mwega

--- a/packages/i18n/locales/kk/chrome.ftl
+++ b/packages/i18n/locales/kk/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Тексерілуде…
 answer-submitting = Жіберілуде…
-
 answer-checking-status = Жауап тексерілуде
 answer-submitting-status = Жауап жіберілуде
-
 answer-correct = Дұрыс
 answer-incorrect = Қате
-
 answer-response-saved = Жауап сақталды
-
 answer-percent-credit = { $percent }% ұпай
 answer-percent-correct = { $percent }% дұрыс
 answer-percent-short = { $percent } %
-
 max-credit-available = Ең жоғары мүмкін ұпай: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] әрекет қалмады
         [one] { $count } әрекет қалды
        *[other] { $count } әрекет қалды
     }
-
 validation-correct = (Дұрыс)
 validation-incorrect = (Қате)
 validation-partially-correct = (Ішінара дұрыс)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } үшін { $count } жауапты көрсету
        *[other] { $answerId } үшін { $count } жауапты көрсету
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Кері байланыс
-
 collapsible-click-to-open = (ашу үшін басыңыз)
 collapsible-click-to-close = (жабу үшін басыңыз)
-
 collapsible-initializing = Дайындалуда…
-
 footnote-show = Сілтемені көрсету
 footnote-hide = Сілтемені жасыру
-
 description-more-information = қосымша ақпарат
-
 
 ## Controls
 
 slider-previous = Алдыңғы
 slider-next = Келесі
-
 keyboard-open = Пернетақтаны ашу
 keyboard-close = Пернетақтаны жабу
-
 choice-input-remove-choice = { $choice } таңдауын алып тастау
-
 matrix-remove-row = Жолды жою
 matrix-add-row = Жол қосу
 matrix-remove-column = Бағанды жою
 matrix-add-column = Баған қосу
-
 subset-add-remove-points = Нүктелерді қосу/жою
 subset-toggle-points-intervals = Нүктелер мен аралықтарды ауыстыру
 subset-move-points = Нүктелерді жылжыту
 subset-clear = Тазалау
-
 orbital-add-row = Жол қосу
 orbital-remove-row = Жолды жою
 orbital-add-box = Ұяшық қосу
@@ -92,13 +73,9 @@ orbital-remove-box = Ұяшықты жою
 orbital-add-up-arrow = Жоғары бағытталған көрсеткі қосу
 orbital-add-down-arrow = Төмен бағытталған көрсеткі қосу
 orbital-remove-arrow = Көрсеткіні жою
-
 orbital-row-label = { $row } жолының белгісі
-
 pretzel-answer = Жауап
-
 summary-statistics-caption = { $column } бағанының жиынтық статистикасы
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = математикалық өрнекті алдын
 math-input-preview = Алдын ала қарау
 math-input-invalid-expression = Жарамсыз өрнек:
 
-
 ## Document status
 
 viewer-initializing = Дайындалуда…
 
-
 ## Errors
 
 error-heading = Қате
-
 error-found-at =
     { $span ->
         [line] { $startLine } жолында табылды.
        *[lines] { $startLine }–{ $endLine } жолдарында табылды.
     }
-
 document-contains-errors = Бұл құжатта қателер бар!
-
 diagnostic-heading-error = Қате
 diagnostic-heading-warning = Ескерту
 diagnostic-heading-information = Ақпарат
 diagnostic-heading-hint = Кеңес
-
 accessibility-heading-level-1 = WCAG AA қолжетімділік бұзушылығы
 accessibility-heading-level-2 = Қолжетімділік хабарламасы
-
 something-went-wrong = Бірдеңе дұрыс болмады.
-
 renderer-load-failed = бейнелеуішті жүктеу мүмкін болмады. Бетті жаңартыңыз.
-
 core-start-failed = Құжат қарау құралын іске қосу мүмкін болмады. Бетті жаңартыңыз.

--- a/packages/i18n/locales/kk/content.ftl
+++ b/packages/i18n/locales/kk/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = күлгін
     .pink = қызғылт
     .brown = қоңыр
-
 line-width =
     .thick = қалың
     .thin = жіңішке
-
 line-style =
     .dashed = үзік
     .dotted = нүктелі
-
 # Noun phrases: they stand in front of «өрнекті» and modify nothing.
 fill-style =
     .horizontal = көлденең сызық
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = кері диагональ сызық
     .dots = нүкте
     .diamonds = ромб
-
 noun =
     .line = түзу
     .line-segment = кесінді
@@ -77,7 +73,6 @@ noun =
     .diamond = ромб
     .cross = айқыш
     .plus = плюс
-
 # Kazakh builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -85,11 +80,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] дұрыс { $numSides }-бұрыш
     }
-
 # Kazakh has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -103,21 +96,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = боялған
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } өрнекті { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } өрнекті { $color } { $filled } { $noun }
@@ -125,7 +114,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } өрнекті { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «жиекті» — "bordered" — carries the "with a border" sense in its own suffix,
 # so neither a preposition nor an article is wanted, and all four branches read
 # alike except for the connective English needs and Kazakh does not.
@@ -136,15 +124,12 @@ style-border-clause =
         [and-article] және { $border } жиекті
        *[with] { $border } жиекті
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } өрнекті { $color } бояу
        *[plain] { $color } бояу
     }
-
 style-unfilled = боялмаған
-
 # «фонда» is the locative of «фон» and says "on the background" by itself, so
 # nothing stands between the two colours.
 style-text =
@@ -152,21 +137,17 @@ style-text =
         [background] { $background } фонда { $color }
        *[plain] { $color }
     }
-
 style-background-none = жоқ
-
 
 ## Boolean words
 
 boolean-true = ақиқат
 boolean-false = жалған
 
-
 ## Answer buttons
 
 answer-submit-label = Тексеру
 answer-submit-label-no-correctness = Жауапты жіберу
-
 
 ## Sectional blocks
 
@@ -191,7 +172,6 @@ section-name =
     .solution = Шешуі
     .task = Тапсырма
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -201,9 +181,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Кеңес
-
 
 ## Tables and figures
 
@@ -214,7 +192,6 @@ table-name =
         [unnumbered-title] Кесте{ ". " }
        *[unnumbered] Кесте
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration }-сурет
@@ -223,22 +200,18 @@ figure-name =
        *[unnumbered] Сурет
     }
 
-
 ## Paginator controls
 
 paginator-previous = Алдыңғы
 paginator-next = Келесі
 paginator-page = Бет
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = немесе
 piecewise-condition-if = егер
 piecewise-condition-otherwise = әйтпесе
-
 
 ## Chemistry
 
@@ -361,7 +334,6 @@ element-name =
     .lv = Ливерморий
     .ts = Теннессин
     .og = Оганесон
-
 element-anion-name =
     .h = Гидрид
     .c = Карбид
@@ -375,8 +347,6 @@ element-anion-name =
     .i = Йодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Жарамсыз химиялық таңба
 chemistry-invalid-ionic-compound = Жарамсыз иондық қосылыс

--- a/packages/i18n/locales/km/chrome.ftl
+++ b/packages/i18n/locales/km/chrome.ftl
@@ -24,69 +24,55 @@
 
 answer-checking = កំពុងពិនិត្យ...
 answer-submitting = កំពុងដាក់ស្នើ...
-
 answer-checking-status = កំពុងពិនិត្យចម្លើយ
 answer-submitting-status = កំពុងដាក់ស្នើចម្លើយ
-
 answer-correct = ត្រឹមត្រូវ
 answer-incorrect = មិនត្រឹមត្រូវ
-
 answer-response-saved = បានរក្សាទុកចម្លើយ
-
 answer-percent-credit = ពិន្ទុ { $percent }%
 answer-percent-correct = ត្រឹមត្រូវ { $percent }%
 answer-percent-short = { $percent }%
-
 max-credit-available = ពិន្ទុអតិបរមាដែលអាចទទួលបាន៖ { $percent }%
-
 attempts-remaining =
     { $count ->
-        [0] គ្មានឱកាសនៅសល់ទេ
-       *[other] នៅសល់ { $count } ឱកាស
+        [0] គ្មានការប៉ុនប៉ងនៅសល់ទេ
+        [one] នៅសល់ការប៉ុនប៉ងចំនួន { $count } ដង
+       *[other] នៅសល់ការប៉ុនប៉ងចំនួន { $count } ដង
     }
-
 validation-correct = (ត្រឹមត្រូវ)
 validation-incorrect = (មិនត្រឹមត្រូវ)
 validation-partially-correct = (ត្រឹមត្រូវខ្លះ)
-
-answer-show-responses = បង្ហាញចម្លើយ { $count } ដែលបានដាក់ស្នើទៅ { $answerId }
-
+answer-show-responses =
+    { $count ->
+        [one] បង្ហាញការឆ្លើយតបចំនួន { $count } ទៅកាន់ { $answerId }
+       *[other] បង្ហាញការឆ្លើយតបចំនួន { $count } ទៅកាន់ { $answerId }
+    }
 
 ## Disclosure panels
 
 feedback-heading = មតិយោបល់
-
 collapsible-click-to-open = (ចុចដើម្បីបើក)
 collapsible-click-to-close = (ចុចដើម្បីបិទ)
-
 collapsible-initializing = កំពុងចាប់ផ្ដើម...
-
 footnote-show = បង្ហាញលេខយោង
 footnote-hide = លាក់លេខយោង
-
 description-more-information = ព័ត៌មានបន្ថែម
-
 
 ## Controls
 
 slider-previous = មុន
 slider-next = បន្ទាប់
-
 keyboard-open = បើកក្ដារចុច
 keyboard-close = បិទក្ដារចុច
-
 choice-input-remove-choice = ដក { $choice } ចេញ
-
 matrix-remove-row = លុបជួរដេក
 matrix-add-row = បន្ថែមជួរដេក
 matrix-remove-column = លុបជួរឈរ
 matrix-add-column = បន្ថែមជួរឈរ
-
 subset-add-remove-points = បន្ថែម/ដកចំណុច
 subset-toggle-points-intervals = ប្ដូររវាងចំណុច និងចន្លោះ
 subset-move-points = ផ្លាស់ទីចំណុច
 subset-clear = សម្អាត
-
 orbital-add-row = បន្ថែមជួរដេក
 orbital-remove-row = លុបជួរដេក
 orbital-add-box = បន្ថែមប្រអប់
@@ -94,13 +80,9 @@ orbital-remove-box = លុបប្រអប់
 orbital-add-up-arrow = បន្ថែមព្រួញឡើងលើ
 orbital-add-down-arrow = បន្ថែមព្រួញចុះក្រោម
 orbital-remove-arrow = លុបព្រួញ
-
 orbital-row-label = ស្លាកសម្រាប់ជួរដេកទី { $row }
-
 pretzel-answer = ចម្លើយ
-
 summary-statistics-caption = ស្ថិតិសង្ខេបនៃ { $column }
-
 
 ## Math input
 
@@ -108,34 +90,25 @@ math-input-preview-region = ការមើលកន្សោមគណិតវ�
 math-input-preview = មើលជាមុន
 math-input-invalid-expression = កន្សោមមិនត្រឹមត្រូវ៖
 
-
 ## Document status
 
 viewer-initializing = កំពុងចាប់ផ្ដើម...
 
-
 ## Errors
 
 error-heading = កំហុស
-
 error-found-at =
     { $span ->
         [line] រកឃើញនៅបន្ទាត់ទី { $startLine }។
        *[lines] រកឃើញនៅបន្ទាត់ទី { $startLine }–{ $endLine }។
     }
-
 document-contains-errors = ឯកសារនេះមានកំហុស!
-
 diagnostic-heading-error = កំហុស
 diagnostic-heading-warning = ការព្រមាន
 diagnostic-heading-information = ព័ត៌មាន
 diagnostic-heading-hint = ការណែនាំ
-
 accessibility-heading-level-1 = ការបំពានលទ្ធភាពប្រើប្រាស់ WCAG AA
 accessibility-heading-level-2 = ការជូនដំណឹងអំពីលទ្ធភាពប្រើប្រាស់
-
 something-went-wrong = មានបញ្ហាកើតឡើង។
-
 renderer-load-failed = កម្មវិធីបង្ហាញមួយផ្ទុកមិនបានទេ។ សូមផ្ទុកទំព័រឡើងវិញ។
-
 core-start-failed = មិនអាចចាប់ផ្ដើមកម្មវិធីមើលឯកសារបានទេ។ សូមផ្ទុកទំព័រឡើងវិញ។

--- a/packages/i18n/locales/km/content.ftl
+++ b/packages/i18n/locales/km/content.ftl
@@ -45,15 +45,12 @@ color =
     .purple = ពណ៌ស្វាយ
     .pink = ពណ៌ផ្កាឈូក
     .brown = ពណ៌ត្នោត
-
 line-width =
     .thick = ក្រាស់
     .thin = ស្ដើង
-
 line-style =
     .dashed = ដាច់ៗ
     .dotted = ចុចៗ
-
 # Noun phrases: they follow «ជាមួយ» and modify nothing.
 fill-style =
     .horizontal = បន្ទាត់ដេក
@@ -62,7 +59,6 @@ fill-style =
     .backdiagonal = បន្ទាត់ទ្រេតបញ្ច្រាស
     .dots = ចំណុច
     .diamonds = រាងចតុកោណស្មើ
-
 noun =
     .line = បន្ទាត់
     .line-segment = អង្កត់
@@ -82,7 +78,6 @@ noun =
     .diamond = រាងចតុកោណស្មើ
     .cross = សញ្ញាកាកបាទ
     .plus = សញ្ញាបូក
-
 # A Khmer count follows what it counts and takes its own classifier word:
 # «ពហុកោណនិយ័ត 5 ជ្រុង», where «ជ្រុង» is the word for side. That whole group
 # sits immediately after the noun and in front of any adjective, so it folds
@@ -93,11 +88,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] ពហុកោណនិយ័ត { $numSides } ជ្រុង
     }
-
 # Khmer has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -111,26 +104,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «បន្ទាត់ក្រាស់ដាច់ៗពណ៌ក្រហម».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun }{ $description }{ $nounTail }
        *[noun] { $noun }{ $description }
     }
-
 # «លាប» is the verb for laying colour on a surface, and every colour word above
 # already carries its own «ពណ៌», so the composition reads «លាបពណ៌ខៀវ» with the
 # colour word said once. A colour that did not come from that table brings no
 # «ពណ៌» with it, and «លាប» stands in front of it unaided.
 style-filled-word = លាប
-
 style-filled =
     { $parts ->
         [pattern] { $filled }{ $color } ជាមួយ{ $pattern }
        *[plain] { $filled }{ $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun }{ $filled }{ $color } ជាមួយ{ $pattern }
@@ -138,7 +127,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun }{ $nounTail }{ $filled }{ $color } ជាមួយ{ $pattern }
        *[plain] { $noun }{ $filled }{ $color }
     }
-
 # «គែម» leads its own adjectives, the way every noun here does. Khmer has no
 # article, so the `-article` branches read like the ones without.
 style-border-clause =
@@ -148,36 +136,29 @@ style-border-clause =
         [and-article] និងគែម{ $border }
        *[with] ជាមួយគែម{ $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern }{ $color }
        *[plain] { $color }
     }
-
 style-unfilled = មិនលាបពណ៌
-
 style-text =
     { $parts ->
         [background] { $color }លើផ្ទៃខាងក្រោយ{ $background }
        *[plain] { $color }
     }
-
 style-background-none = គ្មាន
-
 
 ## Boolean words
 
 boolean-true = ពិត
 boolean-false = មិនពិត
 
-
 ## Answer buttons
 
 answer-submit-label = ពិនិត្យចម្លើយ
 answer-submit-label-no-correctness = ដាក់ស្នើចម្លើយ
-
 
 ## Sectional blocks
 
@@ -202,7 +183,6 @@ section-name =
     .solution = ដំណោះស្រាយ
     .task = កិច្ចការ
     .theorem = ទ្រឹស្តីបទ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -212,9 +192,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ការណែនាំ
-
 
 ## Tables and figures
 
@@ -225,7 +203,6 @@ table-name =
         [unnumbered-title] តារាង{ ": " }
        *[unnumbered] តារាង
     }
-
 figure-name =
     { $parts ->
         [numbered] រូបភាពទី { $enumeration }
@@ -234,22 +211,18 @@ figure-name =
        *[unnumbered] រូបភាព
     }
 
-
 ## Paginator controls
 
 paginator-previous = មុន
 paginator-next = បន្ទាប់
 paginator-page = ទំព័រ
-
 paginator-page-status = { $pageLabel } { $currentPage } ក្នុងចំណោម { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ឬ
 piecewise-condition-if = បើ
 piecewise-condition-otherwise = ក្នុងករណីផ្សេង
-
 
 ## Chemistry
 ##
@@ -265,6 +238,5 @@ piecewise-condition-otherwise = ក្នុងករណីផ្សេង
 ## it in needs no permission.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = សញ្ញាគីមីមិនត្រឹមត្រូវ
 chemistry-invalid-ionic-compound = សមាសធាតុអ៊ីយ៉ុងមិនត្រឹមត្រូវ

--- a/packages/i18n/locales/kmb/chrome.ftl
+++ b/packages/i18n/locales/kmb/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Mu kutala…
 answer-submitting = Mu kutuma…
-
 answer-checking-status = O kitambwijilu kya mu talwa
 answer-submitting-status = O kitambwijilu kya mu tumwa
-
 answer-correct = Kya bhonga
 answer-incorrect = Ki kya bhonga ko
-
 answer-response-saved = O Kitambwijilu Kya Lengejelwa
-
 answer-percent-credit = { $percent }% ya Mbandu
 answer-percent-correct = { $percent }% Kya bhonga
 answer-percent-short = { $percent } %
-
 max-credit-available = Mbandu ya dikota i utena kutambula: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ki kwala kilongelu ko
         [one] kilongelu { $count } kya sala
        *[other] ilongelu { $count } ya sala
     }
-
 validation-correct = (Kya bhonga)
 validation-incorrect = (Ki kya bhonga ko)
 validation-partially-correct = (Kya bhonga mu kitangana)
-
 answer-show-responses =
     { $count ->
         [one] Londekesa kitambwijilu { $count } kya { $answerId }
        *[other] Londekesa itambwijilu { $count } ya { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Kitambwijilu
-
 collapsible-click-to-open = (kwata phala kujikula)
 collapsible-click-to-close = (kwata phala kujika)
-
 collapsible-initializing = Mu kumatekesa…
-
 footnote-show = Londekesa kisonekenu kya boxi
 footnote-hide = Sweka kisonekenu kya boxi
-
 description-more-information = ijimbwete ya mukwa
-
 
 ## Controls
 
 slider-previous = Ya bhitile
 slider-next = Ya kaya
-
 keyboard-open = Jikula o Kiteka
 keyboard-close = Jika o Kiteka
-
 choice-input-remove-choice = Katula { $choice }
-
 matrix-remove-row = Katula o nlonji
 matrix-add-row = Bhakela nlonji
 matrix-remove-column = Katula o koluna
 matrix-add-column = Bhakela koluna
-
 subset-add-remove-points = Bhakela/Katula jimbanza
 subset-toggle-points-intervals = Sokolola jimbanza ni jitembu
 subset-move-points = Kunanguna Jimbanza
 subset-clear = Katula yoso
-
 orbital-add-row = Bhakela Nlonji
 orbital-remove-row = Katula Nlonji
 orbital-add-box = Bhakela Kaxa
@@ -87,13 +68,9 @@ orbital-remove-box = Katula Kaxa
 orbital-add-up-arrow = Bhakela Seta ya Bhulu
 orbital-add-down-arrow = Bhakela Seta ya Boxi
 orbital-remove-arrow = Katula Seta
-
 orbital-row-label = Dijina dya nlonji { $row }
-
 pretzel-answer = Kitambwijilu
-
 summary-statistics-caption = Kijilu kya jinumeru ja { $column }
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = kutala kwa dyanga o kizwelu kya matematika
 math-input-preview = Tala dyanga
 math-input-invalid-expression = Kizwelu ki kyabhonga ko:
 
-
 ## Document status
 
 viewer-initializing = Mu kumatekesa…
 
-
 ## Errors
 
 error-heading = Kibhengelu
-
 error-found-at =
     { $span ->
         [line] Kya sangwa mu nlonji { $startLine }.
        *[lines] Kya sangwa mu jinlonji { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = O divulu didi dyala ni ibhengelu!
-
 diagnostic-heading-error = Kibhengelu
 diagnostic-heading-warning = Kidimbu
 diagnostic-heading-information = Kijimbwete
 diagnostic-heading-hint = Kikwatekesu
-
 accessibility-heading-level-1 = Kubhengela kwa WCAG AA mu Kubhixila
 accessibility-heading-level-2 = Kidimbu kya kubhixila
-
 something-went-wrong = Kima kya mukwa ki kya bhonga ko.
-
 renderer-load-failed = o mulondekesi umoxi ki weza ko. Tu ku bhinga, vutulula o kibhamba.
-
 core-start-failed = O mulondekesi wa divulu ki wa tenene kumatekesa ko. Tu ku bhinga, vutulula o kibhamba.

--- a/packages/i18n/locales/kmb/content.ftl
+++ b/packages/i18n/locales/kmb/content.ftl
@@ -88,7 +88,6 @@ color =
     .purple = ya roxu
     .pink = ya rosa
     .brown = ya kastanyu
-
 line-width =
     .thick =
         { $gender ->
@@ -104,14 +103,12 @@ line-width =
             [c10] ja tetuka
            *[c9] ya tetuka
         }
-
 # Written with the frozen class-9 «ya», the way the Portuguese loans above are:
 # these describe a manner rather than a quality, and a speaker does not agree
 # them with the shape. `style-stroke` puts them last so nothing follows them.
 line-style =
     .dashed = ya jinlonji jitetuka
     .dotted = ya jimbanza
-
 fill-style =
     .horizontal = jinlonji ja lala
     .vertical = jinlonji ja imana
@@ -119,7 +116,6 @@ fill-style =
     .backdiagonal = jinlonji ja bhita ku mbandu ya mukwa
     .dots = jimbanza
     .diamonds = jidiamanti
-
 noun =
     .line = nlonji
     .line-segment = kitangana kya nlonji
@@ -139,7 +135,6 @@ noun =
     .diamond = diamanti
     .cross = kuluzu
     .plus = kimbanza kya kubhakela
-
 # The side count is a counted complement and closes the noun phrase behind the
 # describing words, so it goes in the tail. «-a» agrees here too, but the head
 # noun is always the same word, so the form is fixed and needs no fork — which
@@ -149,7 +144,6 @@ noun-regular-polygon =
         [tail] ya jimbandu { $numSides }
        *[head] poligonu ya kusokela
     }
-
 # The noun class. `c9` is the default, which is what an author's own
 # `markerStyleWord` is as far as this catalog is concerned. Every noun with an
 # overt `ki-` — «kizenge», «kididi», «kitangana», «kimbanza» — answers `c7`, so
@@ -171,7 +165,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ya …» phrase and closes the description, so it moves
@@ -186,13 +179,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c5] dya kuizala
@@ -200,13 +191,11 @@ style-filled-word =
         [c10] ja kuizala
        *[c9] ya kuizala
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ni { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ni { $pattern }
@@ -214,7 +203,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ni { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «jimbandu» is the border and leads its own describing words, so they agree
 # with it rather than with the shape it surrounds — which is why `border`
 # answers `c10` in `noun-gender`. Kimbundu has no article and joins this clause
@@ -226,35 +214,28 @@ style-border-clause =
         [and-article] ni jimbandu { $border }
        *[with] ni jimbandu { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ki kya kuizala ko
-
 style-text =
     { $parts ->
         [background] { $color } ni kunima { $background }
        *[plain] { $color }
     }
-
 style-background-none = kima ki kwala ko
-
 
 ## Boolean words
 
 boolean-true = kidi
 boolean-false = makutu
 
-
 ## Answer buttons
 
 answer-submit-label = Tala o Kikalakalu
 answer-submit-label-no-correctness = Tuma o Kitambwijilu
-
 
 ## Sectional blocks
 
@@ -279,7 +260,6 @@ section-name =
     .solution = Kisokololwelu
     .task = Kikalakalu
     .theorem = Teoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -289,9 +269,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kikwatekesu
-
 
 ## Tables and figures
 
@@ -302,7 +280,6 @@ table-name =
         [unnumbered-title] Tabela{ ": " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Kifika { $enumeration }
@@ -311,25 +288,18 @@ figure-name =
        *[unnumbered] Kifika
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ya bhitile
 paginator-next = Ya kaya
-
 paginator-page = Kibhamba
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = mba
-
 piecewise-condition-if = se
-
 piecewise-condition-otherwise = mu ima yoso ya mukwa
-
 
 ## Chemistry
 ##
@@ -342,6 +312,5 @@ piecewise-condition-otherwise = mu ima yoso ya mukwa
 ## the substitution this seeding effort is careful not to make.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kimbanza kya Kimika ki Kyabhonga ko
 chemistry-invalid-ionic-compound = Kibhungu kya Ioni ki Kyabhonga ko

--- a/packages/i18n/locales/kn/chrome.ftl
+++ b/packages/i18n/locales/kn/chrome.ftl
@@ -21,74 +21,55 @@
 
 answer-checking = ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...
 answer-submitting = ಸಲ್ಲಿಸಲಾಗುತ್ತಿದೆ...
-
 answer-checking-status = ಉತ್ತರ ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ
 answer-submitting-status = ಉತ್ತರ ಸಲ್ಲಿಸಲಾಗುತ್ತಿದೆ
-
 answer-correct = ಸರಿ
 answer-incorrect = ತಪ್ಪು
-
 answer-response-saved = ಉತ್ತರ ಉಳಿಸಲಾಗಿದೆ
-
 answer-percent-credit = { $percent }% ಅಂಕ
 answer-percent-correct = { $percent }% ಸರಿ
 answer-percent-short = { $percent }%
-
 max-credit-available = ಲಭ್ಯವಿರುವ ಗರಿಷ್ಠ ಅಂಕ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ಯಾವುದೇ ಪ್ರಯತ್ನ ಉಳಿದಿಲ್ಲ
         [one] { $count } ಪ್ರಯತ್ನ ಉಳಿದಿದೆ
        *[other] { $count } ಪ್ರಯತ್ನಗಳು ಉಳಿದಿವೆ
     }
-
 validation-correct = (ಸರಿ)
 validation-incorrect = (ತಪ್ಪು)
 validation-partially-correct = (ಭಾಗಶಃ ಸರಿ)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } ಗೆ ಬಂದ { $count } ಉತ್ತರವನ್ನು ತೋರಿಸು
        *[other] { $answerId } ಗೆ ಬಂದ { $count } ಉತ್ತರಗಳನ್ನು ತೋರಿಸು
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ಪ್ರತಿಕ್ರಿಯೆ
-
 collapsible-click-to-open = (ತೆರೆಯಲು ಕ್ಲಿಕ್ ಮಾಡಿ)
 collapsible-click-to-close = (ಮುಚ್ಚಲು ಕ್ಲಿಕ್ ಮಾಡಿ)
-
 collapsible-initializing = ಆರಂಭವಾಗುತ್ತಿದೆ...
-
 footnote-show = ಅಡಿಟಿಪ್ಪಣಿ ತೋರಿಸು
 footnote-hide = ಅಡಿಟಿಪ್ಪಣಿ ಮರೆಮಾಡು
-
 description-more-information = ಹೆಚ್ಚಿನ ಮಾಹಿತಿ
-
 
 ## Controls
 
 slider-previous = ಹಿಂದಿನದು
 slider-next = ಮುಂದಿನದು
-
 keyboard-open = ಕೀಲಿಮಣೆ ತೆರೆ
 keyboard-close = ಕೀಲಿಮಣೆ ಮುಚ್ಚು
-
 choice-input-remove-choice = { $choice } ತೆಗೆ
-
 matrix-remove-row = ಸಾಲು ತೆಗೆ
 matrix-add-row = ಸಾಲು ಸೇರಿಸು
 matrix-remove-column = ಕಂಬ ತೆಗೆ
 matrix-add-column = ಕಂಬ ಸೇರಿಸು
-
 subset-add-remove-points = ಬಿಂದುಗಳನ್ನು ಸೇರಿಸು/ತೆಗೆ
 subset-toggle-points-intervals = ಬಿಂದುಗಳು ಮತ್ತು ಅಂತರಗಳ ನಡುವೆ ಬದಲಿಸು
 subset-move-points = ಬಿಂದುಗಳನ್ನು ಸರಿಸು
 subset-clear = ಅಳಿಸು
-
 # A `box` here is one orbital, drawn as a square: ಚೌಕ.
 orbital-add-row = ಸಾಲು ಸೇರಿಸು
 orbital-remove-row = ಸಾಲು ತೆಗೆ
@@ -97,13 +78,9 @@ orbital-remove-box = ಚೌಕ ತೆಗೆ
 orbital-add-up-arrow = ಮೇಲ್ಬಾಣ ಸೇರಿಸು
 orbital-add-down-arrow = ಕೆಳಬಾಣ ಸೇರಿಸು
 orbital-remove-arrow = ಬಾಣ ತೆಗೆ
-
 orbital-row-label = ಸಾಲು { $row } ಗೆ ಲೇಬಲ್
-
 pretzel-answer = ಉತ್ತರ
-
 summary-statistics-caption = { $column } ನ ಸಾರಾಂಶ ಅಂಕಿಅಂಶಗಳು
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = ಗಣಿತ ಅಭಿವ್ಯಕ್ತಿ ಮು�
 math-input-preview = ಮುನ್ನೋಟ
 math-input-invalid-expression = ಅಮಾನ್ಯ ಅಭಿವ್ಯಕ್ತಿ:
 
-
 ## Document status
 
 viewer-initializing = ಆರಂಭವಾಗುತ್ತಿದೆ...
 
-
 ## Errors
 
 error-heading = ದೋಷ
-
 error-found-at =
     { $span ->
         [line] { $startLine } ನೇ ಸಾಲಿನಲ್ಲಿ ಕಂಡುಬಂದಿದೆ.
        *[lines] { $startLine }–{ $endLine } ಸಾಲುಗಳಲ್ಲಿ ಕಂಡುಬಂದಿದೆ.
     }
-
 document-contains-errors = ಈ ದಸ್ತಾವೇಜಿನಲ್ಲಿ ದೋಷಗಳಿವೆ!
-
 diagnostic-heading-error = ದೋಷ
 diagnostic-heading-warning = ಎಚ್ಚರಿಕೆ
 diagnostic-heading-information = ಮಾಹಿತಿ
 diagnostic-heading-hint = ಸುಳಿವು
-
 accessibility-heading-level-1 = WCAG AA ಪ್ರವೇಶಸಾಧ್ಯತೆ ಉಲ್ಲಂಘನೆ
 accessibility-heading-level-2 = ಪ್ರವೇಶಸಾಧ್ಯತೆ ಎಚ್ಚರಿಕೆ
-
 something-went-wrong = ಏನೋ ತಪ್ಪಾಗಿದೆ.
-
 renderer-load-failed = ಒಂದು ರೆಂಡರರ್ ಲೋಡ್ ಆಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಪುಟವನ್ನು ಮತ್ತೆ ಲೋಡ್ ಮಾಡಿ.
-
 core-start-failed = ದಸ್ತಾವೇಜು ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಲಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಪುಟವನ್ನು ಮತ್ತೆ ಲೋಡ್ ಮಾಡಿ.

--- a/packages/i18n/locales/kn/content.ftl
+++ b/packages/i18n/locales/kn/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = ನೇರಳೆ
     .pink = ಗುಲಾಬಿ
     .brown = ಕಂದು
-
 line-width =
     .thick = ದಪ್ಪ
     .thin = ತೆಳು
-
 line-style =
     .dashed = ತುಂಡು ಗೆರೆಯ
     .dotted = ಚುಕ್ಕಿಯ
-
 # Noun phrases: they stand in front of the «ಜೊತೆಗೆ» the composition messages
 # supply, and modify nothing.
 fill-style =
@@ -58,7 +55,6 @@ fill-style =
     .backdiagonal = ವಿರುದ್ಧ ಕರ್ಣ ಗೆರೆಗಳು
     .dots = ಚುಕ್ಕಿಗಳು
     .diamonds = ವಜ್ರಾಕೃತಿಗಳು
-
 noun =
     .line = ಸರಳರೇಖೆ
     .line-segment = ರೇಖಾಖಂಡ
@@ -78,7 +74,6 @@ noun =
     .diamond = ವಜ್ರಾಕೃತಿ
     .cross = ಅಡ್ಡಗುರುತು
     .plus = ಕೂಡಿಸು ಗುರುತು
-
 # The side count precedes the noun, as every modifier in Kannada does, so it
 # folds into the head and there is no tail.
 noun-regular-polygon =
@@ -86,12 +81,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ಬಾಹುಗಳ ಸಮ ಬಹುಭುಜಾಕೃತಿ
     }
-
 # Kannada marks gender on verbs and pronouns, not on the adjectives in these
 # phrases, so every noun answers the same and the answer goes unused — as in
 # English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,21 +98,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ತುಂಬಿದ
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } ಜೊತೆಗೆ
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } ಜೊತೆಗೆ
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } ಜೊತೆಗೆ
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ಅಂಚು» is a fixed word, so the comitative is written onto it directly, and
 # «ಮತ್ತು» opens the further clause where English opens it with "and". Kannada
 # has no article, so the two `-article` branches read like the ones without.
@@ -138,15 +126,12 @@ style-border-clause =
         [and-article] ಮತ್ತು { $border } ಅಂಚಿನೊಂದಿಗೆ
        *[with] { $border } ಅಂಚಿನೊಂದಿಗೆ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ತುಂಬದ
-
 # «ಹಿನ್ನೆಲೆ» takes the locative -ಯಲ್ಲಿ, so the background leads and the text
 # colour follows it.
 style-text =
@@ -154,21 +139,17 @@ style-text =
         [background] { $background } ಹಿನ್ನೆಲೆಯಲ್ಲಿ { $color }
        *[plain] { $color }
     }
-
 style-background-none = ಯಾವುದೂ ಇಲ್ಲ
-
 
 ## Boolean words
 
 boolean-true = ನಿಜ
 boolean-false = ಸುಳ್ಳು
 
-
 ## Answer buttons
 
 answer-submit-label = ಪರಿಶೀಲಿಸು
 answer-submit-label-no-correctness = ಉತ್ತರ ಸಲ್ಲಿಸು
-
 
 ## Sectional blocks
 
@@ -193,7 +174,6 @@ section-name =
     .solution = ಪರಿಹಾರ
     .task = ಕಾರ್ಯ
     .theorem = ಪ್ರಮೇಯ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -203,9 +183,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ಸುಳಿವು
-
 
 ## Tables and figures
 
@@ -216,7 +194,6 @@ table-name =
         [unnumbered-title] ಕೋಷ್ಟಕ{ ": " }
        *[unnumbered] ಕೋಷ್ಟಕ
     }
-
 figure-name =
     { $parts ->
         [numbered] ಚಿತ್ರ { $enumeration }
@@ -225,17 +202,14 @@ figure-name =
        *[unnumbered] ಚಿತ್ರ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ಹಿಂದಿನದು
 paginator-next = ಮುಂದಿನದು
 paginator-page = ಪುಟ
-
 # The total leads, marked with the locative -ರಲ್ಲಿ, which is how Kannada says
 # "3 of 5".
 paginator-page-status = { $numPages } ರಲ್ಲಿ { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
@@ -243,8 +217,8 @@ piecewise-condition-or = ಅಥವಾ
 piecewise-condition-if = ಒಂದು ವೇಳೆ
 piecewise-condition-otherwise = ಇಲ್ಲದಿದ್ದರೆ
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and the 130
 # keys fall back to English.
@@ -263,6 +237,5 @@ piecewise-condition-otherwise = ಇಲ್ಲದಿದ್ದರೆ
 # letters this close to these, supplies the names its textbooks use.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ಅಮಾನ್ಯ ರಾಸಾಯನಿಕ ಸಂಕೇತ
 chemistry-invalid-ionic-compound = ಅಮಾನ್ಯ ಅಯಾನಿಕ ಸಂಯುಕ್ತ

--- a/packages/i18n/locales/ko/chrome.ftl
+++ b/packages/i18n/locales/ko/chrome.ftl
@@ -23,69 +23,50 @@
 
 answer-checking = 확인 중...
 answer-submitting = 제출 중...
-
 answer-checking-status = 답안을 확인하는 중
 answer-submitting-status = 답안을 제출하는 중
-
 answer-correct = 정답
 answer-incorrect = 오답
-
 answer-response-saved = 답안이 저장되었습니다
-
 answer-percent-credit = { $percent }% 점수
 answer-percent-correct = { $percent }% 정답
 answer-percent-short = { $percent }%
-
 max-credit-available = 받을 수 있는 최고 점수: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] 남은 시도 횟수가 없습니다
        *[other] { $count }회 남음
     }
-
 validation-correct = (정답)
 validation-incorrect = (오답)
 validation-partially-correct = (부분 정답)
-
 answer-show-responses = { $answerId }에 대한 답안 { $count }개 보기
-
 
 ## Disclosure panels
 
 feedback-heading = 피드백
-
 collapsible-click-to-open = (클릭하여 열기)
 collapsible-click-to-close = (클릭하여 닫기)
-
 collapsible-initializing = 초기화 중...
-
 footnote-show = 각주 보기
 footnote-hide = 각주 숨기기
-
 description-more-information = 자세한 정보
-
 
 ## Controls
 
 slider-previous = 이전
 slider-next = 다음
-
 keyboard-open = 키보드 열기
 keyboard-close = 키보드 닫기
-
 choice-input-remove-choice = { $choice } 삭제
-
 matrix-remove-row = 행 삭제
 matrix-add-row = 행 추가
 matrix-remove-column = 열 삭제
 matrix-add-column = 열 추가
-
 subset-add-remove-points = 점 추가/삭제
 subset-toggle-points-intervals = 점과 구간 전환
 subset-move-points = 점 이동
 subset-clear = 지우기
-
 # A `box` here is one orbital, drawn as a square: 상자.
 orbital-add-row = 행 추가
 orbital-remove-row = 행 삭제
@@ -94,13 +75,9 @@ orbital-remove-box = 상자 삭제
 orbital-add-up-arrow = 위쪽 화살표 추가
 orbital-add-down-arrow = 아래쪽 화살표 추가
 orbital-remove-arrow = 화살표 삭제
-
 orbital-row-label = { $row }행의 레이블
-
 pretzel-answer = 답
-
 summary-statistics-caption = { $column }의 요약 통계량
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = 수식 미리 보기
 math-input-preview = 미리 보기
 math-input-invalid-expression = 잘못된 수식:
 
-
 ## Document status
 
 viewer-initializing = 초기화 중...
 
-
 ## Errors
 
 error-heading = 오류
-
 error-found-at =
     { $span ->
         [line] { $startLine }행에서 발견되었습니다.
        *[lines] { $startLine }–{ $endLine }행에서 발견되었습니다.
     }
-
 document-contains-errors = 이 문서에는 오류가 있습니다!
-
 diagnostic-heading-error = 오류
 diagnostic-heading-warning = 경고
 diagnostic-heading-information = 정보
 diagnostic-heading-hint = 힌트
-
 accessibility-heading-level-1 = WCAG AA 접근성 위반
 accessibility-heading-level-2 = 접근성 알림
-
 something-went-wrong = 문제가 발생했습니다.
-
 renderer-load-failed = 렌더러를 불러오지 못했습니다. 페이지를 새로 고쳐 주세요.
-
 core-start-failed = 문서 뷰어를 시작할 수 없습니다. 페이지를 새로 고쳐 주세요.

--- a/packages/i18n/locales/ko/content.ftl
+++ b/packages/i18n/locales/ko/content.ftl
@@ -30,15 +30,12 @@ color =
     .purple = 보라색
     .pink = 분홍색
     .brown = 갈색
-
 line-width =
     .thick = 굵은
     .thin = 가는
-
 line-style =
     .dashed = 파선
     .dotted = 점선
-
 # Noun phrases: they precede 무늬가 있는 and modify nothing.
 fill-style =
     .horizontal = 가로줄
@@ -47,7 +44,6 @@ fill-style =
     .backdiagonal = 역대각선
     .dots = 점
     .diamonds = 마름모
-
 noun =
     .line = 직선
     .line-segment = 선분
@@ -67,7 +63,6 @@ noun =
     .diamond = 마름모
     .cross = 십자
     .plus = 더하기 기호
-
 # Korean puts the side count inside the noun itself — 정5각형 — so the whole
 # thing is one head and there is no tail.
 noun-regular-polygon =
@@ -75,11 +70,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] 정{ $numSides }각형
     }
-
 # Korean has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -95,21 +88,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = 채워진
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } 무늬가 있는 { $color }으로 { $filled }
        *[plain] { $color }으로 { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } 무늬가 있는 { $color }으로 { $filled } { $noun }
@@ -117,7 +106,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } 무늬가 있는 { $color }으로 { $filled } { $noun } { $nounTail }
        *[plain] { $color }으로 { $filled } { $noun }
     }
-
 # Korean needs no article, so the `-article` branches read the same as the ones
 # without.
 style-border-clause =
@@ -127,35 +115,28 @@ style-border-clause =
         [and-article] 그리고 { $border } 테두리
        *[with] { $border } 테두리가 있는
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = 채워지지 않은
-
 style-text =
     { $parts ->
         [background] { $color }, 배경은 { $background }
        *[plain] { $color }
     }
-
 style-background-none = 없음
-
 
 ## Boolean words
 
 boolean-true = 참
 boolean-false = 거짓
 
-
 ## Answer buttons
 
 answer-submit-label = 정답 확인
 answer-submit-label-no-correctness = 답안 제출
-
 
 ## Sectional blocks
 
@@ -180,7 +161,6 @@ section-name =
     .solution = 풀이
     .task = 과제
     .theorem = 정리
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -190,9 +170,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = 힌트
-
 
 ## Tables and figures
 
@@ -203,7 +181,6 @@ table-name =
         [unnumbered-title] 표{ ": " }
        *[unnumbered] 표
     }
-
 figure-name =
     { $parts ->
         [numbered] 그림 { $enumeration }
@@ -212,15 +189,12 @@ figure-name =
        *[unnumbered] 그림
     }
 
-
 ## Paginator controls
 
 paginator-previous = 이전
 paginator-next = 다음
 paginator-page = 페이지
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
@@ -229,7 +203,6 @@ piecewise-condition-or = 또는
 # that can come first — 만약 rather than the clause-final 일 때.
 piecewise-condition-if = 만약
 piecewise-condition-otherwise = 그 외의 경우
-
 
 ## Chemistry
 
@@ -354,7 +327,6 @@ element-name =
     .lv = 리버모륨
     .ts = 테네신
     .og = 오가네손
-
 element-anion-name =
     .h = 수소화물
     .c = 탄화물
@@ -368,8 +340,6 @@ element-anion-name =
     .i = 아이오딘화물
     .at = 아스타틴화물
     .ts = 테네신화물
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = 잘못된 화학 기호
 chemistry-invalid-ionic-compound = 잘못된 이온 화합물

--- a/packages/i18n/locales/kok/chrome.ftl
+++ b/packages/i18n/locales/kok/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = तपासता…
 answer-submitting = धाडटा…
-
 answer-checking-status = जाप तपासता
 answer-submitting-status = जाप धाडटा
-
 answer-correct = बरोबर
 answer-incorrect = चुकीचें
-
 answer-response-saved = जाप जतनाय केली
-
 answer-percent-credit = { $percent }% गुण
 answer-percent-correct = { $percent }% बरोबर
 answer-percent-short = { $percent } %
-
 max-credit-available = चडांत चड मेळपाचे गुण: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] एकूय यत्न उरूंक ना
         [one] { $count } यत्न उरला
        *[other] { $count } यत्न उरल्यात
     }
-
 validation-correct = (बरोबर)
 validation-incorrect = (चुकीचें)
 validation-partially-correct = (अर्दकुटें बरोबर)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } खातीर { $count } जाप दाखयात
        *[other] { $answerId } खातीर { $count } जापो दाखयात
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिसाद
-
 collapsible-click-to-open = (उगडपाक क्लिक करात)
 collapsible-click-to-close = (बंद करपाक क्लिक करात)
-
 collapsible-initializing = सुरू जाता…
-
 footnote-show = तळटीप दाखयात
 footnote-hide = तळटीप लिपयात
-
 description-more-information = चड म्हायती
-
 
 ## Controls
 
 slider-previous = फाटलें
 slider-next = फुडलें
-
 keyboard-open = कळफलक उगडात
 keyboard-close = कळफलक बंद करात
-
 choice-input-remove-choice = { $choice } काडून उडयात
-
 matrix-remove-row = ओळ काडून उडयात
 matrix-add-row = ओळ जोडात
 matrix-remove-column = स्तंभ काडून उडयात
 matrix-add-column = स्तंभ जोडात
-
 subset-add-remove-points = बिंदू जोडात/काडात
 subset-toggle-points-intervals = बिंदू आनी अंतराळ बदलात
 subset-move-points = बिंदू हालयात
 subset-clear = पुसात
-
 orbital-add-row = ओळ जोडात
 orbital-remove-row = ओळ काडून उडयात
 orbital-add-box = पेटी जोडात
@@ -87,13 +68,9 @@ orbital-remove-box = पेटी काडून उडयात
 orbital-add-up-arrow = वयलो बाण जोडात
 orbital-add-down-arrow = सकयलो बाण जोडात
 orbital-remove-arrow = बाण काडून उडयात
-
 orbital-row-label = ओळ { $row } खातीर नामपट्टी
-
 pretzel-answer = जाप
-
 summary-statistics-caption = { $column } हाचो सांख्यिकी सार
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = गणिती अभिव्यक्तीची
 math-input-preview = झलक
 math-input-invalid-expression = अवैध अभिव्यक्ती:
 
-
 ## Document status
 
 viewer-initializing = सुरू जाता…
 
-
 ## Errors
 
 error-heading = चूक
-
 error-found-at =
     { $span ->
         [line] ओळ { $startLine } चेर मेळ्ळें।
        *[lines] ओळ { $startLine }–{ $endLine } चेर मेळ्ळें।
     }
-
 document-contains-errors = ह्या दस्तावेजांत चुको आसात!
-
 diagnostic-heading-error = चूक
 diagnostic-heading-warning = शिटकावणी
 diagnostic-heading-information = म्हायती
 diagnostic-heading-hint = सुचोवणी
-
 accessibility-heading-level-1 = WCAG AA सुगमताय उल्लंघन
 accessibility-heading-level-2 = सुगमताय सुचोवणी
-
 something-went-wrong = कितेंतरी चुकलें।
-
 renderer-load-failed = एक प्रदर्शक लोड जावंक ना। उपकार करून पान परत लोड करात।
-
 core-start-failed = दस्तावेज दर्शक सुरू जावंक ना। उपकार करून पान परत लोड करात।

--- a/packages/i18n/locales/kok/content.ftl
+++ b/packages/i18n/locales/kok/content.ftl
@@ -138,12 +138,10 @@ color =
         }
     .pink = गुलाबी
     .brown = तपकिरी
-
 # Neither ends in -ो, so neither inflects.
 line-width =
     .thick = जाड
     .thin = बारीक
-
 # «तुटक» is invariable; «टिंबांचो» is a genitive adjective and inflects like
 # any other word in -ो.
 line-style =
@@ -160,7 +158,6 @@ line-style =
                    *[m] टिंबांचो
                 }
         }
-
 # Plural nouns rather than adjectives, with genders of their own. «वापरून»
 # ("using") is invariable and takes them bare, which is what lets both
 # `style-filled` and `style-fill` set them beside a colour that agrees with
@@ -172,7 +169,6 @@ fill-style =
     .backdiagonal = उरफाट्यो तिरप्यो रेघो
     .dots = टिंबां
     .diamonds = समभुज चौकोन
-
 noun =
     .line = रेघ
     .line-segment = रेघखंड
@@ -192,7 +188,6 @@ noun =
     .diamond = समभुज चौकोन
     .cross = फुली
     .plus = अधिक चिन्न
-
 # «भुजांचो» agrees with «बहुभुज», which is masculine, so the count attaches to
 # the noun that follows and there is no tail.
 noun-regular-polygon =
@@ -200,7 +195,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } भुजांचो नेमकीचो बहुभुज
     }
-
 # Besides the nouns above, `$noun` may be «regular-polygon» (बहुभुज, m) or the
 # head of a phrase the description does not name: «border» (कड, f), «fill»
 # (भरण, n), «text» (मजकूर, m), «background» (फांटभूंय, f).
@@ -218,7 +212,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -231,13 +224,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -246,7 +237,6 @@ style-filled-word =
         [n] भरिल्लें
        *[m] भरिल्लो
     }
-
 # «वापरून» ("using") is invariable and takes the pattern bare, so the clause
 # English appends comes to the front here.
 style-filled =
@@ -254,7 +244,6 @@ style-filled =
         [pattern] { $pattern } वापरून { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } वापरून { $filled } { $color } { $noun }
@@ -262,7 +251,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } वापरून { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # -सयत is a postposition, so «कड» goes oblique to «कडे-» and the adjectives in
 # front of it take the oblique -या that `border-clause` supplies. Konkani has
 # no article, which leaves the `-article` branches reading like the others.
@@ -273,7 +261,6 @@ style-border-clause =
         [and-article] आनी { $border } कडेसयत
        *[with] { $border } कडेसयत
     }
-
 # The colour arrives agreeing with «भरण», which is neuter, so it needs that
 # noun beside it.
 style-fill =
@@ -281,9 +268,7 @@ style-fill =
         [pattern] { $pattern } वापरून { $color } भरण
        *[plain] { $color } भरण
     }
-
 style-unfilled = भरणाविणें
-
 # -एर is a postposition too, so the background's colour is oblique; the text's
 # own colour, which follows, agrees with «मजकूर» and is direct masculine.
 style-text =
@@ -291,21 +276,17 @@ style-text =
         [background] { $background } फांटभुंयेर { $color }
        *[plain] { $color }
     }
-
 style-background-none = कांयच ना
-
 
 ## Boolean words
 
 boolean-true = खरें
 boolean-false = फट
 
-
 ## Answer buttons
 
 answer-submit-label = तपासात
 answer-submit-label-no-correctness = जाप धाडात
-
 
 ## Sectional blocks
 
@@ -330,7 +311,6 @@ section-name =
     .solution = सोडवण
     .task = काम
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -340,9 +320,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = सुचोवणी
-
 
 ## Tables and figures
 
@@ -353,7 +331,6 @@ table-name =
         [unnumbered-title] कोश्टक{ ": " }
        *[unnumbered] कोश्टक
     }
-
 figure-name =
     { $parts ->
         [numbered] आकृती { $enumeration }
@@ -362,27 +339,21 @@ figure-name =
        *[unnumbered] आकृती
     }
 
-
 ## Paginator controls
 
 paginator-previous = फाटलें
 paginator-next = फुडलें
 paginator-page = पान
-
 # «X पैकीं Y» — "Y out of X" — puts the total first, so the two counts change
 # places. «पैकीं» is the partitive, Marathi's «पैकी»; «भितर» would read
 # "inside".
 paginator-page-status = { $numPages } पैकीं { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = वा
-
 piecewise-condition-if = जर
-
 piecewise-condition-otherwise = ना जाल्यार
-
 
 ## Chemistry
 ##
@@ -397,6 +368,5 @@ piecewise-condition-otherwise = ना जाल्यार
 ## which other language does the teaching.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अवैध रसायनीक चिन्न
 chemistry-invalid-ionic-compound = अवैध आयनीक संयुग

--- a/packages/i18n/locales/kpe/chrome.ftl
+++ b/packages/i18n/locales/kpe/chrome.ftl
@@ -42,74 +42,55 @@
 
 answer-checking = A bɛi kɔlɔ-taa…
 answer-submitting = A bɛi ci-taa…
-
 answer-checking-status = Jaabi kɔlɔ-taa
 answer-submitting-status = Jaabi ci-taa
-
 answer-correct = A tɔɔ
 answer-incorrect = A tɔɔ gaa
-
 answer-response-saved = Jaabi marala
-
 answer-percent-credit = { $percent }% pɔn
 answer-percent-correct = { $percent }% tɔɔ
 answer-percent-short = { $percent } %
-
 max-credit-available = Pɔn gbɛtɛ mu wa sɔrɔ ma: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kɛcogo he to gaa
         [one] kɛcogo { $count } to
        *[other] kɛcogo { $count } to
     }
-
 validation-correct = (A tɔɔ)
 validation-incorrect = (A tɔɔ gaa)
 validation-partially-correct = (A tɔɔ yɔrɔ dɔ ma)
-
 answer-show-responses =
     { $count ->
         [one] Jaabi { $count } jira { $answerId } ma
        *[other] Jaabi { $count } jira { $answerId } ma
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Kɔlɔyaa-jaabi
-
 collapsible-click-to-open = (a digi ka a wulo)
 collapsible-click-to-close = (a digi ka a tugu)
-
 collapsible-initializing = A bɛi damina-taa…
-
 footnote-show = Duguma-sɛbɛ jira
 footnote-hide = Duguma-sɛbɛ dogo
-
 description-more-information = kunnafoni gbɛtɛ
-
 
 ## Controls
 
 slider-previous = Kɔrɔ
 slider-next = Nata
-
 keyboard-open = Klaviye wulo
 keyboard-close = Klaviye tugu
-
 choice-input-remove-choice = { $choice } bɔ
-
 matrix-remove-row = Laa bɔ
 matrix-add-row = Laa fa
 matrix-remove-column = Kolo bɔ
 matrix-add-column = Kolo fa
-
 subset-add-remove-points = Kɛlɛ-ŋa fa/bɔ
 subset-toggle-points-intervals = Kɛlɛ-ŋa nda tila-yɔrɔ-ŋa falɛ
 subset-move-points = Kɛlɛ-ŋa lamaga
 subset-clear = Bɛɛ bɔ
-
 orbital-add-row = Laa fa
 orbital-remove-row = Laa bɔ
 orbital-add-box = Kɛsu fa
@@ -117,13 +98,9 @@ orbital-remove-box = Kɛsu bɔ
 orbital-add-up-arrow = Sanfɛ-bin fa
 orbital-add-down-arrow = Dugumafɛ-bin fa
 orbital-remove-arrow = Bin bɔ
-
 orbital-row-label = Laa { $row } tɔgɔ
-
 pretzel-answer = Jaabi
-
 summary-statistics-caption = { $column } jate-ŋa kunkurunni
-
 
 ## Math input
 
@@ -131,34 +108,25 @@ math-input-preview-region = jate-kuma ɲɛfɔli
 math-input-preview = Ɲɛfɔli
 math-input-invalid-expression = Kuma sɔsɔi:
 
-
 ## Document status
 
 viewer-initializing = A bɛi damina-taa…
 
-
 ## Errors
 
 error-heading = Fele
-
 error-found-at =
     { $span ->
         [line] A sɔrɔla laa { $startLine } ma.
        *[lines] A sɔrɔla laa { $startLine }–{ $endLine } ma.
     }
-
 document-contains-errors = Sɛbɛ nin fele-ŋa bɛ a la!
-
 diagnostic-heading-error = Fele
 diagnostic-heading-warning = Kɔlɔyaa
 diagnostic-heading-information = Kunnafoni
 diagnostic-heading-hint = Nɔnabɔli
-
 accessibility-heading-level-1 = WCAG AA aksɛsibiliti tɛmɛli
 accessibility-heading-level-2 = Aksɛsibiliti kɔlɔyaa
-
 something-went-wrong = Fɛn dɔ tɔɔ gaa.
-
 renderer-load-failed = jirala se gaa ka wuli. Ɲɛ nin segin.
-
 core-start-failed = Sɛbɛ-jirala se gaa ka damina. Ɲɛ nin segin.

--- a/packages/i18n/locales/kpe/content.ftl
+++ b/packages/i18n/locales/kpe/content.ftl
@@ -62,15 +62,12 @@ color =
     .purple = fuu-wɔlɔ
     .pink = wɔlɔ-faa
     .brown = ndunia-wɔlɔ
-
 line-width =
     .thick = gbagba
     .thin = kpinkpin
-
 line-style =
     .dashed = tɛgɛli
     .dotted = kɛlɛ-kɛlɛ
-
 fill-style =
     .horizontal = laa-laa
     .vertical = kologboo-kologboo
@@ -78,7 +75,6 @@ fill-style =
     .backdiagonal = gbaali-kpogbo
     .dots = kɛlɛ-ŋa
     .diamonds = kula-taamaa-ŋa
-
 noun =
     .line = tan
     .line-segment = tan-kunkun
@@ -98,15 +94,12 @@ noun =
     .diamond = kula-taamaa
     .cross = kula-fele
     .plus = pulusi
-
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] fan-caa { $numSides } lɔnni
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -120,21 +113,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = fanla
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } nda
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } nda
@@ -142,7 +131,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } nda
        *[plain] { $filled } { $color } { $noun }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] { $border } gbansan nda
@@ -150,35 +138,28 @@ style-border-clause =
         [and-article] nda { $border } gbansan
        *[with] { $border } gbansan nda
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = fanla gaa
-
 style-text =
     { $parts ->
         [background] { $color } nda kpogbo-kolo { $background } nda
        *[plain] { $color }
     }
-
 style-background-none = ɓoyi
-
 
 ## Boolean words
 
 boolean-true = true
 boolean-false = false
 
-
 ## Answer buttons
 
 answer-submit-label = Jaabi kɔlɔ
 answer-submit-label-no-correctness = Jaabi ci
-
 
 ## Sectional blocks
 
@@ -203,7 +184,6 @@ section-name =
     .solution = Jaabi-jɛnjɛn
     .task = Kɛta-baalu
     .theorem = Sɛbɛ-tigi-kuma
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -213,9 +193,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Nɔnabɔli
-
 
 ## Tables and figures
 
@@ -226,7 +204,6 @@ table-name =
         [unnumbered-title] Tabali{ ": " }
        *[unnumbered] Tabali
     }
-
 figure-name =
     { $parts ->
         [numbered] Ja { $enumeration }
@@ -235,32 +212,24 @@ figure-name =
        *[unnumbered] Ja
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kɔrɔ
 paginator-next = Nata
 paginator-page = Peji
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = wala
-
 piecewise-condition-if = ni
-
 piecewise-condition-otherwise = fɛn gbɛtɛ bɛɛ na
-
 
 ## Chemistry
 ##
 ## Left out — see this file's header for why the two-country school-system
 ## split makes a single fallback the wrong shape here.
 
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Elemɛn-taamaa Sɔsɔi
 chemistry-invalid-ionic-compound = Yɛlɛma-fan Sɔsɔi

--- a/packages/i18n/locales/kr/chrome.ftl
+++ b/packages/i18n/locales/kr/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Kalakcin…
 answer-submitting = Sadin…
-
 answer-checking-status = Jawabga kalakcin
 answer-submitting-status = Jawabga sadin
-
 answer-correct = Haqqa
 answer-incorrect = Haqqani
-
 answer-response-saved = Jawab Ngǝwuna
-
 answer-percent-credit = { $percent }% poyintwa
 answer-percent-correct = { $percent }% haqqa
 answer-percent-short = { $percent } %
-
 max-credit-available = Poyintwa kura barwa: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] karangi bago
         [one] karangi { $count } bar
        *[other] karangiwa { $count } bar
     }
-
 validation-correct = (Haqqa)
 validation-incorrect = (Haqqani)
 validation-partially-correct = (Fartuben haqqa)
-
 answer-show-responses =
     { $count ->
         [one] Jawab { $count } { $answerId }-be cirǝge
        *[other] Jawabwa { $count } { $answerId }-be cirǝge
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Kalamnzǝ
-
 collapsible-click-to-open = (kilage kǝntǝge)
 collapsible-click-to-close = (kilage tǝwuge)
-
 collapsible-initializing = Jibin…
-
 footnote-show = Alama kǝskabe cirǝge
 footnote-hide = Alama kǝskabe ngǝwuge
-
 description-more-information = kalamwa gade
-
 
 ## Controls
 
 slider-previous = Ngǝwube
 slider-next = Waube
-
 keyboard-open = Kiboodga Kǝntǝge
 keyboard-close = Kiboodga Tǝwuge
-
 choice-input-remove-choice = { $choice } burge
-
 matrix-remove-row = Layinga burge
 matrix-add-row = Layinga zawuge
 matrix-remove-column = Kolomga burge
 matrix-add-column = Kolomga zawuge
-
 subset-add-remove-points = Poyintwaga zawuge/burge
 subset-toggle-points-intervals = Poyintwa be fartuwaga gǝrǝge
 subset-move-points = Poyintwaga Jǝlage
 subset-clear = Kambe burge
-
 orbital-add-row = Layinga Zawuge
 orbital-remove-row = Layinga Burge
 orbital-add-box = Sanduqga Zawuge
@@ -86,13 +67,9 @@ orbital-remove-box = Sanduqga Burge
 orbital-add-up-arrow = Kǝnyi Kǝlabega Zawuge
 orbital-add-down-arrow = Kǝnyi Kǝskabega Zawuge
 orbital-remove-arrow = Kǝnyiga Burge
-
 orbital-row-label = Layin { $row }-be cin
-
 pretzel-answer = Jawab
-
 summary-statistics-caption = { $column }-be kǝlkǝlwa
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = kǝlkǝl kalambe cirǝwu ngǝwube
 math-input-preview = Cirǝwu ngǝwube
 math-input-invalid-expression = Kalam ngǝlani:
 
-
 ## Document status
 
 viewer-initializing = Jibin…
 
-
 ## Errors
 
 error-heading = Karsa
-
 error-found-at =
     { $span ->
         [line] Layin { $startLine }-ro rukcǝna.
        *[lines] Layinwa { $startLine }–{ $endLine }-ro rukcǝna.
     }
-
 document-contains-errors = Kitabu adǝ karsawa jinzǝ!
-
 diagnostic-heading-error = Karsa
 diagnostic-heading-warning = Nyirtu
 diagnostic-heading-information = Kalam
 diagnostic-heading-hint = Alama
-
 accessibility-heading-level-1 = WCAG AA jǝmbe karsa
 accessibility-heading-level-2 = Jǝmbe nyirtu
-
 something-went-wrong = Ndu gade ngǝlani.
-
 renderer-load-failed = cirǝgema isǝni. Bilage, belaga gǝrǝge.
-
 core-start-failed = Kitabu-be cirǝgema jibǝni. Bilage, belaga gǝrǝge.

--- a/packages/i18n/locales/kr/content.ftl
+++ b/packages/i18n/locales/kr/content.ftl
@@ -48,17 +48,14 @@ color =
     .purple = papul
     .pink = pinki
     .brown = burawun
-
 line-width =
     .thick = kura
     .thin = dibi
-
 # Written as invariable «-be» phrases rather than as qualifiers, so that they
 # can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = kǝska-be
     .dotted = tǝndi-be
-
 fill-style =
     .horizontal = layinwa kǝlanzǝ
     .vertical = layinwa dǝganzǝ
@@ -66,7 +63,6 @@ fill-style =
     .backdiagonal = layinwa gǝnyinzǝ kǝskabe
     .dots = tǝndiwa
     .diamonds = dayamonwa
-
 noun =
     .line = layin
     .line-segment = layin fartu
@@ -86,7 +82,6 @@ noun =
     .diamond = dayamon
     .cross = kurus
     .plus = alama zawube
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -94,11 +89,9 @@ noun-regular-polygon =
         [tail] kǝskawa { $numSides } jinzǝ
        *[head] poligon lawanbe
     }
-
 # No grammatical gender, so this answers one token for every noun and the
 # answer goes unused — the shape `locales/en` has.
 noun-gender = tilo
-
 
 ## Style composition
 
@@ -112,21 +105,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = dinzǝ
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern }-a
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } { $pattern }-a
@@ -134,7 +123,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } { $pattern }-a
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Kanuri has no article, and joins this clause with the invariable «-a»
 # whatever came before it, so all four branches read alike.
 style-border-clause =
@@ -144,35 +132,28 @@ style-border-clause =
         [and-article] kǝska { $border }-a
        *[with] kǝska { $border }-a
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = dinzǝni
-
 style-text =
     { $parts ->
         [background] { $color } kǝska { $background }-be
        *[plain] { $color }
     }
-
 style-background-none = ndu bago
-
 
 ## Boolean words
 
 boolean-true = haqqa
 boolean-false = kǝzǝna
 
-
 ## Answer buttons
 
 answer-submit-label = Kalakce Jiliwu
 answer-submit-label-no-correctness = Jawab Sadi
-
 
 ## Sectional blocks
 
@@ -197,7 +178,6 @@ section-name =
     .solution = Kǝlanzǝ
     .task = Jiliwu
     .theorem = Tiyorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -207,9 +187,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Alama
-
 
 ## Tables and figures
 
@@ -220,7 +198,6 @@ table-name =
         [unnumbered-title] Tebur{ ": " }
        *[unnumbered] Tebur
     }
-
 figure-name =
     { $parts ->
         [numbered] Suratu { $enumeration }
@@ -229,24 +206,18 @@ figure-name =
        *[unnumbered] Suratu
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ngǝwube
 paginator-next = Waube
 paginator-page = Bela
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ya
-
 piecewise-condition-if = adǝga
-
 piecewise-condition-otherwise = kǝlawa dǝga
-
 
 ## Chemistry
 ##
@@ -263,6 +234,5 @@ piecewise-condition-otherwise = kǝlawa dǝga
 ## already is.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Alama Kemistiribe Ngǝlani
 chemistry-invalid-ionic-compound = Ayon Kǝlanzǝbe Ngǝlani

--- a/packages/i18n/locales/kri/chrome.ftl
+++ b/packages/i18n/locales/kri/chrome.ftl
@@ -13,74 +13,55 @@
 
 answer-checking = De chɛk…
 answer-submitting = De sɛn…
-
 answer-checking-status = Wi de chɛk di ansa
 answer-submitting-status = Wi de sɛn di ansa
-
 answer-correct = I kɔrɛkt
 answer-incorrect = I nɔ kɔrɛkt
-
 answer-response-saved = Wi Dɔn Sev Yu Ansa
-
 answer-percent-credit = { $percent }% Krɛdit
 answer-percent-correct = { $percent }% Kɔrɛkt
 answer-percent-short = { $percent } %
-
 max-credit-available = Di mɔs krɛdit we yu kin gɛt: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nɔ tray lɛf
         [one] { $count } tray lɛf
        *[other] { $count } tray lɛf
     }
-
 validation-correct = (I kɔrɛkt)
 validation-incorrect = (I nɔ kɔrɛkt)
 validation-partially-correct = (I kɔrɛkt smɔl)
-
 answer-show-responses =
     { $count ->
         [one] Sho { $count } ansa fɔ { $answerId }
        *[other] Sho { $count } ansa fɔ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Fidbak
-
 collapsible-click-to-open = (klik fɔ opin)
 collapsible-click-to-close = (klik fɔ klos)
-
 collapsible-initializing = I de stat…
-
 footnote-show = Sho di fut-not
 footnote-hide = Ayd di fut-not
-
 description-more-information = mɔ infɔmeshɔn
-
 
 ## Controls
 
 slider-previous = Di wan we dɔn pas
 slider-next = Nɛks
-
 keyboard-open = Opin Kibɔd
 keyboard-close = Klos Kibɔd
-
 choice-input-remove-choice = Pul { $choice }
-
 matrix-remove-row = Pul ro
 matrix-add-row = Ad ro
 matrix-remove-column = Pul kɔlum
 matrix-add-column = Ad kɔlum
-
 subset-add-remove-points = Ad/Pul pɔynt dɛn
 subset-toggle-points-intervals = Chenj bitwin pɔynt ɛn intaval
 subset-move-points = Muv Di Pɔynt Dɛn
 subset-clear = Kliya
-
 orbital-add-row = Ad Ro
 orbital-remove-row = Pul Ro
 orbital-add-box = Ad Bɔks
@@ -88,13 +69,9 @@ orbital-remove-box = Pul Bɔks
 orbital-add-up-arrow = Ad Aro We Fes Ɔp
 orbital-add-down-arrow = Ad Aro We Fes Dɔŋ
 orbital-remove-arrow = Pul Aro
-
 orbital-row-label = Nem fɔ ro { $row }
-
 pretzel-answer = Ansa
-
 summary-statistics-caption = Sɔmari statistiks fɔ { $column }
-
 
 ## Math input
 
@@ -102,34 +79,25 @@ math-input-preview-region = privyu pan di mat ɛkspreshɔn
 math-input-preview = Privyu
 math-input-invalid-expression = Ɛkspreshɔn we nɔ kɔrɛkt:
 
-
 ## Document status
 
 viewer-initializing = I de stat…
 
-
 ## Errors
 
 error-heading = Ɛra
-
 error-found-at =
     { $span ->
         [line] Wi si am pan layn { $startLine }.
        *[lines] Wi si am pan layn { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dis dɔkyumɛnt gɛt ɛra insay!
-
 diagnostic-heading-error = Ɛra
 diagnostic-heading-warning = Wɔnin
 diagnostic-heading-information = Infɔ
 diagnostic-heading-hint = Klu
-
 accessibility-heading-level-1 = WCAG AA Aksɛsibiliti Vayoleshɔn
 accessibility-heading-level-2 = Aksɛsibiliti alat
-
 something-went-wrong = Sɔntin nɔ go fayn.
-
 renderer-load-failed = wan rɛndara nɔ lod. Duya lod di pej bak.
-
 core-start-failed = Di dɔkyumɛnt viwa nɔ ebul fɔ stat. Duya lod di pej bak.

--- a/packages/i18n/locales/kri/content.ftl
+++ b/packages/i18n/locales/kri/content.ftl
@@ -51,11 +51,9 @@ color =
     .purple = pɔpul
     .pink = pink
     .brown = braun
-
 line-width =
     .thick = tik
     .thin = tin
-
 # Reduplication used attributively, the same move `locales/pcm` makes. A «we de
 # brok-brok» clause would be the more literal rendering and is wrong here: the
 # description is *followed* by the noun, so a relative clause would sit in front
@@ -63,7 +61,6 @@ line-width =
 line-style =
     .dashed = brok-brok
     .dotted = dɔt-dɔt
-
 fill-style =
     .horizontal = layn dɛn we lidɔm
     .vertical = layn dɛn we tinap
@@ -71,7 +68,6 @@ fill-style =
     .backdiagonal = layn dɛn we slant di ɔda say
     .dots = dɔt dɛn
     .diamonds = dayamɔn dɛn
-
 noun =
     .line = layn
     .line-segment = pis pan layn
@@ -91,7 +87,6 @@ noun =
     .diamond = dayamɔn
     .cross = krɔs
     .plus = plɔs mak
-
 # The side count is a relative clause and closes the noun phrase behind the
 # describing words, so it goes in the tail.
 noun-regular-polygon =
@@ -99,11 +94,9 @@ noun-regular-polygon =
         [tail] we gɛt { $numSides } say
        *[head] pɔligɔn we ɔl di say dɛn na wan
     }
-
 # Krio has no noun class and no gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = wan
-
 
 ## Style composition
 
@@ -120,24 +113,20 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «dɔn ful» — the completive `dɔn` rather than an English passive. There is no
 # adjective here to inflect; the whole word is a verb phrase, as it is in
 # `locales/pcm`.
 style-filled-word = dɔn ful
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } wit { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } wit { $pattern }
@@ -145,7 +134,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wit { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Krio has no indefinite article where English wants one here, so the
 # `-article` branches read the same as their bare counterparts. The «wit» /
 # «ɛn» distinction — first clause against a further one — is real and survives.
@@ -156,23 +144,18 @@ style-border-clause =
         [and-article] ɛn { $border } bɔda
        *[with] wit { $border } bɔda
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = i nɔ ful
-
 style-text =
     { $parts ->
         [background] { $color } wit { $background } bakgrɔn
        *[plain] { $color }
     }
-
 style-background-none = natin
-
 
 ## Boolean words
 ##
@@ -182,12 +165,10 @@ style-background-none = natin
 boolean-true = na tru
 boolean-false = na lay
 
-
 ## Answer buttons
 
 answer-submit-label = Chɛk Wok
 answer-submit-label-no-correctness = Sɛn Ansa
-
 
 ## Sectional blocks
 
@@ -212,7 +193,6 @@ section-name =
     .solution = Ansa fɔ di prɔblɛm
     .task = Wok
     .theorem = Tiɔrɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -222,9 +202,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Klu
-
 
 ## Tables and figures
 
@@ -235,7 +213,6 @@ table-name =
         [unnumbered-title] Tebul{ ": " }
        *[unnumbered] Tebul
     }
-
 figure-name =
     { $parts ->
         [numbered] Piksho { $enumeration }
@@ -244,25 +221,18 @@ figure-name =
        *[unnumbered] Piksho
     }
 
-
 ## Paginator controls
 
 paginator-previous = Di wan we dɔn pas
 paginator-next = Nɛks
-
 paginator-page = Pej
-
 paginator-page-status = { $pageLabel } { $currentPage } pan { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ɔ
-
 piecewise-condition-if = if
-
 piecewise-condition-otherwise = if i nɔ so
-
 
 ## Chemistry
 ##
@@ -276,6 +246,5 @@ piecewise-condition-otherwise = if i nɔ so
 ## back all but identical to `locales/en`.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kɛmistri Simbɔl We Nɔ Kɔrɛkt
 chemistry-invalid-ionic-compound = Ayɔnik Kɔmpaun We Nɔ Kɔrɛkt

--- a/packages/i18n/locales/ks/chrome.ftl
+++ b/packages/i18n/locales/ks/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = پرٛژھان…
 answer-submitting = بیٖجان…
-
 answer-checking-status = جواب پرٛژھان
 answer-submitting-status = جواب بیٖجان
-
 answer-correct = دُرُست
 answer-incorrect = غلط
-
 answer-response-saved = جواب محفوظ کۆرمُت
-
 answer-percent-credit = { $percent }% نمبر
 answer-percent-correct = { $percent }% دُرُست
 answer-percent-short = { $percent } %
-
 max-credit-available = زیادٕ کھۄتہٕ زیادٕ نمبر: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] کہٕنٛہہ کوشِش چھُ نہٕ باقی
         [one] { $count } کوشِش باقی
        *[other] { $count } کوشِشہٕ باقی
     }
-
 validation-correct = (دُرُست)
 validation-incorrect = (غلط)
 validation-partially-correct = (حِصٕ داری دُرُست)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } خٲطرٕ { $count } جواب ہٲوِو
        *[other] { $answerId } خٲطرٕ { $count } جواب ہٲوِو
     }
 
-
 ## Disclosure panels
 
 feedback-heading = رٲے
-
 collapsible-click-to-open = (کھولنہٕ خٲطرٕ کلِک کرِو)
 collapsible-click-to-close = (بند کرنہٕ خٲطرٕ کلِک کرِو)
-
 collapsible-initializing = شُروٗع گژھان…
-
 footnote-show = پادنوٹ ہٲوِو
 footnote-hide = پادنوٹ ژھوپٲوِو
-
 description-more-information = زیادٕ معلوٗمات
-
 
 ## Controls
 
 slider-previous = پَتٕم
 slider-next = بۆنٕم
-
 keyboard-open = کیٖبورڈ کھولِو
 keyboard-close = کیٖبورڈ بند کرِو
-
 choice-input-remove-choice = { $choice } کڈِو
-
 matrix-remove-row = قطار کڈِو
 matrix-add-row = قطار شٲمِل کرِو
 matrix-remove-column = ستوٗن کڈِو
 matrix-add-column = ستوٗن شٲمِل کرِو
-
 subset-add-remove-points = نُختہٕ شٲمِل کرِو/کڈِو
 subset-toggle-points-intervals = نُختہٕ تہٕ وقفہٕ بدلٲوِو
 subset-move-points = نُختہٕ پکنٲوِو
 subset-clear = مٹٲوِو
-
 orbital-add-row = قطار شٲمِل کرِو
 orbital-remove-row = قطار کڈِو
 orbital-add-box = ڈبہٕ شٲمِل کرِو
@@ -86,13 +67,9 @@ orbital-remove-box = ڈبہٕ کڈِو
 orbital-add-up-arrow = ہیورٕ تیٖر شٲمِل کرِو
 orbital-add-down-arrow = بۆنہٕ تیٖر شٲمِل کرِو
 orbital-remove-arrow = تیٖر کڈِو
-
 orbital-row-label = قطار { $row } ہٕنٛد لیبل
-
 pretzel-answer = جواب
-
 summary-statistics-caption = { $column } ہٕنٛد شُمٲریاتی خُلاصہٕ
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ریاضی اِظہارُک پؠش نظارٕ
 math-input-preview = پؠش نظارٕ
 math-input-invalid-expression = غلط اِظہار:
 
-
 ## Document status
 
 viewer-initializing = شُروٗع گژھان…
 
-
 ## Errors
 
 error-heading = غلطی
-
 error-found-at =
     { $span ->
         [line] لَکیٖر { $startLine } پؠٹھ لبنہٕ آو۔
        *[lines] لَکیٖر { $startLine }–{ $endLine } پؠٹھ لبنہٕ آو۔
     }
-
 document-contains-errors = یَتھ دستاویزس منٛز چھِ غلطی!
-
 diagnostic-heading-error = غلطی
 diagnostic-heading-warning = تَنبیٖہ
 diagnostic-heading-information = معلوٗمات
 diagnostic-heading-hint = اِشارٕ
-
 accessibility-heading-level-1 = WCAG AA رسٲیی خِلاف ورزی
 accessibility-heading-level-2 = رسٲیی اِطلاع
-
 something-went-wrong = کینٛہہ غلط سپُد۔
-
 renderer-load-failed = اَکھ ہاوَن وول لوڈ نہٕ سپُد۔ مہربٲنی کرِتھ صفحہٕ دۄبارٕ لوڈ کرِو۔
-
 core-start-failed = دستاویز ہاوَن وول شُروٗع نہٕ سپُد۔ مہربٲنی کرِتھ صفحہٕ دۄبارٕ لوڈ کرِو۔

--- a/packages/i18n/locales/ks/content.ftl
+++ b/packages/i18n/locales/ks/content.ftl
@@ -49,15 +49,12 @@ color =
     .purple = بٲنٛگٕنی
     .pink = گُلٲبی
     .brown = بوٚر
-
 line-width =
     .thick = تھۆل
     .thin = پتلٕ
-
 line-style =
     .dashed = ٹوٗٹِتھ
     .dotted = نُختٕدار
-
 fill-style =
     .horizontal = سیودٕ ریکھہ
     .vertical = کھڈٕ ریکھہ
@@ -65,7 +62,6 @@ fill-style =
     .backdiagonal = اُلٹہ تِرچھہِ ریکھہ
     .dots = نُختہٕ
     .diamonds = سمچتُربھُج
-
 noun =
     .line = ریکھہ
     .line-segment = ریکھہ کھنٛڈ
@@ -85,7 +81,6 @@ noun =
     .diamond = سمچتُربھُج
     .cross = ضَربُک نِشان
     .plus = جمٕعُک نِشان
-
 # «-بھُجٕچ» is welded onto the count and has one shape whatever number lands in
 # front of it, so the weld is sound in the way the affix rule allows. The
 # adjectives precede the noun, so there is no tail.
@@ -94,7 +89,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides }-بھُجٕچ باقاعدٕ بہُبھُج
     }
-
 # Filled in for the sake of the `$gender` fork this catalog does not yet write;
 # see the header. `$noun` may also be «regular-polygon» (بہُبھُج, m) or the head
 # of a phrase the description does not name: «border» (کِنار, m), «fill»
@@ -109,7 +103,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -122,15 +115,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = بھرِتھ
-
 # «سٟتؠ» ("with") is a postposition and follows what it governs, so the pattern
 # moves to the front of the phrase where English appends it.
 style-filled =
@@ -138,7 +128,6 @@ style-filled =
         [pattern] { $pattern } سٟتؠ { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } سٟتؠ { $filled } { $color } { $noun }
@@ -146,7 +135,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } سٟتؠ { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Kashmiri has no article, so the two `-article` branches read like their
 # neighbours; «تہٕ» is the conjunction and stands in front.
 style-border-clause =
@@ -156,35 +144,28 @@ style-border-clause =
         [and-article] تہٕ { $border } کِنار سٟتؠ
        *[with] { $border } کِنار سٟتؠ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } سٟتؠ { $color } بھرَن
        *[plain] { $color } بھرَن
     }
-
 style-unfilled = ناہ بھرِتھ
-
 style-text =
     { $parts ->
         [background] { $background } پؠٹھ بوٗنس پؠٹھ { $color }
        *[plain] { $color }
     }
-
 style-background-none = کہٕنٛہہ نہٕ
-
 
 ## Boolean words
 
 boolean-true = سٔتؠ
 boolean-false = ٲپُز
 
-
 ## Answer buttons
 
 answer-submit-label = پرٛژھِو
 answer-submit-label-no-correctness = جواب بیٖجِو
-
 
 ## Sectional blocks
 
@@ -209,7 +190,6 @@ section-name =
     .solution = حَل
     .task = کٲم
     .theorem = مسٕلہٕ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -219,9 +199,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = اِشارٕ
-
 
 ## Tables and figures
 
@@ -232,7 +210,6 @@ table-name =
         [unnumbered-title] جدول{ ": " }
        *[unnumbered] جدول
     }
-
 figure-name =
     { $parts ->
         [numbered] شکل { $enumeration }
@@ -241,26 +218,20 @@ figure-name =
        *[unnumbered] شکل
     }
 
-
 ## Paginator controls
 
 paginator-previous = پَتٕم
 paginator-next = بۆنٕم
 paginator-page = صفحہٕ
-
 # «X منٛز Y» — "Y of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } منٛز { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = یا
-
 piecewise-condition-if = اگر
-
 piecewise-condition-otherwise = نتہٕ
-
 
 ## Chemistry
 ##
@@ -276,6 +247,5 @@ piecewise-condition-otherwise = نتہٕ
 ## substances known long before the elements were.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = غلط کیمیٲوی نِشان
 chemistry-invalid-ionic-compound = غلط آیٕنِک مُرکب

--- a/packages/i18n/locales/ktu/chrome.ftl
+++ b/packages/i18n/locales/ktu/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Ke tala…
 answer-submitting = Ke tinda…
-
 answer-checking-status = Mvutu ke tadila
 answer-submitting-status = Mvutu ke tindama
-
 answer-correct = Ya kyeleka
 answer-incorrect = Ya mbi
-
 answer-response-saved = Mvutu Kubumbama
-
 answer-percent-credit = { $percent }% ya Bapwe
 answer-percent-correct = { $percent }% Ya kyeleka
 answer-percent-short = { $percent } %
-
 max-credit-available = Bapwe mingi ya kele: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kumeka ya kubikala kele ve
         [one] kumeka { $count } me bikala
        *[other] kumeka { $count } me bikala
     }
-
 validation-correct = (Ya kyeleka)
 validation-incorrect = (Ya mbi)
 validation-partially-correct = (Ya kyeleka na kitini)
-
 answer-show-responses =
     { $count ->
         [one] Songa mvutu { $count } na { $answerId }
        *[other] Songa bamvutu { $count } na { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ntendula
-
 collapsible-click-to-open = (fina sambu na kukangula)
 collapsible-click-to-close = (fina sambu na kukanga)
-
 collapsible-initializing = Ke yantika…
-
 footnote-show = Songa nsangu ya nsi
 footnote-hide = Bumba nsangu ya nsi
-
 description-more-information = bansangu ya nkaka
-
 
 ## Controls
 
 slider-previous = Ya ntete
 slider-next = Ya nima
-
 keyboard-open = Kangula Klavie
 keyboard-close = Kanga Klavie
-
 choice-input-remove-choice = Katula { $choice }
-
 matrix-remove-row = Katula linya
 matrix-add-row = Yika linya
 matrix-remove-column = Katula kolone
 matrix-add-column = Yika kolone
-
 subset-add-remove-points = Yika/Katula bapwente
 subset-toggle-points-intervals = Soba bapwente ti bitini
 subset-move-points = Nikisa Bapwente
 subset-clear = Katula yonso
-
 orbital-add-row = Yika Linya
 orbital-remove-row = Katula Linya
 orbital-add-box = Yika Kesi
@@ -86,13 +67,9 @@ orbital-remove-box = Katula Kesi
 orbital-add-up-arrow = Yika Nsonga ya Zulu
 orbital-add-down-arrow = Yika Nsonga ya Nsi
 orbital-remove-arrow = Katula Nsonga
-
 orbital-row-label = Zina ya linya { $row }
-
 pretzel-answer = Mvutu
-
 summary-statistics-caption = Nsukulu ya batalu ya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = kutala na ntwala ya batalu
 math-input-preview = Kutala na ntwala
 math-input-invalid-expression = Mbikudulu ya mbi:
 
-
 ## Document status
 
 viewer-initializing = Ke yantika…
 
-
 ## Errors
 
 error-heading = Mbi
-
 error-found-at =
     { $span ->
         [line] Yo me monana na linya { $startLine }.
        *[lines] Yo me monana na balinya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Mukanda yai kele ti bambi!
-
 diagnostic-heading-error = Mbi
 diagnostic-heading-warning = Lukebisu
 diagnostic-heading-information = Nsangu
 diagnostic-heading-hint = Kidimbu
-
 accessibility-heading-level-1 = Kulutisa WCAG AA ya Kukuma
 accessibility-heading-level-2 = Lukebisu ya kukuma
-
 something-went-wrong = Kima mosi me kwenda mbote ve.
-
 renderer-load-failed = kisongi me kwisa ve. Pardo, vutukisa lutiti.
-
 core-start-failed = Kisongi ya mukanda me yantika ve. Pardo, vutukisa lutiti.

--- a/packages/i18n/locales/ktu/content.ftl
+++ b/packages/i18n/locales/ktu/content.ftl
@@ -51,15 +51,12 @@ color =
     .purple = ya vyole
     .pink = ya loze
     .brown = ya mabele
-
 line-width =
     .thick = ya nene
     .thin = ya fioti
-
 line-style =
     .dashed = ya batini
     .dotted = ya bantoni
-
 fill-style =
     .horizontal = balinya ya kulala
     .vertical = balinya ya kutelama
@@ -67,7 +64,6 @@ fill-style =
     .backdiagonal = balinya ya kubenda na lweka ya nkaka
     .dots = bantoni
     .diamonds = badiama
-
 noun =
     .line = linya
     .line-segment = kitini ya linya
@@ -87,7 +83,6 @@ noun =
     .diamond = diama
     .cross = kuluzu
     .plus = kidimbu ya kuyika
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -95,13 +90,11 @@ noun-regular-polygon =
         [tail] ya kele ti bansuki { $numSides }
        *[head] kifwani ya bansuki ya kiteso mosi
     }
-
 # One token, because Kituba has one: nothing in the language selects on the
 # class a noun's frozen prefix came from. A branch for a class would be a
 # variant nothing can reach — see `locales/zu`'s header for that rule stated
 # where the classes are real.
 noun-gender = mosi
-
 
 ## Style composition
 
@@ -115,21 +108,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ya kufuluka
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ti { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ti { $pattern }
@@ -137,7 +126,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ti { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Kituba has no article and joins this clause with the invariable «ti», so all
 # four branches read alike.
 style-border-clause =
@@ -147,35 +135,28 @@ style-border-clause =
         [and-article] ti ndilu { $border }
        *[with] ti ndilu { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ya kufuluka ve
-
 style-text =
     { $parts ->
         [background] { $color } na nima { $background }
        *[plain] { $color }
     }
-
 style-background-none = ata kima ve
-
 
 ## Boolean words
 
 boolean-true = ya kyeleka
 boolean-false = ya luvunu
 
-
 ## Answer buttons
 
 answer-submit-label = Tala Kisalu
 answer-submit-label-no-correctness = Tinda Mvutu
-
 
 ## Sectional blocks
 
@@ -200,7 +181,6 @@ section-name =
     .solution = Nsukulu
     .task = Kisalu
     .theorem = Teoreme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -210,9 +190,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kidimbu
-
 
 ## Tables and figures
 
@@ -223,7 +201,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Kifwani { $enumeration }
@@ -232,24 +209,18 @@ figure-name =
        *[unnumbered] Kifwani
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ya ntete
 paginator-next = Ya nima
 paginator-page = Lutiti
-
 paginator-page-status = { $pageLabel } { $currentPage } na kati ya { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = to
-
 piecewise-condition-if = kana
-
 piecewise-condition-otherwise = na bisika ya nkaka yonso
-
 
 ## Chemistry
 ##
@@ -261,6 +232,5 @@ piecewise-condition-otherwise = na bisika ya nkaka yonso
 ## curriculum — the same answer `locales/ln` and `locales/lua` give.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kidimbu ya Shimi Ya Mbi
 chemistry-invalid-ionic-compound = Kuvukisa ya Bayoni Ya Mbi

--- a/packages/i18n/locales/kv/chrome.ftl
+++ b/packages/i18n/locales/kv/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Видлалӧ…
 answer-submitting = Мӧдӧдӧ…
-
 answer-checking-status = Вочакыв видлалӧ
 answer-submitting-status = Вочакыв мӧдӧдӧ
-
 answer-correct = Веськыд
 answer-incorrect = Абу веськыд
-
 answer-response-saved = Вочакыв видзӧма
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% веськыд
 answer-percent-short = { $percent } %
-
 max-credit-available = Босьтны позян медся ыджыд балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] видлӧм абу кольӧма
         [one] { $count } видлӧм кольӧма
        *[other] { $count } видлӧм кольӧма
     }
-
 validation-correct = (Веськыд)
 validation-incorrect = (Абу веськыд)
 validation-partially-correct = (Юкӧнӧн веськыд)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } вылӧ { $count } вочакыв петкӧдлыны
        *[other] { $answerId } вылӧ { $count } вочакыв петкӧдлыны
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Бӧр висьталӧм
-
 collapsible-click-to-open = (восьтны вӧсна ляпкы)
 collapsible-click-to-close = (пӧдлавны вӧсна ляпкы)
-
 collapsible-initializing = Дасьтысьӧ…
-
 footnote-show = Пасйӧд петкӧдлыны
 footnote-hide = Пасйӧд дзебны
-
 description-more-information = содтӧд юӧр
-
 
 ## Controls
 
 slider-previous = Бӧрлань
 slider-next = Водзлань
-
 keyboard-open = Клавиатура восьтны
 keyboard-close = Клавиатура пӧдлавны
-
 choice-input-remove-choice = { $choice } бӧрйӧм бӧрйыны
-
 matrix-remove-row = Визь бӧрйыны
 matrix-add-row = Визь содтыны
 matrix-remove-column = Юрбитан бӧрйыны
 matrix-add-column = Юрбитан содтыны
-
 subset-add-remove-points = Пас содтыны/бӧрйыны
 subset-toggle-points-intervals = Пасъяс да коласъяс вежны
 subset-move-points = Пасъяс вуджӧдны
 subset-clear = Сӧстӧммӧдны
-
 orbital-add-row = Визь содтыны
 orbital-remove-row = Визь бӧрйыны
 orbital-add-box = Клетка содтыны
@@ -91,13 +72,9 @@ orbital-remove-box = Клетка бӧрйыны
 orbital-add-up-arrow = Вылӧ ньӧв содтыны
 orbital-add-down-arrow = Улӧ ньӧв содтыны
 orbital-remove-arrow = Ньӧв бӧрйыны
-
 orbital-row-label = { $row } визьлӧн пасыс
-
 pretzel-answer = Вочакыв
-
 summary-statistics-caption = { $column } юрбитанлӧн йитӧд статистикаыс
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = математическӧй висьталӧмлӧ�
 math-input-preview = Водзвыв видзӧдлӧм
 math-input-invalid-expression = Абу веськыд висьталӧм:
 
-
 ## Document status
 
 viewer-initializing = Дасьтысьӧ…
 
-
 ## Errors
 
 error-heading = Тшыкӧдчӧм
-
 error-found-at =
     { $span ->
         [line] Аддзӧм визь: { $startLine }.
        *[lines] Аддзӧм визьяс: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Тайӧ документын тшыкӧдчӧмъяс эмӧсь!
-
 diagnostic-heading-error = Тшыкӧдчӧм
 diagnostic-heading-warning = Пасйӧм
 diagnostic-heading-information = Юӧр
 diagnostic-heading-hint = Индӧд
-
 accessibility-heading-level-1 = WCAG AA воан позянлун торкӧм
 accessibility-heading-level-2 = Воан позянлун йылысь юӧр
-
 something-went-wrong = Мыйкӧ абу веськыда петіс.
-
 renderer-load-failed = серпасалысьсӧ пыртны эз артмы. Лист бок выльмӧд.
-
 core-start-failed = Документ видзӧдысьсӧ заводитны эз артмы. Лист бок выльмӧд.

--- a/packages/i18n/locales/kv/content.ftl
+++ b/packages/i18n/locales/kv/content.ftl
@@ -38,15 +38,12 @@ color =
     .purple = фиолетовӧй
     .pink = гӧрдоват
     .brown = мугӧм
-
 line-width =
     .thick = кыз
     .thin = вӧсньыд
-
 line-style =
     .dashed = вундалӧм
     .dotted = пасъялӧм
-
 # Noun phrases: they stand in front of «серӧн» and modify nothing.
 fill-style =
     .horizontal = горизонтальнӧй визь
@@ -55,7 +52,6 @@ fill-style =
     .backdiagonal = паныд диагональнӧй визь
     .dots = пас
     .diamonds = ромб
-
 noun =
     .line = веськыд визь
     .line-segment = юкӧн
@@ -75,7 +71,6 @@ noun =
     .diamond = ромб
     .cross = перекрест
     .plus = плюс
-
 # Komi builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -83,11 +78,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] веськыд { $numSides } пельӧса
     }
-
 # Komi has no grammatical gender, so every noun answers the same and the answer
 # goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -101,21 +94,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = мавтӧм
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } серӧн { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } серӧн { $color } { $filled } { $noun }
@@ -123,7 +112,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } серӧн { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «дорӧн» is the instrumental of «дор», "edge", and carries the whole of "with
 # a border" in its own suffix, so neither a preposition nor an article is
 # wanted — `locales/udm`'s «дуроен» exactly, in the sister language.
@@ -134,15 +122,12 @@ style-border-clause =
         [and-article] да { $border } дорӧн
        *[with] { $border } дорӧн
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } серӧн { $color } мавтӧм
        *[plain] { $color } мавтӧм
     }
-
 style-unfilled = мавтытӧм
-
 # «вылын» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.
 style-text =
@@ -150,21 +135,17 @@ style-text =
         [background] { $background } фон вылын { $color }
        *[plain] { $color }
     }
-
 style-background-none = абу
-
 
 ## Boolean words
 
 boolean-true = збыль
 boolean-false = абу збыль
 
-
 ## Answer buttons
 
 answer-submit-label = Видлавны
 answer-submit-label-no-correctness = Вочакыв мӧдӧдны
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = Вӧчӧм
     .task = Уджтас
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Индӧд
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Серпас { $enumeration }
@@ -221,15 +198,12 @@ figure-name =
        *[unnumbered] Серпас
     }
 
-
 ## Paginator controls
 
 paginator-previous = Бӧрлань
 paginator-next = Водзлань
 paginator-page = Лист бок
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -242,7 +216,6 @@ piecewise-condition-or = либӧ
 piecewise-condition-if = кӧ
 piecewise-condition-otherwise = мӧд ногӧн
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -251,6 +224,5 @@ piecewise-condition-otherwise = мӧд ногӧн
 ## Russian ones — the school-system case this batch shares throughout.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Абу веськыд химическӧй пас
 chemistry-invalid-ionic-compound = Абу веськыд ион йитӧд

--- a/packages/i18n/locales/ky/chrome.ftl
+++ b/packages/i18n/locales/ky/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Текшерилүүдө…
 answer-submitting = Жөнөтүлүүдө…
-
 answer-checking-status = Жооп текшерилүүдө
 answer-submitting-status = Жооп жөнөтүлүүдө
-
 answer-correct = Туура
 answer-incorrect = Ката
-
 answer-response-saved = Жооп сакталды
-
 answer-percent-credit = { $percent }% упай
 answer-percent-correct = { $percent }% туура
 answer-percent-short = { $percent } %
-
 max-credit-available = Мүмкүн болгон эң жогорку упай: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] аракет калган жок
         [one] { $count } аракет калды
        *[other] { $count } аракет калды
     }
-
 validation-correct = (Туура)
 validation-incorrect = (Ката)
 validation-partially-correct = (Жарым-жартылай туура)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } үчүн { $count } жоопту көрсөтүү
        *[other] { $answerId } үчүн { $count } жоопту көрсөтүү
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Кайтарым байланыш
-
 collapsible-click-to-open = (ачуу үчүн басыңыз)
 collapsible-click-to-close = (жабуу үчүн басыңыз)
-
 collapsible-initializing = Даярдалууда…
-
 footnote-show = Шилтемени көрсөтүү
 footnote-hide = Шилтемени жашыруу
-
 description-more-information = кошумча маалымат
-
 
 ## Controls
 
 slider-previous = Мурунку
 slider-next = Кийинки
-
 keyboard-open = Тергичти ачуу
 keyboard-close = Тергичти жабуу
-
 choice-input-remove-choice = { $choice } тандоосун алып салуу
-
 matrix-remove-row = Сапты өчүрүү
 matrix-add-row = Сап кошуу
 matrix-remove-column = Мамычаны өчүрүү
 matrix-add-column = Мамыча кошуу
-
 subset-add-remove-points = Чекиттерди кошуу/өчүрүү
 subset-toggle-points-intervals = Чекиттер менен аралыктарды алмаштыруу
 subset-move-points = Чекиттерди жылдыруу
 subset-clear = Тазалоо
-
 orbital-add-row = Сап кошуу
 orbital-remove-row = Сапты өчүрүү
 orbital-add-box = Уяча кошуу
@@ -92,13 +73,9 @@ orbital-remove-box = Уячаны өчүрүү
 orbital-add-up-arrow = Өйдө караган жебе кошуу
 orbital-add-down-arrow = Ылдый караган жебе кошуу
 orbital-remove-arrow = Жебени өчүрүү
-
 orbital-row-label = { $row } сабынын белгиси
-
 pretzel-answer = Жооп
-
 summary-statistics-caption = { $column } мамычасынын жыйынтык статистикасы
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = математикалык туюнтманын ал
 math-input-preview = Алдын ала көрүнүш
 math-input-invalid-expression = Жараксыз туюнтма:
 
-
 ## Document status
 
 viewer-initializing = Даярдалууда…
 
-
 ## Errors
 
 error-heading = Ката
-
 error-found-at =
     { $span ->
         [line] { $startLine } сабынан табылды.
        *[lines] { $startLine }–{ $endLine } саптарынан табылды.
     }
-
 document-contains-errors = Бул документте каталар бар!
-
 diagnostic-heading-error = Ката
 diagnostic-heading-warning = Эскертүү
 diagnostic-heading-information = Маалымат
 diagnostic-heading-hint = Кеңеш
-
 accessibility-heading-level-1 = WCAG AA жеткиликтүүлүк бузуусу
 accessibility-heading-level-2 = Жеткиликтүүлүк билдирүүсү
-
 something-went-wrong = Бир нерсе туура эмес болду.
-
 renderer-load-failed = чагылдыргычты жүктөө мүмкүн болбоду. Бетти жаңыртыңыз.
-
 core-start-failed = Документти карап көрүү куралын иштетүү мүмкүн болбоду. Бетти жаңыртыңыз.

--- a/packages/i18n/locales/ky/content.ftl
+++ b/packages/i18n/locales/ky/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = кызгылт көк
     .pink = ачык кызгылт
     .brown = күрөң
-
 line-width =
     .thick = калың
     .thin = ичке
-
 line-style =
     .dashed = үзүк
     .dotted = чекиттүү
-
 # Noun phrases: they stand in front of «оюмдуу» and modify nothing.
 fill-style =
     .horizontal = туурасынан сызык
@@ -53,7 +50,6 @@ fill-style =
     .backdiagonal = карама-каршы диагоналдык сызык
     .dots = чекит
     .diamonds = ромб
-
 noun =
     .line = түз сызык
     .line-segment = кесинди
@@ -73,7 +69,6 @@ noun =
     .diamond = ромб
     .cross = крест
     .plus = плюс
-
 # Kyrgyz builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -81,11 +76,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] туура { $numSides }-бурчтук
     }
-
 # Kyrgyz has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -99,21 +92,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = боёлгон
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } оюмдуу { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } оюмдуу { $color } { $filled } { $noun }
@@ -121,7 +110,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } оюмдуу { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «жээктүү» — "bordered" — carries the "with a border" sense in its own suffix,
 # so neither a preposition nor an article is wanted, and all four branches read
 # alike except for the connective English needs and Kyrgyz does not.
@@ -132,15 +120,12 @@ style-border-clause =
         [and-article] жана { $border } жээктүү
        *[with] { $border } жээктүү
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } оюмдуу { $color } боёк
        *[plain] { $color } боёк
     }
-
 style-unfilled = боёлбогон
-
 # «фондо» is the locative of «фон» and says "on the background" by itself, so
 # nothing stands between the two colours.
 style-text =
@@ -148,21 +133,17 @@ style-text =
         [background] { $background } фондо { $color }
        *[plain] { $color }
     }
-
 style-background-none = жок
-
 
 ## Boolean words
 
 boolean-true = чын
 boolean-false = жалган
 
-
 ## Answer buttons
 
 answer-submit-label = Текшерүү
 answer-submit-label-no-correctness = Жоопту жөнөтүү
-
 
 ## Sectional blocks
 
@@ -187,7 +168,6 @@ section-name =
     .solution = Чыгарылышы
     .task = Тапшырма
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -197,9 +177,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Кеңеш
-
 
 ## Tables and figures
 
@@ -210,7 +188,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration }-сүрөт
@@ -219,22 +196,18 @@ figure-name =
        *[unnumbered] Сүрөт
     }
 
-
 ## Paginator controls
 
 paginator-previous = Мурунку
 paginator-next = Кийинки
 paginator-page = Бет
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = же
 piecewise-condition-if = эгер
 piecewise-condition-otherwise = болбосо
-
 
 ## Chemistry
 
@@ -357,7 +330,6 @@ element-name =
     .lv = Ливерморий
     .ts = Теннессин
     .og = Оганесон
-
 element-anion-name =
     .h = Гидрид
     .c = Карбид
@@ -371,8 +343,6 @@ element-anion-name =
     .i = Йодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Жараксыз химиялык белги
 chemistry-invalid-ionic-compound = Жараксыз иондук кошулма

--- a/packages/i18n/locales/lb/chrome.ftl
+++ b/packages/i18n/locales/lb/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = Iwwerpréiwen…
 answer-submitting = Schécken…
-
 answer-checking-status = Äntwert gëtt iwwerpréift
 answer-submitting-status = Äntwert gëtt geschéckt
-
 answer-correct = Richteg
 answer-incorrect = Falsch
-
 answer-response-saved = Äntwert gespäichert
-
 answer-percent-credit = { $percent }% Punkten
 answer-percent-correct = { $percent }% richteg
 answer-percent-short = { $percent } %
-
 max-credit-available = Maximal méiglech Punkten: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] keng Versich méi iwwreg
         [one] nach { $count } Versuch iwwreg
        *[other] nach { $count } Versich iwwreg
     }
-
 validation-correct = (Richteg)
 validation-incorrect = (Falsch)
 validation-partially-correct = (Deelweis richteg)
-
 answer-show-responses =
     { $count ->
         [one] { $count } Äntwert op { $answerId } weisen
        *[other] { $count } Äntwerten op { $answerId } weisen
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Réckmeldung
-
 collapsible-click-to-open = (klickt fir opzemaachen)
 collapsible-click-to-close = (klickt fir zouzemaachen)
-
 collapsible-initializing = Start…
-
 footnote-show = Foussnout weisen
 footnote-hide = Foussnout verstoppen
-
 description-more-information = méi Informatioun
-
 
 ## Controls
 
 slider-previous = Zréck
 slider-next = Weider
-
 keyboard-open = Tastatur opmaachen
 keyboard-close = Tastatur zoumaachen
-
 choice-input-remove-choice = { $choice } ewechhuelen
-
 matrix-remove-row = Zeil ewechhuelen
 matrix-add-row = Zeil derbäisetzen
 matrix-remove-column = Kolonn ewechhuelen
 matrix-add-column = Kolonn derbäisetzen
-
 subset-add-remove-points = Punkten derbäisetzen/ewechhuelen
 subset-toggle-points-intervals = Tëscht Punkten an Intervaller wiesselen
 subset-move-points = Punkte réckelen
 subset-clear = Läschen
-
 orbital-add-row = Zeil derbäisetzen
 orbital-remove-row = Zeil ewechhuelen
 orbital-add-box = Këscht derbäisetzen
@@ -93,13 +74,9 @@ orbital-remove-box = Këscht ewechhuelen
 orbital-add-up-arrow = Pfeil no uewe derbäisetzen
 orbital-add-down-arrow = Pfeil no ënne derbäisetzen
 orbital-remove-arrow = Pfeil ewechhuelen
-
 orbital-row-label = Bezeechnung fir Zeil { $row }
-
 pretzel-answer = Äntwert
-
 summary-statistics-caption = Zesummefaassend Statistike vu { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = Virschau vum mathemateschen Ausdrock
 math-input-preview = Virschau
 math-input-invalid-expression = Ongëltegen Ausdrock:
 
-
 ## Document status
 
 viewer-initializing = Start…
 
-
 ## Errors
 
 error-heading = Feeler
-
 error-found-at =
     { $span ->
         [line] Fonnt op der Linn { $startLine }.
        *[lines] Fonnt op de Linnen { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dëst Dokument enthält Feeler!
-
 diagnostic-heading-error = Feeler
 diagnostic-heading-warning = Warnung
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Hiweis
-
 accessibility-heading-level-1 = Verstouss géint d'Accessibilitéit no WCAG AA
 accessibility-heading-level-2 = Hiweis zur Accessibilitéit
-
 something-went-wrong = Eppes ass schifgaangen.
-
 renderer-load-failed = e Modul fir d'Uweise konnt net gelueden ginn. Luet d'Säit nei.
-
 core-start-failed = De Visualiséierer vum Dokument konnt net gestart ginn. Luet d'Säit nei.

--- a/packages/i18n/locales/lb/content.ftl
+++ b/packages/i18n/locales/lb/content.ftl
@@ -86,7 +86,6 @@ color =
             [n] brongt
            *[m] bronge
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -100,7 +99,6 @@ line-width =
             [n] dënnt
            *[m] dënne
         }
-
 # A participle used as an adjective takes the same endings, except that a stem
 # already ending in `t` has nothing to add for the neuter.
 line-style =
@@ -116,7 +114,6 @@ line-style =
             [n] gepunkt
            *[m] gepunkte
         }
-
 # Plural noun phrases, which is what follows «mat» in `style-filled`. A plural
 # adjective is the bare stem, so these agree with nothing.
 fill-style =
@@ -126,7 +123,6 @@ fill-style =
     .backdiagonal = ëmgedréint diagonal Linnen
     .dots = Punkten
     .diamonds = Rauten
-
 noun =
     .line = Linn
     .line-segment = Streck
@@ -146,7 +142,6 @@ noun =
     .diamond = Raut
     .cross = Kräiz
     .plus = Plus
-
 # Luxembourgish keeps the side count in front of the noun, as a compound, so
 # the whole of it is one head and there is no tail. The head noun is `-Eck`,
 # which is neuter, so the adjective inside it takes the neuter `-t` — and
@@ -157,7 +152,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelméissegt { $numSides }-Eck
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (which is
 # `{ $numSides }-Eck`, n) or the head of a phrase the description never names:
 # `border` (Rand, m), `fill` (Fëllung, f), `text` (Text, m), `background`
@@ -181,7 +175,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -194,26 +187,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [f] gefëllt
         [n] gefëllt
        *[m] gefëllte
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } mat { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } mat { $pattern }
@@ -221,7 +210,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } mat { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «Rand» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds. Luxembourgish has an indefinite article, «e»,
 # so the two `-article` branches really do differ from the two without.
@@ -232,35 +220,28 @@ style-border-clause =
         [and-article] an engem { $border } Rand
        *[with] mat { $border } Rand
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } Fëllung mat { $pattern }
        *[plain] { $color } Fëllung
     }
-
 style-unfilled = net gefëllt
-
 style-text =
     { $parts ->
         [background] { $color } op engem { $background } Hannergrond
        *[plain] { $color }
     }
-
 style-background-none = keen
-
 
 ## Boolean words
 
 boolean-true = wouer
 boolean-false = falsch
 
-
 ## Answer buttons
 
 answer-submit-label = Iwwerpréifen
 answer-submit-label-no-correctness = Äntwert schécken
-
 
 ## Sectional blocks
 
@@ -285,7 +266,6 @@ section-name =
     .solution = Léisung
     .task = Aufgab
     .theorem = Theorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -295,9 +275,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Hiweis
-
 
 ## Tables and figures
 
@@ -308,7 +286,6 @@ table-name =
         [unnumbered-title] Tabell{ ": " }
        *[unnumbered] Tabell
     }
-
 figure-name =
     { $parts ->
         [numbered] Figur { $enumeration }
@@ -317,22 +294,18 @@ figure-name =
        *[unnumbered] Figur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Zréck
 paginator-next = Weider
 paginator-page = Säit
-
 paginator-page-status = { $pageLabel } { $currentPage } vun { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = oder
 piecewise-condition-if = wann
 piecewise-condition-otherwise = soss
-
 
 ## Chemistry
 ##
@@ -343,6 +316,5 @@ piecewise-condition-otherwise = soss
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ongëltegt chemescht Symbol
 chemistry-invalid-ionic-compound = Ongëlteg ionesch Verbindung

--- a/packages/i18n/locales/lg/chrome.ftl
+++ b/packages/i18n/locales/lg/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Ekebera...
 answer-submitting = Eweereza...
-
 answer-checking-status = Ekebera eky'okuddamu
 answer-submitting-status = Eweereza eky'okuddamu
-
 answer-correct = Kituufu
 answer-incorrect = Si kituufu
-
 answer-response-saved = Eky'okuddamu Kitereddwa
-
 answer-percent-credit = Amanya { $percent }%
 answer-percent-correct = { $percent }% Kituufu
 answer-percent-short = { $percent } %
-
 max-credit-available = Amanya agasinga agasoboka: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tewali mulundi gusigadde
         [one] omulundi { $count } gusigadde
        *[other] emirundi { $count } gisigadde
     }
-
 validation-correct = (Kituufu)
 validation-incorrect = (Si kituufu)
 validation-partially-correct = (Kituufu mu kitundu)
-
 answer-show-responses =
     { $count ->
         [one] Laga eky'okuddamu { $count } ekya { $answerId }
        *[other] Laga eby'okuddamu { $count } ebya { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Okuddamu kw'Omusomesa
-
 collapsible-click-to-open = (nyiga okuggulawo)
 collapsible-click-to-close = (nyiga okuggalawo)
-
 collapsible-initializing = Etandika...
-
 footnote-show = Laga ekiwandiiko eky'emmanga
 footnote-hide = Kweka ekiwandiiko eky'emmanga
-
 description-more-information = ebirala ebikwata ku kino
-
 
 ## Controls
 
 slider-previous = Ekiyise
 slider-next = Ekiddako
-
 keyboard-open = Ggulawo Kiibbodi
 keyboard-close = Ggalawo Kiibbodi
-
 choice-input-remove-choice = Ggyawo { $choice }
-
 matrix-remove-row = Ggyawo olunyiriri olugalamidde
 matrix-add-row = Yongerako olunyiriri olugalamidde
 matrix-remove-column = Ggyawo olunyiriri oluyimiridde
 matrix-add-column = Yongerako olunyiriri oluyimiridde
-
 subset-add-remove-points = Yongerako/Ggyawo obutonnyeze
 subset-toggle-points-intervals = Kyusa wakati w'obutonnyeze n'ebbanga
 subset-move-points = Situla Obutonnyeze
 subset-clear = Sangula
-
 # A `box` here is one orbital, drawn as a square: «akasanduuko».
 orbital-add-row = Yongerako Olunyiriri
 orbital-remove-row = Ggyawo Olunyiriri
@@ -96,13 +77,9 @@ orbital-remove-box = Ggyawo Akasanduuko
 orbital-add-up-arrow = Yongerako Akasaale Akatunuulidde Waggulu
 orbital-add-down-arrow = Yongerako Akasaale Akatunuulidde Wansi
 orbital-remove-arrow = Ggyawo Akasaale
-
 orbital-row-label = Erinnya ly'olunyiriri { $row }
-
 pretzel-answer = Eky'okuddamu
-
 summary-statistics-caption = Enkomerero y'ebibalo bya { $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = okulaba mu maaso ng'ebigambo by'okubala
 math-input-preview = Okulaba mu maaso
 math-input-invalid-expression = Ebigambo tebituufu:
 
-
 ## Document status
 
 viewer-initializing = Etandika...
 
-
 ## Errors
 
 error-heading = Ensobi
-
 error-found-at =
     { $span ->
         [line] Kizuuliddwa ku lunyiriri { $startLine }.
        *[lines] Kizuuliddwa ku nnyiriri { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ekiwandiiko kino kirimu ensobi!
-
 diagnostic-heading-error = Ensobi
 diagnostic-heading-warning = Okulabula
 diagnostic-heading-information = Ebiwandiiko
 diagnostic-heading-hint = Amagezi
-
 accessibility-heading-level-1 = Okumenya Etteeka lya WCAG AA ery'Okutuukirira
 accessibility-heading-level-2 = Okulabula ku kutuukirira
-
 something-went-wrong = Waliwo ekitagenze bulungi.
-
 renderer-load-failed = omulaga omu tegusobodde kutandika. Ddamu ozzeemu olupapula.
-
 core-start-failed = Omulaga w'ekiwandiiko tasobodde kutandika. Ddamu ozzeemu olupapula.

--- a/packages/i18n/locales/lg/content.ftl
+++ b/packages/i18n/locales/lg/content.ftl
@@ -90,7 +90,6 @@ color =
     .purple = kakobe
     .pink = pinki
     .brown = kikanvu
-
 line-width =
     .thick =
         { $gender ->
@@ -110,14 +109,12 @@ line-width =
             [c12] akatono
            *[c9] entono
         }
-
 # Written as invariable «olwa …» phrases rather than as adjectives, so that
 # they agree with nothing and can close the description. `style-stroke` puts
 # them last for that reason.
 line-style =
     .dashed = olw'obutundutundu
     .dotted = olw'obutonnyeze
-
 fill-style =
     .horizontal = ennyiriri ezigalamidde
     .vertical = ennyiriri eziyimiridde
@@ -125,7 +122,6 @@ fill-style =
     .backdiagonal = ennyiriri ezisenzeeko emabega
     .dots = obutonnyeze
     .diamonds = daayimondi
-
 noun =
     .line = olunyiriri
     .line-segment = ekitundu ky'olunyiriri
@@ -145,7 +141,6 @@ noun =
     .diamond = daayimondi
     .cross = omusaalaba
     .plus = akabonero k'okugatta
-
 # The side count goes in the tail, behind the adjectives, because «erina
 # enjuyi 5» is a relative clause and Luganda closes a noun phrase with one
 # rather than opening one.
@@ -154,7 +149,6 @@ noun-regular-polygon =
         [tail] erina enjuyi { $numSides }
        *[head] poligoni enkanyi
     }
-
 noun-gender =
     { $noun ->
         [line] c11
@@ -174,7 +168,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -187,13 +180,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] omujjuvu
@@ -203,13 +194,11 @@ style-filled-word =
         [c12] akajjuvu
        *[c9] enjjuvu
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } n'{ $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } n'{ $pattern }
@@ -217,7 +206,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } n'{ $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «olukugiro» is class 11 and leads its own adjectives, so the border's words
 # agree with it and not with the shape it surrounds. Luganda has no article, so
 # the two `-article` branches read like the two without, and the complement is
@@ -231,35 +219,28 @@ style-border-clause =
         [and-article] n'olukugiro { $border }
        *[with] n'olukugiro { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tejjuzibbwa
-
 style-text =
     { $parts ->
         [background] { $color } ku mabega { $background }
        *[plain] { $color }
     }
-
 style-background-none = tewali
-
 
 ## Boolean words
 
 boolean-true = kituufu
 boolean-false = bulimba
 
-
 ## Answer buttons
 
 answer-submit-label = Kebera Omulimu
 answer-submit-label-no-correctness = Weereza Eky'okuddamu
-
 
 ## Sectional blocks
 
@@ -284,7 +265,6 @@ section-name =
     .solution = Eky'okugonjoola
     .task = Omulimu
     .theorem = Tiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -294,9 +274,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Amagezi
-
 
 ## Tables and figures
 
@@ -307,7 +285,6 @@ table-name =
         [unnumbered-title] Ttebulo{ ": " }
        *[unnumbered] Ttebulo
     }
-
 figure-name =
     { $parts ->
         [numbered] Ekifaananyi { $enumeration }
@@ -316,22 +293,18 @@ figure-name =
        *[unnumbered] Ekifaananyi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ekiyise
 paginator-next = Ekiddako
 paginator-page = Olupapula
-
 paginator-page-status = { $pageLabel } { $currentPage } ku { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = oba
 piecewise-condition-if = singa
 piecewise-condition-otherwise = bwe kitaba bwe kityo
-
 
 ## Chemistry
 
@@ -341,6 +314,5 @@ piecewise-condition-otherwise = bwe kitaba bwe kityo
 # already, and the seed has no settled Luganda list to reproduce. A speaker
 # adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Akabonero ka Kemikaali Akatatuufu
 chemistry-invalid-ionic-compound = Ekitabuliddwa kya Ayoni Ekitatuufu

--- a/packages/i18n/locales/ln/chrome.ftl
+++ b/packages/i18n/locales/ln/chrome.ftl
@@ -21,74 +21,55 @@
 
 answer-checking = Ezali kotala...
 answer-submitting = Ezali kotinda...
-
 answer-checking-status = Ezali kotala eyano
 answer-submitting-status = Ezali kotinda eyano
-
 answer-correct = Ebongi
 answer-incorrect = Ebongi te
-
 answer-response-saved = Eyano Ebombami
-
 answer-percent-credit = Motuya { $percent }%
 answer-percent-correct = { $percent }% Ebongi
 answer-percent-short = { $percent } %
-
 max-credit-available = Motuya monene oyo ekoki kozwama: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] momekano moko etikali te
         [one] momekano { $count } etikali
        *[other] mimekano { $count } etikali
     }
-
 validation-correct = (Ebongi)
 validation-incorrect = (Ebongi te)
 validation-partially-correct = (Ebongi na ndambo)
-
 answer-show-responses =
     { $count ->
         [one] Lakisá eyano { $count } ya { $answerId }
        *[other] Lakisá biyano { $count } ya { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Eyano ya Molakisi
-
 collapsible-click-to-open = (finá mpo na kofungola)
 collapsible-click-to-close = (finá mpo na kokanga)
-
 collapsible-initializing = Ezali kobanda...
-
 footnote-show = Lakisá liyebisi ya nse
 footnote-hide = Bombá liyebisi ya nse
-
 description-more-information = basango mosusu
-
 
 ## Controls
 
 slider-previous = Eleki
 slider-next = Elandi
-
 keyboard-open = Fungolá Klavye
 keyboard-close = Kangá Klavye
-
 choice-input-remove-choice = Longolá { $choice }
-
 matrix-remove-row = Longolá molɔngɔ ya kolala
 matrix-add-row = Bakisá molɔngɔ ya kolala
 matrix-remove-column = Longolá molɔngɔ ya kotɛlɛma
 matrix-add-column = Bakisá molɔngɔ ya kotɛlɛma
-
 subset-add-remove-points = Bakisá/Longolá matono
 subset-toggle-points-intervals = Bongolá kati ya matono na bantaka
 subset-move-points = Longolá Matono
 subset-clear = Pɛtolá
-
 # A `box` here is one orbital, drawn as a square: «sanduku».
 orbital-add-row = Bakisá Molɔngɔ
 orbital-remove-row = Longolá Molɔngɔ
@@ -97,13 +78,9 @@ orbital-remove-box = Longolá Sanduku
 orbital-add-up-arrow = Bakisá Likula ya Likolo
 orbital-add-down-arrow = Bakisá Likula ya Nse
 orbital-remove-arrow = Longolá Likula
-
 orbital-row-label = Nkombo ya molɔngɔ { $row }
-
 pretzel-answer = Eyano
-
 summary-statistics-caption = Motango mokuse ya { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = botali liboso ya maloba ya matematiki
 math-input-preview = Botali liboso
 math-input-invalid-expression = Maloba ebongi te:
 
-
 ## Document status
 
 viewer-initializing = Ezali kobanda...
 
-
 ## Errors
 
 error-heading = Libunga
-
 error-found-at =
     { $span ->
         [line] Emonani na molɔngɔ { $startLine }.
        *[lines] Emonani na milɔngɔ { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Mokanda oyo ezali na mabunga!
-
 diagnostic-heading-error = Libunga
 diagnostic-heading-warning = Likebisi
 diagnostic-heading-information = Sango
 diagnostic-heading-hint = Toli
-
 accessibility-heading-level-1 = Kobuka Mibeko ya WCAG AA mpo na Bokɔti
 accessibility-heading-level-2 = Likebisi mpo na bokɔti
-
 something-went-wrong = Eloko moko esalemi malamu te.
-
 renderer-load-failed = molakisi moko ekokaki kokɔta te. Zongisá lokasa.
-
 core-start-failed = Molakisi ya mokanda akokaki kobanda te. Zongisá lokasa.

--- a/packages/i18n/locales/ln/content.ftl
+++ b/packages/i18n/locales/ln/content.ftl
@@ -56,7 +56,6 @@ color =
     .purple = violɛ
     .pink = rozɛ
     .brown = marɔ
-
 line-width =
     .thick =
         { $gender ->
@@ -72,14 +71,12 @@ line-width =
             [c7] ekɛ
            *[c9] ekɛ
         }
-
 # Written as invariable «na …» phrases rather than as adjectives, so that they
 # agree with nothing and can close the description. `style-stroke` puts them
 # last for that reason.
 line-style =
     .dashed = na bantɔkɔ
     .dotted = na bapwɛ
-
 fill-style =
     .horizontal = milɔngɔ ya kolala
     .vertical = milɔngɔ ya kotɛlɛma
@@ -87,7 +84,6 @@ fill-style =
     .backdiagonal = milɔngɔ ya ngwɛ ya nsima
     .dots = bapwɛ
     .diamonds = balozanje
-
 noun =
     .line = molɔngɔ
     .line-segment = eteni ya molɔngɔ
@@ -107,7 +103,6 @@ noun =
     .diamond = lozanje
     .cross = ekulusu
     .plus = elembo ya kobakisa
-
 # The side count goes in the tail, behind the adjectives, because «oyo ezali na
 # mipanzi 5» is a relative clause and Lingala closes a noun phrase with one
 # rather than opening one.
@@ -116,7 +111,6 @@ noun-regular-polygon =
         [tail] oyo ezali na mipanzi { $numSides }
        *[head] poligonɛ ya bokokani
     }
-
 # The noun class, which is what an adjective agrees with. `c9` is the default
 # and the class of every loanword, including a word an author supplies.
 noun-gender =
@@ -133,7 +127,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «na …» phrase and closes the description, so it moves
@@ -148,13 +141,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] motondi
@@ -162,13 +153,11 @@ style-filled-word =
         [c7] etondi
        *[c9] etondi
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -176,7 +165,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «ndelo» leads its own adjectives, so the border's words agree with it and not
 # with the shape it surrounds. Lingala has no article and joins a complement
 # with the invariable «na», so all four branches read alike.
@@ -187,35 +175,28 @@ style-border-clause =
         [and-article] na ndelo { $border }
        *[with] na ndelo { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = etondi te
-
 style-text =
     { $parts ->
         [background] { $color } likolo ya nsima { $background }
        *[plain] { $color }
     }
-
 style-background-none = eloko te
-
 
 ## Boolean words
 
 boolean-true = solo
 boolean-false = lokuta
 
-
 ## Answer buttons
 
 answer-submit-label = Talá Mosala
 answer-submit-label-no-correctness = Tinda Eyano
-
 
 ## Sectional blocks
 
@@ -240,7 +221,6 @@ section-name =
     .solution = Bosili
     .task = Mosala
     .theorem = Teorɛmɛ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -250,9 +230,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Toli
-
 
 ## Tables and figures
 
@@ -263,7 +241,6 @@ table-name =
         [unnumbered-title] Tabelo{ ": " }
        *[unnumbered] Tabelo
     }
-
 figure-name =
     { $parts ->
         [numbered] Elilingi { $enumeration }
@@ -272,22 +249,18 @@ figure-name =
        *[unnumbered] Elilingi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Eleki
 paginator-next = Elandi
 paginator-page = Lokasa
-
 paginator-page-status = { $pageLabel } { $currentPage } na kati ya { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = to
 piecewise-condition-if = soki
 piecewise-condition-otherwise = soki te
-
 
 ## Chemistry
 
@@ -297,6 +270,5 @@ piecewise-condition-otherwise = soki te
 # European language already, and the seed has no settled Lingala list to
 # reproduce. A speaker adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Elembo ya Shimi Ebongi Te
 chemistry-invalid-ionic-compound = Bosangani ya Ioni Ebongi Te

--- a/packages/i18n/locales/lo/chrome.ftl
+++ b/packages/i18n/locales/lo/chrome.ftl
@@ -23,69 +23,50 @@
 
 answer-checking = ກຳລັງກວດ...
 answer-submitting = ກຳລັງສົ່ງ...
-
 answer-checking-status = ກຳລັງກວດຄຳຕອບ
 answer-submitting-status = ກຳລັງສົ່ງຄຳຕອບ
-
 answer-correct = ຖືກຕ້ອງ
 answer-incorrect = ບໍ່ຖືກຕ້ອງ
-
 answer-response-saved = ບັນທຶກຄຳຕອບແລ້ວ
-
 answer-percent-credit = ຄະແນນ { $percent }%
 answer-percent-correct = ຖືກຕ້ອງ { $percent }%
 answer-percent-short = { $percent }%
-
 max-credit-available = ຄະແນນສູງສຸດທີ່ສາມາດໄດ້ຮັບ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ບໍ່ມີໂອກາດເຫຼືອ
        *[other] ເຫຼືອ { $count } ໂອກາດ
     }
-
 validation-correct = (ຖືກຕ້ອງ)
 validation-incorrect = (ບໍ່ຖືກຕ້ອງ)
 validation-partially-correct = (ຖືກຕ້ອງບາງສ່ວນ)
-
 answer-show-responses = ສະແດງ { $count } ຄຳຕອບທີ່ສົ່ງໃຫ້ { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = ຄຳຕິຊົມ
-
 collapsible-click-to-open = (ຄລິກເພື່ອເປີດ)
 collapsible-click-to-close = (ຄລິກເພື່ອປິດ)
-
 collapsible-initializing = ກຳລັງເລີ່ມຕົ້ນ...
-
 footnote-show = ສະແດງໝາຍເຫດທ້າຍໜ້າ
 footnote-hide = ເຊື່ອງໝາຍເຫດທ້າຍໜ້າ
-
 description-more-information = ຂໍ້ມູນເພີ່ມເຕີມ
-
 
 ## Controls
 
 slider-previous = ກ່ອນໜ້າ
 slider-next = ຕໍ່ໄປ
-
 keyboard-open = ເປີດແປ້ນພິມ
 keyboard-close = ປິດແປ້ນພິມ
-
 choice-input-remove-choice = ເອົາ { $choice } ອອກ
-
 matrix-remove-row = ລຶບແຖວ
 matrix-add-row = ເພີ່ມແຖວ
 matrix-remove-column = ລຶບຖັນ
 matrix-add-column = ເພີ່ມຖັນ
-
 subset-add-remove-points = ເພີ່ມ/ລຶບຈຸດ
 subset-toggle-points-intervals = ສະຫຼັບລະຫວ່າງຈຸດ ແລະ ຊ່ວງ
 subset-move-points = ຍ້າຍຈຸດ
 subset-clear = ລຶບລ້າງ
-
 orbital-add-row = ເພີ່ມແຖວ
 orbital-remove-row = ລຶບແຖວ
 orbital-add-box = ເພີ່ມກ່ອງ
@@ -93,13 +74,9 @@ orbital-remove-box = ລຶບກ່ອງ
 orbital-add-up-arrow = ເພີ່ມລູກສອນຂຶ້ນ
 orbital-add-down-arrow = ເພີ່ມລູກສອນລົງ
 orbital-remove-arrow = ລຶບລູກສອນ
-
 orbital-row-label = ປ້າຍສຳລັບແຖວທີ { $row }
-
 pretzel-answer = ຄຳຕອບ
-
 summary-statistics-caption = ສະຖິຕິສະຫຼຸບຂອງ { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = ການເບິ່ງຕົວຢ່າງນິ�
 math-input-preview = ເບິ່ງຕົວຢ່າງ
 math-input-invalid-expression = ນິພົນບໍ່ຖືກຕ້ອງ:
 
-
 ## Document status
 
 viewer-initializing = ກຳລັງເລີ່ມຕົ້ນ...
 
-
 ## Errors
 
 error-heading = ຂໍ້ຜິດພາດ
-
 error-found-at =
     { $span ->
         [line] ພົບຢູ່ແຖວທີ { $startLine }.
        *[lines] ພົບຢູ່ແຖວທີ { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = ເອກະສານນີ້ມີຂໍ້ຜິດພາດ!
-
 diagnostic-heading-error = ຂໍ້ຜິດພາດ
 diagnostic-heading-warning = ຄຳເຕືອນ
 diagnostic-heading-information = ຂໍ້ມູນ
 diagnostic-heading-hint = ຄຳໃບ້
-
 accessibility-heading-level-1 = ການລະເມີດການເຂົ້າເຖິງ WCAG AA
 accessibility-heading-level-2 = ການແຈ້ງເຕືອນການເຂົ້າເຖິງ
-
 something-went-wrong = ມີບາງຢ່າງຜິດພາດ.
-
 renderer-load-failed = ໂຕສະແດງຜົນໜຶ່ງໂຫຼດບໍ່ໄດ້. ກະລຸນາໂຫຼດໜ້ານີ້ຄືນໃໝ່.
-
 core-start-failed = ບໍ່ສາມາດເລີ່ມໂຕເບິ່ງເອກະສານໄດ້. ກະລຸນາໂຫຼດໜ້ານີ້ຄືນໃໝ່.

--- a/packages/i18n/locales/lo/content.ftl
+++ b/packages/i18n/locales/lo/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = ສີມ່ວງ
     .pink = ສີບົວ
     .brown = ສີນ້ຳຕານ
-
 line-width =
     .thick = ໜາ
     .thin = ບາງ
-
 line-style =
     .dashed = ຂີດຂາດ
     .dotted = ຈຸດ
-
 # Noun phrases: they follow «ພ້ອມ» and modify nothing.
 fill-style =
     .horizontal = ເສັ້ນນອນ
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = ເສັ້ນທະແຍງກັບ
     .dots = ຈຸດ
     .diamonds = ຮູບຂ້າວຫຼາມຕັດ
-
 noun =
     .line = ເສັ້ນຊື່
     .line-segment = ພາກຂອງເສັ້ນຊື່
@@ -77,7 +73,6 @@ noun =
     .diamond = ຮູບຂ້າວຫຼາມຕັດ
     .cross = ເຄື່ອງໝາຍກາກະບາດ
     .plus = ເຄື່ອງໝາຍບວກ
-
 # The count and the word it counts — «ດ້ານ», side — sit together immediately
 # after the noun and in front of any adjective, so they fold into the head and
 # there is no tail. Putting them after the adjectives would separate «ດ້ານ»
@@ -87,11 +82,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] ຮູບຫຼາຍແຫຼ່ຽມດ້ານເທົ່າ { $numSides } ດ້ານ
     }
-
 # Lao has no grammatical gender, so every noun answers the same and the answer
 # goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,27 +98,23 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «ເສັ້ນຊື່ໜາຂີດຂາດສີແດງ».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun }{ $description }{ $nounTail }
        *[noun] { $noun }{ $description }
     }
-
 # «ລະບາຍ» is the verb for laying colour on a surface, and every colour word
 # above already carries its own «ສີ», so the composition reads «ລະບາຍສີຟ້າ»
 # with the colour word said once. A colour that did not come from that table
 # brings no «ສີ» with it, and «ລະບາຍ» stands in front of it unaided.
 # `style-unfilled` stands on its own and keeps the full «ບໍ່ລະບາຍສີ».
 style-filled-word = ລະບາຍ
-
 style-filled =
     { $parts ->
         [pattern] { $filled }{ $color } ພ້ອມ{ $pattern }
        *[plain] { $filled }{ $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun }{ $filled }{ $color } ພ້ອມ{ $pattern }
@@ -133,7 +122,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun }{ $nounTail }{ $filled }{ $color } ພ້ອມ{ $pattern }
        *[plain] { $noun }{ $filled }{ $color }
     }
-
 # «ຂອບ» leads its own adjectives, the way every noun here does. Lao has no
 # article, so the `-article` branches read like the ones without.
 style-border-clause =
@@ -143,36 +131,29 @@ style-border-clause =
         [and-article] ແລະຂອບ{ $border }
        *[with] ພ້ອມຂອບ{ $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern }{ $color }
        *[plain] { $color }
     }
-
 style-unfilled = ບໍ່ລະບາຍສີ
-
 style-text =
     { $parts ->
         [background] { $color }ເທິງພື້ນຫຼັງ{ $background }
        *[plain] { $color }
     }
-
 style-background-none = ບໍ່ມີ
-
 
 ## Boolean words
 
 boolean-true = ຈິງ
 boolean-false = ເທັດ
 
-
 ## Answer buttons
 
 answer-submit-label = ກວດຄຳຕອບ
 answer-submit-label-no-correctness = ສົ່ງຄຳຕອບ
-
 
 ## Sectional blocks
 
@@ -197,7 +178,6 @@ section-name =
     .solution = ວິທີແກ້
     .task = ໜ້າວຽກ
     .theorem = ທິດສະດີບົດ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -207,9 +187,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ຄຳໃບ້
-
 
 ## Tables and figures
 
@@ -220,7 +198,6 @@ table-name =
         [unnumbered-title] ຕາຕະລາງ{ ": " }
        *[unnumbered] ຕາຕະລາງ
     }
-
 figure-name =
     { $parts ->
         [numbered] ຮູບທີ { $enumeration }
@@ -229,22 +206,18 @@ figure-name =
        *[unnumbered] ຮູບ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ກ່ອນໜ້າ
 paginator-next = ຕໍ່ໄປ
 paginator-page = ໜ້າ
-
 paginator-page-status = { $pageLabel } { $currentPage } ຈາກ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ຫຼື
 piecewise-condition-if = ຖ້າ
 piecewise-condition-otherwise = ກໍລະນີອື່ນ
-
 
 ## Chemistry
 ##
@@ -259,6 +232,5 @@ piecewise-condition-otherwise = ກໍລະນີອື່ນ
 ## fill in, and filling it in needs no permission.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ສັນຍາລັກເຄມີບໍ່ຖືກຕ້ອງ
 chemistry-invalid-ionic-compound = ສານປະກອບໄອອອນບໍ່ຖືກຕ້ອງ

--- a/packages/i18n/locales/lom/chrome.ftl
+++ b/packages/i18n/locales/lom/chrome.ftl
@@ -25,74 +25,55 @@
 
 answer-checking = A bɛi kɔlɔ-taa…
 answer-submitting = A bɛi ci-taa…
-
 answer-checking-status = Jaabi kɔlɔ-taa
 answer-submitting-status = Jaabi ci-taa
-
 answer-correct = A mɛni
 answer-incorrect = A mɛni gaa
-
 answer-response-saved = Jaabi marala
-
 answer-percent-credit = { $percent }% pɔn
 answer-percent-correct = { $percent }% mɛni
 answer-percent-short = { $percent } %
-
 max-credit-available = Pɔn gbɛtɛ mu wa sɔrɔ ma: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kɛcogo he to gaa
         [one] kɛcogo { $count } to
        *[other] kɛcogo { $count } to
     }
-
 validation-correct = (A mɛni)
 validation-incorrect = (A mɛni gaa)
 validation-partially-correct = (A mɛni yɔrɔ dɔ ma)
-
 answer-show-responses =
     { $count ->
         [one] Jaabi { $count } jira { $answerId } ma
        *[other] Jaabi { $count } jira { $answerId } ma
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Kɔlɔyaa-jaabi
-
 collapsible-click-to-open = (a digi ka a wulo)
 collapsible-click-to-close = (a digi ka a tugu)
-
 collapsible-initializing = A bɛi damina-taa…
-
 footnote-show = Duguma-sɛbɛ jira
 footnote-hide = Duguma-sɛbɛ dogo
-
 description-more-information = kunnafoni gbɛtɛ
-
 
 ## Controls
 
 slider-previous = Kɔrɔ
 slider-next = Nata
-
 keyboard-open = Klaviye wulo
 keyboard-close = Klaviye tugu
-
 choice-input-remove-choice = { $choice } bɔ
-
 matrix-remove-row = Laa bɔ
 matrix-add-row = Laa fa
 matrix-remove-column = Kolo bɔ
 matrix-add-column = Kolo fa
-
 subset-add-remove-points = Kɛlɛ-nu fa/bɔ
 subset-toggle-points-intervals = Kɛlɛ-nu nun tila-yɔrɔ-nu falɛ
 subset-move-points = Kɛlɛ-nu lamaga
 subset-clear = Bɛɛ bɔ
-
 orbital-add-row = Laa fa
 orbital-remove-row = Laa bɔ
 orbital-add-box = Kɛsu fa
@@ -100,13 +81,9 @@ orbital-remove-box = Kɛsu bɔ
 orbital-add-up-arrow = Sanfɛ-bin fa
 orbital-add-down-arrow = Dugumafɛ-bin fa
 orbital-remove-arrow = Bin bɔ
-
 orbital-row-label = Laa { $row } tɔgɔ
-
 pretzel-answer = Jaabi
-
 summary-statistics-caption = { $column } jate-nu kunkurunni
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = jate-kuma ɲɛfɔli
 math-input-preview = Ɲɛfɔli
 math-input-invalid-expression = Kuma sɔsɔlen:
 
-
 ## Document status
 
 viewer-initializing = A bɛi damina-taa…
 
-
 ## Errors
 
 error-heading = Fele
-
 error-found-at =
     { $span ->
         [line] A sɔrɔla laa { $startLine } ma.
        *[lines] A sɔrɔla laa { $startLine }–{ $endLine } ma.
     }
-
 document-contains-errors = Sɛbɛ nin fele-nu bɛ a la!
-
 diagnostic-heading-error = Fele
 diagnostic-heading-warning = Kɔlɔyaa
 diagnostic-heading-information = Kunnafoni
 diagnostic-heading-hint = Nɔnabɔli
-
 accessibility-heading-level-1 = WCAG AA sekokɔrɔ tɛmɛli
 accessibility-heading-level-2 = Sekokɔrɔ kɔlɔyaa
-
 something-went-wrong = Fɛn dɔ mɛni gaa.
-
 renderer-load-failed = jirala se gaa ka wuli. Ɲɛ nin segin.
-
 core-start-failed = Sɛbɛ-jirala se gaa ka damina. Ɲɛ nin segin.

--- a/packages/i18n/locales/lom/content.ftl
+++ b/packages/i18n/locales/lom/content.ftl
@@ -64,15 +64,12 @@ color =
     .purple = kula-kolo
     .pink = woilei-fanyi
     .brown = ndunya-kolo
-
 line-width =
     .thick = gbagba
     .thin = kpinkpin
-
 line-style =
     .dashed = tɛgɛlen
     .dotted = kɛlɛ-kɛlɛ
-
 fill-style =
     .horizontal = laa-laa
     .vertical = kologboo-kologboo
@@ -80,7 +77,6 @@ fill-style =
     .backdiagonal = gbaalen-kpogbo
     .dots = kɛlɛ-nu
     .diamonds = kula-taamaa-nu
-
 noun =
     .line = tan
     .line-segment = tan-kunkun
@@ -100,15 +96,12 @@ noun =
     .diamond = kula-taamaa
     .cross = kula-fele
     .plus = pulusi
-
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] fan-caa { $numSides } lɔnni
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -122,21 +115,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = fanla
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } nun
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } nun
@@ -144,7 +133,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } nun
        *[plain] { $filled } { $color } { $noun }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] { $border } gbansan nun
@@ -152,35 +140,28 @@ style-border-clause =
         [and-article] nun { $border } gbansan
        *[with] { $border } gbansan nun
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = fanla gaa
-
 style-text =
     { $parts ->
         [background] { $color } nun kpogbo-kolo { $background } nun
        *[plain] { $color }
     }
-
 style-background-none = ɓoyi
-
 
 ## Boolean words
 
 boolean-true = true
 boolean-false = false
 
-
 ## Answer buttons
 
 answer-submit-label = Jaabi kɔlɔ
 answer-submit-label-no-correctness = Jaabi ci
-
 
 ## Sectional blocks
 
@@ -205,7 +186,6 @@ section-name =
     .solution = Jaabi-jɛnjɛn
     .task = Kɛta-baalu
     .theorem = Sɛbɛ-tigi-kuma
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -215,9 +195,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Nɔnabɔli
-
 
 ## Tables and figures
 
@@ -228,7 +206,6 @@ table-name =
         [unnumbered-title] Tabali{ ": " }
        *[unnumbered] Tabali
     }
-
 figure-name =
     { $parts ->
         [numbered] Ja { $enumeration }
@@ -237,32 +214,24 @@ figure-name =
        *[unnumbered] Ja
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kɔrɔ
 paginator-next = Nata
 paginator-page = Peji
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = wala
-
 piecewise-condition-if = ni
-
 piecewise-condition-otherwise = fɛn gbɛtɛ bɛɛ na
-
 
 ## Chemistry
 ##
 ## Left out — see this file's header for why the two-country school-system
 ## split makes a single fallback the wrong shape here.
 
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Elemɛn-taamaa Sɔsɔlen
 chemistry-invalid-ionic-compound = Yɛlɛma-fan Sɔsɔlen

--- a/packages/i18n/locales/lt/chrome.ftl
+++ b/packages/i18n/locales/lt/chrome.ftl
@@ -22,21 +22,15 @@
 
 answer-checking = Tikrinama…
 answer-submitting = Pateikiama…
-
 answer-checking-status = Atsakymo tikrinimas
 answer-submitting-status = Atsakymo pateikimas
-
 answer-correct = Teisinga
 answer-incorrect = Neteisinga
-
 answer-response-saved = Atsakymas įrašytas
-
 answer-percent-credit = { $percent }% balo
 answer-percent-correct = { $percent }% teisinga
 answer-percent-short = { $percent } %
-
 max-credit-available = Didžiausias galimas balas: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] bandymų nebeliko
@@ -44,11 +38,9 @@ attempts-remaining =
         [few] liko { $count } bandymai
        *[other] liko { $count } bandymų
     }
-
 validation-correct = (Teisinga)
 validation-incorrect = (Neteisinga)
 validation-partially-correct = (Iš dalies teisinga)
-
 answer-show-responses =
     { $count ->
         [one] Rodyti { $count } atsakymą į { $answerId }
@@ -56,42 +48,31 @@ answer-show-responses =
        *[other] Rodyti { $count } atsakymų į { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Grįžtamasis ryšys
-
 collapsible-click-to-open = (spustelėkite, kad atvertumėte)
 collapsible-click-to-close = (spustelėkite, kad užvertumėte)
-
 collapsible-initializing = Paruošiama…
-
 footnote-show = Rodyti išnašą
 footnote-hide = Slėpti išnašą
-
 description-more-information = daugiau informacijos
-
 
 ## Controls
 
 slider-previous = Atgal
 slider-next = Pirmyn
-
 keyboard-open = Atverti klaviatūrą
 keyboard-close = Užverti klaviatūrą
-
 choice-input-remove-choice = Pašalinti { $choice }
-
 matrix-remove-row = Pašalinti eilutę
 matrix-add-row = Pridėti eilutę
 matrix-remove-column = Pašalinti stulpelį
 matrix-add-column = Pridėti stulpelį
-
 subset-add-remove-points = Pridėti / pašalinti taškus
 subset-toggle-points-intervals = Perjungti tarp taškų ir intervalų
 subset-move-points = Perkelti taškus
 subset-clear = Išvalyti
-
 orbital-add-row = Pridėti eilutę
 orbital-remove-row = Pašalinti eilutę
 orbital-add-box = Pridėti langelį
@@ -99,13 +80,9 @@ orbital-remove-box = Pašalinti langelį
 orbital-add-up-arrow = Pridėti rodyklę aukštyn
 orbital-add-down-arrow = Pridėti rodyklę žemyn
 orbital-remove-arrow = Pašalinti rodyklę
-
 orbital-row-label = { $row } eilutės žymė
-
 pretzel-answer = Atsakymas
-
 summary-statistics-caption = { $column } suvestinė statistika
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = matematinės išraiškos peržiūra
 math-input-preview = Peržiūra
 math-input-invalid-expression = Netinkama išraiška:
 
-
 ## Document status
 
 viewer-initializing = Paruošiama…
 
-
 ## Errors
 
 error-heading = Klaida
-
 error-found-at =
     { $span ->
         [line] Rasta { $startLine } eilutėje.
        *[lines] Rasta { $startLine }–{ $endLine } eilutėse.
     }
-
 document-contains-errors = Šiame dokumente yra klaidų!
-
 diagnostic-heading-error = Klaida
 diagnostic-heading-warning = Įspėjimas
 diagnostic-heading-information = Informacija
 diagnostic-heading-hint = Užuomina
-
 accessibility-heading-level-1 = WCAG AA prieinamumo pažeidimas
 accessibility-heading-level-2 = Prieinamumo pranešimas
-
 something-went-wrong = Kažkas nepavyko.
-
 renderer-load-failed = nepavyko įkelti atvaizdavimo modulio. Įkelkite puslapį iš naujo.
-
 core-start-failed = Nepavyko paleisti dokumento peržiūros. Įkelkite puslapį iš naujo.

--- a/packages/i18n/locales/lt/content.ftl
+++ b/packages/i18n/locales/lt/content.ftl
@@ -159,7 +159,6 @@ color =
                    *[m] rudas
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -183,7 +182,6 @@ line-width =
                    *[m] plonas
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -207,7 +205,6 @@ line-style =
                    *[m] taškinis
                 }
         }
-
 # Noun phrases in the instrumental, which is the case «su» takes. They agree
 # with nothing.
 fill-style =
@@ -217,7 +214,6 @@ fill-style =
     .backdiagonal = atvirkštinėmis įstrižomis linijomis
     .dots = taškais
     .diamonds = rombais
-
 noun =
     .line = tiesė
     .line-segment = atkarpa
@@ -237,7 +233,6 @@ noun =
     .diamond = rombas
     .cross = kryžius
     .plus = pliusas
-
 # Lithuanian keeps the side count in front of the noun, so the whole of it is
 # one head and there is no tail.
 noun-regular-polygon =
@@ -245,7 +240,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] taisyklingasis { $numSides }-kampis
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (daugiakampis, m)
 # or the head of a phrase the description never names: `border` (rėmelis, m),
 # `fill` (užpildas, m), `text` (tekstas, m), `background` (fonas, m).
@@ -261,7 +255,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -274,13 +267,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -288,13 +279,11 @@ style-filled-word =
         [f] užpildyta
        *[m] užpildytas
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } su { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } su { $pattern }
@@ -302,7 +291,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } su { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «rėmelis» is masculine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Lithuanian has no article, so the two `-article`
 # branches read like the two without.
@@ -313,7 +301,6 @@ style-border-clause =
         [and-article] ir { $border } rėmeliu
        *[with] su { $border } rėmeliu
     }
-
 # The fill-pattern words are instrumental plurals, because their other use is
 # the «su { $pattern }» clause in `style-filled`. So this message supplies a
 # noun for them to hang off — «užpildas», masculine, which is the gender
@@ -323,9 +310,7 @@ style-fill =
         [pattern] { $color } užpildas su { $pattern }
        *[plain] { $color } užpildas
     }
-
 style-unfilled = neužpildytas
-
 # The background sits in the locative and carries no preposition of its own, so
 # the two colours simply follow one another.
 style-text =
@@ -333,21 +318,17 @@ style-text =
         [background] { $color } { $background } fone
        *[plain] { $color }
     }
-
 style-background-none = nėra
-
 
 ## Boolean words
 
 boolean-true = tiesa
 boolean-false = netiesa
 
-
 ## Answer buttons
 
 answer-submit-label = Tikrinti
 answer-submit-label-no-correctness = Pateikti atsakymą
-
 
 ## Sectional blocks
 
@@ -372,7 +353,6 @@ section-name =
     .solution = Sprendimas
     .task = Užduotis
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -382,9 +362,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Užuomina
-
 
 ## Tables and figures
 
@@ -395,7 +373,6 @@ table-name =
         [unnumbered-title] Lentelė{ ". " }
        *[unnumbered] Lentelė
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration } pav.
@@ -404,22 +381,18 @@ figure-name =
        *[unnumbered] Paveikslas
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ankstesnis
 paginator-next = Kitas
 paginator-page = Puslapis
-
 paginator-page-status = { $pageLabel } { $currentPage } iš { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = arba
 piecewise-condition-if = jei
 piecewise-condition-otherwise = kitaip
-
 
 ## Chemistry
 
@@ -542,7 +515,6 @@ element-name =
     .lv = Livermoris
     .ts = Tenesinas
     .og = Oganesonas
-
 element-anion-name =
     .h = Hidridas
     .c = Karbidas
@@ -556,8 +528,6 @@ element-anion-name =
     .i = Jodidas
     .at = Astatidas
     .ts = Tenesidas
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Netinkamas cheminis simbolis
 chemistry-invalid-ionic-compound = Netinkamas joninis junginys

--- a/packages/i18n/locales/lua/chrome.ftl
+++ b/packages/i18n/locales/lua/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Tudi tutangila…
 answer-submitting = Tudi tutuma…
-
 answer-checking-status = Diandamuna didi ditangilibua
 answer-submitting-status = Diandamuna didi ditumibua
-
 answer-correct = Mmimpe
 answer-incorrect = Kammimpe
-
 answer-response-saved = Diandamuna Dilamibue
-
 answer-percent-credit = { $percent }% ya Manganyi
 answer-percent-correct = { $percent }% Mmimpe
 answer-percent-short = { $percent } %
-
 max-credit-available = Manganyi a bungi adiku: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] katuena ne diteta didi dishala
         [one] kudi diteta { $count } didi dishala
        *[other] kudi mateta { $count } adi ashala
     }
-
 validation-correct = (Mmimpe)
 validation-incorrect = (Kammimpe)
 validation-partially-correct = (Mmimpe ku citupa)
-
 answer-show-responses =
     { $count ->
         [one] Leja diandamuna { $count } kudi { $answerId }
        *[other] Leja mandamuna { $count } kudi { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Dilumbuluisha
-
 collapsible-click-to-open = (kanda bua kubulula)
 collapsible-click-to-close = (kanda bua kukanga)
-
 collapsible-initializing = Tudi tutuadija…
-
 footnote-show = Leja cifundilu cia kuinshi
 footnote-hide = Sokoka cifundilu cia kuinshi
-
 description-more-information = ngumu mikuabo
-
 
 ## Controls
 
 slider-previous = Cidi kumpala
 slider-next = Cidi kunyima
-
 keyboard-open = Bulula Klavie
 keyboard-close = Kanga Klavie
-
 choice-input-remove-choice = Umbusha { $choice }
-
 matrix-remove-row = Umbusha mulongo
 matrix-add-row = Bueja mulongo
 matrix-remove-column = Umbusha mutshi
 matrix-add-column = Bueja mutshi
-
 subset-add-remove-points = Bueja/Umbusha mpwente
 subset-toggle-points-intervals = Shintulula mpwente ne bitupa
 subset-move-points = Nyemesha Mpwente
 subset-clear = Umbusha bionso
-
 orbital-add-row = Bueja Mulongo
 orbital-remove-row = Umbusha Mulongo
 orbital-add-box = Bueja Kasandu
@@ -86,13 +67,9 @@ orbital-remove-box = Umbusha Kasandu
 orbital-add-up-arrow = Bueja Kasonga ka Kuulu
 orbital-add-down-arrow = Bueja Kasonga ka Kuinshi
 orbital-remove-arrow = Umbusha Kasonga
-
 orbital-row-label = Dina dia mulongo { $row }
-
 pretzel-answer = Diandamuna
-
 summary-statistics-caption = Dijingulula dia mbalu ya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ditangila kumpala dia mbalu
 math-input-preview = Ditangila kumpala
 math-input-invalid-expression = Diambila kadidi dimpe:
 
-
 ## Document status
 
 viewer-initializing = Tudi tutuadija…
 
-
 ## Errors
 
 error-heading = Dipanga
-
 error-found-at =
     { $span ->
         [line] Didi disangana ku mulongo { $startLine }.
        *[lines] Didi disangana ku milongo { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Mukanda eu udi ne mapanga!
-
 diagnostic-heading-error = Dipanga
 diagnostic-heading-warning = Didimuija
 diagnostic-heading-information = Ngumu
 diagnostic-heading-hint = Cimanyinu
-
 accessibility-heading-level-1 = Dipita dia WCAG AA dia Difikila
 accessibility-heading-level-2 = Didimuija dia difikila
-
 something-went-wrong = Kudi cintu kacienza bimpe.
-
 renderer-load-failed = mulejianyi kavua mufike. Tuasakidila pingaja dibeji.
-
 core-start-failed = Mulejianyi wa mukanda kavua mutuadije. Tuasakidila pingaja dibeji.

--- a/packages/i18n/locales/lua/content.ftl
+++ b/packages/i18n/locales/lua/content.ftl
@@ -69,7 +69,6 @@ color =
     .purple = purupure
     .pink = roze
     .brown = maro
-
 line-width =
     .thick =
         { $gender ->
@@ -85,13 +84,11 @@ line-width =
             [c7] cikese
            *[c9] nkese
         }
-
 # Written as an invariable «ne …» phrase, so that it agrees with nothing and
 # can close the description; `style-stroke` puts it last for that reason.
 line-style =
     .dashed = ne tutupa
     .dotted = ne tuntonga
-
 fill-style =
     .horizontal = milongo milaale
     .vertical = milongo mimane
@@ -99,7 +96,6 @@ fill-style =
     .backdiagonal = milongo miendakane ku lubadi lukuabo
     .dots = tuntonga
     .diamonds = madiama
-
 noun =
     .line = mulongo
     .line-segment = citupa cia mulongo
@@ -119,7 +115,6 @@ noun =
     .diamond = diama
     .cross = kulusu
     .plus = cimanyinu cia dibueja
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -127,7 +122,6 @@ noun-regular-polygon =
         [tail] cidi ne mpanga { $numSides }
        *[head] cimfuanyi cia mpanga mifuanangane
     }
-
 # The noun class. `c9` is the default and the class a loanword joins, which is
 # what an author's own `markerStyleWord` is as far as this catalog is
 # concerned.
@@ -151,7 +145,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ne …» phrase and closes the description, so it moves
@@ -166,13 +159,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] muwule
@@ -180,13 +171,11 @@ style-filled-word =
         [c7] ciwule
        *[c9] nwule
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ne { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ne { $pattern }
@@ -194,7 +183,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ne { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «mukalu» is class 3 and leads its own describing words, so they agree with it
 # rather than with the shape it surrounds. Ciluba has no article and joins this
 # clause with the invariable «ne», so all four branches read alike.
@@ -205,35 +193,28 @@ style-border-clause =
         [and-article] ne mukalu { $border }
        *[with] ne mukalu { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = kacidi ciwule
-
 style-text =
     { $parts ->
         [background] { $color } ku nyima { $background }
        *[plain] { $color }
     }
-
 style-background-none = katuena ne cintu
-
 
 ## Boolean words
 
 boolean-true = bulelela
 boolean-false = dishima
 
-
 ## Answer buttons
 
 answer-submit-label = Tangila Mudimu
 answer-submit-label-no-correctness = Tuma Diandamuna
-
 
 ## Sectional blocks
 
@@ -258,7 +239,6 @@ section-name =
     .solution = Disungula
     .task = Mudimu
     .theorem = Teoreme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -268,9 +248,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Cimanyinu
-
 
 ## Tables and figures
 
@@ -281,7 +259,6 @@ table-name =
         [unnumbered-title] Tabelo{ ": " }
        *[unnumbered] Tabelo
     }
-
 figure-name =
     { $parts ->
         [numbered] Cimfuanyi { $enumeration }
@@ -290,24 +267,18 @@ figure-name =
        *[unnumbered] Cimfuanyi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Cidi kumpala
 paginator-next = Cidi kunyima
 paginator-page = Dibeji
-
 paginator-page-status = { $pageLabel } { $currentPage } munkatshi mua { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = anyi
-
 piecewise-condition-if = bikala
-
 piecewise-condition-otherwise = miaba mikuabo yonso
-
 
 ## Chemistry
 ##
@@ -320,6 +291,5 @@ piecewise-condition-otherwise = miaba mikuabo yonso
 ## and `locales/ktu` give from the same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Cimanyinu cia Shimi Kacidi Cimpe
 chemistry-invalid-ionic-compound = Disangisha dia Ayoni Kadidi Dimpe

--- a/packages/i18n/locales/luo/chrome.ftl
+++ b/packages/i18n/locales/luo/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Inono…
 answer-submitting = Ior…
-
 answer-checking-status = Duoko inono
 answer-submitting-status = Duoko ior
-
 answer-correct = Kare
 answer-incorrect = Ok kare
-
 answer-response-saved = Duoko Okan
-
 answer-percent-credit = { $percent }% mar Point
 answer-percent-correct = { $percent }% Kare
 answer-percent-short = { $percent } %
-
 max-credit-available = Point maduong'ie moloyo: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] onge tem modong'
         [one] odong' tem { $count }
        *[other] odong' tem { $count }
     }
-
 validation-correct = (Kare)
 validation-incorrect = (Ok kare)
 validation-partially-correct = (Kare e bathe moko)
-
 answer-show-responses =
     { $count ->
         [one] Nyis duoko { $count } mar { $answerId }
        *[other] Nyis duoko { $count } mar { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Paro
-
 collapsible-click-to-open = (dii mondo iyaw)
 collapsible-click-to-close = (dii mondo iumo)
-
 collapsible-initializing = Ichako…
-
 footnote-show = Nyis ndiko mar piny
 footnote-hide = Pand ndiko mar piny
-
 description-more-information = weche momedore
-
 
 ## Controls
 
 slider-previous = Mokalo
 slider-next = Maluwo
-
 keyboard-open = Yaw Kibod
 keyboard-close = Um Kibod
-
 choice-input-remove-choice = Gol { $choice }
-
 matrix-remove-row = Gol laini
 matrix-add-row = Med laini
 matrix-remove-column = Gol siro
 matrix-add-column = Med siro
-
 subset-add-remove-points = Med/Gol tong'
 subset-toggle-points-intervals = Lok tong' gi kind
 subset-move-points = Yieng' Tong'
 subset-clear = Ruch
-
 orbital-add-row = Med Laini
 orbital-remove-row = Gol Laini
 orbital-add-box = Med Sanduku
@@ -86,13 +67,9 @@ orbital-remove-box = Gol Sanduku
 orbital-add-up-arrow = Med Asere Modhi Malo
 orbital-add-down-arrow = Med Asere Modhi Piny
 orbital-remove-arrow = Gol Asere
-
 orbital-row-label = Nying laini { $row }
-
 pretzel-answer = Duoko
-
 summary-statistics-caption = Kwan machiek mar { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = neno motelo mar wach kwan
 math-input-preview = Neno motelo
 math-input-invalid-expression = Wach ma ok kare:
 
-
 ## Document status
 
 viewer-initializing = Ichako…
 
-
 ## Errors
 
 error-heading = Bayo
-
 error-found-at =
     { $span ->
         [line] Oyudi e laini mar { $startLine }.
        *[lines] Oyudi e laini mag { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ndikoni nigi bayo!
-
 diagnostic-heading-error = Bayo
 diagnostic-heading-warning = Siem
 diagnostic-heading-information = Weche
 diagnostic-heading-hint = Ranyisi
-
 accessibility-heading-level-1 = Ketho Chik mar WCAG AA mar Chopo
 accessibility-heading-level-2 = Siem mar chopo
-
 something-went-wrong = Nitie gima ok odhi maber.
-
 renderer-load-failed = janyis okier chako. Kiyie chak ich kendo.
-
 core-start-failed = Janyis mar ndiko okier chako. Kiyie chak ich kendo.

--- a/packages/i18n/locales/luo/content.ftl
+++ b/packages/i18n/locales/luo/content.ftl
@@ -63,15 +63,12 @@ color =
     .purple = rambulu
     .pink = pinki
     .brown = rabuor
-
 line-width =
     .thick = mabor
     .thin = manyilili
-
 line-style =
     .dashed = mokethore
     .dotted = man-gi tonde
-
 fill-style =
     .horizontal = laini monindo
     .vertical = laini mochung'
@@ -79,7 +76,6 @@ fill-style =
     .backdiagonal = laini mopadore komachielo
     .dots = tonde
     .diamonds = almaz
-
 noun =
     .line = laini
     .line-segment = bath laini
@@ -99,7 +95,6 @@ noun =
     .diamond = almaz
     .cross = msalaba
     .plus = ranyisi mar medo
-
 # The side count is a relative clause and closes the noun phrase behind the
 # adjectives rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -107,10 +102,8 @@ noun-regular-polygon =
         [tail] man-gi bethe { $numSides }
        *[head] kido mopogore maromre
     }
-
 # Nothing selects on it: Dholuo has no gender and no noun classes.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -129,7 +122,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] ma{ $color }
     }
-
 # The noun leads and its adjectives follow, with the noun's own relative
 # complement closing the phrase.
 style-with-noun =
@@ -137,15 +129,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = mopong'
-
 style-filled =
     { $parts ->
         [pattern] { $filled } ma{ $color } gi { $pattern }
        *[plain] { $filled } ma{ $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } ma{ $color } gi { $pattern }
@@ -153,7 +142,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } ma{ $color } gi { $pattern }
        *[plain] { $noun } { $filled } ma{ $color }
     }
-
 # Dholuo has no article, so the two `-article` branches read like their
 # neighbours; «gi» joins the clause and does not change shape.
 style-border-clause =
@@ -163,35 +151,28 @@ style-border-clause =
         [and-article] gi giko { $border }
        *[with] gi giko { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } ma{ $color }
        *[plain] ma{ $color }
     }
-
 style-unfilled = ok opong'
-
 style-text =
     { $parts ->
         [background] ma{ $color } e ng'e ma{ $background }
        *[plain] ma{ $color }
     }
-
 style-background-none = onge
-
 
 ## Boolean words
 
 boolean-true = adiera
 boolean-false = miriambo
 
-
 ## Answer buttons
 
 answer-submit-label = Non Tich
 answer-submit-label-no-correctness = Or Duoko
-
 
 ## Sectional blocks
 
@@ -216,7 +197,6 @@ section-name =
     .solution = Yoo mar loso
     .task = Tich
     .theorem = Thiorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -226,9 +206,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ranyisi
-
 
 ## Tables and figures
 
@@ -239,7 +217,6 @@ table-name =
         [unnumbered-title] Tebulo{ ": " }
        *[unnumbered] Tebulo
     }
-
 figure-name =
     { $parts ->
         [numbered] Picha { $enumeration }
@@ -248,24 +225,18 @@ figure-name =
        *[unnumbered] Picha
     }
 
-
 ## Paginator controls
 
 paginator-previous = Mokalo
 paginator-next = Maluwo
 paginator-page = Ich
-
 paginator-page-status = { $pageLabel } { $currentPage } kuom { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kata
-
 piecewise-condition-if = ka
-
 piecewise-condition-otherwise = ka ok kamano
-
 
 ## Chemistry
 ##
@@ -277,6 +248,5 @@ piecewise-condition-otherwise = ka ok kamano
 ## periodic table there and the fallback *is* the curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ranyisi mar Kemikal ma Ok Kare
 chemistry-invalid-ionic-compound = Riwruok mar Ayon ma Ok Kare

--- a/packages/i18n/locales/lv/chrome.ftl
+++ b/packages/i18n/locales/lv/chrome.ftl
@@ -25,21 +25,15 @@
 
 answer-checking = Notiek pārbaude…
 answer-submitting = Notiek iesniegšana…
-
 answer-checking-status = Atbildes pārbaude
 answer-submitting-status = Atbildes iesniegšana
-
 answer-correct = Pareizi
 answer-incorrect = Nepareizi
-
 answer-response-saved = Atbilde saglabāta
-
 answer-percent-credit = { $percent }% no punktiem
 answer-percent-correct = { $percent }% pareizi
 answer-percent-short = { $percent } %
-
 max-credit-available = Lielākais iespējamais punktu skaits: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] mēģinājumu vairs nav
@@ -47,11 +41,9 @@ attempts-remaining =
         [one] atlicis { $count } mēģinājums
        *[other] atlikuši { $count } mēģinājumi
     }
-
 validation-correct = (Pareizi)
 validation-incorrect = (Nepareizi)
 validation-partially-correct = (Daļēji pareizi)
-
 answer-show-responses =
     { $count ->
         [zero] Rādīt { $count } atbilžu uz { $answerId }
@@ -59,42 +51,31 @@ answer-show-responses =
        *[other] Rādīt { $count } atbildes uz { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Atgriezeniskā saite
-
 collapsible-click-to-open = (noklikšķiniet, lai atvērtu)
 collapsible-click-to-close = (noklikšķiniet, lai aizvērtu)
-
 collapsible-initializing = Notiek sagatavošana…
-
 footnote-show = Rādīt piezīmi
 footnote-hide = Slēpt piezīmi
-
 description-more-information = vairāk informācijas
-
 
 ## Controls
 
 slider-previous = Atpakaļ
 slider-next = Uz priekšu
-
 keyboard-open = Atvērt tastatūru
 keyboard-close = Aizvērt tastatūru
-
 choice-input-remove-choice = Noņemt { $choice }
-
 matrix-remove-row = Noņemt rindu
 matrix-add-row = Pievienot rindu
 matrix-remove-column = Noņemt kolonnu
 matrix-add-column = Pievienot kolonnu
-
 subset-add-remove-points = Pievienot/noņemt punktus
 subset-toggle-points-intervals = Pārslēgt starp punktiem un intervāliem
 subset-move-points = Pārvietot punktus
 subset-clear = Notīrīt
-
 orbital-add-row = Pievienot rindu
 orbital-remove-row = Noņemt rindu
 orbital-add-box = Pievienot lodziņu
@@ -102,13 +83,9 @@ orbital-remove-box = Noņemt lodziņu
 orbital-add-up-arrow = Pievienot bultu uz augšu
 orbital-add-down-arrow = Pievienot bultu uz leju
 orbital-remove-arrow = Noņemt bultu
-
 orbital-row-label = { $row }. rindas apzīmējums
-
 pretzel-answer = Atbilde
-
 summary-statistics-caption = { $column } kopsavilkuma statistika
-
 
 ## Math input
 
@@ -116,34 +93,25 @@ math-input-preview-region = matemātiskās izteiksmes priekšskatījums
 math-input-preview = Priekšskatījums
 math-input-invalid-expression = Nederīga izteiksme:
 
-
 ## Document status
 
 viewer-initializing = Notiek sagatavošana…
 
-
 ## Errors
 
 error-heading = Kļūda
-
 error-found-at =
     { $span ->
         [line] Atrasta { $startLine }. rindā.
        *[lines] Atrasta { $startLine }.–{ $endLine }. rindā.
     }
-
 document-contains-errors = Šajā dokumentā ir kļūdas!
-
 diagnostic-heading-error = Kļūda
 diagnostic-heading-warning = Brīdinājums
 diagnostic-heading-information = Informācija
 diagnostic-heading-hint = Padoms
-
 accessibility-heading-level-1 = WCAG AA piekļūstamības pārkāpums
 accessibility-heading-level-2 = Piekļūstamības paziņojums
-
 something-went-wrong = Kaut kas nogāja greizi.
-
 renderer-load-failed = neizdevās ielādēt attēlošanas moduli. Pārlādējiet lapu.
-
 core-start-failed = Neizdevās palaist dokumenta skatītāju. Pārlādējiet lapu.

--- a/packages/i18n/locales/lv/content.ftl
+++ b/packages/i18n/locales/lv/content.ftl
@@ -155,7 +155,6 @@ color =
                    *[m] brūns
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -179,7 +178,6 @@ line-width =
                    *[m] plāns
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -203,7 +201,6 @@ line-style =
                    *[m] punktēts
                 }
         }
-
 # Noun phrases in the dative, which is the case every Latvian preposition takes
 # in the plural — so «ar» governs the accusative in `style-border-clause` above
 # and the dative here. They agree with nothing.
@@ -214,7 +211,6 @@ fill-style =
     .backdiagonal = apgrieztām diagonālām līnijām
     .dots = punktiem
     .diamonds = rombiem
-
 noun =
     .line = taisne
     .line-segment = nogrieznis
@@ -234,7 +230,6 @@ noun =
     .diamond = rombs
     .cross = krusts
     .plus = pluss
-
 # Latvian keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -242,7 +237,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regulārs { $numSides }-stūris
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (daudzstūris, m) or
 # the head of a phrase the description never names: `border` (apmale, f),
 # `fill` (pildījums, m), `text` (teksts, m), `background` (fons, m).
@@ -258,7 +252,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -271,13 +264,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -285,13 +276,11 @@ style-filled-word =
         [f] aizpildīta
        *[m] aizpildīts
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ar { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } ar { $pattern }
@@ -299,7 +288,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } ar { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «apmale» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Latvian has no article, so the two `-article`
 # branches read like the two without.
@@ -310,7 +298,6 @@ style-border-clause =
         [and-article] un { $border } apmali
        *[with] ar { $border } apmali
     }
-
 # The fill-pattern words are dative plurals, because their other use is the
 # «ar { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «pildījums», masculine, which is the gender
@@ -320,29 +307,23 @@ style-fill =
         [pattern] { $color } pildījums ar { $pattern }
        *[plain] { $color } pildījums
     }
-
 style-unfilled = neaizpildīts
-
 style-text =
     { $parts ->
         [background] { $color } uz { $background } fona
        *[plain] { $color }
     }
-
 style-background-none = nav
-
 
 ## Boolean words
 
 boolean-true = patiess
 boolean-false = aplams
 
-
 ## Answer buttons
 
 answer-submit-label = Pārbaudīt
 answer-submit-label-no-correctness = Iesniegt atbildi
-
 
 ## Sectional blocks
 
@@ -367,7 +348,6 @@ section-name =
     .solution = Risinājums
     .task = Uzdevums
     .theorem = Teorēma
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -377,9 +357,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Padoms
-
 
 ## Tables and figures
 
@@ -390,7 +368,6 @@ table-name =
         [unnumbered-title] Tabula{ ". " }
        *[unnumbered] Tabula
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration }. attēls
@@ -399,22 +376,18 @@ figure-name =
        *[unnumbered] Attēls
     }
 
-
 ## Paginator controls
 
 paginator-previous = Iepriekšējā
 paginator-next = Nākamā
 paginator-page = Lappuse
-
 paginator-page-status = { $pageLabel } { $currentPage } no { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = vai
 piecewise-condition-if = ja
 piecewise-condition-otherwise = citādi
-
 
 ## Chemistry
 
@@ -537,7 +510,6 @@ element-name =
     .lv = Livermorijs
     .ts = Tenesīns
     .og = Oganesons
-
 element-anion-name =
     .h = Hidrīds
     .c = Karbīds
@@ -551,8 +523,6 @@ element-anion-name =
     .i = Jodīds
     .at = Astatīds
     .ts = Tenesīds
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Nederīgs ķīmiskais simbols
 chemistry-invalid-ionic-compound = Nederīgs jonu savienojums

--- a/packages/i18n/locales/mad/chrome.ftl
+++ b/packages/i18n/locales/mad/chrome.ftl
@@ -29,21 +29,15 @@
 
 answer-checking = Mareksa…
 answer-submitting = Ngèrèm…
-
 answer-checking-status = Mareksa jhâwâban
 answer-submitting-status = Ngèrèm jhâwâban
-
 answer-correct = Bendher
 answer-incorrect = Ta' bendher
-
 answer-response-saved = Jhâwâbanna la èsimpen
-
 answer-percent-credit = { $percent }% kredit
 answer-percent-correct = { $percent }% bendher
 answer-percent-short = { $percent } %
-
 max-credit-available = Kredit se paleng bânnya' se ekaollè: { $percent }%
-
 # No select: «coba» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -51,51 +45,38 @@ attempts-remaining =
         [0] tadâ' pole coba se karè
        *[other] karè { $count } coba
     }
-
 validation-correct = (Bendher)
 validation-incorrect = (Ta' bendher)
 validation-partially-correct = (Bendher sabâgiyân)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Toduwagi { $count } jhâwâban kaangguy { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komentar
-
 collapsible-click-to-open = (klik sopaja abukka')
 collapsible-click-to-close = (klik sopaja atotop)
-
 collapsible-initializing = Molaè…
-
 footnote-show = Toduwagi footnote
 footnote-hide = Nyèmponnè footnote
-
 description-more-information = katerrangan laèn
-
 
 ## Controls
 
 slider-previous = Sabellunna
 slider-next = Salanjudde
-
 keyboard-open = Bukka' papan tuts
 keyboard-close = Totop papan tuts
-
 choice-input-remove-choice = Buwang { $choice }
-
 matrix-remove-row = Buwang barisa
 matrix-add-row = Tambâ baris
 matrix-remove-column = Buwang kolomma
 matrix-add-column = Tambâ kolom
-
 subset-add-remove-points = Nambâ/Mowang titik
 subset-toggle-points-intervals = Ngoba titik ban interval
 subset-move-points = Pindâ titikka
 subset-clear = Berseagi
-
 orbital-add-row = Tambâ baris
 orbital-remove-row = Buwang barisa
 orbital-add-box = Tambâ kotak
@@ -103,13 +84,9 @@ orbital-remove-box = Buwang kotakka
 orbital-add-up-arrow = Tambâ panah ka attas
 orbital-add-down-arrow = Tambâ panah ka bâbâ
 orbital-remove-arrow = Buwang panahha
-
 orbital-row-label = Label kaangguy baris { $row }
-
 pretzel-answer = Jhâwâban
-
 summary-statistics-caption = Ringkesan statistik { $column }
-
 
 ## Math input
 
@@ -117,34 +94,25 @@ math-input-preview-region = pratinjau ungkapan matematika
 math-input-preview = Pratinjau
 math-input-invalid-expression = Ungkapan se ta' sah:
 
-
 ## Document status
 
 viewer-initializing = Molaè…
 
-
 ## Errors
 
 error-heading = Kasalaan
-
 error-found-at =
     { $span ->
         [line] Etemmo e baris { $startLine }.
        *[lines] Etemmo e baris { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumen rèya badâ kasalaanna!
-
 diagnostic-heading-error = Kasalaan
 diagnostic-heading-warning = Parèngèdan
 diagnostic-heading-information = Katerrangan
 diagnostic-heading-hint = Petodu
-
 accessibility-heading-level-1 = Palanggharân aksesibilitas WCAG AA
 accessibility-heading-level-2 = Parèngèdan parkara aksesibilitas
-
 something-went-wrong = Badâ se sala.
-
 renderer-load-failed = badâ renderer se ta' bisa emowat. Nyo'on mowat pole kacana.
-
 core-start-failed = Panèngalan dokumen ta' bisa emolaè. Nyo'on mowat pole kacana.

--- a/packages/i18n/locales/mad/content.ftl
+++ b/packages/i18n/locales/mad/content.ftl
@@ -33,15 +33,12 @@ color =
     .purple = ungu
     .pink = mera ngodhâ
     .brown = coklat
-
 line-width =
     .thick = kandel
     .thin = tipis
-
 line-style =
     .dashed = pote'-pote'
     .dotted = titik-titik
-
 # Noun phrases. Madurese marks no plural on the noun, so «garis» is the word for
 # one line and for many alike.
 fill-style =
@@ -51,7 +48,6 @@ fill-style =
     .backdiagonal = garis mèrèng tabâli'
     .dots = titik
     .diamonds = bellâ ketupat
-
 noun =
     .line = garis
     .line-segment = roas garis
@@ -71,7 +67,6 @@ noun =
     .diamond = bellâ ketupat
     .cross = sèlang
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -79,10 +74,8 @@ noun-regular-polygon =
         [tail] se badâ { $numSides } essèna
        *[head] poligon beraturan
     }
-
 # One answer for every noun: Madurese has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -96,22 +89,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = possa'
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } bân { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } bân { $pattern }
@@ -119,7 +108,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } bân { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Madurese has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «bân» against «sarta».
@@ -130,35 +118,28 @@ style-border-clause =
         [and-article] sarta penggir { $border }
        *[with] bân penggir { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ta' possa'
-
 style-text =
     { $parts ->
         [background] { $color } bân latar { $background }
        *[plain] { $color }
     }
-
 style-background-none = tadâ'
-
 
 ## Boolean words
 
 boolean-true = bendher
 boolean-false = sala
 
-
 ## Answer buttons
 
 answer-submit-label = Pareksa lalakon
 answer-submit-label-no-correctness = Kèrèm jhâwâban
-
 
 ## Sectional blocks
 
@@ -185,7 +166,6 @@ section-name =
     .solution = Panyalesaan
     .task = Tugas
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -195,9 +175,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Petodu
-
 
 ## Tables and figures
 
@@ -208,7 +186,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Gâmbhâr { $enumeration }
@@ -217,22 +194,18 @@ figure-name =
        *[unnumbered] Gâmbhâr
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sabellunna
 paginator-next = Salanjudde
 paginator-page = Kaca
-
 paginator-page-status = { $pageLabel } { $currentPage } dâri { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = otabâ
 piecewise-condition-if = mon
 piecewise-condition-otherwise = mon bunten
-
 
 ## Chemistry
 ##
@@ -242,6 +215,5 @@ piecewise-condition-otherwise = mon bunten
 ## and Madurese has no settled table of its own to seed from.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kimia se ta' sah
 chemistry-invalid-ionic-compound = Sanyawa ionik se ta' sah

--- a/packages/i18n/locales/mai/chrome.ftl
+++ b/packages/i18n/locales/mai/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = जाँचि रहल अछि…
 answer-submitting = पठा रहल अछि…
-
 answer-checking-status = उत्तर जाँचि रहल अछि
 answer-submitting-status = उत्तर पठा रहल अछि
-
 answer-correct = सही
 answer-incorrect = गलत
-
 answer-response-saved = उत्तर सहेजल गेल
-
 answer-percent-credit = { $percent }% अंक
 answer-percent-correct = { $percent }% सही
 answer-percent-short = { $percent } %
-
 max-credit-available = अधिकतम उपलब्ध अंक: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] कोनो प्रयास बाँकी नहि
         [one] { $count } प्रयास बाँकी
        *[other] { $count } प्रयास बाँकी
     }
-
 validation-correct = (सही)
 validation-incorrect = (गलत)
 validation-partially-correct = (आंशिक रूपेँ सही)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } लेल { $count } उत्तर देखाउ
        *[other] { $answerId } लेल { $count } उत्तर देखाउ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिपुष्टि
-
 collapsible-click-to-open = (खोलबा लेल क्लिक करू)
 collapsible-click-to-close = (बंद करबा लेल क्लिक करू)
-
 collapsible-initializing = शुरू भऽ रहल अछि…
-
 footnote-show = पादटीप देखाउ
 footnote-hide = पादटीप नुकाउ
-
 description-more-information = आओर जानकारी
-
 
 ## Controls
 
 slider-previous = पछिला
 slider-next = अगिला
-
 keyboard-open = कुंजीपटल खोलू
 keyboard-close = कुंजीपटल बंद करू
-
 choice-input-remove-choice = { $choice } हटाउ
-
 matrix-remove-row = पाँती हटाउ
 matrix-add-row = पाँती जोड़ू
 matrix-remove-column = स्तंभ हटाउ
 matrix-add-column = स्तंभ जोड़ू
-
 subset-add-remove-points = बिंदु जोड़ू/हटाउ
 subset-toggle-points-intervals = बिंदु आ अंतराल बदलू
 subset-move-points = बिंदु घसकाउ
 subset-clear = मेटाउ
-
 orbital-add-row = पाँती जोड़ू
 orbital-remove-row = पाँती हटाउ
 orbital-add-box = बक्सा जोड़ू
@@ -87,13 +68,9 @@ orbital-remove-box = बक्सा हटाउ
 orbital-add-up-arrow = ऊपर वला तीर जोड़ू
 orbital-add-down-arrow = नीचाँ वला तीर जोड़ू
 orbital-remove-arrow = तीर हटाउ
-
 orbital-row-label = पाँती { $row } क लेबल
-
 pretzel-answer = उत्तर
-
 summary-statistics-caption = { $column } क सांख्यिकी सार
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = गणितीय व्यंजन क पूर�
 math-input-preview = पूर्वावलोकन
 math-input-invalid-expression = अमान्य व्यंजन:
 
-
 ## Document status
 
 viewer-initializing = शुरू भऽ रहल अछि…
 
-
 ## Errors
 
 error-heading = त्रुटि
-
 error-found-at =
     { $span ->
         [line] पाँती { $startLine } पर भेटल।
        *[lines] पाँती { $startLine }–{ $endLine } पर भेटल।
     }
-
 document-contains-errors = ई दस्तावेज मे त्रुटि अछि!
-
 diagnostic-heading-error = त्रुटि
 diagnostic-heading-warning = चेतावनी
 diagnostic-heading-information = जानकारी
 diagnostic-heading-hint = संकेत
-
 accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
 accessibility-heading-level-2 = सुगम्यता सूचना
-
 something-went-wrong = किछु गड़बड़ भऽ गेल।
-
 renderer-load-failed = एकटा प्रदर्शक लोड नहि भऽ सकल। कृपया पृष्ठ फेर लोड करू।
-
 core-start-failed = दस्तावेज दर्शक शुरू नहि भऽ सकल। कृपया पृष्ठ फेर लोड करू।

--- a/packages/i18n/locales/mai/content.ftl
+++ b/packages/i18n/locales/mai/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = बैंगनी
     .pink = गुलाबी
     .brown = भूर
-
 line-width =
     .thick = मोट
     .thin = पातर
-
 line-style =
     .dashed = टूटल
     .dotted = बिंदुदार
-
 fill-style =
     .horizontal = आड़ी रेखा
     .vertical = ठाढ़ रेखा
@@ -56,7 +53,6 @@ fill-style =
     .backdiagonal = उनटल तिरछी रेखा
     .dots = बिंदु
     .diamonds = समचतुर्भुज
-
 noun =
     .line = रेखा
     .line-segment = रेखाखंड
@@ -76,7 +72,6 @@ noun =
     .diamond = समचतुर्भुज
     .cross = गुणा चिन्ह
     .plus = जोड़ चिन्ह
-
 # «-भुजा वला» takes the count and stands in front of the noun, so nothing
 # follows the adjectives and the tail is empty. The ending has one shape
 # whatever number lands before it.
@@ -85,10 +80,8 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides }-भुजा वला समबहुभुज
     }
-
 # Nothing selects on it, because no word in this catalog agrees with anything.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -102,15 +95,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = भरल
-
 # «सँ» is a postposition and follows what it governs, so the pattern moves to
 # the front of the phrase where English appends it.
 style-filled =
@@ -118,7 +108,6 @@ style-filled =
         [pattern] { $pattern } सँ { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } सँ { $filled } { $color } { $noun }
@@ -126,7 +115,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } सँ { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Maithili has no article, so the two `-article` branches read like their
 # neighbours; «आ» is the conjunction and stands in front.
 style-border-clause =
@@ -136,35 +124,28 @@ style-border-clause =
         [and-article] आ { $border } किनार सहित
        *[with] { $border } किनार सहित
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } सँ { $color } भरनी
        *[plain] { $color } भरनी
     }
-
 style-unfilled = बिनु भरल
-
 style-text =
     { $parts ->
         [background] { $background } पृष्ठभूमि पर { $color }
        *[plain] { $color }
     }
-
 style-background-none = किछु नहि
-
 
 ## Boolean words
 
 boolean-true = सत्य
 boolean-false = असत्य
 
-
 ## Answer buttons
 
 answer-submit-label = जाँचू
 answer-submit-label-no-correctness = उत्तर पठाउ
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = हल
     .task = काज
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = संकेत
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] सारणी{ ": " }
        *[unnumbered] सारणी
     }
-
 figure-name =
     { $parts ->
         [numbered] चित्र { $enumeration }
@@ -221,26 +198,20 @@ figure-name =
        *[unnumbered] चित्र
     }
 
-
 ## Paginator controls
 
 paginator-previous = पछिला
 paginator-next = अगिला
 paginator-page = पृष्ठ
-
 # «X मे सँ Y» — "Y out of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } मे सँ { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = वा
-
 piecewise-condition-if = जँ
-
 piecewise-condition-otherwise = अन्यथा
-
 
 ## Chemistry
 ##
@@ -256,6 +227,5 @@ piecewise-condition-otherwise = अन्यथा
 ## record, told for the first time with another Indian language as the medium.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अमान्य रासायनिक चिन्ह
 chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक

--- a/packages/i18n/locales/men/chrome.ftl
+++ b/packages/i18n/locales/men/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = A gbɔɔ…
 answer-submitting = A ve…
-
 answer-checking-status = Ta njepei gbɔɔ
 answer-submitting-status = Ta njepei ve
-
 answer-correct = A tonya
 answer-incorrect = Ii tonya
-
 answer-response-saved = Njepei Yɛlɛnga
-
 answer-percent-credit = { $percent }% Ndoli
 answer-percent-correct = { $percent }% Tonya
 answer-percent-short = { $percent } %
-
 max-credit-available = Ndoli wa bi majɔɔ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] gɔɔla gbi ii lɔ
         [one] gɔɔla { $count } lɔ
        *[other] gɔɔla { $count } ti lɔ
     }
-
 validation-correct = (A tonya)
 validation-incorrect = (Ii tonya)
 validation-partially-correct = (A tonya gbua)
-
 answer-show-responses =
     { $count ->
         [one] Gɛnɛ njepei { $count } { $answerId } va
        *[other] Gɛnɛ njepeisia { $count } { $answerId } va
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Njepe woma
-
 collapsible-click-to-open = (tɔkpɔ kɔ i gbɔyɔ)
 collapsible-click-to-close = (tɔkpɔ kɔ i gbɔkɔ)
-
 collapsible-initializing = A yɛpɛ…
-
 footnote-show = Gɛnɛ nyɛingɔ na lɔ kunafɔ
 footnote-hide = Lombi nyɛingɔ na lɔ kunafɔ
-
 description-more-information = hinda gbe hugɔɔla
-
 
 ## Controls
 
 slider-previous = Na wa ma
 slider-next = Na wa woma
-
 keyboard-open = Gbɔyɔ Kibɔd
 keyboard-close = Gbɔkɔ Kibɔd
-
 choice-input-remove-choice = Wumbu { $choice }
-
 matrix-remove-row = Wumbu lɔlɔi
 matrix-add-row = Gbua lɔlɔi
 matrix-remove-column = Wumbu kɔlum
 matrix-add-column = Gbua kɔlum
-
 subset-add-remove-points = Gbua/Wumbu tɔkpɔisia
 subset-toggle-points-intervals = Wote tɔkpɔisia kɛ wati sia
 subset-move-points = Hiti Tɔkpɔisia
 subset-clear = Wumbu kpɛlɛ
-
 orbital-add-row = Gbua Lɔlɔi
 orbital-remove-row = Wumbu Lɔlɔi
 orbital-add-box = Gbua Bɔks
@@ -86,13 +67,9 @@ orbital-remove-box = Wumbu Bɔks
 orbital-add-up-arrow = Gbua Aro Na Lɔ Woma
 orbital-add-down-arrow = Gbua Aro Na Lɔ Kunafɔ
 orbital-remove-arrow = Wumbu Aro
-
 orbital-row-label = Lɔlɔi { $row } biyei
-
 pretzel-answer = Njepei
-
 summary-statistics-caption = { $column } nambasia hugɔɔla
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = mat njepei gɛnɛ ma
 math-input-preview = Gɛnɛ ma
 math-input-invalid-expression = Njepe na ii tonya:
 
-
 ## Document status
 
 viewer-initializing = A yɛpɛ…
 
-
 ## Errors
 
 error-heading = Hinda nyamu
-
 error-found-at =
     { $span ->
         [line] Ti majɔɔ laing { $startLine } ma.
        *[lines] Ti majɔɔ laingsia { $startLine }–{ $endLine } ma.
     }
-
 document-contains-errors = Buk ji hinda nyamusia lɔ hu!
-
 diagnostic-heading-error = Hinda nyamu
 diagnostic-heading-warning = Ngiti wa
 diagnostic-heading-information = Hugɔɔla
 diagnostic-heading-hint = Ngiti
-
 accessibility-heading-level-1 = WCAG AA Majɔɔla Sawa Wɔlɔla
 accessibility-heading-level-2 = Majɔɔla ngiti wa
-
 something-went-wrong = Hinda yila ii yɛlɛ kɛnɛi.
-
 renderer-load-failed = gɛnɛmɔi yila ii wanga. Kɔ bi pej ji wote.
-
 core-start-failed = Buk gɛnɛmɔi ii gula i yɛpɛ. Kɔ bi pej ji wote.

--- a/packages/i18n/locales/men/content.ftl
+++ b/packages/i18n/locales/men/content.ftl
@@ -72,17 +72,14 @@ color =
     .purple = pɔpul
     .pink = pink
     .brown = braun
-
 line-width =
     .thick = wa
     .thin = kulɔ
-
 # Written as «kɛ …» phrases rather than as bare qualifiers, so that they close
 # the description. `style-stroke` puts them last.
 line-style =
     .dashed = kɛ ngeya-ngeya
     .dotted = kɛ tɔkpɔ-tɔkpɔ
-
 fill-style =
     .horizontal = laingi ti lɔ va
     .vertical = laingi ti lɔ lɔlɔ
@@ -90,7 +87,6 @@ fill-style =
     .backdiagonal = laingi ti lɔ kpandi na gbe wu
     .dots = tɔkpɔ
     .diamonds = dayamɔn
-
 noun =
     .line = laing
     .line-segment = laing gbua
@@ -110,7 +106,6 @@ noun =
     .diamond = dayamɔn
     .cross = krɔs
     .plus = plɔs tɔkpɔi
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words, so it goes in the tail. It is also the one place the definite would
 # have been least awkward — the tail ends in a numeral rather than in a
@@ -121,12 +116,10 @@ noun-regular-polygon =
         [tail] na kɛ gbua { $numSides }
        *[head] pɔligɔn yekpe
     }
-
 # Mende has no noun class and no gender, so every noun answers the same and the
 # answer goes unused — the shape `locales/mnk`, `locales/bm` and `locales/dyu`
 # have, and for the same reason.
 noun-gender = yila
-
 
 ## Style composition
 
@@ -142,7 +135,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and the describing words follow, which is what puts a
 # placeable at the end of the phrase and keeps the definite suffix out of this
 # file. See the header.
@@ -151,15 +143,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = gbuani
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kɛ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kɛ { $pattern }
@@ -167,7 +156,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kɛ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «ngɔwu» is the border and leads its own describing words. Mende has no
 # article and joins this clause with the invariable «kɛ», so all four branches
 # read alike.
@@ -178,35 +166,28 @@ style-border-clause =
         [and-article] kɛ ngɔwu { $border }
        *[with] kɛ ngɔwu { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ii gbuani
-
 style-text =
     { $parts ->
         [background] { $color } kɛ woma { $background }
        *[plain] { $color }
     }
-
 style-background-none = hama gbi ii lɔ
-
 
 ## Boolean words
 
 boolean-true = tonya
 boolean-false = ngunya
 
-
 ## Answer buttons
 
 answer-submit-label = Gbɔɔ Yenge
 answer-submit-label-no-correctness = Ve Njepei
-
 
 ## Sectional blocks
 
@@ -231,7 +212,6 @@ section-name =
     .solution = Hinda gulɔla
     .task = Yenge
     .theorem = Tiɔrɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -241,9 +221,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ngiti
-
 
 ## Tables and figures
 
@@ -254,7 +232,6 @@ table-name =
         [unnumbered-title] Tebul{ ": " }
        *[unnumbered] Tebul
     }
-
 figure-name =
     { $parts ->
         [numbered] Kɛlɛma { $enumeration }
@@ -263,25 +240,18 @@ figure-name =
        *[unnumbered] Kɛlɛma
     }
 
-
 ## Paginator controls
 
 paginator-previous = Na wa ma
 paginator-next = Na wa woma
-
 paginator-page = Pej
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ɔɔ
-
 piecewise-condition-if = ina
-
 piecewise-condition-otherwise = hinda gbi hu na
-
 
 ## Chemistry
 ##
@@ -294,6 +264,5 @@ piecewise-condition-otherwise = hinda gbi hu na
 ## same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kɛmistri Tɔkpɔi Ii Tonya
 chemistry-invalid-ionic-compound = Ayɔn Gbɔɔla Ii Tonya

--- a/packages/i18n/locales/mg/chrome.ftl
+++ b/packages/i18n/locales/mg/chrome.ftl
@@ -19,69 +19,50 @@
 
 answer-checking = Manamarina...
 answer-submitting = Mandefa...
-
 answer-checking-status = Manamarina ny valiny
 answer-submitting-status = Mandefa ny valiny
-
 answer-correct = Marina
 answer-incorrect = Diso
-
 answer-response-saved = Voatahiry ny valiny
-
 answer-percent-credit = Naoty { $percent }%
 answer-percent-correct = Marina { $percent }%
 answer-percent-short = { $percent }%
-
 max-credit-available = Naoty ambony indrindra azo: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tsy misy fanandramana sisa
        *[other] sisa { $count } fanandramana
     }
-
 validation-correct = (Marina)
 validation-incorrect = (Diso)
 validation-partially-correct = (Marina amin'ny ampahany)
-
 answer-show-responses = Asehoy ny valiny { $count } ho an'ny { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Fanehoan-kevitra
-
 collapsible-click-to-open = (tsindrio hanokatra)
 collapsible-click-to-close = (tsindrio hanidy)
-
 collapsible-initializing = Manomboka...
-
 footnote-show = Asehoy ny fanamarihana ambany pejy
 footnote-hide = Afeno ny fanamarihana ambany pejy
-
 description-more-information = fanazavana fanampiny
-
 
 ## Controls
 
 slider-previous = Teo aloha
 slider-next = Manaraka
-
 keyboard-open = Sokafy ny fitendry
 keyboard-close = Akatony ny fitendry
-
 choice-input-remove-choice = Esory ny { $choice }
-
 matrix-remove-row = Esory ny andalana
 matrix-add-row = Ampio andalana
 matrix-remove-column = Esory ny tsanganana
 matrix-add-column = Ampio tsanganana
-
 subset-add-remove-points = Ampio/Esory teboka
 subset-toggle-points-intervals = Ovay ny teboka sy ny elanelana
 subset-move-points = Afindrao ny teboka
 subset-clear = Fafao
-
 orbital-add-row = Ampio andalana
 orbital-remove-row = Esory ny andalana
 orbital-add-box = Ampio boaty
@@ -89,13 +70,9 @@ orbital-remove-box = Esory ny boaty
 orbital-add-up-arrow = Ampio zana-tsipika miakatra
 orbital-add-down-arrow = Ampio zana-tsipika midina
 orbital-remove-arrow = Esory ny zana-tsipika
-
 orbital-row-label = Marika ho an'ny andalana { $row }
-
 pretzel-answer = Valiny
-
 summary-statistics-caption = Statistika famintinana ny { $column }
-
 
 ## Math input
 
@@ -103,34 +80,25 @@ math-input-preview-region = topi-maso amin'ny fomba fanehoana matematika
 math-input-preview = Topi-maso
 math-input-invalid-expression = Fomba fanehoana tsy mety:
 
-
 ## Document status
 
 viewer-initializing = Manomboka...
 
-
 ## Errors
 
 error-heading = Hadisoana
-
 error-found-at =
     { $span ->
         [line] Hita eo amin'ny andalana { $startLine }.
        *[lines] Hita eo amin'ny andalana { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Misy hadisoana ity antontan-taratasy ity!
-
 diagnostic-heading-error = Hadisoana
 diagnostic-heading-warning = Fampitandremana
 diagnostic-heading-information = Fanazavana
 diagnostic-heading-hint = Toro-hevitra
-
 accessibility-heading-level-1 = Fandikana ny fahafahana miditra WCAG AA
 accessibility-heading-level-2 = Fampitandremana momba ny fahafahana miditra
-
 something-went-wrong = Nisy tsy nety.
-
 renderer-load-failed = nisy mpanolotra tsy tafiditra. Avereno alefa ny pejy.
-
 core-start-failed = Tsy afaka nanomboka ny mpijery antontan-taratasy. Avereno alefa ny pejy.

--- a/packages/i18n/locales/mg/content.ftl
+++ b/packages/i18n/locales/mg/content.ftl
@@ -41,15 +41,12 @@ color =
     .purple = volomparasy
     .pink = mavokely
     .brown = volontany
-
 line-width =
     .thick = matevina
     .thin = manify
-
 line-style =
     .dashed = tapatapaka
     .dotted = teboteboka
-
 # Noun phrases: they follow «miaraka amin'ny» and modify nothing.
 fill-style =
     .horizontal = tsipika mandry
@@ -58,7 +55,6 @@ fill-style =
     .backdiagonal = tsipika mihilana mifamadika
     .dots = teboka
     .diamonds = diamondra
-
 noun =
     .line = tsipika
     .line-segment = sombin-tsipika
@@ -78,7 +74,6 @@ noun =
     .diamond = diamondra
     .cross = lakroa
     .plus = marika plus
-
 # The side count follows the noun and precedes its adjectives, so it folds into
 # the head and there is no tail: «polygonina ara-dalàna { $numSides } lafiny».
 noun-regular-polygon =
@@ -86,11 +81,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] polygonina ara-dalàna { $numSides } lafiny
     }
-
 # Malagasy has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,22 +97,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «tsipika matevina tapatapaka mena».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = feno
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } miaraka amin'ny { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } miaraka amin'ny { $pattern }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } miaraka amin'ny { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] miaraka amin'ny sisiny { $border }
@@ -135,36 +123,29 @@ style-border-clause =
         [and-article] ary sisiny { $border }
        *[with] miaraka amin'ny sisiny { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tsy feno
-
 style-text =
     { $parts ->
         [background] { $color } amin'ny fotony { $background }
        *[plain] { $color }
     }
-
 style-background-none = tsy misy
-
 
 ## Boolean words
 
 boolean-true = marina
 boolean-false = diso
 
-
 ## Answer buttons
 
 answer-submit-label = Hamarino ny asa
 answer-submit-label-no-correctness = Alefaso ny valiny
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = Vahaolana
     .task = Asa
     .theorem = Teôrema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Toro-hevitra
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] Tabilao{ ": " }
        *[unnumbered] Tabilao
     }
-
 figure-name =
     { $parts ->
         [numbered] Sary { $enumeration }
@@ -221,22 +198,18 @@ figure-name =
        *[unnumbered] Sary
     }
 
-
 ## Paginator controls
 
 paginator-previous = Teo aloha
 paginator-next = Manaraka
 paginator-page = Pejy
-
 paginator-page-status = { $pageLabel } { $currentPage } amin'ny { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = na
 piecewise-condition-if = raha
 piecewise-condition-otherwise = raha tsy izany
-
 
 ## Chemistry
 ##
@@ -249,6 +222,5 @@ piecewise-condition-otherwise = raha tsy izany
 ## it is a fact about a curriculum rather than about a language family.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Marika simika tsy mety
 chemistry-invalid-ionic-compound = Fitambarana ionika tsy mety

--- a/packages/i18n/locales/mi/chrome.ftl
+++ b/packages/i18n/locales/mi/chrome.ftl
@@ -22,69 +22,50 @@
 
 answer-checking = Kei te tirotiro...
 answer-submitting = Kei te tuku...
-
 answer-checking-status = Kei te tirotiro i te whakautu
 answer-submitting-status = Kei te tuku i te whakautu
-
 answer-correct = Tika
 answer-incorrect = Hē
-
 answer-response-saved = Kua tiakina te whakautu
-
 answer-percent-credit = { $percent }% o te kaute
 answer-percent-correct = { $percent }% tika
 answer-percent-short = { $percent }%
-
 max-credit-available = Te kaute mōrahi e wātea ana: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kāore he ngana e toe ana
        *[other] e toe ana { $count } ngana
     }
-
 validation-correct = (Tika)
 validation-incorrect = (Hē)
 validation-partially-correct = (Tika ā-wāhanga)
-
 answer-show-responses = Whakaaturia ngā whakautu { $count } ki { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Urupare
-
 collapsible-click-to-open = (pāwhiri kia whakatuwhera)
 collapsible-click-to-close = (pāwhiri kia kati)
-
 collapsible-initializing = Kei te tīmata...
-
 footnote-show = Whakaaturia te tuhinga waewae
 footnote-hide = Hunaia te tuhinga waewae
-
 description-more-information = ētahi atu mōhiohio
-
 
 ## Controls
 
 slider-previous = Mua
 slider-next = Muri
-
 keyboard-open = Whakatuwheratia te papapātuhi
 keyboard-close = Katia te papapātuhi
-
 choice-input-remove-choice = Tangohia { $choice }
-
 matrix-remove-row = Tangohia te rārangi
 matrix-add-row = Tāpirihia he rārangi
 matrix-remove-column = Tangohia te tīwae
 matrix-add-column = Tāpirihia he tīwae
-
 subset-add-remove-points = Tāpiri/Tango ira
 subset-toggle-points-intervals = Whakawhitia ngā ira me ngā āwhe
 subset-move-points = Nekehia ngā ira
 subset-clear = Ūkuia
-
 orbital-add-row = Tāpirihia he rārangi
 orbital-remove-row = Tangohia te rārangi
 orbital-add-box = Tāpirihia he pouaka
@@ -92,13 +73,9 @@ orbital-remove-box = Tangohia te pouaka
 orbital-add-up-arrow = Tāpirihia he pere whakarunga
 orbital-add-down-arrow = Tāpirihia he pere whakararo
 orbital-remove-arrow = Tangohia te pere
-
 orbital-row-label = Tapanga mō te rārangi { $row }
-
 pretzel-answer = Whakautu
-
 summary-statistics-caption = Tauanga whakarāpopoto o { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = arokite o te kīanga pāngarau
 math-input-preview = Arokite
 math-input-invalid-expression = Kīanga muhu:
 
-
 ## Document status
 
 viewer-initializing = Kei te tīmata...
 
-
 ## Errors
 
 error-heading = Hapa
-
 error-found-at =
     { $span ->
         [line] I kitea i te rārangi { $startLine }.
        *[lines] I kitea i ngā rārangi { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = He hapa kei roto i tēnei tuhinga!
-
 diagnostic-heading-error = Hapa
 diagnostic-heading-warning = Whakatūpato
 diagnostic-heading-information = Mōhiohio
 diagnostic-heading-hint = Tohutohu
-
 accessibility-heading-level-1 = Takahitanga urunga WCAG AA
 accessibility-heading-level-2 = Whakatūpato urunga
-
 something-went-wrong = I hē tētahi mea.
-
 renderer-load-failed = kāore tētahi kaiwhakaatu i uta. Tēnā, utaina anō te whārangi.
-
 core-start-failed = Kāore i taea te tīmata i te kaitirotiro tuhinga. Tēnā, utaina anō te whārangi.

--- a/packages/i18n/locales/mi/content.ftl
+++ b/packages/i18n/locales/mi/content.ftl
@@ -38,15 +38,12 @@ color =
     .purple = waiporoporo
     .pink = māwhero
     .brown = parauri
-
 line-width =
     .thick = mātotoru
     .thin = angiangi
-
 line-style =
     .dashed = motumotu
     .dotted = ira
-
 # Noun phrases: they follow «me» and modify nothing.
 fill-style =
     .horizontal = rārangi whakapae
@@ -55,7 +52,6 @@ fill-style =
     .backdiagonal = rārangi hauroki whakamuri
     .dots = ira
     .diamonds = taimana
-
 noun =
     .line = rārangi
     .line-segment = wāhanga rārangi
@@ -75,7 +71,6 @@ noun =
     .diamond = taimana
     .cross = ripeka
     .plus = tohu tāpiri
-
 # The side count follows the noun and precedes its adjectives, so it folds into
 # the head and there is no tail: «tapamaha ōrite { $numSides } taha».
 noun-regular-polygon =
@@ -83,11 +78,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] tapamaha ōrite { $numSides } taha
     }
-
 # Māori has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -101,22 +94,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «rārangi mātotoru motumotu whero».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = kī
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } me { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } me { $pattern }
@@ -124,7 +113,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } me { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] me te tapa { $border }
@@ -132,36 +120,29 @@ style-border-clause =
         [and-article] me te tapa { $border }
        *[with] me te tapa { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = kore kī
-
 style-text =
     { $parts ->
         [background] { $color } i runga i te papamuri { $background }
        *[plain] { $color }
     }
-
 style-background-none = kāore
-
 
 ## Boolean words
 
 boolean-true = pono
 boolean-false = hē
 
-
 ## Answer buttons
 
 answer-submit-label = Tirohia te mahi
 answer-submit-label-no-correctness = Tukuna te whakautu
-
 
 ## Sectional blocks
 
@@ -186,7 +167,6 @@ section-name =
     .solution = Otinga
     .task = Mahi
     .theorem = Kaupapa
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -196,9 +176,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tohutohu
-
 
 ## Tables and figures
 
@@ -209,7 +187,6 @@ table-name =
         [unnumbered-title] Ripanga{ ": " }
        *[unnumbered] Ripanga
     }
-
 figure-name =
     { $parts ->
         [numbered] Whakaahua { $enumeration }
@@ -218,15 +195,12 @@ figure-name =
        *[unnumbered] Whakaahua
     }
 
-
 ## Paginator controls
 
 paginator-previous = Mua
 paginator-next = Muri
 paginator-page = Whārangi
-
 paginator-page-status = { $pageLabel } { $currentPage } o { $numPages }
-
 
 ## Piecewise functions
 
@@ -238,7 +212,6 @@ paginator-page-status = { $pageLabel } { $currentPage } o { $numPages }
 piecewise-condition-or = rānei
 piecewise-condition-if = mēnā
 piecewise-condition-otherwise = ki te kore
-
 
 ## Chemistry
 ##
@@ -252,6 +225,5 @@ piecewise-condition-otherwise = ki te kore
 ## should add here, and adding it needs no permission.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Tohu matū muhu
 chemistry-invalid-ionic-compound = Pūhui iona muhu

--- a/packages/i18n/locales/min/chrome.ftl
+++ b/packages/i18n/locales/min/chrome.ftl
@@ -25,21 +25,15 @@
 
 answer-checking = Mamareso…
 answer-submitting = Mangirim…
-
 answer-checking-status = Mamareso jawaban
 answer-submitting-status = Mangirim jawaban
-
 answer-correct = Batua
 answer-incorrect = Indak batua
-
 answer-response-saved = Jawaban alah disimpan
-
 answer-percent-credit = { $percent }% kredit
 answer-percent-correct = { $percent }% batua
 answer-percent-short = { $percent } %
-
 max-credit-available = Kredit paliang gadang nan bisa didapek: { $percent }%
-
 # No select: «cubo» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -47,51 +41,38 @@ attempts-remaining =
         [0] indak ado cubo nan tingga lai
        *[other] tingga { $count } cubo
     }
-
 validation-correct = (Batua)
 validation-incorrect = (Indak batua)
 validation-partially-correct = (Batua sabagian)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Tampilkan { $count } jawaban untuak { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komentar
-
 collapsible-click-to-open = (klik untuak mambukak)
 collapsible-click-to-close = (klik untuak manutuik)
-
 collapsible-initializing = Mamulai…
-
 footnote-show = Tampilkan footnote
 footnote-hide = Sambunyian footnote
-
 description-more-information = katarangan tambahan
-
 
 ## Controls
 
 slider-previous = Sabalunnyo
 slider-next = Salanjuiknyo
-
 keyboard-open = Bukak papan tuts
 keyboard-close = Tutuik papan tuts
-
 choice-input-remove-choice = Hapuih { $choice }
-
 matrix-remove-row = Hapuih barih
 matrix-add-row = Tambah barih
 matrix-remove-column = Hapuih kolom
 matrix-add-column = Tambah kolom
-
 subset-add-remove-points = Tambah/Hapuih titiak
 subset-toggle-points-intervals = Tuka titiak jo interval
 subset-move-points = Pindahkan titiak
 subset-clear = Basiahkan
-
 orbital-add-row = Tambah barih
 orbital-remove-row = Hapuih barih
 orbital-add-box = Tambah kotak
@@ -99,13 +80,9 @@ orbital-remove-box = Hapuih kotak
 orbital-add-up-arrow = Tambah panah ka ateh
 orbital-add-down-arrow = Tambah panah ka bawah
 orbital-remove-arrow = Hapuih panah
-
 orbital-row-label = Label untuak barih { $row }
-
 pretzel-answer = Jawaban
-
 summary-statistics-caption = Ringkasan statistik { $column }
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = pratinjau ungkapan matematika
 math-input-preview = Pratinjau
 math-input-invalid-expression = Ungkapan nan indak sah:
 
-
 ## Document status
 
 viewer-initializing = Mamulai…
 
-
 ## Errors
 
 error-heading = Kasalahan
-
 error-found-at =
     { $span ->
         [line] Basuo di barih { $startLine }.
        *[lines] Basuo di barih { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumen ko ado kasalahan!
-
 diagnostic-heading-error = Kasalahan
 diagnostic-heading-warning = Peringatan
 diagnostic-heading-information = Katarangan
 diagnostic-heading-hint = Pituah
-
 accessibility-heading-level-1 = Palanggaran aksesibilitas WCAG AA
 accessibility-heading-level-2 = Peringatan tantang aksesibilitas
-
 something-went-wrong = Ado nan salah.
-
 renderer-load-failed = ado renderer nan indak tamuek. Tolong muek ulang laman ko.
-
 core-start-failed = Panampil dokumen indak bisa dimulai. Tolong muek ulang laman ko.

--- a/packages/i18n/locales/min/content.ftl
+++ b/packages/i18n/locales/min/content.ftl
@@ -39,15 +39,12 @@ color =
     .purple = unggu
     .pink = sirah jambu
     .brown = coklaik
-
 line-width =
     .thick = taba
     .thin = tipih
-
 line-style =
     .dashed = putuih-putuih
     .dotted = titiak-titiak
-
 # Noun phrases. Minangkabau marks no plural on the noun, so «garih» is the word
 # for one line and for many alike.
 fill-style =
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = garih serong tabaliak
     .dots = titiak
     .diamonds = balah katupek
-
 noun =
     .line = garih
     .line-segment = ruweh garih
@@ -77,7 +73,6 @@ noun =
     .diamond = balah katupek
     .cross = silang
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -85,10 +80,8 @@ noun-regular-polygon =
         [tail] nan basisi { $numSides }
        *[head] poligon baraturan
     }
-
 # One answer for every noun: Minangkabau has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -102,22 +95,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = taisi
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } jo { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } jo { $pattern }
@@ -125,7 +114,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } jo { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Minangkabau has no article, so the two `-article` branches say what the other
 # two say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «jo» against «sarato».
@@ -136,35 +124,28 @@ style-border-clause =
         [and-article] sarato tapi { $border }
        *[with] jo tapi { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = indak taisi
-
 style-text =
     { $parts ->
         [background] { $color } jo latar { $background }
        *[plain] { $color }
     }
-
 style-background-none = indak ado
-
 
 ## Boolean words
 
 boolean-true = bana
 boolean-false = indak bana
 
-
 ## Answer buttons
 
 answer-submit-label = Pareso karajo
 answer-submit-label-no-correctness = Kirim jawaban
-
 
 ## Sectional blocks
 
@@ -191,7 +172,6 @@ section-name =
     .solution = Panyalasaian
     .task = Tugeh
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -201,9 +181,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pituah
-
 
 ## Tables and figures
 
@@ -214,7 +192,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Gambar { $enumeration }
@@ -223,22 +200,18 @@ figure-name =
        *[unnumbered] Gambar
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sabalunnyo
 paginator-next = Salanjuiknyo
 paginator-page = Laman
-
 paginator-page-status = { $pageLabel } { $currentPage } dari { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = atau
 piecewise-condition-if = jiko
 piecewise-condition-otherwise = jiko indak
-
 
 ## Chemistry
 ##
@@ -252,6 +225,5 @@ piecewise-condition-otherwise = jiko indak
 ## Minangkabau table of all 118 exists to seed from.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kimia nan indak sah
 chemistry-invalid-ionic-compound = Sanyawa ionik nan indak sah

--- a/packages/i18n/locales/mk/chrome.ftl
+++ b/packages/i18n/locales/mk/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Проверување…
 answer-submitting = Испраќање…
-
 answer-checking-status = Проверување на одговорот
 answer-submitting-status = Испраќање на одговорот
-
 answer-correct = Точно
 answer-incorrect = Неточно
-
 answer-response-saved = Одговорот е зачуван
-
 answer-percent-credit = { $percent }% од поените
 answer-percent-correct = { $percent }% точно
 answer-percent-short = { $percent } %
-
 max-credit-available = Најмногу можни поени: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] не преостануваат обиди
         [one] преостанува { $count } обид
        *[other] преостануваат { $count } обиди
     }
-
 validation-correct = (Точно)
 validation-incorrect = (Неточно)
 validation-partially-correct = (Делумно точно)
-
 answer-show-responses =
     { $count ->
         [one] Прикажи { $count } одговор на { $answerId }
        *[other] Прикажи { $count } одговори на { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Повратна информација
-
 collapsible-click-to-open = (кликнете за да отворите)
 collapsible-click-to-close = (кликнете за да затворите)
-
 collapsible-initializing = Иницијализирање…
-
 footnote-show = Прикажи ја фуснотата
 footnote-hide = Скриј ја фуснотата
-
 description-more-information = повеќе информации
-
 
 ## Controls
 
 slider-previous = Назад
 slider-next = Напред
-
 keyboard-open = Отвори ја тастатурата
 keyboard-close = Затвори ја тастатурата
-
 choice-input-remove-choice = Отстрани { $choice }
-
 matrix-remove-row = Отстрани ред
 matrix-add-row = Додај ред
 matrix-remove-column = Отстрани колона
 matrix-add-column = Додај колона
-
 subset-add-remove-points = Додај/отстрани точки
 subset-toggle-points-intervals = Смени меѓу точки и интервали
 subset-move-points = Помести точки
 subset-clear = Исчисти
-
 orbital-add-row = Додај ред
 orbital-remove-row = Отстрани ред
 orbital-add-box = Додај поле
@@ -95,13 +76,9 @@ orbital-remove-box = Отстрани поле
 orbital-add-up-arrow = Додај стрелка нагоре
 orbital-add-down-arrow = Додај стрелка надолу
 orbital-remove-arrow = Отстрани стрелка
-
 orbital-row-label = Ознака за ред { $row }
-
 pretzel-answer = Одговор
-
 summary-statistics-caption = Збирна статистика за { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = преглед на математичкиот из�
 math-input-preview = Преглед
 math-input-invalid-expression = Невалиден израз:
 
-
 ## Document status
 
 viewer-initializing = Иницијализирање…
 
-
 ## Errors
 
 error-heading = Грешка
-
 error-found-at =
     { $span ->
         [line] Пронајдена во редот { $startLine }.
        *[lines] Пронајдена во редовите { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Овој документ содржи грешки!
-
 diagnostic-heading-error = Грешка
 diagnostic-heading-warning = Предупредување
 diagnostic-heading-information = Информација
 diagnostic-heading-hint = Совет
-
 accessibility-heading-level-1 = Прекршување на пристапноста според WCAG AA
 accessibility-heading-level-2 = Известување за пристапност
-
 something-went-wrong = Нешто тргна наопаку.
-
 renderer-load-failed = не успеа да се вчита модул за прикажување. Превчитајте ја страницата.
-
 core-start-failed = Прегледувачот на документот не можеше да се стартува. Превчитајте ја страницата.

--- a/packages/i18n/locales/mk/content.ftl
+++ b/packages/i18n/locales/mk/content.ftl
@@ -91,7 +91,6 @@ color =
             [n] кафеаво
            *[m] кафеав
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -105,7 +104,6 @@ line-width =
             [n] тенко
            *[m] тенок
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -119,7 +117,6 @@ line-style =
             [n] точкесто
            *[m] точкест
         }
-
 # Bare plural noun phrases. Macedonian puts nothing on a noun behind «со», so
 # the words that follow that preposition in `style-filled` are the same ones
 # that stand alone in `style-fill`.
@@ -130,7 +127,6 @@ fill-style =
     .backdiagonal = обратни дијагонални линии
     .dots = точки
     .diamonds = ромбови
-
 noun =
     .line = права
     .line-segment = отсечка
@@ -150,7 +146,6 @@ noun =
     .diamond = ромб
     .cross = крст
     .plus = плус
-
 # Macedonian keeps the side count in front of the noun, so the whole of it is
 # one head and there is no tail.
 noun-regular-polygon =
@@ -158,7 +153,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] правилен { $numSides }-аголник
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (многуаголник, m)
 # or the head of a phrase the description never names: `border` (граница, f),
 # `fill` (исполнување, n), `text` (текст, m), `background` (позадина, f).
@@ -180,7 +174,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -193,26 +186,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [f] исполнета
         [n] исполнето
        *[m] исполнет
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } со { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } со { $pattern }
@@ -220,7 +209,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } со { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «граница» is feminine, so the border's adjectives agree with it rather than
 # with the shape it surrounds. The article is a suffix and is not used here, so
 # the two `-article` branches read like the two without.
@@ -231,7 +219,6 @@ style-border-clause =
         [and-article] и { $border } граница
        *[with] со { $border } граница
     }
-
 # The fill-pattern words need a noun to hang off when they stand on their own,
 # so this supplies «исполнување» — neuter, which is the gender `noun-gender`
 # already answers for `fill`.
@@ -240,9 +227,7 @@ style-fill =
         [pattern] { $color } исполнување со { $pattern }
        *[plain] { $color } исполнување
     }
-
 style-unfilled = неисполнет
-
 # «текст» is masculine and «позадина» feminine, so the two colours here take
 # two different endings — from `noun-gender` alone, with no `$role` involved.
 style-text =
@@ -250,21 +235,17 @@ style-text =
         [background] { $color } на { $background } позадина
        *[plain] { $color }
     }
-
 style-background-none = нема
-
 
 ## Boolean words
 
 boolean-true = точно
 boolean-false = неточно
 
-
 ## Answer buttons
 
 answer-submit-label = Провери
 answer-submit-label-no-correctness = Испрати одговор
-
 
 ## Sectional blocks
 
@@ -289,7 +270,6 @@ section-name =
     .solution = Решение
     .task = Задача
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -299,9 +279,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Совет
-
 
 ## Tables and figures
 
@@ -312,7 +290,6 @@ table-name =
         [unnumbered-title] Табела{ ". " }
        *[unnumbered] Табела
     }
-
 figure-name =
     { $parts ->
         [numbered] Слика { $enumeration }
@@ -321,22 +298,18 @@ figure-name =
        *[unnumbered] Слика
     }
 
-
 ## Paginator controls
 
 paginator-previous = Претходна
 paginator-next = Следна
 paginator-page = Страница
-
 paginator-page-status = { $pageLabel } { $currentPage } од { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = или
 piecewise-condition-if = ако
 piecewise-condition-otherwise = инаку
-
 
 ## Chemistry
 
@@ -459,7 +432,6 @@ element-name =
     .lv = Ливермориум
     .ts = Тенесин
     .og = Оганесон
-
 element-anion-name =
     .h = Хидрид
     .c = Карбид
@@ -473,8 +445,6 @@ element-anion-name =
     .i = Јодид
     .at = Астатид
     .ts = Тенесид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Невалиден хемиски симбол
 chemistry-invalid-ionic-compound = Невалидно јонско соединение

--- a/packages/i18n/locales/ml/chrome.ftl
+++ b/packages/i18n/locales/ml/chrome.ftl
@@ -22,74 +22,55 @@
 
 answer-checking = പരിശോധിക്കുന്നു...
 answer-submitting = സമർപ്പിക്കുന്നു...
-
 answer-checking-status = ഉത്തരം പരിശോധിക്കുന്നു
 answer-submitting-status = ഉത്തരം സമർപ്പിക്കുന്നു
-
 answer-correct = ശരി
 answer-incorrect = തെറ്റ്
-
 answer-response-saved = ഉത്തരം സൂക്ഷിച്ചു
-
 answer-percent-credit = { $percent }% മാർക്ക്
 answer-percent-correct = { $percent }% ശരി
 answer-percent-short = { $percent }%
-
 max-credit-available = ലഭ്യമായ പരമാവധി മാർക്ക്: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ശ്രമങ്ങളൊന്നും ബാക്കിയില്ല
         [one] { $count } ശ്രമം ബാക്കി
        *[other] { $count } ശ്രമങ്ങൾ ബാക്കി
     }
-
 validation-correct = (ശരി)
 validation-incorrect = (തെറ്റ്)
 validation-partially-correct = (ഭാഗികമായി ശരി)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } നു ലഭിച്ച { $count } ഉത്തരം കാണിക്കുക
        *[other] { $answerId } നു ലഭിച്ച { $count } ഉത്തരങ്ങൾ കാണിക്കുക
     }
 
-
 ## Disclosure panels
 
 feedback-heading = പ്രതികരണം
-
 collapsible-click-to-open = (തുറക്കാൻ ക്ലിക്ക് ചെയ്യുക)
 collapsible-click-to-close = (അടയ്ക്കാൻ ക്ലിക്ക് ചെയ്യുക)
-
 collapsible-initializing = ആരംഭിക്കുന്നു...
-
 footnote-show = അടിക്കുറിപ്പ് കാണിക്കുക
 footnote-hide = അടിക്കുറിപ്പ് മറയ്ക്കുക
-
 description-more-information = കൂടുതൽ വിവരം
-
 
 ## Controls
 
 slider-previous = മുൻപത്തേത്
 slider-next = അടുത്തത്
-
 keyboard-open = കീബോർഡ് തുറക്കുക
 keyboard-close = കീബോർഡ് അടയ്ക്കുക
-
 choice-input-remove-choice = { $choice } നീക്കുക
-
 matrix-remove-row = വരി നീക്കുക
 matrix-add-row = വരി ചേർക്കുക
 matrix-remove-column = നിര നീക്കുക
 matrix-add-column = നിര ചേർക്കുക
-
 subset-add-remove-points = ബിന്ദുക്കൾ ചേർക്കുക/നീക്കുക
 subset-toggle-points-intervals = ബിന്ദുക്കളും ഇടവേളകളും തമ്മിൽ മാറ്റുക
 subset-move-points = ബിന്ദുക്കൾ നീക്കുക
 subset-clear = മായ്ക്കുക
-
 # A `box` here is one orbital, drawn as a square: കളം.
 orbital-add-row = വരി ചേർക്കുക
 orbital-remove-row = വരി നീക്കുക
@@ -98,13 +79,9 @@ orbital-remove-box = കളം നീക്കുക
 orbital-add-up-arrow = മുകളിലേക്കുള്ള അമ്പ് ചേർക്കുക
 orbital-add-down-arrow = താഴേക്കുള്ള അമ്പ് ചേർക്കുക
 orbital-remove-arrow = അമ്പ് നീക്കുക
-
 orbital-row-label = വരി { $row } ന്റെ ലേബൽ
-
 pretzel-answer = ഉത്തരം
-
 summary-statistics-caption = { $column } ന്റെ സംഗ്രഹ സ്ഥിതിവിവരക്കണക്കുകൾ
-
 
 ## Math input
 
@@ -112,16 +89,13 @@ math-input-preview-region = ഗണിത വ്യഞ്ജക പൂർവദ�
 math-input-preview = പൂർവദൃശ്യം
 math-input-invalid-expression = അസാധുവായ വ്യഞ്ജകം:
 
-
 ## Document status
 
 viewer-initializing = ആരംഭിക്കുന്നു...
 
-
 ## Errors
 
 error-heading = പിശക്
-
 # The ordinal «-ാം» opens with a combining vowel sign, so it needs a base
 # character in front of it and cannot stand as a word of its own. It is
 # invariant whatever number precedes it, so it is welded to the placeable with
@@ -132,19 +106,13 @@ error-found-at =
         [line] { $startLine }-ാം വരിയിൽ കണ്ടെത്തി.
        *[lines] { $startLine }–{ $endLine } വരികളിൽ കണ്ടെത്തി.
     }
-
 document-contains-errors = ഈ രേഖയിൽ പിശകുകളുണ്ട്!
-
 diagnostic-heading-error = പിശക്
 diagnostic-heading-warning = മുന്നറിയിപ്പ്
 diagnostic-heading-information = വിവരം
 diagnostic-heading-hint = സൂചന
-
 accessibility-heading-level-1 = WCAG AA പ്രാപ്യതാ ലംഘനം
 accessibility-heading-level-2 = പ്രാപ്യതാ മുന്നറിയിപ്പ്
-
 something-went-wrong = എന്തോ കുഴപ്പം സംഭവിച്ചു.
-
 renderer-load-failed = ഒരു റെൻഡറർ ലോഡ് ചെയ്യാനായില്ല. ദയവായി പേജ് വീണ്ടും ലോഡ് ചെയ്യുക.
-
 core-start-failed = രേഖാ ദർശിനി ആരംഭിക്കാനായില്ല. ദയവായി പേജ് വീണ്ടും ലോഡ് ചെയ്യുക.

--- a/packages/i18n/locales/ml/content.ftl
+++ b/packages/i18n/locales/ml/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = പർപ്പിൾ
     .pink = പിങ്ക്
     .brown = തവിട്ട്
-
 line-width =
     .thick = കട്ടിയുള്ള
     .thin = നേർത്ത
-
 line-style =
     .dashed = മുറിഞ്ഞ
     .dotted = കുത്തിട്ട
-
 # Noun phrases: they stand in front of the «സഹിതം» the composition messages
 # supply, and modify nothing.
 fill-style =
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = എതിർ കോണോട്ടു വരകൾ
     .dots = കുത്തുകൾ
     .diamonds = വജ്രാകൃതികൾ
-
 noun =
     .line = നേർരേഖ
     .line-segment = രേഖാഖണ്ഡം
@@ -74,7 +70,6 @@ noun =
     .diamond = വജ്രാകൃതി
     .cross = കുരിശടയാളം
     .plus = സങ്കലനചിഹ്നം
-
 # The side count precedes the noun, as every modifier in Malayalam does, so it
 # folds into the head and there is no tail.
 noun-regular-polygon =
@@ -82,12 +77,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } വശങ്ങളുള്ള സമബഹുഭുജം
     }
-
 # Malayalam marks gender on nouns and pronouns, not on the adjectives in these
 # phrases, so every noun answers the same and the answer goes unused — as in
 # English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -101,21 +94,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = നിറച്ച
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } സഹിതം
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } സഹിതം
@@ -123,7 +112,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } സഹിതം
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «അതിര്» is a fixed word, so the comitative -ഓടെ is written onto it directly,
 # and «കൂടാതെ» opens the further clause where English opens it with "and".
 # Malayalam has no article, so the two `-article` branches read like the ones
@@ -135,15 +123,12 @@ style-border-clause =
         [and-article] കൂടാതെ { $border } അതിരോടെ
        *[with] { $border } അതിരോടെ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = നിറയ്ക്കാത്ത
-
 # «പശ്ചാത്തലം» takes the locative -ത്തിൽ, so the background leads and the text
 # colour follows it.
 style-text =
@@ -151,21 +136,17 @@ style-text =
         [background] { $background } പശ്ചാത്തലത്തിൽ { $color }
        *[plain] { $color }
     }
-
 style-background-none = ഒന്നുമില്ല
-
 
 ## Boolean words
 
 boolean-true = സത്യം
 boolean-false = അസത്യം
 
-
 ## Answer buttons
 
 answer-submit-label = പരിശോധിക്കുക
 answer-submit-label-no-correctness = ഉത്തരം സമർപ്പിക്കുക
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = നിർധാരണം
     .task = ദൗത്യം
     .theorem = സിദ്ധാന്തം
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -200,9 +180,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = സൂചന
-
 
 ## Tables and figures
 
@@ -213,7 +191,6 @@ table-name =
         [unnumbered-title] പട്ടിക{ ": " }
        *[unnumbered] പട്ടിക
     }
-
 figure-name =
     { $parts ->
         [numbered] ചിത്രം { $enumeration }
@@ -222,24 +199,20 @@ figure-name =
        *[unnumbered] ചിത്രം
     }
 
-
 ## Paginator controls
 
 paginator-previous = മുൻപത്തേത്
 paginator-next = അടുത്തത്
 paginator-page = പേജ്
-
 # The total leads, marked with the locative -ൽ, which is how Malayalam says
 # "3 of 5".
 paginator-page-status = { $numPages } ൽ { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = അഥവാ
 piecewise-condition-if = എങ്കിൽ
 piecewise-condition-otherwise = അല്ലെങ്കിൽ
-
 
 ## Chemistry
 
@@ -366,7 +339,6 @@ element-name =
     .lv = ലിവർമോറിയം
     .ts = ടെന്നസ്സിൻ
     .og = ഒഗനെസ്സൺ
-
 element-anion-name =
     .h = ഹൈഡ്രൈഡ്
     .c = കാർബൈഡ്
@@ -380,8 +352,6 @@ element-anion-name =
     .i = അയഡൈഡ്
     .at = അസ്റ്റാറ്റൈഡ്
     .ts = ടെന്നസ്സൈഡ്
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = അസാധുവായ രാസ ചിഹ്നം
 chemistry-invalid-ionic-compound = അസാധുവായ അയോണിക സംയുക്തം

--- a/packages/i18n/locales/mn/chrome.ftl
+++ b/packages/i18n/locales/mn/chrome.ftl
@@ -22,74 +22,55 @@
 
 answer-checking = Шалгаж байна…
 answer-submitting = Илгээж байна…
-
 answer-checking-status = Хариултыг шалгаж байна
 answer-submitting-status = Хариултыг илгээж байна
-
 answer-correct = Зөв
 answer-incorrect = Буруу
-
 answer-response-saved = Хариулт хадгалагдлаа
-
 answer-percent-credit = { $percent }% оноо
 answer-percent-correct = { $percent }% зөв
 answer-percent-short = { $percent } %
-
 max-credit-available = Авах боломжтой дээд оноо: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] оролдлого үлдсэнгүй
         [one] { $count } оролдлого үлдлээ
        *[other] { $count } оролдлого үлдлээ
     }
-
 validation-correct = (Зөв)
 validation-incorrect = (Буруу)
 validation-partially-correct = (Хэсэгчлэн зөв)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } хариултад өгсөн { $count } хариултыг харуулах
        *[other] { $answerId } хариултад өгсөн { $count } хариултыг харуулах
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Санал хүсэлт
-
 collapsible-click-to-open = (нээхийн тулд товшино уу)
 collapsible-click-to-close = (хаахын тулд товшино уу)
-
 collapsible-initializing = Бэлтгэж байна…
-
 footnote-show = Тайлбарыг харуулах
 footnote-hide = Тайлбарыг нуух
-
 description-more-information = нэмэлт мэдээлэл
-
 
 ## Controls
 
 slider-previous = Өмнөх
 slider-next = Дараах
-
 keyboard-open = Гарыг нээх
 keyboard-close = Гарыг хаах
-
 choice-input-remove-choice = { $choice } сонголтыг хасах
-
 matrix-remove-row = Мөр хасах
 matrix-add-row = Мөр нэмэх
 matrix-remove-column = Багана хасах
 matrix-add-column = Багана нэмэх
-
 subset-add-remove-points = Цэг нэмэх/хасах
 subset-toggle-points-intervals = Цэг ба завсрын хооронд сэлгэх
 subset-move-points = Цэгүүдийг зөөх
 subset-clear = Цэвэрлэх
-
 orbital-add-row = Мөр нэмэх
 orbital-remove-row = Мөр хасах
 orbital-add-box = Нүд нэмэх
@@ -97,13 +78,9 @@ orbital-remove-box = Нүд хасах
 orbital-add-up-arrow = Дээш сум нэмэх
 orbital-add-down-arrow = Доош сум нэмэх
 orbital-remove-arrow = Сум хасах
-
 orbital-row-label = { $row } мөрийн шошго
-
 pretzel-answer = Хариулт
-
 summary-statistics-caption = { $column } баганын нэгтгэсэн статистик
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = математик илэрхийллийн урьд
 math-input-preview = Урьдчилсан харагдац
 math-input-invalid-expression = Буруу илэрхийлэл:
 
-
 ## Document status
 
 viewer-initializing = Бэлтгэж байна…
 
-
 ## Errors
 
 error-heading = Алдаа
-
 error-found-at =
     { $span ->
         [line] { $startLine }-р мөрөөс олдлоо.
        *[lines] { $startLine }–{ $endLine }-р мөрүүдээс олдлоо.
     }
-
 document-contains-errors = Энэ баримт бичигт алдаа байна!
-
 diagnostic-heading-error = Алдаа
 diagnostic-heading-warning = Анхааруулга
 diagnostic-heading-information = Мэдээлэл
 diagnostic-heading-hint = Зөвлөмж
-
 accessibility-heading-level-1 = WCAG AA хүртээмжийн зөрчил
 accessibility-heading-level-2 = Хүртээмжийн мэдэгдэл
-
 something-went-wrong = Ямар нэг зүйл буруу боллоо.
-
 renderer-load-failed = дүрслэгчийг ачаалж чадсангүй. Хуудсыг дахин ачаална уу.
-
 core-start-failed = Баримт бичиг үзүүлэгчийг эхлүүлж чадсангүй. Хуудсыг дахин ачаална уу.

--- a/packages/i18n/locales/mn/content.ftl
+++ b/packages/i18n/locales/mn/content.ftl
@@ -42,15 +42,12 @@ color =
     .purple = нил ягаан
     .pink = ягаан
     .brown = бор
-
 line-width =
     .thick = бүдүүн
     .thin = нарийн
-
 line-style =
     .dashed = тасалдсан
     .dotted = цэгэн
-
 # Noun phrases: they stand in front of «хээтэй» and modify nothing.
 fill-style =
     .horizontal = хэвтээ шугам
@@ -59,7 +56,6 @@ fill-style =
     .backdiagonal = эсрэг диагональ шугам
     .dots = цэг
     .diamonds = ромб
-
 noun =
     .line = шулуун
     .line-segment = хэрчим
@@ -79,7 +75,6 @@ noun =
     .diamond = ромб
     .cross = загалмай
     .plus = нэмэх
-
 # Mongolian builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -87,11 +82,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] зөв { $numSides } өнцөгт
     }
-
 # Mongolian has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,21 +98,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = дүүргэлттэй
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } хээтэй { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } хээтэй { $color } { $filled } { $noun }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } хээтэй { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # The comitative carries the "with" in its own ending, so neither a preposition
 # nor an article is wanted, and all four branches read alike except for the
 # connective English needs and Mongolian does not.
@@ -138,15 +126,12 @@ style-border-clause =
         [and-article] ба { $border } хүрээтэй
        *[with] { $border } хүрээтэй
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } хээтэй { $color } дүүргэлт
        *[plain] { $color } дүүргэлт
     }
-
 style-unfilled = дүүргэлтгүй
-
 # «дэвсгэр дээр» — the postposition follows the noun, and the colour in front of
 # it does not move.
 style-text =
@@ -154,21 +139,17 @@ style-text =
         [background] { $background } дэвсгэр дээр { $color }
        *[plain] { $color }
     }
-
 style-background-none = байхгүй
-
 
 ## Boolean words
 
 boolean-true = үнэн
 boolean-false = худал
 
-
 ## Answer buttons
 
 answer-submit-label = Шалгах
 answer-submit-label-no-correctness = Хариултаа илгээх
-
 
 ## Sectional blocks
 
@@ -193,7 +174,6 @@ section-name =
     .solution = Бодолт
     .task = Даалгавар
     .theorem = Теорем
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -203,9 +183,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Зөвлөмж
-
 
 ## Tables and figures
 
@@ -216,7 +194,6 @@ table-name =
         [unnumbered-title] Хүснэгт{ ". " }
        *[unnumbered] Хүснэгт
     }
-
 figure-name =
     { $parts ->
         [numbered] Зураг { $enumeration }
@@ -225,22 +202,18 @@ figure-name =
        *[unnumbered] Зураг
     }
 
-
 ## Paginator controls
 
 paginator-previous = Өмнөх
 paginator-next = Дараах
 paginator-page = Хуудас
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = эсвэл
 piecewise-condition-if = хэрэв
 piecewise-condition-otherwise = бусад тохиолдолд
-
 
 ## Chemistry
 
@@ -363,7 +336,6 @@ element-name =
     .lv = Ливермори
     .ts = Теннессин
     .og = Оганесон
-
 element-anion-name =
     .h = Гидрид
     .c = Карбид
@@ -377,8 +349,6 @@ element-anion-name =
     .i = Иодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Буруу химийн тэмдэг
 chemistry-invalid-ionic-compound = Буруу ионы нэгдэл

--- a/packages/i18n/locales/mni/chrome.ftl
+++ b/packages/i18n/locales/mni/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = য়েংশিল্লি…
 answer-submitting = থাদোক্লি…
-
 answer-checking-status = পাউখুম য়েংশিল্লি
 answer-submitting-status = পাউখুম থাদোক্লি
-
 answer-correct = অচুম্বা
 answer-incorrect = অরানবা
-
 answer-response-saved = পাউখুম থমজিনখ্রে
-
 answer-percent-credit = { $percent }% মাক
 answer-percent-correct = { $percent }% অচুম্বা
 answer-percent-short = { $percent } %
-
 max-credit-available = ফংবা য়াবা খ্বাইদগী য়াম্বা মাক: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] হোৎনবা অমত্তা লৈত্রে
         [one] হোৎনবা { $count } লৈরি
        *[other] হোৎনবা { $count } লৈরি
     }
-
 validation-correct = (অচুম্বা)
 validation-incorrect = (অরানবা)
 validation-partially-correct = (শরুক অমা অচুম্বা)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId }গী পাউখুম { $count } উৎলু
        *[other] { $answerId }গী পাউখুম { $count } উৎলু
     }
 
-
 ## Disclosure panels
 
 feedback-heading = পাউখুম ৱারোল
-
 collapsible-click-to-open = (হাংদোক্নবা ক্লিক তৌরো)
 collapsible-click-to-close = (থিংজিন্নবা ক্লিক তৌরো)
-
 collapsible-initializing = হৌরকলি…
-
 footnote-show = খোঙজেল ৱারোল উৎলু
 footnote-hide = খোঙজেল ৱারোল লোৎলু
-
 description-more-information = হেন্না পাউ
-
 
 ## Controls
 
 slider-previous = মমাংগী
 slider-next = মথংগী
-
 keyboard-open = কীবোর্দ হাংদোকউ
 keyboard-close = কীবোর্দ থিংজিল্লু
-
 choice-input-remove-choice = { $choice } লৌথোকউ
-
 matrix-remove-row = পরিং লৌথোকউ
 matrix-add-row = পরিং হাপচিল্লু
 matrix-remove-column = কোলম লৌথোকউ
 matrix-add-column = কোলম হাপচিল্লু
-
 subset-add-remove-points = চেৎ হাপচিল্লু/লৌথোকউ
 subset-toggle-points-intervals = চেৎ অমসুং অন্তরাল হোংদোকউ
 subset-move-points = চেৎ হোংদোকউ
 subset-clear = মুত্থৎলু
-
 orbital-add-row = পরিং হাপচিল্লু
 orbital-remove-row = পরিং লৌথোকউ
 orbital-add-box = বক্স হাপচিল্লু
@@ -86,13 +67,9 @@ orbital-remove-box = বক্স লৌথোকউ
 orbital-add-up-arrow = মথক্তা চংবা তেন হাপচিল্লু
 orbital-add-down-arrow = মখাদা চংবা তেন হাপচিল্লু
 orbital-remove-arrow = তেন লৌথোকউ
-
 orbital-row-label = পরিং { $row }গী মমিং
-
 pretzel-answer = পাউখুম
-
 summary-statistics-caption = { $column }গী সাংখ্যিক পুন্সিল
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = গণিতকী ৱাহৈ ময়েক অ�
 math-input-preview = অহানবা উবা
 math-input-invalid-expression = অরানবা ৱাহৈ ময়েক:
 
-
 ## Document status
 
 viewer-initializing = হৌরকলি…
 
-
 ## Errors
 
 error-heading = অশোয়বা
-
 error-found-at =
     { $span ->
         [line] পরেং { $startLine }দা ফংলে।
        *[lines] পরেং { $startLine }–{ $endLine }দা ফংলে।
     }
-
 document-contains-errors = দোকুমেন্ত অসিদা অশোয়বা লৈরি!
-
 diagnostic-heading-error = অশোয়বা
 diagnostic-heading-warning = চেকশিন ৱাফম
 diagnostic-heading-information = পাউ
 diagnostic-heading-hint = খুদম
-
 accessibility-heading-level-1 = WCAG AA শিজিন্নবা য়াবগী ৱাথোক
 accessibility-heading-level-2 = শিজিন্নবা য়াবগী চেকশিন ৱাফম
-
 something-went-wrong = করিগুম্বা অমা শোয়খ্রে।
-
 renderer-load-failed = উৎপা মশীন অমা লোদ তৌবা ঙমখিদে। লামায় অসি অমুক হন্না লোদ তৌবিয়ু।
-
 core-start-failed = দোকুমেন্ত উৎপা মশীন হৌবা ঙমখিদে। লামায় অসি অমুক হন্না লোদ তৌবিয়ু।

--- a/packages/i18n/locales/mni/content.ftl
+++ b/packages/i18n/locales/mni/content.ftl
@@ -52,15 +52,12 @@ color =
     .purple = বেগুনী
     .pink = গোলাপী
     .brown = খয়েরী
-
 line-width =
     .thick = অচৌবা
     .thin = অপীকপা
-
 line-style =
     .dashed = তক্থোকপা
     .dotted = চেৎনবা
-
 fill-style =
     .horizontal = পরিং পরেং
     .vertical = লেপপা পরেং
@@ -68,7 +65,6 @@ fill-style =
     .backdiagonal = ওন্থোকপা তিংথোকপা পরেং
     .dots = চেৎ
     .diamonds = সমচতুর্ভুজ
-
 noun =
     .line = পরেং
     .line-segment = পরেং শরুক
@@ -88,7 +84,6 @@ noun =
     .diamond = সমচতুর্ভুজ
     .cross = গুণন খুদম
     .plus = পুনশিনবা খুদম
-
 # The count follows the noun the way every other modifier does, so the head
 # carries the noun alone and the tail carries the complement. The three
 # post-nominal catalogs in this batch — this one, `bo` and `dz` — are the ones
@@ -98,10 +93,8 @@ noun-regular-polygon =
         [tail] মায়কৈ { $numSides } লৈবা
        *[head] অচুম্বা বহুভুজ
     }
-
 # Nothing selects on it: Meitei has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -115,7 +108,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives follow the noun, so the two halves change places against
 # English. A noun with a tail puts the tail last, after the adjectives it
 # qualifies.
@@ -124,9 +116,7 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = থল্লবা
-
 # «-না» is the instrumental and has one shape whatever precedes it, so welding
 # it onto a placeable is sound.
 style-filled =
@@ -134,7 +124,6 @@ style-filled =
         [pattern] { $filled } { $color } { $pattern }না
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } { $pattern }না
@@ -142,7 +131,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } { $pattern }না
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «মপান» is the border and stands in front of its own adjective, so the
 # comitative «-গা» welds onto the placeable rather than onto a word this
 # catalog writes. Meitei has no article, so the `-article` branches read like
@@ -154,36 +142,29 @@ style-border-clause =
         [and-article] অমসুং মপান { $border }গা লোয়ননা
        *[with] মপান { $border }গা লোয়ননা
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }না
        *[plain] { $color }
     }
-
 style-unfilled = থল্লদবা
-
 # «-দা» is the locative and has one shape too.
 style-text =
     { $parts ->
         [background] মতুং { $background }দা { $color }
        *[plain] { $color }
     }
-
 style-background-none = করিসু লৈতে
-
 
 ## Boolean words
 
 boolean-true = অচুম্বা
 boolean-false = অরানবা
 
-
 ## Answer buttons
 
 answer-submit-label = য়েংশিল্লু
 answer-submit-label-no-correctness = পাউখুম থাদোকউ
-
 
 ## Sectional blocks
 
@@ -208,7 +189,6 @@ section-name =
     .solution = পাউখুম লম্বী
     .task = থবক
     .theorem = প্রমেয়
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -218,9 +198,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = খুদম
-
 
 ## Tables and figures
 
@@ -231,7 +209,6 @@ table-name =
         [unnumbered-title] তেবল{ ": " }
        *[unnumbered] তেবল
     }
-
 figure-name =
     { $parts ->
         [numbered] মমি { $enumeration }
@@ -240,26 +217,20 @@ figure-name =
        *[unnumbered] মমি
     }
 
-
 ## Paginator controls
 
 paginator-previous = মমাংগী
 paginator-next = মথংগী
 paginator-page = লামায়
-
 # «X-দগী Y» — "Y out of X" — puts the total first, so the two counts change
 # places. The ablative «-দগী» has one shape whatever precedes it.
 paginator-page-status = { $numPages }-দগী { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = নত্ত্রগা
-
 piecewise-condition-if = করিগুম্বা
-
 piecewise-condition-otherwise = নত্ত্রবদি
-
 
 ## Chemistry
 ##
@@ -273,6 +244,5 @@ piecewise-condition-otherwise = নত্ত্রবদি
 ## is the curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = অরানবা রাসায়নিক খুদম
 chemistry-invalid-ionic-compound = অরানবা আয়নিক যৌগিক

--- a/packages/i18n/locales/mnk/chrome.ftl
+++ b/packages/i18n/locales/mnk/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Koroosiroo be keriŋ…
 answer-submitting = Kiiroo be keriŋ…
-
 answer-checking-status = Jaabiroo be koroosi kaŋ
 answer-submitting-status = Jaabiroo be kii kaŋ
-
 answer-correct = A benta
 answer-incorrect = A maŋ beŋ
-
 answer-response-saved = Jaabiroo maabota
-
 answer-percent-credit = { $percent }% poyintoolu
 answer-percent-correct = { $percent }% benta
 answer-percent-short = { $percent } %
-
 max-credit-available = Poyint jamaa meŋ be sotoo la: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kata te tu la
         [one] kata { $count } tuta
        *[other] kata { $count } tuta
     }
-
 validation-correct = (A benta)
 validation-incorrect = (A maŋ beŋ)
 validation-partially-correct = (A benta karoo doo la)
-
 answer-show-responses =
     { $count ->
         [one] Jaabiroo { $count } yitandi { $answerId } ye
        *[other] Jaabiroo { $count } yitandi { $answerId } ye
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Yaamaroo
-
 collapsible-click-to-open = (a bito ka a yele)
 collapsible-click-to-close = (a bito ka a soroŋ)
-
 collapsible-initializing = A be dati kaŋ…
-
 footnote-show = Duuma safeeroo yitandi
 footnote-hide = Duuma safeeroo maabo
-
 description-more-information = kibaari doolu
-
 
 ## Controls
 
 slider-previous = Meŋ tambita
 slider-next = Meŋ ka naa
-
 keyboard-open = Kiiboodoo Yele
 keyboard-close = Kiiboodoo Soroŋ
-
 choice-input-remove-choice = { $choice } bondi
-
 matrix-remove-row = Laayinoo bondi
 matrix-add-row = Laayinoo lafaa
 matrix-remove-column = Kolonoo bondi
 matrix-add-column = Kolonoo lafaa
-
 subset-add-remove-points = Tombondiŋolu lafaa/bondi
 subset-toggle-points-intervals = Tombondiŋolu niŋ tembendiroolu faliŋ
 subset-move-points = Tombondiŋolu Maamandi
 subset-clear = Bee bondi
-
 orbital-add-row = Laayinoo Lafaa
 orbital-remove-row = Laayinoo Bondi
 orbital-add-box = Keesoo Lafaa
@@ -87,13 +68,9 @@ orbital-remove-box = Keesoo Bondi
 orbital-add-up-arrow = Santo Kalabeñoo Lafaa
 orbital-add-down-arrow = Duuma Kalabeñoo Lafaa
 orbital-remove-arrow = Kalabeñoo Bondi
-
 orbital-row-label = Laayinoo { $row } too
-
 pretzel-answer = Jaabiroo
-
 summary-statistics-caption = { $column } konteroolu kuntoo
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = konteroo kumakaŋ juubeeri foloo
 math-input-preview = Juubeeri foloo
 math-input-invalid-expression = Kumakaŋ kuruŋo:
 
-
 ## Document status
 
 viewer-initializing = A be dati kaŋ…
 
-
 ## Errors
 
 error-heading = Filoo
-
 error-found-at =
     { $span ->
         [line] A jeta laayinoo { $startLine } to.
        *[lines] A jeta laayinoolu { $startLine }–{ $endLine } to.
     }
-
 document-contains-errors = Ñiŋ kitaaboo ye filoolu soto!
-
 diagnostic-heading-error = Filoo
 diagnostic-heading-warning = Dandalaaroo
 diagnostic-heading-information = Kibaaroo
 diagnostic-heading-hint = Yitandiroo
-
 accessibility-heading-level-1 = WCAG AA futandiroo tambiroo
 accessibility-heading-level-2 = Futandiroo dandalaaroo
-
 something-went-wrong = Feŋ ne maŋ ke a ñaama.
-
 renderer-load-failed = yitandirilaa maŋ futa. Dukare, karataa murundi.
-
 core-start-failed = Kitaaboo yitandirilaa maŋ dati. Dukare, karataa murundi.

--- a/packages/i18n/locales/mnk/content.ftl
+++ b/packages/i18n/locales/mnk/content.ftl
@@ -50,18 +50,15 @@ color =
     .purple = purupuloo
     .pink = piŋkoo
     .brown = burawunoo
-
 line-width =
     .thick = waroo
     .thin = meseŋo
-
 # Written as invariable «niŋ …» phrases rather than as qualifiers, so that they
 # take no `-o` agreement and can close the description. `style-stroke` puts
 # them last.
 line-style =
     .dashed = niŋ dasoolu
     .dotted = niŋ tombondiŋolu
-
 fill-style =
     .horizontal = laayinoolu meŋ laata
     .vertical = laayinoolu meŋ loota
@@ -69,7 +66,6 @@ fill-style =
     .backdiagonal = laayinoolu meŋ jenketa karoo doo la
     .dots = tombondiŋolu
     .diamonds = dayamondoolu
-
 noun =
     .line = laayinoo
     .line-segment = laayin kuntoo
@@ -89,7 +85,6 @@ noun =
     .diamond = dayamondoo
     .cross = kurusoo
     .plus = lafaa taamanseeroo
-
 # The side count follows the qualifiers, behind «meŋ ye … soto», because
 # Mandinka closes a noun phrase with a relative rather than opening one.
 noun-regular-polygon =
@@ -97,11 +92,9 @@ noun-regular-polygon =
         [tail] meŋ ye karoo { $numSides } soto
        *[head] poligoŋ tembendiŋo
     }
-
 # No grammatical gender, so this answers one token for every noun and the
 # answer goes unused — the shape `locales/en` has.
 noun-gender = kiliŋ
-
 
 ## Style composition
 
@@ -115,21 +108,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = faariŋo
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } niŋ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } niŋ { $pattern }
@@ -137,7 +126,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } niŋ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Mandinka has no article, and joins this clause with the invariable «niŋ»
 # whatever came before it, so all four branches read alike.
 style-border-clause =
@@ -147,35 +135,28 @@ style-border-clause =
         [and-article] niŋ naanewo { $border }
        *[with] niŋ naanewo { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = meŋ maŋ faa
-
 style-text =
     { $parts ->
         [background] { $color } niŋ kooma { $background }
        *[plain] { $color }
     }
-
 style-background-none = feŋ te jee
-
 
 ## Boolean words
 
 boolean-true = tooñaa
 boolean-false = faniyaa
 
-
 ## Answer buttons
 
 answer-submit-label = Dookuwo Koroosi
 answer-submit-label-no-correctness = Jaabiroo Kii
-
 
 ## Sectional blocks
 
@@ -200,7 +181,6 @@ section-name =
     .solution = Bataa dandaŋo
     .task = Dookuwo
     .theorem = Teyoreemoo
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -210,9 +190,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Yitandiroo
-
 
 ## Tables and figures
 
@@ -223,7 +201,6 @@ table-name =
         [unnumbered-title] Tabuloo{ ": " }
        *[unnumbered] Tabuloo
     }
-
 figure-name =
     { $parts ->
         [numbered] Natamboo { $enumeration }
@@ -232,24 +209,18 @@ figure-name =
        *[unnumbered] Natamboo
     }
 
-
 ## Paginator controls
 
 paginator-previous = Meŋ tambita
 paginator-next = Meŋ ka naa
 paginator-page = Karataa
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = waraŋ
-
 piecewise-condition-if = niŋ
-
 piecewise-condition-otherwise = dulaa doolu bee to
-
 
 ## Chemistry
 ##
@@ -267,6 +238,5 @@ piecewise-condition-otherwise = dulaa doolu bee to
 ## Africa.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kemisitiri Taamanseer Kuruŋo
 chemistry-invalid-ionic-compound = Ayoŋ Ñaboo Kuruŋo

--- a/packages/i18n/locales/mos/chrome.ftl
+++ b/packages/i18n/locales/mos/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Gesgo…
 answer-submitting = Tʋʋbgo…
-
 answer-checking-status = B gesda leoorã
 answer-submitting-status = B tʋmda leoorã
-
 answer-correct = Yaa sɩda
 answer-incorrect = Pa sɩda ye
-
 answer-response-saved = B baka leoorã
-
 answer-percent-credit = { $percent }% poẽ
 answer-percent-correct = { $percent }% sɩda
 answer-percent-short = { $percent } %
-
 max-credit-available = Poẽ wʋsg sẽn beẽ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] makr baa a ye ka be ye
         [one] makr { $count } n ket
        *[other] makr { $count } n ket
     }
-
 validation-correct = (Yaa sɩda)
 validation-incorrect = (Pa sɩda ye)
 validation-partially-correct = (Yaa sɩda babg pʋgẽ)
-
 answer-show-responses =
     { $count ->
         [one] Wilg leoor { $count } sẽn kẽed { $answerId }
        *[other] Wilg leoor { $count } sẽn kẽed { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Leoor-noor
-
 collapsible-click-to-open = (nams n pak)
 collapsible-click-to-close = (nams n pag)
-
 collapsible-initializing = Sɩngre…
-
 footnote-show = Wilg tẽngr gũusgã
 footnote-hide = Solg tẽngr gũusgã
-
 description-more-information = kibar a taab
-
 
 ## Controls
 
 slider-previous = Sẽn looge
 slider-next = Sẽn pʋgende
-
 keyboard-open = Pak Klaviɛɛr
 keyboard-close = Pag Klaviɛɛr
-
 choice-input-remove-choice = Yiis { $choice }
-
 matrix-remove-row = Yiis sõore
 matrix-add-row = Paas sõore
 matrix-remove-column = Yiis kolon
 matrix-add-column = Paas kolon
-
 subset-add-remove-points = Paas/Yiis poẽ rãmba
 subset-toggle-points-intervals = Tek poẽ rãmb ne babs
 subset-move-points = Vees Poẽ rãmba
 subset-clear = Yiis fãa
-
 orbital-add-row = Paas Sõore
 orbital-remove-row = Yiis Sõore
 orbital-add-box = Paas Kogend
@@ -87,13 +68,9 @@ orbital-remove-box = Yiis Kogend
 orbital-add-up-arrow = Paas Peb sẽn kẽng zug
 orbital-add-down-arrow = Paas Peb sẽn kẽng tẽngre
 orbital-remove-arrow = Yiis Peb
-
 orbital-row-label = Sõor { $row } yʋʋre
-
 pretzel-answer = Leoore
-
 summary-statistics-caption = { $column } sõdb koɛɛgã
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = sõdb goam gesg pĩnda
 math-input-preview = Gesg pĩnda
 math-input-invalid-expression = Goam sẽn pa zems:
 
-
 ## Document status
 
 viewer-initializing = Sɩngre…
 
-
 ## Errors
 
 error-heading = Kongre
-
 error-found-at =
     { $span ->
         [line] B yãa sõor { $startLine } zug.
        *[lines] B yãa sõor { $startLine }–{ $endLine } zug.
     }
-
 document-contains-errors = Sebrã tara kongre!
-
 diagnostic-heading-error = Kongre
 diagnostic-heading-warning = Keoogre
 diagnostic-heading-information = Kibare
 diagnostic-heading-hint = Bãnde
-
 accessibility-heading-level-1 = WCAG AA tõog-paoodg kongre
 accessibility-heading-level-2 = Tõog-paoodg keoogre
-
 something-went-wrong = Bũmb n pa zems ye.
-
 renderer-load-failed = wilgdã pa ta ye. Bɩ y le pak seb-nengã.
-
 core-start-failed = Sebrã wilgd pa sɩng ye. Bɩ y le pak seb-nengã.

--- a/packages/i18n/locales/mos/content.ftl
+++ b/packages/i18n/locales/mos/content.ftl
@@ -84,7 +84,6 @@ color =
     .purple = viole
     .pink = roze
     .brown = maroŋ
-
 line-width =
     .thick =
         { $gender ->
@@ -100,7 +99,6 @@ line-width =
             [c4] bilem
            *[c1] bilga
         }
-
 # Written as an invariable «ne …» phrase, so that it agrees with nothing and
 # can close the description; `style-stroke` puts it last for that reason. That
 # is also what keeps the class suffix off the end of the phrase, where a
@@ -108,7 +106,6 @@ line-width =
 line-style =
     .dashed = ne tirɛ
     .dotted = ne poẽ-poẽ
-
 fill-style =
     .horizontal = sõoya sẽn gãe
     .vertical = sõoya sẽn yals
@@ -116,7 +113,6 @@ fill-style =
     .backdiagonal = sõoya sẽn kẽng zãnga a to wã
     .dots = poẽ-poẽ
     .diamonds = diamã
-
 noun =
     .line = sõore
     .line-segment = sõor sɛgmã
@@ -136,7 +132,6 @@ noun =
     .diamond = diamã
     .cross = kruwa
     .plus = paas-bãnde
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -144,7 +139,6 @@ noun-regular-polygon =
         [tail] sẽn tar kɩrems { $numSides }
        *[head] poligonre sẽn zems
     }
-
 # The noun class. A Mooré noun's class is usually legible in its own suffix —
 # «sõore» is `-re`, so `c3` — but the class is a fact about the noun rather
 # than about its ending, and two entries here say so: «zĩiga» is `c2` despite
@@ -168,7 +162,6 @@ noun-gender =
        *[other] c1
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ne …» phrase and closes the description, so it moves
@@ -183,13 +176,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c2] pidgo
@@ -197,13 +188,11 @@ style-filled-word =
         [c4] pidem
        *[c1] pidga
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ne { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ne { $pattern }
@@ -211,7 +200,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ne { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «noore» is the border and leads its own describing words, so they agree with
 # it rather than with the shape it surrounds. Mooré has no article and joins
 # this clause with the invariable «ne», so all four branches read alike.
@@ -222,35 +210,28 @@ style-border-clause =
         [and-article] ne noore { $border }
        *[with] ne noore { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = pa pid ye
-
 style-text =
     { $parts ->
         [background] { $color } ne poorẽ { $background }
        *[plain] { $color }
     }
-
 style-background-none = baa fʋɩ
-
 
 ## Boolean words
 
 boolean-true = sɩda
 boolean-false = ziri
 
-
 ## Answer buttons
 
 answer-submit-label = Ges Tʋʋmdã
 answer-submit-label-no-correctness = Tʋm Leoorã
-
 
 ## Sectional blocks
 
@@ -275,7 +256,6 @@ section-name =
     .solution = Tɩɩm
     .task = Tʋʋmde
     .theorem = Teorɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -285,9 +265,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Bãnde
-
 
 ## Tables and figures
 
@@ -298,7 +276,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Fiigɩɩr { $enumeration }
@@ -307,24 +284,18 @@ figure-name =
        *[unnumbered] Fiigɩɩr
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sẽn looge
 paginator-next = Sẽn pʋgende
 paginator-page = Seb-neng
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = wall
-
 piecewise-condition-if = sã n yaa
-
 piecewise-condition-otherwise = zĩis a taab fãa
-
 
 ## Chemistry
 ##
@@ -337,6 +308,5 @@ piecewise-condition-otherwise = zĩis a taab fãa
 ## ministry and `locales/dag` does not, Ghana teaching it in English.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Sɩmi Bãnd Sẽn Pa Zems
 chemistry-invalid-ionic-compound = Ayõ Lagengr Sẽn Pa Zems

--- a/packages/i18n/locales/mr/chrome.ftl
+++ b/packages/i18n/locales/mr/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = तपासले जात आहे...
 answer-submitting = पाठवले जात आहे...
-
 answer-checking-status = उत्तर तपासले जात आहे
 answer-submitting-status = उत्तर पाठवले जात आहे
-
 answer-correct = बरोबर
 answer-incorrect = चूक
-
 answer-response-saved = उत्तर जतन केले
-
 answer-percent-credit = { $percent }% गुण
 answer-percent-correct = { $percent }% बरोबर
 answer-percent-short = { $percent }%
-
 max-credit-available = कमाल शक्य गुण: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] एकही प्रयत्न शिल्लक नाही
         [one] { $count } प्रयत्न शिल्लक
        *[other] { $count } प्रयत्न शिल्लक
     }
-
 validation-correct = (बरोबर)
 validation-incorrect = (चूक)
 validation-partially-correct = (अंशतः बरोबर)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } ची { $count } उत्तरे दाखवा
        *[other] { $answerId } ची { $count } उत्तरे दाखवा
     }
 
-
 ## Disclosure panels
 
 feedback-heading = अभिप्राय
-
 collapsible-click-to-open = (उघडण्यासाठी क्लिक करा)
 collapsible-click-to-close = (बंद करण्यासाठी क्लिक करा)
-
 collapsible-initializing = सुरू केले जात आहे...
-
 footnote-show = तळटीप दाखवा
 footnote-hide = तळटीप लपवा
-
 description-more-information = अधिक माहिती
-
 
 ## Controls
 
 slider-previous = मागील
 slider-next = पुढील
-
 keyboard-open = कीबोर्ड उघडा
 keyboard-close = कीबोर्ड बंद करा
-
 choice-input-remove-choice = { $choice } काढा
-
 matrix-remove-row = ओळ काढा
 matrix-add-row = ओळ जोडा
 matrix-remove-column = स्तंभ काढा
 matrix-add-column = स्तंभ जोडा
-
 subset-add-remove-points = बिंदू जोडा/काढा
 subset-toggle-points-intervals = बिंदू आणि अंतराल यांमध्ये बदला
 subset-move-points = बिंदू हलवा
 subset-clear = पुसा
-
 # A `box` here is one orbital, drawn as a square: खण.
 orbital-add-row = ओळ जोडा
 orbital-remove-row = ओळ काढा
@@ -94,13 +75,9 @@ orbital-remove-box = खण काढा
 orbital-add-up-arrow = वरचा बाण जोडा
 orbital-add-down-arrow = खालचा बाण जोडा
 orbital-remove-arrow = बाण काढा
-
 orbital-row-label = ओळ { $row } चे लेबल
-
 pretzel-answer = उत्तर
-
 summary-statistics-caption = { $column } ची सारांश सांख्यिकी
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = गणिती पदावलीचे पूर�
 math-input-preview = पूर्वावलोकन
 math-input-invalid-expression = अवैध पदावली:
 
-
 ## Document status
 
 viewer-initializing = सुरू केले जात आहे...
 
-
 ## Errors
 
 error-heading = त्रुटी
-
 error-found-at =
     { $span ->
         [line] ओळ { $startLine } वर आढळली.
        *[lines] ओळ { $startLine }–{ $endLine } वर आढळली.
     }
-
 document-contains-errors = या दस्तऐवजात त्रुटी आहेत!
-
 diagnostic-heading-error = त्रुटी
 diagnostic-heading-warning = इशारा
 diagnostic-heading-information = माहिती
 diagnostic-heading-hint = सूचना
-
 accessibility-heading-level-1 = WCAG AA सुलभता उल्लंघन
 accessibility-heading-level-2 = सुलभता इशारा
-
 something-went-wrong = काहीतरी चुकले.
-
 renderer-load-failed = एक रेंडरर लोड होऊ शकला नाही. कृपया पृष्ठ पुन्हा लोड करा.
-
 core-start-failed = दस्तऐवज दर्शक सुरू होऊ शकला नाही. कृपया पृष्ठ पुन्हा लोड करा.

--- a/packages/i18n/locales/mr/content.ftl
+++ b/packages/i18n/locales/mr/content.ftl
@@ -116,16 +116,13 @@ color =
         }
     .pink = गुलाबी
     .brown = तपकिरी
-
 # Neither ends in -आ, so neither inflects.
 line-width =
     .thick = जाड
     .thin = बारीक
-
 line-style =
     .dashed = तुटक
     .dotted = ठिपकेदार
-
 # Plural nouns rather than adjectives, with genders of their own — रेषा is
 # feminine and ठिपके masculine. वापरून ("using") is invariable and takes them
 # bare, which is what lets both `style-filled` and `style-fill` set them beside
@@ -137,7 +134,6 @@ fill-style =
     .backdiagonal = उलट तिरप्या रेषा
     .dots = ठिपके
     .diamonds = समभुज चौकोन
-
 noun =
     .line = रेषा
     .line-segment = रेषाखंड
@@ -157,7 +153,6 @@ noun =
     .diamond = समभुज चौकोन
     .cross = फुली
     .plus = अधिक चिन्ह
-
 # बाजूंचा agrees with बहुभुज, which is masculine, so the count attaches to the
 # noun that follows and there is no tail.
 noun-regular-polygon =
@@ -165,7 +160,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } बाजूंचा नियमित बहुभुज
     }
-
 # Besides the nouns above, `$noun` may be «regular-polygon» (बहुभुज, m) or the
 # head of a phrase the description does not name: «border» (किनार, f), «fill»
 # (भरण, n), «text» (मजकूर, m), «background» (पार्श्वभूमी, f).
@@ -183,7 +177,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -196,13 +189,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -211,7 +202,6 @@ style-filled-word =
         [n] भरलेले
        *[m] भरलेला
     }
-
 # वापरून ("using") is invariable and takes the pattern bare, so the clause
 # English appends comes to the front here.
 style-filled =
@@ -219,7 +209,6 @@ style-filled =
         [pattern] { $pattern } वापरून { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } वापरून { $filled } { $color } { $noun }
@@ -227,7 +216,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } वापरून { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # -सह is a postposition, so किनार goes oblique to किनारी- and the adjectives in
 # front of it take the oblique -या that `border-clause` supplies. Marathi has
 # no article, which leaves the `-article` branches reading like the others.
@@ -238,7 +226,6 @@ style-border-clause =
         [and-article] आणि { $border } किनारीसह
        *[with] { $border } किनारीसह
     }
-
 # The colour arrives agreeing with «भरण», which is neuter, so it needs that
 # noun beside it — «निळे» in front of the feminine «आडव्या रेषा» agrees with
 # neither. The pattern hangs off वापरून, as it does in `style-filled`.
@@ -247,10 +234,8 @@ style-fill =
         [pattern] { $pattern } वापरून { $color } भरण
        *[plain] { $color } भरण
     }
-
 # Invariable, because nothing is passed to agree it with.
 style-unfilled = भरणविरहित
-
 # -वर is a postposition too, so the background's colour is oblique; the text's
 # own colour, which follows, agrees with मजकूर and is direct masculine.
 style-text =
@@ -258,21 +243,17 @@ style-text =
         [background] { $background } पार्श्वभूमीवर { $color }
        *[plain] { $color }
     }
-
 style-background-none = काहीही नाही
-
 
 ## Boolean words
 
 boolean-true = खरे
 boolean-false = खोटे
 
-
 ## Answer buttons
 
 answer-submit-label = तपासा
 answer-submit-label-no-correctness = उत्तर पाठवा
-
 
 ## Sectional blocks
 
@@ -297,7 +278,6 @@ section-name =
     .solution = उकल
     .task = कार्य
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -307,9 +287,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = सूचना
-
 
 ## Tables and figures
 
@@ -320,7 +298,6 @@ table-name =
         [unnumbered-title] सारणी{ ": " }
        *[unnumbered] सारणी
     }
-
 figure-name =
     { $parts ->
         [numbered] आकृती { $enumeration }
@@ -329,26 +306,20 @@ figure-name =
        *[unnumbered] आकृती
     }
 
-
 ## Paginator controls
 
 paginator-previous = मागील
 paginator-next = पुढील
 paginator-page = पृष्ठ
-
 # «X पैकी Y» — "Y out of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } पैकी { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = किंवा
-
 piecewise-condition-if = जर
-
 piecewise-condition-otherwise = अन्यथा
-
 
 ## Chemistry
 ##
@@ -476,7 +447,6 @@ element-name =
     .lv = लिव्हरमोरियम
     .ts = टेनेसिन
     .og = ओगानेसन
-
 element-anion-name =
     .h = हायड्राइड
     .c = कार्बाइड
@@ -490,8 +460,6 @@ element-anion-name =
     .i = आयोडाइड
     .at = ॲस्टाटाइड
     .ts = टेनेसाइड
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अवैध रासायनिक चिन्ह
 chemistry-invalid-ionic-compound = अवैध आयनिक संयुग

--- a/packages/i18n/locales/ms/chrome.ftl
+++ b/packages/i18n/locales/ms/chrome.ftl
@@ -20,48 +20,34 @@
 
 answer-checking = Menyemak...
 answer-submitting = Menghantar...
-
 answer-checking-status = Menyemak jawapan
 answer-submitting-status = Menghantar jawapan
-
 answer-correct = Betul
 answer-incorrect = Salah
-
 answer-response-saved = Jawapan Disimpan
-
 answer-percent-credit = { $percent }% Markah
 answer-percent-correct = { $percent }% Betul
 answer-percent-short = { $percent }%
-
 max-credit-available = Markah maksimum yang boleh diperoleh: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tiada percubaan berbaki
        *[other] { $count } percubaan berbaki
     }
-
 validation-correct = (Betul)
 validation-incorrect = (Salah)
 validation-partially-correct = (Betul sebahagian)
-
 answer-show-responses = Tunjukkan { $count } jawapan kepada { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Maklum Balas
-
 collapsible-click-to-open = (klik untuk buka)
 collapsible-click-to-close = (klik untuk tutup)
-
 collapsible-initializing = Memulakan...
-
 footnote-show = Tunjukkan nota kaki
 footnote-hide = Sembunyikan nota kaki
-
 description-more-information = maklumat lanjut
-
 
 ## Controls
 
@@ -70,22 +56,17 @@ description-more-information = maklumat lanjut
 # and `paginator-next` are.
 slider-previous = Sebelumnya
 slider-next = Seterusnya
-
 keyboard-open = Buka Papan Kekunci
 keyboard-close = Tutup Papan Kekunci
-
 choice-input-remove-choice = Buang { $choice }
-
 matrix-remove-row = Buang baris
 matrix-add-row = Tambah baris
 matrix-remove-column = Buang lajur
 matrix-add-column = Tambah lajur
-
 subset-add-remove-points = Tambah/Buang titik
 subset-toggle-points-intervals = Tukar antara titik dan selang
 subset-move-points = Alih Titik
 subset-clear = Kosongkan
-
 # A `box` here is one orbital, drawn as a square: kotak.
 orbital-add-row = Tambah Baris
 orbital-remove-row = Buang Baris
@@ -94,13 +75,9 @@ orbital-remove-box = Buang Kotak
 orbital-add-up-arrow = Tambah Anak Panah Atas
 orbital-add-down-arrow = Tambah Anak Panah Bawah
 orbital-remove-arrow = Buang Anak Panah
-
 orbital-row-label = Label bagi baris { $row }
-
 pretzel-answer = Jawapan
-
 summary-statistics-caption = Statistik ringkasan bagi { $column }
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = pratonton ungkapan matematik
 math-input-preview = Pratonton
 math-input-invalid-expression = Ungkapan tidak sah:
 
-
 ## Document status
 
 viewer-initializing = Memulakan...
 
-
 ## Errors
 
 error-heading = Ralat
-
 error-found-at =
     { $span ->
         [line] Ditemui pada baris { $startLine }.
        *[lines] Ditemui pada baris { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumen ini mengandungi ralat!
-
 diagnostic-heading-error = Ralat
 diagnostic-heading-warning = Amaran
 diagnostic-heading-information = Maklumat
 diagnostic-heading-hint = Petunjuk
-
 accessibility-heading-level-1 = Pelanggaran Kebolehcapaian WCAG AA
 accessibility-heading-level-2 = Amaran kebolehcapaian
-
 something-went-wrong = Ada sesuatu yang tidak kena.
-
 renderer-load-failed = satu pemapar gagal dimuatkan. Sila muat semula halaman ini.
-
 core-start-failed = Pemapar dokumen tidak dapat dimulakan. Sila muat semula halaman ini.

--- a/packages/i18n/locales/ms/content.ftl
+++ b/packages/i18n/locales/ms/content.ftl
@@ -29,15 +29,12 @@ color =
     .purple = ungu
     .pink = merah jambu
     .brown = perang
-
 line-width =
     .thick = tebal
     .thin = nipis
-
 line-style =
     .dashed = putus-putus
     .dotted = bertitik
-
 # Noun phrases: they follow «dengan» and modify nothing.
 fill-style =
     .horizontal = garis mengufuk
@@ -46,7 +43,6 @@ fill-style =
     .backdiagonal = garis pepenjuru songsang
     .dots = titik
     .diamonds = rombus
-
 noun =
     .line = garis lurus
     .line-segment = tembereng garis
@@ -66,7 +62,6 @@ noun =
     .diamond = rombus
     .cross = tanda pangkah
     .plus = tanda campur
-
 # The side count sits immediately after the noun — «poligon sekata bersisi 5» —
 # before any adjective, so it folds into the head and there is no tail. Putting
 # it after the adjectives would separate «bersisi» from the number counting it.
@@ -75,11 +70,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] poligon sekata bersisi { $numSides }
     }
-
 # Malay has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -93,7 +86,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «garis lurus tebal putus-putus
 # merah».
 style-with-noun =
@@ -101,15 +93,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = berisi
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } dengan { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } dengan { $pattern }
@@ -117,7 +106,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } dengan { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «sempadan» leads its own adjectives, the same way every noun here does.
 style-border-clause =
     { $parts ->
@@ -126,36 +114,29 @@ style-border-clause =
         [and-article] dan sempadan { $border }
        *[with] dengan sempadan { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tidak berisi
-
 style-text =
     { $parts ->
         [background] { $color } dengan latar belakang { $background }
        *[plain] { $color }
     }
-
 style-background-none = tiada
-
 
 ## Boolean words
 
 boolean-true = benar
 boolean-false = palsu
 
-
 ## Answer buttons
 
 answer-submit-label = Semak Jawapan
 answer-submit-label-no-correctness = Hantar Jawapan
-
 
 ## Sectional blocks
 
@@ -180,7 +161,6 @@ section-name =
     .solution = Penyelesaian
     .task = Tugasan
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -190,9 +170,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Petunjuk
-
 
 ## Tables and figures
 
@@ -203,7 +181,6 @@ table-name =
         [unnumbered-title] Jadual{ ": " }
        *[unnumbered] Jadual
     }
-
 figure-name =
     { $parts ->
         [numbered] Rajah { $enumeration }
@@ -212,22 +189,18 @@ figure-name =
        *[unnumbered] Rajah
     }
 
-
 ## Paginator controls
 
 paginator-previous = Sebelumnya
 paginator-next = Seterusnya
 paginator-page = Halaman
-
 paginator-page-status = { $pageLabel } { $currentPage } daripada { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = atau
 piecewise-condition-if = jika
 piecewise-condition-otherwise = selainnya
-
 
 ## Chemistry
 
@@ -355,7 +328,6 @@ element-name =
     .lv = livermorium
     .ts = tennessin
     .og = oganeson
-
 element-anion-name =
     .h = hidrida
     .c = karbida
@@ -369,8 +341,6 @@ element-anion-name =
     .i = iodida
     .at = astatida
     .ts = tennessida
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol Kimia Tidak Sah
 chemistry-invalid-ionic-compound = Sebatian Ionik Tidak Sah

--- a/packages/i18n/locales/mt/chrome.ftl
+++ b/packages/i18n/locales/mt/chrome.ftl
@@ -13,25 +13,20 @@
 # twenty and up stay singular. So `many` here is the 11–19 branch and reads
 # with a singular noun, which is what separates it from `few`.
 
+
 ## Answer submission
 
 answer-checking = Qed jiġi ċċekkjat…
 answer-submitting = Qed jintbagħat…
-
 answer-checking-status = It-tweġiba qed tiġi ċċekkjata
 answer-submitting-status = It-tweġiba qed tintbagħat
-
 answer-correct = Korretta
 answer-incorrect = Mhux korretta
-
 answer-response-saved = It-tweġiba ġiet salvata
-
 answer-percent-credit = { $percent }% tal-punteġġ
 answer-percent-correct = { $percent }% korrett
 answer-percent-short = { $percent } %
-
 max-credit-available = L-ogħla punteġġ disponibbli: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ma fadal l-ebda prova
@@ -41,11 +36,9 @@ attempts-remaining =
         [many] fadal { $count }-il prova
        *[other] fadal { $count } prova
     }
-
 validation-correct = (Korretta)
 validation-incorrect = (Mhux korretta)
 validation-partially-correct = (Parzjalment korretta)
-
 answer-show-responses =
     { $count ->
         [one] Uri { $count } tweġiba għal { $answerId }
@@ -55,42 +48,31 @@ answer-show-responses =
        *[other] Uri { $count } tweġiba għal { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Rispons
-
 collapsible-click-to-open = (ikklikkja biex tiftaħ)
 collapsible-click-to-close = (ikklikkja biex tagħlaq)
-
 collapsible-initializing = Qed jinbeda…
-
 footnote-show = Uri n-nota f'qiegħ il-paġna
 footnote-hide = Aħbi n-nota f'qiegħ il-paġna
-
 description-more-information = aktar informazzjoni
-
 
 ## Controls
 
 slider-previous = Ta' qabel
 slider-next = Li jmiss
-
 keyboard-open = Iftaħ it-tastiera
 keyboard-close = Agħlaq it-tastiera
-
 choice-input-remove-choice = Neħħi { $choice }
-
 matrix-remove-row = Neħħi ringiela
 matrix-add-row = Żid ringiela
 matrix-remove-column = Neħħi kolonna
 matrix-add-column = Żid kolonna
-
 subset-add-remove-points = Żid/neħħi punti
 subset-toggle-points-intervals = Aqleb bejn punti u intervalli
 subset-move-points = Mexxi l-punti
 subset-clear = Ħassar
-
 orbital-add-row = Żid ringiela
 orbital-remove-row = Neħħi ringiela
 orbital-add-box = Żid kaxxa
@@ -98,13 +80,9 @@ orbital-remove-box = Neħħi kaxxa
 orbital-add-up-arrow = Żid vleġġa 'l fuq
 orbital-add-down-arrow = Żid vleġġa 'l isfel
 orbital-remove-arrow = Neħħi vleġġa
-
 orbital-row-label = Tikketta għar-ringiela { $row }
-
 pretzel-answer = Tweġiba
-
 summary-statistics-caption = Statistika fil-qosor ta' { $column }
-
 
 ## Math input
 
@@ -112,34 +90,25 @@ math-input-preview-region = previżjoni tal-espressjoni matematika
 math-input-preview = Previżjoni
 math-input-invalid-expression = Espressjoni invalida:
 
-
 ## Document status
 
 viewer-initializing = Qed jinbeda…
 
-
 ## Errors
 
 error-heading = Żball
-
 error-found-at =
     { $span ->
         [line] Instab fil-linja { $startLine }.
        *[lines] Instab fil-linji { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dan id-dokument fih żbalji!
-
 diagnostic-heading-error = Żball
 diagnostic-heading-warning = Twissija
 diagnostic-heading-information = Informazzjoni
 diagnostic-heading-hint = Ħjiel
-
 accessibility-heading-level-1 = Ksur tal-aċċessibbiltà WCAG AA
 accessibility-heading-level-2 = Twissija dwar l-aċċessibbiltà
-
 something-went-wrong = Xi ħaġa marret ħażin.
-
 renderer-load-failed = renderer ma setax jitgħabba. Jekk jogħġbok, erġa' għabbi l-paġna.
-
 core-start-failed = Il-viewer tad-dokument ma setax jinbeda. Jekk jogħġbok, erġa' għabbi l-paġna.

--- a/packages/i18n/locales/mt/content.ftl
+++ b/packages/i18n/locales/mt/content.ftl
@@ -72,7 +72,6 @@ color =
     .purple = vjola
     .pink = roża
     .brown = kannella
-
 line-width =
     .thick =
         { $gender ->
@@ -84,7 +83,6 @@ line-width =
             [f] rqiqa
            *[m] irqiq
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -96,7 +94,6 @@ line-style =
             [f] ittikkjata
            *[m] ittikkjat
         }
-
 # Noun phrases standing behind «b'». They modify nothing and take no gender.
 fill-style =
     .horizontal = linji orizzontali
@@ -105,7 +102,6 @@ fill-style =
     .backdiagonal = linji djagonali maqluba
     .dots = tikek
     .diamonds = rombi
-
 noun =
     .line = linja
     .line-segment = segment
@@ -125,7 +121,6 @@ noun =
     .diamond = rombu
     .cross = salib
     .plus = plus
-
 # The side count follows the style adjectives so that they stay beside the noun
 # they agree with.
 noun-regular-polygon =
@@ -133,7 +128,6 @@ noun-regular-polygon =
         [tail] ta' { $numSides } naħat
        *[head] poligonu regolari
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (poligonu, m) or
 # the head of a phrase the description never names: `border` (bordura, f),
 # `fill` (mili, m), `text` (test, m), `background` (sfond, m).
@@ -147,7 +141,6 @@ noun-gender =
         [border] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -163,25 +156,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] mimlija
        *[m] mimli
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } b'{ $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } b'{ $pattern }
@@ -189,7 +178,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } b'{ $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «bordura» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds.
 style-border-clause =
@@ -199,35 +187,28 @@ style-border-clause =
         [and-article] u bordura { $border }
        *[with] bi bordura { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] mili { $color } b'{ $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = mhux mimli
-
 style-text =
     { $parts ->
         [background] { $color } fuq sfond { $background }
        *[plain] { $color }
     }
-
 style-background-none = xejn
-
 
 ## Boolean words
 
 boolean-true = veru
 boolean-false = falz
 
-
 ## Answer buttons
 
 answer-submit-label = Iċċekkja
 answer-submit-label-no-correctness = Ibgħat it-tweġiba
-
 
 ## Sectional blocks
 
@@ -252,7 +233,6 @@ section-name =
     .solution = Soluzzjoni
     .task = Kompitu
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -262,9 +242,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ħjiel
-
 
 ## Tables and figures
 
@@ -275,7 +253,6 @@ table-name =
         [unnumbered-title] Tabella{ ": " }
        *[unnumbered] Tabella
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -284,22 +261,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ta' qabel
 paginator-next = Li jmiss
 paginator-page = Paġna
-
 paginator-page-status = { $pageLabel } { $currentPage } minn { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = jew
 piecewise-condition-if = jekk
 piecewise-condition-otherwise = inkella
-
 
 ## Chemistry
 
@@ -422,7 +395,6 @@ element-name =
     .lv = Livermorju
     .ts = Tenessin
     .og = Oganesson
-
 element-anion-name =
     .h = Idrur
     .c = Karbur
@@ -436,8 +408,6 @@ element-anion-name =
     .i = Jodur
     .at = Astatur
     .ts = Tenessur
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbolu kimiku invalidu
 chemistry-invalid-ionic-compound = Kompost joniku invalidu

--- a/packages/i18n/locales/my/chrome.ftl
+++ b/packages/i18n/locales/my/chrome.ftl
@@ -23,72 +23,53 @@
 
 answer-checking = စစ်ဆေးနေသည်...
 answer-submitting = ပို့နေသည်...
-
 answer-checking-status = အဖြေကို စစ်ဆေးနေသည်
 answer-submitting-status = အဖြေကို ပို့နေသည်
-
 answer-correct = မှန်
 answer-incorrect = မှား
-
 answer-response-saved = အဖြေကို သိမ်းဆည်းပြီး
-
 answer-percent-credit = { $percent }% အမှတ်
 answer-percent-correct = { $percent }% မှန်
 answer-percent-short = { $percent }%
-
 max-credit-available = ရနိုင်သည့် အမြင့်ဆုံးအမှတ်: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ကြိုးစားခွင့် မကျန်တော့ပါ
        *[other] ကြိုးစားခွင့် { $count } ကြိမ် ကျန်သည်
     }
-
 validation-correct = (မှန်)
 validation-incorrect = (မှား)
 validation-partially-correct = (တစ်စိတ်တစ်ပိုင်း မှန်)
-
 answer-show-responses =
     { $count ->
        *[other] { $answerId } ၏ အဖြေ { $count } ခုကို ပြရန်
     }
 
-
 ## Disclosure panels
 
 feedback-heading = တုံ့ပြန်ချက်
-
 collapsible-click-to-open = (ဖွင့်ရန် နှိပ်ပါ)
 collapsible-click-to-close = (ပိတ်ရန် နှိပ်ပါ)
-
 collapsible-initializing = စတင်နေသည်...
-
 footnote-show = အောက်ခြေမှတ်စု ပြရန်
 footnote-hide = အောက်ခြေမှတ်စု ဖျောက်ရန်
-
 description-more-information = နောက်ထပ်အချက်အလက်
-
 
 ## Controls
 
 slider-previous = ယခင်
 slider-next = နောက်
-
 keyboard-open = ကီးဘုတ် ဖွင့်ရန်
 keyboard-close = ကီးဘုတ် ပိတ်ရန်
-
 choice-input-remove-choice = { $choice } ဖယ်ရန်
-
 matrix-remove-row = အတန်း ဖယ်ရန်
 matrix-add-row = အတန်း ထည့်ရန်
 matrix-remove-column = ကော်လံ ဖယ်ရန်
 matrix-add-column = ကော်လံ ထည့်ရန်
-
 subset-add-remove-points = အမှတ် ထည့်ရန်/ဖယ်ရန်
 subset-toggle-points-intervals = အမှတ်နှင့် ကြားကာလ အပြန်အလှန်ပြောင်းရန်
 subset-move-points = အမှတ်များ ရွှေ့ရန်
 subset-clear = ရှင်းလင်းရန်
-
 # A `box` here is one orbital, drawn as a square: အကွက်.
 orbital-add-row = အတန်း ထည့်ရန်
 orbital-remove-row = အတန်း ဖယ်ရန်
@@ -97,13 +78,9 @@ orbital-remove-box = အကွက် ဖယ်ရန်
 orbital-add-up-arrow = အထက်မြှား ထည့်ရန်
 orbital-add-down-arrow = အောက်မြှား ထည့်ရန်
 orbital-remove-arrow = မြှား ဖယ်ရန်
-
 orbital-row-label = အတန်း { $row } ၏ အညွှန်း
-
 pretzel-answer = အဖြေ
-
 summary-statistics-caption = { $column } ၏ အကျဉ်းချုပ် စာရင်းအင်း
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = သင်္ချာဖော်ပြချက် 
 math-input-preview = အစမ်းကြည့်ရှုမှု
 math-input-invalid-expression = မမှန်ကန်သော ဖော်ပြချက်:
 
-
 ## Document status
 
 viewer-initializing = စတင်နေသည်...
 
-
 ## Errors
 
 error-heading = အမှား
-
 error-found-at =
     { $span ->
         [line] စာကြောင်း { $startLine } တွင် တွေ့ရသည်။
        *[lines] စာကြောင်း { $startLine }–{ $endLine } တွင် တွေ့ရသည်။
     }
-
 document-contains-errors = ဤစာတမ်းတွင် အမှားများ ပါဝင်သည်!
-
 diagnostic-heading-error = အမှား
 diagnostic-heading-warning = သတိပေးချက်
 diagnostic-heading-information = အချက်အလက်
 diagnostic-heading-hint = အရိပ်အမြွက်
-
 accessibility-heading-level-1 = WCAG AA အသုံးပြုနိုင်စွမ်း ချိုးဖောက်မှု
 accessibility-heading-level-2 = အသုံးပြုနိုင်စွမ်း သတိပေးချက်
-
 something-went-wrong = တစ်ခုခု မှားသွားသည်။
-
 renderer-load-failed = ရန်ဒါရာတစ်ခု မတင်နိုင်ပါ။ စာမျက်နှာကို ပြန်တင်ပါ။
-
 core-start-failed = စာတမ်းကြည့်ရှုစနစ်ကို မစတင်နိုင်ပါ။ စာမျက်နှာကို ပြန်တင်ပါ။

--- a/packages/i18n/locales/my/content.ftl
+++ b/packages/i18n/locales/my/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = ခရမ်းရောင်
     .pink = ပန်းရောင်
     .brown = အညိုရောင်
-
 line-width =
     .thick = ထူသော
     .thin = ပါးသော
-
 line-style =
     .dashed = မျဉ်းပြတ်
     .dotted = အစက်ချ
-
 # Noun phrases rather than adjectives: ဖြင့် ("with") takes them bare.
 fill-style =
     .horizontal = အလျားလိုက်မျဉ်းများ
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = ပြောင်းပြန်ထောင့်ဖြတ်မျဉ်းများ
     .dots = အစက်များ
     .diamonds = စိန်ပုံများ
-
 noun =
     .line = မျဉ်း
     .line-segment = မျဉ်းပိုင်း
@@ -74,7 +70,6 @@ noun =
     .diamond = စိန်ပုံ
     .cross = ကြက်ခြေခတ်
     .plus = အပေါင်းလက္ခဏာ
-
 # The side count attaches to the noun that follows, so the whole phrase is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -82,11 +77,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] အနား { $numSides } ခုပါ ပုံမှန်ဗဟုဂံ
     }
-
 # Burmese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,15 +93,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ဖြည့်ထားသော
-
 # ဖြင့် ("with") follows the pattern it applies to, so the clause English
 # appends comes to the front here.
 style-filled =
@@ -116,7 +106,6 @@ style-filled =
         [pattern] { $pattern }ဖြင့် { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern }ဖြင့် { $filled } { $color } { $noun }
@@ -124,7 +113,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern }ဖြင့် { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # ဖြင့် is a postposition, so it follows ဘောင် rather than preceding it as
 # English's `with` does. Burmese has no article, which leaves the `-article`
 # branches reading like the others.
@@ -135,15 +123,12 @@ style-border-clause =
         [and-article] နှင့် { $border } ဘောင်ဖြင့်
        *[with] { $border } ဘောင်ဖြင့်
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = အဖြည့်မရှိသော
-
 # ပေါ်တွင် ("on") follows နောက်ခံ, and the colour word in front of it is
 # untouched by that.
 style-text =
@@ -151,21 +136,17 @@ style-text =
         [background] { $background } နောက်ခံပေါ်တွင် { $color }
        *[plain] { $color }
     }
-
 style-background-none = မရှိပါ
-
 
 ## Boolean words
 
 boolean-true = မှန်
 boolean-false = မှား
 
-
 ## Answer buttons
 
 answer-submit-label = စစ်ဆေးရန်
 answer-submit-label-no-correctness = အဖြေ တင်သွင်းရန်
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = အဖြေရှာနည်း
     .task = လုပ်ငန်းတာဝန်
     .theorem = သီအိုရမ်
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -200,9 +180,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = အရိပ်အမြွက်
-
 
 ## Tables and figures
 
@@ -213,7 +191,6 @@ table-name =
         [unnumbered-title] ဇယား{ ": " }
        *[unnumbered] ဇယား
     }
-
 figure-name =
     { $parts ->
         [numbered] ပုံ { $enumeration }
@@ -222,28 +199,23 @@ figure-name =
        *[unnumbered] ပုံ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ယခင်
 paginator-next = နောက်
 paginator-page = စာမျက်နှာ
-
 # «X ထဲမှ Y» — "Y out of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } ထဲမှ { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = သို့မဟုတ်
-
 piecewise-condition-if = အကယ်၍
-
 piecewise-condition-otherwise = ထိုမှတပါး
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and those
 # 130 keys fall back to English.
@@ -257,6 +229,5 @@ piecewise-condition-otherwise = ထိုမှတပါး
 # Nepali already make, and for the same reason.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = မမှန်ကန်သော ဓာတုသင်္ကေတ
 chemistry-invalid-ionic-compound = မမှန်ကန်သော အိုင်သွန်ဒြပ်ပေါင်း

--- a/packages/i18n/locales/myv/chrome.ftl
+++ b/packages/i18n/locales/myv/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Ваннови…
 answer-submitting = Кучови…
-
 answer-checking-status = Каршо валось ваннови
 answer-submitting-status = Каршо валось кучови
-
 answer-correct = Виде
 answer-incorrect = А виде
-
 answer-response-saved = Каршо валось ванстозь
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% виде
 answer-percent-short = { $percent } %
-
 max-credit-available = Саемс маштови сехте покш балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] снартнема арась
         [one] { $count } снартнема кадовсь
        *[other] { $count } снартнема кадовсь
     }
-
 validation-correct = (Виде)
 validation-incorrect = (А виде)
 validation-partially-correct = (Пельксэнь коряс виде)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } лангс { $count } каршо вал невтемс
        *[other] { $answerId } лангс { $count } каршо вал невтемс
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Мекев ёвтамо
-
 collapsible-click-to-open = (панжомга лепштик)
 collapsible-click-to-close = (пекстамга лепштик)
-
 collapsible-initializing = Анокстави…
-
 footnote-show = Тешкстамонть невтемс
 footnote-hide = Тешкстамонть кекшемс
-
 description-more-information = поладкс тевпаро
-
 
 ## Controls
 
 slider-previous = Икелень
 slider-next = Сы
-
 keyboard-open = Клавиатуранть панжомс
 keyboard-close = Клавиатуранть пекстамс
-
 choice-input-remove-choice = { $choice } кочкамонть саемс
-
 matrix-remove-row = Рядонть саемс
 matrix-add-row = Ряд поладомс
 matrix-remove-column = Баганонть саемс
 matrix-add-column = Баган поладомс
-
 subset-add-remove-points = Точка поладомс/саемс
 subset-toggle-points-intervals = Точкатнень ды юткотнень полавтомс
 subset-move-points = Точкатнень ютавтомс
 subset-clear = Ванськавтомс
-
 orbital-add-row = Ряд поладомс
 orbital-remove-row = Рядонть саемс
 orbital-add-box = Клетка поладомс
@@ -91,13 +72,9 @@ orbital-remove-box = Клетканть саемс
 orbital-add-up-arrow = Верев нал поладомс
 orbital-add-down-arrow = Алов нал поладомс
 orbital-remove-arrow = Налонть саемс
-
 orbital-row-label = { $row } рядонь тешкс
-
 pretzel-answer = Каршо вал
-
 summary-statistics-caption = { $column } баганонь прядомань статистика
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = математикань ёвтамонь икель
 math-input-preview = Икелькс ваномась
 math-input-invalid-expression = А виде ёвтамо:
 
-
 ## Document status
 
 viewer-initializing = Анокстави…
 
-
 ## Errors
 
 error-heading = Ильведевкс
-
 error-found-at =
     { $span ->
         [line] Муезь ряд: { $startLine }.
        *[lines] Муезь рядт: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Те документсэнть улить ильведевкст!
-
 diagnostic-heading-error = Ильведевкс
 diagnostic-heading-warning = Икелев пелькстамо
 diagnostic-heading-information = Тевпаро
 diagnostic-heading-hint = Невтевкске
-
 accessibility-heading-level-1 = WCAG AA пачкодемань коламо
 accessibility-heading-level-2 = Пачкодемадо тевпаро
-
 something-went-wrong = Мезеяк а виде лиссь.
-
 renderer-load-failed = артыцянть аволь саевсь. Лопанть одкстомтык.
-
 core-start-failed = Документэнь ваныцянть аволь ушодовсь. Лопанть одкстомтык.

--- a/packages/i18n/locales/myv/content.ftl
+++ b/packages/i18n/locales/myv/content.ftl
@@ -35,15 +35,12 @@ color =
     .purple = фиолетовой
     .pink = розовой
     .brown = коричневой
-
 line-width =
     .thick = эчке
     .thin = човине
-
 line-style =
     .dashed = сезнезь
     .dotted = точкань
-
 # Noun phrases: they stand in front of «мазылгавтомасо» and modify nothing.
 fill-style =
     .horizontal = горизонтальной линия
@@ -52,7 +49,6 @@ fill-style =
     .backdiagonal = каршо диагональной линия
     .dots = точка
     .diamonds = ромб
-
 noun =
     .line = виде линия
     .line-segment = пелькске
@@ -72,7 +68,6 @@ noun =
     .diamond = ромб
     .cross = крёст
     .plus = плюс
-
 # Erzya builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -80,11 +75,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] видестэ { $numSides } ужо
     }
-
 # Erzya has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -98,21 +91,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = артозь
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } мазылгавтомасо { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } мазылгавтомасо { $color } { $filled } { $noun }
@@ -120,7 +109,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } мазылгавтомасо { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «чиресэ» is the inessive of «чире», "edge", and carries the whole of "with a
 # border" in its own suffix — the same shape `locales/udm` and `locales/kv`
 # use, arriving from the other end of Uralic.
@@ -131,15 +119,12 @@ style-border-clause =
         [and-article] ды { $border } чиресэ
        *[with] { $border } чиресэ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } мазылгавтомасо { $color } артома
        *[plain] { $color } артома
     }
-
 style-unfilled = апак арта
-
 # «лангсо» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.
 style-text =
@@ -147,21 +132,17 @@ style-text =
         [background] { $background } фон лангсо { $color }
        *[plain] { $color }
     }
-
 style-background-none = арась
-
 
 ## Boolean words
 
 boolean-true = виде
 boolean-false = а виде
 
-
 ## Answer buttons
 
 answer-submit-label = Ванномс
 answer-submit-label-no-correctness = Каршо валонть кучомс
-
 
 ## Sectional blocks
 
@@ -186,7 +167,6 @@ section-name =
     .solution = Решения
     .task = Задания
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -196,9 +176,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Невтевкске
-
 
 ## Tables and figures
 
@@ -209,7 +187,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Артовкс { $enumeration }
@@ -218,15 +195,12 @@ figure-name =
        *[unnumbered] Артовкс
     }
 
-
 ## Paginator controls
 
 paginator-previous = Икелень
 paginator-next = Сы
 paginator-page = Лопа
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -241,7 +215,6 @@ piecewise-condition-or = эли
 piecewise-condition-if = бути
 piecewise-condition-otherwise = лия таркава
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -250,6 +223,5 @@ piecewise-condition-otherwise = лия таркава
 ## ones — the school-system case this batch shares throughout.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = А виде химиянь тешкс
 chemistry-invalid-ionic-compound = А виде иононь сюлмавкс

--- a/packages/i18n/locales/nah/chrome.ftl
+++ b/packages/i18n/locales/nah/chrome.ftl
@@ -36,21 +36,15 @@
 
 answer-checking = Motta…
 answer-submitting = Motitlani…
-
 answer-checking-status = Motta in tlanānquilīlli
 answer-submitting-status = Motitlani in tlanānquilīlli
-
 answer-correct = Cualli
 answer-incorrect = Ahmo cualli
-
 answer-response-saved = Ōmopix in tlanānquilīlli
-
 answer-percent-credit = { $percent }% ipatiuh
 answer-percent-correct = { $percent }% cualli
 answer-percent-short = { $percent } %
-
 max-credit-available = Ipatiuh in tlein ōmpa cah: { $percent }%
-
 # No select: «tlayehyecōlli» is inanimate and takes no plural, so both English
 # categories render the same words. The count still arrives and is still
 # formatted. `[0]` stays, because "none left" is its own sentence.
@@ -59,52 +53,39 @@ attempts-remaining =
         [0] ahmo ōc mocāhua tlayehyecōlli
        *[other] mocāhua { $count } tlayehyecōlli
     }
-
 validation-correct = (Cualli)
 validation-incorrect = (Ahmo cualli)
 validation-partially-correct = (Achi cualli)
-
 # No select, for the reason given above. The answer is named rather than
 # possessed: the possessive prefix would have to be «ī-» or «īn-» according to
 # what follows it, and what follows it is a value this catalog never sees.
 answer-show-responses = Xicnēxti { $count } tlanānquilīlli, in ītōcā { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Tlacuepcāyōtl
-
 collapsible-click-to-open = (xictzōtzona inic motlapōz)
 collapsible-click-to-close = (xictzōtzona inic motzacuāz)
-
 collapsible-initializing = Pēhua…
-
 footnote-show = Xicnēxti in tlatzintlān tlahcuilōlli
 footnote-hide = Xictlāti in tlatzintlān tlahcuilōlli
-
 description-more-information = occequi tlamachiliztli
-
 
 ## Controls
 
 slider-previous = Yehuā
 slider-next = Niman
-
 keyboard-open = Xictlapo in tlatzotzonalōni
 keyboard-close = Xictzacua in tlatzotzonalōni
-
 choice-input-remove-choice = Xicquīxti { $choice }
-
 matrix-remove-row = Xicquīxti cē tlamelāuhcāyōtl
 matrix-add-row = Xicaxilti cē tlamelāuhcāyōtl
 matrix-remove-column = Xicquīxti cē tlaquetzalli
 matrix-add-column = Xicaxilti cē tlaquetzalli
-
 subset-add-remove-points = Xicaxilti/Xicquīxti tlīltzintli
 subset-toggle-points-intervals = Xicpatla tlīltzintli īhuān tlanepantlah
 subset-move-points = Xicolīni tlīltzintli
 subset-clear = Xicpohpōhua
-
 orbital-add-row = Xicaxilti cē tlamelāuhcāyōtl
 orbital-remove-row = Xicquīxti cē tlamelāuhcāyōtl
 orbital-add-box = Xicaxilti cē pehpechtli
@@ -112,13 +93,9 @@ orbital-remove-box = Xicquīxti cē pehpechtli
 orbital-add-up-arrow = Xicaxilti cē mītl ahcopa
 orbital-add-down-arrow = Xicaxilti cē mītl tlanipa
 orbital-remove-arrow = Xicquīxti cē mītl
-
 orbital-row-label = Ītōcā in tlamelāuhcāyōtl { $row }
-
 pretzel-answer = Tlanānquilīlli
-
 summary-statistics-caption = Ītlapōhualtzin in { $column }
-
 
 ## Math input
 
@@ -126,34 +103,25 @@ math-input-preview-region = tlapōhualiztli tlahtōlli achto tlachiyaliztli
 math-input-preview = Achto tlachiyaliztli
 math-input-invalid-expression = Tlahtōlli ahmo cualli:
 
-
 ## Document status
 
 viewer-initializing = Pēhua…
 
-
 ## Errors
 
 error-heading = Tlahtlacōlli
-
 error-found-at =
     { $span ->
         [line] Ōmottac ipan tlamelāuhcāyōtl { $startLine }.
        *[lines] Ōmottac ipan tlamelāuhcāyōtl { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Inin āmoxtli quipiya tlahtlacōlli!
-
 diagnostic-heading-error = Tlahtlacōlli
 diagnostic-heading-warning = Tlanahuatīlli
 diagnostic-heading-information = Tlamachiliztli
 diagnostic-heading-hint = Tlapalēhuīlli
-
 accessibility-heading-level-1 = WCAG AA tlahtlacōlli ipan calaquiliztli
 accessibility-heading-level-2 = Tlanahuatīlli ipan calaquiliztli
-
 something-went-wrong = Itlah ahmo cualli ōmochīuh.
-
 renderer-load-failed = cē tlanēxtiāni ahmo ōhuālla. Mā xicyancuīli in āmoxpechtli.
-
 core-start-failed = In āmoxtlachiyalōni ahmo ōhuel pēuh. Mā xicyancuīli in āmoxpechtli.

--- a/packages/i18n/locales/nah/content.ftl
+++ b/packages/i18n/locales/nah/content.ftl
@@ -51,15 +51,12 @@ color =
     .purple = camohpaltic
     .pink = tlāztalēhualtic
     .brown = cuappaltic
-
 line-width =
     .thick = tomāhuac
     .thin = canāhuac
-
 line-style =
     .dashed = tlacotōctic
     .dotted = tlacuihcuiltic
-
 # Noun phrases, which is what the head of `style-fill` is. Nahuatl does not
 # pluralize these, so they are the same words for one and for many.
 fill-style =
@@ -69,7 +66,6 @@ fill-style =
     .backdiagonal = tlīlli tlanacaztic tlacuepcāyōtl
     .dots = tlīltzintli
     .diamonds = rombo
-
 noun =
     .line = tlīlli
     .line-segment = tlīlcotōnalli
@@ -89,7 +85,6 @@ noun =
     .diamond = rombo
     .cross = cuauhnepanōlli
     .plus = nepanōlli machiyōtl
-
 # The side count is a prenominal modifier, so it stays in the head and the tail
 # is empty — English's shape, reached by a different road.
 noun-regular-polygon =
@@ -97,11 +92,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } nacaztic tlaneneuhcāyōtl
     }
-
 # One answer for every noun: Nahuatl has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -115,7 +108,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives precede the noun, so this is English's order. The `[noun-tail]`
 # branch is unreachable from Nahuatl's own `noun-regular-polygon`; it is kept
 # because it is what a partly-corrected catalog falls back to.
@@ -124,9 +116,7 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = tlatēmītilli
-
 # «īca», "with", is a free word and precedes what it governs, so nothing is
 # welded to `$pattern` — the absolutive stays on it and the phrase is apposition.
 style-filled =
@@ -134,7 +124,6 @@ style-filled =
         [pattern] { $filled } { $color } īca { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } īca { $pattern }
@@ -142,7 +131,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } īca { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «tenāmitl», the border, is written as its own word rather than compounded onto
 # the description, for the absolutive reason in this file's header. Nahuatl has no
 # article, so English's four branches are two distinct strings; all four are
@@ -154,7 +142,6 @@ style-border-clause =
         [and-article] īhuān cē { $border } tenāmitl
        *[with] īca { $border } tenāmitl
     }
-
 # Here the pattern is the head noun — "blue diamonds" — and the colour precedes
 # it, so the phrase needs nothing at all.
 style-fill =
@@ -162,29 +149,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ahmo tlatēmītilli
-
 style-text =
     { $parts ->
         [background] { $color } īca cē { $background } tlacuitlapampa
        *[plain] { $color }
     }
-
 style-background-none = ahtlein
-
 
 ## Boolean words
 
 boolean-true = nelli
 boolean-false = ahnelli
 
-
 ## Answer buttons
 
 answer-submit-label = Xictta in tlachīhualli
 answer-submit-label-no-correctness = Xictitlani in tlanānquilīlli
-
 
 ## Sectional blocks
 
@@ -211,7 +192,6 @@ section-name =
     .solution = Tlanāmictīlli
     .task = Tlatequipanōlli
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -221,9 +201,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tlapalēhuīlli
-
 
 ## Tables and figures
 
@@ -234,7 +212,6 @@ table-name =
         [unnumbered-title] Tlapōhualpechtli{ ": " }
        *[unnumbered] Tlapōhualpechtli
     }
-
 figure-name =
     { $parts ->
         [numbered] Tlaīxiptlayōtl { $enumeration }
@@ -243,22 +220,18 @@ figure-name =
        *[unnumbered] Tlaīxiptlayōtl
     }
 
-
 ## Paginator controls
 
 paginator-previous = Yehuā
 paginator-next = Niman
 paginator-page = Āmoxpechtli
-
 paginator-page-status = { $pageLabel } { $currentPage } īhuīc { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ahnōzo
 piecewise-condition-if = intlā
 piecewise-condition-otherwise = ahnōzo cē
-
 
 ## Chemistry
 ##
@@ -270,6 +243,5 @@ piecewise-condition-otherwise = ahnōzo cē
 ## than the English a student can check against their own book.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Machiyōtl kimiko ahmo cualli
 chemistry-invalid-ionic-compound = Tlanechicōlli ioniko ahmo cualli

--- a/packages/i18n/locales/nb/chrome.ftl
+++ b/packages/i18n/locales/nb/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Sjekker…
 answer-submitting = Sender…
-
 answer-checking-status = Sjekker svar
 answer-submitting-status = Sender svar
-
 answer-correct = Riktig
 answer-incorrect = Feil
-
 answer-response-saved = Svar lagret
-
 answer-percent-credit = { $percent } % poeng
 answer-percent-correct = { $percent } % riktig
 answer-percent-short = { $percent } %
-
 max-credit-available = Høyeste oppnåelige poengsum: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] ingen forsøk igjen
        *[other] { $count } forsøk igjen
     }
-
 validation-correct = (Riktig)
 validation-incorrect = (Feil)
 validation-partially-correct = (Delvis riktig)
-
 answer-show-responses = Vis { $count } svar til { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Tilbakemelding
-
 collapsible-click-to-open = (klikk for å åpne)
 collapsible-click-to-close = (klikk for å lukke)
-
 collapsible-initializing = Initialiserer…
-
 footnote-show = Vis fotnote
 footnote-hide = Skjul fotnote
-
 description-more-information = mer informasjon
-
 
 ## Controls
 
 slider-previous = Forrige
 slider-next = Neste
-
 keyboard-open = Åpne tastaturet
 keyboard-close = Lukk tastaturet
-
 choice-input-remove-choice = Fjern { $choice }
-
 matrix-remove-row = Fjern rad
 matrix-add-row = Legg til rad
 matrix-remove-column = Fjern kolonne
 matrix-add-column = Legg til kolonne
-
 subset-add-remove-points = Legg til / fjern punkter
 subset-toggle-points-intervals = Veksle mellom punkter og intervaller
 subset-move-points = Flytt punkter
 subset-clear = Tøm
-
 orbital-add-row = Legg til rad
 orbital-remove-row = Fjern rad
 orbital-add-box = Legg til rute
@@ -90,13 +71,9 @@ orbital-remove-box = Fjern rute
 orbital-add-up-arrow = Legg til pil opp
 orbital-add-down-arrow = Legg til pil ned
 orbital-remove-arrow = Fjern pil
-
 orbital-row-label = Etikett for rad { $row }
-
 pretzel-answer = Svar
-
 summary-statistics-caption = Oppsummerende statistikk for { $column }
-
 
 ## Math input
 
@@ -104,34 +81,25 @@ math-input-preview-region = forhåndsvisning av matematisk uttrykk
 math-input-preview = Forhåndsvisning
 math-input-invalid-expression = Ugyldig uttrykk:
 
-
 ## Document status
 
 viewer-initializing = Initialiserer…
 
-
 ## Errors
 
 error-heading = Feil
-
 error-found-at =
     { $span ->
         [line] Funnet på linje { $startLine }.
        *[lines] Funnet på linjene { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dette dokumentet inneholder feil!
-
 diagnostic-heading-error = Feil
 diagnostic-heading-warning = Advarsel
 diagnostic-heading-information = Informasjon
 diagnostic-heading-hint = Tips
-
 accessibility-heading-level-1 = Tilgjengelighetsbrudd etter WCAG AA
 accessibility-heading-level-2 = Tilgjengelighetsmerknad
-
 something-went-wrong = Noe gikk galt.
-
 renderer-load-failed = en gjengivelsesmodul kunne ikke lastes. Last inn siden på nytt.
-
 core-start-failed = Dokumentviseren kunne ikke startes. Last inn siden på nytt.

--- a/packages/i18n/locales/nb/content.ftl
+++ b/packages/i18n/locales/nb/content.ftl
@@ -64,7 +64,6 @@ color =
             [neuter] brunt
            *[common] brun
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -76,11 +75,9 @@ line-width =
             [neuter] tynt
            *[common] tynn
         }
-
 line-style =
     .dashed = stiplet
     .dotted = prikket
-
 fill-style =
     .horizontal = vannrette linjer
     .vertical = loddrette linjer
@@ -88,7 +85,6 @@ fill-style =
     .backdiagonal = motsatte diagonale linjer
     .dots = prikker
     .diamonds = romber
-
 noun =
     .line = linje
     .line-segment = linjestykke
@@ -108,7 +104,6 @@ noun =
     .diamond = rombe
     .cross = kryss
     .plus = pluss
-
 # Norwegian names a regular polygon by its side count in one word —
 # «regelmessig 5-kant» — so the count stays in the head and there is no tail.
 # «-kant» is common, like «trekant».
@@ -117,7 +112,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelmessig { $numSides }-kant
     }
-
 # `$noun` can also be `regular-polygon` (kant, common) or a head the
 # description never names: `border` (kant, common), `fill` (fylling, common),
 # `text` (tekst, common), `background` (bakgrunn, common).
@@ -134,7 +128,6 @@ noun-gender =
        *[other] common
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -147,23 +140,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «fylt» already ends in `-t`, so it does not inflect and takes no `$gender`
 # branch.
 style-filled-word = fylt
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } med { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } med { $pattern }
@@ -171,7 +160,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } med { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «kant» is common, so the indefinite article is «en» — a word of its own,
 # which is why the distinction English draws between the `-article` branches
 # and the others survives here.
@@ -182,35 +170,28 @@ style-border-clause =
         [and-article] og en { $border } kant
        *[with] med { $border } kant
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ufylt
-
 style-text =
     { $parts ->
         [background] { $color } på { $background } bakgrunn
        *[plain] { $color }
     }
-
 style-background-none = ingen
-
 
 ## Boolean words
 
 boolean-true = sann
 boolean-false = usann
 
-
 ## Answer buttons
 
 answer-submit-label = Sjekk
 answer-submit-label-no-correctness = Send inn svar
-
 
 ## Sectional blocks
 
@@ -235,7 +216,6 @@ section-name =
     .solution = Løsning
     .task = Arbeidsoppgave
     .theorem = Setning
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -245,9 +225,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Hint
-
 
 ## Tables and figures
 
@@ -258,7 +236,6 @@ table-name =
         [unnumbered-title] Tabell{ ": " }
        *[unnumbered] Tabell
     }
-
 figure-name =
     { $parts ->
         [numbered] Figur { $enumeration }
@@ -267,22 +244,18 @@ figure-name =
        *[unnumbered] Figur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Forrige
 paginator-next = Neste
 paginator-page = Side
-
 paginator-page-status = { $pageLabel } { $currentPage } av { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = eller
 piecewise-condition-if = hvis
 piecewise-condition-otherwise = ellers
-
 
 ## Chemistry
 
@@ -405,7 +378,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenness
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Karbid
@@ -419,8 +391,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ugyldig kjemisk symbol
 chemistry-invalid-ionic-compound = Ugyldig ioneforbindelse

--- a/packages/i18n/locales/nds/chrome.ftl
+++ b/packages/i18n/locales/nds/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Warrt nakeken…
 answer-submitting = Warrt afschickt…
-
 answer-checking-status = Antwoort warrt nakeken
 answer-submitting-status = Antwoort warrt afschickt
-
 answer-correct = Richtig
 answer-incorrect = Verkehrt
-
 answer-response-saved = Antwoort sekert
-
 answer-percent-credit = { $percent }% Pünkte
 answer-percent-correct = { $percent }% richtig
 answer-percent-short = { $percent } %
-
 max-credit-available = Hööchst mööglich Pünkte: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] keen Versöök mehr över
         [one] noch { $count } Versöök över
        *[other] noch { $count } Versöken över
     }
-
 validation-correct = (Richtig)
 validation-incorrect = (Verkehrt)
 validation-partially-correct = (Deelwies richtig)
-
 answer-show-responses =
     { $count ->
         [one] { $count } Antwoort op { $answerId } wiesen
        *[other] { $count } Antwoorden op { $answerId } wiesen
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Torüchmellen
-
 collapsible-click-to-open = (klick to’n Opmaken)
 collapsible-click-to-close = (klick to’n Tomaken)
-
 collapsible-initializing = Start…
-
 footnote-show = Footnoot wiesen
 footnote-hide = Footnoot versteken
-
 description-more-information = mehr Informatschoon
-
 
 ## Controls
 
 slider-previous = Torüch
 slider-next = Wieder
-
 keyboard-open = Tastatuur opmaken
 keyboard-close = Tastatuur tomaken
-
 choice-input-remove-choice = { $choice } wegnehmen
-
 matrix-remove-row = Reeg wegnehmen
 matrix-add-row = Reeg tofögen
 matrix-remove-column = Striep wegnehmen
 matrix-add-column = Striep tofögen
-
 subset-add-remove-points = Pünkte tofögen/wegnehmen
 subset-toggle-points-intervals = Twischen Pünkte un Intervallen wesseln
 subset-move-points = Pünkte verschuven
 subset-clear = Leddig maken
-
 orbital-add-row = Reeg tofögen
 orbital-remove-row = Reeg wegnehmen
 orbital-add-box = Kasten tofögen
@@ -92,13 +73,9 @@ orbital-remove-box = Kasten wegnehmen
 orbital-add-up-arrow = Piel na baven tofögen
 orbital-add-down-arrow = Piel na nerrn tofögen
 orbital-remove-arrow = Piel wegnehmen
-
 orbital-row-label = Beteken för Reeg { $row }
-
 pretzel-answer = Antwoort
-
 summary-statistics-caption = Tosamenfaten Statistiken vun { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = Vöransicht vun’n mathemaatschen Utdruck
 math-input-preview = Vöransicht
 math-input-invalid-expression = Ungülltig Utdruck:
 
-
 ## Document status
 
 viewer-initializing = Start…
 
-
 ## Errors
 
 error-heading = Fehler
-
 error-found-at =
     { $span ->
         [line] Funnen in Reeg { $startLine }.
        *[lines] Funnen in de Regen { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = In dit Dokument sünd Fehlers!
-
 diagnostic-heading-error = Fehler
 diagnostic-heading-warning = Wohrschau
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Henwies
-
 accessibility-heading-level-1 = Verstoot gegen de Togänglichkeit na WCAG AA
 accessibility-heading-level-2 = Wohrschau to de Togänglichkeit
-
 something-went-wrong = Dor is wat schiefgahn.
-
 renderer-load-failed = en Modul för dat Wiesen kunn nich laadt warrn. Laad de Siet nieg.
-
 core-start-failed = De Dokumentkieker kunn nich start warrn. Laad de Siet nieg.

--- a/packages/i18n/locales/nds/content.ftl
+++ b/packages/i18n/locales/nds/content.ftl
@@ -80,7 +80,6 @@ color =
             [n] bruun
            *[other] bruune
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -92,7 +91,6 @@ line-width =
             [n] dünn
            *[other] dünne
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -104,7 +102,6 @@ line-style =
             [n] püntelt
            *[other] püntelte
         }
-
 # Plural noun phrases, which is what follows «mit» in `style-filled`. A plural
 # adjective always takes `-e`, so these agree with nothing.
 fill-style =
@@ -114,7 +111,6 @@ fill-style =
     .backdiagonal = ümdreihte diagonale Lienen
     .dots = Pünkte
     .diamonds = Ruten
-
 noun =
     .line = Lien
     .line-segment = Streek
@@ -134,7 +130,6 @@ noun =
     .diamond = Ruut
     .cross = Krüüz
     .plus = Plus
-
 # Low German keeps the side count in front of the noun, as a compound, so the
 # whole of it is one head and there is no tail. The head noun is `-Eck`, which
 # is neuter, so the adjective inside it is the bare stem — and `noun-gender`
@@ -145,7 +140,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelmatig { $numSides }-Eck
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (which is
 # `{ $numSides }-Eck`, n) or the head of a phrase the description never names:
 # `border` (Rand, m), `fill` (Füllung, f), `text` (Text, m), `background`
@@ -174,7 +168,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -187,25 +180,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [n] füllt
        *[other] füllte
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } mit { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } mit { $pattern }
@@ -213,7 +202,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } mit { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «Rand» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds. Low German has an indefinite article, «en», so
 # the two `-article` branches really do differ from the two without.
@@ -224,35 +212,28 @@ style-border-clause =
         [and-article] un en { $border } Rand
        *[with] mit { $border } Rand
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } Füllung mit { $pattern }
        *[plain] { $color } Füllung
     }
-
 style-unfilled = nich füllt
-
 style-text =
     { $parts ->
         [background] { $color } op en { $background } Achtergrund
        *[plain] { $color }
     }
-
 style-background-none = keen
-
 
 ## Boolean words
 
 boolean-true = wohr
 boolean-false = falsch
 
-
 ## Answer buttons
 
 answer-submit-label = Nakieken
 answer-submit-label-no-correctness = Antwoort afschicken
-
 
 ## Sectional blocks
 
@@ -277,7 +258,6 @@ section-name =
     .solution = Lösung
     .task = Opdrag
     .theorem = Theorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -287,9 +267,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Henwies
-
 
 ## Tables and figures
 
@@ -300,7 +278,6 @@ table-name =
         [unnumbered-title] Tabell{ ": " }
        *[unnumbered] Tabell
     }
-
 figure-name =
     { $parts ->
         [numbered] Figuur { $enumeration }
@@ -309,22 +286,18 @@ figure-name =
        *[unnumbered] Figuur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Torüch
 paginator-next = Wieder
 paginator-page = Siet
-
 paginator-page-status = { $pageLabel } { $currentPage } vun { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = oder
 piecewise-condition-if = wenn
 piecewise-condition-otherwise = sünst
-
 
 ## Chemistry
 ##
@@ -335,6 +308,5 @@ piecewise-condition-otherwise = sünst
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ungülltig cheemsch Symbool
 chemistry-invalid-ionic-compound = Ungülltige ioonsche Verbinnen

--- a/packages/i18n/locales/ne/chrome.ftl
+++ b/packages/i18n/locales/ne/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = जाँच गरिँदै छ...
 answer-submitting = पठाइँदै छ...
-
 answer-checking-status = उत्तर जाँच गरिँदै छ
 answer-submitting-status = उत्तर पठाइँदै छ
-
 answer-correct = सही
 answer-incorrect = गलत
-
 answer-response-saved = उत्तर सुरक्षित गरियो
-
 answer-percent-credit = { $percent }% अंक
 answer-percent-correct = { $percent }% सही
 answer-percent-short = { $percent }%
-
 max-credit-available = अधिकतम सम्भव अंक: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] कुनै प्रयास बाँकी छैन
         [one] { $count } प्रयास बाँकी
        *[other] { $count } प्रयास बाँकी
     }
-
 validation-correct = (सही)
 validation-incorrect = (गलत)
 validation-partially-correct = (आंशिक रूपमा सही)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } का { $count } उत्तर देखाउनुहोस्
        *[other] { $answerId } का { $count } उत्तर देखाउनुहोस्
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिक्रिया
-
 collapsible-click-to-open = (खोल्न क्लिक गर्नुहोस्)
 collapsible-click-to-close = (बन्द गर्न क्लिक गर्नुहोस्)
-
 collapsible-initializing = सुरु गरिँदै छ...
-
 footnote-show = पादटिप्पणी देखाउनुहोस्
 footnote-hide = पादटिप्पणी लुकाउनुहोस्
-
 description-more-information = थप जानकारी
-
 
 ## Controls
 
 slider-previous = अघिल्लो
 slider-next = अर्को
-
 keyboard-open = किबोर्ड खोल्नुहोस्
 keyboard-close = किबोर्ड बन्द गर्नुहोस्
-
 choice-input-remove-choice = { $choice } हटाउनुहोस्
-
 matrix-remove-row = पङ्क्ति हटाउनुहोस्
 matrix-add-row = पङ्क्ति थप्नुहोस्
 matrix-remove-column = स्तम्भ हटाउनुहोस्
 matrix-add-column = स्तम्भ थप्नुहोस्
-
 subset-add-remove-points = बिन्दु थप्नुहोस्/हटाउनुहोस्
 subset-toggle-points-intervals = बिन्दु र अन्तरालबीच फेर्नुहोस्
 subset-move-points = बिन्दु सार्नुहोस्
 subset-clear = मेट्नुहोस्
-
 # A `box` here is one orbital, drawn as a square: कोठा.
 orbital-add-row = पङ्क्ति थप्नुहोस्
 orbital-remove-row = पङ्क्ति हटाउनुहोस्
@@ -95,13 +76,9 @@ orbital-remove-box = कोठा हटाउनुहोस्
 orbital-add-up-arrow = माथिको तीर थप्नुहोस्
 orbital-add-down-arrow = तलको तीर थप्नुहोस्
 orbital-remove-arrow = तीर हटाउनुहोस्
-
 orbital-row-label = पङ्क्ति { $row } को लेबल
-
 pretzel-answer = उत्तर
-
 summary-statistics-caption = { $column } को सारांश तथ्याङ्क
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = गणितीय अभिव्यक्तिक
 math-input-preview = पूर्वावलोकन
 math-input-invalid-expression = अमान्य अभिव्यक्ति:
 
-
 ## Document status
 
 viewer-initializing = सुरु गरिँदै छ...
 
-
 ## Errors
 
 error-heading = त्रुटि
-
 error-found-at =
     { $span ->
         [line] पङ्क्ति { $startLine } मा भेटियो।
        *[lines] पङ्क्ति { $startLine }–{ $endLine } मा भेटियो।
     }
-
 document-contains-errors = यो कागजातमा त्रुटिहरू छन्!
-
 diagnostic-heading-error = त्रुटि
 diagnostic-heading-warning = चेतावनी
 diagnostic-heading-information = जानकारी
 diagnostic-heading-hint = संकेत
-
 accessibility-heading-level-1 = WCAG AA पहुँचयोग्यता उल्लङ्घन
 accessibility-heading-level-2 = पहुँचयोग्यता चेतावनी
-
 something-went-wrong = केही गडबड भयो।
-
 renderer-load-failed = एउटा रेन्डरर लोड हुन सकेन। कृपया पृष्ठ फेरि लोड गर्नुहोस्।
-
 core-start-failed = कागजात दर्शक सुरु हुन सकेन। कृपया पृष्ठ फेरि लोड गर्नुहोस्।

--- a/packages/i18n/locales/ne/content.ftl
+++ b/packages/i18n/locales/ne/content.ftl
@@ -36,15 +36,12 @@ color =
     .purple = बैजनी
     .pink = गुलाबी
     .brown = खैरो
-
 line-width =
     .thick = बाक्लो
     .thin = पातलो
-
 line-style =
     .dashed = धर्के
     .dotted = थोप्ले
-
 # Plural nouns rather than adjectives: «प्रयोग गरी» ("using") takes them bare.
 fill-style =
     .horizontal = तेर्सा रेखा
@@ -53,7 +50,6 @@ fill-style =
     .backdiagonal = उल्टो विकर्ण रेखा
     .dots = थोप्ला
     .diamonds = समचतुर्भुज
-
 noun =
     .line = रेखा
     .line-segment = रेखाखण्ड
@@ -73,7 +69,6 @@ noun =
     .diamond = समचतुर्भुज
     .cross = क्रस
     .plus = जोड चिन्ह
-
 # The side count attaches to the noun that follows, so the whole phrase is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -81,12 +76,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } भुजा भएको नियमित बहुभुज
     }
-
 # Nepali marks gender on an adjective only for an animate noun, and nothing
 # described here is one, so every noun answers the same and the answer goes
 # unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,15 +93,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = भरिएको
-
 # «प्रयोग गरी» ("using") is invariable and takes the pattern bare, so the
 # clause English appends comes to the front here.
 style-filled =
@@ -116,7 +106,6 @@ style-filled =
         [pattern] { $pattern } प्रयोग गरी { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } प्रयोग गरी { $filled } { $color } { $noun }
@@ -124,7 +113,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } प्रयोग गरी { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # -सहित follows किनारा, where English's `with` precedes its noun. Nepali has no
 # article, which leaves the `-article` branches reading like the others.
 style-border-clause =
@@ -134,15 +122,12 @@ style-border-clause =
         [and-article] र { $border } किनारासहित
        *[with] { $border } किनारासहित
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = नभरिएको
-
 # The locative -मा marks पृष्ठभूमि, and the colour word in front of it is
 # untouched by that.
 style-text =
@@ -150,21 +135,17 @@ style-text =
         [background] { $background } पृष्ठभूमिमा { $color }
        *[plain] { $color }
     }
-
 style-background-none = कुनै पनि छैन
-
 
 ## Boolean words
 
 boolean-true = सत्य
 boolean-false = असत्य
 
-
 ## Answer buttons
 
 answer-submit-label = जाँच्नुहोस्
 answer-submit-label-no-correctness = उत्तर पठाउनुहोस्
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = समाधान
     .task = कार्य
     .theorem = प्रमेय
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = संकेत
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] तालिका{ ": " }
        *[unnumbered] तालिका
     }
-
 figure-name =
     { $parts ->
         [numbered] चित्र { $enumeration }
@@ -221,28 +198,23 @@ figure-name =
        *[unnumbered] चित्र
     }
 
-
 ## Paginator controls
 
 paginator-previous = अघिल्लो
 paginator-next = अर्को
 paginator-page = पृष्ठ
-
 # «X मध्ये Y» — "Y of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } मध्ये { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = वा
-
 piecewise-condition-if = यदि
-
 piecewise-condition-otherwise = अन्यथा
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and those
 # 130 keys fall back to English.
@@ -257,6 +229,5 @@ piecewise-condition-otherwise = अन्यथा
 # script this shares, do have such a set and supply it.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अमान्य रासायनिक चिन्ह
 chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक

--- a/packages/i18n/locales/nl/chrome.ftl
+++ b/packages/i18n/locales/nl/chrome.ftl
@@ -18,32 +18,24 @@
 
 answer-checking = Controleren...
 answer-submitting = Verzenden...
-
 answer-checking-status = Antwoord wordt gecontroleerd
 answer-submitting-status = Antwoord wordt verzonden
-
 answer-correct = Goed
 answer-incorrect = Fout
-
 answer-response-saved = Antwoord opgeslagen
-
 answer-percent-credit = { $percent }% punten
 answer-percent-correct = { $percent }% goed
 answer-percent-short = { $percent } %
-
 max-credit-available = Maximaal haalbaar: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] geen pogingen meer
         [one] nog { $count } poging
        *[other] nog { $count } pogingen
     }
-
 validation-correct = (Goed)
 validation-incorrect = (Fout)
 validation-partially-correct = (Gedeeltelijk goed)
-
 # `Tonen` is the infinitive, per the register note above.
 answer-show-responses =
     { $count ->
@@ -51,42 +43,31 @@ answer-show-responses =
        *[other] { $count } antwoorden op { $answerId } tonen
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Feedback
-
 collapsible-click-to-open = (klik om te openen)
 collapsible-click-to-close = (klik om te sluiten)
-
 collapsible-initializing = Initialiseren...
-
 footnote-show = Voetnoot tonen
 footnote-hide = Voetnoot verbergen
-
 description-more-information = meer informatie
-
 
 ## Controls
 
 slider-previous = Vorige
 slider-next = Volgende
-
 keyboard-open = Toetsenbord openen
 keyboard-close = Toetsenbord sluiten
-
 choice-input-remove-choice = { $choice } verwijderen
-
 matrix-remove-row = Rij verwijderen
 matrix-add-row = Rij toevoegen
 matrix-remove-column = Kolom verwijderen
 matrix-add-column = Kolom toevoegen
-
 subset-add-remove-points = Punten toevoegen/verwijderen
 subset-toggle-points-intervals = Wisselen tussen punten en intervallen
 subset-move-points = Punten verplaatsen
 subset-clear = Wissen
-
 # A `box` here is one orbital, drawn as a square: `vakje`.
 orbital-add-row = Rij toevoegen
 orbital-remove-row = Rij verwijderen
@@ -95,13 +76,9 @@ orbital-remove-box = Vakje verwijderen
 orbital-add-up-arrow = Pijl omhoog toevoegen
 orbital-add-down-arrow = Pijl omlaag toevoegen
 orbital-remove-arrow = Pijl verwijderen
-
 orbital-row-label = Label voor rij { $row }
-
 pretzel-answer = Antwoord
-
 summary-statistics-caption = Samenvattende statistieken van { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = voorbeeld van de wiskundige uitdrukking
 math-input-preview = Voorbeeld
 math-input-invalid-expression = Ongeldige uitdrukking:
 
-
 ## Document status
 
 viewer-initializing = Initialiseren...
 
-
 ## Errors
 
 error-heading = Fout
-
 error-found-at =
     { $span ->
         [line] Gevonden op regel { $startLine }.
        *[lines] Gevonden op de regels { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dit document bevat fouten!
-
 diagnostic-heading-error = Fout
 diagnostic-heading-warning = Waarschuwing
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Tip
-
 accessibility-heading-level-1 = Schending van WCAG AA-toegankelijkheid
 accessibility-heading-level-2 = Toegankelijkheidsmelding
-
 something-went-wrong = Er is iets misgegaan.
-
 renderer-load-failed = een weergavecomponent kon niet worden geladen. Laad de pagina opnieuw.
-
 core-start-failed = De documentweergave kon niet worden gestart. Laad de pagina opnieuw.

--- a/packages/i18n/locales/nl/content.ftl
+++ b/packages/i18n/locales/nl/content.ftl
@@ -75,7 +75,6 @@ color =
             [n] bruin
            *[c] bruine
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -87,7 +86,6 @@ line-width =
             [n] dun
            *[c] dunne
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -99,7 +97,6 @@ line-style =
             [n] gestippeld
            *[c] gestippelde
         }
-
 # Noun phrases: they follow `met` and agree with nothing.
 fill-style =
     .horizontal = horizontale lijnen
@@ -108,7 +105,6 @@ fill-style =
     .backdiagonal = tegengesteld diagonale lijnen
     .dots = stippen
     .diamonds = ruiten
-
 noun =
     .line = lijn
     .line-segment = lijnstuk
@@ -128,7 +124,6 @@ noun =
     .diamond = ruit
     .cross = kruis
     .plus = plusteken
-
 # Dutch keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -136,7 +131,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelmatige { $numSides }-hoek
     }
-
 # `het`-words are the marked case, so they are the ones listed. Besides the
 # nouns above, `$noun` can be `regular-polygon` (de veelhoek) or the head of a
 # phrase the description never names: `border` (de rand), `fill` (de vulling),
@@ -153,7 +147,6 @@ noun-gender =
        *[other] c
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -166,25 +159,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [n] gevuld
        *[c] gevulde
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } met { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } met { $pattern }
@@ -192,7 +181,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } met { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # `rand` is a de-word, so the border's adjectives agree with it and not with
 # the shape it surrounds.
 style-border-clause =
@@ -202,7 +190,6 @@ style-border-clause =
         [and-article] en een { $border } rand
        *[with] met { $border } rand
     }
-
 # The gender this message is handed is the one `noun-gender` answers for
 # `fill` — `c`, for the de-word `vulling` — so it names that noun and the
 # colour takes its `-e` against it in both variants. The pattern follows in
@@ -212,29 +199,23 @@ style-fill =
         [pattern] { $color } vulling met { $pattern }
        *[plain] { $color } vulling
     }
-
 style-unfilled = niet gevuld
-
 style-text =
     { $parts ->
         [background] { $color } op een { $background } achtergrond
        *[plain] { $color }
     }
-
 style-background-none = geen
-
 
 ## Boolean words
 
 boolean-true = waar
 boolean-false = onwaar
 
-
 ## Answer buttons
 
 answer-submit-label = Controleren
 answer-submit-label-no-correctness = Antwoord indienen
-
 
 ## Sectional blocks
 
@@ -259,7 +240,6 @@ section-name =
     .solution = Oplossing
     .task = Taak
     .theorem = Stelling
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -269,9 +249,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tip
-
 
 ## Tables and figures
 
@@ -282,7 +260,6 @@ table-name =
         [unnumbered-title] Tabel{ ": " }
        *[unnumbered] Tabel
     }
-
 figure-name =
     { $parts ->
         [numbered] Figuur { $enumeration }
@@ -291,22 +268,18 @@ figure-name =
        *[unnumbered] Figuur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Vorige
 paginator-next = Volgende
 paginator-page = Pagina
-
 paginator-page-status = { $pageLabel } { $currentPage } van { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = of
 piecewise-condition-if = als
 piecewise-condition-otherwise = anders
-
 
 ## Chemistry
 
@@ -429,7 +402,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennessine
     .og = Oganesson
-
 element-anion-name =
     .h = Hydride
     .c = Carbide
@@ -443,8 +415,6 @@ element-anion-name =
     .i = Jodide
     .at = Astatide
     .ts = Tennesside
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ongeldig chemisch symbool
 chemistry-invalid-ionic-compound = Ongeldige ionverbinding

--- a/packages/i18n/locales/nso/chrome.ftl
+++ b/packages/i18n/locales/nso/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Go lekolwa…
 answer-submitting = Go romelwa…
-
 answer-checking-status = Karabo e a lekolwa
 answer-submitting-status = Karabo e a romelwa
-
 answer-correct = E nepagetše
 answer-incorrect = Ga se ya nepagala
-
 answer-response-saved = Karabo e Bolokilwe
-
 answer-percent-credit = { $percent }% ya Meputso
 answer-percent-correct = { $percent }% e Nepagetše
 answer-percent-short = { $percent } %
-
 max-credit-available = Meputso ye kgolo yeo e lego gona: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ga go na maiteko a šetšego
         [one] go šetše maiteko a { $count }
        *[other] go šetše maiteko a { $count }
     }
-
 validation-correct = (E nepagetše)
 validation-incorrect = (Ga se ya nepagala)
 validation-partially-correct = (E nepagetše ka seripa)
-
 answer-show-responses =
     { $count ->
         [one] Bontšha karabo e { $count } go { $answerId }
        *[other] Bontšha dikarabo tše { $count } go { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Tshwaotshwao
-
 collapsible-click-to-open = (kgotla go bula)
 collapsible-click-to-close = (kgotla go tswalela)
-
 collapsible-initializing = Go thongwa…
-
 footnote-show = Bontšha lengwalo la ka tlase
 footnote-hide = Uta lengwalo la ka tlase
-
 description-more-information = tshedimošo ye nngwe
-
 
 ## Controls
 
 slider-previous = Pele
 slider-next = Latelago
-
 keyboard-open = Bula Khiiboto
 keyboard-close = Tswalela Khiiboto
-
 choice-input-remove-choice = Tloša { $choice }
-
 matrix-remove-row = Tloša mothaladi
 matrix-add-row = Oketša mothaladi
 matrix-remove-column = Tloša kholomo
 matrix-add-column = Oketša kholomo
-
 subset-add-remove-points = Oketša/Tloša dintlha
 subset-toggle-points-intervals = Fetola dintlha le dikgao
 subset-move-points = Šuthiša Dintlha
 subset-clear = Phumola
-
 orbital-add-row = Oketša Mothaladi
 orbital-remove-row = Tloša Mothaladi
 orbital-add-box = Oketša Lepokisi
@@ -86,13 +67,9 @@ orbital-remove-box = Tloša Lepokisi
 orbital-add-up-arrow = Oketša Mosebe wa Godimo
 orbital-add-down-arrow = Oketša Mosebe wa Tlase
 orbital-remove-arrow = Tloša Mosebe
-
 orbital-row-label = Leina la mothaladi wa { $row }
-
 pretzel-answer = Karabo
-
 summary-statistics-caption = Kakaretšo ya dipalopalo tša { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ponelopele ya polelwana ya dipalo
 math-input-preview = Ponelopele
 math-input-invalid-expression = Polelwana ye e fošagetšego:
 
-
 ## Document status
 
 viewer-initializing = Go thongwa…
 
-
 ## Errors
 
 error-heading = Phošo
-
 error-found-at =
     { $span ->
         [line] E hweditšwe mothalading wa { $startLine }.
        *[lines] E hweditšwe methalading ya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tokumente ye e na le diphošo!
-
 diagnostic-heading-error = Phošo
 diagnostic-heading-warning = Temošo
 diagnostic-heading-information = Tshedimošo
 diagnostic-heading-hint = Keletšo
-
 accessibility-heading-level-1 = Tlolo ya WCAG AA ya Phihlelelo
 accessibility-heading-level-2 = Temošo ya phihlelelo
-
 something-went-wrong = Go na le se se sa sepelago gabotse.
-
 renderer-load-failed = mmontšhi o palelwe go laisa. Hle laiša letlakala gape.
-
 core-start-failed = Mmontšhi wa tokumente ga se a kgone go thoma. Hle laiša letlakala gape.

--- a/packages/i18n/locales/nso/content.ftl
+++ b/packages/i18n/locales/nso/content.ftl
@@ -95,7 +95,6 @@ color =
     .purple = phephole
     .pink = phinki
     .brown = sootho
-
 line-width =
     .thick =
         { $gender ->
@@ -111,14 +110,12 @@ line-width =
             [c7] se sesesane
            *[c9] e sesane
         }
-
 # Written as an invariable «ka …» phrase rather than as an adjective, so that
 # it agrees with nothing and can close the phrase. `style-stroke` puts it last
 # for that reason.
 line-style =
     .dashed = ka dikgaotšo
     .dotted = ka marontho
-
 # Noun phrases: they follow «ka» or «gomme le» and modify nothing.
 fill-style =
     .horizontal = methaladi ya go rapama
@@ -127,7 +124,6 @@ fill-style =
     .backdiagonal = methaladi ya sekhutlwana se se retologilego
     .dots = marontho
     .diamonds = ditaamane
-
 noun =
     .line = mothaladi
     .line-segment = karolo ya mothaladi
@@ -147,7 +143,6 @@ noun =
     .diamond = taamane
     .cross = sefapano
     .plus = leswao la tlaleletšo
-
 # The side count is a possessive complement — «sa mahlakore a 5» — and closes
 # the noun phrase behind the adjectives rather than opening it, so it goes in
 # the tail.
@@ -156,7 +151,6 @@ noun-regular-polygon =
         [tail] sa mahlakore a { $numSides }
        *[head] sekhutlokhutlo se se lekanego
     }
-
 # The noun class, which is what a concording word agrees with. `c9` is the
 # default and the class of every loanword, including a word an author supplies.
 noun-gender =
@@ -178,7 +172,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «ka …» phrase and closes the description, so it moves
@@ -193,7 +186,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow, with the noun's own possessive
 # complement closing the phrase: «sekhutlokhutlo se se lekanego e khubedu sa
 # mahlakore a 5».
@@ -202,7 +194,6 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] o tladitšwego
@@ -210,13 +201,11 @@ style-filled-word =
         [c7] se tladitšwego
        *[c9] e tladitšwego
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ka { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ka { $pattern }
@@ -224,7 +213,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ka { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «mollwane» is class 3 and leads its own adjectives, so the border's words
 # agree with it rather than with the shape it surrounds. Northern Sotho has no
 # article and joins this clause with the invariable «le», so all four branches
@@ -236,35 +224,28 @@ style-border-clause =
         [and-article] le mollwane { $border }
        *[with] le mollwane { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ga se ya tlala
-
 style-text =
     { $parts ->
         [background] { $color } godimo ga bokamorago { $background }
        *[plain] { $color }
     }
-
 style-background-none = ga go na selo
-
 
 ## Boolean words
 
 boolean-true = therešo
 boolean-false = maaka
 
-
 ## Answer buttons
 
 answer-submit-label = Lekola Mošomo
 answer-submit-label-no-correctness = Romela Karabo
-
 
 ## Sectional blocks
 
@@ -289,7 +270,6 @@ section-name =
     .solution = Tharollo
     .task = Mošomo
     .theorem = Teoreme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -299,9 +279,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Keletšo
-
 
 ## Tables and figures
 
@@ -312,7 +290,6 @@ table-name =
         [unnumbered-title] Lenaneo{ ": " }
        *[unnumbered] Lenaneo
     }
-
 figure-name =
     { $parts ->
         [numbered] Seswantšho { $enumeration }
@@ -321,24 +298,18 @@ figure-name =
        *[unnumbered] Seswantšho
     }
 
-
 ## Paginator controls
 
 paginator-previous = Pele
 paginator-next = Latelago
 paginator-page = Letlakala
-
 paginator-page-status = { $pageLabel } { $currentPage } go { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = goba
-
 piecewise-condition-if = ge
-
 piecewise-condition-otherwise = go sego bjalo
-
 
 ## Chemistry
 ##
@@ -353,6 +324,5 @@ piecewise-condition-otherwise = go sego bjalo
 ## about the medium of instruction rather than about either language.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Leswao la Khemi le Fošagetšego
 chemistry-invalid-ionic-compound = Motswako wa Ayone o Fošagetšego

--- a/packages/i18n/locales/ny/chrome.ftl
+++ b/packages/i18n/locales/ny/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Ikuyang'ana...
 answer-submitting = Ikutumiza...
-
 answer-checking-status = Ikuyang'ana yankho
 answer-submitting-status = Ikutumiza yankho
-
 answer-correct = Zolondola
 answer-incorrect = Zolakwika
-
 answer-response-saved = Yankho Lasungidwa
-
 answer-percent-credit = Mfundo { $percent }%
 answer-percent-correct = { $percent }% Zolondola
 answer-percent-short = { $percent }%
-
 max-credit-available = Mfundo zapamwamba zopezeka: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] palibe zoyesa zotsala
         [one] chatsala choyesa { $count }
        *[other] zatsala zoyesa { $count }
     }
-
 validation-correct = (Zolondola)
 validation-incorrect = (Zolakwika)
 validation-partially-correct = (Zolondola pang'ono)
-
 answer-show-responses =
     { $count ->
         [one] Onetsani yankho { $count } la { $answerId }
        *[other] Onetsani mayankho { $count } a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ndemanga
-
 collapsible-click-to-open = (dinani kuti mutsegule)
 collapsible-click-to-close = (dinani kuti mutseke)
-
 collapsible-initializing = Ikuyamba...
-
 footnote-show = Onetsani chidziwitso chapansi
 footnote-hide = Bisani chidziwitso chapansi
-
 description-more-information = zambiri
-
 
 ## Controls
 
 slider-previous = M'mbuyo
 slider-next = Kutsogolo
-
 keyboard-open = Tsegulani Kiyibodi
 keyboard-close = Tsekani Kiyibodi
-
 choice-input-remove-choice = Chotsani { $choice }
-
 matrix-remove-row = Chotsani mzere
 matrix-add-row = Onjezani mzere
 matrix-remove-column = Chotsani ndime
 matrix-add-column = Onjezani ndime
-
 subset-add-remove-points = Onjezani/Chotsani mfundo
 subset-toggle-points-intervals = Sinthani pakati pa mfundo ndi mipata
 subset-move-points = Sunthani Mfundo
 subset-clear = Fufutani
-
 # A `box` here is one orbital, drawn as a square: bokosi.
 orbital-add-row = Onjezani Mzere
 orbital-remove-row = Chotsani Mzere
@@ -92,13 +73,9 @@ orbital-remove-box = Chotsani Bokosi
 orbital-add-up-arrow = Onjezani Muvi Wopita M'mwamba
 orbital-add-down-arrow = Onjezani Muvi Wopita Pansi
 orbital-remove-arrow = Chotsani Muvi
-
 orbital-row-label = Chizindikiro cha mzere { $row }
-
 pretzel-answer = Yankho
-
 summary-statistics-caption = Chidule cha ziwerengero za { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = chiwonetsero cha mawu a masamu
 math-input-preview = Chiwonetsero
 math-input-invalid-expression = Mawu olakwika:
 
-
 ## Document status
 
 viewer-initializing = Ikuyamba...
 
-
 ## Errors
 
 error-heading = Cholakwika
-
 error-found-at =
     { $span ->
         [line] Chapezeka pa mzere { $startLine }.
        *[lines] Chapezeka pa mizere { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Chikalata ichi chili ndi zolakwika!
-
 diagnostic-heading-error = Cholakwika
 diagnostic-heading-warning = Chenjezo
 diagnostic-heading-information = Chidziwitso
 diagnostic-heading-hint = Chithandizo
-
 accessibility-heading-level-1 = Kuphwanya Kupezeka kwa WCAG AA
 accessibility-heading-level-2 = Chenjezo la kupezeka
-
 something-went-wrong = Pali chinachake chomwe sichinayende bwino.
-
 renderer-load-failed = chiwonetsero china sichinathe kutsitsidwa. Chonde tsitsaninso tsamba.
-
 core-start-failed = Chiwonetsero cha chikalata sichinathe kuyambitsidwa. Chonde tsitsaninso tsamba.

--- a/packages/i18n/locales/ny/content.ftl
+++ b/packages/i18n/locales/ny/content.ftl
@@ -126,7 +126,6 @@ color =
             [c7] cha bulawuni
            *[c9] ya bulawuni
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -144,14 +143,12 @@ line-width =
             [c7] chowonda
            *[c9] yowonda
         }
-
 # An invariable «wokhala ndi …» would concord too, so the dash pattern is
 # written as a bare «ndi …» phrase — "with …" — which agrees with nothing and
 # closes the description. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = ndi zigamba
     .dotted = ndi timadontho
-
 fill-style =
     .horizontal = mizere yopingasa
     .vertical = mizere yoyima
@@ -159,7 +156,6 @@ fill-style =
     .backdiagonal = mizere yopendama mbali ina
     .dots = timadontho
     .diamonds = ma daimondi
-
 noun =
     .line = mzere
     .line-segment = chigawo cha mzere
@@ -179,7 +175,6 @@ noun =
     .diamond = daimondi
     .cross = mtanda
     .plus = chizindikiro chowonjezera
-
 # The side count goes in the tail, behind the describing words: Chichewa closes
 # a noun phrase with a «cha …» complement rather than opening one with it.
 noun-regular-polygon =
@@ -187,7 +182,6 @@ noun-regular-polygon =
         [tail] cha mbali { $numSides }
        *[head] chithunzi cholingana
     }
-
 noun-gender =
     { $noun ->
         [line] c3
@@ -207,7 +201,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -220,13 +213,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] wodzazidwa
@@ -235,13 +226,11 @@ style-filled-word =
         [c7] chodzazidwa
        *[c9] yodzazidwa
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ndi { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ndi { $pattern }
@@ -249,7 +238,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ndi { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «malire» is class 6, so the border's words agree with it and not with the
 # shape it surrounds. Chichewa has no article and joins a complement with the
 # invariable «ndi», so all four branches read alike.
@@ -260,35 +248,28 @@ style-border-clause =
         [and-article] ndi malire { $border }
        *[with] ndi malire { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = osadzazidwa
-
 style-text =
     { $parts ->
         [background] { $color } pa mbuyo { $background }
        *[plain] { $color }
     }
-
 style-background-none = palibe
-
 
 ## Boolean words
 
 boolean-true = zoona
 boolean-false = zabodza
 
-
 ## Answer buttons
 
 answer-submit-label = Yang'anani Ntchito
 answer-submit-label-no-correctness = Tumizani Yankho
-
 
 ## Sectional blocks
 
@@ -313,7 +294,6 @@ section-name =
     .solution = Yankho
     .task = Ntchito
     .theorem = Chiphunzitso
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -323,9 +303,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Chithandizo
-
 
 ## Tables and figures
 
@@ -336,7 +314,6 @@ table-name =
         [unnumbered-title] Tebulo{ ": " }
        *[unnumbered] Tebulo
     }
-
 figure-name =
     { $parts ->
         [numbered] Chithunzi { $enumeration }
@@ -345,15 +322,12 @@ figure-name =
        *[unnumbered] Chithunzi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Zapitazo
 paginator-next = Zotsatira
 paginator-page = Tsamba
-
 paginator-page-status = { $pageLabel } { $currentPage } mwa { $numPages }
-
 
 ## Piecewise functions
 
@@ -361,8 +335,8 @@ piecewise-condition-or = kapena
 piecewise-condition-if = ngati
 piecewise-condition-otherwise = kupanda kutero
 
-
 ## Chemistry
+
 
 # Chichewa is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. Malawian
@@ -371,6 +345,5 @@ piecewise-condition-otherwise = kupanda kutero
 # own textbook.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Chizindikiro cha Mankhwala Cholakwika
 chemistry-invalid-ionic-compound = Chophatikiza cha Ayoni Cholakwika

--- a/packages/i18n/locales/nyn/chrome.ftl
+++ b/packages/i18n/locales/nyn/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Nikicendererezibwa…
 answer-submitting = Nikyohererezibwa…
-
 answer-checking-status = Eky'okugarukamu nikicendererezibwa
 answer-submitting-status = Eky'okugarukamu nikyohererezibwa
-
 answer-correct = Nikyo
 answer-incorrect = Tikyo
-
 answer-response-saved = Eky'okugarukamu Kibiikirwe
-
 answer-percent-credit = { $percent }% ez'Amanota
 answer-percent-correct = { $percent }% Nikyo
 answer-percent-short = { $percent } %
-
 max-credit-available = Amanota maingi agariho: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] tihariho kugyezaho okusigaire
         [one] hasigaire okugyezaho { $count }
        *[other] hasigaire okugyezaho { $count }
     }
-
 validation-correct = (Nikyo)
 validation-incorrect = (Tikyo)
 validation-partially-correct = (Nikyo aha rubaju)
-
 answer-show-responses =
     { $count ->
         [one] Yoreka eky'okugarukamu { $count } aha { $answerId }
        *[other] Yoreka eby'okugarukamu { $count } aha { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ekiteekateeko
-
 collapsible-click-to-open = (kanda okwigura)
 collapsible-click-to-close = (kanda okwigara)
-
 collapsible-initializing = Nikitandika…
-
 footnote-show = Yoreka ekyandiikirwe aha nsi
 footnote-hide = Sherekyera ekyandiikirwe aha nsi
-
 description-more-information = amakuru maingi
-
 
 ## Controls
 
 slider-previous = Ekihweireho
 slider-next = Ekirikukuratsya
-
 keyboard-open = Igura Kiiboodi
 keyboard-close = Igara Kiiboodi
-
 choice-input-remove-choice = Ihaho { $choice }
-
 matrix-remove-row = Ihaho omurongo
 matrix-add-row = Ongyeraho omurongo
 matrix-remove-column = Ihaho empagi
 matrix-add-column = Ongyeraho empagi
-
 subset-add-remove-points = Ongyeraho/Ihaho obudomo
 subset-toggle-points-intervals = Hindura obudomo n'ebicweka
 subset-move-points = Rugurura Obudomo
 subset-clear = Ihaho byona
-
 orbital-add-row = Ongyeraho Omurongo
 orbital-remove-row = Ihaho Omurongo
 orbital-add-box = Ongyeraho Akasanduuko
@@ -87,13 +68,9 @@ orbital-remove-box = Ihaho Akasanduuko
 orbital-add-up-arrow = Ongyeraho Akambi Karikuza Ahaiguru
 orbital-add-down-arrow = Ongyeraho Akambi Karikuza Ahansi
 orbital-remove-arrow = Ihaho Akambi
-
 orbital-row-label = Eiziina ry'omurongo { $row }
-
 pretzel-answer = Eky'okugarukamu
-
 summary-statistics-caption = Ekifundikirwe ky'ebibaro bya { $column }
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = okureeba omu maisho eby'ebibaro
 math-input-preview = Okureeba omu maisho
 math-input-invalid-expression = Ekigambo ekitari kyo:
 
-
 ## Document status
 
 viewer-initializing = Nikitandika…
 
-
 ## Errors
 
 error-heading = Ekihabo
-
 error-found-at =
     { $span ->
         [line] Kishangirwe aha murongo { $startLine }.
        *[lines] Kishangirwe aha mirongo { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ekitabo eki kiine ebihabo!
-
 diagnostic-heading-error = Ekihabo
 diagnostic-heading-warning = Okurabura
 diagnostic-heading-information = Amakuru
 diagnostic-heading-hint = Akamanyiso
-
 accessibility-heading-level-1 = Okuhenda WCAG AA omu Kuhikaho
 accessibility-heading-level-2 = Okurabura kw'okuhikaho
-
 something-went-wrong = Hariho ekitagyenzire gye.
-
 renderer-load-failed = omworeki tarahikire. Nooyeshengyereza garura orupapura.
-
 core-start-failed = Omworeki w'ekitabo tarutandikire. Nooyeshengyereza garura orupapura.

--- a/packages/i18n/locales/nyn/content.ftl
+++ b/packages/i18n/locales/nyn/content.ftl
@@ -135,7 +135,6 @@ color =
             [c12] ka buraawuni
            *[c9] ya buraawuni
         }
-
 # The adjective concord, which is not the particle the colours take.
 line-width =
     .thick =
@@ -154,13 +153,11 @@ line-width =
             [c12] kakye
            *[c9] ekye
         }
-
 # Written as an invariable «na …» phrase, so that it agrees with nothing and
 # can close the description; `style-stroke` puts it last for that reason.
 line-style =
     .dashed = na tubaraaza
     .dotted = na tudomo
-
 fill-style =
     .horizontal = emirongo eyegamiire
     .vertical = emirongo eyemereire
@@ -168,7 +165,6 @@ fill-style =
     .backdiagonal = emirongo eyeserekera oruhande orundi
     .dots = tudomo
     .diamonds = amadaimonde
-
 noun =
     .line = omurongo
     .line-segment = ekicweka ky'omurongo
@@ -188,7 +184,6 @@ noun =
     .diamond = edaimonde
     .cross = omusaraba
     .plus = ekimanyiso ky'okwongyeraho
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -196,7 +191,6 @@ noun-regular-polygon =
         [tail] ekiine empande { $numSides }
        *[head] ekishushani ekingana empande
     }
-
 # The noun class. `c9` is the default and the class a loanword joins, which is
 # what an author's own `markerStyleWord` is as far as this catalog is
 # concerned.
@@ -223,7 +217,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «na …» phrase and closes the description, so it moves
@@ -238,13 +231,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] ogwijwire
@@ -253,13 +244,11 @@ style-filled-word =
         [c12] akijwire
        *[c9] eyijwire
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -267,7 +256,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «omupaka» is class 3, as `locales/rn`'s «umupaka» and `locales/lua`'s
 # «mukalu» are, and it leads its own describing words, so they agree with it
 # rather than with the shape it surrounds. Runyankore has no article and joins
@@ -279,35 +267,28 @@ style-border-clause =
         [and-article] n'omupaka { $border }
        *[with] n'omupaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = tikyijwire
-
 style-text =
     { $parts ->
         [background] { $color } aha nyima { $background }
        *[plain] { $color }
     }
-
 style-background-none = tihariho
-
 
 ## Boolean words
 
 boolean-true = ni buzima
 boolean-false = ti buzima
 
-
 ## Answer buttons
 
 answer-submit-label = Cenderezamu Omurimo
 answer-submit-label-no-correctness = Ohereza Eky'okugarukamu
-
 
 ## Sectional blocks
 
@@ -332,7 +313,6 @@ section-name =
     .solution = Eky'okukiza
     .task = Omurimo
     .theorem = Tiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -342,9 +322,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Akamanyiso
-
 
 ## Tables and figures
 
@@ -355,7 +333,6 @@ table-name =
         [unnumbered-title] Etaburo{ ": " }
        *[unnumbered] Etaburo
     }
-
 figure-name =
     { $parts ->
         [numbered] Ekishushani { $enumeration }
@@ -364,24 +341,18 @@ figure-name =
        *[unnumbered] Ekishushani
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ekihweireho
 paginator-next = Ekirikukuratsya
 paginator-page = Orupapura
-
 paginator-page-status = { $pageLabel } { $currentPage } aha { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = nari
-
 piecewise-condition-if = ku
-
 piecewise-condition-otherwise = ahandi hoona
-
 
 ## Chemistry
 ##
@@ -393,6 +364,5 @@ piecewise-condition-otherwise = ahandi hoona
 ## curriculum — the same answer `locales/lg` gives from the same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ekimanyiso kya Kemistule Ekitari Kyo
 chemistry-invalid-ionic-compound = Enteeraniso y'Ayoni Etari Yo

--- a/packages/i18n/locales/oc/chrome.ftl
+++ b/packages/i18n/locales/oc/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = Verificacion…
 answer-submitting = Mandadís…
-
 answer-checking-status = Verificacion de la responsa
 answer-submitting-status = Mandadís de la responsa
-
 answer-correct = Corrècte
 answer-incorrect = Incorrècte
-
 answer-response-saved = Responsa enregistrada
-
 answer-percent-credit = { $percent }% de punts
 answer-percent-correct = { $percent }% corrècte
 answer-percent-short = { $percent } %
-
 max-credit-available = Punts maximals possibles : { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] cap d'ensag que demòre
         [one] demòra { $count } ensag
        *[other] demòran { $count } ensages
     }
-
 validation-correct = (Corrècte)
 validation-incorrect = (Incorrècte)
 validation-partially-correct = (Parcialament corrècte)
-
 answer-show-responses =
     { $count ->
         [one] Mostrar { $count } responsa a { $answerId }
        *[other] Mostrar { $count } responsas a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Comentari
-
 collapsible-click-to-open = (clicatz per dobrir)
 collapsible-click-to-close = (clicatz per tampar)
-
 collapsible-initializing = Aviada…
-
 footnote-show = Mostrar la nòta
 footnote-hide = Amagar la nòta
-
 description-more-information = mai d'informacions
-
 
 ## Controls
 
 slider-previous = Precedent
 slider-next = Seguent
-
 keyboard-open = Dobrir lo clavièr
 keyboard-close = Tampar lo clavièr
-
 choice-input-remove-choice = Levar { $choice }
-
 matrix-remove-row = Levar una linha
 matrix-add-row = Apondre una linha
 matrix-remove-column = Levar una colomna
 matrix-add-column = Apondre una colomna
-
 subset-add-remove-points = Apondre/levar de punts
 subset-toggle-points-intervals = Bascular entre punts e intervals
 subset-move-points = Desplaçar los punts
 subset-clear = Escafar
-
 orbital-add-row = Apondre una linha
 orbital-remove-row = Levar una linha
 orbital-add-box = Apondre una casa
@@ -93,13 +74,9 @@ orbital-remove-box = Levar una casa
 orbital-add-up-arrow = Apondre una sageta cap amont
 orbital-add-down-arrow = Apondre una sageta cap aval
 orbital-remove-arrow = Levar una sageta
-
 orbital-row-label = Etiqueta de la linha { $row }
-
 pretzel-answer = Responsa
-
 summary-statistics-caption = Estatisticas resumidas de { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = apercebut de l'expression matematica
 math-input-preview = Apercebut
 math-input-invalid-expression = Expression invalida :
 
-
 ## Document status
 
 viewer-initializing = Aviada…
 
-
 ## Errors
 
 error-heading = Error
-
 error-found-at =
     { $span ->
         [line] Trobada a la linha { $startLine }.
        *[lines] Trobada a las linhas { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Aqueste document conten d'errors !
-
 diagnostic-heading-error = Error
 diagnostic-heading-warning = Avertiment
 diagnostic-heading-information = Informacion
 diagnostic-heading-hint = Indici
-
 accessibility-heading-level-1 = Violacion d'accessibilitat segon WCAG AA
 accessibility-heading-level-2 = Alèrta d'accessibilitat
-
 something-went-wrong = Quicòm a mal virat.
-
 renderer-load-failed = un modul d'afichatge s'es pas cargat. Tornatz cargar la pagina.
-
 core-start-failed = Lo visionador del document a pas pogut èsser aviat. Tornatz cargar la pagina.

--- a/packages/i18n/locales/oc/content.ftl
+++ b/packages/i18n/locales/oc/content.ftl
@@ -78,7 +78,6 @@ color =
            *[m] ròse
         }
     .brown = marron
-
 line-width =
     .thick =
         { $gender ->
@@ -90,7 +89,6 @@ line-width =
             [f] prima
            *[m] prim
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -102,7 +100,6 @@ line-style =
             [f] puntejada
            *[m] puntejat
         }
-
 # Plural noun phrases, which is what follows «amb» in `style-filled`. They
 # agree with nothing.
 fill-style =
@@ -112,7 +109,6 @@ fill-style =
     .backdiagonal = linhas diagonalas inversas
     .dots = punts
     .diamonds = lausanjas
-
 noun =
     .line = linha
     .line-segment = segment
@@ -132,13 +128,11 @@ noun =
     .diamond = lausanja
     .cross = crotz
     .plus = mai
-
 noun-regular-polygon =
     { $part ->
         [tail] de { $numSides } costats
        *[head] poligòn regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (poligòn, m) or the
 # head of a phrase the description never names: `border` (bordadura, f), `fill`
 # (emplenatge, m), `text` (tèxte, m), `background` (fons, m).
@@ -157,7 +151,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -170,7 +163,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it, which is the opposite of
 # English. A noun that splits — the regular polygon — puts its complement after
 # the adjectives that agree with its head.
@@ -179,19 +171,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] emplenada
        *[m] emplenat
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } amb { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } amb { $pattern }
@@ -199,7 +188,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } amb { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «bordadura» is feminine, so the border's adjectives agree with it rather than
 # with the shape it surrounds.
 style-border-clause =
@@ -209,7 +197,6 @@ style-border-clause =
         [and-article] e una bordadura { $border }
        *[with] amb bordadura { $border }
     }
-
 # The fill-pattern words are plural nouns, because their other use is the
 # «amb { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «emplenatge», masculine, which is the gender
@@ -220,29 +207,23 @@ style-fill =
         [pattern] emplenatge { $color } amb { $pattern }
        *[plain] emplenatge { $color }
     }
-
 style-unfilled = pas emplenat
-
 style-text =
     { $parts ->
         [background] { $color } sus un fons { $background }
        *[plain] { $color }
     }
-
 style-background-none = cap
-
 
 ## Boolean words
 
 boolean-true = verai
 boolean-false = fals
 
-
 ## Answer buttons
 
 answer-submit-label = Verificar
 answer-submit-label-no-correctness = Mandar la responsa
-
 
 ## Sectional blocks
 
@@ -267,7 +248,6 @@ section-name =
     .solution = Solucion
     .task = Prètzfach
     .theorem = Teorèma
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -277,9 +257,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Indici
-
 
 ## Tables and figures
 
@@ -290,7 +268,6 @@ table-name =
         [unnumbered-title] Taula{ ". " }
        *[unnumbered] Taula
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -299,22 +276,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Precedenta
 paginator-next = Seguenta
 paginator-page = Pagina
-
 paginator-page-status = { $pageLabel } { $currentPage } sus { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = se
 piecewise-condition-otherwise = siquenon
-
 
 ## Chemistry
 ##
@@ -325,6 +298,5 @@ piecewise-condition-otherwise = siquenon
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbòl quimic invalid
 chemistry-invalid-ionic-compound = Compausat ionic invalid

--- a/packages/i18n/locales/oj/chrome.ftl
+++ b/packages/i18n/locales/oj/chrome.ftl
@@ -27,21 +27,15 @@
 
 answer-checking = Agindaaso…
 answer-submitting = Izhinizha'igaade…
-
 answer-checking-status = Agindaan nakwetamowin
 answer-submitting-status = Izhinizha'amaw nakwetamowin
-
 answer-correct = Gwayak
 answer-incorrect = Gaawiin gwayak
-
 answer-response-saved = Gii-asigina'igaade nakwetamowin
-
 answer-percent-credit = { $percent }% dibaakonigewin
 answer-percent-correct = { $percent }% gwayak
 answer-percent-short = { $percent } %
-
 max-credit-available = Gichi-dibaakonigewin ayaamagak: { $percent }%
-
 # The select stays: the inanimate plural is marked and the verb agrees with it, so
 # these really are three different sentences. `[0]` names none, which is a fourth.
 attempts-remaining =
@@ -50,11 +44,9 @@ attempts-remaining =
         [one] { $count } gagwedaagewin ishkwaamagad
        *[other] { $count } gagwedaagewinan ishkwaamagadoon
     }
-
 validation-correct = (Gwayak)
 validation-incorrect = (Gaawiin gwayak)
 validation-partially-correct = (Aabita gwayak)
-
 # The select stays, for the reason above. The answer is named with «ezhinikaazod»
 # — "the one so called" — rather than possessed, because a possessive prefix's
 # shape would be decided by `$answerId`.
@@ -64,42 +56,31 @@ answer-show-responses =
        *[other] Waabanda'iwe { $count } nakwetamowinan, { $answerId } ezhinikaazod
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Nakwetamowin-wiindamaagewin
-
 collapsible-click-to-open = (bagidin ji-baakinigaadeg)
 collapsible-click-to-close = (bagidin ji-gibaakwa'igaadeg)
-
 collapsible-initializing = Maajitaamagad…
-
 footnote-show = Waabanda'iwe naabishkaan-ozhibii'igan
 footnote-hide = Gaadoon naabishkaan-ozhibii'igan
-
 description-more-information = nawaj wiindamaagewin
-
 
 ## Controls
 
 slider-previous = Ishkweyaang
 slider-next = Niigaan
-
 keyboard-open = Baakinan mazina'iganaabik
 keyboard-close = Gibaakwa'an mazina'iganaabik
-
 choice-input-remove-choice = Webinan { $choice }
-
 matrix-remove-row = Webinan bezhig shingishing
 matrix-add-row = Agonan bezhig shingishing
 matrix-remove-column = Webinan bezhig gaabawi
 matrix-add-column = Agonan bezhig gaabawi
-
 subset-add-remove-points = Agonan/Webinan mazina'igaansan
 subset-toggle-points-intervals = Aanjitoon mazina'igaansan gaye dazhiwinan
 subset-move-points = Ani-izhiwidoon mazina'igaansan
 subset-clear = Gaasii'an
-
 orbital-add-row = Agonan bezhig shingishing
 orbital-remove-row = Webinan bezhig shingishing
 orbital-add-box = Agonan bezhig makak
@@ -107,13 +88,9 @@ orbital-remove-box = Webinan bezhig makak
 orbital-add-up-arrow = Agonan bezhig bikwak ishpiming
 orbital-add-down-arrow = Agonan bezhig bikwak niisaayi'ii
 orbital-remove-arrow = Webinan bezhig bikwak
-
 orbital-row-label = Izhinikaazowin shingishing { $row }
-
 pretzel-answer = Nakwetamowin
-
 summary-statistics-caption = Agindaasowinan { $column } onji
-
 
 ## Math input
 
@@ -121,34 +98,25 @@ math-input-preview-region = agindaasowin-ikidowin waabanda'iwewin
 math-input-preview = Niigaan-waabanda'iwewin
 math-input-invalid-expression = Gaawiin gwayak ikidowin:
 
-
 ## Document status
 
 viewer-initializing = Maajitaamagad…
 
-
 ## Errors
 
 error-heading = Bataadowin
-
 error-found-at =
     { $span ->
         [line] Gii-mikigaade shingishing { $startLine } ishkwaandeg.
        *[lines] Gii-mikigaade shingishingoon { $startLine }–{ $endLine } ishkwaandeg.
     }
-
 document-contains-errors = O'ow mazina'igan bataadowinan otayaanan!
-
 diagnostic-heading-error = Bataadowin
 diagnostic-heading-warning = Aakoziwin-wiindamaagewin
 diagnostic-heading-information = Wiindamaagewin
 diagnostic-heading-hint = Wiidookaagewin
-
 accessibility-heading-level-1 = WCAG AA bimaadiziwin-bagidinigewin banaadaagewin
 accessibility-heading-level-2 = Bagidinigewin-wiindamaagewin
-
 something-went-wrong = Gegoo gaawiin gii-gwayakosesinoon.
-
 renderer-load-failed = bezhig waabanda'iwewin gaawiin gii-dagoshinzinoon. Aanjitoon mazina'igan.
-
 core-start-failed = Mazina'igan-waabanda'iwewin gaawiin gii-maajitaasinoon. Aanjitoon mazina'igan.

--- a/packages/i18n/locales/oj/content.ftl
+++ b/packages/i18n/locales/oj/content.ftl
@@ -126,7 +126,6 @@ color =
             [anim] makade-ozaawizi
            *[inan] makade-ozaawaa
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -138,7 +137,6 @@ line-width =
             [anim] bibagizi
            *[inan] bibagaa
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -150,7 +148,6 @@ line-style =
             [anim] agwaawaadizi
            *[inan] agwaawaadaan
         }
-
 # Noun phrases, and the plural is the inanimate plural `-an`/`-oon`, because
 # these are things rather than beings. This is one of the two places animacy is
 # visible in the noun itself rather than only in the verb agreeing with it.
@@ -161,7 +158,6 @@ fill-style =
     .backdiagonal = aazhawaakwaan jiigaatigoon aanjisejig
     .dots = agwaawaadeg
     .diamonds = wiingashkoon
-
 noun =
     .line = jiigaatig
     .line-segment = jiigaatig bakwezhigan
@@ -181,7 +177,6 @@ noun =
     .diamond = wiingashk
     .cross = aazhidebide'igan
     .plus = agindaasowin-mazina'igan
-
 # The side count precedes the noun, so the head holds it and the `[tail]` branch
 # is empty — English's shape.
 noun-regular-polygon =
@@ -189,7 +184,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } endaso-wiikwaan naasaab
     }
-
 # **Animacy, not masculine and feminine.** Nothing here is derivable: Ojibwe
 # assigns animacy word by word, and a shape's assignment is a fact about the word
 # rather than about the shape. Every entry below is a guess this file is asking a
@@ -208,7 +202,6 @@ noun-gender =
        *[other] inan
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -221,7 +214,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The describing verbs precede the noun, which is English's order — but they are
 # verbs standing beside it rather than modifiers of it, and Ojibwe would more
 # usually fold them in. See this file's header for why they are not folded.
@@ -230,13 +222,11 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [anim] mooshkinezi
        *[inan] mooshkinebii
     }
-
 # «gaye», "and also", joins the pattern rather than a case marker: nothing can be
 # welded to `$pattern`, and no preverb can be chosen without seeing it.
 style-filled =
@@ -244,7 +234,6 @@ style-filled =
         [pattern] { $filled } { $color }, gaye { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun }, gaye { $pattern }
@@ -252,7 +241,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail }, gaye { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «jiigaatigwaan», the border, is inanimate, so the border's own describing verbs
 # agree with *it* rather than with the shape it surrounds — which is exactly what
 # the `border` entry in `noun-gender` is for.
@@ -271,7 +259,6 @@ style-border-clause =
         [and-article] miinawaa { $border } jiigaatigwaan
        *[with] gaye { $border } jiigaatigwaan
     }
-
 # Here the pattern is the head, so the colour precedes it and the phrase needs
 # nothing.
 style-fill =
@@ -279,29 +266,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = gaawiin mooshkinebiisinoon
-
 style-text =
     { $parts ->
         [background] { $color }, { $background } atesing
        *[plain] { $color }
     }
-
 style-background-none = gaawiin gegoo
-
 
 ## Boolean words
 
 boolean-true = geget
 boolean-false = gaawiin geget
 
-
 ## Answer buttons
 
 answer-submit-label = Nanaa'ichige
 answer-submit-label-no-correctness = Izhinizha'amaw nakwetamowin
-
 
 ## Sectional blocks
 
@@ -329,7 +310,6 @@ section-name =
     .solution = Nanaa'igewin
     .task = Anokiiwin
     .theorem = Teyoorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -339,9 +319,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Wiidookaagewin
-
 
 ## Tables and figures
 
@@ -352,7 +330,6 @@ table-name =
         [unnumbered-title] Adoopowin{ ": " }
        *[unnumbered] Adoopowin
     }
-
 figure-name =
     { $parts ->
         [numbered] Mazinaakizon { $enumeration }
@@ -361,22 +338,18 @@ figure-name =
        *[unnumbered] Mazinaakizon
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ishkweyaang
 paginator-next = Niigaan
 paginator-page = Bezhig-mazina'igan
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = gemaa
 piecewise-condition-if = giishpin
 piecewise-condition-otherwise = bakaan igo
-
 
 ## Chemistry
 ##
@@ -390,6 +363,5 @@ piecewise-condition-otherwise = bakaan igo
 ## the English a student meets in their own textbook.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Gaawiin gwayak mazina'igan (chemistry)
 chemistry-invalid-ionic-compound = Gaawiin gwayak ionic-mamaw-ayi'ii

--- a/packages/i18n/locales/om/chrome.ftl
+++ b/packages/i18n/locales/om/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Ilaalaa jira...
 answer-submitting = Ergaa jira...
-
 answer-checking-status = Deebii ilaalaa jira
 answer-submitting-status = Deebii ergaa jira
-
 answer-correct = Sirrii
 answer-incorrect = Sirrii miti
-
 answer-response-saved = Deebiin Olkaa'ameera
-
 answer-percent-credit = Qabxii { $percent }%
 answer-percent-correct = { $percent }% Sirrii
 answer-percent-short = { $percent }%
-
 max-credit-available = Qabxii ol'aanaa argamu: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] yaaliin hafe hin jiru
         [one] yaaliin { $count } hafeera
        *[other] yaaliiwwan { $count } hafaniiru
     }
-
 validation-correct = (Sirrii)
 validation-incorrect = (Sirrii miti)
 validation-partially-correct = (Gartokkoon sirrii)
-
 answer-show-responses =
     { $count ->
         [one] Deebii { $count } kan { $answerId } agarsiisi
        *[other] Deebiiwwan { $count } kan { $answerId } agarsiisi
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Deebii Qajeelchaa
-
 collapsible-click-to-open = (banuuf tuqi)
 collapsible-click-to-close = (cufuuf tuqi)
-
 collapsible-initializing = Jalqabaa jira...
-
 footnote-show = Yaadannoo jalaa agarsiisi
 footnote-hide = Yaadannoo jalaa dhoksi
-
 description-more-information = odeeffannoo dabalataa
-
 
 ## Controls
 
 slider-previous = Duubatti
 slider-next = Fuulduratti
-
 keyboard-open = Gabatee Qubee Bani
 keyboard-close = Gabatee Qubee Cufi
-
 choice-input-remove-choice = { $choice } haqi
-
 matrix-remove-row = Tarree haqi
 matrix-add-row = Tarree dabali
 matrix-remove-column = Utubaa haqi
 matrix-add-column = Utubaa dabali
-
 subset-add-remove-points = Tuqaalee dabali/haqi
 subset-toggle-points-intervals = Tuqaalee fi giddu-gala gidduu jijjiiri
 subset-move-points = Tuqaalee Sochoosi
 subset-clear = Haqi
-
 # A `box` here is one orbital, drawn as a square: saanduqa.
 orbital-add-row = Tarree Dabali
 orbital-remove-row = Tarree Haqi
@@ -93,13 +74,9 @@ orbital-remove-box = Saanduqa Haqi
 orbital-add-up-arrow = Xiyya Ol Aanu Dabali
 orbital-add-down-arrow = Xiyya Gad Aanu Dabali
 orbital-remove-arrow = Xiyya Haqi
-
 orbital-row-label = Mallattoo tarree { $row }
-
 pretzel-answer = Deebii
-
 summary-statistics-caption = Cuunfaa istaatistiksii { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = duraa-ilaalcha ibsa herregaa
 math-input-preview = Duraa-ilaalcha
 math-input-invalid-expression = Ibsa sirrii hin taane:
 
-
 ## Document status
 
 viewer-initializing = Jalqabaa jira...
 
-
 ## Errors
 
 error-heading = Dogoggora
-
 error-found-at =
     { $span ->
         [line] Sarara { $startLine } irratti argame.
        *[lines] Sararoota { $startLine }–{ $endLine } irratti argame.
     }
-
 document-contains-errors = Barreeffamni kun dogoggora qaba!
-
 diagnostic-heading-error = Dogoggora
 diagnostic-heading-warning = Akeekkachiisa
 diagnostic-heading-information = Odeeffannoo
 diagnostic-heading-hint = Qajeelfama
-
 accessibility-heading-level-1 = Sarbama Argamummaa WCAG AA
 accessibility-heading-level-2 = Akeekkachiisa argamummaa
-
 something-went-wrong = Wanti tokko sirriitti hin deemne.
-
 renderer-load-failed = agarsiisaan tokko fe'amuu hin dandeenye. Maaloo fuula kana irra deebi'aa fe'aa.
-
 core-start-failed = Agarsiisaan barreeffamaa jalqabuu hin dandeenye. Maaloo fuula kana irra deebi'aa fe'aa.

--- a/packages/i18n/locales/om/content.ftl
+++ b/packages/i18n/locales/om/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = hoomacha
     .pink = biloo
     .brown = magaala
-
 line-width =
     .thick = furdaa
     .thin = qal'aa
-
 line-style =
     .dashed = kutaa-kutaa
     .dotted = tuqaa-tuqaa
-
 # Noun phrases: they follow «waliin» and modify nothing.
 fill-style =
     .horizontal = sarara ciisaa
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = sarara jal'ataa faallaa
     .dots = tuqaalee
     .diamonds = daayimandii
-
 noun =
     .line = sarara
     .line-segment = kutaa sararaa
@@ -74,7 +70,6 @@ noun =
     .diamond = daayimandii
     .cross = fannoo
     .plus = mallattoo ida'uu
-
 # The side count goes in the tail, behind the adjectives: «boca walqixa diimaa
 # rogoota 5 qabu».
 noun-regular-polygon =
@@ -82,11 +77,9 @@ noun-regular-polygon =
         [tail] rogoota { $numSides } qabu
        *[head] boca walqixa
     }
-
 # Every noun this catalog names is masculine — see the header. The feminine
 # exists in the language and simply has no member here yet.
 noun-gender = m
-
 
 ## Style composition
 
@@ -100,21 +93,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = guutame
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } waliin
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } { $pattern } waliin
@@ -122,7 +111,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } { $pattern } waliin
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «daangaa» leads its own adjectives, the same way every noun here does, and
 # «waliin» closes the clause rather than opening it: Oromo is a postpositional
 # language, so the word joining the border to the shape follows the whole
@@ -135,35 +123,28 @@ style-border-clause =
         [and-article] fi daangaa { $border } waliin
        *[with] daangaa { $border } waliin
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = hin guutamne
-
 style-text =
     { $parts ->
         [background] { $color } duubbee { $background } irratti
        *[plain] { $color }
     }
-
 style-background-none = hin jiru
-
 
 ## Boolean words
 
 boolean-true = dhugaa
 boolean-false = soba
 
-
 ## Answer buttons
 
 answer-submit-label = Hojii Ilaali
 answer-submit-label-no-correctness = Deebii Ergi
-
 
 ## Sectional blocks
 
@@ -188,7 +169,6 @@ section-name =
     .solution = Furmaata
     .task = Hojii
     .theorem = Seera
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -198,9 +178,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Qajeelfama
-
 
 ## Tables and figures
 
@@ -211,7 +189,6 @@ table-name =
         [unnumbered-title] Gabatee{ ": " }
        *[unnumbered] Gabatee
     }
-
 figure-name =
     { $parts ->
         [numbered] Fakkii { $enumeration }
@@ -220,15 +197,12 @@ figure-name =
        *[unnumbered] Fakkii
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kan darbe
 paginator-next = Kan itti aanu
 paginator-page = Fuula
-
 paginator-page-status = { $pageLabel } { $currentPage } kan { $numPages }
-
 
 ## Piecewise functions
 
@@ -236,8 +210,8 @@ piecewise-condition-or = yookaan
 piecewise-condition-if = yoo
 piecewise-condition-otherwise = yoo kanaan ta'uu baate
 
-
 ## Chemistry
+
 
 # Oromo is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. Ethiopian
@@ -245,6 +219,5 @@ piecewise-condition-otherwise = yoo kanaan ta'uu baate
 # has reached a classroom to seed from.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Mallattoo Keemikaalaa Sirrii Hin Taane
 chemistry-invalid-ionic-compound = Walmakaa Ayoonii Sirrii Hin Taane

--- a/packages/i18n/locales/or/chrome.ftl
+++ b/packages/i18n/locales/or/chrome.ftl
@@ -22,69 +22,50 @@
 
 answer-checking = ଯାଞ୍ଚ କରାଯାଉଛି...
 answer-submitting = ପଠାଯାଉଛି...
-
 answer-checking-status = ଉତ୍ତର ଯାଞ୍ଚ କରାଯାଉଛି
 answer-submitting-status = ଉତ୍ତର ପଠାଯାଉଛି
-
 answer-correct = ସଠିକ
 answer-incorrect = ଭୁଲ
-
 answer-response-saved = ଉତ୍ତର ସଂରକ୍ଷିତ ହେଲା
-
 answer-percent-credit = { $percent }% ନମ୍ବର
 answer-percent-correct = { $percent }% ସଠିକ
 answer-percent-short = { $percent }%
-
 max-credit-available = ସର୍ବାଧିକ ସମ୍ଭାବ୍ୟ ନମ୍ବର: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] କୌଣସି ପ୍ରୟାସ ବାକି ନାହିଁ
        *[other] { $count } ପ୍ରୟାସ ବାକି
     }
-
 validation-correct = (ସଠିକ)
 validation-incorrect = (ଭୁଲ)
 validation-partially-correct = (ଆଂଶିକ ସଠିକ)
-
 answer-show-responses = { $answerId } ପାଇଁ { $count } ଉତ୍ତର ଦେଖାନ୍ତୁ
-
 
 ## Disclosure panels
 
 feedback-heading = ପ୍ରତିକ୍ରିୟା
-
 collapsible-click-to-open = (ଖୋଲିବାକୁ କ୍ଲିକ କରନ୍ତୁ)
 collapsible-click-to-close = (ବନ୍ଦ କରିବାକୁ କ୍ଲିକ କରନ୍ତୁ)
-
 collapsible-initializing = ଆରମ୍ଭ ହେଉଛି...
-
 footnote-show = ପାଦଟୀକା ଦେଖାନ୍ତୁ
 footnote-hide = ପାଦଟୀକା ଲୁଚାନ୍ତୁ
-
 description-more-information = ଅଧିକ ସୂଚନା
-
 
 ## Controls
 
 slider-previous = ପୂର୍ବବର୍ତ୍ତୀ
 slider-next = ପରବର୍ତ୍ତୀ
-
 keyboard-open = କୀବୋର୍ଡ ଖୋଲନ୍ତୁ
 keyboard-close = କୀବୋର୍ଡ ବନ୍ଦ କରନ୍ତୁ
-
 choice-input-remove-choice = { $choice } ହଟାନ୍ତୁ
-
 matrix-remove-row = ଧାଡ଼ି ହଟାନ୍ତୁ
 matrix-add-row = ଧାଡ଼ି ଯୋଡ଼ନ୍ତୁ
 matrix-remove-column = ସ୍ତମ୍ଭ ହଟାନ୍ତୁ
 matrix-add-column = ସ୍ତମ୍ଭ ଯୋଡ଼ନ୍ତୁ
-
 subset-add-remove-points = ବିନ୍ଦୁ ଯୋଡ଼ନ୍ତୁ/ହଟାନ୍ତୁ
 subset-toggle-points-intervals = ବିନ୍ଦୁ ଓ ଅନ୍ତରାଳ ମଧ୍ୟରେ ବଦଳାନ୍ତୁ
 subset-move-points = ବିନ୍ଦୁ ଘୁଞ୍ଚାନ୍ତୁ
 subset-clear = ଲିଭାନ୍ତୁ
-
 # A `box` here is one orbital, drawn as a square: ଖାନା.
 orbital-add-row = ଧାଡ଼ି ଯୋଡ଼ନ୍ତୁ
 orbital-remove-row = ଧାଡ଼ି ହଟାନ୍ତୁ
@@ -93,13 +74,9 @@ orbital-remove-box = ଖାନା ହଟାନ୍ତୁ
 orbital-add-up-arrow = ଉପର ତୀର ଯୋଡ଼ନ୍ତୁ
 orbital-add-down-arrow = ତଳ ତୀର ଯୋଡ଼ନ୍ତୁ
 orbital-remove-arrow = ତୀର ହଟାନ୍ତୁ
-
 orbital-row-label = ଧାଡ଼ି { $row } ର ଲେବଲ
-
 pretzel-answer = ଉତ୍ତର
-
 summary-statistics-caption = { $column } ର ସାରାଂଶ ପରିସଂଖ୍ୟାନ
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = ଗାଣିତିକ ଅଭିବ୍ୟକ୍ତି
 math-input-preview = ପୂର୍ବାବଲୋକନ
 math-input-invalid-expression = ଅବୈଧ ଅଭିବ୍ୟକ୍ତି:
 
-
 ## Document status
 
 viewer-initializing = ଆରମ୍ଭ ହେଉଛି...
 
-
 ## Errors
 
 error-heading = ତ୍ରୁଟି
-
 error-found-at =
     { $span ->
         [line] { $startLine } ଧାଡ଼ିରେ ମିଳିଲା।
        *[lines] { $startLine }–{ $endLine } ଧାଡ଼ିରେ ମିଳିଲା।
     }
-
 document-contains-errors = ଏହି ଦଲିଲରେ ତ୍ରୁଟି ଅଛି!
-
 diagnostic-heading-error = ତ୍ରୁଟି
 diagnostic-heading-warning = ଚେତାବନୀ
 diagnostic-heading-information = ସୂଚନା
 diagnostic-heading-hint = ସୂଚନା ସଙ୍କେତ
-
 accessibility-heading-level-1 = WCAG AA ଅଭିଗମ୍ୟତା ଉଲ୍ଲଙ୍ଘନ
 accessibility-heading-level-2 = ଅଭିଗମ୍ୟତା ଚେତାବନୀ
-
 something-went-wrong = କିଛି ଭୁଲ ହେଲା।
-
 renderer-load-failed = ଗୋଟିଏ ରେଣ୍ଡରର ଲୋଡ ହୋଇପାରିଲା ନାହିଁ। ଦୟାକରି ପୃଷ୍ଠାଟି ପୁଣି ଲୋଡ କରନ୍ତୁ।
-
 core-start-failed = ଦଲିଲ ଦର୍ଶକ ଆରମ୍ଭ ହୋଇପାରିଲା ନାହିଁ। ଦୟାକରି ପୃଷ୍ଠାଟି ପୁଣି ଲୋଡ କରନ୍ତୁ।

--- a/packages/i18n/locales/or/content.ftl
+++ b/packages/i18n/locales/or/content.ftl
@@ -33,15 +33,12 @@ color =
     .purple = ବାଇଗଣୀ
     .pink = ଗୋଲାପୀ
     .brown = ମାଟିଆ
-
 line-width =
     .thick = ମୋଟା
     .thin = ପତଳା
-
 line-style =
     .dashed = ଛିନ୍ନ
     .dotted = ବିନ୍ଦୁଯୁକ୍ତ
-
 # Noun phrases: they stand in front of the «ସହିତ» the composition messages
 # supply, and modify nothing.
 fill-style =
@@ -51,7 +48,6 @@ fill-style =
     .backdiagonal = ବିପରୀତ କର୍ଣ୍ଣ ରେଖା
     .dots = ବିନ୍ଦୁ
     .diamonds = ହୀରା
-
 noun =
     .line = ସରଳରେଖା
     .line-segment = ରେଖାଖଣ୍ଡ
@@ -71,7 +67,6 @@ noun =
     .diamond = ହୀରା
     .cross = କ୍ରସ ଚିହ୍ନ
     .plus = ଯୋଗ ଚିହ୍ନ
-
 # The side count precedes the noun, as every modifier in Odia does, so it folds
 # into the head and there is no tail.
 noun-regular-polygon =
@@ -79,11 +74,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ବାହୁ ବିଶିଷ୍ଟ ନିୟମିତ ବହୁଭୁଜ
     }
-
 # Odia adjectives take no agreement marking, so every noun answers the same and
 # the answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -97,21 +90,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ପୂରଣ ହୋଇଥିବା
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } ସହିତ
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } ସହିତ
@@ -119,7 +108,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } ସହିତ
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ଧାର» takes the same postposition, and «ଏବଂ» opens the further clause where
 # English opens it with "and". Odia has no article, so the two `-article`
 # branches read like the ones without.
@@ -130,15 +118,12 @@ style-border-clause =
         [and-article] ଏବଂ { $border } ଧାର ସହିତ
        *[with] { $border } ଧାର ସହିତ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ପୂରଣ ନହୋଇଥିବା
-
 # «ପୃଷ୍ଠଭୂମି» takes the locative -ରେ, so the background leads and the text
 # colour follows it.
 style-text =
@@ -146,21 +131,17 @@ style-text =
         [background] { $background } ପୃଷ୍ଠଭୂମିରେ { $color }
        *[plain] { $color }
     }
-
 style-background-none = କିଛି ନାହିଁ
-
 
 ## Boolean words
 
 boolean-true = ସତ
 boolean-false = ମିଥ୍ୟା
 
-
 ## Answer buttons
 
 answer-submit-label = ଯାଞ୍ଚ କରନ୍ତୁ
 answer-submit-label-no-correctness = ଉତ୍ତର ପଠାନ୍ତୁ
-
 
 ## Sectional blocks
 
@@ -185,7 +166,6 @@ section-name =
     .solution = ସମାଧାନ
     .task = କାର୍ଯ୍ୟ
     .theorem = ଉପପାଦ୍ୟ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -195,9 +175,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ସୂଚନା
-
 
 ## Tables and figures
 
@@ -208,7 +186,6 @@ table-name =
         [unnumbered-title] ସାରଣୀ{ ": " }
        *[unnumbered] ସାରଣୀ
     }
-
 figure-name =
     { $parts ->
         [numbered] ଚିତ୍ର { $enumeration }
@@ -217,23 +194,19 @@ figure-name =
        *[unnumbered] ଚିତ୍ର
     }
 
-
 ## Paginator controls
 
 paginator-previous = ପୂର୍ବବର୍ତ୍ତୀ
 paginator-next = ପରବର୍ତ୍ତୀ
 paginator-page = ପୃଷ୍ଠା
-
 # The total leads, marked with «ମଧ୍ୟରୁ», which is how Odia says "3 of 5".
 paginator-page-status = { $numPages } ମଧ୍ୟରୁ { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = କିମ୍ବା
 piecewise-condition-if = ଯଦି
 piecewise-condition-otherwise = ଅନ୍ୟଥା
-
 
 ## Chemistry
 
@@ -360,7 +333,6 @@ element-name =
     .lv = ଲିଭରମୋରିୟମ
     .ts = ଟେନେସିନ
     .og = ଓଗାନେସନ
-
 element-anion-name =
     .h = ହାଇଡ୍ରାଇଡ
     .c = କାର୍ବାଇଡ
@@ -374,8 +346,6 @@ element-anion-name =
     .i = ଆୟୋଡାଇଡ
     .at = ଆଷ୍ଟାଟାଇଡ
     .ts = ଟେନେସାଇଡ
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ଅବୈଧ ରାସାୟନିକ ସଙ୍କେତ
 chemistry-invalid-ionic-compound = ଅବୈଧ ଆୟୋନିକ ଯୌଗିକ

--- a/packages/i18n/locales/os/chrome.ftl
+++ b/packages/i18n/locales/os/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Бæрæг кæны…
 answer-submitting = Арвиты…
-
 answer-checking-status = Дзуапп бæрæг кæны
 answer-submitting-status = Дзуапп арвиты
-
 answer-correct = Раст
 answer-incorrect = Раст нæу
-
 answer-response-saved = Дзуапп бавæрд
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% раст
 answer-percent-short = { $percent } %
-
 max-credit-available = Райсæн ис фылдæр балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] фæлварæн нал баззад
         [one] { $count } фæлварæн баззад
        *[other] { $count } фæлварæн баззад
     }
-
 validation-correct = (Раст)
 validation-incorrect = (Раст нæу)
 validation-partially-correct = (Хайыл раст)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId }-мæ { $count } дзуапп равдисын
        *[other] { $answerId }-мæ { $count } дзуапп равдисын
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Фæстæмæ дзуапп
-
 collapsible-click-to-open = (байгом кæнынæн ныххæц)
 collapsible-click-to-close = (æхгæнынæн ныххæц)
-
 collapsible-initializing = Цæттæ кæны…
-
 footnote-show = Фиппаинаг равдисын
 footnote-hide = Фиппаинаг бамбæхсын
-
 description-more-information = фылдæр информаци
-
 
 ## Controls
 
 slider-previous = Разæй
 slider-next = Дарддæр
-
 keyboard-open = Клавиатурæ байгом кæнын
 keyboard-close = Клавиатурæ æхгæнын
-
 choice-input-remove-choice = { $choice } æвзарæн аппарын
-
 matrix-remove-row = Рæнхъ аппарын
 matrix-add-row = Рæнхъ бафтауын
 matrix-remove-column = Цæджындз аппарын
 matrix-add-column = Цæджындз бафтауын
-
 subset-add-remove-points = Стъæлф бафтауын/аппарын
 subset-toggle-points-intervals = Стъæлфытæ æмæ интервалтæ ивын
 subset-move-points = Стъæлфытæ аивын
 subset-clear = Ссыгъдæг кæнын
-
 orbital-add-row = Рæнхъ бафтауын
 orbital-remove-row = Рæнхъ аппарын
 orbital-add-box = Клеткæ бафтауын
@@ -91,13 +72,9 @@ orbital-remove-box = Клеткæ аппарын
 orbital-add-up-arrow = Уæлæмæ фат бафтауын
 orbital-add-down-arrow = Дæлæмæ фат бафтауын
 orbital-remove-arrow = Фат аппарын
-
 orbital-row-label = { $row } рæнхъы нысан
-
 pretzel-answer = Дзуапп
-
 summary-statistics-caption = { $column } цæджындзы фæстаг статистикæ
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = математикон æвдисæны разæй �
 math-input-preview = Разæй фенын
 math-input-invalid-expression = Раст нæу æвдисæн:
 
-
 ## Document status
 
 viewer-initializing = Цæттæ кæны…
 
-
 ## Errors
 
 error-heading = Рæдыд
-
 error-found-at =
     { $span ->
         [line] Ссард рæнхъ: { $startLine }.
        *[lines] Ссард рæнхъытæ: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ацы документы рæдыдтытæ ис!
-
 diagnostic-heading-error = Рæдыд
 diagnostic-heading-warning = Фæдзæхст
 diagnostic-heading-information = Информаци
 diagnostic-heading-hint = Амынд
-
 accessibility-heading-level-1 = WCAG AA бахæццæйы халд
 accessibility-heading-level-2 = Бахæццæйы тыххæй хъусынгæнинаг
-
 something-went-wrong = Исты раст нæ рауад.
-
 renderer-load-failed = нывгæнæг æрбавгæрдын нæ бантыст. Фарс ногæй байгом кæн.
-
 core-start-failed = Документы уынæг сыздæхын нæ бантыст. Фарс ногæй байгом кæн.

--- a/packages/i18n/locales/os/content.ftl
+++ b/packages/i18n/locales/os/content.ftl
@@ -46,15 +46,12 @@ color =
     .purple = фиолетон
     .pink = розæхуыз
     .brown = морæ
-
 line-width =
     .thick = бæзджын
     .thin = тæнæг
-
 line-style =
     .dashed = скъуыдтæ
     .dotted = стъæлфытимæ
-
 # Noun phrases: they stand in front of «нывимæ» and modify nothing.
 fill-style =
     .horizontal = горизонталон хахх
@@ -63,7 +60,6 @@ fill-style =
     .backdiagonal = ныхмæ диагоналон хахх
     .dots = стъæлф
     .diamonds = ромб
-
 noun =
     .line = раст хахх
     .line-segment = хахххай
@@ -83,7 +79,6 @@ noun =
     .diamond = ромб
     .cross = дзуар
     .plus = плюс
-
 # Ossetian builds the word from the side count in front of the noun, so the
 # whole of it is one head and there is no tail.
 noun-regular-polygon =
@@ -91,11 +86,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] раст { $numSides }-къуымон
     }
-
 # Ossetian has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -109,21 +102,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ахуырст
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } нывимæ { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } нывимæ { $color } { $filled } { $noun }
@@ -131,7 +120,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } нывимæ { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «кæронимæ» — "with an edge" — is written after the colour word this catalog
 # supplies, so the comitative suffix lands on a noun of its own rather than on
 # a placeable, and neither a preposition nor an article is wanted.
@@ -142,15 +130,12 @@ style-border-clause =
         [and-article] æмæ { $border } кæронимæ
        *[with] { $border } кæронимæ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } нывимæ { $color } ахорæн
        *[plain] { $color } ахорæн
     }
-
 style-unfilled = ахуырст нæу
-
 # «уæлæ» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.
 style-text =
@@ -158,21 +143,17 @@ style-text =
         [background] { $background } фон уæлæ { $color }
        *[plain] { $color }
     }
-
 style-background-none = нæй
-
 
 ## Boolean words
 
 boolean-true = раст
 boolean-false = раст нæу
 
-
 ## Answer buttons
 
 answer-submit-label = Бабæрæг кæнын
 answer-submit-label-no-correctness = Дзуапп арвитын
-
 
 ## Sectional blocks
 
@@ -197,7 +178,6 @@ section-name =
     .solution = Раиртасæн
     .task = Хæслæвæрд
     .theorem = Теоремæ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -207,9 +187,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Амынд
-
 
 ## Tables and figures
 
@@ -220,7 +198,6 @@ table-name =
         [unnumbered-title] Таблицæ{ ". " }
        *[unnumbered] Таблицæ
     }
-
 figure-name =
     { $parts ->
         [numbered] Ныв { $enumeration }
@@ -229,15 +206,12 @@ figure-name =
        *[unnumbered] Ныв
     }
 
-
 ## Paginator controls
 
 paginator-previous = Разæй
 paginator-next = Дарддæр
 paginator-page = Фарс
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -250,7 +224,6 @@ piecewise-condition-or = кæнæ
 piecewise-condition-if = кæд
 piecewise-condition-otherwise = æндæр хуызы
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -261,6 +234,5 @@ piecewise-condition-otherwise = æндæр хуызы
 ## rather than one.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Раст нæу химион нысан
 chemistry-invalid-ionic-compound = Раст нæу ионон баиу

--- a/packages/i18n/locales/pa/chrome.ftl
+++ b/packages/i18n/locales/pa/chrome.ftl
@@ -24,74 +24,55 @@
 
 answer-checking = ਜਾਂਚ ਹੋ ਰਹੀ ਹੈ...
 answer-submitting = ਭੇਜਿਆ ਜਾ ਰਿਹਾ ਹੈ...
-
 answer-checking-status = ਜਵਾਬ ਦੀ ਜਾਂਚ ਹੋ ਰਹੀ ਹੈ
 answer-submitting-status = ਜਵਾਬ ਭੇਜਿਆ ਜਾ ਰਿਹਾ ਹੈ
-
 answer-correct = ਸਹੀ
 answer-incorrect = ਗਲਤ
-
 answer-response-saved = ਜਵਾਬ ਸਾਂਭ ਲਿਆ
-
 answer-percent-credit = { $percent }% ਅੰਕ
 answer-percent-correct = { $percent }% ਸਹੀ
 answer-percent-short = { $percent }%
-
 max-credit-available = ਵੱਧ ਤੋਂ ਵੱਧ ਸੰਭਵ ਅੰਕ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ਕੋਈ ਕੋਸ਼ਿਸ਼ ਬਾਕੀ ਨਹੀਂ
         [one] { $count } ਕੋਸ਼ਿਸ਼ ਬਾਕੀ
        *[other] { $count } ਕੋਸ਼ਿਸ਼ਾਂ ਬਾਕੀ
     }
-
 validation-correct = (ਸਹੀ)
 validation-incorrect = (ਗਲਤ)
 validation-partially-correct = (ਅੰਸ਼ਕ ਤੌਰ ’ਤੇ ਸਹੀ)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } ਦਾ { $count } ਜਵਾਬ ਵਿਖਾਓ
        *[other] { $answerId } ਦੇ { $count } ਜਵਾਬ ਵਿਖਾਓ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ਪ੍ਰਤੀਕਰਮ
-
 collapsible-click-to-open = (ਖੋਲ੍ਹਣ ਲਈ ਕਲਿੱਕ ਕਰੋ)
 collapsible-click-to-close = (ਬੰਦ ਕਰਨ ਲਈ ਕਲਿੱਕ ਕਰੋ)
-
 collapsible-initializing = ਸ਼ੁਰੂ ਹੋ ਰਿਹਾ ਹੈ...
-
 footnote-show = ਫੁਟਨੋਟ ਵਿਖਾਓ
 footnote-hide = ਫੁਟਨੋਟ ਲੁਕਾਓ
-
 description-more-information = ਹੋਰ ਜਾਣਕਾਰੀ
-
 
 ## Controls
 
 slider-previous = ਪਿਛਲਾ
 slider-next = ਅਗਲਾ
-
 keyboard-open = ਕੀ-ਬੋਰਡ ਖੋਲ੍ਹੋ
 keyboard-close = ਕੀ-ਬੋਰਡ ਬੰਦ ਕਰੋ
-
 choice-input-remove-choice = { $choice } ਹਟਾਓ
-
 matrix-remove-row = ਕਤਾਰ ਹਟਾਓ
 matrix-add-row = ਕਤਾਰ ਜੋੜੋ
 matrix-remove-column = ਕਾਲਮ ਹਟਾਓ
 matrix-add-column = ਕਾਲਮ ਜੋੜੋ
-
 subset-add-remove-points = ਬਿੰਦੂ ਜੋੜੋ/ਹਟਾਓ
 subset-toggle-points-intervals = ਬਿੰਦੂਆਂ ਅਤੇ ਅੰਤਰਾਲਾਂ ਵਿਚਕਾਰ ਬਦਲੋ
 subset-move-points = ਬਿੰਦੂ ਸਰਕਾਓ
 subset-clear = ਮਿਟਾਓ
-
 # A `box` here is one orbital, drawn as a square: ਖਾਨਾ.
 orbital-add-row = ਕਤਾਰ ਜੋੜੋ
 orbital-remove-row = ਕਤਾਰ ਹਟਾਓ
@@ -100,13 +81,9 @@ orbital-remove-box = ਖਾਨਾ ਹਟਾਓ
 orbital-add-up-arrow = ਉੱਪਰਲਾ ਤੀਰ ਜੋੜੋ
 orbital-add-down-arrow = ਹੇਠਲਾ ਤੀਰ ਜੋੜੋ
 orbital-remove-arrow = ਤੀਰ ਹਟਾਓ
-
 orbital-row-label = ਕਤਾਰ { $row } ਦਾ ਲੇਬਲ
-
 pretzel-answer = ਜਵਾਬ
-
 summary-statistics-caption = { $column } ਦੇ ਸਾਰ ਅੰਕੜੇ
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = ਗਣਿਤ ਸਮੀਕਰਨ ਦੀ ਝਲਕ
 math-input-preview = ਝਲਕ
 math-input-invalid-expression = ਗਲਤ ਸਮੀਕਰਨ:
 
-
 ## Document status
 
 viewer-initializing = ਸ਼ੁਰੂ ਹੋ ਰਿਹਾ ਹੈ...
 
-
 ## Errors
 
 error-heading = ਗਲਤੀ
-
 error-found-at =
     { $span ->
         [line] ਸਤਰ { $startLine } ਉੱਤੇ ਮਿਲੀ।
        *[lines] ਸਤਰ { $startLine }–{ $endLine } ਉੱਤੇ ਮਿਲੀ।
     }
-
 document-contains-errors = ਇਸ ਦਸਤਾਵੇਜ਼ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ!
-
 diagnostic-heading-error = ਗਲਤੀ
 diagnostic-heading-warning = ਚੇਤਾਵਨੀ
 diagnostic-heading-information = ਜਾਣਕਾਰੀ
 diagnostic-heading-hint = ਸੰਕੇਤ
-
 accessibility-heading-level-1 = WCAG AA ਪਹੁੰਚਯੋਗਤਾ ਉਲੰਘਣਾ
 accessibility-heading-level-2 = ਪਹੁੰਚਯੋਗਤਾ ਚੇਤਾਵਨੀ
-
 something-went-wrong = ਕੁਝ ਗਲਤ ਹੋ ਗਿਆ।
-
 renderer-load-failed = ਇੱਕ ਰੈਂਡਰਰ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕਿਆ। ਕਿਰਪਾ ਕਰਕੇ ਸਫ਼ਾ ਮੁੜ ਲੋਡ ਕਰੋ।
-
 core-start-failed = ਦਸਤਾਵੇਜ਼ ਦਰਸ਼ਕ ਸ਼ੁਰੂ ਨਹੀਂ ਹੋ ਸਕਿਆ। ਕਿਰਪਾ ਕਰਕੇ ਸਫ਼ਾ ਮੁੜ ਲੋਡ ਕਰੋ।

--- a/packages/i18n/locales/pa/content.ftl
+++ b/packages/i18n/locales/pa/content.ftl
@@ -100,7 +100,6 @@ color =
                    *[m] ਭੂਰਾ
                 }
         }
-
 # No `$role` fork on these two or on `line-style` below, unlike the colours: a
 # width and a dash pattern are only ever said of a stroke, which is placed
 # `standalone` or in `border-clause` and never in the one clause position that
@@ -116,7 +115,6 @@ line-width =
             [f] ਪਤਲੀ
            *[m] ਪਤਲਾ
         }
-
 # ਬਿੰਦੀਦਾਰ ends in a consonant and never changes; ਟੁੱਟਵਾਂ does.
 line-style =
     .dashed =
@@ -125,7 +123,6 @@ line-style =
            *[m] ਟੁੱਟਵਾਂ
         }
     .dotted = ਬਿੰਦੀਦਾਰ
-
 # Noun phrases: they stand in front of the «ਨਾਲ» the composition messages
 # supply, or in front of the «ਵਾਲੀ» in `style-fill`, and agree with nothing
 # themselves.
@@ -136,7 +133,6 @@ fill-style =
     .backdiagonal = ਉਲਟ ਵਿਕਰਣ ਲਕੀਰਾਂ
     .dots = ਬਿੰਦੀਆਂ
     .diamonds = ਹੀਰੇ
-
 noun =
     .line = ਰੇਖਾ
     .line-segment = ਰੇਖਾਖੰਡ
@@ -156,7 +152,6 @@ noun =
     .diamond = ਹੀਰਾ
     .cross = ਕਾਟਾ
     .plus = ਜਮ੍ਹਾਂ ਚਿੰਨ੍ਹ
-
 # The side count precedes the noun, as every modifier in Punjabi does, so it
 # folds into the head and there is no tail.
 noun-regular-polygon =
@@ -164,7 +159,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ਭੁਜਾਵਾਂ ਵਾਲਾ ਨਿਯਮਿਤ ਬਹੁਭੁਜ
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (ਬਹੁਭੁਜ, m) or the
 # head of a phrase: `border` (ਕਿਨਾਰੀ, f), `fill` (ਭਰਾਈ, f), `text` (ਲਿਖਤ, f),
 # `background` (ਪਿਛੋਕੜ, m). English leaves all four unnamed; the composition
@@ -181,7 +175,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -194,26 +187,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Said only of the shape itself, so it takes no `$role` branch.
 style-filled-word =
     { $gender ->
         [f] ਭਰੀ
        *[m] ਭਰਿਆ
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern } ਨਾਲ
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern } ਨਾਲ
@@ -221,7 +210,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } ਨਾਲ
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ਕਿਨਾਰੀ» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Punjabi has no article, so the two `-article`
 # branches read like the ones without.
@@ -232,7 +220,6 @@ style-border-clause =
         [and-article] ਅਤੇ { $border } ਕਿਨਾਰੀ ਨਾਲ
        *[with] { $border } ਕਿਨਾਰੀ ਨਾਲ
     }
-
 # The colour arrives agreeing with `fill`, which `noun-gender` answers feminine
 # — but the pattern words are plural nouns of their own gender (ਹੀਰੇ m), so
 # putting the colour straight in front of one would disagree with it. So the
@@ -243,12 +230,10 @@ style-fill =
         [pattern] { $pattern } ਵਾਲੀ { $color } ਭਰਾਈ
        *[plain] { $color } ਭਰਾਈ
     }
-
 # The other answer the same variable gives, and it takes no `$gender`, so it
 # names the noun rather than inflecting an adjective for a gender it was not
 # told — as «बिना भराव» does in `hi`.
 style-unfilled = ਬਿਨਾਂ ਭਰਾਈ
-
 # «ਪਿਛੋਕੜ» is masculine and takes the postposition «ਉੱਤੇ», which is what puts
 # its colour in the oblique.
 style-text =
@@ -256,21 +241,17 @@ style-text =
         [background] { $background } ਪਿਛੋਕੜ ਉੱਤੇ { $color }
        *[plain] { $color }
     }
-
 style-background-none = ਕੋਈ ਨਹੀਂ
-
 
 ## Boolean words
 
 boolean-true = ਸਹੀ
 boolean-false = ਗਲਤ
 
-
 ## Answer buttons
 
 answer-submit-label = ਜਾਂਚੋ
 answer-submit-label-no-correctness = ਜਵਾਬ ਭੇਜੋ
-
 
 ## Sectional blocks
 
@@ -295,7 +276,6 @@ section-name =
     .solution = ਹੱਲ
     .task = ਕਾਰਜ
     .theorem = ਪ੍ਰਮੇਯ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -305,9 +285,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ਸੰਕੇਤ
-
 
 ## Tables and figures
 
@@ -318,7 +296,6 @@ table-name =
         [unnumbered-title] ਸਾਰਣੀ{ ": " }
        *[unnumbered] ਸਾਰਣੀ
     }
-
 figure-name =
     { $parts ->
         [numbered] ਚਿੱਤਰ { $enumeration }
@@ -327,16 +304,13 @@ figure-name =
        *[unnumbered] ਚਿੱਤਰ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ਪਿਛਲਾ
 paginator-next = ਅਗਲਾ
 paginator-page = ਸਫ਼ਾ
-
 # The total leads, marked with «ਵਿੱਚੋਂ», which is how Punjabi says "3 of 5".
 paginator-page-status = { $numPages } ਵਿੱਚੋਂ { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
@@ -344,8 +318,8 @@ piecewise-condition-or = ਜਾਂ
 piecewise-condition-if = ਜੇ
 piecewise-condition-otherwise = ਨਹੀਂ ਤਾਂ
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and the 130
 # keys fall back to English.
@@ -359,6 +333,5 @@ piecewise-condition-otherwise = ਨਹੀਂ ਤਾਂ
 # `lint:i18n` reports the gap until a chemist who writes Punjabi supplies them.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ਗਲਤ ਰਸਾਇਣਕ ਚਿੰਨ੍ਹ
 chemistry-invalid-ionic-compound = ਗਲਤ ਆਇਓਨਿਕ ਯੌਗਿਕ

--- a/packages/i18n/locales/pam/chrome.ftl
+++ b/packages/i18n/locales/pam/chrome.ftl
@@ -29,21 +29,15 @@
 
 answer-checking = Sisiyasat…
 answer-submitting = Ipapadala…
-
 answer-checking-status = Sisiyasat ya ing pakibat
 answer-submitting-status = Ipapadala ne ing pakibat
-
 answer-correct = Tama
 answer-incorrect = Ali tama
-
 answer-response-saved = Meimbak ne ing pakibat
-
 answer-percent-credit = { $percent }% a kredito
 answer-percent-correct = { $percent }% a tama
 answer-percent-short = { $percent } %
-
 max-credit-available = Kamaragulan a kreditong makakuha: { $percent }%
-
 # No select: «subuk» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -51,51 +45,38 @@ attempts-remaining =
         [0] alang natad a subuk
        *[other] { $count } a subuk ing natad
     }
-
 validation-correct = (Tama)
 validation-incorrect = (Ali tama)
 validation-partially-correct = (Tama king dake)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Ipakit ing { $count } a pakibat para king { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komento
-
 collapsible-click-to-open = (i-klik ban mabuklat)
 collapsible-click-to-close = (i-klik ban masara)
-
 collapsible-initializing = Migsisimula…
-
 footnote-show = Ipakit ing footnote
 footnote-hide = Isalikut ing footnote
-
 description-more-information = dagdag a impormasyon
-
 
 ## Controls
 
 slider-previous = Milabas
 slider-next = Tutuki
-
 keyboard-open = Buklat ing teklado
 keyboard-close = Isara ing teklado
-
 choice-input-remove-choice = Alilan ing { $choice }
-
 matrix-remove-row = Alilan ing gulis
 matrix-add-row = Dagdagan pang gulis
 matrix-remove-column = Alilan ing haligi
 matrix-add-column = Dagdagan pang haligi
-
 subset-add-remove-points = Pagdagdag/Pag-alis da reng punto
 subset-toggle-points-intervals = Pamalit da reng punto at interbalo
 subset-move-points = Igalo la reng punto
 subset-clear = Linisan
-
 orbital-add-row = Dagdagan pang gulis
 orbital-remove-row = Alilan ing gulis
 orbital-add-box = Dagdagan pang kaha
@@ -103,13 +84,9 @@ orbital-remove-box = Alilan ing kaha
 orbital-add-up-arrow = Dagdagan pang panang paitas
 orbital-add-down-arrow = Dagdagan pang panang palalam
 orbital-remove-arrow = Alilan ing pana
-
 orbital-row-label = Etiketa para king gulis { $row }
-
 pretzel-answer = Pakibat
-
 summary-statistics-caption = Buung estadistika ning { $column }
-
 
 ## Math input
 
@@ -117,34 +94,25 @@ math-input-preview-region = mumunang pamanakit king ekspresyon a matematika
 math-input-preview = Mumunang pamanakit
 math-input-invalid-expression = Ali balido a ekspresyon:
 
-
 ## Document status
 
 viewer-initializing = Migsisimula…
 
-
 ## Errors
 
 error-heading = Kamalian
-
 error-found-at =
     { $span ->
         [line] Mekit king gulis { $startLine }.
        *[lines] Mekit karing gulis { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Atin kamalian ining dokumento!
-
 diagnostic-heading-error = Kamalian
 diagnostic-heading-warning = Babala
 diagnostic-heading-information = Impormasyon
 diagnostic-heading-hint = Giya
-
 accessibility-heading-level-1 = Pamanlabag king aksesibilidad a WCAG AA
 accessibility-heading-level-2 = Babala tungkul king aksesibilidad
-
 something-went-wrong = Atin bageng mekamali.
-
 renderer-load-failed = atin renderer a ali me-load. Pakisuyung i-reload ing bulung.
-
 core-start-failed = Ali me-umpisan ing pamanakit king dokumento. Pakisuyung i-reload ing bulung.

--- a/packages/i18n/locales/pam/content.ftl
+++ b/packages/i18n/locales/pam/content.ftl
@@ -45,15 +45,12 @@ color =
     .purple = lila
     .pink = rosas
     .brown = kape
-
 line-width =
     .thick = makapal
     .thin = manipis
-
 line-style =
     .dashed = putul-putul
     .dotted = tuldik-tuldik
-
 # Noun phrases. Kapampangan marks no plural on the noun, so «gulis» is the word
 # for one line and for many alike.
 fill-style =
@@ -63,7 +60,6 @@ fill-style =
     .backdiagonal = kabaligtaran a mihilis a gulis
     .dots = tuldik
     .diamonds = diyamante
-
 noun =
     .line = linya
     .line-segment = segmento
@@ -83,16 +79,13 @@ noun =
     .diamond = diyamante
     .cross = krus
     .plus = plus
-
 noun-regular-polygon =
     { $part ->
         [tail] a atin { $numSides } a gilid
        *[head] regular a poligono
     }
-
 # One answer for every noun: Kapampangan has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,21 +100,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } a { $noun } { $nounTail }
        *[noun] { $description } a { $noun }
     }
-
 style-filled-word = mitmo
-
 style-filled =
     { $parts ->
         [pattern] { $filled } a { $color } a atin { $pattern }
        *[plain] { $filled } a { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } a { $color } a { $noun } a atin { $pattern }
@@ -129,7 +118,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } a { $color } a { $noun } { $nounTail } a atin { $pattern }
        *[plain] { $filled } a { $color } a { $noun }
     }
-
 # Kapampangan has no article, so the two `-article` branches say what the other
 # two say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «a atin» against «at».
@@ -140,35 +128,28 @@ style-border-clause =
         [and-article] at { $border } a gilid
        *[with] a atin { $border } a gilid
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } a { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ali mitmo
-
 style-text =
     { $parts ->
         [background] { $color } a atin { $background } a background
        *[plain] { $color }
     }
-
 style-background-none = ala
-
 
 ## Boolean words
 
 boolean-true = tutu
 boolean-false = ali tutu
 
-
 ## Answer buttons
 
 answer-submit-label = Siyasatan ing pakibat
 answer-submit-label-no-correctness = Ipadala ing pakibat
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = Solusyon
     .task = Dapat
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Giya
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] Talaan{ ": " }
        *[unnumbered] Talaan
     }
-
 figure-name =
     { $parts ->
         [numbered] Pigura { $enumeration }
@@ -228,22 +205,18 @@ figure-name =
        *[unnumbered] Pigura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Milabas
 paginator-next = Tutuki
 paginator-page = Bulung
-
 paginator-page-status = { $pageLabel } { $currentPage } king { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = nung
 piecewise-condition-otherwise = nung ali
-
 
 ## Chemistry
 ##
@@ -254,6 +227,5 @@ piecewise-condition-otherwise = nung ali
 ## keys out.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ali balido a simbolong kemikal
 chemistry-invalid-ionic-compound = Ali balido a kompuwestong ioniko

--- a/packages/i18n/locales/pcm/chrome.ftl
+++ b/packages/i18n/locales/pcm/chrome.ftl
@@ -13,74 +13,55 @@
 
 answer-checking = Dey chẹk…
 answer-submitting = Dey sẹnd…
-
 answer-checking-status = Wi dey chẹk di ansa
 answer-submitting-status = Wi dey sẹnd di ansa
-
 answer-correct = E korẹkt
 answer-incorrect = E no korẹkt
-
 answer-response-saved = Wi Don Sev Yọ Ansa
-
 answer-percent-credit = { $percent }% Krẹdit
 answer-percent-correct = { $percent }% Korẹkt
 answer-percent-short = { $percent } %
-
 max-credit-available = Di mọst krẹdit wey yu fit gẹt: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] no tray rẹmen
         [one] { $count } tray rẹmen
        *[other] { $count } tray rẹmen
     }
-
 validation-correct = (E korẹkt)
 validation-incorrect = (E no korẹkt)
 validation-partially-correct = (E korẹkt smọl)
-
 answer-show-responses =
     { $count ->
         [one] Sho { $count } ansa fọ { $answerId }
        *[other] Sho { $count } ansa fọ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Fidbak
-
 collapsible-click-to-open = (klik make e opin)
 collapsible-click-to-close = (klik make e klos)
-
 collapsible-initializing = E dey stat…
-
 footnote-show = Sho di fut-not
 footnote-hide = Haid di fut-not
-
 description-more-information = mọ infọmeshọn
-
 
 ## Controls
 
 slider-previous = Wan Wey Pass
 slider-next = Nẹks
-
 keyboard-open = Opin Kibọd
 keyboard-close = Klos Kibọd
-
 choice-input-remove-choice = Rimuv { $choice }
-
 matrix-remove-row = Rimuv ro
 matrix-add-row = Add ro
 matrix-remove-column = Rimuv kọlum
 matrix-add-column = Add kọlum
-
 subset-add-remove-points = Add/Rimuv point dem
 subset-toggle-points-intervals = Switch bitwin point an intaval
 subset-move-points = Muv Point Dem
 subset-clear = Kliar
-
 orbital-add-row = Add Ro
 orbital-remove-row = Rimuv Ro
 orbital-add-box = Add Bọks
@@ -88,13 +69,9 @@ orbital-remove-box = Rimuv Bọks
 orbital-add-up-arrow = Add Aro Wey Fes Ọp
 orbital-add-down-arrow = Add Aro Wey Fes Daun
 orbital-remove-arrow = Rimuv Aro
-
 orbital-row-label = Nem fọ ro { $row }
-
 pretzel-answer = Ansa
-
 summary-statistics-caption = Sọmari statistiks fọ { $column }
-
 
 ## Math input
 
@@ -102,34 +79,25 @@ math-input-preview-region = privyu of di mat ẹkspreshọn
 math-input-preview = Privyu
 math-input-invalid-expression = Ẹkspreshọn wey no korẹkt:
 
-
 ## Document status
 
 viewer-initializing = E dey stat…
 
-
 ## Errors
 
 error-heading = Ẹra
-
 error-found-at =
     { $span ->
         [line] Wi si am fọ lain { $startLine }.
        *[lines] Wi si am fọ lain { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dis dọkyumẹnt gẹt ẹra insai am!
-
 diagnostic-heading-error = Ẹra
 diagnostic-heading-warning = Wọnin
 diagnostic-heading-information = Infọ
 diagnostic-heading-hint = Hint
-
 accessibility-heading-level-1 = WCAG AA Aksẹsibiliti Vayolashọn
 accessibility-heading-level-2 = Aksẹsibiliti alat
-
 something-went-wrong = Sọmtin no go wẹl.
-
 renderer-load-failed = wan rẹndara no lod. Abeg rilod di pej.
-
 core-start-failed = Di dọkyumẹnt viwa no fit stat. Abeg rilod di pej.

--- a/packages/i18n/locales/pcm/content.ftl
+++ b/packages/i18n/locales/pcm/content.ftl
@@ -61,11 +61,9 @@ color =
     .purple = purple
     .pink = pink
     .brown = brown
-
 line-width =
     .thick = thick
     .thin = thin
-
 # Reduplication used attributively, which is how Naijá makes a modifier out of
 # a verb without building a relative clause. A «wey dey brok-brok» clause would
 # be the more literal rendering and is wrong here: the description is *followed*
@@ -74,7 +72,6 @@ line-width =
 line-style =
     .dashed = brok-brok
     .dotted = dot-dot
-
 fill-style =
     .horizontal = lain wey lie down
     .vertical = lain wey stand up
@@ -82,7 +79,6 @@ fill-style =
     .backdiagonal = lain wey slant di oda way
     .dots = dot dem
     .diamonds = daimon dem
-
 noun =
     .line = lain
     .line-segment = pis of lain
@@ -102,7 +98,6 @@ noun =
     .diamond = daimon
     .cross = kros
     .plus = plọs mak
-
 # The side count is a relative clause and closes the noun phrase behind the
 # describing words rather than opening it, so it goes in the tail — the same
 # place `locales/tiv` puts its own.
@@ -111,11 +106,9 @@ noun-regular-polygon =
         [tail] wey gẹt { $numSides } sait
        *[head] poligọn wey ẹvri sait dey di sem
     }
-
 # Nigerian Pidgin has no noun class and no gender, so every noun answers the
 # same and the answer goes unused.
 noun-gender = wan
-
 
 ## Style composition
 
@@ -132,23 +125,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «don full» — the completive `don` rather than an English passive. There is no
 # adjective here to inflect; the whole word is a verb phrase.
 style-filled-word = don full
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } wit { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } wit { $pattern }
@@ -156,7 +145,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wit { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Naijá has no indefinite article where English wants one here, so the
 # `-article` branches read the same as their bare counterparts. The distinction
 # `$parts` carries is still a real one — «wit» opens a clause and «an» chains a
@@ -168,23 +156,18 @@ style-border-clause =
         [and-article] an { $border } bọda
        *[with] wit { $border } bọda
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = e no full
-
 style-text =
     { $parts ->
         [background] { $color } wit { $background } bakgraun
        *[plain] { $color }
     }
-
 style-background-none = nọtin
-
 
 ## Boolean words
 ##
@@ -195,12 +178,10 @@ style-background-none = nọtin
 boolean-true = na tru
 boolean-false = na lai
 
-
 ## Answer buttons
 
 answer-submit-label = Chẹk Wọk
 answer-submit-label-no-correctness = Sẹnd Ansa
-
 
 ## Sectional blocks
 
@@ -225,7 +206,6 @@ section-name =
     .solution = Solushọn
     .task = Task
     .theorem = Tiọrẹm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -235,9 +215,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Hint
-
 
 ## Tables and figures
 
@@ -248,7 +226,6 @@ table-name =
         [unnumbered-title] Tebul{ ": " }
        *[unnumbered] Tebul
     }
-
 figure-name =
     { $parts ->
         [numbered] Figọ { $enumeration }
@@ -257,25 +234,18 @@ figure-name =
        *[unnumbered] Figọ
     }
 
-
 ## Paginator controls
 
 paginator-previous = Wan Wey Pass
 paginator-next = Nẹks
-
 paginator-page = Pej
-
 paginator-page-status = { $pageLabel } { $currentPage } fọ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ọ
-
 piecewise-condition-if = if
-
 piecewise-condition-otherwise = if no bi so
-
 
 ## Chemistry
 ##
@@ -290,6 +260,5 @@ piecewise-condition-otherwise = if no bi so
 ## `locales/yo` and `locales/tiv` leave the same gap for the same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kẹmistri Simbọl Wey No Korẹkt
 chemistry-invalid-ionic-compound = Ayọnik Kompaun Wey No Korẹkt

--- a/packages/i18n/locales/pl/chrome.ftl
+++ b/packages/i18n/locales/pl/chrome.ftl
@@ -21,21 +21,15 @@
 
 answer-checking = Sprawdzanie...
 answer-submitting = Wysyłanie...
-
 answer-checking-status = Sprawdzanie odpowiedzi
 answer-submitting-status = Wysyłanie odpowiedzi
-
 answer-correct = Poprawnie
 answer-incorrect = Niepoprawnie
-
 answer-response-saved = Odpowiedź zapisana
-
 answer-percent-credit = { $percent }% punktów
 answer-percent-correct = { $percent }% poprawnie
 answer-percent-short = { $percent }%
-
 max-credit-available = Maksymalny dostępny wynik: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] brak pozostałych prób
@@ -44,11 +38,9 @@ attempts-remaining =
         [many] pozostało { $count } prób
        *[other] pozostało { $count } próby
     }
-
 validation-correct = (Poprawnie)
 validation-incorrect = (Niepoprawnie)
 validation-partially-correct = (Częściowo poprawnie)
-
 answer-show-responses =
     { $count ->
         [one] Pokaż { $count } odpowiedź na { $answerId }
@@ -57,42 +49,31 @@ answer-show-responses =
        *[other] Pokaż { $count } odpowiedzi na { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Informacja zwrotna
-
 collapsible-click-to-open = (kliknij, aby otworzyć)
 collapsible-click-to-close = (kliknij, aby zamknąć)
-
 collapsible-initializing = Inicjowanie...
-
 footnote-show = Pokaż przypis
 footnote-hide = Ukryj przypis
-
 description-more-information = więcej informacji
-
 
 ## Controls
 
 slider-previous = Poprzedni
 slider-next = Następny
-
 keyboard-open = Otwórz klawiaturę
 keyboard-close = Zamknij klawiaturę
-
 choice-input-remove-choice = Usuń { $choice }
-
 matrix-remove-row = Usuń wiersz
 matrix-add-row = Dodaj wiersz
 matrix-remove-column = Usuń kolumnę
 matrix-add-column = Dodaj kolumnę
-
 subset-add-remove-points = Dodaj/usuń punkty
 subset-toggle-points-intervals = Przełącz punkty i przedziały
 subset-move-points = Przesuń punkty
 subset-clear = Wyczyść
-
 # A `box` here is one orbital, drawn as a square: klatka.
 orbital-add-row = Dodaj wiersz
 orbital-remove-row = Usuń wiersz
@@ -101,13 +82,9 @@ orbital-remove-box = Usuń klatkę
 orbital-add-up-arrow = Dodaj strzałkę w górę
 orbital-add-down-arrow = Dodaj strzałkę w dół
 orbital-remove-arrow = Usuń strzałkę
-
 orbital-row-label = Etykieta wiersza { $row }
-
 pretzel-answer = Odpowiedź
-
 summary-statistics-caption = Statystyki opisowe dla { $column }
-
 
 ## Math input
 
@@ -115,34 +92,25 @@ math-input-preview-region = podgląd wyrażenia matematycznego
 math-input-preview = Podgląd
 math-input-invalid-expression = Nieprawidłowe wyrażenie:
 
-
 ## Document status
 
 viewer-initializing = Inicjowanie...
 
-
 ## Errors
 
 error-heading = Błąd
-
 error-found-at =
     { $span ->
         [line] Znaleziono w wierszu { $startLine }.
        *[lines] Znaleziono w wierszach { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ten dokument zawiera błędy!
-
 diagnostic-heading-error = Błąd
 diagnostic-heading-warning = Ostrzeżenie
 diagnostic-heading-information = Informacja
 diagnostic-heading-hint = Wskazówka
-
 accessibility-heading-level-1 = Naruszenie dostępności WCAG AA
 accessibility-heading-level-2 = Ostrzeżenie o dostępności
-
 something-went-wrong = Coś poszło nie tak.
-
 renderer-load-failed = nie udało się wczytać komponentu renderującego. Odśwież stronę.
-
 core-start-failed = Nie udało się uruchomić przeglądarki dokumentu. Odśwież stronę.

--- a/packages/i18n/locales/pl/content.ftl
+++ b/packages/i18n/locales/pl/content.ftl
@@ -172,7 +172,6 @@ color =
                    *[m] brązowy
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -198,7 +197,6 @@ line-width =
                    *[m] cienki
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -224,7 +222,6 @@ line-style =
                    *[m] kropkowany
                 }
         }
-
 # Noun phrases in the accusative plural, which is the case «w» takes when it
 # names a pattern — «w romby», the way Polish describes patterned cloth. The
 # accusative of a non-virile plural is spelled like the nominative, so the same
@@ -237,7 +234,6 @@ fill-style =
     .backdiagonal = odwrotnie ukośne linie
     .dots = kropki
     .diamonds = romby
-
 noun =
     .line = prosta
     .line-segment = odcinek
@@ -257,7 +253,6 @@ noun =
     .diamond = romb
     .cross = krzyżyk
     .plus = plus
-
 # Polish counts the sides after the noun, so the count closes the phrase
 # behind the adjectives: «gruby czerwony wielokąt foremny o 5 bokach».
 noun-regular-polygon =
@@ -265,7 +260,6 @@ noun-regular-polygon =
         [tail] o { $numSides } bokach
        *[head] wielokąt foremny
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (wielokąt, m) or
 # the head of a phrase the description never names: `border` (obramowanie, n),
 # `fill` (wypełnienie, n), `text` (tekst, m), `background` (tło, n).
@@ -283,7 +277,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -296,14 +289,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, and the complement closes the phrase.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every
 # description and takes no `$role` branch.
 style-filled-word =
@@ -312,13 +303,11 @@ style-filled-word =
         [n] wypełnione
        *[m] wypełniony
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } w { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } w { $pattern }
@@ -326,7 +315,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } w { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «z» governs the instrumental, which the `border-clause` branch of every
 # adjective supplies. Polish has no article, so the `-article` branches read
 # the same as the ones without.
@@ -342,15 +330,12 @@ style-border-clause =
         [and-article] i z { $border } obramowaniem
        *[with] z { $border } obramowaniem
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = niewypełniony
-
 # «na» governs the locative, which for a neuter noun is spelled like the
 # instrumental — which is why the `background-clause` and `border-clause`
 # branches of every adjective coincide.
@@ -359,21 +344,17 @@ style-text =
         [background] { $color } na { $background } tle
        *[plain] { $color }
     }
-
 style-background-none = brak
-
 
 ## Boolean words
 
 boolean-true = prawda
 boolean-false = fałsz
 
-
 ## Answer buttons
 
 answer-submit-label = Sprawdź
 answer-submit-label-no-correctness = Wyślij odpowiedź
-
 
 ## Sectional blocks
 
@@ -398,7 +379,6 @@ section-name =
     .solution = Rozwiązanie
     .task = Zadanie do wykonania
     .theorem = Twierdzenie
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -408,9 +388,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Wskazówka
-
 
 ## Tables and figures
 
@@ -421,7 +399,6 @@ table-name =
         [unnumbered-title] Tabela{ ": " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Rysunek { $enumeration }
@@ -430,22 +407,18 @@ figure-name =
        *[unnumbered] Rysunek
     }
 
-
 ## Paginator controls
 
 paginator-previous = Poprzednia
 paginator-next = Następna
 paginator-page = Strona
-
 paginator-page-status = { $pageLabel } { $currentPage } z { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = lub
 piecewise-condition-if = jeśli
 piecewise-condition-otherwise = w przeciwnym razie
-
 
 ## Chemistry
 
@@ -568,7 +541,6 @@ element-name =
     .lv = Liwermor
     .ts = Tenes
     .og = Oganeson
-
 element-anion-name =
     .h = Wodorek
     .c = Węglik
@@ -582,8 +554,6 @@ element-anion-name =
     .i = Jodek
     .at = Astatek
     .ts = Tenesek
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Nieprawidłowy symbol chemiczny
 chemistry-invalid-ionic-compound = Nieprawidłowy związek jonowy

--- a/packages/i18n/locales/ps/chrome.ftl
+++ b/packages/i18n/locales/ps/chrome.ftl
@@ -24,73 +24,55 @@
 
 answer-checking = کتنه روانه ده...
 answer-submitting = لېږل روان دي...
-
 answer-checking-status = ځواب کتل کیږي
 answer-submitting-status = ځواب لېږل کیږي
-
 answer-correct = سم
 answer-incorrect = ناسم
-
 answer-response-saved = ځواب خوندي شو
-
 answer-percent-credit = { $percent }% نمرې
 answer-percent-correct = { $percent }% سم
 answer-percent-short = { $percent }%
-
 max-credit-available = تر ټولو لوړه ممکنه نمره: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] هېڅ هڅه نه ده پاتې
         [one] { $count } هڅه پاتې ده
        *[other] { $count } هڅې پاتې دي
     }
-
 validation-correct = (سم ځواب)
 validation-incorrect = (ناسم ځواب)
 validation-partially-correct = (جزوي سم ځواب)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } ته لېږل شوی { $count } ځواب وښایاست
        *[other] { $answerId } ته لېږل شوي { $count } ځوابونه وښایاست
     }
 
-
 ## Disclosure panels
 
 feedback-heading = نظر
-
 collapsible-click-to-open = (د پرانیستلو لپاره کلیک وکړئ)
 collapsible-click-to-close = (د تړلو لپاره کلیک وکړئ)
 collapsible-initializing = چمتو کیږي...
-
 footnote-show = پښتوونه وښایاست
 footnote-hide = پښتوونه پټه کړئ
-
 description-more-information = نور معلومات
-
 
 ## Controls
 
 slider-previous = پخوانی
 slider-next = راتلونکی
-
 keyboard-open = کیبورډ پرانیزئ
 keyboard-close = کیبورډ وتړئ
-
 choice-input-remove-choice = { $choice } لرې کړئ
-
 matrix-remove-row = کتار لرې کړئ
 matrix-add-row = کتار زیات کړئ
 matrix-remove-column = ستون لرې کړئ
 matrix-add-column = ستون زیات کړئ
-
 subset-add-remove-points = ټکي زیات/لرې کړئ
 subset-toggle-points-intervals = د ټکو او وقفو ترمنځ بدلون
 subset-move-points = ټکي وخوځوئ
 subset-clear = پاک کړئ
-
 orbital-add-row = کتار زیات کړئ
 orbital-remove-row = کتار لرې کړئ
 orbital-add-box = خانه زیاته کړئ
@@ -98,13 +80,9 @@ orbital-remove-box = خانه لرې کړئ
 orbital-add-up-arrow = پورته غشی زیات کړئ
 orbital-add-down-arrow = ښکته غشی زیات کړئ
 orbital-remove-arrow = غشی لرې کړئ
-
 orbital-row-label = د کتار { $row } نوم
-
 pretzel-answer = ځواب
-
 summary-statistics-caption = د ستون { $column } احصایوي لنډیز
-
 
 ## Math input
 
@@ -112,37 +90,28 @@ math-input-preview-region = د ریاضي عبارت مخکتنه
 math-input-preview = مخکتنه
 math-input-invalid-expression = ناسم عبارت:
 
-
 ## Document status
 
 viewer-initializing = چمتو کیږي...
 
-
 ## Errors
 
 error-heading = تېروتنه
-
 error-found-at =
     { $span ->
         [line] په کرښه { $startLine } کې وموندل شوه۔
        *[lines] په کرښو { $startLine } تر { $endLine } کې وموندل شوه۔
     }
-
 document-contains-errors = په دې سند کې تېروتنې شته!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = تېروتنه
 diagnostic-heading-warning = خبرداری
 diagnostic-heading-information = معلومات
 diagnostic-heading-hint = اشاره
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = د WCAG AA له مخې د لاسرسي سرغړونه
 accessibility-heading-level-2 = د لاسرسي خبرتیا
-
 something-went-wrong = یو څه ناسم شول۔
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = یوه برخه بار نه شوه۔ مهرباني وکړئ مخ بیا بار کړئ۔
-
 core-start-failed = د سند لیدونکی پیل نه شو۔ مهرباني وکړئ مخ بیا بار کړئ۔

--- a/packages/i18n/locales/ps/content.ftl
+++ b/packages/i18n/locales/ps/content.ftl
@@ -122,7 +122,6 @@ color =
     .purple = بنفشي
     .pink = ګلابي
     .brown = نسواري
-
 line-width =
     .thick =
         { $role ->
@@ -150,12 +149,10 @@ line-width =
                    *[m] نری
                 }
         }
-
 # Both are reduplicated phrases rather than adjectives, so neither inflects.
 line-style =
     .dashed = ټوټه ټوټه
     .dotted = ټکي ټکي
-
 # Noun phrases rather than adjectives; they agree with nothing, so `style-fill`
 # gives them a noun to hang off rather than printing them bare.
 fill-style =
@@ -165,7 +162,6 @@ fill-style =
     .backdiagonal = مخالفې کږې کرښې
     .dots = ټکي
     .diamonds = لوزنګونه
-
 noun =
     .line = کرښه
     .line-segment = د کرښې ټوټه
@@ -185,7 +181,6 @@ noun =
     .diamond = لوزنګ
     .cross = کراس
     .plus = د جمعې نښه
-
 # Pashto keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -193,7 +188,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ضلعې لرونکی منظم څو ضلعي
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (څو ضلعي, m) or the
 # head of a phrase the description never names: `border` (څنډه, f), `fill`
 # (ډکاو, m), `text` (متن, m), `background` (شاليد, m).
@@ -211,7 +205,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -224,47 +217,45 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [f] ډکه
        *[m] ډک
     }
-
 # «لرونکی» inflects like any adjective in ی, and it agrees with the shape
 # rather than with the pattern in front of it: «ټکي لرونکې کرښه», «ټکي لرونکی
 # مربع». `style-fill` writes it with no branch at all, because the noun it
 # agrees with there is «ډکاو», which is always masculine.
 style-filled =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] لرونکې
-           *[m] لرونکی
-        } { $color } { $filled }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] لرونکې
+               *[m] لرونکی
+            } { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] لرونکې
-           *[m] لرونکی
-        } { $color } { $filled } { $noun }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] لرونکې
+               *[m] لرونکی
+            } { $color } { $filled } { $noun }
         [plain-tail] { $color } { $filled } { $noun } { $nounTail }
-        [pattern-tail] { $pattern } { $gender ->
-            [f] لرونکې
-           *[m] لرونکی
-        } { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail]
+            { $pattern } { $gender ->
+                [f] لرونکې
+               *[m] لرونکی
+            } { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «سره» is a postposition, so the border phrase closes with it. Pashto has no
 # indefinite article, so the two `-article` branches say what their plain
 # counterparts do.
@@ -275,7 +266,6 @@ style-border-clause =
         [and-article] او له { $border } څنډې سره
        *[with] له { $border } څنډې سره
     }
-
 # The pattern words agree with nothing, so this message supplies «ډکاو» —
 # masculine, the gender `noun-gender` already answers for `fill` — for the
 # colour to agree with in both variants.
@@ -284,29 +274,23 @@ style-fill =
         [pattern] { $pattern } لرونکی { $color } ډکاو
        *[plain] { $color } ډکاو
     }
-
 style-unfilled = بې ډکاوه
-
 style-text =
     { $parts ->
         [background] په { $background } شاليد کې { $color }
        *[plain] { $color }
     }
-
 style-background-none = هیڅ
-
 
 ## Boolean words
 
 boolean-true = سم
 boolean-false = ناسم
 
-
 ## Answer buttons
 
 answer-submit-label = ځواب وګورئ
 answer-submit-label-no-correctness = ځواب واستوئ
-
 
 ## Sectional blocks
 
@@ -331,7 +315,6 @@ section-name =
     .solution = حل
     .task = دنده
     .theorem = تیورم
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -341,9 +324,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = اشاره
-
 
 ## Tables and figures
 
@@ -354,7 +335,6 @@ table-name =
         [unnumbered-title] جدول{ ": " }
        *[unnumbered] جدول
     }
-
 figure-name =
     { $parts ->
         [numbered] انځور { $enumeration }
@@ -363,28 +343,21 @@ figure-name =
        *[unnumbered] انځور
     }
 
-
 ## Paginator controls
 
 paginator-previous = پخوانی
 paginator-next = راتلونکی
 paginator-page = مخ
-
 paginator-page-status = { $pageLabel } { $currentPage } له { $numPages } څخه
-
 
 ## Piecewise functions
 
 piecewise-condition-or = یا
-
 piecewise-condition-if = که
-
 piecewise-condition-otherwise = په بل صورت کې
-
 
 ## Chemistry
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ناسمه کیمیاوي نښه
 chemistry-invalid-ionic-compound = ناسم آیوني ترکیب

--- a/packages/i18n/locales/pt/chrome.ftl
+++ b/packages/i18n/locales/pt/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = Verificando...
 answer-submitting = Enviando...
-
 answer-checking-status = Verificando a resposta
 answer-submitting-status = Enviando a resposta
-
 answer-correct = Correto
 answer-incorrect = Incorreto
-
 answer-response-saved = Resposta salva
-
 answer-percent-credit = { $percent }% de nota
 answer-percent-correct = { $percent }% correto
 answer-percent-short = { $percent }%
-
 max-credit-available = Nota máxima disponível: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nenhuma tentativa restante
         [one] { $count } tentativa restante
        *[other] { $count } tentativas restantes
     }
-
 validation-correct = (Correto)
 validation-incorrect = (Incorreto)
 validation-partially-correct = (Parcialmente correto)
-
 answer-show-responses =
     { $count ->
         [one] Mostrar { $count } resposta de { $answerId }
        *[other] Mostrar { $count } respostas de { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Comentários
-
 collapsible-click-to-open = (clique para abrir)
 collapsible-click-to-close = (clique para fechar)
-
 collapsible-initializing = Inicializando...
-
 footnote-show = Mostrar nota de rodapé
 footnote-hide = Ocultar nota de rodapé
-
 description-more-information = mais informações
-
 
 ## Controls
 
 slider-previous = Anterior
 slider-next = Próximo
-
 keyboard-open = Abrir teclado
 keyboard-close = Fechar teclado
-
 choice-input-remove-choice = Remover { $choice }
-
 matrix-remove-row = Remover linha
 matrix-add-row = Adicionar linha
 matrix-remove-column = Remover coluna
 matrix-add-column = Adicionar coluna
-
 subset-add-remove-points = Adicionar/remover pontos
 subset-toggle-points-intervals = Alternar entre pontos e intervalos
 subset-move-points = Mover pontos
 subset-clear = Limpar
-
 # A `box` here is one orbital, drawn as a square: caixa.
 orbital-add-row = Adicionar linha
 orbital-remove-row = Remover linha
@@ -95,13 +76,9 @@ orbital-remove-box = Remover caixa
 orbital-add-up-arrow = Adicionar seta para cima
 orbital-add-down-arrow = Adicionar seta para baixo
 orbital-remove-arrow = Remover seta
-
 orbital-row-label = Rótulo da linha { $row }
-
 pretzel-answer = Resposta
-
 summary-statistics-caption = Estatísticas descritivas de { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = pré-visualização da expressão matemática
 math-input-preview = Pré-visualização
 math-input-invalid-expression = Expressão inválida:
 
-
 ## Document status
 
 viewer-initializing = Inicializando...
 
-
 ## Errors
 
 error-heading = Erro
-
 error-found-at =
     { $span ->
         [line] Encontrado na linha { $startLine }.
        *[lines] Encontrado nas linhas { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Este documento contém erros!
-
 diagnostic-heading-error = Erro
 diagnostic-heading-warning = Aviso
 diagnostic-heading-information = Informação
 diagnostic-heading-hint = Dica
-
 accessibility-heading-level-1 = Violação de acessibilidade WCAG AA
 accessibility-heading-level-2 = Alerta de acessibilidade
-
 something-went-wrong = Algo deu errado.
-
 renderer-load-failed = um renderizador não pôde ser carregado. Recarregue a página.
-
 core-start-failed = Não foi possível iniciar o visualizador de documentos. Recarregue a página.

--- a/packages/i18n/locales/pt/content.ftl
+++ b/packages/i18n/locales/pt/content.ftl
@@ -59,7 +59,6 @@ color =
         }
     .pink = rosa
     .brown = marrom
-
 line-width =
     .thick =
         { $gender ->
@@ -71,7 +70,6 @@ line-width =
             [f] fina
            *[m] fino
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -83,7 +81,6 @@ line-style =
             [f] pontilhada
            *[m] pontilhado
         }
-
 # Noun phrases: they follow «com» and agree with nothing.
 fill-style =
     .horizontal = linhas horizontais
@@ -92,7 +89,6 @@ fill-style =
     .backdiagonal = linhas diagonais invertidas
     .dots = pontos
     .diamonds = losangos
-
 noun =
     .line = linha
     .line-segment = segmento
@@ -112,7 +108,6 @@ noun =
     .diamond = losango
     .cross = cruz
     .plus = sinal de mais
-
 # The noun is split: «polígono regular» carries the agreement and «de 5 lados»
 # closes the phrase behind the adjectives. Were the complement to come first,
 # the adjectives would be stranded away from the noun they agree with.
@@ -121,7 +116,6 @@ noun-regular-polygon =
         [tail] de { $numSides } lados
        *[head] polígono regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polígono, m) or
 # the head of a phrase the description never names: `border` (borda, f), `fill`
 # (preenchimento, m), `text` (texto, m), `background` (fundo, m).
@@ -139,7 +133,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -152,26 +145,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and the adjectives follow: «linha tracejada grossa vermelha».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] preenchida
        *[m] preenchido
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } com { $pattern }
        *[plain] { $color } { $filled }
     }
-
 # The complement stays beside its own noun rather than at the end: «polígono
 # regular de 5 lados azul preenchido».
 style-filled-with-noun =
@@ -181,7 +170,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } com { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «borda» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds — and the article is «uma».
 style-border-clause =
@@ -191,36 +179,29 @@ style-border-clause =
         [and-article] e uma borda { $border }
        *[with] com borda { $border }
     }
-
 # «de cor» avoids having to agree the colour with a plural pattern word.
 style-fill =
     { $parts ->
         [pattern] { $pattern } de cor { $color }
        *[plain] { $color }
     }
-
 style-unfilled = sem preenchimento
-
 style-text =
     { $parts ->
         [background] { $color } com um fundo { $background }
        *[plain] { $color }
     }
-
 style-background-none = nenhum
-
 
 ## Boolean words
 
 boolean-true = verdadeiro
 boolean-false = falso
 
-
 ## Answer buttons
 
 answer-submit-label = Verificar
 answer-submit-label-no-correctness = Enviar resposta
-
 
 ## Sectional blocks
 
@@ -245,7 +226,6 @@ section-name =
     .solution = Solução
     .task = Tarefa
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -255,9 +235,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Dica
-
 
 ## Tables and figures
 
@@ -268,7 +246,6 @@ table-name =
         [unnumbered-title] Tabela{ ": " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -277,22 +254,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anterior
 paginator-next = Próxima
 paginator-page = Página
-
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ou
 piecewise-condition-if = se
 piecewise-condition-otherwise = caso contrário
-
 
 ## Chemistry
 
@@ -415,7 +388,6 @@ element-name =
     .lv = Livermório
     .ts = Tenesso
     .og = Oganessônio
-
 element-anion-name =
     .h = Hidreto
     .c = Carbeto
@@ -429,8 +401,6 @@ element-anion-name =
     .i = Iodeto
     .at = Astateto
     .ts = Tenesseto
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Símbolo químico inválido
 chemistry-invalid-ionic-compound = Composto iônico inválido

--- a/packages/i18n/locales/qu/chrome.ftl
+++ b/packages/i18n/locales/qu/chrome.ftl
@@ -31,21 +31,15 @@
 
 answer-checking = Qhawachkan…
 answer-submitting = Apachichkan…
-
 answer-checking-status = Kutichiyta qhawachkan
 answer-submitting-status = Kutichiyta apachichkan
-
 answer-correct = Allin
 answer-incorrect = Mana allinchu
-
 answer-response-saved = Kutichiy waqaychasqa
-
 answer-percent-credit = { $percent }% chanin
 answer-percent-correct = { $percent }% allin
 answer-percent-short = { $percent } %
-
 max-credit-available = Aswan hatun chanin: { $percent }%
-
 # No select: «ruray» does not take «-kuna» after a numeral, so both English
 # categories render the same words. The count still arrives and is still
 # formatted. `[0]` stays, because "none left" is its own sentence.
@@ -54,53 +48,40 @@ attempts-remaining =
         [0] manaña ima ruraypas puchunchu
        *[other] { $count } ruray puchun
     }
-
 validation-correct = (Allin)
 validation-incorrect = (Mana allinchu)
 validation-partially-correct = (Wakinlla allin)
-
 # No select, for the reason given above. The answer is reached by naming it —
 # «{ $answerId } sutiyuq tapuypaq», "for the question named X" — rather than by
 # putting the dative «-man» on `$answerId`, which would weld a suffix to a value
 # this catalog never sees.
 answer-show-responses = { $answerId } sutiyuq tapuypaq { $count } kutichiy rikuchiy
 
-
 ## Disclosure panels
 
 feedback-heading = Kutichiy rimay
-
 collapsible-click-to-open = (kichanapaq ñit'iy)
 collapsible-click-to-close = (wichq'anapaq ñit'iy)
-
 collapsible-initializing = Qallarichkan…
-
 footnote-show = Uraypi qillqata rikuchiy
 footnote-hide = Uraypi qillqata pakay
-
 description-more-information = aswan willay
-
 
 ## Controls
 
 slider-previous = Ñawpaq
 slider-next = Qhipa
-
 keyboard-open = Ñit'ipanata kichay
 keyboard-close = Ñit'ipanata wichq'ay
-
 choice-input-remove-choice = { $choice } qichuy
-
 matrix-remove-row = Siqita qichuy
 matrix-add-row = Siqita yapay
 matrix-remove-column = Sayaqta qichuy
 matrix-add-column = Sayaqta yapay
-
 subset-add-remove-points = Chimpukunata yapay/qichuy
 subset-toggle-points-intervals = Chimpumanta chawpimanpas tikray
 subset-move-points = Chimpukunata astay
 subset-clear = Pichay
-
 orbital-add-row = Siqita yapay
 orbital-remove-row = Siqita qichuy
 orbital-add-box = Q'ipita yapay
@@ -108,13 +89,9 @@ orbital-remove-box = Q'ipita qichuy
 orbital-add-up-arrow = Wichay wach'ita yapay
 orbital-add-down-arrow = Uray wach'ita yapay
 orbital-remove-arrow = Wach'ita qichuy
-
 orbital-row-label = { $row } siqipaq suti
-
 pretzel-answer = Kutichiy
-
 summary-statistics-caption = { $column } huñusqa yupaykuna
-
 
 ## Math input
 
@@ -122,34 +99,25 @@ math-input-preview-region = yupay rimay ñawpaq rikuchiy
 math-input-preview = Ñawpaq rikuchiy
 math-input-invalid-expression = Mana allin rimay:
 
-
 ## Document status
 
 viewer-initializing = Qallarichkan…
 
-
 ## Errors
 
 error-heading = Pantay
-
 error-found-at =
     { $span ->
         [line] { $startLine } siqipi tarisqa.
        *[lines] { $startLine }–{ $endLine } siqikunapi tarisqa.
     }
-
 document-contains-errors = Kay qillqapi pantaykuna kachkan!
-
 diagnostic-heading-error = Pantay
 diagnostic-heading-warning = Yuyaychay
 diagnostic-heading-information = Willay
 diagnostic-heading-hint = Yanapay
-
 accessibility-heading-level-1 = WCAG AA chayanapaq p'akiy
 accessibility-heading-level-2 = Chayanapaq yuyaychay
-
 something-went-wrong = Imapas mana allinchu karqan.
-
 renderer-load-failed = huk rikuchiq mana chayamurqanchu. Ama hina kaspa, p'anqata musuqmanta chaqnay.
-
 core-start-failed = Qillqa rikuchiq mana qallarikuyta atirqanchu. Ama hina kaspa, p'anqata musuqmanta chaqnay.

--- a/packages/i18n/locales/qu/content.ftl
+++ b/packages/i18n/locales/qu/content.ftl
@@ -50,15 +50,12 @@ color =
     .purple = kulli
     .pink = panti
     .brown = ch'umpi
-
 line-width =
     .thick = rakhu
     .thin = ñañu
-
 line-style =
     .dashed = t'aqasqa
     .dotted = chiqchi
-
 # Noun phrases, which is what the head of `style-fill` is. «-kuna» is written
 # here because nothing precedes them to say how many.
 fill-style =
@@ -68,7 +65,6 @@ fill-style =
     .backdiagonal = kutichisqa wingu siq'ikuna
     .dots = chiqchikuna
     .diamonds = rombokuna
-
 noun =
     .line = siq'i
     .line-segment = siq'i phatma
@@ -88,7 +84,6 @@ noun =
     .diamond = rombo
     .cross = chakana
     .plus = yapay unancha
-
 # The side count is a prenominal modifier, so it stays in the head and the tail
 # is empty — English's shape, reached by a different road. «-yuq» welds onto
 # «waqta», which this catalog writes, not onto `$numSides`.
@@ -97,11 +92,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } waqtayuq kikin achka k'uchu
     }
-
 # One answer for every noun: Quechua has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -115,7 +108,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives precede the noun, so this is English's order. The `[noun-tail]`
 # branch is unreachable from Quechua's own `noun-regular-polygon`, which supplies
 # no tail; it is kept because it is what a partly-corrected catalog falls back
@@ -125,9 +117,7 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = hunt'asqa
-
 # The pattern is a comitative complement, and Quechua's comitative is the suffix
 # «-wan», which cannot be welded to `$pattern`. So the pattern is named rather
 # than marked: «pallaynin { $pattern }» — "its design: diamonds".
@@ -136,7 +126,6 @@ style-filled =
         [pattern] { $filled } { $color }, pallaynin { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun }, pallaynin { $pattern }
@@ -144,7 +133,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail }, pallaynin { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «-yuq», "having", lands on «manya» — the border — which this catalog writes,
 # and the adjectives precede it. Quechua has no articles, so English's four
 # branches collapse to two distinct strings; all four are written out because
@@ -157,7 +145,6 @@ style-border-clause =
         [and-article] hinaspa { $border } manyayuq
        *[with] { $border } manyayuq
     }
-
 # Here the pattern is the **head noun** — "blue diamonds" — so it needs no case
 # suffix at all and the colour simply precedes it. The same value that had to be
 # named in `style-filled` needs nothing here, which is what makes that message's
@@ -167,29 +154,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = mana hunt'asqa
-
 style-text =
     { $parts ->
         [background] { $background } qhipayuq { $color }
        *[plain] { $color }
     }
-
 style-background-none = mana kanchu
-
 
 ## Boolean words
 
 boolean-true = cheqaq
 boolean-false = llulla
 
-
 ## Answer buttons
 
 answer-submit-label = Llamk'ayta qhaway
 answer-submit-label-no-correctness = Kutichiyta apachiy
-
 
 ## Sectional blocks
 
@@ -214,7 +195,6 @@ section-name =
     .solution = Paskay
     .task = Ruranapaq
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -224,9 +204,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Yanapay
-
 
 ## Tables and figures
 
@@ -237,7 +215,6 @@ table-name =
         [unnumbered-title] Tabla{ ": " }
        *[unnumbered] Tabla
     }
-
 figure-name =
     { $parts ->
         [numbered] Rikch'a { $enumeration }
@@ -246,24 +223,20 @@ figure-name =
        *[unnumbered] Rikch'a
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ñawpaq
 paginator-next = Qhipa
 paginator-page = P'anqa
-
 # The ablative «-manta» lands on «p'anqa», which this catalog writes, so the
 # total precedes it and the whole reads "of N pages, Page 3".
 paginator-page-status = { $numPages } p'anqamanta { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = icha
 piecewise-condition-if = sichus
 piecewise-condition-otherwise = mana chayqa
-
 
 ## Chemistry
 ##
@@ -276,6 +249,5 @@ piecewise-condition-otherwise = mana chayqa
 ## least check against their own book.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Mana allin unancha kimiku
 chemistry-invalid-ionic-compound = Mana allin huñu iyoniku

--- a/packages/i18n/locales/quc/chrome.ftl
+++ b/packages/i18n/locales/quc/chrome.ftl
@@ -35,21 +35,15 @@
 
 answer-checking = Kanikʼoxik…
 answer-submitting = Kataqik…
-
 answer-checking-status = Kanikʼoxik ri tzalijisabʼal
 answer-submitting-status = Kataqik ri tzalijisabʼal
-
 answer-correct = Utz
 answer-incorrect = Man utz taj
-
 answer-response-saved = Xkʼol ri tzalijisabʼal
-
 answer-percent-credit = { $percent }% rajil
 answer-percent-correct = { $percent }% utz
 answer-percent-short = { $percent } %
-
 max-credit-available = Ri nimalaj rajil kʼo: { $percent }%
-
 # No select: «tijonik» is inanimate and takes no plural, so both English
 # categories render the same words. The count still arrives and is still
 # formatted. `[0]` stays, because "none left" is its own sentence.
@@ -58,52 +52,39 @@ attempts-remaining =
         [0] maj chi tijonik kʼo kanaj
        *[other] { $count } tijonik kʼo kanaj
     }
-
 validation-correct = (Utz)
 validation-incorrect = (Man utz taj)
 validation-partially-correct = (Jubʼiqʼ utz)
-
 # No select, for the reason given above. The answer is reached with «rech» rather
 # than with the possessive prefix, whose shape `$answerId`'s first sound would
 # decide.
 answer-show-responses = Chakʼutu { $count } tzalijisabʼal rech { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Tzalijisan tzij
-
 collapsible-click-to-open = (chapitzʼa rech kajaqik)
 collapsible-click-to-close = (chapitzʼa rech katzʼapix)
-
 collapsible-initializing = Kachaplebʼex…
-
 footnote-show = Chakʼutu ri tzʼibʼ pa uxeʼ
 footnote-hide = Chawewaj ri tzʼibʼ pa uxeʼ
-
 description-more-information = kʼi na etamabʼal
-
 
 ## Controls
 
 slider-previous = Nabʼe
 slider-next = Kʼisbʼal
-
 keyboard-open = Chajaqa ri kʼutbʼal tzʼibʼ
 keyboard-close = Chatzʼapij ri kʼutbʼal tzʼibʼ
-
 choice-input-remove-choice = Chesaj { $choice }
-
 matrix-remove-row = Chesaj jun wokaj
 matrix-add-row = Chakoj jun wokaj
 matrix-remove-column = Chesaj jun tikbʼal
 matrix-add-column = Chakoj jun tikbʼal
-
 subset-add-remove-points = Chakoj/Chesaj tzʼubʼ
 subset-toggle-points-intervals = Chakʼexa tzʼubʼ rukʼ nikʼajibʼal
 subset-move-points = Chasilabʼisaj ri tzʼubʼ
 subset-clear = Chachup
-
 orbital-add-row = Chakoj jun wokaj
 orbital-remove-row = Chesaj jun wokaj
 orbital-add-box = Chakoj jun kaxa
@@ -111,13 +92,9 @@ orbital-remove-box = Chesaj jun kaxa
 orbital-add-up-arrow = Chakoj jun chʼabʼ upa akʼanibʼal
 orbital-add-down-arrow = Chakoj jun chʼabʼ upa qajibʼal
 orbital-remove-arrow = Chesaj jun chʼabʼ
-
 orbital-row-label = Ubʼiʼ ri wokaj { $row }
-
 pretzel-answer = Tzalijisabʼal
-
 summary-statistics-caption = Ri ajilanik rech { $column }
-
 
 ## Math input
 
@@ -125,34 +102,25 @@ math-input-preview-region = kʼutbʼal rech ri ajilanik tzij
 math-input-preview = Nabʼe kʼutbʼal
 math-input-invalid-expression = Man utz taj ri tzij:
 
-
 ## Document status
 
 viewer-initializing = Kachaplebʼex…
 
-
 ## Errors
 
 error-heading = Sachbʼal
-
 error-found-at =
     { $span ->
         [line] Xriqitaj pa ri juchʼ { $startLine }.
        *[lines] Xriqitaj pa ri juchʼ { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Wa wuj kʼo sachbʼal chupam!
-
 diagnostic-heading-error = Sachbʼal
 diagnostic-heading-warning = Pixabʼ
 diagnostic-heading-information = Etamabʼal
 diagnostic-heading-hint = Tobʼanik
-
 accessibility-heading-level-1 = WCAG AA sachbʼal rech okibʼal
 accessibility-heading-level-2 = Pixabʼ rech okibʼal
-
 something-went-wrong = Kʼo jasachike man utz taj xbʼantajik.
-
 renderer-load-failed = jun kʼutunel man xoponik taj. Chakʼexa chi ri wuj.
-
 core-start-failed = Ri ilonel rech wuj man xkowin taj kachaplebʼexik. Chakʼexa chi ri wuj.

--- a/packages/i18n/locales/quc/content.ftl
+++ b/packages/i18n/locales/quc/content.ftl
@@ -47,15 +47,12 @@ color =
     .purple = morad
     .pink = kyaqsaq
     .brown = kape
-
 line-width =
     .thick = pim
     .thin = xax
-
 line-style =
     .dashed = qʼatom
     .dotted = tzʼubʼutzʼubʼ
-
 # Noun phrases, which is what the head of `style-fill` is. Kʼicheʼ does not
 # pluralize these, so they are the same words for one and for many.
 fill-style =
@@ -65,7 +62,6 @@ fill-style =
     .backdiagonal = juchʼ pa xukut tzalijisam
     .dots = tzʼubʼ
     .diamonds = rombo
-
 noun =
     .line = juchʼ
     .line-segment = juchʼ qʼatom
@@ -85,7 +81,6 @@ noun =
     .diamond = rombo
     .cross = kurus
     .plus = retal kʼiyinem
-
 # The side count is a prenominal modifier, so it stays in the head and the tail is
 # empty. The «u-» on «uxukut» is fixed: «xukut» is a word this catalog writes.
 noun-regular-polygon =
@@ -93,11 +88,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } uxukut junam
     }
-
 # One answer for every noun: Kʼicheʼ has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -111,7 +104,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives precede the noun, so this is English's order. The `[noun-tail]`
 # branch is unreachable from Kʼicheʼ's own `noun-regular-polygon`; it is kept
 # because it is what a partly-corrected catalog falls back to.
@@ -120,9 +112,7 @@ style-with-noun =
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = nojisam
-
 # «rukʼ», "with", is a free word, so nothing is welded to `$pattern`. The
 # possessive prefix could not have been used here: its shape would depend on the
 # pattern's first sound.
@@ -131,7 +121,6 @@ style-filled =
         [pattern] { $filled } { $color } rukʼ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } rukʼ { $pattern }
@@ -139,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } rukʼ { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # The «u-» on «utzʼapibʼal» is fixed, because «tzʼapibʼal» is written here.
 # Kʼicheʼ has no article, so English's four branches are two distinct strings; all
 # four are written out because they are four positions.
@@ -150,7 +138,6 @@ style-border-clause =
         [and-article] xuqujeʼ jun { $border } utzʼapibʼal
        *[with] rukʼ { $border } utzʼapibʼal
     }
-
 # Here the pattern is the head noun — "blue diamonds" — and the colour precedes
 # it, so the phrase needs nothing at all.
 style-fill =
@@ -158,29 +145,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = man nojisam taj
-
 style-text =
     { $parts ->
         [background] { $color } rukʼ jun { $background } uwach
        *[plain] { $color }
     }
-
 style-background-none = maj
-
 
 ## Boolean words
 
 boolean-true = qas
 boolean-false = man qas taj
 
-
 ## Answer buttons
 
 answer-submit-label = Chanikʼoj ri chak
 answer-submit-label-no-correctness = Chataqa ri tzalijisabʼal
-
 
 ## Sectional blocks
 
@@ -207,7 +188,6 @@ section-name =
     .solution = Solbʼal
     .task = Taqanik
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -217,9 +197,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tobʼanik
-
 
 ## Tables and figures
 
@@ -230,7 +208,6 @@ table-name =
         [unnumbered-title] Cholajil{ ": " }
        *[unnumbered] Cholajil
     }
-
 figure-name =
     { $parts ->
         [numbered] Wachibʼal { $enumeration }
@@ -239,23 +216,19 @@ figure-name =
        *[unnumbered] Wachibʼal
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nabʼe
 paginator-next = Kʼisbʼal
 paginator-page = Wuj
-
 # «rech», "of", carries a fixed prefix because it is a word this catalog writes.
 paginator-page-status = { $pageLabel } { $currentPage } rech { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = we
 piecewise-condition-otherwise = we man
-
 
 ## Chemistry
 ##
@@ -266,6 +239,5 @@ piecewise-condition-otherwise = we man
 ## table for a seed to reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Man utz taj ri retal kimiko
 chemistry-invalid-ionic-compound = Man utz taj ri riqoj ioniko

--- a/packages/i18n/locales/rm/chrome.ftl
+++ b/packages/i18n/locales/rm/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = Controllar…
 answer-submitting = Trametter…
-
 answer-checking-status = Controllar la resposta
 answer-submitting-status = Trametter la resposta
-
 answer-correct = Correct
 answer-incorrect = Nuncorrect
-
 answer-response-saved = Resposta memorisada
-
 answer-percent-credit = { $percent }% dals puncts
 answer-percent-correct = { $percent }% correct
 answer-percent-short = { $percent } %
-
 max-credit-available = Puncts maximals pussaivels: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] naginas empruvas pli
         [one] resta { $count } empruva
        *[other] restan { $count } empruvas
     }
-
 validation-correct = (Correct)
 validation-incorrect = (Nuncorrect)
 validation-partially-correct = (Per part correct)
-
 answer-show-responses =
     { $count ->
         [one] Mussar { $count } resposta a { $answerId }
        *[other] Mussar { $count } respostas a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Commentari
-
 collapsible-click-to-open = (cliccar per avrir)
 collapsible-click-to-close = (cliccar per serrar)
-
 collapsible-initializing = Aviar…
-
 footnote-show = Mussar la nota
 footnote-hide = Zuppentar la nota
-
 description-more-information = dapli infurmaziuns
-
 
 ## Controls
 
 slider-previous = Precedent
 slider-next = Proxim
-
 keyboard-open = Avrir la tastatura
 keyboard-close = Serrar la tastatura
-
 choice-input-remove-choice = Allontanar { $choice }
-
 matrix-remove-row = Allontanar ina lingia
 matrix-add-row = Agiuntar ina lingia
 matrix-remove-column = Allontanar ina colonna
 matrix-add-column = Agiuntar ina colonna
-
 subset-add-remove-points = Agiuntar/allontanar puncts
 subset-toggle-points-intervals = Midar tranter puncts ed intervals
 subset-move-points = Spustar ils puncts
 subset-clear = Svidar
-
 orbital-add-row = Agiuntar ina lingia
 orbital-remove-row = Allontanar ina lingia
 orbital-add-box = Agiuntar ina chascha
@@ -93,13 +74,9 @@ orbital-remove-box = Allontanar ina chascha
 orbital-add-up-arrow = Agiuntar ina frizza si
 orbital-add-down-arrow = Agiuntar ina frizza giu
 orbital-remove-arrow = Allontanar ina frizza
-
 orbital-row-label = Etichetta da la lingia { $row }
-
 pretzel-answer = Resposta
-
 summary-statistics-caption = Statisticas resumadas da { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = prevista da l'expressiun matematica
 math-input-preview = Prevista
 math-input-invalid-expression = Expressiun nunvalida:
 
-
 ## Document status
 
 viewer-initializing = Aviar…
 
-
 ## Errors
 
 error-heading = Errur
-
 error-found-at =
     { $span ->
         [line] Chattà en la lingia { $startLine }.
        *[lines] Chattà en las lingias { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Quest document cuntegna errurs!
-
 diagnostic-heading-error = Errur
 diagnostic-heading-warning = Avertiment
 diagnostic-heading-information = Infurmaziun
 diagnostic-heading-hint = Indicaziun
-
 accessibility-heading-level-1 = Violaziun da l'accessibladad tenor WCAG AA
 accessibility-heading-level-2 = Avis d'accessibladad
-
 something-went-wrong = Insatge è ì mal.
-
 renderer-load-failed = in modul da represchentaziun n'è betg vegnì chargià. Chargiai danovamain la pagina.
-
 core-start-failed = Il visualisatur dal document n'ha betg pudì vegnir avià. Chargiai danovamain la pagina.

--- a/packages/i18n/locales/rm/content.ftl
+++ b/packages/i18n/locales/rm/content.ftl
@@ -74,7 +74,6 @@ color =
             [f] bruna
            *[m] brun
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -86,7 +85,6 @@ line-width =
             [f] fina
            *[m] fin
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -98,7 +96,6 @@ line-style =
             [f] puntinada
            *[m] puntinà
         }
-
 # Plural noun phrases, which is what follows «cun» in `style-filled`. They
 # agree with nothing.
 fill-style =
@@ -108,7 +105,6 @@ fill-style =
     .backdiagonal = lingias diagonalas invertidas
     .dots = puncts
     .diamonds = rombs
-
 noun =
     .line = retta
     .line-segment = segment
@@ -128,13 +124,11 @@ noun =
     .diamond = romb
     .cross = crusch
     .plus = plus
-
 noun-regular-polygon =
     { $part ->
         [tail] da { $numSides } lats
        *[head] poligon regular
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (poligon, m) or the
 # head of a phrase the description never names: `border` (urlet, m), `fill`
 # (emplenida, f), `text` (text, m), `background` (fund, m).
@@ -152,7 +146,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -165,7 +158,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it, which is the opposite of
 # English. A noun that splits — the regular polygon — puts its complement after
 # the adjectives that agree with its head.
@@ -174,19 +166,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] emplenida
        *[m] emplenì
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } cun { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } cun { $pattern }
@@ -194,7 +183,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } cun { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «urlet» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds.
 style-border-clause =
@@ -204,7 +192,6 @@ style-border-clause =
         [and-article] ed in urlet { $border }
        *[with] cun urlet { $border }
     }
-
 # The fill-pattern words are plural nouns, because their other use is the
 # «cun { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «emplenida», feminine, which is the gender
@@ -214,29 +201,23 @@ style-fill =
         [pattern] emplenida { $color } cun { $pattern }
        *[plain] emplenida { $color }
     }
-
 style-unfilled = betg emplenì
-
 style-text =
     { $parts ->
         [background] { $color } sin in fund { $background }
        *[plain] { $color }
     }
-
 style-background-none = nagin
-
 
 ## Boolean words
 
 boolean-true = ver
 boolean-false = fauss
 
-
 ## Answer buttons
 
 answer-submit-label = Controllar
 answer-submit-label-no-correctness = Trametter la resposta
-
 
 ## Sectional blocks
 
@@ -261,7 +242,6 @@ section-name =
     .solution = Soluziun
     .task = Incaric
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -271,9 +251,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Indicaziun
-
 
 ## Tables and figures
 
@@ -284,7 +262,6 @@ table-name =
         [unnumbered-title] Tabella{ ". " }
        *[unnumbered] Tabella
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -293,22 +270,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Precedent
 paginator-next = Proxim
 paginator-page = Pagina
-
 paginator-page-status = { $pageLabel } { $currentPage } da { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = u
 piecewise-condition-if = sche
 piecewise-condition-otherwise = uschiglio
-
 
 ## Chemistry
 ##
@@ -319,6 +292,5 @@ piecewise-condition-otherwise = uschiglio
 ## Romansh table — there is nothing settled here for a seed to reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol chemic nunvalid
 chemistry-invalid-ionic-compound = Colliaziun ionica nunvalida

--- a/packages/i18n/locales/rn/chrome.ftl
+++ b/packages/i18n/locales/rn/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Kuriko birasuzumwa…
 answer-submitting = Kuriko birarungikwa…
-
 answer-checking-status = Inyishu iriko irasuzumwa
 answer-submitting-status = Inyishu iriko irarungikwa
-
 answer-correct = Ni vyo
 answer-incorrect = Si vyo
-
 answer-response-saved = Inyishu Yabitswe
-
 answer-percent-credit = { $percent }% vy'Amanota
 answer-percent-correct = { $percent }% Ni vyo
 answer-percent-short = { $percent } %
-
 max-credit-available = Amanota menshi ashoboka: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nta kugerageza gusigaye
         [one] hasigaye ukugerageza { $count }
        *[other] hasigaye ukugerageza { $count }
     }
-
 validation-correct = (Ni vyo)
 validation-incorrect = (Si vyo)
 validation-partially-correct = (Ni vyo ku ruhande)
-
 answer-show-responses =
     { $count ->
         [one] Erekana inyishu { $count } kuri { $answerId }
        *[other] Erekana inyishu { $count } kuri { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Iciyumviro
-
 collapsible-click-to-open = (kanda kugira wugurure)
 collapsible-click-to-close = (kanda kugira wugare)
-
 collapsible-initializing = Kuriko biratangura…
-
 footnote-show = Erekana icitonderwa co hasi
 footnote-hide = Nyegeza icitonderwa co hasi
-
 description-more-information = amakuru menshi
-
 
 ## Controls
 
 slider-previous = Iheruka
 slider-next = Ikurikira
-
 keyboard-open = Ugurura Klaviye
 keyboard-close = Ugara Klaviye
-
 choice-input-remove-choice = Kura { $choice }
-
 matrix-remove-row = Kura umurongo
 matrix-add-row = Ongerako umurongo
 matrix-remove-column = Kura inkingi
 matrix-add-column = Ongerako inkingi
-
 subset-add-remove-points = Ongerako/Kura utudomo
 subset-toggle-points-intervals = Hindura utudomo n'ibiringo
 subset-move-points = Imura Utudomo
 subset-clear = Kurayo
-
 orbital-add-row = Ongerako Umurongo
 orbital-remove-row = Kura Umurongo
 orbital-add-box = Ongerako Agasandugu
@@ -86,13 +67,9 @@ orbital-remove-box = Kura Agasandugu
 orbital-add-up-arrow = Ongerako Akambi Kaja Hejuru
 orbital-add-down-arrow = Ongerako Akambi Kaja Hasi
 orbital-remove-arrow = Kura Akambi
-
 orbital-row-label = Izina ry'umurongo { $row }
-
 pretzel-answer = Inyishu
-
 summary-statistics-caption = Incamake y'imibare ya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ukurabira imbere kw'imvugo y'imibare
 math-input-preview = Kurabira imbere
 math-input-invalid-expression = Imvugo itari yo:
 
-
 ## Document status
 
 viewer-initializing = Kuriko biratangura…
 
-
 ## Errors
 
 error-heading = Ikosa
-
 error-found-at =
     { $span ->
         [line] Ryabonetse ku murongo { $startLine }.
        *[lines] Ryabonetse ku mirongo { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Iki gitabu kirimwo amakosa!
-
 diagnostic-heading-error = Ikosa
 diagnostic-heading-warning = Imburi
 diagnostic-heading-information = Amakuru
 diagnostic-heading-hint = Akaboko
-
 accessibility-heading-level-1 = Ukurenga kwa WCAG AA kw'Ukugerwako
 accessibility-heading-level-2 = Imburi y'ukugerwako
-
 something-went-wrong = Hari ikitagenze neza.
-
 renderer-load-failed = umwerekanyi ntiyashitse. Turagusavye subiramwo urupapuro.
-
 core-start-failed = Umwerekanyi w'igitabu ntiyatanguye. Turagusavye subiramwo urupapuro.

--- a/packages/i18n/locales/rn/content.ftl
+++ b/packages/i18n/locales/rn/content.ftl
@@ -127,7 +127,6 @@ color =
             [c7] c'ikawa
            *[c9] y'ikawa
         }
-
 # The adjective concord, which is not the concord the verbs above take.
 line-width =
     .thick =
@@ -144,13 +143,11 @@ line-width =
             [c7] gito
            *[c9] nto
         }
-
 # Written as an invariable «w'…» phrase that agrees with nothing, so it can
 # close the description; `style-stroke` puts it last for that reason.
 line-style =
     .dashed = w'udukona
     .dotted = w'ududomo
-
 fill-style =
     .horizontal = imirongo iryamye
     .vertical = imirongo ihagaze
@@ -158,7 +155,6 @@ fill-style =
     .backdiagonal = imirongo iciye ku rundi ruhande
     .dots = ududomo
     .diamonds = amadiyama
-
 noun =
     .line = umurongo
     .line-segment = igice c'umurongo
@@ -178,7 +174,6 @@ noun =
     .diamond = idiyama
     .cross = umusaraba
     .plus = ikimenyetso co kwongerako
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -186,7 +181,6 @@ noun-regular-polygon =
         [tail] ifise impande { $numSides }
        *[head] ishusho ingana impande
     }
-
 # The noun class. `c9` is the default and the class a loanword joins, which is
 # what an author's own `markerStyleWord` is as far as this catalog is
 # concerned.
@@ -205,7 +199,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is an invariable «w'…» phrase and closes the description, so
@@ -220,13 +213,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] wuzuye
@@ -234,13 +225,11 @@ style-filled-word =
         [c7] cuzuye
        *[c9] yuzuye
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } hamwe na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } hamwe na { $pattern }
@@ -248,7 +237,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } hamwe na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «umupaka» is class 3, so the border's words agree with it and not with the
 # shape it surrounds. Kirundi has no article and joins a complement with the
 # invariable «hamwe n'», so all four branches read alike.
@@ -259,35 +247,28 @@ style-border-clause =
         [and-article] hamwe n'umupaka { $border }
        *[with] hamwe n'umupaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ntiyuzuye
-
 style-text =
     { $parts ->
         [background] { $color } ku nyuma { $background }
        *[plain] { $color }
     }
-
 style-background-none = nta na kimwe
-
 
 ## Boolean words
 
 boolean-true = ni vyo
 boolean-false = si vyo
 
-
 ## Answer buttons
 
 answer-submit-label = Genzura Igikorwa
 answer-submit-label-no-correctness = Rungika Inyishu
-
 
 ## Sectional blocks
 
@@ -312,7 +293,6 @@ section-name =
     .solution = Umuti
     .task = Igikorwa
     .theorem = Teoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -322,9 +302,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Akaboko
-
 
 ## Tables and figures
 
@@ -335,7 +313,6 @@ table-name =
         [unnumbered-title] Urutonde{ ": " }
        *[unnumbered] Urutonde
     }
-
 figure-name =
     { $parts ->
         [numbered] Ishusho { $enumeration }
@@ -344,24 +321,18 @@ figure-name =
        *[unnumbered] Ishusho
     }
 
-
 ## Paginator controls
 
 paginator-previous = Iheruka
 paginator-next = Ikurikira
 paginator-page = Urupapuro
-
 paginator-page-status = { $pageLabel } { $currentPage } kuri { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = canke
-
 piecewise-condition-if = igihe
-
 piecewise-condition-otherwise = ahandi hose
-
 
 ## Chemistry
 ##
@@ -373,6 +344,5 @@ piecewise-condition-otherwise = ahandi hose
 ## curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ikimenyetso ca Shimi Kitari Co
 chemistry-invalid-ionic-compound = Ivanga ry'Ayoni Ritari Ryo

--- a/packages/i18n/locales/ro/chrome.ftl
+++ b/packages/i18n/locales/ro/chrome.ftl
@@ -20,21 +20,15 @@
 
 answer-checking = Se verifică…
 answer-submitting = Se trimite…
-
 answer-checking-status = Se verifică răspunsul
 answer-submitting-status = Se trimite răspunsul
-
 answer-correct = Corect
 answer-incorrect = Incorect
-
 answer-response-saved = Răspuns salvat
-
 answer-percent-credit = { $percent }% punctaj
 answer-percent-correct = { $percent }% corect
 answer-percent-short = { $percent } %
-
 max-credit-available = Punctaj maxim disponibil: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nicio încercare rămasă
@@ -42,11 +36,9 @@ attempts-remaining =
         [few] au rămas { $count } încercări
        *[other] au rămas { $count } de încercări
     }
-
 validation-correct = (Corect)
 validation-incorrect = (Incorect)
 validation-partially-correct = (Parțial corect)
-
 answer-show-responses =
     { $count ->
         [one] Afișează { $count } răspuns la { $answerId }
@@ -54,42 +46,31 @@ answer-show-responses =
        *[other] Afișează { $count } de răspunsuri la { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Feedback
-
 collapsible-click-to-open = (clic pentru a deschide)
 collapsible-click-to-close = (clic pentru a închide)
-
 collapsible-initializing = Se inițializează…
-
 footnote-show = Afișează nota de subsol
 footnote-hide = Ascunde nota de subsol
-
 description-more-information = mai multe informații
-
 
 ## Controls
 
 slider-previous = Înapoi
 slider-next = Înainte
-
 keyboard-open = Deschide tastatura
 keyboard-close = Închide tastatura
-
 choice-input-remove-choice = Elimină { $choice }
-
 matrix-remove-row = Elimină linia
 matrix-add-row = Adaugă o linie
 matrix-remove-column = Elimină coloana
 matrix-add-column = Adaugă o coloană
-
 subset-add-remove-points = Adaugă/elimină puncte
 subset-toggle-points-intervals = Comută puncte și intervale
 subset-move-points = Mută puncte
 subset-clear = Șterge
-
 orbital-add-row = Adaugă un rând
 orbital-remove-row = Elimină rândul
 orbital-add-box = Adaugă o căsuță
@@ -97,13 +78,9 @@ orbital-remove-box = Elimină căsuța
 orbital-add-up-arrow = Adaugă o săgeată în sus
 orbital-add-down-arrow = Adaugă o săgeată în jos
 orbital-remove-arrow = Elimină săgeata
-
 orbital-row-label = Etichetă pentru rândul { $row }
-
 pretzel-answer = Răspuns
-
 summary-statistics-caption = Statistici sumare pentru { $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = previzualizare a expresiei matematice
 math-input-preview = Previzualizare
 math-input-invalid-expression = Expresie nevalidă:
 
-
 ## Document status
 
 viewer-initializing = Se inițializează…
 
-
 ## Errors
 
 error-heading = Eroare
-
 error-found-at =
     { $span ->
         [line] Găsit la linia { $startLine }.
        *[lines] Găsit la liniile { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Acest document conține erori!
-
 diagnostic-heading-error = Eroare
 diagnostic-heading-warning = Avertisment
 diagnostic-heading-information = Informație
 diagnostic-heading-hint = Indiciu
-
 accessibility-heading-level-1 = Încălcare a accesibilității WCAG AA
 accessibility-heading-level-2 = Alertă de accesibilitate
-
 something-went-wrong = Ceva nu a mers bine.
-
 renderer-load-failed = un modul de randare nu a putut fi încărcat. Reîncărcați pagina.
-
 core-start-failed = Vizualizatorul de documente nu a putut fi pornit. Reîncărcați pagina.

--- a/packages/i18n/locales/ro/content.ftl
+++ b/packages/i18n/locales/ro/content.ftl
@@ -125,7 +125,6 @@ color =
         }
     .pink = roz
     .brown = maro
-
 line-width =
     .thick =
         { $role ->
@@ -139,7 +138,6 @@ line-width =
                 }
         }
     .thin = subțire
-
 line-style =
     .dashed =
         { $role ->
@@ -163,7 +161,6 @@ line-style =
                    *[m] punctat
                 }
         }
-
 fill-style =
     .horizontal = linii orizontale
     .vertical = linii verticale
@@ -171,7 +168,6 @@ fill-style =
     .backdiagonal = linii diagonale inverse
     .dots = puncte
     .diamonds = romburi
-
 noun =
     .line = dreaptă
     .line-segment = segment
@@ -191,7 +187,6 @@ noun =
     .diamond = romb
     .cross = cruce
     .plus = plus
-
 # The side count is a counted noun, so it takes «de» above nineteen — «cu 20 de
 # laturi» against «cu 19 laturi». `$numSides` is a real number, so the catalog
 # can select on it and get that right without the code knowing the rule.
@@ -205,7 +200,6 @@ noun-regular-polygon =
             }
        *[head] poligon regulat
     }
-
 # A neuter noun agrees like a masculine in the singular, and every description
 # here is singular, so `n` is never answered. `$noun` can also be
 # `regular-polygon` (poligon, n) or a head the description never names:
@@ -225,7 +219,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -238,7 +231,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives follow it, which is the whole of
 # Romanian's reordering.
 style-with-noun =
@@ -246,7 +238,6 @@ style-with-noun =
         [noun-tail] { $noun } { $nounTail } { $description }
        *[noun] { $noun } { $description }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -254,13 +245,11 @@ style-filled-word =
         [f] umplută
        *[m] umplut
     }
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } cu { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } cu { $pattern }
@@ -268,7 +257,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } cu { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # «un» is a word of its own and stands before the noun, so unlike the definite
 # article it can be written here — and the distinction English draws between
 # the `-article` branches and the others survives into Romanian.
@@ -279,36 +267,29 @@ style-border-clause =
         [and-article] și un chenar { $border }
        *[with] cu chenar { $border }
     }
-
 # The pattern is the noun and the colour describes it, so the colour follows.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = neumplut
-
 style-text =
     { $parts ->
         [background] { $color } pe fundal { $background }
        *[plain] { $color }
     }
-
 style-background-none = niciunul
-
 
 ## Boolean words
 
 boolean-true = adevărat
 boolean-false = fals
 
-
 ## Answer buttons
 
 answer-submit-label = Verifică
 answer-submit-label-no-correctness = Trimite răspunsul
-
 
 ## Sectional blocks
 ##
@@ -337,7 +318,6 @@ section-name =
     .solution = Soluția
     .task = Sarcina
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -347,9 +327,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Indiciu
-
 
 ## Tables and figures
 
@@ -360,7 +338,6 @@ table-name =
         [unnumbered-title] Tabelul{ ": " }
        *[unnumbered] Tabelul
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -369,22 +346,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Anterioară
 paginator-next = Următoare
 paginator-page = Pagina
-
 paginator-page-status = { $pageLabel } { $currentPage } din { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = sau
 piecewise-condition-if = dacă
 piecewise-condition-otherwise = altfel
-
 
 ## Chemistry
 
@@ -507,7 +480,6 @@ element-name =
     .lv = Livermoriu
     .ts = Tenesiu
     .og = Oganesson
-
 element-anion-name =
     .h = Hidrură
     .c = Carbură
@@ -521,8 +493,6 @@ element-anion-name =
     .i = Iodură
     .at = Astatură
     .ts = Tenesură
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol chimic nevalid
 chemistry-invalid-ionic-compound = Compus ionic nevalid

--- a/packages/i18n/locales/ru/chrome.ftl
+++ b/packages/i18n/locales/ru/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Проверка…
 answer-submitting = Отправка…
-
 answer-checking-status = Проверка ответа
 answer-submitting-status = Отправка ответа
-
 answer-correct = Верно
 answer-incorrect = Неверно
-
 answer-response-saved = Ответ сохранён
-
 answer-percent-credit = { $percent } % зачёта
 answer-percent-correct = { $percent } % верно
 answer-percent-short = { $percent } %
-
 max-credit-available = Максимально возможный зачёт: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] попыток не осталось
@@ -46,11 +40,9 @@ attempts-remaining =
         [many] осталось { $count } попыток
        *[other] осталось { $count } попытки
     }
-
 validation-correct = (Верно)
 validation-incorrect = (Неверно)
 validation-partially-correct = (Частично верно)
-
 answer-show-responses =
     { $count ->
         [one] Показать { $count } ответ на { $answerId }
@@ -59,42 +51,31 @@ answer-show-responses =
        *[other] Показать { $count } ответа на { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Обратная связь
-
 collapsible-click-to-open = (нажмите, чтобы открыть)
 collapsible-click-to-close = (нажмите, чтобы закрыть)
-
 collapsible-initializing = Инициализация…
-
 footnote-show = Показать сноску
 footnote-hide = Скрыть сноску
-
 description-more-information = подробнее
-
 
 ## Controls
 
 slider-previous = Назад
 slider-next = Вперёд
-
 keyboard-open = Открыть клавиатуру
 keyboard-close = Закрыть клавиатуру
-
 choice-input-remove-choice = Удалить { $choice }
-
 matrix-remove-row = Удалить строку
 matrix-add-row = Добавить строку
 matrix-remove-column = Удалить столбец
 matrix-add-column = Добавить столбец
-
 subset-add-remove-points = Добавить/удалить точки
 subset-toggle-points-intervals = Переключить точки и интервалы
 subset-move-points = Переместить точки
 subset-clear = Очистить
-
 # A `box` here is one orbital, drawn as a square: `ячейка`.
 orbital-add-row = Добавить строку
 orbital-remove-row = Удалить строку
@@ -103,13 +84,9 @@ orbital-remove-box = Удалить ячейку
 orbital-add-up-arrow = Добавить стрелку вверх
 orbital-add-down-arrow = Добавить стрелку вниз
 orbital-remove-arrow = Удалить стрелку
-
 orbital-row-label = Подпись строки { $row }
-
 pretzel-answer = Ответ
-
 summary-statistics-caption = Описательные статистики для { $column }
-
 
 ## Math input
 
@@ -117,34 +94,25 @@ math-input-preview-region = предварительный просмотр ма
 math-input-preview = Просмотр
 math-input-invalid-expression = Недопустимое выражение:
 
-
 ## Document status
 
 viewer-initializing = Инициализация…
 
-
 ## Errors
 
 error-heading = Ошибка
-
 error-found-at =
     { $span ->
         [line] Найдена в строке { $startLine }.
        *[lines] Найдена в строках { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = В этом документе есть ошибки!
-
 diagnostic-heading-error = Ошибка
 diagnostic-heading-warning = Предупреждение
 diagnostic-heading-information = Информация
 diagnostic-heading-hint = Подсказка
-
 accessibility-heading-level-1 = Нарушение доступности WCAG AA
 accessibility-heading-level-2 = Предупреждение о доступности
-
 something-went-wrong = Что-то пошло не так.
-
 renderer-load-failed = не удалось загрузить компонент отображения. Пожалуйста, перезагрузите страницу.
-
 core-start-failed = Не удалось запустить просмотрщик документа. Пожалуйста, перезагрузите страницу.

--- a/packages/i18n/locales/ru/content.ftl
+++ b/packages/i18n/locales/ru/content.ftl
@@ -172,7 +172,6 @@ color =
                    *[m] коричневый
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -198,7 +197,6 @@ line-width =
                    *[m] тонкий
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -224,7 +222,6 @@ line-style =
                    *[m] пунктирный
                 }
         }
-
 # Noun phrases in the instrumental, which is the case «с» takes. They agree
 # with nothing.
 fill-style =
@@ -234,7 +231,6 @@ fill-style =
     .backdiagonal = обратными диагональными линиями
     .dots = точками
     .diamonds = ромбами
-
 noun =
     .line = прямая
     .line-segment = отрезок
@@ -254,7 +250,6 @@ noun =
     .diamond = ромб
     .cross = крест
     .plus = знак плюс
-
 # Russian keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -262,7 +257,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] правильный { $numSides }-угольник
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (многоугольник, m)
 # or the head of a phrase the description never names: `border` (граница, f),
 # `fill` (заливка, f), `text` (текст, m), `background` (фон, m).
@@ -289,7 +283,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -302,13 +295,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every
 # description and takes no `$role` branch.
 style-filled-word =
@@ -317,13 +308,11 @@ style-filled-word =
         [n] закрашенное
        *[m] закрашенный
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } с { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } с { $pattern }
@@ -331,7 +320,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } с { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «граница» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Russian has no article, so the two article branches
 # read the same as the ones without.
@@ -342,7 +330,6 @@ style-border-clause =
         [and-article] и { $border } границей
        *[with] с { $border } границей
     }
-
 # The fill-pattern words are instrumental plurals, because their other use is
 # the «с { $pattern }» clause in `style-filled`. So this message supplies a
 # noun for them to hang off — «заливка», feminine, which is the gender
@@ -353,29 +340,23 @@ style-fill =
         [pattern] { $color } заливка с { $pattern }
        *[plain] { $color } заливка
     }
-
 style-unfilled = незакрашенный
-
 style-text =
     { $parts ->
         [background] { $color } на { $background } фоне
        *[plain] { $color }
     }
-
 style-background-none = нет
-
 
 ## Boolean words
 
 boolean-true = истина
 boolean-false = ложь
 
-
 ## Answer buttons
 
 answer-submit-label = Проверить
 answer-submit-label-no-correctness = Отправить ответ
-
 
 ## Sectional blocks
 
@@ -400,7 +381,6 @@ section-name =
     .solution = Решение
     .task = Задача
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -410,9 +390,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Подсказка
-
 
 ## Tables and figures
 
@@ -423,7 +401,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Рисунок { $enumeration }
@@ -432,22 +409,18 @@ figure-name =
        *[unnumbered] Рисунок
     }
 
-
 ## Paginator controls
 
 paginator-previous = Назад
 paginator-next = Вперёд
 paginator-page = Страница
-
 paginator-page-status = { $pageLabel } { $currentPage } из { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = или
 piecewise-condition-if = если
 piecewise-condition-otherwise = иначе
-
 
 ## Chemistry
 
@@ -570,7 +543,6 @@ element-name =
     .lv = Ливерморий
     .ts = Теннессин
     .og = Оганесон
-
 element-anion-name =
     .h = Гидрид
     .c = Карбид
@@ -584,8 +556,6 @@ element-anion-name =
     .i = Иодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Недопустимый химический символ
 chemistry-invalid-ionic-compound = Недопустимое ионное соединение

--- a/packages/i18n/locales/rw/chrome.ftl
+++ b/packages/i18n/locales/rw/chrome.ftl
@@ -16,74 +16,55 @@
 
 answer-checking = Kugenzura...
 answer-submitting = Kohereza...
-
 answer-checking-status = Kugenzura igisubizo
 answer-submitting-status = Kohereza igisubizo
-
 answer-correct = Ni cyo
 answer-incorrect = Si cyo
-
 answer-response-saved = Igisubizo Cyabitswe
-
 answer-percent-credit = Amanota { $percent }%
 answer-percent-correct = { $percent }% Ni cyo
 answer-percent-short = { $percent }%
-
 max-credit-available = Amanota ntarengwa ashoboka: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nta gerageza risigaye
         [one] hasigaye igerageza { $count }
        *[other] hasigaye amagerageza { $count }
     }
-
 validation-correct = (Ni cyo)
 validation-incorrect = (Si cyo)
 validation-partially-correct = (Ni cyo ku gice)
-
 answer-show-responses =
     { $count ->
         [one] Erekana igisubizo { $count } kuri { $answerId }
        *[other] Erekana ibisubizo { $count } kuri { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ibitekerezo
-
 collapsible-click-to-open = (kanda kugira ngo ufungure)
 collapsible-click-to-close = (kanda kugira ngo ufunge)
-
 collapsible-initializing = Gutangira...
-
 footnote-show = Erekana inyandiko yo hasi
 footnote-hide = Hisha inyandiko yo hasi
-
 description-more-information = amakuru arushijeho
-
 
 ## Controls
 
 slider-previous = Inyuma
 slider-next = Imbere
-
 keyboard-open = Fungura Klavye
 keyboard-close = Funga Klavye
-
 choice-input-remove-choice = Kuraho { $choice }
-
 matrix-remove-row = Kuraho umurongo
 matrix-add-row = Ongeraho umurongo
 matrix-remove-column = Kuraho inkingi
 matrix-add-column = Ongeraho inkingi
-
 subset-add-remove-points = Ongeraho/Kuraho ududomo
 subset-toggle-points-intervals = Hindura hagati y'ududomo n'intera
 subset-move-points = Himura Ududomo
 subset-clear = Siba
-
 # A `box` here is one orbital, drawn as a square: agasanduku.
 orbital-add-row = Ongeraho Umurongo
 orbital-remove-row = Kuraho Umurongo
@@ -92,13 +73,9 @@ orbital-remove-box = Kuraho Agasanduku
 orbital-add-up-arrow = Ongeraho Akambi Kajya Hejuru
 orbital-add-down-arrow = Ongeraho Akambi Kajya Hasi
 orbital-remove-arrow = Kuraho Akambi
-
 orbital-row-label = Akarango k'umurongo { $row }
-
 pretzel-answer = Igisubizo
-
 summary-statistics-caption = Incamake y'imibare ya { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = igaragazwa ry'imvugo y'imibare
 math-input-preview = Igaragazwa
 math-input-invalid-expression = Imvugo itemewe:
 
-
 ## Document status
 
 viewer-initializing = Gutangira...
 
-
 ## Errors
 
 error-heading = Ikosa
-
 error-found-at =
     { $span ->
         [line] Ryabonetse ku murongo { $startLine }.
        *[lines] Ryabonetse ku mirongo { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Iyi nyandiko irimo amakosa!
-
 diagnostic-heading-error = Ikosa
 diagnostic-heading-warning = Umuburo
 diagnostic-heading-information = Amakuru
 diagnostic-heading-hint = Inama
-
 accessibility-heading-level-1 = Kutubahiriza Ukugerwaho kwa WCAG AA
 accessibility-heading-level-2 = Umuburo w'ukugerwaho
-
 something-went-wrong = Hari ikitagenze neza.
-
 renderer-load-failed = igaragaza rimwe ntiryashoboye gupakirwa. Ongera upakire urupapuro.
-
 core-start-failed = Igaragaza ry'inyandiko ntiryashoboye gutangira. Ongera upakire urupapuro.

--- a/packages/i18n/locales/rw/content.ftl
+++ b/packages/i18n/locales/rw/content.ftl
@@ -117,7 +117,6 @@ color =
             [c7] cy'ikawa
            *[c9] y'ikawa
         }
-
 # True adjectives, and so the adjective concord rather than the subject one.
 line-width =
     .thick =
@@ -134,13 +133,11 @@ line-width =
             [c7] gito
            *[c9] nto
         }
-
 # An invariable «ufite …» phrase — "having …" — so that it agrees with nothing
 # and can close the description. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = ufite uduce
     .dotted = ufite udutonyanga
-
 fill-style =
     .horizontal = imirongo iryamye
     .vertical = imirongo ihagaze
@@ -148,7 +145,6 @@ fill-style =
     .backdiagonal = imirongo iberamye ku ruhande rundi
     .dots = udutonyanga
     .diamonds = amadiyama
-
 noun =
     .line = umurongo
     .line-segment = igice cy'umurongo
@@ -168,7 +164,6 @@ noun =
     .diamond = idiyama
     .cross = umusaraba
     .plus = ikimenyetso cyo kongeramo
-
 # The side count goes in the tail, behind the describing words: Kinyarwanda
 # closes a noun phrase with a relative rather than opening one with it.
 noun-regular-polygon =
@@ -176,7 +171,6 @@ noun-regular-polygon =
         [tail] ifite impande { $numSides }
        *[head] ishusho ingana impande
     }
-
 noun-gender =
     { $noun ->
         [line] c3
@@ -192,7 +186,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -205,13 +198,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] wuzuye
@@ -219,13 +210,11 @@ style-filled-word =
         [c7] cyuzuye
        *[c9] yuzuye
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } hamwe na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } hamwe na { $pattern }
@@ -233,7 +222,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } hamwe na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «umupaka» is class 3, so the border's words agree with it and not with the
 # shape it surrounds. Kinyarwanda has no article and joins a complement with
 # the invariable «hamwe n'», so all four branches read alike.
@@ -244,35 +232,28 @@ style-border-clause =
         [and-article] hamwe n'umupaka { $border }
        *[with] hamwe n'umupaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ntiyuzuye
-
 style-text =
     { $parts ->
         [background] { $color } ku mbuganyuma { $background }
        *[plain] { $color }
     }
-
 style-background-none = nta na kimwe
-
 
 ## Boolean words
 
 boolean-true = ni byo
 boolean-false = si byo
 
-
 ## Answer buttons
 
 answer-submit-label = Genzura Umurimo
 answer-submit-label-no-correctness = Ohereza Igisubizo
-
 
 ## Sectional blocks
 
@@ -297,7 +278,6 @@ section-name =
     .solution = Igisubizo
     .task = Umurimo
     .theorem = Teoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -307,9 +287,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Inama
-
 
 ## Tables and figures
 
@@ -320,7 +298,6 @@ table-name =
         [unnumbered-title] Imbonerahamwe{ ": " }
        *[unnumbered] Imbonerahamwe
     }
-
 figure-name =
     { $parts ->
         [numbered] Ishusho { $enumeration }
@@ -329,15 +306,12 @@ figure-name =
        *[unnumbered] Ishusho
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ibanza
 paginator-next = Ikurikira
 paginator-page = Urupapuro
-
 paginator-page-status = { $pageLabel } { $currentPage } kuri { $numPages }
-
 
 ## Piecewise functions
 
@@ -345,8 +319,8 @@ piecewise-condition-or = cyangwa
 piecewise-condition-if = niba
 piecewise-condition-otherwise = ubundi
 
-
 ## Chemistry
+
 
 # Kinyarwanda is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. Rwandan
@@ -355,6 +329,5 @@ piecewise-condition-otherwise = ubundi
 # in their own textbook.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ikimenyetso cya Shimi Kitemewe
 chemistry-invalid-ionic-compound = Umuvange wa Ayoni Utemewe

--- a/packages/i18n/locales/sa/chrome.ftl
+++ b/packages/i18n/locales/sa/chrome.ftl
@@ -15,21 +15,15 @@
 
 answer-checking = परीक्ष्यते…
 answer-submitting = प्रेष्यते…
-
 answer-checking-status = उत्तरं परीक्ष्यते
 answer-submitting-status = उत्तरं प्रेष्यते
-
 answer-correct = शुद्धम्
 answer-incorrect = अशुद्धम्
-
 answer-response-saved = उत्तरं रक्षितम्
-
 answer-percent-credit = { $percent }% अङ्काः
 answer-percent-correct = { $percent }% शुद्धम्
 answer-percent-short = { $percent } %
-
 max-credit-available = उपलब्धाः अधिकतमाः अङ्काः: { $percent }%
-
 # Sanskrit leaves a noun singular after a numeral far less readily than the
 # modern languages beside it do, but it also has a dual this catalog cannot
 # reach: `Intl.PluralRules` has no Sanskrit data and reports the English
@@ -41,53 +35,40 @@ attempts-remaining =
         [one] { $count } प्रयत्नः अवशिष्टः
        *[other] { $count } प्रयत्नाः अवशिष्टाः
     }
-
 validation-correct = (शुद्धम्)
 validation-incorrect = (अशुद्धम्)
 validation-partially-correct = (आंशिकतया शुद्धम्)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId }-कृते { $count } उत्तरं दर्श्यताम्
        *[other] { $answerId }-कृते { $count } उत्तराणि दर्श्यन्ताम्
     }
 
-
 ## Disclosure panels
 
 feedback-heading = प्रतिपुष्टिः
-
 collapsible-click-to-open = (उद्घाटनाय नुद्यताम्)
 collapsible-click-to-close = (पिधानाय नुद्यताम्)
-
 collapsible-initializing = आरभ्यते…
-
 footnote-show = पादटिप्पणी दर्श्यताम्
 footnote-hide = पादटिप्पणी गोप्यताम्
-
 description-more-information = अधिका सूचना
-
 
 ## Controls
 
 slider-previous = पूर्वम्
 slider-next = अग्रिमम्
-
 keyboard-open = कुञ्जीपटलम् उद्घाट्यताम्
 keyboard-close = कुञ्जीपटलं पिधीयताम्
-
 choice-input-remove-choice = { $choice } अपनीयताम्
-
 matrix-remove-row = पङ्क्तिः अपनीयताम्
 matrix-add-row = पङ्क्तिः योज्यताम्
 matrix-remove-column = स्तम्भः अपनीयताम्
 matrix-add-column = स्तम्भः योज्यताम्
-
 subset-add-remove-points = बिन्दवः योज्यन्ताम् अपनीयन्तां वा
 subset-toggle-points-intervals = बिन्दवः अन्तरालाश्च परिवर्त्यन्ताम्
 subset-move-points = बिन्दवः चाल्यन्ताम्
 subset-clear = मार्ज्यताम्
-
 orbital-add-row = पङ्क्तिः योज्यताम्
 orbital-remove-row = पङ्क्तिः अपनीयताम्
 orbital-add-box = पेटिका योज्यताम्
@@ -95,13 +76,9 @@ orbital-remove-box = पेटिका अपनीयताम्
 orbital-add-up-arrow = ऊर्ध्वबाणः योज्यताम्
 orbital-add-down-arrow = अधोबाणः योज्यताम्
 orbital-remove-arrow = बाणः अपनीयताम्
-
 orbital-row-label = { $row } पङ्क्तेः नामाङ्कनम्
-
 pretzel-answer = उत्तरम्
-
 summary-statistics-caption = { $column } इत्यस्य साङ्ख्यिकीसारः
-
 
 ## Math input
 
@@ -109,35 +86,26 @@ math-input-preview-region = गणितीयव्यञ्जनस्य प
 math-input-preview = पूर्वावलोकनम्
 math-input-invalid-expression = अमान्यं व्यञ्जनम्:
 
-
 ## Document status
 
 viewer-initializing = आरभ्यते…
 
-
 ## Errors
 
 error-heading = दोषः
-
 error-found-at =
     { $span ->
         [line] { $startLine } पङ्क्तौ प्राप्तः।
        *[lines] { $startLine }–{ $endLine } पङ्क्तिषु प्राप्तः।
     }
-
 document-contains-errors = अस्मिन् लेखे दोषाः सन्ति!
-
 diagnostic-heading-error = दोषः
 diagnostic-heading-warning = सावधानम्
 diagnostic-heading-information = सूचना
 diagnostic-heading-hint = सङ्केतः
-
 # `WCAG AA` is the name of the standard and is left as it stands.
 accessibility-heading-level-1 = WCAG AA सुगम्यताभङ्गः
 accessibility-heading-level-2 = सुगम्यतासूचना
-
 something-went-wrong = किमपि विपरीतं जातम्।
-
 renderer-load-failed = प्रदर्शकः आनेतुं न शक्तः। कृपया पृष्ठं पुनः लोड्यताम्।
-
 core-start-failed = लेखदर्शकः आरब्धुं न शक्तः। कृपया पृष्ठं पुनः लोड्यताम्।

--- a/packages/i18n/locales/sa/content.ftl
+++ b/packages/i18n/locales/sa/content.ftl
@@ -190,7 +190,6 @@ color =
                    *[m] कपिशः
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -216,7 +215,6 @@ line-width =
                    *[m] सूक्ष्मः
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -242,7 +240,6 @@ line-style =
                    *[m] बिन्दुमयः
                 }
         }
-
 # Instrumental plurals, because everywhere these are used puts «सह» after them
 # — «बिन्दुभिः सह», "with dots". Writing them in the nominative and inflecting
 # them in the frame is not possible: the frame would have to know which stem
@@ -254,7 +251,6 @@ fill-style =
     .backdiagonal = विपरीतकर्णरेखाभिः
     .dots = बिन्दुभिः
     .diamonds = समचतुर्भुजैः
-
 noun =
     .line = रेखा
     .line-segment = रेखाखण्डः
@@ -274,7 +270,6 @@ noun =
     .diamond = समचतुर्भुजः
     .cross = गुणनचिह्नम्
     .plus = योगचिह्नम्
-
 # «-भुजः» is a bahuvrīhi ending welded onto the count — "having 5 sides" — and
 # it has one shape whatever number lands in front of it, so the weld is sound
 # in the way the README's affix rule allows. समबहुभुजः is masculine, and the
@@ -284,7 +279,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides }-भुजः समबहुभुजः
     }
-
 # Besides the nouns above, `$noun` may be «regular-polygon» (समबहुभुजः, m) or
 # the head of a phrase the description does not name: «border» (सीमा, f),
 # «fill» (पूरणम्, n), «text» (पाठ्यम्, n), «background» (पृष्ठभूमिः, f).
@@ -306,7 +300,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 # Adjectives precede the noun, and are written apart from it rather than
@@ -322,13 +315,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Said only of the shape itself, so it agrees with `$gender` and takes no
 # `$role` branch.
 style-filled-word =
@@ -337,7 +328,6 @@ style-filled-word =
         [n] पूरितम्
        *[m] पूरितः
     }
-
 # «सह» governs the instrumental and follows what it governs, which is why the
 # pattern comes first here where English appends it.
 style-filled =
@@ -345,7 +335,6 @@ style-filled =
         [pattern] { $pattern } सह { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } सह { $filled } { $color } { $noun }
@@ -353,7 +342,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } सह { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «सीमया सह» is instrumental, which is the case `border-clause` supplies. «तथा»
 # rather than «च» for the `and` branches: «च» is enclitic and would have to
 # stand after the phrase it joins, where a placeable already sits. Sanskrit has
@@ -365,7 +353,6 @@ style-border-clause =
         [and-article] तथा { $border } सीमया सह
        *[with] { $border } सीमया सह
     }
-
 # The colour arrives agreeing with «पूरणम्», which is neuter, so the noun has
 # to stand beside it: «नीलम्» alone would be read as agreeing with whatever the
 # reader last saw.
@@ -374,10 +361,8 @@ style-fill =
         [pattern] { $pattern } सह { $color } पूरणम्
        *[plain] { $color } पूरणम्
     }
-
 # Nothing is passed to agree this with, so it is fixed in the neuter.
 style-unfilled = अपूरितम्
-
 # The background's colour is locative — «नीलायां पृष्ठभूमौ», on a blue
 # background — and the text's own colour, which follows, is nominative neuter
 # agreeing with «पाठ्यम्». Both words on the right of the placeable are this
@@ -387,21 +372,17 @@ style-text =
         [background] { $background } पृष्ठभूमौ { $color }
        *[plain] { $color }
     }
-
 style-background-none = किमपि न
-
 
 ## Boolean words
 
 boolean-true = सत्यम्
 boolean-false = असत्यम्
 
-
 ## Answer buttons
 
 answer-submit-label = परीक्ष्यताम्
 answer-submit-label-no-correctness = उत्तरं प्रेष्यताम्
-
 
 ## Sectional blocks
 
@@ -426,7 +407,6 @@ section-name =
     .solution = समाधानम्
     .task = कार्यम्
     .theorem = प्रमेयम्
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -436,9 +416,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = सङ्केतः
-
 
 ## Tables and figures
 
@@ -449,7 +427,6 @@ table-name =
         [unnumbered-title] सारणी{ ": " }
        *[unnumbered] सारणी
     }
-
 figure-name =
     { $parts ->
         [numbered] चित्रम् { $enumeration }
@@ -458,27 +435,21 @@ figure-name =
        *[unnumbered] चित्रम्
     }
 
-
 ## Paginator controls
 
 paginator-previous = पूर्वम्
 paginator-next = अग्रिमम्
 paginator-page = पृष्ठम्
-
 # «X-मध्ये Y» — "Y among X" — puts the total first, so the two counts change
 # places. «-मध्ये» is a locative in form and partitive in sense; it is welded
 # to a placeable and has one shape whatever precedes it.
 paginator-page-status = { $numPages }-मध्ये { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = अथवा
-
 piecewise-condition-if = यदि
-
 piecewise-condition-otherwise = अन्यथा
-
 
 ## Chemistry
 ##
@@ -496,6 +467,5 @@ piecewise-condition-otherwise = अन्यथा
 ## reading Sanskrit meets in their chemistry class anyway.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = अमान्यं रासायनिकं चिह्नम्
 chemistry-invalid-ionic-compound = अमान्यम् आयनिकं यौगिकम्

--- a/packages/i18n/locales/sah/chrome.ftl
+++ b/packages/i18n/locales/sah/chrome.ftl
@@ -25,69 +25,50 @@
 
 answer-checking = Бэрэбиэркэлэнэр…
 answer-submitting = Ыытыллар…
-
 answer-checking-status = Хоруй бэрэбиэркэлэнэр
 answer-submitting-status = Хоруй ыытыллар
-
 answer-correct = Сөп
 answer-incorrect = Сыыһа
-
 answer-response-saved = Хоруй хараллыбыта
-
 answer-percent-credit = { $percent }% баал
 answer-percent-correct = { $percent }% сөп
 answer-percent-short = { $percent } %
-
 max-credit-available = Ылыахха сөптөөх үрдүк баал: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] боруобалыыр кыах хаалбата
        *[other] { $count } боруобалыыр кыах хаалла
     }
-
 validation-correct = (Сөп)
 validation-incorrect = (Сыыһа)
 validation-partially-correct = (Аҥаардастыы сөп)
-
 answer-show-responses = { $answerId } диэҥҥэ { $count } хоруйу көрдөр
-
 
 ## Disclosure panels
 
 feedback-heading = Хардары этии
-
 collapsible-click-to-open = (аһар туһугар баттаа)
 collapsible-click-to-close = (сабар туһугар баттаа)
-
 collapsible-initializing = Бэлэмнэнэр…
-
 footnote-show = Бэлиэтээһини көрдөр
 footnote-hide = Бэлиэтээһини кистээ
-
 description-more-information = эбии информация
-
 
 ## Controls
 
 slider-previous = Иннинээҕи
 slider-next = Аныгыскы
-
 keyboard-open = Клавиатураны аһар
 keyboard-close = Клавиатураны сабар
-
 choice-input-remove-choice = { $choice } талыытын сот
-
 matrix-remove-row = Строканы сот
 matrix-add-row = Строка эп
 matrix-remove-column = Колонканы сот
 matrix-add-column = Колонка эп
-
 subset-add-remove-points = Туочука эбии/сотуу
 subset-toggle-points-intervals = Туочукалары уонна кэрчиктэри уларыт
 subset-move-points = Туочукалары көһөр
 subset-clear = Ыраастаа
-
 orbital-add-row = Строка эп
 orbital-remove-row = Строканы сот
 orbital-add-box = Кыаһы эп
@@ -95,13 +76,9 @@ orbital-remove-box = Кыаһы сот
 orbital-add-up-arrow = Үөһэ ох эп
 orbital-add-down-arrow = Аллара ох эп
 orbital-remove-arrow = Оҕу сот
-
 orbital-row-label = { $row } строка бэлиэтэ
-
 pretzel-answer = Хоруй
-
 summary-statistics-caption = { $column } колонка түмүк статистиката
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = математика этиитин иннинэ к�
 math-input-preview = Иннинэ көрүү
 math-input-invalid-expression = Сыыһа этии:
 
-
 ## Document status
 
 viewer-initializing = Бэлэмнэнэр…
 
-
 ## Errors
 
 error-heading = Алҕас
-
 error-found-at =
     { $span ->
         [line] Булуллубут строка: { $startLine }.
        *[lines] Булуллубут строкалар: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Бу дьокумуоҥҥа алҕастар бааллар!
-
 diagnostic-heading-error = Алҕас
 diagnostic-heading-warning = Сэрэтии
 diagnostic-heading-information = Информация
 diagnostic-heading-hint = Сүбэ
-
 accessibility-heading-level-1 = WCAG AA туттуллар кыаҕын кэһиитэ
 accessibility-heading-level-2 = Туттуллар кыаҕын туһунан биллэрии
-
 something-went-wrong = Туох эрэ сыыһа тахсыбыт.
-
 renderer-load-failed = ойуулааччыны хачайдыы иликпит. Сирэйи саҥалыы хачайдаа.
-
 core-start-failed = Дьокумуон көрөр тэрилин саҕалыыр кыах суох. Сирэйи саҥалыы хачайдаа.

--- a/packages/i18n/locales/sah/content.ftl
+++ b/packages/i18n/locales/sah/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = фиолетовай
     .pink = розовай
     .brown = кугас
-
 line-width =
     .thick = халыҥ
     .thin = синньигэс
-
 line-style =
     .dashed = быстах-быстах
     .dotted = туочукалаах
-
 # Noun phrases: they stand in front of «оҥоһуулаах» and modify nothing.
 fill-style =
     .horizontal = горизонтальнай сурааһын
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = утары диагональ сурааһын
     .dots = туочука
     .diamonds = ромб
-
 noun =
     .line = көнө сурааһын
     .line-segment = кэрчик
@@ -77,7 +73,6 @@ noun =
     .diamond = ромб
     .cross = кириэс
     .plus = плюс
-
 # Sakha builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -85,11 +80,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] тэҥ { $numSides } муннуктаах
     }
-
 # Sakha has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -103,21 +96,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = кырааскалаах
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } оҥоһуулаах { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } оҥоһуулаах { $color } { $filled } { $noun }
@@ -125,7 +114,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } оҥоһуулаах { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «кыраныыстаах» — "having an edge" — carries the "with a border" sense in its
 # own suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
@@ -135,15 +123,12 @@ style-border-clause =
         [and-article] уонна { $border } кыраныыстаах
        *[with] { $border } кыраныыстаах
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } оҥоһуулаах { $color } кырааска
        *[plain] { $color } кырааска
     }
-
 style-unfilled = кырааската суох
-
 # «үрдүгэр» — "on top of" — is a postposition and follows the background
 # colour, so nothing stands between the two words the way English's "with a"
 # does.
@@ -152,21 +137,17 @@ style-text =
         [background] { $background } фон үрдүгэр { $color }
        *[plain] { $color }
     }
-
 style-background-none = суох
-
 
 ## Boolean words
 
 boolean-true = сөп
 boolean-false = сыыһа
 
-
 ## Answer buttons
 
 answer-submit-label = Бэрэбиэркэлээ
 answer-submit-label-no-correctness = Хоруйу ыыт
-
 
 ## Sectional blocks
 
@@ -191,7 +172,6 @@ section-name =
     .solution = Быһаарыы
     .task = Үлэ
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -201,9 +181,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Сүбэ
-
 
 ## Tables and figures
 
@@ -214,7 +192,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Ойуу { $enumeration }
@@ -223,15 +200,12 @@ figure-name =
        *[unnumbered] Ойуу
     }
 
-
 ## Paginator controls
 
 paginator-previous = Иннинээҕи
 paginator-next = Аныгыскы
 paginator-page = Сирэй
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -248,7 +222,6 @@ piecewise-condition-or = эбэтэр
 piecewise-condition-if = буоллаҕына
 piecewise-condition-otherwise = атын түгэннэргэ
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -261,6 +234,5 @@ piecewise-condition-otherwise = атын түгэннэргэ
 ## inferred: what is missing is a settled list of all 118, not the schooling.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Сыыһа хиимийэ бэлиэтэ
 chemistry-invalid-ionic-compound = Сыыһа ион холбоһуга

--- a/packages/i18n/locales/sat/chrome.ftl
+++ b/packages/i18n/locales/sat/chrome.ftl
@@ -12,21 +12,15 @@
 
 answer-checking = ᱧᱮᱞ ᱠᱟᱱᱟ…
 answer-submitting = ᱠᱩᱞ ᱠᱟᱱᱟ…
-
 answer-checking-status = ᱛᱮᱞᱟ ᱧᱮᱞ ᱠᱟᱱᱟ
 answer-submitting-status = ᱛᱮᱞᱟ ᱠᱩᱞ ᱠᱟᱱᱟ
-
 answer-correct = ᱴᱷᱤᱠ
 answer-incorrect = ᱵᱷᱩᱞ
-
 answer-response-saved = ᱛᱮᱞᱟ ᱫᱚᱦᱚ ᱦᱩᱭᱮᱱᱟ
-
 answer-percent-credit = { $percent }% ᱱᱚᱢᱵᱚᱨ
 answer-percent-correct = { $percent }% ᱴᱷᱤᱠ
 answer-percent-short = { $percent } %
-
 max-credit-available = ᱵᱟᱰᱟᱭ ᱦᱩᱭᱩᱜ ᱠᱟᱱ ᱢᱟᱨᱟᱝ ᱱᱚᱢᱵᱚᱨ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ᱡᱟᱦᱟᱸ ᱠᱩᱨᱩᱢᱩᱴᱩ ᱵᱟᱝ ᱛᱟᱦᱮᱸᱱᱟ
@@ -34,11 +28,9 @@ attempts-remaining =
         [two] { $count } ᱠᱩᱨᱩᱢᱩᱴᱩᱠᱤᱱ ᱛᱟᱦᱮᱸᱱᱟ
        *[other] { $count } ᱠᱩᱨᱩᱢᱩᱴᱩᱠᱚ ᱛᱟᱦᱮᱸᱱᱟ
     }
-
 validation-correct = (ᱴᱷᱤᱠ)
 validation-incorrect = (ᱵᱷᱩᱞ)
 validation-partially-correct = (ᱦᱟᱹᱴᱤᱧ ᱛᱮ ᱴᱷᱤᱠ)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } ᱞᱟᱹᱜᱤᱫ { $count } ᱛᱮᱞᱟ ᱩᱫᱩᱜ ᱢᱮ
@@ -46,42 +38,31 @@ answer-show-responses =
        *[other] { $answerId } ᱞᱟᱹᱜᱤᱫ { $count } ᱛᱮᱞᱟᱠᱚ ᱩᱫᱩᱜ ᱢᱮ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ᱛᱮᱞᱟ ᱠᱟᱛᱷᱟ
-
 collapsible-click-to-open = (ᱡᱷᱤᱡ ᱞᱟᱹᱜᱤᱫ ᱠᱞᱤᱠ ᱢᱮ)
 collapsible-click-to-close = (ᱵᱚᱸᱫ ᱞᱟᱹᱜᱤᱫ ᱠᱞᱤᱠ ᱢᱮ)
-
 collapsible-initializing = ᱮᱛᱦᱚᱵ ᱠᱟᱱᱟ…
-
 footnote-show = ᱡᱟᱸᱜᱟ ᱴᱤᱯᱚᱱ ᱩᱫᱩᱜ ᱢᱮ
 footnote-hide = ᱡᱟᱸᱜᱟ ᱴᱤᱯᱚᱱ ᱩᱠᱩ ᱢᱮ
-
 description-more-information = ᱟᱨᱦᱚᱸ ᱠᱟᱛᱷᱟ
-
 
 ## Controls
 
 slider-previous = ᱢᱟᱲᱟᱝᱟᱜ
 slider-next = ᱛᱟᱭᱚᱢᱟᱜ
-
 keyboard-open = ᱠᱤᱵᱚᱨᱰ ᱡᱷᱤᱡ ᱢᱮ
 keyboard-close = ᱠᱤᱵᱚᱨᱰ ᱵᱚᱸᱫ ᱢᱮ
-
 choice-input-remove-choice = { $choice } ᱚᱪᱚᱜ ᱢᱮ
-
 matrix-remove-row = ᱥᱟᱨᱤ ᱚᱪᱚᱜ ᱢᱮ
 matrix-add-row = ᱥᱟᱨᱤ ᱥᱮᱞᱮᱫ ᱢᱮ
 matrix-remove-column = ᱠᱷᱟᱸᱴ ᱚᱪᱚᱜ ᱢᱮ
 matrix-add-column = ᱠᱷᱟᱸᱴ ᱥᱮᱞᱮᱫ ᱢᱮ
-
 subset-add-remove-points = ᱴᱩᱰᱟᱹᱜ ᱥᱮᱞᱮᱫ/ᱚᱪᱚᱜ ᱢᱮ
 subset-toggle-points-intervals = ᱴᱩᱰᱟᱹᱜ ᱟᱨ ᱟᱸᱛᱚᱨᱟᱞ ᱵᱚᱫᱚᱞ ᱢᱮ
 subset-move-points = ᱴᱩᱰᱟᱹᱜ ᱟᱛᱟᱝ ᱢᱮ
 subset-clear = ᱢᱮᱴᱟᱣ ᱢᱮ
-
 orbital-add-row = ᱥᱟᱨᱤ ᱥᱮᱞᱮᱫ ᱢᱮ
 orbital-remove-row = ᱥᱟᱨᱤ ᱚᱪᱚᱜ ᱢᱮ
 orbital-add-box = ᱵᱟᱠᱚᱥ ᱥᱮᱞᱮᱫ ᱢᱮ
@@ -89,13 +70,9 @@ orbital-remove-box = ᱵᱟᱠᱚᱥ ᱚᱪᱚᱜ ᱢᱮ
 orbital-add-up-arrow = ᱪᱮᱛᱟᱱ ᱛᱤᱨ ᱥᱮᱞᱮᱫ ᱢᱮ
 orbital-add-down-arrow = ᱞᱟᱛᱟᱨ ᱛᱤᱨ ᱥᱮᱞᱮᱫ ᱢᱮ
 orbital-remove-arrow = ᱛᱤᱨ ᱚᱪᱚᱜ ᱢᱮ
-
 orbital-row-label = ᱥᱟᱨᱤ { $row } ᱨᱮᱱ ᱧᱩᱛᱩᱢ
-
 pretzel-answer = ᱛᱮᱞᱟ
-
 summary-statistics-caption = { $column } ᱨᱮᱱ ᱥᱟᱸᱠᱷᱭᱤᱠᱤ ᱥᱟᱨ
-
 
 ## Math input
 
@@ -103,34 +80,25 @@ math-input-preview-region = ᱜᱟᱱᱤᱛ ᱠᱟᱛᱷᱟ ᱨᱮᱱ ᱢᱟᱲ�
 math-input-preview = ᱢᱟᱲᱟᱝ ᱧᱮᱞ
 math-input-invalid-expression = ᱵᱟᱝ ᱴᱷᱤᱠ ᱠᱟᱛᱷᱟ:
 
-
 ## Document status
 
 viewer-initializing = ᱮᱛᱦᱚᱵ ᱠᱟᱱᱟ…
 
-
 ## Errors
 
 error-heading = ᱵᱷᱩᱞ
-
 error-found-at =
     { $span ->
         [line] ᱥᱟᱨᱤ { $startLine } ᱨᱮ ᱧᱟᱢ ᱦᱩᱭᱮᱱᱟ।
        *[lines] ᱥᱟᱨᱤ { $startLine }–{ $endLine } ᱨᱮ ᱧᱟᱢ ᱦᱩᱭᱮᱱᱟ।
     }
-
 document-contains-errors = ᱱᱚᱶᱟ ᱫᱟᱞᱤᱞ ᱨᱮ ᱵᱷᱩᱞ ᱢᱮᱱᱟᱜᱼᱟ!
-
 diagnostic-heading-error = ᱵᱷᱩᱞ
 diagnostic-heading-warning = ᱦᱟᱸᱥᱤᱭᱟᱨ
 diagnostic-heading-information = ᱠᱟᱛᱷᱟ
 diagnostic-heading-hint = ᱪᱤᱱᱦᱟᱹ
-
 accessibility-heading-level-1 = WCAG AA ᱥᱩᱜᱚᱢ ᱨᱮᱱ ᱵᱷᱩᱞ
 accessibility-heading-level-2 = ᱥᱩᱜᱚᱢ ᱨᱮᱱ ᱠᱟᱛᱷᱟ
-
 something-went-wrong = ᱚᱠᱟ ᱦᱚᱸ ᱵᱷᱩᱞ ᱦᱩᱭᱮᱱᱟ।
-
 renderer-load-failed = ᱢᱤᱫ ᱩᱫᱩᱜᱤᱡ ᱞᱚᱰ ᱵᱟᱭ ᱦᱩᱭ ᱠᱮᱫᱼᱟ। ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱥᱟᱦᱴᱟ ᱫᱚᱦᱲᱟ ᱞᱚᱰ ᱢᱮ।
-
 core-start-failed = ᱫᱟᱞᱤᱞ ᱩᱫᱩᱜᱤᱡ ᱵᱟᱭ ᱮᱛᱦᱚᱵ ᱠᱮᱫᱼᱟ। ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱥᱟᱦᱴᱟ ᱫᱚᱦᱲᱟ ᱞᱚᱰ ᱢᱮ।

--- a/packages/i18n/locales/sat/content.ftl
+++ b/packages/i18n/locales/sat/content.ftl
@@ -49,15 +49,12 @@ color =
     .purple = ᱵᱮᱜᱩᱱᱤ
     .pink = ᱜᱩᱞᱟᱹᱯᱤ
     .brown = ᱠᱷᱟᱭᱨᱤ
-
 line-width =
     .thick = ᱢᱚᱴᱟ
     .thin = ᱯᱟᱛᱞᱟ
-
 line-style =
     .dashed = ᱨᱟᱲᱟᱜ
     .dotted = ᱴᱩᱰᱟᱹᱜᱟᱱ
-
 fill-style =
     .horizontal = ᱜᱤᱛᱤᱡ ᱜᱟᱨᱠᱚ
     .vertical = ᱴᱮᱸᱜᱚᱱ ᱜᱟᱨᱠᱚ
@@ -65,7 +62,6 @@ fill-style =
     .backdiagonal = ᱩᱞᱴᱟ ᱠᱚᱱᱟ ᱜᱟᱨᱠᱚ
     .dots = ᱴᱩᱰᱟᱹᱜᱠᱚ
     .diamonds = ᱥᱚᱢᱪᱟᱛᱩᱨᱵᱷᱩᱡ
-
 noun =
     .line = ᱜᱟᱨ
     .line-segment = ᱜᱟᱨ ᱦᱟᱹᱴᱤᱧ
@@ -85,7 +81,6 @@ noun =
     .diamond = ᱥᱚᱢᱪᱟᱛᱩᱨᱵᱷᱩᱡ
     .cross = ᱜᱩᱬᱟ ᱪᱤᱱᱦᱟᱹ
     .plus = ᱡᱚᱲᱟᱣ ᱪᱤᱱᱦᱟᱹ
-
 # The side count stands in front of the noun with the rest of the modifiers,
 # so the tail is empty.
 noun-regular-polygon =
@@ -93,10 +88,8 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ᱫᱷᱟᱨᱮᱱ ᱥᱚᱢ ᱵᱚᱦᱩᱵᱷᱩᱡ
     }
-
 # Nothing selects on it: Santali has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -110,15 +103,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = ᱯᱮᱨᱮᱡᱟᱜ
-
 # «ᱛᱮ» is the instrumental postposition and follows what it governs, so the
 # pattern moves to the front of the phrase where English appends it. It has one
 # shape whatever precedes it.
@@ -127,7 +117,6 @@ style-filled =
         [pattern] { $pattern } ᱛᱮ { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } ᱛᱮ { $filled } { $color } { $noun }
@@ -135,7 +124,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } ᱛᱮ { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Santali has no article, so the two `-article` branches read like their
 # neighbours; «ᱟᱨ» is the conjunction and stands in front.
 style-border-clause =
@@ -145,36 +133,29 @@ style-border-clause =
         [and-article] ᱟᱨ { $border } ᱠᱤᱱᱟᱨ ᱥᱟᱶ
        *[with] { $border } ᱠᱤᱱᱟᱨ ᱥᱟᱶ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } ᱛᱮ { $color } ᱯᱮᱨᱮᱡ
        *[plain] { $color } ᱯᱮᱨᱮᱡ
     }
-
 style-unfilled = ᱵᱟᱝ ᱯᱮᱨᱮᱡᱟᱜ
-
 # «ᱨᱮ» is the locative postposition, and has one shape too.
 style-text =
     { $parts ->
         [background] { $background } ᱛᱟᱭᱚᱢ ᱨᱮ { $color }
        *[plain] { $color }
     }
-
 style-background-none = ᱡᱟᱦᱟᱸ ᱵᱟᱝ
-
 
 ## Boolean words
 
 boolean-true = ᱥᱟᱨᱤ
 boolean-false = ᱵᱟᱝ ᱥᱟᱨᱤ
 
-
 ## Answer buttons
 
 answer-submit-label = ᱧᱮᱞ ᱢᱮ
 answer-submit-label-no-correctness = ᱛᱮᱞᱟ ᱠᱩᱞ ᱢᱮ
-
 
 ## Sectional blocks
 
@@ -199,7 +180,6 @@ section-name =
     .solution = ᱛᱮᱭᱟᱨ
     .task = ᱠᱟᱹᱢᱤ
     .theorem = ᱯᱨᱚᱢᱮᱭ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -209,9 +189,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ᱪᱤᱱᱦᱟᱹ
-
 
 ## Tables and figures
 
@@ -222,7 +200,6 @@ table-name =
         [unnumbered-title] ᱥᱟᱨᱬᱤ{ ": " }
        *[unnumbered] ᱥᱟᱨᱬᱤ
     }
-
 figure-name =
     { $parts ->
         [numbered] ᱪᱤᱛᱟᱹᱨ { $enumeration }
@@ -231,26 +208,20 @@ figure-name =
        *[unnumbered] ᱪᱤᱛᱟᱹᱨ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ᱢᱟᱲᱟᱝᱟᱜ
 paginator-next = ᱛᱟᱭᱚᱢᱟᱜ
 paginator-page = ᱥᱟᱦᱴᱟ
-
 # «X ᱠᱷᱚᱱ Y» — "Y out of X" — puts the total first, so the two counts change
 # places.
 paginator-page-status = { $numPages } ᱠᱷᱚᱱ { $pageLabel } { $currentPage }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = ᱥᱮ
-
 piecewise-condition-if = ᱡᱩᱫᱤ
-
 piecewise-condition-otherwise = ᱵᱟᱝ ᱠᱷᱟᱱ
-
 
 ## Chemistry
 ##
@@ -266,6 +237,5 @@ piecewise-condition-otherwise = ᱵᱟᱝ ᱠᱷᱟᱱ
 ## Indo-Aryan catalogs in this batch record.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ᱵᱟᱝ ᱴᱷᱤᱠ ᱨᱟᱥᱟᱭᱚᱱᱤᱠ ᱪᱤᱱᱦᱟᱹ
 chemistry-invalid-ionic-compound = ᱵᱟᱝ ᱴᱷᱤᱠ ᱟᱭᱚᱱᱤᱠ ᱡᱚᱛᱚ

--- a/packages/i18n/locales/sc/chrome.ftl
+++ b/packages/i18n/locales/sc/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Controllende…
 answer-submitting = Imbiende…
-
 answer-checking-status = Controllende sa risposta
 answer-submitting-status = Imbiende sa risposta
-
 answer-correct = Curretu
 answer-incorrect = Non curretu
-
 answer-response-saved = Risposta sarvada
-
 answer-percent-credit = { $percent }% de puntos
 answer-percent-correct = { $percent }% curretu
 answer-percent-short = { $percent } %
-
 max-credit-available = Puntos màssimos possìbiles: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] no b'at prus proas
         [one] b'at ancora { $count } proa
        *[other] b'at ancora { $count } proas
     }
-
 validation-correct = (Curretu)
 validation-incorrect = (Non curretu)
 validation-partially-correct = (In parte curretu)
-
 answer-show-responses =
     { $count ->
         [one] Ammustra { $count } risposta a { $answerId }
        *[other] Ammustra { $count } rispostas a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Cummentu
-
 collapsible-click-to-open = (crica pro abèrrere)
 collapsible-click-to-close = (crica pro serrare)
-
 collapsible-initializing = Aviende…
-
 footnote-show = Ammustra sa nota
 footnote-hide = Cua sa nota
-
 description-more-information = prus informatziones
-
 
 ## Controls
 
 slider-previous = Pretzedente
 slider-next = Sighente
-
 keyboard-open = Aberi sa tastiera
 keyboard-close = Serra sa tastiera
-
 choice-input-remove-choice = Boga { $choice }
-
 matrix-remove-row = Boga una riga
 matrix-add-row = Annanghe una riga
 matrix-remove-column = Boga una colunna
 matrix-add-column = Annanghe una colunna
-
 subset-add-remove-points = Annanghe/boga puntos
 subset-toggle-points-intervals = Càmbia intre puntos e intervallos
 subset-move-points = Move sos puntos
 subset-clear = Lìmpia
-
 orbital-add-row = Annanghe una riga
 orbital-remove-row = Boga una riga
 orbital-add-box = Annanghe una casella
@@ -92,13 +73,9 @@ orbital-remove-box = Boga una casella
 orbital-add-up-arrow = Annanghe una fritza a subra
 orbital-add-down-arrow = Annanghe una fritza a bassu
 orbital-remove-arrow = Boga una fritza
-
 orbital-row-label = Etichetta de sa riga { $row }
-
 pretzel-answer = Risposta
-
 summary-statistics-caption = Istatìsticas resumidas de { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = anteprima de s'espressione matemàtica
 math-input-preview = Anteprima
 math-input-invalid-expression = Espressione non vàlida:
 
-
 ## Document status
 
 viewer-initializing = Aviende…
 
-
 ## Errors
 
 error-heading = Errore
-
 error-found-at =
     { $span ->
         [line] Agatadu in sa lìnia { $startLine }.
        *[lines] Agatadu in sas lìnias { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Custu documentu tenet errores!
-
 diagnostic-heading-error = Errore
 diagnostic-heading-warning = Avisu
 diagnostic-heading-information = Informatzione
 diagnostic-heading-hint = Cussìgiu
-
 accessibility-heading-level-1 = Violatzione de s'atzessibilidade segundu WCAG AA
 accessibility-heading-level-2 = Avisu de atzessibilidade
-
 something-went-wrong = Calchi cosa est andada male.
-
 renderer-load-failed = unu mòdulu de visualizatzione non s'est carrigadu. Càrriga torra sa pàgina.
-
 core-start-failed = Su visualizadore de su documentu non s'est pòdidu aviare. Càrriga torra sa pàgina.

--- a/packages/i18n/locales/sc/content.ftl
+++ b/packages/i18n/locales/sc/content.ftl
@@ -62,7 +62,6 @@ color =
     .purple = viola
     .pink = rosa
     .brown = marrone
-
 line-width =
     .thick =
         { $gender ->
@@ -74,7 +73,6 @@ line-width =
             [f] fina
            *[m] finu
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -86,7 +84,6 @@ line-style =
             [f] puntinada
            *[m] puntinadu
         }
-
 # Plural noun phrases, which is what follows «cun» in `style-filled`. They
 # agree with nothing.
 fill-style =
@@ -96,7 +93,6 @@ fill-style =
     .backdiagonal = lineas diagonales imbersas
     .dots = puntos
     .diamonds = rombos
-
 noun =
     .line = reta
     .line-segment = segmentu
@@ -116,13 +112,11 @@ noun =
     .diamond = rombu
     .cross = rughe
     .plus = prus
-
 noun-regular-polygon =
     { $part ->
         [tail] de { $numSides } lados
        *[head] polìgonu regulare
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (polìgonu, m) or
 # the head of a phrase the description never names: `border` (oru, m), `fill`
 # (prenidura, f), `text` (testu, m), `background` (fundu, m).
@@ -140,7 +134,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -153,7 +146,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it, which is the opposite of
 # English. A noun that splits — the regular polygon — puts its complement after
 # the adjectives that agree with its head.
@@ -162,19 +154,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] prena
        *[m] prenu
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } cun { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } cun { $pattern }
@@ -182,7 +171,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } cun { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «oru» is masculine, so the border's adjectives agree with it rather than with
 # the shape it surrounds.
 style-border-clause =
@@ -192,7 +180,6 @@ style-border-clause =
         [and-article] e unu oru { $border }
        *[with] cun oru { $border }
     }
-
 # The fill-pattern words are plural nouns, because their other use is the
 # «cun { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «prenidura», feminine, which is the gender
@@ -202,29 +189,23 @@ style-fill =
         [pattern] prenidura { $color } cun { $pattern }
        *[plain] prenidura { $color }
     }
-
 style-unfilled = no prenu
-
 style-text =
     { $parts ->
         [background] { $color } subra unu fundu { $background }
        *[plain] { $color }
     }
-
 style-background-none = perunu
-
 
 ## Boolean words
 
 boolean-true = beru
 boolean-false = farsu
 
-
 ## Answer buttons
 
 answer-submit-label = Controlla
 answer-submit-label-no-correctness = Imbia sa risposta
-
 
 ## Sectional blocks
 
@@ -249,7 +230,6 @@ section-name =
     .solution = Solutzione
     .task = Incàrrigu
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -259,9 +239,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Cussìgiu
-
 
 ## Tables and figures
 
@@ -272,7 +250,6 @@ table-name =
         [unnumbered-title] Tabella{ ". " }
        *[unnumbered] Tabella
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -281,22 +258,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Pretzedente
 paginator-next = Sighente
 paginator-page = Pàgina
-
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = si
 piecewise-condition-otherwise = si nono
-
 
 ## Chemistry
 ##
@@ -307,6 +280,5 @@ piecewise-condition-otherwise = si nono
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Sìmbulu chìmicu non vàlidu
 chemistry-invalid-ionic-compound = Cumpostu iònicu non vàlidu

--- a/packages/i18n/locales/scn/chrome.ftl
+++ b/packages/i18n/locales/scn/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Cuntrullannu…
 answer-submitting = Mannannu…
-
 answer-checking-status = Cuntrollu dâ risposta
 answer-submitting-status = Mannata dâ risposta
-
 answer-correct = Giustu
 answer-incorrect = Sbagghiatu
-
 answer-response-saved = Risposta sarvata
-
 answer-percent-credit = { $percent }% di punti
 answer-percent-correct = { $percent }% giustu
 answer-percent-short = { $percent } %
-
 max-credit-available = Punti màssimi dispunìbbili: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nun ci sunnu chiù provi
         [one] resta { $count } prova
        *[other] rèstanu { $count } provi
     }
-
 validation-correct = (Giustu)
 validation-incorrect = (Sbagghiatu)
 validation-partially-correct = (In parti giustu)
-
 answer-show-responses =
     { $count ->
         [one] Ammustra { $count } risposta a { $answerId }
        *[other] Ammustra { $count } risposti a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Cummentu
-
 collapsible-click-to-open = (clicca pi grapiri)
 collapsible-click-to-close = (clicca pi chiuiri)
-
 collapsible-initializing = Aviannu…
-
 footnote-show = Ammustra a nota
 footnote-hide = Ammuccia a nota
-
 description-more-information = chiù nfurmazzioni
-
 
 ## Controls
 
 slider-previous = Precedenti
 slider-next = Successivu
-
 keyboard-open = Grapi a tastera
 keyboard-close = Chiui a tastera
-
 choice-input-remove-choice = Leva { $choice }
-
 matrix-remove-row = Leva na riga
 matrix-add-row = Junci na riga
 matrix-remove-column = Leva na culonna
 matrix-add-column = Junci na culonna
-
 subset-add-remove-points = Junci/leva punti
 subset-toggle-points-intervals = Cancia tra punti e ntervalli
 subset-move-points = Movi i punti
 subset-clear = Puliddìa
-
 orbital-add-row = Junci na riga
 orbital-remove-row = Leva na riga
 orbital-add-box = Junci na casella
@@ -95,13 +76,9 @@ orbital-remove-box = Leva na casella
 orbital-add-up-arrow = Junci na frizza versu supra
 orbital-add-down-arrow = Junci na frizza versu sutta
 orbital-remove-arrow = Leva na frizza
-
 orbital-row-label = Etichetta dâ riga { $row }
-
 pretzel-answer = Risposta
-
 summary-statistics-caption = Statìstichi riassuntivi di { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = antiprima dâ sprissioni matimàtica
 math-input-preview = Antiprima
 math-input-invalid-expression = Sprissioni non vàlida:
 
-
 ## Document status
 
 viewer-initializing = Aviannu…
 
-
 ## Errors
 
 error-heading = Erruri
-
 error-found-at =
     { $span ->
         [line] Attruvatu ntâ riga { $startLine }.
        *[lines] Attruvatu ntê righi { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Stu ducumentu cunteni erruri!
-
 diagnostic-heading-error = Erruri
 diagnostic-heading-warning = Avvisu
 diagnostic-heading-information = Nfurmazzioni
 diagnostic-heading-hint = Suggerimentu
-
 accessibility-heading-level-1 = Viulazzioni di l'accissibbilità secunnu WCAG AA
 accessibility-heading-level-2 = Avvisu d'accissibbilità
-
 something-went-wrong = Quarchi cosa jiu mali.
-
 renderer-load-failed = un mòdulu di visualizzazzioni nun si carricau. Càrrica arrè a pàggina.
-
 core-start-failed = U visualizzaturi dû ducumentu nun si potti aviari. Càrrica arrè a pàggina.

--- a/packages/i18n/locales/scn/content.ftl
+++ b/packages/i18n/locales/scn/content.ftl
@@ -57,7 +57,6 @@ color =
     .purple = viola
     .pink = rosa
     .brown = marruni
-
 line-width =
     .thick =
         { $gender ->
@@ -65,7 +64,6 @@ line-width =
            *[m] grossu
         }
     .thin = suttili
-
 line-style =
     .dashed =
         { $gender ->
@@ -77,7 +75,6 @@ line-style =
             [f] puntiata
            *[m] puntiatu
         }
-
 # Plural noun phrases, which is what follows «cu» in `style-filled`. They agree
 # with nothing.
 fill-style =
@@ -87,7 +84,6 @@ fill-style =
     .backdiagonal = linii diagunali 'nvirsi
     .dots = punti
     .diamonds = rummi
-
 noun =
     .line = retta
     .line-segment = sigmentu
@@ -107,13 +103,11 @@ noun =
     .diamond = rummu
     .cross = cruci
     .plus = chiù
-
 noun-regular-polygon =
     { $part ->
         [tail] di { $numSides } lati
        *[head] pulìgunu rigulari
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (pulìgunu, m) or
 # the head of a phrase the description never names: `border` (orlu, m), `fill`
 # (jinchimentu, m), `text` (testu, m), `background` (sfunnu, m).
@@ -130,7 +124,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -143,7 +136,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first and the adjectives after it, which is the opposite of
 # English. A noun that splits — the regular polygon — puts its complement after
 # the adjectives that agree with its head.
@@ -152,19 +144,16 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] jinchiuta
        *[m] jinchiutu
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } cu { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } cu { $pattern }
@@ -172,7 +161,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } cu { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «orlu» is masculine, so the border's adjectives agree with it rather than
 # with the shape it surrounds.
 style-border-clause =
@@ -182,7 +170,6 @@ style-border-clause =
         [and-article] e n'orlu { $border }
        *[with] cu orlu { $border }
     }
-
 # The fill-pattern words are plural nouns, because their other use is the
 # «cu { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «jinchimentu», masculine, which is the gender
@@ -192,29 +179,23 @@ style-fill =
         [pattern] jinchimentu { $color } cu { $pattern }
        *[plain] jinchimentu { $color }
     }
-
 style-unfilled = nun jinchiutu
-
 style-text =
     { $parts ->
         [background] { $color } supra un sfunnu { $background }
        *[plain] { $color }
     }
-
 style-background-none = nuddu
-
 
 ## Boolean words
 
 boolean-true = veru
 boolean-false = fausu
 
-
 ## Answer buttons
 
 answer-submit-label = Cuntrolla
 answer-submit-label-no-correctness = Manna a risposta
-
 
 ## Sectional blocks
 
@@ -239,7 +220,6 @@ section-name =
     .solution = Suluzzioni
     .task = Còmpitu
     .theorem = Tiurema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -249,9 +229,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Suggerimentu
-
 
 ## Tables and figures
 
@@ -262,7 +240,6 @@ table-name =
         [unnumbered-title] Tabbella{ ". " }
        *[unnumbered] Tabbella
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -271,22 +248,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Precedenti
 paginator-next = Successivu
 paginator-page = Pàggina
-
 paginator-page-status = { $pageLabel } { $currentPage } di { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = si
 piecewise-condition-otherwise = sinnò
-
 
 ## Chemistry
 ##
@@ -297,6 +270,5 @@ piecewise-condition-otherwise = sinnò
 ## reproduce.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Sìmmulu chìmicu non vàlidu
 chemistry-invalid-ionic-compound = Cumpostu iònicu non vàlidu

--- a/packages/i18n/locales/sd/chrome.ftl
+++ b/packages/i18n/locales/sd/chrome.ftl
@@ -24,72 +24,54 @@
 
 answer-checking = جانچجي رهيو آهي...
 answer-submitting = موڪليو پيو وڃي...
-
 answer-checking-status = جواب جانچجي رهيو آهي
 answer-submitting-status = جواب موڪليو پيو وڃي
-
 answer-correct = صحيح
 answer-incorrect = غلط
-
 answer-response-saved = جواب محفوظ ٿي ويو
-
 answer-percent-credit = { $percent }% نمبر
 answer-percent-correct = { $percent }% صحيح
 answer-percent-short = { $percent }%
-
 max-credit-available = وڌ ۾ وڌ ممڪن نمبر: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ڪا به ڪوشش باقي ناهي
         [one] { $count } ڪوشش باقي
        *[other] { $count } ڪوششون باقي
     }
-
 validation-correct = (صحيح جواب)
 validation-incorrect = (غلط جواب)
 validation-partially-correct = (جزوي طور تي صحيح جواب)
-
 # «جواب» is spelled alike in the singular and the plural, so this one needs no
 # branch — unlike `attempts-remaining` above, whose «ڪوشش» pluralizes to
 # «ڪوششون».
 answer-show-responses = { $answerId } ڏانهن موڪليل { $count } جواب ڏيکاريو
 
-
 ## Disclosure panels
 
 feedback-heading = راءِ
-
 collapsible-click-to-open = (کولڻ لاءِ ڪلڪ ڪريو)
 collapsible-click-to-close = (بند ڪرڻ لاءِ ڪلڪ ڪريو)
 collapsible-initializing = تيار ٿي رهيو آهي...
-
 footnote-show = پاد نوٽ ڏيکاريو
 footnote-hide = پاد نوٽ لڪايو
-
 description-more-information = وڌيڪ ڄاڻ
-
 
 ## Controls
 
 slider-previous = پويون
 slider-next = ايندڙ
-
 keyboard-open = ڪي بورڊ کوليو
 keyboard-close = ڪي بورڊ بند ڪريو
-
 choice-input-remove-choice = { $choice } هٽايو
-
 matrix-remove-row = قطار هٽايو
 matrix-add-row = قطار شامل ڪريو
 matrix-remove-column = ڪالم هٽايو
 matrix-add-column = ڪالم شامل ڪريو
-
 subset-add-remove-points = نقطا شامل ڪريو/هٽايو
 subset-toggle-points-intervals = نقطن ۽ وقفن جي وچ ۾ مٽايو
 subset-move-points = نقطا هلايو
 subset-clear = صاف ڪريو
-
 orbital-add-row = قطار شامل ڪريو
 orbital-remove-row = قطار هٽايو
 orbital-add-box = خانو شامل ڪريو
@@ -97,13 +79,9 @@ orbital-remove-box = خانو هٽايو
 orbital-add-up-arrow = مٿي وارو تير شامل ڪريو
 orbital-add-down-arrow = هيٺ وارو تير شامل ڪريو
 orbital-remove-arrow = تير هٽايو
-
 orbital-row-label = قطار { $row } جو نالو
-
 pretzel-answer = جواب
-
 summary-statistics-caption = ڪالم { $column } جو شمارياتي خلاصو
-
 
 ## Math input
 
@@ -111,37 +89,28 @@ math-input-preview-region = رياضياتي جملي جو اڳ نظارو
 math-input-preview = اڳ نظارو
 math-input-invalid-expression = نامعتبر جملو:
 
-
 ## Document status
 
 viewer-initializing = تيار ٿي رهيو آهي...
 
-
 ## Errors
 
 error-heading = خرابي
-
 error-found-at =
     { $span ->
         [line] سٽ { $startLine } تي ملي۔
        *[lines] سٽ { $startLine } کان { $endLine } تائين ملي۔
     }
-
 document-contains-errors = هن دستاويز ۾ خرابيون آهن!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = خرابي
 diagnostic-heading-warning = خبردار
 diagnostic-heading-information = ڄاڻ
 diagnostic-heading-hint = اشارو
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = WCAG AA موجب رسائي جي ڀڃڪڙي
 accessibility-heading-level-2 = رسائي بابت خبردار
-
 something-went-wrong = ڪجهه غلط ٿي ويو۔
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = هڪ جزو لوڊ نه ٿي سگهيو۔ مهرباني ڪري صفحو ٻيهر لوڊ ڪريو۔
-
 core-start-failed = دستاويز جو ناظر شروع نه ٿي سگهيو۔ مهرباني ڪري صفحو ٻيهر لوڊ ڪريو۔

--- a/packages/i18n/locales/sd/content.ftl
+++ b/packages/i18n/locales/sd/content.ftl
@@ -113,7 +113,6 @@ color =
                    *[m] ڀورو
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -137,12 +136,10 @@ line-width =
                    *[m] سنهو
                 }
         }
-
 # Both are unmarked, so neither inflects.
 line-style =
     .dashed = ٽٽل
     .dotted = نقطيدار
-
 # Noun phrases in the oblique plural, because their other use is in front of
 # «وارو» — a postposition that governs the oblique and inflects like a marked
 # adjective itself. They agree with nothing, so `style-fill` has to give them
@@ -154,7 +151,6 @@ fill-style =
     .backdiagonal = ابتڙ ترڇن ليڪن
     .dots = نقطن
     .diamonds = لوزن
-
 noun =
     .line = ليڪ
     .line-segment = ليڪ جو ٽڪرو
@@ -174,7 +170,6 @@ noun =
     .diamond = لوزو
     .cross = ڪراس
     .plus = جمع جو نشان
-
 # Sindhi keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -182,7 +177,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } پاسن وارو باقاعده گھڻ ڪنڊو
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (گھڻ ڪنڊو, m) or
 # the head of a phrase the description never names: `border` (ڪنارو, m),
 # `fill` (ڀراءُ, m), `text` (متن, m), `background` (پس منظر, m).
@@ -193,7 +187,6 @@ noun-gender =
         [polyline] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -207,18 +200,15 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «ڀريل» is a participle and does not inflect, so this takes no branch even
 # though it is handed a gender.
 style-filled-word = ڀريل
-
 # «وارو» is a marked adjective itself, and it agrees with the shape rather than
 # with the pattern in front of it: «نقطن واري ليڪ», «نقطن وارو چورس». It is
 # always said of the shape, so the direct form is the only one needed here —
@@ -226,27 +216,28 @@ style-filled-word = ڀريل
 # there is «ڀراءُ», which is always masculine.
 style-filled =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] واري
-           *[m] وارو
-        } { $color } { $filled }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] واري
+               *[m] وارو
+            } { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] واري
-           *[m] وارو
-        } { $color } { $filled } { $noun }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] واري
+               *[m] وارو
+            } { $color } { $filled } { $noun }
         [plain-tail] { $color } { $filled } { $noun } { $nounTail }
-        [pattern-tail] { $pattern } { $gender ->
-            [f] واري
-           *[m] وارو
-        } { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail]
+            { $pattern } { $gender ->
+                [f] واري
+               *[m] وارو
+            } { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «سان» is a postposition, so «ڪنارو» takes the oblique «ڪناري» and so do its
 # adjectives — which is what the `border-clause` branch supplies. Sindhi has no
 # article, so the `-article` branches read the same as the ones without.
@@ -257,7 +248,6 @@ style-border-clause =
         [and-article] ۽ { $border } ڪناري سان
        *[with] { $border } ڪناري سان
     }
-
 # The fill-pattern words are oblique plurals, so this message supplies a noun
 # for them to hang off — «ڀراءُ», masculine, which is the gender `noun-gender`
 # already answers for `fill`.
@@ -266,29 +256,23 @@ style-fill =
         [pattern] { $pattern } وارو { $color } ڀراءُ
        *[plain] { $color } ڀراءُ
     }
-
 style-unfilled = بنا ڀراءَ
-
 style-text =
     { $parts ->
         [background] { $background } پس منظر تي { $color }
        *[plain] { $color }
     }
-
 style-background-none = ڪجهه به نه
-
 
 ## Boolean words
 
 boolean-true = صحيح
 boolean-false = غلط
 
-
 ## Answer buttons
 
 answer-submit-label = جواب جانچيو
 answer-submit-label-no-correctness = جواب موڪليو
-
 
 ## Sectional blocks
 
@@ -313,7 +297,6 @@ section-name =
     .solution = حل
     .task = ڪم
     .theorem = نظريو
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -323,9 +306,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = اشارو
-
 
 ## Tables and figures
 
@@ -336,7 +317,6 @@ table-name =
         [unnumbered-title] جدول{ ": " }
        *[unnumbered] جدول
     }
-
 figure-name =
     { $parts ->
         [numbered] شڪل { $enumeration }
@@ -345,28 +325,21 @@ figure-name =
        *[unnumbered] شڪل
     }
 
-
 ## Paginator controls
 
 paginator-previous = پويون
 paginator-next = ايندڙ
 paginator-page = صفحو
-
 paginator-page-status = { $numPages } مان { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = يا
-
 piecewise-condition-if = جيڪڏهن
-
 piecewise-condition-otherwise = ٻي صورت ۾
-
 
 ## Chemistry
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = نامعتبر ڪيميائي نشان
 chemistry-invalid-ionic-compound = نامعتبر آئوني مرڪب

--- a/packages/i18n/locales/se/chrome.ftl
+++ b/packages/i18n/locales/se/chrome.ftl
@@ -30,21 +30,15 @@
 
 answer-checking = Dárkkisteamen…
 answer-submitting = Sáddemin…
-
 answer-checking-status = Dárkkista vástádusa
 answer-submitting-status = Sádde vástádusa
-
 answer-correct = Riekta
 answer-incorrect = Boastut
-
 answer-response-saved = Vástádus lea vurkejuvvon
-
 answer-percent-credit = { $percent }% čuoggás
 answer-percent-correct = { $percent }% riekta
 answer-percent-short = { $percent } %
-
 max-credit-available = Eanemus čuoggát: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] eai leat šat geahččaleamit báhcán
@@ -52,53 +46,40 @@ attempts-remaining =
         [two] { $count } geahččaleami báhcá
        *[other] { $count } geahččaleami báhcá
     }
-
 validation-correct = (Riekta)
 validation-incorrect = (Boastut)
 validation-partially-correct = (Belohahkii riekta)
-
 # No select: the noun is the object of «čájet» and takes the accusative
 # singular after every numeral, so all three categories would render the same
 # string. The count still arrives and is still formatted; only the branching
 # is gone.
 answer-show-responses = Čájet { $count } vástádusa dása: { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Máhcahat
-
 collapsible-click-to-open = (coahkkal rahpat)
 collapsible-click-to-close = (coahkkal gokčat)
-
 collapsible-initializing = Álggaheamen…
-
 footnote-show = Čájet vuolitnotáhta
 footnote-hide = Čiega vuolitnotáhta
-
 description-more-information = eanet dieđut
-
 
 ## Controls
 
 slider-previous = Ovddit
 slider-next = Boahtte
-
 keyboard-open = Raba boallobeavdi
 keyboard-close = Gokča boallobeavdi
-
 choice-input-remove-choice = Váldde eret { $choice }
-
 matrix-remove-row = Váldde eret linnjá
 matrix-add-row = Lasit linnjá
 matrix-remove-column = Váldde eret ceahkki
 matrix-add-column = Lasit ceahkki
-
 subset-add-remove-points = Lasit/váldde eret čuoggáid
 subset-toggle-points-intervals = Molsso čuoggáid ja gaskkaid gaskkas
 subset-move-points = Sirdde čuoggáid
 subset-clear = Sálke
-
 orbital-add-row = Lasit linnjá
 orbital-remove-row = Váldde eret linnjá
 orbital-add-box = Lasit bovssa
@@ -106,13 +87,9 @@ orbital-remove-box = Váldde eret bovssa
 orbital-add-up-arrow = Lasit njuolla bajás
 orbital-add-down-arrow = Lasit njuolla vulos
 orbital-remove-arrow = Váldde eret njuolla
-
 orbital-row-label = Linnjá { $row } namahus
-
 pretzel-answer = Vástádus
-
 summary-statistics-caption = { $column } čoahkkáigeassin
-
 
 ## Math input
 
@@ -120,34 +97,25 @@ math-input-preview-region = matematihkalaš cealkaga ovdačájeheapmi
 math-input-preview = Ovdačájeheapmi
 math-input-invalid-expression = Gustohis cealkka:
 
-
 ## Document status
 
 viewer-initializing = Álggaheamen…
 
-
 ## Errors
 
 error-heading = Meattáhus
-
 error-found-at =
     { $span ->
         [line] Gávdnon linnjás { $startLine }.
        *[lines] Gávdnon linnjáin { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dán dokumeanttas leat meattáhusat!
-
 diagnostic-heading-error = Meattáhus
 diagnostic-heading-warning = Váruhus
 diagnostic-heading-information = Diehtu
 diagnostic-heading-hint = Ráva
-
 accessibility-heading-level-1 = WCAG AA olahanvuođa rihkkun
 accessibility-heading-level-2 = Olahanvuođa váruhus
-
 something-went-wrong = Juoga manai boastut.
-
 renderer-load-failed = čájehanmoduvla ii viežžan. Viečča siiddu ođđasit.
-
 core-start-failed = Dokumeantačájeheaddji ii sáhttán álggahuvvot. Viečča siiddu ođđasit.

--- a/packages/i18n/locales/se/content.ftl
+++ b/packages/i18n/locales/se/content.ftl
@@ -51,15 +51,12 @@ color =
     .purple = fiolehtta
     .pink = roosa
     .brown = ruškes
-
 line-width =
     .thick = asse
     .thin = seaggi
-
 line-style =
     .dashed = sárgolaš
     .dotted = čuoggálaš
-
 # Comitative plurals. The `-iguin` ending is Sami's own word for "with", which
 # is why `style-filled` below places these straight after the colour and writes
 # no preposition of its own: the ending already said it.
@@ -70,7 +67,6 @@ fill-style =
     .backdiagonal = nuppe guvlui diagonála sárgguiguin
     .dots = čuoggáiguin
     .diamonds = rombbaiguin
-
 noun =
     .line = linnjá
     .line-segment = linnjáoassi
@@ -90,7 +86,6 @@ noun =
     .diamond = romba
     .cross = ruossa
     .plus = plus
-
 # Sami keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -98,12 +93,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] dássedis { $numSides }-bealat polygona
     }
-
 # Sami has no grammatical gender, so nothing above reads this and every noun
 # answers alike. It is here because the argument is passed to every adjective
 # and a message that resolves to nothing would render `{noun-gender}`.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -117,15 +110,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = devdojuvvon
-
 # The pattern words carry their own «with» in their comitative ending, so
 # nothing is written between them and what they follow.
 style-filled =
@@ -133,7 +123,6 @@ style-filled =
         [pattern] { $filled } { $color } { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern }
@@ -141,7 +130,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ravddain» is «ravda», a border, in the comitative — the case that carries
 # "with" — so the clause needs no preposition either. Sami has no article, so
 # the two `-article` branches read like the two without.
@@ -152,35 +140,28 @@ style-border-clause =
         [and-article] ja { $border } ravddain
        *[with] { $border } ravddain
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } deavdda { $pattern }
        *[plain] { $color } deavdda
     }
-
 style-unfilled = devdekeahtes
-
 style-text =
     { $parts ->
         [background] { $color } { $background } duogážiin
        *[plain] { $color }
     }
-
 style-background-none = ii mihkkiige
-
 
 ## Boolean words
 
 boolean-true = duohta
 boolean-false = eahpeduohta
 
-
 ## Answer buttons
 
 answer-submit-label = Dárkkis barggu
 answer-submit-label-no-correctness = Sádde vástádusa
-
 
 ## Sectional blocks
 
@@ -205,7 +186,6 @@ section-name =
     .solution = Čoavddus
     .task = Bargu
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -215,9 +195,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ráva
-
 
 ## Tables and figures
 
@@ -228,7 +206,6 @@ table-name =
         [unnumbered-title] Tabealla{ ": " }
        *[unnumbered] Tabealla
     }
-
 figure-name =
     { $parts ->
         [numbered] Govva { $enumeration }
@@ -237,22 +214,18 @@ figure-name =
        *[unnumbered] Govva
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ovddit
 paginator-next = Boahtte
 paginator-page = Siidu
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = dahje
 piecewise-condition-if = jos
 piecewise-condition-otherwise = muđui
-
 
 ## Chemistry
 ##
@@ -264,6 +237,5 @@ piecewise-condition-otherwise = muđui
 ## would report a fact about a border rather than about the language.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Gustohis kemiijalaš symbola
 chemistry-invalid-ionic-compound = Gustohis iovnnalaš oktavuohta

--- a/packages/i18n/locales/sg/chrome.ftl
+++ b/packages/i18n/locales/sg/chrome.ftl
@@ -13,69 +13,50 @@
 
 answer-checking = Bâa…
 answer-submitting = Tokua…
-
 answer-checking-status = A yeke bâa kîri-tënë
 answer-submitting-status = A yeke tokua kîri-tënë
-
 answer-correct = A yeke tâ
 answer-incorrect = A yeke tâ pëpe
-
 answer-response-saved = A bata kîri-tënë
-
 answer-percent-credit = { $percent }% tî apoin
 answer-percent-correct = { $percent }% a yeke tâ
 answer-percent-short = { $percent } %
-
 max-credit-available = Kötä apoin so ayeke: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] mbênî tarä angbâ pëpe
        *[other] tarä { $count } angbâ
     }
-
 validation-correct = (A yeke tâ)
 validation-incorrect = (A yeke tâ pëpe)
 validation-partially-correct = (A yeke tâ na mbâgë)
-
 answer-show-responses = Fa akîri-tënë { $count } tî { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Wängö
-
 collapsible-click-to-open = (pîka tî zi)
 collapsible-click-to-close = (pîka tî kânga)
-
 collapsible-initializing = A yeke tö ndâ…
-
 footnote-show = Fa nôte tî gbe
 footnote-hide = Honde nôte tî gbe
-
 description-more-information = tënë ndê
-
 
 ## Controls
 
 slider-previous = Kôzo
 slider-next = Na pekô
-
 keyboard-open = Zi Klavîe
 keyboard-close = Kânga Klavîe
-
 choice-input-remove-choice = Zî { $choice }
-
 matrix-remove-row = Zî lignë
 matrix-add-row = Zîa lignë
 matrix-remove-column = Zî kolöne
 matrix-add-column = Zîa kolöne
-
 subset-add-remove-points = Zîa/Zî apoin
 subset-toggle-points-intervals = Gbîan apoin na angoi
 subset-move-points = Gue na Apoin
 subset-clear = Sukûla
-
 orbital-add-row = Zîa Lignë
 orbital-remove-row = Zî Lignë
 orbital-add-box = Zîa Bôite
@@ -83,13 +64,9 @@ orbital-remove-box = Zî Bôite
 orbital-add-up-arrow = Zîa Flêshe tî Ndüzü
 orbital-add-down-arrow = Zîa Flêshe tî Gbe
 orbital-remove-arrow = Zî Flêshe
-
 orbital-row-label = Îri tî lignë { $row }
-
 pretzel-answer = Kîri-tënë
-
 summary-statistics-caption = Bûngbïngö tî awüngö tî { $column }
-
 
 ## Math input
 
@@ -97,34 +74,25 @@ math-input-preview-region = bängö kôzo tî tënë tî nömbre
 math-input-preview = Bängö kôzo
 math-input-invalid-expression = Tënë so ayeke tâ pëpe:
 
-
 ## Document status
 
 viewer-initializing = A yeke tö ndâ…
 
-
 ## Errors
 
 error-heading = Fîon
-
 error-found-at =
     { $span ->
         [line] A wara na lignë { $startLine }.
        *[lines] A wara na alignë { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Mbëtï sô ayeke na afîon!
-
 diagnostic-heading-error = Fîon
 diagnostic-heading-warning = Gbotöngö-mê
 diagnostic-heading-information = Tënë
 diagnostic-heading-hint = Fängö-lêgë
-
 accessibility-heading-level-1 = Fütïngö WCAG AA tî Sïngö
 accessibility-heading-level-2 = Gbotöngö-mê tî sïngö
-
 something-went-wrong = Mbênî ye ague nzönî pëpe.
-
 renderer-load-failed = wafängö-ye alîngbi tî lodë pëpe. Sâra nzönî lodë lêmbëtï nînga.
-
 core-start-failed = Wafängö-mbëtï alîngbi tî tö ndâ pëpe. Sâra nzönî lodë lêmbëtï nînga.

--- a/packages/i18n/locales/sg/content.ftl
+++ b/packages/i18n/locales/sg/content.ftl
@@ -52,15 +52,12 @@ color =
     .purple = viölê
     .pink = rôzo
     .brown = maröon
-
 line-width =
     .thick = kötä
     .thin = kete
-
 line-style =
     .dashed = na akete mbâgë
     .dotted = na apoin
-
 fill-style =
     .horizontal = alignë so alängö
     .vertical = alignë so aluti
@@ -68,7 +65,6 @@ fill-style =
     .backdiagonal = alignë so aveke na mbâgë ndê
     .dots = apoin
     .diamonds = adiamäan
-
 noun =
     .line = lignë
     .line-segment = mbâgë tî lignë
@@ -88,7 +84,6 @@ noun =
     .diamond = diamäan
     .cross = kürüzo
     .plus = fä tî bûngbi
-
 # The side count is a relative clause and closes the noun phrase behind the
 # describing words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -96,10 +91,8 @@ noun-regular-polygon =
         [tail] so ayeke na ambâgë { $numSides }
        *[head] poligöne so alîngbi
     }
-
 # Nothing selects on it: Sango has no gender and no noun classes.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -113,7 +106,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its describing words follow, with the noun's own relative
 # complement closing the phrase.
 style-with-noun =
@@ -121,15 +113,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = so asï
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -137,7 +126,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Sango has no article, so the two `-article` branches read like their
 # neighbours; «na» joins the clause and never changes shape.
 style-border-clause =
@@ -147,35 +135,28 @@ style-border-clause =
         [and-article] na ndâmbo { $border }
        *[with] na ndâmbo { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = asï pëpe
-
 style-text =
     { $parts ->
         [background] { $color } na ndö tî pekô { $background }
        *[plain] { $color }
     }
-
 style-background-none = mbênî ye pëpe
-
 
 ## Boolean words
 
 boolean-true = tâ tënë
 boolean-false = mvene
 
-
 ## Answer buttons
 
 answer-submit-label = Bâa Kua
 answer-submit-label-no-correctness = Tokua Kîri-tënë
-
 
 ## Sectional blocks
 
@@ -200,7 +181,6 @@ section-name =
     .solution = Kîrïngö-ndâ
     .task = Kua
     .theorem = Tëorêm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -210,9 +190,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Fängö-lêgë
-
 
 ## Tables and figures
 
@@ -223,7 +201,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Fôto { $enumeration }
@@ -232,25 +209,18 @@ figure-name =
        *[unnumbered] Fôto
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kôzo
 paginator-next = Na pekô
-
 paginator-page = Lêmbëtï
-
 paginator-page-status = { $pageLabel } { $currentPage } na yâ tî { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = wala
-
 piecewise-condition-if = tônde
-
 piecewise-condition-otherwise = tônde ayeke tongasô pëpe
-
 
 ## Chemistry
 ##
@@ -263,6 +233,5 @@ piecewise-condition-otherwise = tônde ayeke tongasô pëpe
 ## `locales/ln`'s, reached through a third education ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Fä tî Shimïi so Ayeke Sïönî
 chemistry-invalid-ionic-compound = Bûngbïngö tî Iôni so Ayeke Sïönî

--- a/packages/i18n/locales/shi/chrome.ftl
+++ b/packages/i18n/locales/shi/chrome.ftl
@@ -16,21 +16,15 @@
 
 answer-checking = ⴰⵙⵏⵇⴷ…
 answer-submitting = ⵜⵓⵣⵏⴰ…
-
 answer-checking-status = ⵜⵉⵔⵉⵔⵉⵜ ⵜⵜⵓⵙⵏⵇⴰⴷ
 answer-submitting-status = ⵜⵉⵔⵉⵔⵉⵜ ⵜⵜⵓⵣⵏ
-
 answer-correct = ⴷ ⵜⵉⴷⵜ
 answer-incorrect = ⵓⵔ ⴷ ⵜⵉⴷⵜ
-
 answer-response-saved = ⵜⵉⵔⵉⵔⵉⵜ ⵜⵜⵓⵃⴹⴰ
-
 answer-percent-credit = { $percent }% ⵏ ⵜⵏⵇⵉⴹⵉⵏ
 answer-percent-correct = { $percent }% ⴷ ⵜⵉⴷⵜ
 answer-percent-short = { $percent } %
-
 max-credit-available = ⵜⵉⵏⵇⵉⴹⵉⵏ ⵓⴳⴳⴰⵔ ⵍⵍⴰⵏⵉⵏ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ⵓⵔ ⵉⵍⵍⵉ ⵓⵄⵔⴰⴹ ⵉⵇⵇⵉⵎⵏ
@@ -38,11 +32,9 @@ attempts-remaining =
         [few] ⵇⵇⵉⵎⵏ { $count } ⵏ ⵢⵉⵄⵔⴰⴹⵏ
        *[other] ⵇⵇⵉⵎⵏ { $count } ⵏ ⵢⵉⵄⵔⴰⴹⵏ
     }
-
 validation-correct = (ⴷ ⵜⵉⴷⵜ)
 validation-incorrect = (ⵓⵔ ⴷ ⵜⵉⴷⵜ)
 validation-partially-correct = (ⴷ ⵜⵉⴷⵜ ⵙ ⵓⵃⵔⵉⵛ)
-
 answer-show-responses =
     { $count ->
         [one] ⵎⵍ { $count } ⵏ ⵜⵔⵉⵔⵉⵜ ⵉ { $answerId }
@@ -50,42 +42,31 @@ answer-show-responses =
        *[other] ⵎⵍ { $count } ⵏ ⵜⵔⵉⵔⵉⵢⵉⵏ ⵉ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ⵉⵡⵏⵏⵉⵜⵏ
-
 collapsible-click-to-open = (ⵙⵉⵜ ⴰⴼⴰⴷ ⴰⴷ ⵜⵔⵣⵎⵜ)
 collapsible-click-to-close = (ⵙⵉⵜ ⴰⴼⴰⴷ ⴰⴷ ⵜⵇⵇⵏⵜ)
-
 collapsible-initializing = ⴰⵙⵏⴽⵔ…
-
 footnote-show = ⵎⵍ ⵜⴰⵣⵎⵉⵍⵜ ⵏ ⵡⴰⴷⴷⴰ
 footnote-hide = ⵃⴹⵓ ⵜⴰⵣⵎⵉⵍⵜ ⵏ ⵡⴰⴷⴷⴰ
-
 description-more-information = ⵓⴳⴳⴰⵔ ⵏ ⵜⵍⵖⵓⵜ
-
 
 ## Controls
 
 slider-previous = ⴰⵣⵡⵉⵔ
 slider-next = ⴰⴹⴼⵉⵔ
-
 keyboard-open = ⵔⵣⵎ ⴰⵏⴰⵙⵉⵡ
 keyboard-close = ⵇⵇⵏ ⴰⵏⴰⵙⵉⵡ
-
 choice-input-remove-choice = ⴽⴽⵙ { $choice }
-
 matrix-remove-row = ⴽⴽⵙ ⵉⵣⵉⵔⵉⴳ
 matrix-add-row = ⵔⵏⵓ ⵉⵣⵉⵔⵉⴳ
 matrix-remove-column = ⴽⴽⵙ ⵜⴰⴳⵊⴷⵉⵜ
 matrix-add-column = ⵔⵏⵓ ⵜⴰⴳⵊⴷⵉⵜ
-
 subset-add-remove-points = ⵔⵏⵓ/ⴽⴽⵙ ⵜⵉⵏⵇⵉⴹⵉⵏ
 subset-toggle-points-intervals = ⵙⵏⴼⵍ ⵜⵉⵏⵇⵉⴹⵉⵏ ⴷ ⵡⴰⴽⵓⴷⵏ
 subset-move-points = ⵙⵎⵓⵜⵜⵉ ⵜⵉⵏⵇⵉⴹⵉⵏ
 subset-clear = ⵙⴼⴹ
-
 orbital-add-row = ⵔⵏⵓ ⵉⵣⵉⵔⵉⴳ
 orbital-remove-row = ⴽⴽⵙ ⵉⵣⵉⵔⵉⴳ
 orbital-add-box = ⵔⵏⵓ ⵜⴰⵏⴰⴽⴰ
@@ -93,13 +74,9 @@ orbital-remove-box = ⴽⴽⵙ ⵜⴰⵏⴰⴽⴰ
 orbital-add-up-arrow = ⵔⵏⵓ ⵜⴰⵏⵛⵛⴰⴱⵜ ⵙ ⵓⴼⵍⵍⴰ
 orbital-add-down-arrow = ⵔⵏⵓ ⵜⴰⵏⵛⵛⴰⴱⵜ ⵙ ⵡⴰⴷⴷⴰ
 orbital-remove-arrow = ⴽⴽⵙ ⵜⴰⵏⵛⵛⴰⴱⵜ
-
 orbital-row-label = ⵜⴰⴱⵣⵉⵎⵜ ⵏ ⵢⵉⵣⵉⵔⵉⴳ { $row }
-
 pretzel-answer = ⵜⵉⵔⵉⵔⵉⵜ
-
 summary-statistics-caption = ⴰⴳⵣⵓⵍ ⵏ ⵜⵙⵉⴹⴰ ⵏ { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵣⵡⴰⵔⴰⵏⵜ �
 math-input-preview = ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵣⵡⴰⵔⴰⵏⵜ
 math-input-invalid-expression = ⵜⴰⵏⴼⴰⵍⵉⵜ ⵜⴰⵔⴰⵎⵖⵜⵓⵜ:
 
-
 ## Document status
 
 viewer-initializing = ⴰⵙⵏⴽⵔ…
 
-
 ## Errors
 
 error-heading = ⵜⴰⵣⴳⴰⵍⵜ
-
 error-found-at =
     { $span ->
         [line] ⵜⵜⵓⴼ ⴳ ⵢⵉⵣⵉⵔⵉⴳ { $startLine }.
        *[lines] ⵜⵜⵓⴼ ⴳ ⵢⵉⵣⵉⵔⵉⴳⵏ { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = ⴰⵙⵎⵍⵉ ⴰⴷ ⵉⵍⴰ ⵜⵉⵣⴳⴰⵍ!
-
 diagnostic-heading-error = ⵜⴰⵣⴳⴰⵍⵜ
 diagnostic-heading-warning = ⴰⵍⵖⵓ
 diagnostic-heading-information = ⵜⴰⵍⵖⵓⵜ
 diagnostic-heading-hint = ⵜⴰⵏⵖⵔⵓⴼⵜ
-
 accessibility-heading-level-1 = ⴰⵣⴳⴰⵔ WCAG AA ⵏ ⵡⴰⵏⴽⵛⵓⵎ
 accessibility-heading-level-2 = ⴰⵍⵖⵓ ⵏ ⵡⴰⵏⴽⵛⵓⵎ
-
 something-went-wrong = ⵉⵍⵍⴰ ⵎⴰ ⵓⵔ ⵉⴷⴷⵉⵏ ⵙ ⵓⵣⴳⴰⵍ.
-
 renderer-load-failed = ⴰⵎⵙⴽⵏ ⵓⵔ ⵉⵣⴹⴰⵕ ⴰⴷ ⵢⴰⵍⵉ. ⵎⴽ ⵜⵔⵉⴷ ⵙⵎⴰⵢⵏⵓ ⴰⵙⴰⵜⵓ.
-
 core-start-failed = ⴰⵎⵙⴽⵏ ⵏ ⵓⵙⵎⵍⵉ ⵓⵔ ⵉⵣⴹⴰⵕ ⴰⴷ ⵉⴱⴷⵓ. ⵎⴽ ⵜⵔⵉⴷ ⵙⵎⴰⵢⵏⵓ ⴰⵙⴰⵜⵓ.

--- a/packages/i18n/locales/shi/content.ftl
+++ b/packages/i18n/locales/shi/content.ftl
@@ -77,7 +77,6 @@ color =
     .purple = ⴰⵕⴳⵡⴰⵏⵉ
     .pink = ⵡⴰⵔⴷⵉ
     .brown = ⵇⴰⵀⵡⵉ
-
 line-width =
     .thick =
         { $gender ->
@@ -89,11 +88,9 @@ line-width =
             [f] ⵜⴰⵔⵇⵇⴰⵇⵜ
            *[m] ⴰⵔⵇⵇⴰⵇ
         }
-
 line-style =
     .dashed = ⵙ ⵜⴳⵣⵓⵎⵉⵏ
     .dotted = ⵙ ⵜⵏⵇⵉⴹⵉⵏ
-
 # Written in the annexed state, because every place these words are placed puts
 # them behind ⵙ; see this file's header.
 fill-style =
@@ -103,7 +100,6 @@ fill-style =
     .backdiagonal = ⵢⵉⵣⵉⵔⵉⴳⵏ ⵉⵥⵍⴰⵢⵏⵉⵏ ⵙ ⵜⴰⵎⴰ ⵢⴰⴹⵏⵉⵏ
     .dots = ⵜⵏⵇⵉⴹⵉⵏ
     .diamonds = ⵜⵍⵎⴰⵙⵉⵏ
-
 noun =
     .line = ⵉⵣⵉⵔⵉⴳ
     .line-segment = ⴰⴳⵣⵓⵎ ⵏ ⵢⵉⵣⵉⵔⵉⴳ
@@ -123,13 +119,11 @@ noun =
     .diamond = ⵜⴰⵍⵎⴰⵙⵜ
     .cross = ⴰⵎⴳⵔⵉⴷ
     .plus = ⴰⵣⴰⵎⵓⵍ ⵏ ⵓⵔⵏⵓ
-
 noun-regular-polygon =
     { $part ->
         [tail] ⵙ { $numSides } ⵏ ⵢⵉⴷⵉⵙⴰⵏ
        *[head] ⴰⵎⴳⴳⵜⵙⴷⵉⵙ ⴰⵎⵛⵜⵓ
     }
-
 noun-gender =
     { $noun ->
         [function] f
@@ -141,7 +135,6 @@ noun-gender =
         [parabola] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -155,25 +148,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] ⵜⵛⵛⵓⵔ
        *[m] ⵉⵛⵛⵓⵔ
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ⵙ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ⵙ { $pattern }
@@ -181,7 +170,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ⵙ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] ⵙ ⵜⵎⴰ { $border }
@@ -189,35 +177,28 @@ style-border-clause =
         [and-article] ⴷ ⵜⵎⴰ { $border }
        *[with] ⵙ ⵜⵎⴰ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } ⵙ { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ⵓⵔ ⵉⵛⵛⵓⵔ
-
 style-text =
     { $parts ->
         [background] { $color } ⵅⴼ ⵓⴳⵉⵍⴰⵍ { $background }
        *[plain] { $color }
     }
-
 style-background-none = ⵓⵔ ⵉⵍⵍⵉ
-
 
 ## Boolean words
 
 boolean-true = ⵜⵉⴷⵜ
 boolean-false = ⵜⴰⴽⵔⴹⵉⵜ
 
-
 ## Answer buttons
 
 answer-submit-label = ⵙⵏⵇⴷ ⵜⴰⵡⵓⵔⵉ
 answer-submit-label-no-correctness = ⴰⵣⵏ ⵜⵉⵔⵉⵔⵉⵜ
-
 
 ## Sectional blocks
 
@@ -242,7 +223,6 @@ section-name =
     .solution = ⵜⵉⴼⵔⴰⵜ
     .task = ⵜⴰⵡⵓⵔⵉ
     .theorem = ⵜⴰⵎⴰⵎⴽⵜ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -252,9 +232,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ⵜⴰⵍⵖⵓⵜ
-
 
 ## Tables and figures
 
@@ -265,7 +243,6 @@ table-name =
         [unnumbered-title] ⵜⴰⴼⵍⵡⵉⵜ{ ": " }
        *[unnumbered] ⵜⴰⴼⵍⵡⵉⵜ
     }
-
 figure-name =
     { $parts ->
         [numbered] ⵜⵓⴳⵏⴰ { $enumeration }
@@ -274,24 +251,18 @@ figure-name =
        *[unnumbered] ⵜⵓⴳⵏⴰ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ⴰⵣⵡⵉⵔ
 paginator-next = ⴰⴹⴼⵉⵔ
 paginator-page = ⴰⵙⴰⵜⵓ
-
 paginator-page-status = { $pageLabel } { $currentPage } ⵣⴳ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ⵏⵖ
-
 piecewise-condition-if = ⵎⴽ
-
 piecewise-condition-otherwise = ⵏⵖ ⵓⵍⴰ
-
 
 ## Chemistry
 ##
@@ -303,6 +274,5 @@ piecewise-condition-otherwise = ⵏⵖ ⵓⵍⴰ
 ## fallback *is* the curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ⴰⵣⴰⵎⵓⵍ ⴰⴽⵉⵎⵢⴰⵏ ⴰⵔⴰⵎⵖⵜⵓ
 chemistry-invalid-ionic-compound = ⴰⵙⴷⵓⴽⴽⵍ ⴰⵢⵓⵏⴰⵏ ⴰⵔⴰⵎⵖⵜⵓ

--- a/packages/i18n/locales/si/chrome.ftl
+++ b/packages/i18n/locales/si/chrome.ftl
@@ -26,74 +26,55 @@
 
 answer-checking = පරීක්ෂා කරමින්...
 answer-submitting = යොමු කරමින්...
-
 answer-checking-status = පිළිතුර පරීක්ෂා කරමින්
 answer-submitting-status = පිළිතුර යොමු කරමින්
-
 answer-correct = නිවැරදියි
 answer-incorrect = වැරදියි
-
 answer-response-saved = පිළිතුර සුරකින ලදී
-
 answer-percent-credit = ලකුණු { $percent }%
 answer-percent-correct = නිවැරදි { $percent }%
 answer-percent-short = { $percent }%
-
 max-credit-available = ලබාගත හැකි උපරිම ලකුණු: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] උත්සාහයන් ඉතිරි නැත
         [one] උත්සාහ { $count }ක් ඉතිරිව ඇත
        *[other] උත්සාහ { $count }ක් ඉතිරිව ඇත
     }
-
 validation-correct = (නිවැරදියි)
 validation-incorrect = (වැරදියි)
 validation-partially-correct = (අර්ධ වශයෙන් නිවැරදියි)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } වෙත යොමු කළ පිළිතුරු { $count } පෙන්වන්න
        *[other] { $answerId } වෙත යොමු කළ පිළිතුරු { $count } පෙන්වන්න
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ප්‍රතිපෝෂණ
-
 collapsible-click-to-open = (විවෘත කිරීමට ක්ලික් කරන්න)
 collapsible-click-to-close = (වැසීමට ක්ලික් කරන්න)
-
 collapsible-initializing = ආරම්භ වෙමින්...
-
 footnote-show = පාද සටහන පෙන්වන්න
 footnote-hide = පාද සටහන සඟවන්න
-
 description-more-information = වැඩි විස්තර
-
 
 ## Controls
 
 slider-previous = පෙර
 slider-next = මීළඟ
-
 keyboard-open = යතුරුපුවරුව විවෘත කරන්න
 keyboard-close = යතුරුපුවරුව වසන්න
-
 choice-input-remove-choice = { $choice } ඉවත් කරන්න
-
 matrix-remove-row = පේළිය ඉවත් කරන්න
 matrix-add-row = පේළියක් එක් කරන්න
 matrix-remove-column = තීරුව ඉවත් කරන්න
 matrix-add-column = තීරුවක් එක් කරන්න
-
 subset-add-remove-points = ලක්ෂ්‍ය එක් කරන්න/ඉවත් කරන්න
 subset-toggle-points-intervals = ලක්ෂ්‍ය සහ අන්තර මාරු කරන්න
 subset-move-points = ලක්ෂ්‍ය ගෙන යන්න
 subset-clear = හිස් කරන්න
-
 orbital-add-row = පේළියක් එක් කරන්න
 orbital-remove-row = පේළිය ඉවත් කරන්න
 orbital-add-box = කොටුවක් එක් කරන්න
@@ -101,13 +82,9 @@ orbital-remove-box = කොටුව ඉවත් කරන්න
 orbital-add-up-arrow = ඉහළට ඊතලයක් එක් කරන්න
 orbital-add-down-arrow = පහළට ඊතලයක් එක් කරන්න
 orbital-remove-arrow = ඊතලය ඉවත් කරන්න
-
 orbital-row-label = { $row } වන පේළියේ ලේබලය
-
 pretzel-answer = පිළිතුර
-
 summary-statistics-caption = { $column } හි සාරාංශ සංඛ්‍යාන
-
 
 ## Math input
 
@@ -115,34 +92,25 @@ math-input-preview-region = ගණිත ප්‍රකාශන පෙරද�
 math-input-preview = පෙරදසුන
 math-input-invalid-expression = අවලංගු ප්‍රකාශනයකි:
 
-
 ## Document status
 
 viewer-initializing = ආරම්භ වෙමින්...
 
-
 ## Errors
 
 error-heading = දෝෂය
-
 error-found-at =
     { $span ->
         [line] { $startLine } වන පේළියේ හමු විය.
        *[lines] { $startLine }–{ $endLine } පේළිවල හමු විය.
     }
-
 document-contains-errors = මෙම ලේඛනයේ දෝෂ ඇත!
-
 diagnostic-heading-error = දෝෂය
 diagnostic-heading-warning = අනතුරු ඇඟවීම
 diagnostic-heading-information = තොරතුරු
 diagnostic-heading-hint = ඉඟිය
-
 accessibility-heading-level-1 = WCAG AA ප්‍රවේශ්‍යතා උල්ලංඝනය
 accessibility-heading-level-2 = ප්‍රවේශ්‍යතා දැනුම්දීම
-
 something-went-wrong = යම් දෙයක් වැරදී ඇත.
-
 renderer-load-failed = විදහාපාන්නෙකු පූරණය කිරීමට අසමත් විය. කරුණාකර පිටුව නැවත පූරණය කරන්න.
-
 core-start-failed = ලේඛන දර්ශකය ආරම්භ කළ නොහැකි විය. කරුණාකර පිටුව නැවත පූරණය කරන්න.

--- a/packages/i18n/locales/si/content.ftl
+++ b/packages/i18n/locales/si/content.ftl
@@ -43,15 +43,12 @@ color =
     .purple = දම්
     .pink = රෝස
     .brown = දුඹුරු
-
 line-width =
     .thick = ඝන
     .thin = තුනී
-
 line-style =
     .dashed = ඉරි සහිත
     .dotted = තිත් සහිත
-
 # Noun phrases: they follow «සමඟ» and modify nothing.
 fill-style =
     .horizontal = තිරස් රේඛා
@@ -60,7 +57,6 @@ fill-style =
     .backdiagonal = ප්‍රතිවිකර්ණ රේඛා
     .dots = තිත්
     .diamonds = දියමන්ති
-
 noun =
     .line = රේඛාව
     .line-segment = රේඛා ඛණ්ඩය
@@ -80,7 +76,6 @@ noun =
     .diamond = දියමන්තිය
     .cross = කුරුසය
     .plus = ධන ලකුණ
-
 # The side count is a phrase in front of the noun, as the adjectives are, so it
 # folds into the head and there is no tail: «පැති 5ක් සහිත සමකෝණික බහුඅස්‍රය».
 # «පැති» is the word for sides and «-ක්» the indefinite the count takes.
@@ -89,11 +84,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] පැති { $numSides }ක් සහිත සමකෝණික බහුඅස්‍රය
     }
-
 # Sinhala adjectives do not agree, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,23 +100,19 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «පිරවූ», the participle "filled", stands in front of the colour the way every
 # other adjective here does.
 style-filled-word = පිරවූ
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } සමඟ { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } සමඟ { $filled } { $color } { $noun }
@@ -131,7 +120,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } සමඟ { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «සමඟ» is a postposition and follows what it governs, so the border phrase
 # comes first and the word joining it last. Sinhala has no article, so the
 # `-article` branches read like the ones without.
@@ -142,36 +130,29 @@ style-border-clause =
         [and-article] සහ { $border } මායිමක්
        *[with] { $border } මායිමක් සමඟ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = නොපිරවූ
-
 # «මත», on, is a postposition and follows the background it governs.
 style-text =
     { $parts ->
         [background] { $background } පසුබිමක් මත { $color }
        *[plain] { $color }
     }
-
 style-background-none = කිසිවක් නැත
-
 
 ## Boolean words
 
 boolean-true = සත්‍ය
 boolean-false = අසත්‍ය
 
-
 ## Answer buttons
 
 answer-submit-label = පිළිතුර පරීක්ෂා කරන්න
 answer-submit-label-no-correctness = පිළිතුර යොමු කරන්න
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = විසඳුම
     .task = කාර්යය
     .theorem = ප්‍රමේයය
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ඉඟිය
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] වගුව{ ": " }
        *[unnumbered] වගුව
     }
-
 figure-name =
     { $parts ->
         [numbered] රූපය { $enumeration }
@@ -228,22 +205,18 @@ figure-name =
        *[unnumbered] රූපය
     }
 
-
 ## Paginator controls
 
 paginator-previous = පෙර
 paginator-next = මීළඟ
 paginator-page = පිටුව
-
 paginator-page-status = { $numPages } න් { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = හෝ
 piecewise-condition-if = නම්
 piecewise-condition-otherwise = එසේ නොමැති නම්
-
 
 ## Chemistry
 ##
@@ -258,6 +231,5 @@ piecewise-condition-otherwise = එසේ නොමැති නම්
 ## a Sinhala speaker should fill in, and filling it in needs no permission.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = අවලංගු රසායනික සංකේතයකි
 chemistry-invalid-ionic-compound = අවලංගු අයනික සංයෝගයකි

--- a/packages/i18n/locales/sk/chrome.ftl
+++ b/packages/i18n/locales/sk/chrome.ftl
@@ -22,21 +22,15 @@
 
 answer-checking = Prebieha kontrola…
 answer-submitting = Prebieha odosielanie…
-
 answer-checking-status = Kontrola odpovede
 answer-submitting-status = Odosielanie odpovede
-
 answer-correct = Správne
 answer-incorrect = Nesprávne
-
 answer-response-saved = Odpoveď uložená
-
 answer-percent-credit = { $percent } % hodnotenia
 answer-percent-correct = { $percent } % správne
 answer-percent-short = { $percent } %
-
 max-credit-available = Maximálne možné hodnotenie: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] nezostávajú žiadne pokusy
@@ -44,11 +38,9 @@ attempts-remaining =
         [few] zostávajú { $count } pokusy
        *[other] zostáva { $count } pokusov
     }
-
 validation-correct = (Správne)
 validation-incorrect = (Nesprávne)
 validation-partially-correct = (Čiastočne správne)
-
 answer-show-responses =
     { $count ->
         [one] Zobraziť { $count } odpoveď na { $answerId }
@@ -56,42 +48,31 @@ answer-show-responses =
        *[other] Zobraziť { $count } odpovedí na { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Spätná väzba
-
 collapsible-click-to-open = (kliknutím otvoriť)
 collapsible-click-to-close = (kliknutím zavrieť)
-
 collapsible-initializing = Inicializácia…
-
 footnote-show = Zobraziť poznámku pod čiarou
 footnote-hide = Skryť poznámku pod čiarou
-
 description-more-information = viac informácií
-
 
 ## Controls
 
 slider-previous = Späť
 slider-next = Ďalej
-
 keyboard-open = Otvoriť klávesnicu
 keyboard-close = Zavrieť klávesnicu
-
 choice-input-remove-choice = Odobrať { $choice }
-
 matrix-remove-row = Odobrať riadok
 matrix-add-row = Pridať riadok
 matrix-remove-column = Odobrať stĺpec
 matrix-add-column = Pridať stĺpec
-
 subset-add-remove-points = Pridať/odobrať body
 subset-toggle-points-intervals = Prepnúť body a intervaly
 subset-move-points = Presunúť body
 subset-clear = Vymazať
-
 orbital-add-row = Pridať riadok
 orbital-remove-row = Odobrať riadok
 orbital-add-box = Pridať políčko
@@ -99,13 +80,9 @@ orbital-remove-box = Odobrať políčko
 orbital-add-up-arrow = Pridať šípku nahor
 orbital-add-down-arrow = Pridať šípku nadol
 orbital-remove-arrow = Odobrať šípku
-
 orbital-row-label = Označenie riadka { $row }
-
 pretzel-answer = Odpoveď
-
 summary-statistics-caption = Súhrnné štatistiky pre { $column }
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = náhľad matematického výrazu
 math-input-preview = Náhľad
 math-input-invalid-expression = Neplatný výraz:
 
-
 ## Document status
 
 viewer-initializing = Inicializácia…
 
-
 ## Errors
 
 error-heading = Chyba
-
 error-found-at =
     { $span ->
         [line] Nájdené na riadku { $startLine }.
        *[lines] Nájdené na riadkoch { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tento dokument obsahuje chyby!
-
 diagnostic-heading-error = Chyba
 diagnostic-heading-warning = Varovanie
 diagnostic-heading-information = Informácia
 diagnostic-heading-hint = Pomôcka
-
 accessibility-heading-level-1 = Porušenie prístupnosti WCAG AA
 accessibility-heading-level-2 = Upozornenie na prístupnosť
-
 something-went-wrong = Niečo sa pokazilo.
-
 renderer-load-failed = vykresľovací modul sa nepodarilo načítať. Je potrebné znova načítať stránku.
-
 core-start-failed = Prehliadač dokumentu sa nepodarilo spustiť. Je potrebné znova načítať stránku.

--- a/packages/i18n/locales/sk/content.ftl
+++ b/packages/i18n/locales/sk/content.ftl
@@ -175,7 +175,6 @@ color =
                    *[m] hnedý
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -201,7 +200,6 @@ line-width =
                    *[m] tenký
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -227,7 +225,6 @@ line-style =
                    *[m] bodkovaný
                 }
         }
-
 # Noun phrases in the accusative plural, which is the case «v» takes when it
 # names a pattern — «v bodky», the way Slovak describes patterned cloth. The
 # accusative plural of an inanimate noun is spelled like the nominative, so the
@@ -239,7 +236,6 @@ fill-style =
     .backdiagonal = opačne šikmé čiary
     .dots = bodky
     .diamonds = kosoštvorce
-
 noun =
     .line = priamka
     .line-segment = úsečka
@@ -259,7 +255,6 @@ noun =
     .diamond = kosoštvorec
     .cross = krížik
     .plus = plus
-
 # Slovak names a regular polygon by its side count in one word — «pravidelný
 # 5-uholník» — so the count stays in the head and there is no tail, exactly as
 # in English. Czech next door splits it, which is the point of `$part` being a
@@ -269,7 +264,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] pravidelný { $numSides }-uholník
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (mnohouholník, m)
 # or the head of a phrase the description never names: `border` (okraj, m),
 # `fill` (výplň, f), `text` (text, m), `background` (pozadie, n).
@@ -290,7 +284,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -303,13 +296,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -318,13 +309,11 @@ style-filled-word =
         [n] vyplnené
        *[m] vyplnený
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } v { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } v { $pattern }
@@ -332,7 +321,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } v { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «s» governs the instrumental, which the `border-clause` branch of every
 # adjective supplies. Slovak has no article, so the `-article` branches read
 # the same as the ones without.
@@ -343,15 +331,12 @@ style-border-clause =
         [and-article] a s { $border } okrajom
        *[with] s { $border } okrajom
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = nevyplnený
-
 # «na» governs the locative, which is what the `background-clause` branch of
 # every adjective supplies — «na čiernom pozadí».
 style-text =
@@ -359,21 +344,17 @@ style-text =
         [background] { $color } na { $background } pozadí
        *[plain] { $color }
     }
-
 style-background-none = žiadne
-
 
 ## Boolean words
 
 boolean-true = pravda
 boolean-false = nepravda
 
-
 ## Answer buttons
 
 answer-submit-label = Skontrolovať
 answer-submit-label-no-correctness = Odoslať odpoveď
-
 
 ## Sectional blocks
 
@@ -398,7 +379,6 @@ section-name =
     .solution = Riešenie
     .task = Zadanie
     .theorem = Veta
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -408,9 +388,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pomôcka
-
 
 ## Tables and figures
 
@@ -421,7 +399,6 @@ table-name =
         [unnumbered-title] Tabuľka{ ": " }
        *[unnumbered] Tabuľka
     }
-
 figure-name =
     { $parts ->
         [numbered] Obrázok { $enumeration }
@@ -430,22 +407,18 @@ figure-name =
        *[unnumbered] Obrázok
     }
 
-
 ## Paginator controls
 
 paginator-previous = Predchádzajúca
 paginator-next = Ďalšia
 paginator-page = Strana
-
 paginator-page-status = { $pageLabel } { $currentPage } z { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = alebo
 piecewise-condition-if = ak
 piecewise-condition-otherwise = inak
-
 
 ## Chemistry
 
@@ -568,7 +541,6 @@ element-name =
     .lv = Livermorium
     .ts = Tennessín
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Karbid
@@ -582,8 +554,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Neplatná chemická značka
 chemistry-invalid-ionic-compound = Neplatná iónová zlúčenina

--- a/packages/i18n/locales/sl/chrome.ftl
+++ b/packages/i18n/locales/sl/chrome.ftl
@@ -25,21 +25,15 @@
 
 answer-checking = Preverjanje …
 answer-submitting = Pošiljanje …
-
 answer-checking-status = Preverjanje odgovora
 answer-submitting-status = Pošiljanje odgovora
-
 answer-correct = Pravilno
 answer-incorrect = Napačno
-
 answer-response-saved = Odgovor je shranjen
-
 answer-percent-credit = { $percent }% točk
 answer-percent-correct = { $percent }% pravilno
 answer-percent-short = { $percent } %
-
 max-credit-available = Največ mogočih točk: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ni več poskusov
@@ -48,11 +42,9 @@ attempts-remaining =
         [few] ostajajo { $count } poskusi
        *[other] ostaja { $count } poskusov
     }
-
 validation-correct = (Pravilno)
 validation-incorrect = (Napačno)
 validation-partially-correct = (Delno pravilno)
-
 answer-show-responses =
     { $count ->
         [one] Pokaži { $count } odgovor na { $answerId }
@@ -61,42 +53,31 @@ answer-show-responses =
        *[other] Pokaži { $count } odgovorov na { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Povratna informacija
-
 collapsible-click-to-open = (kliknite za odpiranje)
 collapsible-click-to-close = (kliknite za zapiranje)
-
 collapsible-initializing = Zagon …
-
 footnote-show = Pokaži opombo
 footnote-hide = Skrij opombo
-
 description-more-information = več informacij
-
 
 ## Controls
 
 slider-previous = Nazaj
 slider-next = Naprej
-
 keyboard-open = Odpri tipkovnico
 keyboard-close = Zapri tipkovnico
-
 choice-input-remove-choice = Odstrani { $choice }
-
 matrix-remove-row = Odstrani vrstico
 matrix-add-row = Dodaj vrstico
 matrix-remove-column = Odstrani stolpec
 matrix-add-column = Dodaj stolpec
-
 subset-add-remove-points = Dodaj/odstrani točke
 subset-toggle-points-intervals = Preklopi med točkami in intervali
 subset-move-points = Premakni točke
 subset-clear = Počisti
-
 orbital-add-row = Dodaj vrstico
 orbital-remove-row = Odstrani vrstico
 orbital-add-box = Dodaj polje
@@ -104,13 +85,9 @@ orbital-remove-box = Odstrani polje
 orbital-add-up-arrow = Dodaj puščico navzgor
 orbital-add-down-arrow = Dodaj puščico navzdol
 orbital-remove-arrow = Odstrani puščico
-
 orbital-row-label = Oznaka za vrstico { $row }
-
 pretzel-answer = Odgovor
-
 summary-statistics-caption = Povzetek statistik za { $column }
-
 
 ## Math input
 
@@ -118,34 +95,25 @@ math-input-preview-region = predogled matematičnega izraza
 math-input-preview = Predogled
 math-input-invalid-expression = Neveljaven izraz:
 
-
 ## Document status
 
 viewer-initializing = Zagon …
 
-
 ## Errors
 
 error-heading = Napaka
-
 error-found-at =
     { $span ->
         [line] Najdena v vrstici { $startLine }.
        *[lines] Najdena v vrsticah { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ta dokument vsebuje napake!
-
 diagnostic-heading-error = Napaka
 diagnostic-heading-warning = Opozorilo
 diagnostic-heading-information = Informacija
 diagnostic-heading-hint = Namig
-
 accessibility-heading-level-1 = Kršitev dostopnosti po WCAG AA
 accessibility-heading-level-2 = Opozorilo o dostopnosti
-
 something-went-wrong = Nekaj je šlo narobe.
-
 renderer-load-failed = modula za izris ni bilo mogoče naložiti. Znova naložite stran.
-
 core-start-failed = Pregledovalnika dokumenta ni bilo mogoče zagnati. Znova naložite stran.

--- a/packages/i18n/locales/sl/content.ftl
+++ b/packages/i18n/locales/sl/content.ftl
@@ -175,7 +175,6 @@ color =
                    *[m] rjav
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -201,7 +200,6 @@ line-width =
                    *[m] tanek
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -227,7 +225,6 @@ line-style =
                    *[m] pikčast
                 }
         }
-
 # Instrumental plurals, each carrying the preposition that governs it — «s»
 # before a voiceless sound and «z» before a voiced one, which is a fact about
 # the following word and so is settled here rather than where the pattern is
@@ -239,7 +236,6 @@ fill-style =
     .backdiagonal = z obratnimi diagonalnimi črtami
     .dots = s pikami
     .diamonds = z rombi
-
 noun =
     .line = premica
     .line-segment = daljica
@@ -259,7 +255,6 @@ noun =
     .diamond = romb
     .cross = križ
     .plus = plus
-
 # Slovenian keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -267,7 +262,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] pravilni { $numSides }-kotnik
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (mnogokotnik, m) or
 # the head of a phrase the description never names: `border` (rob, m), `fill`
 # (polnilo, n), `text` (besedilo, n), `background` (ozadje, n).
@@ -288,7 +282,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -301,13 +294,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -316,14 +307,12 @@ style-filled-word =
         [n] zapolnjeno
        *[m] zapolnjen
     }
-
 # `{ $pattern }` arrives with its own preposition, so none is written here.
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } { $pattern }
@@ -331,7 +320,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «rob» is masculine, so the border's adjectives agree with it and not with the
 # shape it surrounds. Slovenian has no article, so the two `-article` branches
 # read like the two without.
@@ -342,7 +330,6 @@ style-border-clause =
         [and-article] in { $border } robom
        *[with] z { $border } robom
     }
-
 # The fill-pattern words are instrumental plurals, so this message supplies a
 # noun for the colour to hang off — «polnilo», neuter, which is the gender
 # `noun-gender` already answers for `fill`.
@@ -351,29 +338,23 @@ style-fill =
         [pattern] { $color } polnilo { $pattern }
        *[plain] { $color } polnilo
     }
-
 style-unfilled = nezapolnjen
-
 style-text =
     { $parts ->
         [background] { $color } na { $background } ozadju
        *[plain] { $color }
     }
-
 style-background-none = brez
-
 
 ## Boolean words
 
 boolean-true = resnično
 boolean-false = neresnično
 
-
 ## Answer buttons
 
 answer-submit-label = Preveri
 answer-submit-label-no-correctness = Pošlji odgovor
-
 
 ## Sectional blocks
 
@@ -398,7 +379,6 @@ section-name =
     .solution = Rešitev
     .task = Naloga
     .theorem = Izrek
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -408,9 +388,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Namig
-
 
 ## Tables and figures
 
@@ -421,7 +399,6 @@ table-name =
         [unnumbered-title] Tabela{ ": " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Slika { $enumeration }
@@ -430,22 +407,18 @@ figure-name =
        *[unnumbered] Slika
     }
 
-
 ## Paginator controls
 
 paginator-previous = Prejšnja
 paginator-next = Naslednja
 paginator-page = Stran
-
 paginator-page-status = { $pageLabel } { $currentPage } od { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ali
 piecewise-condition-if = če
 piecewise-condition-otherwise = sicer
-
 
 ## Chemistry
 
@@ -568,7 +541,6 @@ element-name =
     .lv = Livermorij
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrid
     .c = Karbid
@@ -582,8 +554,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tenesid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Neveljaven kemijski simbol
 chemistry-invalid-ionic-compound = Neveljavna ionska spojina

--- a/packages/i18n/locales/sm/chrome.ftl
+++ b/packages/i18n/locales/sm/chrome.ftl
@@ -22,69 +22,50 @@
 
 answer-checking = O loʻo siaki...
 answer-submitting = O loʻo lafo...
-
 answer-checking-status = O loʻo siaki le tali
 answer-submitting-status = O loʻo lafo le tali
-
 answer-correct = Saʻo
 answer-incorrect = Sesē
-
 answer-response-saved = Ua sefe le tali
-
 answer-percent-credit = { $percent }% o togi
 answer-percent-correct = { $percent }% saʻo
 answer-percent-short = { $percent }%
-
 max-credit-available = O togi sili e mafai ona maua: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ua leai se taumafaiga o totoe
        *[other] o totoe { $count } taumafaiga
     }
-
 validation-correct = (Saʻo)
 validation-incorrect = (Sesē)
 validation-partially-correct = (Saʻo se vaega)
-
 answer-show-responses = Faʻaali tali e { $count } i le { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Manatu faʻaalia
-
 collapsible-click-to-open = (kiliki e tatala)
 collapsible-click-to-close = (kiliki e tapuni)
-
 collapsible-initializing = O loʻo amata...
-
 footnote-show = Faʻaali le faʻamatalaga i lalo
 footnote-hide = Nātia le faʻamatalaga i lalo
-
 description-more-information = faʻamatalaga atili
-
 
 ## Controls
 
 slider-previous = Muamua
 slider-next = Sosoʻo
-
 keyboard-open = Tatala le kipoti
 keyboard-close = Tapuni le kipoti
-
 choice-input-remove-choice = Aveʻese { $choice }
-
 matrix-remove-row = Aveʻese le laina
 matrix-add-row = Faʻaopoopo se laina
 matrix-remove-column = Aveʻese le koluma
 matrix-add-column = Faʻaopoopo se koluma
-
 subset-add-remove-points = Faʻaopoopo/Aveʻese poini
 subset-toggle-points-intervals = Sui va o poini ma vaitaimi
 subset-move-points = Siitia poini
 subset-clear = Faʻamamā
-
 orbital-add-row = Faʻaopoopo se laina
 orbital-remove-row = Aveʻese le laina
 orbital-add-box = Faʻaopoopo se pusa
@@ -92,13 +73,9 @@ orbital-remove-box = Aveʻese le pusa
 orbital-add-up-arrow = Faʻaopoopo se aū i luga
 orbital-add-down-arrow = Faʻaopoopo se aū i lalo
 orbital-remove-arrow = Aveʻese le aū
-
 orbital-row-label = Igoa mo le laina { $row }
-
 pretzel-answer = Tali
-
 summary-statistics-caption = Faʻamaumauga aotelega o { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = vaʻaiga muamua o le faʻamatalaga matematika
 math-input-preview = Vaʻaiga muamua
 math-input-invalid-expression = Faʻamatalaga lē saʻo:
 
-
 ## Document status
 
 viewer-initializing = O loʻo amata...
 
-
 ## Errors
 
 error-heading = Mea sesē
-
 error-found-at =
     { $span ->
         [line] Na maua i le laina { $startLine }.
        *[lines] Na maua i laina { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = O loʻo iai ni mea sesē i lenei pepa!
-
 diagnostic-heading-error = Mea sesē
 diagnostic-heading-warning = Lapataʻiga
 diagnostic-heading-information = Faʻamatalaga
 diagnostic-heading-hint = Fautuaga
-
 accessibility-heading-level-1 = Solitulafono i avanoa faigofie WCAG AA
 accessibility-heading-level-2 = Lapataʻiga i avanoa faigofie
-
 something-went-wrong = Sa iai se mea na sesē.
-
 renderer-load-failed = e leʻi uta se tagata faʻaali. Faʻamolemole toe uta le itulau.
-
 core-start-failed = E leʻi mafai ona amata le tagata vaʻai pepa. Faʻamolemole toe uta le itulau.

--- a/packages/i18n/locales/sm/content.ftl
+++ b/packages/i18n/locales/sm/content.ftl
@@ -42,15 +42,12 @@ color =
     .purple = viole
     .pink = piniki
     .brown = enaena
-
 line-width =
     .thick = mafiafia
     .thin = manifinifi
-
 line-style =
     .dashed = motumotu
     .dotted = togitogi
-
 # Noun phrases: they follow «faʻatasi ma» and modify nothing.
 fill-style =
     .horizontal = laina faʻalava
@@ -59,7 +56,6 @@ fill-style =
     .backdiagonal = laina faʻapiʻo faʻafeagai
     .dots = togitogi
     .diamonds = taimane
-
 noun =
     .line = laina
     .line-segment = vaega o le laina
@@ -79,7 +75,6 @@ noun =
     .diamond = taimane
     .cross = koluse
     .plus = faʻailoga faʻaopoopo
-
 # The side count follows the noun and precedes its adjectives, so it folds into
 # the head and there is no tail.
 noun-regular-polygon =
@@ -87,11 +82,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] poligoni tutusa itu e { $numSides }
     }
-
 # Samoan has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,22 +98,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «laina mafiafia motumotu mūmū».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = faʻatumu
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } faʻatasi ma { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } faʻatasi ma { $pattern }
@@ -128,7 +117,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } faʻatasi ma { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] faʻatasi ma se tuaoi { $border }
@@ -136,36 +124,29 @@ style-border-clause =
         [and-article] ma se tuaoi { $border }
        *[with] faʻatasi ma se tuaoi { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = e leʻi faʻatumuina
-
 style-text =
     { $parts ->
         [background] { $color } i luga o se pito i tua { $background }
        *[plain] { $color }
     }
-
 style-background-none = leai
-
 
 ## Boolean words
 
 boolean-true = moni
 boolean-false = sesē
 
-
 ## Answer buttons
 
 answer-submit-label = Siaki le galuega
 answer-submit-label-no-correctness = Lafo le tali
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = Fofō
     .task = Galuega
     .theorem = Aʻoaʻoga faʻamaonia
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -200,9 +180,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Fautuaga
-
 
 ## Tables and figures
 
@@ -213,7 +191,6 @@ table-name =
         [unnumbered-title] Laulau{ ": " }
        *[unnumbered] Laulau
     }
-
 figure-name =
     { $parts ->
         [numbered] Ata { $enumeration }
@@ -222,22 +199,18 @@ figure-name =
        *[unnumbered] Ata
     }
 
-
 ## Paginator controls
 
 paginator-previous = Muamua
 paginator-next = Sosoʻo
 paginator-page = Itulau
-
 paginator-page-status = { $pageLabel } { $currentPage } mai le { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = pe
 piecewise-condition-if = afai
 piecewise-condition-otherwise = a leai
-
 
 ## Chemistry
 ##
@@ -249,6 +222,5 @@ piecewise-condition-otherwise = a leai
 ## the vocabulary a student meets in their own classroom.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Faʻailoga kemikolo lē saʻo
 chemistry-invalid-ionic-compound = Tuʻufaʻatasiga ionika lē saʻo

--- a/packages/i18n/locales/sn/chrome.ftl
+++ b/packages/i18n/locales/sn/chrome.ftl
@@ -23,70 +23,51 @@
 
 answer-checking = Iri kuongorora...
 answer-submitting = Iri kutumira...
-
 answer-checking-status = Iri kuongorora mhinduro
 answer-submitting-status = Iri kutumira mhinduro
-
 answer-correct = Yakarurama
 answer-incorrect = Haina kururama
-
 answer-response-saved = Mhinduro Yachengetwa
-
 answer-percent-credit = Mamakisi { $percent }%
 answer-percent-correct = { $percent }% Yakarurama
 answer-percent-short = { $percent } %
-
 max-credit-available = Mamakisi epamusoro anowanikwa: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] hapana edzo yasara
         [one] edzo { $count } yasara
        *[other] maedzo { $count } asara
     }
-
 validation-correct = (Yakarurama)
 validation-incorrect = (Haina kururama)
 validation-partially-correct = (Yakarurama pane zvimwe)
-
 answer-show-responses = Ratidza mhinduro { $count } dza{ $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Mhinduro yeMudzidzisi
-
 collapsible-click-to-open = (dzvanya kuti uvhure)
 collapsible-click-to-close = (dzvanya kuti uvhare)
-
 collapsible-initializing = Iri kutanga...
-
 footnote-show = Ratidza cherechedzo yepasi
 footnote-hide = Vanza cherechedzo yepasi
-
 description-more-information = mamwe mashoko
-
 
 ## Controls
 
 slider-previous = Yapfuura
 slider-next = Inotevera
-
 keyboard-open = Vhura Kibhodhi
 keyboard-close = Vhara Kibhodhi
-
 choice-input-remove-choice = Bvisa { $choice }
-
 matrix-remove-row = Bvisa mutsara wakarara
 matrix-add-row = Wedzera mutsara wakarara
 matrix-remove-column = Bvisa mutsara wakamira
 matrix-add-column = Wedzera mutsara wakamira
-
 subset-add-remove-points = Wedzera/Bvisa mapoindi
 subset-toggle-points-intervals = Chinjanisa pakati pemapoindi nenhambo
 subset-move-points = Fambisa Mapoindi
 subset-clear = Dzima
-
 # A `box` here is one orbital, drawn as a square: «bhokisi».
 orbital-add-row = Wedzera Mutsara
 orbital-remove-row = Bvisa Mutsara
@@ -95,13 +76,9 @@ orbital-remove-box = Bvisa Bhokisi
 orbital-add-up-arrow = Wedzera Museve Wekumusoro
 orbital-add-down-arrow = Wedzera Museve Wepasi
 orbital-remove-arrow = Bvisa Museve
-
 orbital-row-label = Zita remutsara { $row }
-
 pretzel-answer = Mhinduro
-
 summary-statistics-caption = Pfupiso yehuwandu hwe{ $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = pfungwa yekutarisa kwechirevo chemasvomhu
 math-input-preview = Tarisa
 math-input-invalid-expression = Chirevo hachina kururama:
 
-
 ## Document status
 
 viewer-initializing = Iri kutanga...
 
-
 ## Errors
 
 error-heading = Kukanganisa
-
 error-found-at =
     { $span ->
         [line] Yawanikwa pamutsara { $startLine }.
        *[lines] Yawanikwa pamitsara { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Gwaro rino rine zvikanganiso!
-
 diagnostic-heading-error = Kukanganisa
 diagnostic-heading-warning = Yambiro
 diagnostic-heading-information = Ruzivo
 diagnostic-heading-hint = Zano
-
 accessibility-heading-level-1 = Kutyorwa kweWCAG AA kweKuwanikwa
 accessibility-heading-level-2 = Yambiro yekuwanikwa
-
 something-went-wrong = Pane chakakanganisika.
-
 renderer-load-failed = muratidzi mumwe wakundikana kurodha. Ndapota dzokorora peji.
-
 core-start-failed = Muratidzi wegwaro haana kukwanisa kutanga. Ndapota dzokorora peji.

--- a/packages/i18n/locales/sn/content.ftl
+++ b/packages/i18n/locales/sn/content.ftl
@@ -78,7 +78,6 @@ color =
     .purple = pepuru
     .pink = pingi
     .brown = bhurauni
-
 line-width =
     .thick =
         { $gender ->
@@ -94,14 +93,12 @@ line-width =
             [c7] chitete
            *[c9] tete
         }
-
 # Written as invariable «ane …» phrases rather than as adjectives, so that they
 # agree with nothing and can close the description. `style-stroke` puts them
 # last for that reason.
 line-style =
     .dashed = ane zvidimbu
     .dotted = ane madotsi
-
 fill-style =
     .horizontal = mitsara yakarara
     .vertical = mitsara yakamira
@@ -109,7 +106,6 @@ fill-style =
     .backdiagonal = mitsara yakatsveyama kumashure
     .dots = madotsi
     .diamonds = madhaimondi
-
 noun =
     .line = mutsara
     .line-segment = chidimbu chemutsara
@@ -129,7 +125,6 @@ noun =
     .diamond = dhaimondi
     .cross = muchinjikwa
     .plus = chiratidzo chekuwedzera
-
 # The side count goes in the tail, behind the adjectives, because «ine mativi
 # 5» is a relative phrase and Shona closes a noun phrase with it rather than
 # opening one.
@@ -138,7 +133,6 @@ noun-regular-polygon =
         [tail] ine mativi { $numSides }
        *[head] poligoni yakaenzana
     }
-
 noun-gender =
     { $noun ->
         [line] c3
@@ -153,7 +147,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -166,13 +159,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] wakazadzwa
@@ -180,13 +171,11 @@ style-filled-word =
         [c7] chakazadzwa
        *[c9] yakazadzwa
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ne{ $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ne{ $pattern }
@@ -194,7 +183,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ne{ $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «muganhu» is class 3 and leads its own adjectives, so the border's words
 # agree with it and not with the shape it surrounds. Shona has no article, so
 # the two `-article` branches read like the two without, and «une» — a relative
@@ -207,23 +195,18 @@ style-border-clause =
         [and-article] une muganhu { $border }
        *[with] une muganhu { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = isina kuzadzwa
-
 style-text =
     { $parts ->
         [background] { $color } pamusoro pechigadziko { $background }
        *[plain] { $color }
     }
-
 style-background-none = hapana
-
 
 ## Boolean words
 
@@ -232,12 +215,10 @@ boolean-true = chokwadi
 # word for a falsehood here is «manyepo», which is not.
 boolean-false = manyepo
 
-
 ## Answer buttons
 
 answer-submit-label = Ongorora Basa
 answer-submit-label-no-correctness = Tumira Mhinduro
-
 
 ## Sectional blocks
 
@@ -262,7 +243,6 @@ section-name =
     .solution = Gadziriso
     .task = Basa
     .theorem = Tiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -272,9 +252,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Zano
-
 
 ## Tables and figures
 
@@ -285,7 +263,6 @@ table-name =
         [unnumbered-title] Tafura{ ": " }
        *[unnumbered] Tafura
     }
-
 figure-name =
     { $parts ->
         [numbered] Mufananidzo { $enumeration }
@@ -294,15 +271,12 @@ figure-name =
        *[unnumbered] Mufananidzo
     }
 
-
 ## Paginator controls
 
 paginator-previous = Yapfuura
 paginator-next = Inotevera
 paginator-page = Peji
-
 paginator-page-status = { $pageLabel } { $currentPage } pa{ $numPages }
-
 
 ## Piecewise functions
 
@@ -312,7 +286,6 @@ piecewise-condition-or = kana kuti
 piecewise-condition-if = kana
 piecewise-condition-otherwise = kana zvisina kudaro
 
-
 ## Chemistry
 
 # The 118 element names and the 12 anion names are left out, so those keys fall
@@ -321,6 +294,5 @@ piecewise-condition-otherwise = kana zvisina kudaro
 # already, and the seed has no settled Shona list to reproduce. A speaker
 # adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Chiratidzo cheKemisitiri Chisiri Icho
 chemistry-invalid-ionic-compound = Musanganiswa weIoni Usiri Iwo

--- a/packages/i18n/locales/so/chrome.ftl
+++ b/packages/i18n/locales/so/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Waa la hubinayaa...
 answer-submitting = Waa la dirayaa...
-
 answer-checking-status = Jawaabta waa la hubinayaa
 answer-submitting-status = Jawaabta waa la dirayaa
-
 answer-correct = Sax
 answer-incorrect = Qalad
-
 answer-response-saved = Jawaabta waa la keydiyay
-
 answer-percent-credit = { $percent }% dhibcood
 answer-percent-correct = { $percent }% sax
 answer-percent-short = { $percent } %
-
 max-credit-available = Ugu badnaan la heli karo: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] isku day ma harin
         [one] { $count } isku day ayaa harsan
        *[other] { $count } isku day ayaa harsan
     }
-
 validation-correct = (Sax)
 validation-incorrect = (Qalad)
 validation-partially-correct = (Qayb ahaan sax)
-
 answer-show-responses =
     { $count ->
         [one] Muuji { $count } jawaab oo { $answerId } ah
        *[other] Muuji { $count } jawaab oo { $answerId } ah
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Faallo
-
 collapsible-click-to-open = (guji si aad u furto)
 collapsible-click-to-close = (guji si aad u xirto)
-
 collapsible-initializing = Waa la bilaabayaa...
-
 footnote-show = Muuji faallada hoose
 footnote-hide = Qari faallada hoose
-
 description-more-information = macluumaad dheeraad ah
-
 
 ## Controls
 
 slider-previous = Hore
 slider-next = Xiga
-
 keyboard-open = Fur kiiboodhka
 keyboard-close = Xir kiiboodhka
-
 choice-input-remove-choice = Ka saar { $choice }
-
 matrix-remove-row = Ka saar saf
 matrix-add-row = Ku dar saf
 matrix-remove-column = Ka saar tiir
 matrix-add-column = Ku dar tiir
-
 subset-add-remove-points = Ku dar/ka saar dhibcaha
 subset-toggle-points-intervals = Isku beddel dhibco iyo waqti-xilliyeed
 subset-move-points = Dhaqaaji dhibcaha
 subset-clear = Nadiifi
-
 # A `box` here is one orbital, drawn as a square: `sanduuq`.
 orbital-add-row = Ku dar saf
 orbital-remove-row = Ka saar saf
@@ -93,13 +74,9 @@ orbital-remove-box = Ka saar sanduuq
 orbital-add-up-arrow = Ku dar fallaadh kor u socota
 orbital-add-down-arrow = Ku dar fallaadh hoos u socota
 orbital-remove-arrow = Ka saar fallaadh
-
 orbital-row-label = Summad safka { $row }
-
 pretzel-answer = Jawaab
-
 summary-statistics-caption = Tirakoobka kooban ee { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = horudhac tibaaxda xisaabta
 math-input-preview = Horudhac
 math-input-invalid-expression = Tibaax aan sax ahayn:
 
-
 ## Document status
 
 viewer-initializing = Waa la bilaabayaa...
 
-
 ## Errors
 
 error-heading = Qalad
-
 error-found-at =
     { $span ->
         [line] Waxaa laga helay sadarka { $startLine }.
        *[lines] Waxaa laga helay sadarrada { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dukumentigan waxaa ku jira qaladaad!
-
 diagnostic-heading-error = Qalad
 diagnostic-heading-warning = Digniin
 diagnostic-heading-information = Macluumaad
 diagnostic-heading-hint = Tilmaan
-
 accessibility-heading-level-1 = Xadgudub helitaanka WCAG AA
 accessibility-heading-level-2 = Digniin ku saabsan helitaanka
-
 something-went-wrong = Wax baa qaldamay.
-
 renderer-load-failed = qayb muujineed lama soo rari karin. Fadlan bogga dib u cusboonaysii.
-
 core-start-failed = Daawadaha dukumentiga lama bilaabi karin. Fadlan bogga dib u cusboonaysii.

--- a/packages/i18n/locales/so/content.ftl
+++ b/packages/i18n/locales/so/content.ftl
@@ -30,15 +30,12 @@ color =
     .purple = guduud-buluug
     .pink = casaan khafiif ah
     .brown = bunni
-
 line-width =
     .thick = dhumuc weyn
     .thin = khafiif
-
 line-style =
     .dashed = jarjaran
     .dotted = dhibco leh
-
 # Noun phrases: they follow `oo leh` and agree with nothing.
 fill-style =
     .horizontal = xariiqyo jiifa
@@ -47,7 +44,6 @@ fill-style =
     .backdiagonal = xariiqyo dhinaca kale u jeeda
     .dots = dhibco
     .diamonds = dheeman
-
 noun =
     .line = xariiq
     .line-segment = qayb xariiq
@@ -67,7 +63,6 @@ noun =
     .diamond = dheeman
     .cross = iskutallaab
     .plus = calaamadda lagu daro
-
 # The noun is split: `geesle joogto ah` carries the adjectives and
 # `oo leh 5 dhinac` closes the phrase behind them.
 noun-regular-polygon =
@@ -75,9 +70,7 @@ noun-regular-polygon =
         [tail] oo leh { $numSides } dhinac
        *[head] geesle joogto ah
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -91,22 +84,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $nounTail } { $description }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = buuxsan
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } oo leh { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } oo leh { $pattern }
@@ -114,7 +103,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } oo leh { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] oo leh xuduud { $border }
@@ -122,7 +110,6 @@ style-border-clause =
         [and-article] iyo xuduud { $border }
        *[with] oo leh xuduud { $border }
     }
-
 # Noun then colour, as everywhere else here. The colour words carry their own
 # `ah` where they need one (`casaan khafiif ah`), so this message adds none.
 style-fill =
@@ -130,29 +117,23 @@ style-fill =
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = aan buuxsanayn
-
 style-text =
     { $parts ->
         [background] { $color } oo ku yaal gadaal { $background }
        *[plain] { $color }
     }
-
 style-background-none = midna
-
 
 ## Boolean words
 
 boolean-true = run
 boolean-false = been
 
-
 ## Answer buttons
 
 answer-submit-label = Hubi
 answer-submit-label-no-correctness = Dir jawaabta
-
 
 ## Sectional blocks
 
@@ -177,7 +158,6 @@ section-name =
     .solution = Xal
     .task = Hawl
     .theorem = Aragti
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -187,9 +167,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tilmaan
-
 
 ## Tables and figures
 
@@ -200,7 +178,6 @@ table-name =
         [unnumbered-title] Shax{ ": " }
        *[unnumbered] Shax
     }
-
 figure-name =
     { $parts ->
         [numbered] Sawirka { $enumeration }
@@ -209,15 +186,12 @@ figure-name =
        *[unnumbered] Sawir
     }
 
-
 ## Paginator controls
 
 paginator-previous = Hore
 paginator-next = Xiga
 paginator-page = Bog
-
 paginator-page-status = { $pageLabel } { $currentPage } ka mid ah { $numPages }
-
 
 ## Piecewise functions
 
@@ -225,10 +199,8 @@ piecewise-condition-or = ama
 piecewise-condition-if = haddii
 piecewise-condition-otherwise = haddii kale
 
-
 ## Chemistry
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Calaamad kiimiko ah oo aan sax ahayn
 chemistry-invalid-ionic-compound = Isku-dhis ayoon ah oo aan sax ahayn

--- a/packages/i18n/locales/sq/chrome.ftl
+++ b/packages/i18n/locales/sq/chrome.ftl
@@ -18,74 +18,55 @@
 
 answer-checking = Po kontrollohet…
 answer-submitting = Po dërgohet…
-
 answer-checking-status = Kontrollimi i përgjigjes
 answer-submitting-status = Dërgimi i përgjigjes
-
 answer-correct = Saktë
 answer-incorrect = Gabim
-
 answer-response-saved = Përgjigjja u ruajt
-
 answer-percent-credit = { $percent }% e pikëve
 answer-percent-correct = { $percent }% saktë
 answer-percent-short = { $percent } %
-
 max-credit-available = Pikët më të larta të mundshme: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] nuk ka më përpjekje
         [one] mbetet { $count } përpjekje
        *[other] mbeten { $count } përpjekje
     }
-
 validation-correct = (Saktë)
 validation-incorrect = (Gabim)
 validation-partially-correct = (Pjesërisht saktë)
-
 answer-show-responses =
     { $count ->
         [one] Shfaq { $count } përgjigje për { $answerId }
        *[other] Shfaq { $count } përgjigje për { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Kthim përgjigjeje
-
 collapsible-click-to-open = (klikoni për ta hapur)
 collapsible-click-to-close = (klikoni për ta mbyllur)
-
 collapsible-initializing = Po niset…
-
 footnote-show = Shfaq shënimin
 footnote-hide = Fshih shënimin
-
 description-more-information = më shumë informacion
-
 
 ## Controls
 
 slider-previous = Prapa
 slider-next = Përpara
-
 keyboard-open = Hap tastierën
 keyboard-close = Mbyll tastierën
-
 choice-input-remove-choice = Hiq { $choice }
-
 matrix-remove-row = Hiq rreshtin
 matrix-add-row = Shto rresht
 matrix-remove-column = Hiq shtyllën
 matrix-add-column = Shto shtyllë
-
 subset-add-remove-points = Shto/hiq pika
 subset-toggle-points-intervals = Kalo midis pikave dhe intervaleve
 subset-move-points = Zhvendos pikat
 subset-clear = Pastro
-
 orbital-add-row = Shto rresht
 orbital-remove-row = Hiq rreshtin
 orbital-add-box = Shto kuti
@@ -93,13 +74,9 @@ orbital-remove-box = Hiq kutinë
 orbital-add-up-arrow = Shto shigjetë lart
 orbital-add-down-arrow = Shto shigjetë poshtë
 orbital-remove-arrow = Hiq shigjetën
-
 orbital-row-label = Etiketë për rreshtin { $row }
-
 pretzel-answer = Përgjigje
-
 summary-statistics-caption = Statistika përmbledhëse për { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = paraparje e shprehjes matematike
 math-input-preview = Paraparje
 math-input-invalid-expression = Shprehje e pavlefshme:
 
-
 ## Document status
 
 viewer-initializing = Po niset…
 
-
 ## Errors
 
 error-heading = Gabim
-
 error-found-at =
     { $span ->
         [line] Gjetur në rreshtin { $startLine }.
        *[lines] Gjetur në rreshtat { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ky dokument përmban gabime!
-
 diagnostic-heading-error = Gabim
 diagnostic-heading-warning = Paralajmërim
 diagnostic-heading-information = Informacion
 diagnostic-heading-hint = Ndihmesë
-
 accessibility-heading-level-1 = Shkelje e qasshmërisë sipas WCAG AA
 accessibility-heading-level-2 = Njoftim për qasshmërinë
-
 something-went-wrong = Diçka shkoi keq.
-
 renderer-load-failed = një modul paraqitjeje nuk u ngarkua. Ringarkoni faqen.
-
 core-start-failed = Shikuesi i dokumentit nuk mundi të nisej. Ringarkoni faqen.

--- a/packages/i18n/locales/sq/content.ftl
+++ b/packages/i18n/locales/sq/content.ftl
@@ -92,7 +92,6 @@ color =
     .purple = vjollcë
     .pink = rozë
     .brown = kafe
-
 line-width =
     .thick =
         { $role ->
@@ -116,7 +115,6 @@ line-width =
                    *[m] i hollë
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -140,7 +138,6 @@ line-style =
                    *[m] i pikëzuar
                 }
         }
-
 # Bare plural noun phrases. The «me» that governs them is written where they
 # are placed, since the same words follow it in both messages that use them.
 fill-style =
@@ -150,7 +147,6 @@ fill-style =
     .backdiagonal = vija diagonale të kundërta
     .dots = pika
     .diamonds = rombe
-
 noun =
     .line = drejtëz
     .line-segment = segment
@@ -170,7 +166,6 @@ noun =
     .diamond = romb
     .cross = kryq
     .plus = plus
-
 # Albanian counts the sides after the noun, but so does everything else that
 # describes it, so the count can stay inside the head and there is no tail.
 noun-regular-polygon =
@@ -178,7 +173,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] shumëkëndësh i rregullt me { $numSides } brinjë
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (shumëkëndësh, m)
 # or the head of a phrase the description never names: `border` (kufi, m),
 # `fill` (mbushje, f), `text` (tekst, m), `background` (sfond, m).
@@ -195,7 +189,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -208,14 +201,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun comes first in Albanian, so this is the English order reversed.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $nounTail } { $description }
        *[noun] { $noun } { $description }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -223,13 +214,11 @@ style-filled-word =
         [f] e mbushur
        *[m] i mbushur
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } me { $pattern }
        *[plain] { $filled } { $color }
     }
-
 # The noun leads and every describing word follows it, so the shape's name sits
 # in front of `{ $filled }` rather than after it.
 style-filled-with-noun =
@@ -239,7 +228,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } me { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «kufi» is masculine, and behind «me» its describing words take the accusative
 # article «të» whatever gender the shape they surround is. Albanian has no
 # indefinite article, so the two `-article` branches read like the two without.
@@ -250,7 +238,6 @@ style-border-clause =
         [and-article] dhe kufi { $border }
        *[with] me kufi { $border }
     }
-
 # Supplies «mbushje» — feminine, which is the gender `noun-gender` already
 # answers for `fill` — for the colour to agree with, and leads with it.
 style-fill =
@@ -258,29 +245,23 @@ style-fill =
         [pattern] mbushje { $color } me { $pattern }
        *[plain] mbushje { $color }
     }
-
 style-unfilled = i pambushur
-
 style-text =
     { $parts ->
         [background] { $color } me sfond { $background }
        *[plain] { $color }
     }
-
 style-background-none = asnjë
-
 
 ## Boolean words
 
 boolean-true = e vërtetë
 boolean-false = e rreme
 
-
 ## Answer buttons
 
 answer-submit-label = Kontrollo
 answer-submit-label-no-correctness = Dërgo përgjigjen
-
 
 ## Sectional blocks
 
@@ -305,7 +286,6 @@ section-name =
     .solution = Zgjidhje
     .task = Detyrë
     .theorem = Teoremë
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -315,9 +295,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ndihmesë
-
 
 ## Tables and figures
 
@@ -328,7 +306,6 @@ table-name =
         [unnumbered-title] Tabela{ ": " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -337,22 +314,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = E mëparshmja
 paginator-next = Tjetra
 paginator-page = Faqja
-
 paginator-page-status = { $pageLabel } { $currentPage } nga { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ose
 piecewise-condition-if = nëse
 piecewise-condition-otherwise = përndryshe
-
 
 ## Chemistry
 
@@ -475,7 +448,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrur
     .c = Karbur
@@ -489,8 +461,6 @@ element-anion-name =
     .i = Jodur
     .at = Astatur
     .ts = Tenesur
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kimik i pavlefshëm
 chemistry-invalid-ionic-compound = Përbërje jonike e pavlefshme

--- a/packages/i18n/locales/sr/chrome.ftl
+++ b/packages/i18n/locales/sr/chrome.ftl
@@ -23,21 +23,15 @@
 
 answer-checking = Провера…
 answer-submitting = Слање…
-
 answer-checking-status = Провера одговора
 answer-submitting-status = Слање одговора
-
 answer-correct = Тачно
 answer-incorrect = Нетачно
-
 answer-response-saved = Одговор је сачуван
-
 answer-percent-credit = { $percent }% поена
 answer-percent-correct = { $percent }% тачно
 answer-percent-short = { $percent } %
-
 max-credit-available = Највише могућих поена: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] нема више покушаја
@@ -45,11 +39,9 @@ attempts-remaining =
         [few] преостају { $count } покушаја
        *[other] преостаје { $count } покушаја
     }
-
 validation-correct = (Тачно)
 validation-incorrect = (Нетачно)
 validation-partially-correct = (Делимично тачно)
-
 answer-show-responses =
     { $count ->
         [one] Прикажи { $count } одговор на { $answerId }
@@ -57,42 +49,31 @@ answer-show-responses =
        *[other] Прикажи { $count } одговора на { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Повратна информација
-
 collapsible-click-to-open = (кликните да отворите)
 collapsible-click-to-close = (кликните да затворите)
-
 collapsible-initializing = Покретање…
-
 footnote-show = Прикажи фусноту
 footnote-hide = Сакриј фусноту
-
 description-more-information = више информација
-
 
 ## Controls
 
 slider-previous = Назад
 slider-next = Напред
-
 keyboard-open = Отвори тастатуру
 keyboard-close = Затвори тастатуру
-
 choice-input-remove-choice = Уклони { $choice }
-
 matrix-remove-row = Уклони ред
 matrix-add-row = Додај ред
 matrix-remove-column = Уклони колону
 matrix-add-column = Додај колону
-
 subset-add-remove-points = Додај/уклони тачке
 subset-toggle-points-intervals = Пребаци између тачака и интервала
 subset-move-points = Помери тачке
 subset-clear = Очисти
-
 orbital-add-row = Додај ред
 orbital-remove-row = Уклони ред
 orbital-add-box = Додај поље
@@ -100,13 +81,9 @@ orbital-remove-box = Уклони поље
 orbital-add-up-arrow = Додај стрелицу нагоре
 orbital-add-down-arrow = Додај стрелицу надоле
 orbital-remove-arrow = Уклони стрелицу
-
 orbital-row-label = Ознака за ред { $row }
-
 pretzel-answer = Одговор
-
 summary-statistics-caption = Збирне статистике за { $column }
-
 
 ## Math input
 
@@ -114,34 +91,25 @@ math-input-preview-region = преглед математичког израза
 math-input-preview = Преглед
 math-input-invalid-expression = Неисправан израз:
 
-
 ## Document status
 
 viewer-initializing = Покретање…
 
-
 ## Errors
 
 error-heading = Грешка
-
 error-found-at =
     { $span ->
         [line] Пронађена у реду { $startLine }.
        *[lines] Пронађена у редовима { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Овај документ садржи грешке!
-
 diagnostic-heading-error = Грешка
 diagnostic-heading-warning = Упозорење
 diagnostic-heading-information = Информација
 diagnostic-heading-hint = Савет
-
 accessibility-heading-level-1 = Кршење приступачности према WCAG AA
 accessibility-heading-level-2 = Упозорење о приступачности
-
 something-went-wrong = Нешто је пошло наопако.
-
 renderer-load-failed = модул за приказ није успео да се учита. Поново учитајте страницу.
-
 core-start-failed = Прегледач документа није могао да се покрене. Поново учитајте страницу.

--- a/packages/i18n/locales/sr/content.ftl
+++ b/packages/i18n/locales/sr/content.ftl
@@ -176,7 +176,6 @@ color =
                    *[m] смеђ
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -202,7 +201,6 @@ line-width =
                    *[m] танак
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -228,7 +226,6 @@ line-style =
                    *[m] тачкаст
                 }
         }
-
 # Noun phrases in the instrumental, which is the case «са» takes. They agree
 # with nothing.
 fill-style =
@@ -238,7 +235,6 @@ fill-style =
     .backdiagonal = обрнутим дијагоналним линијама
     .dots = тачкама
     .diamonds = ромбовима
-
 noun =
     .line = права
     .line-segment = дуж
@@ -258,7 +254,6 @@ noun =
     .diamond = ромб
     .cross = крст
     .plus = плус
-
 # Serbian keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -266,7 +261,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] правилни { $numSides }-угао
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (многоугао, m) or
 # the head of a phrase the description never names: `border` (ивица, f), `fill`
 # (испуна, f), `text` (текст, m), `background` (позадина, f).
@@ -288,7 +282,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -301,13 +294,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -316,13 +307,11 @@ style-filled-word =
         [n] испуњено
        *[m] испуњен
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } са { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } са { $pattern }
@@ -330,7 +319,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } са { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ивица» is feminine, so the border's adjectives agree with it and not with
 # the shape it surrounds. Serbian has no article, so the two `-article`
 # branches read like the two without.
@@ -341,7 +329,6 @@ style-border-clause =
         [and-article] и { $border } ивицом
        *[with] са { $border } ивицом
     }
-
 # The fill-pattern words are instrumental plurals, because their other use is
 # the «са { $pattern }» clause in `style-filled`. So this message supplies a
 # noun for them to hang off — «испуна», feminine, which is the gender
@@ -351,29 +338,23 @@ style-fill =
         [pattern] { $color } испуна са { $pattern }
        *[plain] { $color } испуна
     }
-
 style-unfilled = неиспуњен
-
 style-text =
     { $parts ->
         [background] { $color } на { $background } позадини
        *[plain] { $color }
     }
-
 style-background-none = нема
-
 
 ## Boolean words
 
 boolean-true = тачно
 boolean-false = нетачно
 
-
 ## Answer buttons
 
 answer-submit-label = Провери
 answer-submit-label-no-correctness = Пошаљи одговор
-
 
 ## Sectional blocks
 
@@ -398,7 +379,6 @@ section-name =
     .solution = Решење
     .task = Задатак
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -408,9 +388,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Савет
-
 
 ## Tables and figures
 
@@ -421,7 +399,6 @@ table-name =
         [unnumbered-title] Табела{ ". " }
        *[unnumbered] Табела
     }
-
 figure-name =
     { $parts ->
         [numbered] Слика { $enumeration }
@@ -430,22 +407,18 @@ figure-name =
        *[unnumbered] Слика
     }
 
-
 ## Paginator controls
 
 paginator-previous = Претходна
 paginator-next = Следећа
 paginator-page = Страница
-
 paginator-page-status = { $pageLabel } { $currentPage } од { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = или
 piecewise-condition-if = ако
 piecewise-condition-otherwise = иначе
-
 
 ## Chemistry
 
@@ -568,7 +541,6 @@ element-name =
     .lv = Ливерморијум
     .ts = Тенесин
     .og = Оганесон
-
 element-anion-name =
     .h = Хидрид
     .c = Карбид
@@ -582,8 +554,6 @@ element-anion-name =
     .i = Јодид
     .at = Астатид
     .ts = Тенесид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Неисправан хемијски симбол
 chemistry-invalid-ionic-compound = Неисправно јонско једињење

--- a/packages/i18n/locales/ss/chrome.ftl
+++ b/packages/i18n/locales/ss/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Kuyahlolwa…
 answer-submitting = Kuyatfunyelwa…
-
 answer-checking-status = Kuhlolwa imphendvulo
 answer-submitting-status = Kutfunyelwa imphendvulo
-
 answer-correct = Kulungile
 answer-incorrect = Akulungile
-
 answer-response-saved = Imphendvulo Igciniwe
-
 answer-percent-credit = { $percent }% Wemamaki
 answer-percent-correct = { $percent }% Kulungile
 answer-percent-short = { $percent } %
-
 max-credit-available = Emamaki lamaningi lakhona: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] akusekho kuzama lokusele
         [one] kusele kuzama lokungu-{ $count }
        *[other] kusele kuzama lokungu-{ $count }
     }
-
 validation-correct = (Kulungile)
 validation-incorrect = (Akulungile)
 validation-partially-correct = (Kulungile ngalokwengcenye)
-
 answer-show-responses =
     { $count ->
         [one] Khombisa imphendvulo lengu-{ $count } ku-{ $answerId }
        *[other] Khombisa timphendvulo letingu-{ $count } ku-{ $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Imphendvulo yekucondzisa
-
 collapsible-click-to-open = (chafata kute uvule)
 collapsible-click-to-close = (chafata kute uvale)
-
 collapsible-initializing = Kuyacalwa…
-
 footnote-show = Khombisa inothi langaphansi
 footnote-hide = Fihla inothi langaphansi
-
 description-more-information = lwati loluchubekako
-
 
 ## Controls
 
 slider-previous = Kwendlulile
 slider-next = Kulandzelako
-
 keyboard-open = Vula Ikhibhodi
 keyboard-close = Vala Ikhibhodi
-
 choice-input-remove-choice = Susa { $choice }
-
 matrix-remove-row = Susa umudvwa
 matrix-add-row = Ngeta umudvwa
 matrix-remove-column = Susa likholomu
 matrix-add-column = Ngeta likholomu
-
 subset-add-remove-points = Ngeta/Susa emaphuzu
 subset-toggle-points-intervals = Guculula emaphuzu netikhatsi
 subset-move-points = Khweshisa Emaphuzu
 subset-clear = Sula
-
 orbital-add-row = Ngeta Umudvwa
 orbital-remove-row = Susa Umudvwa
 orbital-add-box = Ngeta Libhokisi
@@ -86,13 +67,9 @@ orbital-remove-box = Susa Libhokisi
 orbital-add-up-arrow = Ngeta Umcibisholo Wenhla
 orbital-add-down-arrow = Ngeta Umcibisholo Wenzansi
 orbital-remove-arrow = Susa Umcibisholo
-
 orbital-row-label = Libito lomudvwa { $row }
-
 pretzel-answer = Imphendvulo
-
 summary-statistics-caption = Sifinyeto setibalo te-{ $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = kubukwa kwenkhulumo yetibalo
 math-input-preview = Kubukwa
 math-input-invalid-expression = Inkhulumo lengasiyo:
 
-
 ## Document status
 
 viewer-initializing = Kuyacalwa…
 
-
 ## Errors
 
 error-heading = Liphutsa
-
 error-found-at =
     { $span ->
         [line] Litfolwe emudvweni { $startLine }.
        *[lines] Litfolwe emidvweni { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Lomculu unemaphutsa!
-
 diagnostic-heading-error = Liphutsa
 diagnostic-heading-warning = Secwayiso
 diagnostic-heading-information = Lwati
 diagnostic-heading-hint = Sicondziso
-
 accessibility-heading-level-1 = Kwephulwa Kwe-WCAG AA Kwekufinyeleleka
 accessibility-heading-level-2 = Secwayiso sekufinyeleleka
-
 something-went-wrong = Kukhona lokungahambanga kahle.
-
 renderer-load-failed = umkhombisi wehlulekile kulayisha. Sicela ulayishe likhasi kabusha.
-
 core-start-failed = Umbukisi wemculu awukhonanga kucala. Sicela ulayishe likhasi kabusha.

--- a/packages/i18n/locales/ss/content.ftl
+++ b/packages/i18n/locales/ss/content.ftl
@@ -79,7 +79,6 @@ color =
     .purple = lophephuli
     .pink = lophinki
     .brown = lonsundvu
-
 line-width =
     .thick =
         { $gender ->
@@ -95,14 +94,12 @@ line-width =
             [c7] lesincane
            *[c9] lencane
         }
-
 # Written as an invariable «nge…» phrase rather than as a describing word, so
 # that it agrees with nothing and can close the phrase. `style-stroke` puts it
 # last for that reason.
 line-style =
     .dashed = ngetincetu
     .dotted = ngemachashati
-
 # Noun phrases: they follow «nge» or «na» and modify nothing.
 fill-style =
     .horizontal = imidvwa levundlile
@@ -111,7 +108,6 @@ fill-style =
     .backdiagonal = imidvwa letsekile ngekuphambene
     .dots = emachashati
     .diamonds = emadayimane
-
 noun =
     .line = umudvwa
     .line-segment = sicheme semudvwa
@@ -131,7 +127,6 @@ noun =
     .diamond = lidayimane
     .cross = siphambano
     .plus = luphawu lwekuhlanganisa
-
 # The side count goes in the tail, behind the describing words, because
 # «lesinetinhlangotsi letingu-5» is a relative phrase and siSwati closes a noun
 # phrase with one rather than opening it.
@@ -140,7 +135,6 @@ noun-regular-polygon =
         [tail] lesinetinhlangotsi letingu-{ $numSides }
        *[head] sakhiwo lesilinganako
     }
-
 # The noun class, which is what a describing word agrees with. `c9` is the
 # default and the class of every loanword.
 noun-gender =
@@ -166,7 +160,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «nge…» phrase and closes the description, so it moves
@@ -181,7 +174,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its describing words follow, with the noun's own relative
 # complement closing the phrase.
 style-with-noun =
@@ -189,7 +181,6 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] logcwalisiwe
@@ -197,13 +188,11 @@ style-filled-word =
         [c7] lesigcwalisiwe
        *[c9] legcwalisiwe
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } nge{ $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } nge{ $pattern }
@@ -211,7 +200,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nge{ $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «umngcele» is class 3 and leads its own describing words, so the border's
 # words agree with it rather than with the shape it surrounds. siSwati has no
 # article and joins this clause with the invariable «lonem-», so all four
@@ -223,35 +211,28 @@ style-border-clause =
         [and-article] lonemngcele { $border }
        *[with] lonemngcele { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = akagcwaliswanga
-
 style-text =
     { $parts ->
         [background] { $color } etikwesizinda { $background }
        *[plain] { $color }
     }
-
 style-background-none = kute
-
 
 ## Boolean words
 
 boolean-true = liciniso
 boolean-false = emanga
 
-
 ## Answer buttons
 
 answer-submit-label = Hlola Umsebenti
 answer-submit-label-no-correctness = Tfumela Imphendvulo
-
 
 ## Sectional blocks
 
@@ -276,7 +257,6 @@ section-name =
     .solution = Sisombululo
     .task = Umsebenti
     .theorem = Ithiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -286,9 +266,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Sicondziso
-
 
 ## Tables and figures
 
@@ -299,7 +277,6 @@ table-name =
         [unnumbered-title] Ithebula{ ": " }
        *[unnumbered] Ithebula
     }
-
 figure-name =
     { $parts ->
         [numbered] Umfanekiso { $enumeration }
@@ -308,24 +285,18 @@ figure-name =
        *[unnumbered] Umfanekiso
     }
 
-
 ## Paginator controls
 
 paginator-previous = Lokwendlulile
 paginator-next = Lokulandzelako
 paginator-page = Likhasi
-
 paginator-page-status = { $pageLabel } { $currentPage } kwangu-{ $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = nobe
-
 piecewise-condition-if = nangabe
-
 piecewise-condition-otherwise = ngaphandle kwaloko
-
 
 ## Chemistry
 ##
@@ -338,6 +309,5 @@ piecewise-condition-otherwise = ngaphandle kwaloko
 ## English and the fallback *is* the curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Luphawu Lwemakhemikhali Lolungasilo
 chemistry-invalid-ionic-compound = Inhlanganisela Ye-ayoni Lengasiyo

--- a/packages/i18n/locales/st/chrome.ftl
+++ b/packages/i18n/locales/st/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Ea hlahloba...
 answer-submitting = Ea romela...
-
 answer-checking-status = E hlahloba karabo
 answer-submitting-status = E romela karabo
-
 answer-correct = E nepahetse
 answer-incorrect = Ha e a nepahala
-
 answer-response-saved = Karabo e Bolokiloe
-
 answer-percent-credit = Matshwao { $percent }%
 answer-percent-correct = { $percent }% E nepahetse
 answer-percent-short = { $percent } %
-
 max-credit-available = Matshwao a maholo a fumanehang: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ha ho teko e setseng
         [one] teko e { $count } e setse
        *[other] diteko tse { $count } di setse
     }
-
 validation-correct = (E nepahetse)
 validation-incorrect = (Ha e a nepahala)
 validation-partially-correct = (E nepahetse karolwana)
-
 answer-show-responses =
     { $count ->
         [one] Bontsha karabo e { $count } ho { $answerId }
        *[other] Bontsha dikarabo tse { $count } ho { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Maikutlo
-
 collapsible-click-to-open = (tobetsa ho bula)
 collapsible-click-to-close = (tobetsa ho koala)
-
 collapsible-initializing = Ea qala...
-
 footnote-show = Bontsha tlhaloso ya tlase
 footnote-hide = Pata tlhaloso ya tlase
-
 description-more-information = tlhahisoleseding e nngwe
-
 
 ## Controls
 
 slider-previous = E fetileng
 slider-next = E latelang
-
 keyboard-open = Bula Keyboard
 keyboard-close = Koala Keyboard
-
 choice-input-remove-choice = Tlosa { $choice }
-
 matrix-remove-row = Tlosa mola o robetseng
 matrix-add-row = Eketsa mola o robetseng
 matrix-remove-column = Tlosa mola o emeng
 matrix-add-column = Eketsa mola o emeng
-
 subset-add-remove-points = Eketsa/Tlosa dintlha
 subset-toggle-points-intervals = Fetola pakeng tsa dintlha le dikgeo
 subset-move-points = Sutumetsa Dintlha
 subset-clear = Hlakola
-
 # A `box` here is one orbital, drawn as a square: «lebokose».
 orbital-add-row = Eketsa Mola
 orbital-remove-row = Tlosa Mola
@@ -96,13 +77,9 @@ orbital-remove-box = Tlosa Lebokose
 orbital-add-up-arrow = Eketsa Motsu o Lebileng Hodimo
 orbital-add-down-arrow = Eketsa Motsu o Lebileng Tlase
 orbital-remove-arrow = Tlosa Motsu
-
 orbital-row-label = Lebitso la mola { $row }
-
 pretzel-answer = Karabo
-
 summary-statistics-caption = Kakaretso ya dipalopalo tsa { $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = ponelopele ya polelo ya dipalo
 math-input-preview = Ponelopele
 math-input-invalid-expression = Polelo ha e a nepahala:
 
-
 ## Document status
 
 viewer-initializing = Ea qala...
 
-
 ## Errors
 
 error-heading = Phoso
-
 error-found-at =
     { $span ->
         [line] E fumanwe moleng wa { $startLine }.
        *[lines] E fumanwe melaneng ya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tokomane ena e na le diphoso!
-
 diagnostic-heading-error = Phoso
 diagnostic-heading-warning = Temoso
 diagnostic-heading-information = Tlhahisoleseding
 diagnostic-heading-hint = Keletso
-
 accessibility-heading-level-1 = Tlolo ya WCAG AA ya Phihlelelo
 accessibility-heading-level-2 = Temoso ya phihlelelo
-
 something-went-wrong = Ho na le se sa tsamayang hantle.
-
 renderer-load-failed = mmontshi o le mong ha oa kgona ho kenella. Ka kopo nchafatsa leqephe.
-
 core-start-failed = Mmontshi wa tokomane ha a kgonang ho qala. Ka kopo nchafatsa leqephe.

--- a/packages/i18n/locales/st/content.ftl
+++ b/packages/i18n/locales/st/content.ftl
@@ -87,7 +87,6 @@ color =
     .purple = perese
     .pink = pinki
     .brown = sootho
-
 line-width =
     .thick =
         { $gender ->
@@ -103,14 +102,12 @@ line-width =
             [c7] sesesane
            *[c9] sesane
         }
-
 # Written as invariable «ka …» phrases rather than as adjectives, so that they
 # agree with nothing and can close the description. `style-stroke` puts them
 # last for that reason.
 line-style =
     .dashed = ka dikgaolo
     .dotted = ka dintlha
-
 fill-style =
     .horizontal = mela e robetseng
     .vertical = mela e emeng
@@ -118,7 +115,6 @@ fill-style =
     .backdiagonal = mela e sekameng morao
     .dots = dintlha
     .diamonds = ditaemane
-
 noun =
     .line = mola
     .line-segment = karolo ya mola
@@ -138,7 +134,6 @@ noun =
     .diamond = taemane
     .cross = sefapano
     .plus = letshwao la ho eketsa
-
 # The side count goes in the tail, behind the adjectives, because «e nang le
 # mahlakore a 5» is a relative clause and Sesotho closes a noun phrase with one
 # rather than opening one.
@@ -147,7 +142,6 @@ noun-regular-polygon =
         [tail] e nang le mahlakore a { $numSides }
        *[head] polikone e lekanang
     }
-
 noun-gender =
     { $noun ->
         [line] c3
@@ -164,7 +158,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -177,13 +170,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] o tletseng
@@ -191,13 +182,11 @@ style-filled-word =
         [c7] se tletseng
        *[c9] e tletseng
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ka { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ka { $pattern }
@@ -205,7 +194,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ka { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «moedi» is class 3 and leads its own adjectives, so the border's words agree
 # with it and not with the shape it surrounds. Sesotho has no article, so the
 # two `-article` branches read like the two without, and the complement is
@@ -218,35 +206,28 @@ style-border-clause =
         [and-article] ka moedi { $border }
        *[with] ka moedi { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = e sa tlalang
-
 style-text =
     { $parts ->
         [background] { $color } holim'a bokamorao { $background }
        *[plain] { $color }
     }
-
 style-background-none = ha ho letho
-
 
 ## Boolean words
 
 boolean-true = nnete
 boolean-false = leshano
 
-
 ## Answer buttons
 
 answer-submit-label = Hlahloba Mosebetsi
 answer-submit-label-no-correctness = Romela Karabo
-
 
 ## Sectional blocks
 
@@ -271,7 +252,6 @@ section-name =
     .solution = Tharollo
     .task = Mosebetsi
     .theorem = Thiorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -281,9 +261,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Keletso
-
 
 ## Tables and figures
 
@@ -294,7 +272,6 @@ table-name =
         [unnumbered-title] Tafole{ ": " }
        *[unnumbered] Tafole
     }
-
 figure-name =
     { $parts ->
         [numbered] Setshwantsho { $enumeration }
@@ -303,22 +280,18 @@ figure-name =
        *[unnumbered] Setshwantsho
     }
 
-
 ## Paginator controls
 
 paginator-previous = E fetileng
 paginator-next = E latelang
 paginator-page = Leqephe
-
 paginator-page-status = { $pageLabel } { $currentPage } ho { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kapa
 piecewise-condition-if = ha
 piecewise-condition-otherwise = ho seng joalo
-
 
 ## Chemistry
 
@@ -328,6 +301,5 @@ piecewise-condition-otherwise = ho seng joalo
 # meets them in English already, and the seed has no settled Sesotho list to
 # reproduce. A speaker adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Letshwao la Khemistri le sa Nepahalang
 chemistry-invalid-ionic-compound = Motswako wa Ione o sa Nepahalang

--- a/packages/i18n/locales/su/chrome.ftl
+++ b/packages/i18n/locales/su/chrome.ftl
@@ -26,69 +26,50 @@
 
 answer-checking = Mariksa...
 answer-submitting = Ngirim...
-
 answer-checking-status = Mariksa jawaban
 answer-submitting-status = Ngirim jawaban
-
 answer-correct = Bener
 answer-incorrect = Salah
-
 answer-response-saved = Jawaban Disimpen
-
 answer-percent-credit = Peunteun { $percent }%
 answer-percent-correct = Bener { $percent }%
 answer-percent-short = { $percent }%
-
 max-credit-available = Peunteun pangluhurna nu bisa kahontal: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] teu aya kasempetan nu nyésa
        *[other] nyésa { $count } kasempetan
     }
-
 validation-correct = (Bener)
 validation-incorrect = (Salah)
 validation-partially-correct = (Bener sabagian)
-
 answer-show-responses = Témbongkeun { $count } jawaban pikeun { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Tanggapan
-
 collapsible-click-to-open = (klik pikeun muka)
 collapsible-click-to-close = (klik pikeun nutup)
-
 collapsible-initializing = Ngamimitian...
-
 footnote-show = Témbongkeun catetan suku
 footnote-hide = Nyumputkeun catetan suku
-
 description-more-information = leuwih loba katerangan
-
 
 ## Controls
 
 slider-previous = Saméméhna
 slider-next = Salajengna
-
 keyboard-open = Buka Papan Tombol
 keyboard-close = Tutup Papan Tombol
-
 choice-input-remove-choice = Piceun { $choice }
-
 matrix-remove-row = Piceun baris
 matrix-add-row = Tambah baris
 matrix-remove-column = Piceun kolom
 matrix-add-column = Tambah kolom
-
 subset-add-remove-points = Tambah/Piceun titik
 subset-toggle-points-intervals = Gonta-ganti titik jeung interval
 subset-move-points = Pindahkeun Titik
 subset-clear = Beresihan
-
 orbital-add-row = Tambah Baris
 orbital-remove-row = Piceun Baris
 orbital-add-box = Tambah Kotak
@@ -96,13 +77,9 @@ orbital-remove-box = Piceun Kotak
 orbital-add-up-arrow = Tambah Panah Ka Luhur
 orbital-add-down-arrow = Tambah Panah Ka Handap
 orbital-remove-arrow = Piceun Panah
-
 orbital-row-label = Labél pikeun baris { $row }
-
 pretzel-answer = Jawaban
-
 summary-statistics-caption = Statistik ringkesan tina { $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = pramidang éksprési matematika
 math-input-preview = Pramidang
 math-input-invalid-expression = Éksprési teu bener:
 
-
 ## Document status
 
 viewer-initializing = Ngamimitian...
 
-
 ## Errors
 
 error-heading = Kasalahan
-
 error-found-at =
     { $span ->
         [line] Kapanggih dina baris { $startLine }.
        *[lines] Kapanggih dina baris { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumén ieu ngandung kasalahan!
-
 diagnostic-heading-error = Kasalahan
 diagnostic-heading-warning = Pépéling
 diagnostic-heading-information = Info
 diagnostic-heading-hint = Pituduh
-
 accessibility-heading-level-1 = Palanggaran Aksésibilitas WCAG AA
 accessibility-heading-level-2 = Pépéling aksésibilitas
-
 something-went-wrong = Aya nu salah.
-
 renderer-load-failed = aya perénder nu gagal dimuat. Mangga muat deui kacana.
-
 core-start-failed = Panempo dokumén teu bisa dimimitian. Mangga muat deui kacana.

--- a/packages/i18n/locales/su/content.ftl
+++ b/packages/i18n/locales/su/content.ftl
@@ -32,15 +32,12 @@ color =
     .purple = ungu
     .pink = beureum ngora
     .brown = coklat
-
 line-width =
     .thick = kandel
     .thin = ipis
-
 line-style =
     .dashed = pegat-pegat
     .dotted = titik-titik
-
 # Noun phrases: they follow «jeung» and modify nothing.
 fill-style =
     .horizontal = garis ngadatar
@@ -49,7 +46,6 @@ fill-style =
     .backdiagonal = garis miring sabalikna
     .dots = titik
     .diamonds = wajit
-
 noun =
     .line = garis
     .line-segment = ruas garis
@@ -69,7 +65,6 @@ noun =
     .diamond = wajit
     .cross = tanda silang
     .plus = tanda tambah
-
 # The side count follows the noun and precedes its adjectives, so it folds into
 # the head and there is no tail.
 noun-regular-polygon =
@@ -77,11 +72,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] poligon teratur sisi { $numSides }
     }
-
 # Sundanese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -95,24 +88,20 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «garis kandel pegat-pegat beureum».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 # The participle, matching `style-unfilled`'s «teu dieusian» below; «eusi» on
 # its own is the noun for the contents rather than a word describing the shape.
 style-filled-word = dieusian
-
 style-filled =
     { $parts ->
         [pattern] { $color } { $filled } jeung { $pattern }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } jeung { $pattern }
@@ -120,7 +109,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $color } { $filled } jeung { $pattern }
        *[plain] { $noun } { $color } { $filled }
     }
-
 # Sundanese needs no article, so the `-article` branches read like the ones
 # without. The border is «pinggir», the rim, and not «sisi»: «sisi» is the word
 # `noun-regular-polygon` above counts, so a bordered pentagon would otherwise
@@ -132,36 +120,29 @@ style-border-clause =
         [and-article] jeung pinggir { $border }
        *[with] jeung pinggir { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = teu dieusian
-
 style-text =
     { $parts ->
         [background] { $color } dina latar { $background }
        *[plain] { $color }
     }
-
 style-background-none = euweuh
-
 
 ## Boolean words
 
 boolean-true = bener
 boolean-false = salah
 
-
 ## Answer buttons
 
 answer-submit-label = Pariksa Pagawéan
 answer-submit-label-no-correctness = Kirim Jawaban
-
 
 ## Sectional blocks
 
@@ -186,7 +167,6 @@ section-name =
     .solution = Pamecahan
     .task = Pancén
     .theorem = Téoréma
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -196,9 +176,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Pituduh
-
 
 ## Tables and figures
 
@@ -209,7 +187,6 @@ table-name =
         [unnumbered-title] Tabél{ ": " }
        *[unnumbered] Tabél
     }
-
 figure-name =
     { $parts ->
         [numbered] Gambar { $enumeration }
@@ -218,22 +195,18 @@ figure-name =
        *[unnumbered] Gambar
     }
 
-
 ## Paginator controls
 
 paginator-previous = Saméméhna
 paginator-next = Salajengna
 paginator-page = Kaca
-
 paginator-page-status = { $pageLabel } { $currentPage } ti { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = atawa
 piecewise-condition-if = lamun
 piecewise-condition-otherwise = salian ti éta
-
 
 ## Chemistry
 ##
@@ -366,7 +339,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenesin
     .og = Oganeson
-
 element-anion-name =
     .h = Hidrida
     .c = Karbida
@@ -380,8 +352,6 @@ element-anion-name =
     .i = Iodida
     .at = Astatida
     .ts = Tenesida
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol Kimia Teu Bener
 chemistry-invalid-ionic-compound = Sanyawa Ionik Teu Bener

--- a/packages/i18n/locales/sus/chrome.ftl
+++ b/packages/i18n/locales/sus/chrome.ftl
@@ -22,74 +22,55 @@
 
 answer-checking = A ki matoxin na…
 answer-submitting = A ki rasa na…
-
 answer-checking-status = Yabi matoxin na
 answer-submitting-status = Yabi rasa na
-
 answer-correct = A tonyi
 answer-incorrect = A mu tonyi ra
-
 answer-response-saved = Yabi mara
-
 answer-percent-credit = { $percent }% kerediti
 answer-percent-correct = { $percent }% tonyi
 answer-percent-short = { $percent } %
-
 max-credit-available = Kerediti gbeenyi ki soto la: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] katu mu to
         [one] katu { $count } to
        *[other] katu { $count } to
     }
-
 validation-correct = (A tonyi)
 validation-incorrect = (A mu tonyi ra)
 validation-partially-correct = (A tonyi a dɔxɔn na)
-
 answer-show-responses =
     { $count ->
         [one] Yabi { $count } yitandi { $answerId } ma
        *[other] Yabi { $count } nde yitandi { $answerId } ma
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Raxidi
-
 collapsible-click-to-open = (a mati a ki raba)
 collapsible-click-to-close = (a mati a ki soxo)
-
 collapsible-initializing = A dati na…
-
 footnote-show = Bɔɲɛnyi safari yitandi
 footnote-hide = Bɔɲɛnyi safari maxa
-
 description-more-information = kibari fari
-
 
 ## Controls
 
 slider-previous = Naxan tɛmɛn
 slider-next = Naxan fa
-
 keyboard-open = Kibɔɔdi raba
 keyboard-close = Kibɔɔdi soxo
-
 choice-input-remove-choice = { $choice } bo
-
 matrix-remove-row = Sira bo
 matrix-add-row = Sira lafan
 matrix-remove-column = Kolɔn bo
 matrix-add-column = Kolɔn lafan
-
 subset-add-remove-points = Tonbondiye lafan/bo
 subset-toggle-points-intervals = Tonbondiye nun sinsanyie mafalin
 subset-move-points = Tonbondiye maamandi
 subset-clear = Bɛɛ bo
-
 orbital-add-row = Sira lafan
 orbital-remove-row = Sira bo
 orbital-add-box = Kɛsu lafan
@@ -97,13 +78,9 @@ orbital-remove-box = Kɛsu bo
 orbital-add-up-arrow = Fari kalabɛnyi lafan
 orbital-add-down-arrow = Bun kalabɛnyi lafan
 orbital-remove-arrow = Kalabɛnyi bo
-
 orbital-row-label = Sira { $row } xili
-
 pretzel-answer = Yabi
-
 summary-statistics-caption = { $column } konti xurasoxi
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = konti kumakan raxansen
 math-input-preview = Raxansen
 math-input-invalid-expression = Kumakan mu tonyi ra:
 
-
 ## Document status
 
 viewer-initializing = A dati na…
 
-
 ## Errors
 
 error-heading = Fili
-
 error-found-at =
     { $span ->
         [line] A tofa sira { $startLine } ma.
        *[lines] A tofa sirae { $startLine }–{ $endLine } ma.
     }
-
 document-contains-errors = Kitabuyi sɔtɔ fili nde ra!
-
 diagnostic-heading-error = Fili
 diagnostic-heading-warning = Dangaxun
 diagnostic-heading-information = Kibari
 diagnostic-heading-hint = Malaxidi
-
 accessibility-heading-level-1 = WCAG AA futandiyi tɛmɛn
 accessibility-heading-level-2 = Futandiyi dangaxun
-
 something-went-wrong = Fɛn mu naxɛ a lanyi ra.
-
 renderer-load-failed = yitandirilai mu fa. I ki karati murundi.
-
 core-start-failed = Kitabuyi yitandirilai mu dati. I ki karati murundi.

--- a/packages/i18n/locales/sus/content.ftl
+++ b/packages/i18n/locales/sus/content.ftl
@@ -51,18 +51,15 @@ color =
     .purple = volei
     .pink = rozii
     .brown = mawoni
-
 line-width =
     .thick = xungbei
     .thin = fisenyi
-
 # Written as invariable «nun …» (with …) phrases rather than as qualifiers, so
 # that they take no `-i` agreement and can close the description.
 # `style-stroke` puts them last.
 line-style =
     .dashed = nun tuten-tutenyi
     .dotted = nun tonbondiyie
-
 fill-style =
     .horizontal = sirandie naxee laariyaxi
     .vertical = sirandie naxee lookuxi
@@ -70,7 +67,6 @@ fill-style =
     .backdiagonal = sirandie naxee xungenxi fari doo ma
     .dots = tonbondiye
     .diamonds = diamanie
-
 noun =
     .line = sira
     .line-segment = sira kuntu
@@ -90,7 +86,6 @@ noun =
     .diamond = diamani
     .cross = kurusi
     .plus = lafan taamasenyi
-
 # The side count follows the qualifiers, behind «naxan sɔtɔ …», because Susu
 # closes a noun phrase with a relative rather than opening one — matching
 # `mnk`'s shape for this message.
@@ -99,12 +94,10 @@ noun-regular-polygon =
         [tail] naxan sɔtɔ kore { $numSides } ra
        *[head] poligoni tɛmɛxi
     }
-
 # No grammatical gender, so this answers one token for every noun and the
 # answer goes unused — the shape `locales/en`, `bm`, `dyu` and `mnk` all
 # share.
 noun-gender = kereni
-
 
 ## Style composition
 
@@ -118,21 +111,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ki rafexi
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } nun { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } nun { $pattern }
@@ -140,7 +129,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nun { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Susu has no article, and joins this clause with the invariable «nun»
 # whatever came before it, so all four branches read alike — the shape
 # `mnk`'s equivalent message uses with «niŋ».
@@ -151,35 +139,28 @@ style-border-clause =
         [and-article] nun naanewo { $border }
        *[with] nun naanewo { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = naxan mu rafexi
-
 style-text =
     { $parts ->
         [background] { $color } nun raxidi { $background }
        *[plain] { $color }
     }
-
 style-background-none = fɛn mu a ra
-
 
 ## Boolean words
 
 boolean-true = tonyi
 boolean-false = wafan
 
-
 ## Answer buttons
 
 answer-submit-label = Dɔxɔliyi Matoxin
 answer-submit-label-no-correctness = Yabi Rasa
-
 
 ## Sectional blocks
 
@@ -204,7 +185,6 @@ section-name =
     .solution = Yabi Nakusa
     .task = Dɔxɔliyi
     .theorem = Teoremi
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -214,9 +194,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Malaxidi
-
 
 ## Tables and figures
 
@@ -227,7 +205,6 @@ table-name =
         [unnumbered-title] Tabuli{ ": " }
        *[unnumbered] Tabuli
     }
-
 figure-name =
     { $parts ->
         [numbered] Natanmayi { $enumeration }
@@ -236,24 +213,18 @@ figure-name =
        *[unnumbered] Natanmayi
     }
 
-
 ## Paginator controls
 
 paginator-previous = Naxan tɛmɛn
 paginator-next = Naxan fa
 paginator-page = Karati
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = waraxa
-
 piecewise-condition-if = xa
-
 piecewise-condition-otherwise = dulaa dɔɔ bɛɛ ma
-
 
 ## Chemistry
 ##
@@ -269,6 +240,5 @@ piecewise-condition-otherwise = dulaa dɔɔ bɛɛ ma
 ## three-country, three-medium spread that `mnk`'s note documents.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simi Taamasenyi Mu Tonyi Ra
 chemistry-invalid-ionic-compound = Iyɔn Rafexi Mu Tonyi Ra

--- a/packages/i18n/locales/sv/chrome.ftl
+++ b/packages/i18n/locales/sv/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Kontrollerar…
 answer-submitting = Skickar…
-
 answer-checking-status = Kontrollerar svar
 answer-submitting-status = Skickar svar
-
 answer-correct = Rätt
 answer-incorrect = Fel
-
 answer-response-saved = Svar sparat
-
 answer-percent-credit = { $percent } % poäng
 answer-percent-correct = { $percent } % rätt
 answer-percent-short = { $percent } %
-
 max-credit-available = Högsta möjliga poäng: { $percent } %
-
 attempts-remaining =
     { $count ->
         [0] inga försök kvar
        *[other] { $count } försök kvar
     }
-
 validation-correct = (Rätt)
 validation-incorrect = (Fel)
 validation-partially-correct = (Delvis rätt)
-
 answer-show-responses = Visa { $count } svar till { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Återkoppling
-
 collapsible-click-to-open = (klicka för att öppna)
 collapsible-click-to-close = (klicka för att stänga)
-
 collapsible-initializing = Initierar…
-
 footnote-show = Visa fotnot
 footnote-hide = Dölj fotnot
-
 description-more-information = mer information
-
 
 ## Controls
 
 slider-previous = Föreg.
 slider-next = Nästa
-
 keyboard-open = Öppna tangentbordet
 keyboard-close = Stäng tangentbordet
-
 choice-input-remove-choice = Ta bort { $choice }
-
 matrix-remove-row = Ta bort rad
 matrix-add-row = Lägg till rad
 matrix-remove-column = Ta bort kolumn
 matrix-add-column = Lägg till kolumn
-
 subset-add-remove-points = Lägg till/ta bort punkter
 subset-toggle-points-intervals = Växla mellan punkter och intervall
 subset-move-points = Flytta punkter
 subset-clear = Rensa
-
 orbital-add-row = Lägg till rad
 orbital-remove-row = Ta bort rad
 orbital-add-box = Lägg till ruta
@@ -90,13 +71,9 @@ orbital-remove-box = Ta bort ruta
 orbital-add-up-arrow = Lägg till uppåtpil
 orbital-add-down-arrow = Lägg till nedåtpil
 orbital-remove-arrow = Ta bort pil
-
 orbital-row-label = Etikett för rad { $row }
-
 pretzel-answer = Svar
-
 summary-statistics-caption = Sammanfattande statistik för { $column }
-
 
 ## Math input
 
@@ -104,34 +81,25 @@ math-input-preview-region = förhandsgranskning av matematiskt uttryck
 math-input-preview = Förhandsgranskning
 math-input-invalid-expression = Ogiltigt uttryck:
 
-
 ## Document status
 
 viewer-initializing = Initierar…
 
-
 ## Errors
 
 error-heading = Fel
-
 error-found-at =
     { $span ->
         [line] Hittades på rad { $startLine }.
        *[lines] Hittades på raderna { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Det här dokumentet innehåller fel!
-
 diagnostic-heading-error = Fel
 diagnostic-heading-warning = Varning
 diagnostic-heading-information = Information
 diagnostic-heading-hint = Tips
-
 accessibility-heading-level-1 = Tillgänglighetsbrist enligt WCAG AA
 accessibility-heading-level-2 = Tillgänglighetsanmärkning
-
 something-went-wrong = Något gick fel.
-
 renderer-load-failed = en renderare kunde inte laddas. Ladda om sidan.
-
 core-start-failed = Dokumentvisaren kunde inte startas. Ladda om sidan.

--- a/packages/i18n/locales/sv/content.ftl
+++ b/packages/i18n/locales/sv/content.ftl
@@ -67,7 +67,6 @@ color =
             [neuter] brunt
            *[common] brun
         }
-
 line-width =
     .thick =
         { $gender ->
@@ -79,7 +78,6 @@ line-width =
             [neuter] tunt
            *[common] tunn
         }
-
 line-style =
     .dashed =
         { $gender ->
@@ -91,7 +89,6 @@ line-style =
             [neuter] prickat
            *[common] prickad
         }
-
 fill-style =
     .horizontal = vågräta linjer
     .vertical = lodräta linjer
@@ -99,7 +96,6 @@ fill-style =
     .backdiagonal = omvända diagonala linjer
     .dots = prickar
     .diamonds = romber
-
 noun =
     .line = linje
     .line-segment = sträcka
@@ -119,7 +115,6 @@ noun =
     .diamond = romb
     .cross = kryss
     .plus = plus
-
 # Swedish names a regular polygon by its side count in one word — «regelbunden
 # 5-hörning» — so the count stays in the head and there is no tail.
 noun-regular-polygon =
@@ -127,7 +122,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] regelbunden { $numSides }-hörning
     }
-
 # Common gender is the default because most of these are common, including the
 # three heads a description names without listing: `border` (ram), `fill`
 # (fyllning), `text` (text) and `background` (bakgrund) — and
@@ -139,7 +133,6 @@ noun-gender =
         [plus] neuter
        *[other] common
     }
-
 
 ## Style composition
 
@@ -153,25 +146,21 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [neuter] fyllt
        *[common] fylld
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } med { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } med { $pattern }
@@ -179,7 +168,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } med { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ram» is common, so the indefinite article is «en» — a word of its own, which
 # is why the distinction English draws between the `-article` branches and the
 # others survives here.
@@ -190,35 +178,28 @@ style-border-clause =
         [and-article] och en { $border } ram
        *[with] med { $border } ram
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ofylld
-
 style-text =
     { $parts ->
         [background] { $color } på { $background } bakgrund
        *[plain] { $color }
     }
-
 style-background-none = ingen
-
 
 ## Boolean words
 
 boolean-true = sant
 boolean-false = falskt
 
-
 ## Answer buttons
 
 answer-submit-label = Kontrollera
 answer-submit-label-no-correctness = Skicka svar
-
 
 ## Sectional blocks
 
@@ -243,7 +224,6 @@ section-name =
     .solution = Lösning
     .task = Uppgift
     .theorem = Sats
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -253,9 +233,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ledtråd
-
 
 ## Tables and figures
 
@@ -266,7 +244,6 @@ table-name =
         [unnumbered-title] Tabell{ ": " }
        *[unnumbered] Tabell
     }
-
 figure-name =
     { $parts ->
         [numbered] Figur { $enumeration }
@@ -275,22 +252,18 @@ figure-name =
        *[unnumbered] Figur
     }
 
-
 ## Paginator controls
 
 paginator-previous = Föregående
 paginator-next = Nästa
 paginator-page = Sida
-
 paginator-page-status = { $pageLabel } { $currentPage } av { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = eller
 piecewise-condition-if = om
 piecewise-condition-otherwise = annars
-
 
 ## Chemistry
 
@@ -413,7 +386,6 @@ element-name =
     .lv = Livermorium
     .ts = Tenness
     .og = Oganesson
-
 element-anion-name =
     .h = Hydrid
     .c = Karbid
@@ -427,8 +399,6 @@ element-anion-name =
     .i = Jodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ogiltig kemisk beteckning
 chemistry-invalid-ionic-compound = Ogiltig jonförening

--- a/packages/i18n/locales/sw/chrome.ftl
+++ b/packages/i18n/locales/sw/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Inaangalia...
 answer-submitting = Inawasilisha...
-
 answer-checking-status = Inaangalia jibu
 answer-submitting-status = Inawasilisha jibu
-
 answer-correct = Sahihi
 answer-incorrect = Si sahihi
-
 answer-response-saved = Jibu Limehifadhiwa
-
 answer-percent-credit = Alama { $percent }%
 answer-percent-correct = { $percent }% Sahihi
 answer-percent-short = { $percent }%
-
 max-credit-available = Alama za juu zinazopatikana: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] hakuna majaribio yaliyosalia
         [one] jaribio { $count } limesalia
        *[other] majaribio { $count } yamesalia
     }
-
 validation-correct = (Sahihi)
 validation-incorrect = (Si sahihi)
 validation-partially-correct = (Sahihi kwa sehemu)
-
 answer-show-responses =
     { $count ->
         [one] Onyesha jibu { $count } kwa { $answerId }
        *[other] Onyesha majibu { $count } kwa { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Maoni
-
 collapsible-click-to-open = (bofya ili kufungua)
 collapsible-click-to-close = (bofya ili kufunga)
-
 collapsible-initializing = Inaanzisha...
-
 footnote-show = Onyesha tanbihi
 footnote-hide = Ficha tanbihi
-
 description-more-information = maelezo zaidi
-
 
 ## Controls
 
 slider-previous = Nyuma
 slider-next = Mbele
-
 keyboard-open = Fungua Kibodi
 keyboard-close = Funga Kibodi
-
 choice-input-remove-choice = Ondoa { $choice }
-
 matrix-remove-row = Ondoa safu mlalo
 matrix-add-row = Ongeza safu mlalo
 matrix-remove-column = Ondoa safu wima
 matrix-add-column = Ongeza safu wima
-
 subset-add-remove-points = Ongeza/Ondoa nukta
 subset-toggle-points-intervals = Badilisha kati ya nukta na vipindi
 subset-move-points = Sogeza Nukta
 subset-clear = Futa
-
 # A `box` here is one orbital, drawn as a square: kisanduku.
 orbital-add-row = Ongeza Safu
 orbital-remove-row = Ondoa Safu
@@ -93,13 +74,9 @@ orbital-remove-box = Ondoa Kisanduku
 orbital-add-up-arrow = Ongeza Mshale wa Juu
 orbital-add-down-arrow = Ongeza Mshale wa Chini
 orbital-remove-arrow = Ondoa Mshale
-
 orbital-row-label = Lebo ya safu { $row }
-
 pretzel-answer = Jibu
-
 summary-statistics-caption = Takwimu za muhtasari za { $column }
-
 
 ## Math input
 
@@ -107,34 +84,25 @@ math-input-preview-region = hakikisho la kielezi cha hisabati
 math-input-preview = Hakikisho
 math-input-invalid-expression = Kielezi si sahihi:
 
-
 ## Document status
 
 viewer-initializing = Inaanzisha...
 
-
 ## Errors
 
 error-heading = Hitilafu
-
 error-found-at =
     { $span ->
         [line] Imepatikana kwenye mstari { $startLine }.
        *[lines] Imepatikana kwenye mistari { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Hati hii ina hitilafu!
-
 diagnostic-heading-error = Hitilafu
 diagnostic-heading-warning = Onyo
 diagnostic-heading-information = Taarifa
 diagnostic-heading-hint = Kidokezo
-
 accessibility-heading-level-1 = Ukiukaji wa Ufikivu wa WCAG AA
 accessibility-heading-level-2 = Tahadhari ya ufikivu
-
 something-went-wrong = Kuna kitu kimeenda vibaya.
-
 renderer-load-failed = kionyeshi kimoja kimeshindwa kupakiwa. Tafadhali pakia ukurasa upya.
-
 core-start-failed = Kionyeshi cha hati hakikuweza kuanzishwa. Tafadhali pakia ukurasa upya.

--- a/packages/i18n/locales/sw/content.ftl
+++ b/packages/i18n/locales/sw/content.ftl
@@ -85,7 +85,6 @@ color =
     .purple = zambarau
     .pink = waridi
     .brown = kahawia
-
 line-width =
     .thick =
         { $gender ->
@@ -103,14 +102,12 @@ line-width =
             [c7] chembamba
            *[c9] membamba
         }
-
 # Written as an invariable «kwa …» phrase rather than as an adjective, so that
 # it agrees with nothing and can close the phrase. `style-stroke` puts it last
 # for that reason.
 line-style =
     .dashed = kwa vipande
     .dotted = kwa vitone
-
 # Noun phrases: they follow «kwa» or «na» and modify nothing.
 fill-style =
     .horizontal = mistari mlalo
@@ -119,7 +116,6 @@ fill-style =
     .backdiagonal = mistari mshazari kinyume
     .dots = vitone
     .diamonds = rombi
-
 noun =
     .line = mstari
     .line-segment = kipande cha mstari
@@ -139,7 +135,6 @@ noun =
     .diamond = rombi
     .cross = msalaba
     .plus = alama ya kujumlisha
-
 # The side count goes in the tail, behind the adjectives, because «yenye pande
 # 5» is a relative phrase and Swahili closes a noun phrase with it rather than
 # opening one: «pembenyingi sawa nyekundu yenye pande 5».
@@ -148,7 +143,6 @@ noun-regular-polygon =
         [tail] yenye pande { $numSides }
        *[head] pembenyingi sawa
     }
-
 # The noun class, which is what an adjective agrees with. `c9` is the default
 # and the class of every loanword, including a word an author supplies.
 noun-gender =
@@ -169,7 +163,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «kwa …» phrase and closes the description, so it moves
@@ -184,7 +177,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow, with the noun's own relative
 # complement closing the phrase: «pembenyingi sawa nyekundu yenye pande 5».
 style-with-noun =
@@ -192,7 +184,6 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] uliojazwa
@@ -201,13 +192,11 @@ style-filled-word =
         [c7] kilichojazwa
        *[c9] iliyojazwa
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -215,7 +204,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «mpaka» is class 3 and leads its own adjectives, so the border's words agree
 # with it and not with the shape it surrounds. Swahili has no article and joins
 # a complement with the invariable «na» rather than with a concording relative,
@@ -227,35 +215,28 @@ style-border-clause =
         [and-article] na mpaka { $border }
        *[with] na mpaka { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = bila kujazwa
-
 style-text =
     { $parts ->
         [background] { $color } juu ya mandharinyuma { $background }
        *[plain] { $color }
     }
-
 style-background-none = hakuna
-
 
 ## Boolean words
 
 boolean-true = kweli
 boolean-false = uongo
 
-
 ## Answer buttons
 
 answer-submit-label = Angalia Kazi
 answer-submit-label-no-correctness = Wasilisha Jibu
-
 
 ## Sectional blocks
 
@@ -280,7 +261,6 @@ section-name =
     .solution = Suluhisho
     .task = Kazi
     .theorem = Nadharia
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -290,9 +270,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kidokezo
-
 
 ## Tables and figures
 
@@ -303,7 +281,6 @@ table-name =
         [unnumbered-title] Jedwali{ ": " }
        *[unnumbered] Jedwali
     }
-
 figure-name =
     { $parts ->
         [numbered] Kielelezo { $enumeration }
@@ -312,22 +289,18 @@ figure-name =
        *[unnumbered] Kielelezo
     }
 
-
 ## Paginator controls
 
 paginator-previous = Iliyotangulia
 paginator-next = Ifuatayo
 paginator-page = Ukurasa
-
 paginator-page-status = { $pageLabel } { $currentPage } kati ya { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = au
 piecewise-condition-if = ikiwa
 piecewise-condition-otherwise = vinginevyo
-
 
 ## Chemistry
 
@@ -455,7 +428,6 @@ element-name =
     .lv = livermoriamu
     .ts = tenesini
     .og = oganesoni
-
 element-anion-name =
     .h = hidraidi
     .c = kabaidi
@@ -469,8 +441,6 @@ element-anion-name =
     .i = ayodaidi
     .at = astataidi
     .ts = tenesaidi
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Alama ya Kikemikali Isiyo Sahihi
 chemistry-invalid-ionic-compound = Kiwanja Ayoni Kisicho Sahihi

--- a/packages/i18n/locales/ta/chrome.ftl
+++ b/packages/i18n/locales/ta/chrome.ftl
@@ -23,74 +23,55 @@
 
 answer-checking = சரிபார்க்கிறது...
 answer-submitting = சமர்ப்பிக்கிறது...
-
 answer-checking-status = விடை சரிபார்க்கப்படுகிறது
 answer-submitting-status = விடை சமர்ப்பிக்கப்படுகிறது
-
 answer-correct = சரி
 answer-incorrect = தவறு
-
 answer-response-saved = பதில் சேமிக்கப்பட்டது
-
 answer-percent-credit = { $percent }% மதிப்பெண்
 answer-percent-correct = { $percent }% சரி
 answer-percent-short = { $percent }%
-
 max-credit-available = கிடைக்கக்கூடிய அதிகபட்ச மதிப்பெண்: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] முயற்சிகள் எதுவும் மீதமில்லை
         [one] { $count } முயற்சி மீதமுள்ளது
        *[other] { $count } முயற்சிகள் மீதமுள்ளன
     }
-
 validation-correct = (சரி)
 validation-incorrect = (தவறு)
 validation-partially-correct = (பகுதியளவு சரி)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } க்கான { $count } பதிலைக் காட்டு
        *[other] { $answerId } க்கான { $count } பதில்களைக் காட்டு
     }
 
-
 ## Disclosure panels
 
 feedback-heading = பின்னூட்டம்
-
 collapsible-click-to-open = (திறக்க சொடுக்கவும்)
 collapsible-click-to-close = (மூட சொடுக்கவும்)
-
 collapsible-initializing = தொடங்குகிறது...
-
 footnote-show = அடிக்குறிப்பைக் காட்டு
 footnote-hide = அடிக்குறிப்பை மறை
-
 description-more-information = கூடுதல் தகவல்
-
 
 ## Controls
 
 slider-previous = முந்தையது
 slider-next = அடுத்தது
-
 keyboard-open = விசைப்பலகையைத் திற
 keyboard-close = விசைப்பலகையை மூடு
-
 choice-input-remove-choice = { $choice } ஐ நீக்கு
-
 matrix-remove-row = வரிசையை நீக்கு
 matrix-add-row = வரிசையைச் சேர்
 matrix-remove-column = நிரலை நீக்கு
 matrix-add-column = நிரலைச் சேர்
-
 subset-add-remove-points = புள்ளிகளைச் சேர்/நீக்கு
 subset-toggle-points-intervals = புள்ளிகளுக்கும் இடைவெளிகளுக்கும் இடையே மாற்று
 subset-move-points = புள்ளிகளை நகர்த்து
 subset-clear = அழி
-
 # A `box` here is one orbital, drawn as a square: கட்டம்.
 orbital-add-row = வரிசையைச் சேர்
 orbital-remove-row = வரிசையை நீக்கு
@@ -99,13 +80,9 @@ orbital-remove-box = கட்டத்தை நீக்கு
 orbital-add-up-arrow = மேல் அம்புக்குறியைச் சேர்
 orbital-add-down-arrow = கீழ் அம்புக்குறியைச் சேர்
 orbital-remove-arrow = அம்புக்குறியை நீக்கு
-
 orbital-row-label = வரிசை { $row } க்கான லேபிள்
-
 pretzel-answer = விடை
-
 summary-statistics-caption = { $column } இன் சுருக்கப் புள்ளியியல்
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = கணிதக் கோவை முன்னோ�
 math-input-preview = முன்னோட்டம்
 math-input-invalid-expression = தவறான கோவை:
 
-
 ## Document status
 
 viewer-initializing = தொடங்குகிறது...
 
-
 ## Errors
 
 error-heading = பிழை
-
 error-found-at =
     { $span ->
         [line] வரி { $startLine } இல் கண்டறியப்பட்டது.
        *[lines] { $startLine }–{ $endLine } வரிகளில் கண்டறியப்பட்டது.
     }
-
 document-contains-errors = இந்த ஆவணத்தில் பிழைகள் உள்ளன!
-
 diagnostic-heading-error = பிழை
 diagnostic-heading-warning = எச்சரிக்கை
 diagnostic-heading-information = தகவல்
 diagnostic-heading-hint = உதவிக்குறிப்பு
-
 accessibility-heading-level-1 = WCAG AA அணுகல்தன்மை மீறல்
 accessibility-heading-level-2 = அணுகல்தன்மை எச்சரிக்கை
-
 something-went-wrong = ஏதோ தவறாகிவிட்டது.
-
 renderer-load-failed = ஒரு காட்சியாக்கி ஏற்றப்படவில்லை. பக்கத்தை மீண்டும் ஏற்றவும்.
-
 core-start-failed = ஆவணக் காட்சியாக்கியைத் தொடங்க முடியவில்லை. பக்கத்தை மீண்டும் ஏற்றவும்.

--- a/packages/i18n/locales/ta/content.ftl
+++ b/packages/i18n/locales/ta/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = ஊதா
     .pink = இளஞ்சிவப்பு
     .brown = பழுப்பு
-
 line-width =
     .thick = தடிமனான
     .thin = மெல்லிய
-
 line-style =
     .dashed = துண்டிக்கப்பட்ட
     .dotted = புள்ளியிட்ட
-
 # Noun phrases: they stand in front of the «கொண்ட» the composition messages
 # supply, and modify nothing.
 fill-style =
@@ -55,7 +52,6 @@ fill-style =
     .backdiagonal = எதிர் மூலைவிட்டக் கோடுகள்
     .dots = புள்ளிகள்
     .diamonds = சாய்சதுரங்கள்
-
 noun =
     .line = கோடு
     .line-segment = கோட்டுத்துண்டு
@@ -75,7 +71,6 @@ noun =
     .diamond = சாய்சதுரம்
     .cross = குறுக்குக் குறி
     .plus = கூட்டல் குறி
-
 # The side count precedes the noun, as every modifier in Tamil does, so it
 # folds into the head and there is no tail.
 noun-regular-polygon =
@@ -83,11 +78,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } பக்க ஒழுங்கு பலகோணம்
     }
-
 # Tamil has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -101,15 +94,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = நிரப்பப்பட்ட
-
 # The pattern is marked with «கொண்ட», a participle that stands as a word of
 # its own in front of what it modifies, so the pattern clause leads. The bound
 # «-உடன்» the border takes below cannot be used here: joining it to a word
@@ -121,7 +111,6 @@ style-filled =
         [pattern] { $pattern } கொண்ட { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } கொண்ட { $filled } { $color } { $noun }
@@ -129,7 +118,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } கொண்ட { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «விளிம்பு» is the catalog's own word, so «-உடன்» is joined to it directly,
 # and «மற்றும்» opens the further clause where English opens it with "and".
 # Tamil has no article, so the two `-article` branches read like the ones
@@ -141,15 +129,12 @@ style-border-clause =
         [and-article] மற்றும் { $border } விளிம்புடன்
        *[with] { $border } விளிம்புடன்
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = நிரப்பப்படாத
-
 # «பின்னணி» takes the locative -இல், so the background leads and the text
 # colour follows it.
 style-text =
@@ -157,21 +142,17 @@ style-text =
         [background] { $background } பின்னணியில் { $color }
        *[plain] { $color }
     }
-
 style-background-none = இல்லை
-
 
 ## Boolean words
 
 boolean-true = உண்மை
 boolean-false = பொய்
 
-
 ## Answer buttons
 
 answer-submit-label = சரிபார்
 answer-submit-label-no-correctness = பதிலைச் சமர்ப்பி
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = தீர்வு
     .task = பணி
     .theorem = தேற்றம்
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = உதவிக்குறிப்பு
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] அட்டவணை{ ": " }
        *[unnumbered] அட்டவணை
     }
-
 figure-name =
     { $parts ->
         [numbered] படம் { $enumeration }
@@ -228,24 +205,20 @@ figure-name =
        *[unnumbered] படம்
     }
 
-
 ## Paginator controls
 
 paginator-previous = முந்தையது
 paginator-next = அடுத்தது
 paginator-page = பக்கம்
-
 # The total leads, marked with the locative -இல், which is how Tamil says
 # "3 of 5".
 paginator-page-status = { $numPages } இல் { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = அல்லது
 piecewise-condition-if = எனில்
 piecewise-condition-otherwise = இல்லையெனில்
-
 
 ## Chemistry
 
@@ -373,7 +346,6 @@ element-name =
     .lv = லிவர்மோரியம்
     .ts = டென்னசைன்
     .og = ஓகனிசான்
-
 element-anion-name =
     .h = ஹைட்ரைடு
     .c = கார்பைடு
@@ -387,8 +359,6 @@ element-anion-name =
     .i = அயோடைடு
     .at = அஸ்டட்டைடு
     .ts = டென்னசைடு
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = தவறான வேதியியல் குறியீடு
 chemistry-invalid-ionic-compound = தவறான அயனிச் சேர்மம்

--- a/packages/i18n/locales/te/chrome.ftl
+++ b/packages/i18n/locales/te/chrome.ftl
@@ -21,74 +21,55 @@
 
 answer-checking = సరిచూస్తోంది...
 answer-submitting = సమర్పిస్తోంది...
-
 answer-checking-status = సమాధానం సరిచూడబడుతోంది
 answer-submitting-status = సమాధానం సమర్పించబడుతోంది
-
 answer-correct = సరైనది
 answer-incorrect = తప్పు
-
 answer-response-saved = స్పందన భద్రపరచబడింది
-
 answer-percent-credit = { $percent }% మార్కులు
 answer-percent-correct = { $percent }% సరైనది
 answer-percent-short = { $percent }%
-
 max-credit-available = సాధ్యమైన గరిష్ఠ మార్కులు: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ప్రయత్నాలు ఏవీ మిగలలేదు
         [one] { $count } ప్రయత్నం మిగిలింది
        *[other] { $count } ప్రయత్నాలు మిగిలాయి
     }
-
 validation-correct = (సరైనది)
 validation-incorrect = (తప్పు)
 validation-partially-correct = (పాక్షికంగా సరైనది)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } కు వచ్చిన { $count } స్పందనను చూపు
        *[other] { $answerId } కు వచ్చిన { $count } స్పందనలను చూపు
     }
 
-
 ## Disclosure panels
 
 feedback-heading = సమీక్ష
-
 collapsible-click-to-open = (తెరవడానికి నొక్కండి)
 collapsible-click-to-close = (మూయడానికి నొక్కండి)
-
 collapsible-initializing = ప్రారంభమవుతోంది...
-
 footnote-show = అధోజ్ఞాపికను చూపు
 footnote-hide = అధోజ్ఞాపికను దాచు
-
 description-more-information = మరింత సమాచారం
-
 
 ## Controls
 
 slider-previous = మునుపటిది
 slider-next = తదుపరిది
-
 keyboard-open = కీబోర్డు తెరువు
 keyboard-close = కీబోర్డు మూయి
-
 choice-input-remove-choice = { $choice } ను తొలగించు
-
 matrix-remove-row = వరుసను తొలగించు
 matrix-add-row = వరుసను చేర్చు
 matrix-remove-column = నిలువు వరుసను తొలగించు
 matrix-add-column = నిలువు వరుసను చేర్చు
-
 subset-add-remove-points = బిందువులను చేర్చు/తొలగించు
 subset-toggle-points-intervals = బిందువులు, అంతరాల మధ్య మార్చు
 subset-move-points = బిందువులను కదుపు
 subset-clear = తుడిచివేయి
-
 # A `box` here is one orbital, drawn as a square: గడి.
 orbital-add-row = వరుసను చేర్చు
 orbital-remove-row = వరుసను తొలగించు
@@ -97,13 +78,9 @@ orbital-remove-box = గడిని తొలగించు
 orbital-add-up-arrow = పైకి బాణం చేర్చు
 orbital-add-down-arrow = కిందికి బాణం చేర్చు
 orbital-remove-arrow = బాణాన్ని తొలగించు
-
 orbital-row-label = వరుస { $row } కు లేబుల్
-
 pretzel-answer = సమాధానం
-
 summary-statistics-caption = { $column } యొక్క సంక్షిప్త గణాంకాలు
-
 
 ## Math input
 
@@ -111,16 +88,13 @@ math-input-preview-region = గణిత సమాసం మునుజూప�
 math-input-preview = మునుజూపు
 math-input-invalid-expression = చెల్లని సమాసం:
 
-
 ## Document status
 
 viewer-initializing = ప్రారంభమవుతోంది...
 
-
 ## Errors
 
 error-heading = దోషం
-
 # The ordinal «వ» is invariant whatever number precedes it, and Telugu writes
 # it closed up against the digits — «1వ», not «1 వ» — so it is welded to the
 # placeable, which is the case the README's affix rule allows.
@@ -129,19 +103,13 @@ error-found-at =
         [line] { $startLine }వ పంక్తిలో కనుగొనబడింది.
        *[lines] { $startLine }–{ $endLine } పంక్తులలో కనుగొనబడింది.
     }
-
 document-contains-errors = ఈ పత్రంలో దోషాలు ఉన్నాయి!
-
 diagnostic-heading-error = దోషం
 diagnostic-heading-warning = హెచ్చరిక
 diagnostic-heading-information = సమాచారం
 diagnostic-heading-hint = సూచన
-
 accessibility-heading-level-1 = WCAG AA అందుబాటు ఉల్లంఘన
 accessibility-heading-level-2 = అందుబాటు హెచ్చరిక
-
 something-went-wrong = ఏదో తప్పు జరిగింది.
-
 renderer-load-failed = ఒక రెండరర్ లోడ్ కాలేదు. దయచేసి పేజీని మళ్ళీ లోడ్ చేయండి.
-
 core-start-failed = పత్ర దర్శినిని ప్రారంభించలేకపోయాం. దయచేసి పేజీని మళ్ళీ లోడ్ చేయండి.

--- a/packages/i18n/locales/te/content.ftl
+++ b/packages/i18n/locales/te/content.ftl
@@ -35,15 +35,12 @@ color =
     .purple = ఊదా
     .pink = గులాబీ
     .brown = గోధుమ
-
 line-width =
     .thick = మందపాటి
     .thin = సన్నని
-
 line-style =
     .dashed = తెగిన
     .dotted = చుక్కల
-
 # Noun phrases: they stand in front of the «కలిగిన» the composition messages
 # supply, and modify nothing.
 fill-style =
@@ -53,7 +50,6 @@ fill-style =
     .backdiagonal = వ్యతిరేక వికర్ణ గీతలు
     .dots = చుక్కలు
     .diamonds = వజ్రాకారాలు
-
 noun =
     .line = సరళరేఖ
     .line-segment = రేఖాఖండం
@@ -73,7 +69,6 @@ noun =
     .diamond = వజ్రాకారం
     .cross = అడ్డగుర్తు
     .plus = కూడిక గుర్తు
-
 # The side count precedes the noun, as every modifier in Telugu does, so it
 # folds into the head and there is no tail.
 noun-regular-polygon =
@@ -81,12 +76,10 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } భుజాల క్రమ బహుభుజి
     }
-
 # Telugu marks gender on verbs and pronouns, not on the adjectives in these
 # phrases, so every noun answers the same and the answer goes unused — as in
 # English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,15 +93,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = నింపిన
-
 # The pattern is marked with «కలిగిన», a participle that stands as a word of
 # its own in front of what it modifies, so the pattern clause leads. The bound
 # «-తో» the border takes below cannot be used here: a plural in -లు goes to
@@ -120,7 +110,6 @@ style-filled =
         [pattern] { $pattern } కలిగిన { $filled } { $color }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } కలిగిన { $filled } { $color } { $noun }
@@ -128,7 +117,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } కలిగిన { $filled } { $color } { $noun } { $nounTail }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «అంచు» is the catalog's own word, so «-తో» is joined to it directly, and
 # «మరియు» opens the further clause where English opens it with "and". Telugu
 # has no article, so the two `-article` branches read like the ones without.
@@ -139,15 +127,12 @@ style-border-clause =
         [and-article] మరియు { $border } అంచుతో
        *[with] { $border } అంచుతో
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = నింపని
-
 # «నేపథ్యం» takes the locative -పై, so the background leads and the text
 # colour follows it.
 style-text =
@@ -155,21 +140,17 @@ style-text =
         [background] { $background } నేపథ్యంపై { $color }
        *[plain] { $color }
     }
-
 style-background-none = ఏదీ లేదు
-
 
 ## Boolean words
 
 boolean-true = నిజం
 boolean-false = అబద్ధం
 
-
 ## Answer buttons
 
 answer-submit-label = సరిచూడు
 answer-submit-label-no-correctness = సమాధానం సమర్పించు
-
 
 ## Sectional blocks
 
@@ -194,7 +175,6 @@ section-name =
     .solution = సాధన
     .task = పని
     .theorem = సిద్ధాంతం
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -204,9 +184,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = సూచన
-
 
 ## Tables and figures
 
@@ -217,7 +195,6 @@ table-name =
         [unnumbered-title] పట్టిక{ ": " }
        *[unnumbered] పట్టిక
     }
-
 figure-name =
     { $parts ->
         [numbered] పటం { $enumeration }
@@ -226,24 +203,20 @@ figure-name =
        *[unnumbered] పటం
     }
 
-
 ## Paginator controls
 
 paginator-previous = మునుపటిది
 paginator-next = తదుపరిది
 paginator-page = పేజీ
-
 # The total leads, marked with the locative -లో, which is how Telugu says
 # "3 of 5".
 paginator-page-status = { $numPages } లో { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = లేదా
 piecewise-condition-if = అయితే
 piecewise-condition-otherwise = లేకపోతే
-
 
 ## Chemistry
 
@@ -370,7 +343,6 @@ element-name =
     .lv = లివర్‌మోరియం
     .ts = టెన్నస్సీన్
     .og = ఒగనెసాన్
-
 element-anion-name =
     .h = హైడ్రైడ్
     .c = కార్బైడ్
@@ -384,8 +356,6 @@ element-anion-name =
     .i = అయోడైడ్
     .at = అస్టటైడ్
     .ts = టెన్నస్సైడ్
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = చెల్లని రసాయన చిహ్నం
 chemistry-invalid-ionic-compound = చెల్లని అయానిక సమ్మేళనం

--- a/packages/i18n/locales/tem/chrome.ftl
+++ b/packages/i18n/locales/tem/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = Ɔ chɛk…
 answer-submitting = Ɔ sɔŋ…
-
 answer-checking-status = Ɔ chɛk ʌŋlipi
 answer-submitting-status = Ɔ sɔŋ ʌŋlipi
-
 answer-correct = Kʌ tɔfɔ
 answer-incorrect = Kʌ tɔfɔ bɔm
-
 answer-response-saved = Ʌŋlipi Ma Sɔŋɔ
-
 answer-percent-credit = { $percent }% Kʌbay
 answer-percent-correct = { $percent }% Tɔfɔ
 answer-percent-short = { $percent } %
-
 max-credit-available = Kʌbay kʌbana kʌ mʌ bata: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kʌtʌmpa kʌ bɔm
         [one] kʌtʌmpa { $count } kʌ dəni
        *[other] tʌtʌmpa { $count } tʌ dəni
     }
-
 validation-correct = (Kʌ tɔfɔ)
 validation-incorrect = (Kʌ tɔfɔ bɔm)
 validation-partially-correct = (Kʌ tɔfɔ kʌpath)
-
 answer-show-responses =
     { $count ->
         [one] Yira ʌŋlipi { $count } ka { $answerId }
        *[other] Yira ʌŋlipi { $count } ka { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ʌŋlipi ka kʌkarante
-
 collapsible-click-to-open = (tɔth ma kʌ tuli)
 collapsible-click-to-close = (tɔth ma kʌ kanti)
-
 collapsible-initializing = Kʌ təŋ…
-
 footnote-show = Yira kʌsɔŋ kʌ kʌtəp
 footnote-hide = Kunthu kʌsɔŋ kʌ kʌtəp
-
 description-more-information = tʌkəre tʌbʌŋ
-
 
 ## Controls
 
 slider-previous = Kʌ pʌ
 slider-next = Kʌ tʌŋ
-
 keyboard-open = Tuli Kibɔd
 keyboard-close = Kanti Kibɔd
-
 choice-input-remove-choice = Bɔth { $choice }
-
 matrix-remove-row = Bɔth kʌro
 matrix-add-row = Fɔth kʌro
 matrix-remove-column = Bɔth kʌkɔlum
 matrix-add-column = Fɔth kʌkɔlum
-
 subset-add-remove-points = Fɔth/Bɔth tʌtoni
 subset-toggle-points-intervals = Firi tʌtoni na tʌintaval
 subset-move-points = Bʌŋ Tʌtoni
 subset-clear = Sana
-
 orbital-add-row = Fɔth Kʌro
 orbital-remove-row = Bɔth Kʌro
 orbital-add-box = Fɔth Kʌbɔks
@@ -87,13 +68,9 @@ orbital-remove-box = Bɔth Kʌbɔks
 orbital-add-up-arrow = Fɔth Kʌaro Kʌ Kʌtɔŋ
 orbital-add-down-arrow = Fɔth Kʌaro Kʌ Kʌtəp
 orbital-remove-arrow = Bɔth Kʌaro
-
 orbital-row-label = Ʌŋes ka kʌro { $row }
-
 pretzel-answer = Ʌŋlipi
-
 summary-statistics-caption = Ʌŋkəbath ka tʌnamba tʌ { $column }
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = yira ʌŋkəre ka mat pʌ
 math-input-preview = Yira pʌ
 math-input-invalid-expression = Ʌŋkəre kʌ bana bɔm:
 
-
 ## Document status
 
 viewer-initializing = Kʌ təŋ…
 
-
 ## Errors
 
 error-heading = Kʌwuni
-
 error-found-at =
     { $span ->
         [line] Ma bata ka kʌlayn { $startLine }.
        *[lines] Ma bata ka tʌlayn { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Kʌbuk kʌnɛ kʌ na tʌwuni!
-
 diagnostic-heading-error = Kʌwuni
 diagnostic-heading-warning = Kʌmɔŋ
 diagnostic-heading-information = Ʌŋkəre
 diagnostic-heading-hint = Kʌsandi
-
 accessibility-heading-level-1 = WCAG AA Kʌwuni ka Kʌsɔth
 accessibility-heading-level-2 = Kʌmɔŋ ka kʌsɔth
-
 something-went-wrong = Kʌbʌŋ kʌ bana bɔm.
-
 renderer-load-failed = kʌyiraŋ kʌbʌŋ kʌ ba bɔm. Bɔŋɔ, firi kʌpej.
-
 core-start-failed = Kʌyiraŋ ka kʌbuk kʌ təŋ bɔm. Bɔŋɔ, firi kʌpej.

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -112,7 +112,6 @@ color =
     .purple = pəpul
     .pink = pink
     .brown = braun
-
 line-width =
     .thick =
         { $gender ->
@@ -128,13 +127,11 @@ line-width =
             [c4] ʌŋkəni
            *[c1] kʌkəni
         }
-
 # Written as «na …» phrases rather than as prefixed qualifiers, so that they
 # take no concord and can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = na ʌŋpath-pathi
     .dotted = na ʌŋtoni
-
 fill-style =
     .horizontal = ʌŋlayn ŋa ŋi lay
     .vertical = ʌŋlayn ŋa ŋi yema
@@ -142,7 +139,6 @@ fill-style =
     .backdiagonal = ʌŋlayn ŋa ŋi kəri ka pʌŋ ʌŋbʌŋ
     .dots = ʌŋtoni
     .diamonds = ʌŋdayamɔn
-
 # Every noun below carries its class prefix in writing, so `noun-gender`'s
 # table can be read straight off this message. That is the alliterative-concord
 # property the header describes, and it is what makes this catalog checkable.
@@ -165,7 +161,6 @@ noun =
     .diamond = rʌdayamɔn
     .cross = rʌkrɔs
     .plus = rʌmark rʌ plɔs
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words, so it goes in the tail.
 noun-regular-polygon =
@@ -173,7 +168,6 @@ noun-regular-polygon =
         [tail] tʌ na tʌbʌŋ { $numSides }
        *[head] tʌpɔligɔn tʌ nɔŋ
     }
-
 # The noun class. Read it against `noun` above: each entry that names one of
 # `noun`'s attributes takes the class that attribute's own written prefix
 # carries, and `regular-polygon` takes `c2` because `noun-regular-polygon`'s
@@ -203,7 +197,6 @@ noun-gender =
        *[other] c1
     }
 
-
 ## Style composition
 
 # The dash pattern is a «na …» phrase and closes the description, so it moves
@@ -218,13 +211,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c2] tʌwuni
@@ -232,13 +223,11 @@ style-filled-word =
         [c4] ʌŋwuni
        *[c1] kʌwuni
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } na { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } na { $pattern }
@@ -246,7 +235,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «ʌŋbʌŋ» is the border and leads its own describing words, so they agree with
 # it rather than with the shape it surrounds — which is why `border` answers
 # `c4` in `noun-gender`, matching that word's own «ʌŋ-». Temne has no article
@@ -259,35 +247,28 @@ style-border-clause =
         [and-article] na ʌŋbʌŋ { $border }
        *[with] na ʌŋbʌŋ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = kʌwuni bɔm
-
 style-text =
     { $parts ->
         [background] { $color } na kʌbaka { $background }
        *[plain] { $color }
     }
-
 style-background-none = kəm bɔm
-
 
 ## Boolean words
 
 boolean-true = ʌŋtɔfɔ
 boolean-false = ʌŋgbɔl
 
-
 ## Answer buttons
 
 answer-submit-label = Chɛk Ʌŋpaŋth
 answer-submit-label-no-correctness = Sɔŋ Ʌŋlipi
-
 
 ## Sectional blocks
 
@@ -312,7 +293,6 @@ section-name =
     .solution = Ʌŋsɔlushɔn
     .task = Ʌŋpaŋth
     .theorem = Tiɔrɛm
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -322,9 +302,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kʌsandi
-
 
 ## Tables and figures
 
@@ -335,7 +313,6 @@ table-name =
         [unnumbered-title] Tebul{ ": " }
        *[unnumbered] Tebul
     }
-
 figure-name =
     { $parts ->
         [numbered] Kʌmisal { $enumeration }
@@ -344,25 +321,18 @@ figure-name =
        *[unnumbered] Kʌmisal
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kʌ pʌ
 paginator-next = Kʌ tʌŋ
-
 paginator-page = Kʌpej
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ɔ
-
 piecewise-condition-if = ma
-
 piecewise-condition-otherwise = ka tʌbʌŋ tʌ pəŋ
-
 
 ## Chemistry
 ##
@@ -374,6 +344,5 @@ piecewise-condition-otherwise = ka tʌbʌŋ tʌ pəŋ
 ## curriculum — the same answer `locales/kri` gives from the same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Kʌmark kʌ Kɛmistri kʌ Bana Bɔm
 chemistry-invalid-ionic-compound = Kʌthɔfi kʌ Ayɔn kʌ Bana Bɔm

--- a/packages/i18n/locales/tet/chrome.ftl
+++ b/packages/i18n/locales/tet/chrome.ftl
@@ -24,21 +24,15 @@
 
 answer-checking = Sei verifika…
 answer-submitting = Sei haruka…
-
 answer-checking-status = Sei verifika resposta
 answer-submitting-status = Sei haruka resposta
-
 answer-correct = Loos
 answer-incorrect = La loos
-
 answer-response-saved = Resposta rai ona
-
 answer-percent-credit = { $percent }% kréditu
 answer-percent-correct = { $percent }% loos
 answer-percent-short = { $percent } %
-
 max-credit-available = Kréditu máximu ne'ebé bele hetan: { $percent }%
-
 # No select: «koko» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -46,51 +40,38 @@ attempts-remaining =
         [0] la iha koko ida sei hela
        *[other] sei hela koko { $count }
     }
-
 validation-correct = (Loos)
 validation-incorrect = (La loos)
 validation-partially-correct = (Loos parsialmente)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Hatudu resposta { $count } ba { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komentáriu
-
 collapsible-click-to-open = (klik atu loke)
 collapsible-click-to-close = (klik atu taka)
-
 collapsible-initializing = Hahú hela…
-
 footnote-show = Hatudu footnote
 footnote-hide = Subar footnote
-
 description-more-information = informasaun tan
-
 
 ## Controls
 
 slider-previous = Uluk
 slider-next = Tuirmai
-
 keyboard-open = Loke tekladu
 keyboard-close = Taka tekladu
-
 choice-input-remove-choice = Hasai { $choice }
-
 matrix-remove-row = Hasai liña
 matrix-add-row = Tau tan liña
 matrix-remove-column = Hasai koluna
 matrix-add-column = Tau tan koluna
-
 subset-add-remove-points = Tau/Hasai pontu
 subset-toggle-points-intervals = Troka pontu ho intervalu
 subset-move-points = Book pontu sira
 subset-clear = Hamoos
-
 orbital-add-row = Tau tan liña
 orbital-remove-row = Hasai liña
 orbital-add-box = Tau tan kaixa
@@ -98,13 +79,9 @@ orbital-remove-box = Hasai kaixa
 orbital-add-up-arrow = Tau tan fleixa ba leten
 orbital-add-down-arrow = Tau tan fleixa ba kraik
 orbital-remove-arrow = Hasai fleixa
-
 orbital-row-label = Etiketa ba liña { $row }
-
 pretzel-answer = Resposta
-
 summary-statistics-caption = Rezumu estatístika husi { $column }
-
 
 ## Math input
 
@@ -112,34 +89,25 @@ math-input-preview-region = pré-vizualizasaun ba espresaun matemátika
 math-input-preview = Pré-vizualizasaun
 math-input-invalid-expression = Espresaun la válidu:
 
-
 ## Document status
 
 viewer-initializing = Hahú hela…
 
-
 ## Errors
 
 error-heading = Sala
-
 error-found-at =
     { $span ->
         [line] Hetan iha liña { $startLine }.
        *[lines] Hetan iha liña { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokumentu ne'e iha sala!
-
 diagnostic-heading-error = Sala
 diagnostic-heading-warning = Avizu
 diagnostic-heading-information = Informasaun
 diagnostic-heading-hint = Matadalan
-
 accessibility-heading-level-1 = Violasaun asesibilidade WCAG AA
 accessibility-heading-level-2 = Avizu kona-ba asesibilidade
-
 something-went-wrong = Iha buat ida la loos.
-
 renderer-load-failed = iha renderer ida la bele karega. Favor karega fali pájina ne'e.
-
 core-start-failed = Vizualizadór dokumentu la bele hahú. Favor karega fali pájina ne'e.

--- a/packages/i18n/locales/tet/content.ftl
+++ b/packages/i18n/locales/tet/content.ftl
@@ -43,15 +43,12 @@ color =
     .purple = roxu
     .pink = rosa
     .brown = kastañu
-
 line-width =
     .thick = grosu
     .thin = finu
-
 line-style =
     .dashed = traku-traku
     .dotted = pontu-pontu
-
 # Noun phrases. Tetum marks no plural on the noun, so «liña» is the word for one
 # line and for many alike.
 fill-style =
@@ -61,7 +58,6 @@ fill-style =
     .backdiagonal = liña diagonál kotuk
     .dots = pontu
     .diamonds = losangu
-
 noun =
     .line = liña
     .line-segment = segmentu liña
@@ -81,7 +77,6 @@ noun =
     .diamond = losangu
     .cross = kruz
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -89,11 +84,9 @@ noun-regular-polygon =
         [tail] ho sorin { $numSides }
        *[head] polígonu regulár
     }
-
 # One answer for every noun: Tetum has no grammatical gender, and its borrowed
 # adjectives do not agree either.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -107,22 +100,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = nakonu
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ho { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ho { $pattern }
@@ -130,7 +119,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } ho { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Tetum has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «ho» against «no».
@@ -141,35 +129,28 @@ style-border-clause =
         [and-article] no sorin-lalais { $border }
        *[with] ho sorin-lalais { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = la nakonu
-
 style-text =
     { $parts ->
         [background] { $color } ho fundu { $background }
        *[plain] { $color }
     }
-
 style-background-none = laiha
-
 
 ## Boolean words
 
 boolean-true = loos
 boolean-false = sala
 
-
 ## Answer buttons
 
 answer-submit-label = Verifika serbisu
 answer-submit-label-no-correctness = Haruka resposta
-
 
 ## Sectional blocks
 
@@ -196,7 +177,6 @@ section-name =
     .solution = Solusaun
     .task = Tarefa
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -206,9 +186,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Matadalan
-
 
 ## Tables and figures
 
@@ -219,7 +197,6 @@ table-name =
         [unnumbered-title] Tabela{ ": " }
        *[unnumbered] Tabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
@@ -228,22 +205,18 @@ figure-name =
        *[unnumbered] Figura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Uluk
 paginator-next = Tuirmai
 paginator-page = Pájina
-
 paginator-page-status = { $pageLabel } { $currentPage } husi { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ka
 piecewise-condition-if = se
 piecewise-condition-otherwise = se lae
-
 
 ## Chemistry
 ##
@@ -256,6 +229,5 @@ piecewise-condition-otherwise = se lae
 ## over.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Símbolu kímiku la válidu
 chemistry-invalid-ionic-compound = Kompostu ióniku la válidu

--- a/packages/i18n/locales/tg/chrome.ftl
+++ b/packages/i18n/locales/tg/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = Санҷида мешавад…
 answer-submitting = Фиристода мешавад…
-
 answer-checking-status = Ҷавоб санҷида мешавад
 answer-submitting-status = Ҷавоб фиристода мешавад
-
 answer-correct = Дуруст
 answer-incorrect = Нодуруст
-
 answer-response-saved = Ҷавоб нигоҳ дошта шуд
-
 answer-percent-credit = { $percent }% холҳо
 answer-percent-correct = { $percent }% дуруст
 answer-percent-short = { $percent } %
-
 max-credit-available = Холи аз ҳама баланди имконпазир: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] кӯшиш намондааст
         [one] { $count } кӯшиш мондааст
        *[other] { $count } кӯшиш мондааст
     }
-
 validation-correct = (Дуруст)
 validation-incorrect = (Нодуруст)
 validation-partially-correct = (Қисман дуруст)
-
 answer-show-responses =
     { $count ->
         [one] Нишон додани { $count } ҷавоб ба { $answerId }
        *[other] Нишон додани { $count } ҷавоб ба { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Бозхонд
-
 collapsible-click-to-open = (барои кушодан пахш кунед)
 collapsible-click-to-close = (барои пӯшидан пахш кунед)
-
 collapsible-initializing = Омода мешавад…
-
 footnote-show = Нишон додани эзоҳ
 footnote-hide = Пинҳон кардани эзоҳ
-
 description-more-information = маълумоти иловагӣ
-
 
 ## Controls
 
 slider-previous = Қаблӣ
 slider-next = Навбатӣ
-
 keyboard-open = Кушодани клавиатура
 keyboard-close = Пӯшидани клавиатура
-
 choice-input-remove-choice = Хориҷ кардани { $choice }
-
 matrix-remove-row = Хориҷ кардани сатр
 matrix-add-row = Илова кардани сатр
 matrix-remove-column = Хориҷ кардани сутун
 matrix-add-column = Илова кардани сутун
-
 subset-add-remove-points = Илова/хориҷ кардани нуқтаҳо
 subset-toggle-points-intervals = Иваз кардани нуқтаҳо ва фосилаҳо
 subset-move-points = Ҷойивазкунии нуқтаҳо
 subset-clear = Тоза кардан
-
 orbital-add-row = Илова кардани сатр
 orbital-remove-row = Хориҷ кардани сатр
 orbital-add-box = Илова кардани хона
@@ -94,13 +75,9 @@ orbital-remove-box = Хориҷ кардани хона
 orbital-add-up-arrow = Илова кардани тири боло
 orbital-add-down-arrow = Илова кардани тири поён
 orbital-remove-arrow = Хориҷ кардани тир
-
 orbital-row-label = Нишонаи сатри { $row }
-
 pretzel-answer = Ҷавоб
-
 summary-statistics-caption = Омори ҷамъбастии сутуни { $column }
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = пешнамоиши ифодаи математик
 math-input-preview = Пешнамоиш
 math-input-invalid-expression = Ифодаи нодуруст:
 
-
 ## Document status
 
 viewer-initializing = Омода мешавад…
 
-
 ## Errors
 
 error-heading = Хато
-
 error-found-at =
     { $span ->
         [line] Дар сатри { $startLine } ёфт шуд.
        *[lines] Дар сатрҳои { $startLine }–{ $endLine } ёфт шуд.
     }
-
 document-contains-errors = Ин ҳуҷҷат хатоҳо дорад!
-
 diagnostic-heading-error = Хато
 diagnostic-heading-warning = Огоҳӣ
 diagnostic-heading-information = Маълумот
 diagnostic-heading-hint = Маслиҳат
-
 accessibility-heading-level-1 = Вайронкунии дастрасии WCAG AA
 accessibility-heading-level-2 = Огоҳиномаи дастрасӣ
-
 something-went-wrong = Чизе нодуруст рафт.
-
 renderer-load-failed = тасвиргарро бор кардан нашуд. Лутфан саҳифаро нав кунед.
-
 core-start-failed = Тамошобини ҳуҷҷатро оғоз кардан нашуд. Лутфан саҳифаро нав кунед.

--- a/packages/i18n/locales/tg/content.ftl
+++ b/packages/i18n/locales/tg/content.ftl
@@ -68,15 +68,12 @@ color =
     .purple = бунафш
     .pink = гулгун
     .brown = қаҳваранг
-
 line-width =
     .thick = ғафс
     .thin = борик
-
 line-style =
     .dashed = хат-хат
     .dotted = нуқтадор
-
 fill-style =
     .horizontal = хатҳои уфуқӣ
     .vertical = хатҳои амудӣ
@@ -84,7 +81,6 @@ fill-style =
     .backdiagonal = хатҳои диагоналии баръакс
     .dots = нуқтаҳо
     .diamonds = ромбҳо
-
 noun =
     .line = хат
     .line-segment = порча
@@ -104,7 +100,6 @@ noun =
     .diamond = ромб
     .cross = чорхат
     .plus = плюс
-
 # The side count follows the adjectives rather than standing in front of the
 # noun, so this splits in two the way Spanish's does: the head is the word the
 # adjectives attach to and the tail is the complement after them.
@@ -113,11 +108,9 @@ noun-regular-polygon =
         [tail] бо { $numSides } тараф
        *[head] бисёркунҷаи мунтазам
     }
-
 # Tajik has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in Persian.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -143,21 +136,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun }и { $description } { $nounTail }
        *[noun] { $noun }и { $description }
     }
-
 style-filled-word = пуршуда
-
 style-filled =
     { $parts ->
         [pattern] { $filled }и { $color } бо нақши { $pattern }
        *[plain] { $filled }и { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun }и { $filled }и { $color } бо нақши { $pattern }
@@ -165,7 +154,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun }и { $filled }и { $color } { $nounTail } бо нақши { $pattern }
        *[plain] { $noun }и { $filled }и { $color }
     }
-
 # «бо ҳошияи» — "with a border of" — the izafat here sits on a word this
 # catalog writes. Tajik has no indefinite article, so the two `-article`
 # branches read like the two without.
@@ -176,35 +164,28 @@ style-border-clause =
         [and-article] ва бо ҳошияи { $border }
        *[with] бо ҳошияи { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] пуркунии { $color } бо нақши { $pattern }
        *[plain] пуркунии { $color }
     }
-
 style-unfilled = холӣ
-
 style-text =
     { $parts ->
         [background] { $color } дар заминаи { $background }
        *[plain] { $color }
     }
-
 style-background-none = нест
-
 
 ## Boolean words
 
 boolean-true = дуруст
 boolean-false = нодуруст
 
-
 ## Answer buttons
 
 answer-submit-label = Санҷидан
 answer-submit-label-no-correctness = Ҷавобро фиристодан
-
 
 ## Sectional blocks
 
@@ -229,7 +210,6 @@ section-name =
     .solution = Ҳал
     .task = Супориш
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -239,9 +219,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Маслиҳат
-
 
 ## Tables and figures
 
@@ -252,7 +230,6 @@ table-name =
         [unnumbered-title] Ҷадвал{ ". " }
        *[unnumbered] Ҷадвал
     }
-
 figure-name =
     { $parts ->
         [numbered] Расми { $enumeration }
@@ -261,22 +238,18 @@ figure-name =
        *[unnumbered] Расм
     }
 
-
 ## Paginator controls
 
 paginator-previous = Қаблӣ
 paginator-next = Навбатӣ
 paginator-page = Саҳифа
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ё
 piecewise-condition-if = агар
 piecewise-condition-otherwise = вагарна
-
 
 ## Chemistry
 
@@ -399,7 +372,6 @@ element-name =
     .lv = Ливерморий
     .ts = Теннессин
     .og = Оганесон
-
 element-anion-name =
     .h = Ҳидрид
     .c = Карбид
@@ -413,8 +385,6 @@ element-anion-name =
     .i = Йодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Аломати химиявии нодуруст
 chemistry-invalid-ionic-compound = Пайвастагии ионии нодуруст

--- a/packages/i18n/locales/th/chrome.ftl
+++ b/packages/i18n/locales/th/chrome.ftl
@@ -23,69 +23,50 @@
 
 answer-checking = กำลังตรวจ...
 answer-submitting = กำลังส่ง...
-
 answer-checking-status = กำลังตรวจคำตอบ
 answer-submitting-status = กำลังส่งคำตอบ
-
 answer-correct = ถูก
 answer-incorrect = ผิด
-
 answer-response-saved = บันทึกคำตอบแล้ว
-
 answer-percent-credit = { $percent }% ของคะแนน
 answer-percent-correct = { $percent }% ถูก
 answer-percent-short = { $percent }%
-
 max-credit-available = คะแนนสูงสุดที่ทำได้: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ไม่เหลือโอกาสตอบ
        *[other] เหลืออีก { $count } ครั้ง
     }
-
 validation-correct = (ถูก)
 validation-incorrect = (ผิด)
 validation-partially-correct = (ถูกบางส่วน)
-
 answer-show-responses = แสดงคำตอบ { $count } รายการของ { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = ผลตอบกลับ
-
 collapsible-click-to-open = (คลิกเพื่อเปิด)
 collapsible-click-to-close = (คลิกเพื่อปิด)
-
 collapsible-initializing = กำลังเริ่มต้น...
-
 footnote-show = แสดงเชิงอรรถ
 footnote-hide = ซ่อนเชิงอรรถ
-
 description-more-information = ข้อมูลเพิ่มเติม
-
 
 ## Controls
 
 slider-previous = ก่อนหน้า
 slider-next = ถัดไป
-
 keyboard-open = เปิดแป้นพิมพ์
 keyboard-close = ปิดแป้นพิมพ์
-
 choice-input-remove-choice = เอา { $choice } ออก
-
 matrix-remove-row = ลบแถว
 matrix-add-row = เพิ่มแถว
 matrix-remove-column = ลบหลัก
 matrix-add-column = เพิ่มหลัก
-
 subset-add-remove-points = เพิ่ม/ลบจุด
 subset-toggle-points-intervals = สลับระหว่างจุดกับช่วง
 subset-move-points = ย้ายจุด
 subset-clear = ล้าง
-
 # A `box` here is one orbital, drawn as a square: ช่อง.
 orbital-add-row = เพิ่มแถว
 orbital-remove-row = ลบแถว
@@ -94,13 +75,9 @@ orbital-remove-box = ลบช่อง
 orbital-add-up-arrow = เพิ่มลูกศรขึ้น
 orbital-add-down-arrow = เพิ่มลูกศรลง
 orbital-remove-arrow = ลบลูกศร
-
 orbital-row-label = ชื่อของแถวที่ { $row }
-
 pretzel-answer = คำตอบ
-
 summary-statistics-caption = สถิติสรุปของ { $column }
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = ตัวอย่างนิพจน์คณิ�
 math-input-preview = ตัวอย่าง
 math-input-invalid-expression = นิพจน์ไม่ถูกต้อง:
 
-
 ## Document status
 
 viewer-initializing = กำลังเริ่มต้น...
 
-
 ## Errors
 
 error-heading = ข้อผิดพลาด
-
 error-found-at =
     { $span ->
         [line] พบที่บรรทัด { $startLine }
        *[lines] พบที่บรรทัด { $startLine }–{ $endLine }
     }
-
 document-contains-errors = เอกสารนี้มีข้อผิดพลาด!
-
 diagnostic-heading-error = ข้อผิดพลาด
 diagnostic-heading-warning = คำเตือน
 diagnostic-heading-information = ข้อมูล
 diagnostic-heading-hint = คำใบ้
-
 accessibility-heading-level-1 = การละเมิดการเข้าถึงตาม WCAG AA
 accessibility-heading-level-2 = คำเตือนด้านการเข้าถึง
-
 something-went-wrong = เกิดข้อผิดพลาดบางอย่าง
-
 renderer-load-failed = โหลดตัวแสดงผลไม่สำเร็จ กรุณาโหลดหน้านี้ใหม่
-
 core-start-failed = เริ่มต้นตัวแสดงเอกสารไม่สำเร็จ กรุณาโหลดหน้านี้ใหม่

--- a/packages/i18n/locales/th/content.ftl
+++ b/packages/i18n/locales/th/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = สีม่วง
     .pink = สีชมพู
     .brown = สีน้ำตาล
-
 line-width =
     .thick = หนา
     .thin = บาง
-
 line-style =
     .dashed = ประ
     .dotted = จุด
-
 # Noun phrases: they follow «พร้อม» and modify nothing.
 fill-style =
     .horizontal = เส้นแนวนอน
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = เส้นทแยงมุมกลับด้าน
     .dots = จุด
     .diamonds = รูปข้าวหลามตัด
-
 noun =
     .line = เส้นตรง
     .line-segment = ส่วนของเส้นตรง
@@ -74,7 +70,6 @@ noun =
     .diamond = รูปข้าวหลามตัด
     .cross = เครื่องหมายกากบาท
     .plus = เครื่องหมายบวก
-
 # The side count sits immediately after the noun and before any adjective —
 # «รูปหลายเหลี่ยมด้านเท่า 5 ด้าน» — so it folds into the head and there is no
 # tail. Putting it after the adjectives would separate «ด้าน» from the number
@@ -84,11 +79,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] รูปหลายเหลี่ยมด้านเท่า { $numSides } ด้าน
     }
-
 # Thai has no grammatical gender, so every noun answers the same and the answer
 # goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -102,14 +95,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «เส้นตรงหนาประสีแดง».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun }{ $description }{ $nounTail }
        *[noun] { $noun }{ $description }
     }
-
 # «ระบาย» carries no สี of its own: every colour word above already begins
 # with one, and both messages below place `$filled` immediately in front of
 # `$color` in every variant, so the composition produces «ระบายสีน้ำเงิน» with
@@ -119,13 +110,11 @@ style-with-noun =
 # without one there. `style-unfilled` stands on its own and keeps the full
 # «ไม่ระบายสี».
 style-filled-word = ระบาย
-
 style-filled =
     { $parts ->
         [pattern] { $filled }{ $color } พร้อม{ $pattern }
        *[plain] { $filled }{ $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun }{ $filled }{ $color } พร้อม{ $pattern }
@@ -133,7 +122,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun }{ $nounTail }{ $filled }{ $color } พร้อม{ $pattern }
        *[plain] { $noun }{ $filled }{ $color }
     }
-
 # «ขอบ» leads its own adjectives, the same way every noun here does. Thai needs
 # no article, so the `-article` branches read like the ones without.
 style-border-clause =
@@ -143,36 +131,29 @@ style-border-clause =
         [and-article] และขอบ{ $border }
        *[with] พร้อมขอบ{ $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern }{ $color }
        *[plain] { $color }
     }
-
 style-unfilled = ไม่ระบายสี
-
 style-text =
     { $parts ->
         [background] { $color }บนพื้นหลัง{ $background }
        *[plain] { $color }
     }
-
 style-background-none = ไม่มี
-
 
 ## Boolean words
 
 boolean-true = จริง
 boolean-false = เท็จ
 
-
 ## Answer buttons
 
 answer-submit-label = ตรวจคำตอบ
 answer-submit-label-no-correctness = ส่งคำตอบ
-
 
 ## Sectional blocks
 
@@ -197,7 +178,6 @@ section-name =
     .solution = เฉลย
     .task = ภารกิจ
     .theorem = ทฤษฎีบท
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -207,9 +187,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = คำใบ้
-
 
 ## Tables and figures
 
@@ -220,7 +198,6 @@ table-name =
         [unnumbered-title] ตาราง{ ": " }
        *[unnumbered] ตาราง
     }
-
 figure-name =
     { $parts ->
         [numbered] รูป { $enumeration }
@@ -229,22 +206,18 @@ figure-name =
        *[unnumbered] รูป
     }
 
-
 ## Paginator controls
 
 paginator-previous = ก่อนหน้า
 paginator-next = ถัดไป
 paginator-page = หน้า
-
 paginator-page-status = { $pageLabel } { $currentPage } จาก { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = หรือ
 piecewise-condition-if = เมื่อ
 piecewise-condition-otherwise = กรณีอื่น
-
 
 ## Chemistry
 
@@ -372,7 +345,6 @@ element-name =
     .lv = ลิเวอร์มอเรียม
     .ts = เทนเนสซีน
     .og = ออกาเนสซอน
-
 element-anion-name =
     .h = ไฮไดรด์
     .c = คาร์ไบด์
@@ -386,8 +358,6 @@ element-anion-name =
     .i = ไอโอไดด์
     .at = แอสทาไทด์
     .ts = เทนเนสไซด์
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = สัญลักษณ์เคมีไม่ถูกต้อง
 chemistry-invalid-ionic-compound = สารประกอบไอออนิกไม่ถูกต้อง

--- a/packages/i18n/locales/ti/chrome.ftl
+++ b/packages/i18n/locales/ti/chrome.ftl
@@ -22,74 +22,55 @@
 
 answer-checking = ይምርምር ኣሎ...
 answer-submitting = ይልእኽ ኣሎ...
-
 answer-checking-status = መልሲ ይምርምር ኣሎ
 answer-submitting-status = መልሲ ይልእኽ ኣሎ
-
 answer-correct = ቅኑዕ
 answer-incorrect = ጌጋ
-
 answer-response-saved = መልሲ ተዓቂቡ
-
 answer-percent-credit = ነጥቢ { $percent }%
 answer-percent-correct = { $percent }% ቅኑዕ
 answer-percent-short = { $percent } %
-
 max-credit-available = ዝለዓለ ክርከብ ዝኽእል ነጥቢ፡ { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ዝተረፈ ፈተነ የልቦን
         [one] { $count } ፈተነ ተሪፉ
        *[other] { $count } ፈተነታት ተሪፈን
     }
-
 validation-correct = (ቅኑዕ)
 validation-incorrect = (ጌጋ)
 validation-partially-correct = (ብኸፊል ቅኑዕ)
-
 answer-show-responses =
     { $count ->
         [one] { $count } መልሲ ናብ { $answerId } ኣርኢ
        *[other] { $count } መልስታት ናብ { $answerId } ኣርኢ
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ግብረ-መልሲ
-
 collapsible-click-to-open = (ንምኽፋት ጠውቕ)
 collapsible-click-to-close = (ንምዕጻው ጠውቕ)
-
 collapsible-initializing = ይጅምር ኣሎ...
-
 footnote-show = እግረ-ጽሑፍ ኣርኢ
 footnote-hide = እግረ-ጽሑፍ ሕባእ
-
 description-more-information = ተወሳኺ ሓበሬታ
-
 
 ## Controls
 
 slider-previous = ዝሓለፈ
 slider-next = ዝቕጽል
-
 keyboard-open = ኪቦርድ ክፈት
 keyboard-close = ኪቦርድ ዕጾ
-
 choice-input-remove-choice = { $choice } ኣወግድ
-
 matrix-remove-row = መስርዕ ኣወግድ
 matrix-add-row = መስርዕ ወስኽ
 matrix-remove-column = ዓምዲ ኣወግድ
 matrix-add-column = ዓምዲ ወስኽ
-
 subset-add-remove-points = ነጥብታት ወስኽ/ኣወግድ
 subset-toggle-points-intervals = ኣብ መንጎ ነጥብታትን ክፍተታትን ቀያይር
 subset-move-points = ነጥብታት ኣንቀሳቕስ
 subset-clear = ኣጽሪ
-
 # A `box` here is one orbital, drawn as a square: «ሳጹን».
 orbital-add-row = መስርዕ ወስኽ
 orbital-remove-row = መስርዕ ኣወግድ
@@ -98,13 +79,9 @@ orbital-remove-box = ሳጹን ኣወግድ
 orbital-add-up-arrow = ናብ ላዕሊ ዘመልክት ኮፍታ ወስኽ
 orbital-add-down-arrow = ናብ ታሕቲ ዘመልክት ኮፍታ ወስኽ
 orbital-remove-arrow = ኮፍታ ኣወግድ
-
 orbital-row-label = ስም መስርዕ { $row }
-
 pretzel-answer = መልሲ
-
 summary-statistics-caption = ጽማቝ ስታቲስቲክስ { $column }
-
 
 ## Math input
 
@@ -112,34 +89,25 @@ math-input-preview-region = ቅድመ-ትርኢት ናይ ሒሳብ መግለጺ
 math-input-preview = ቅድመ-ትርኢት
 math-input-invalid-expression = ዘይቅቡል መግለጺ፡
 
-
 ## Document status
 
 viewer-initializing = ይጅምር ኣሎ...
 
-
 ## Errors
 
 error-heading = ጌጋ
-
 error-found-at =
     { $span ->
         [line] ኣብ መስመር { $startLine } ተረኺቡ።
        *[lines] ኣብ መስመራት { $startLine }–{ $endLine } ተረኺቡ።
     }
-
 document-contains-errors = እዚ ሰነድ ጌጋታት ኣለውዎ!
-
 diagnostic-heading-error = ጌጋ
 diagnostic-heading-warning = መጠንቀቕታ
 diagnostic-heading-information = ሓበሬታ
 diagnostic-heading-hint = ፍንጪ
-
 accessibility-heading-level-1 = ጥሕሰት ተበጻሕነት WCAG AA
 accessibility-heading-level-2 = መጠንቀቕታ ተበጻሕነት
-
 something-went-wrong = ገለ ጌጋ ኣጋጢሙ።
-
 renderer-load-failed = ሓደ ኣርኣዪ ክጽዕን ኣይከኣለን። በጃኹም ገጽ ደጊምኩም ጽዓኑ።
-
 core-start-failed = ኣርኣዪ ሰነድ ክጅምር ኣይከኣለን። በጃኹም ገጽ ደጊምኩም ጽዓኑ።

--- a/packages/i18n/locales/ti/content.ftl
+++ b/packages/i18n/locales/ti/content.ftl
@@ -53,7 +53,6 @@ color =
     .purple = ወይናይ
     .pink = ሮዛ
     .brown = ቡናዊ
-
 line-width =
     .thick =
         { $gender ->
@@ -65,14 +64,12 @@ line-width =
             [f] ቀጣን
            *[m] ቀጢን
         }
-
 # Written as «ብ …» phrases rather than as adjectives, so that they agree with
 # nothing. They close the description, which is why `style-stroke` moves them
 # behind the colour.
 line-style =
     .dashed = ብስንጥቕ
     .dotted = ብነጥብታት
-
 fill-style =
     .horizontal = ደቀኛ መስመራት
     .vertical = ቀጥ ዝበሉ መስመራት
@@ -80,7 +77,6 @@ fill-style =
     .backdiagonal = ንድሕሪት ዝሰየፉ መስመራት
     .dots = ነጥብታት
     .diamonds = ኣልማዛት
-
 noun =
     .line = መስመር
     .line-segment = ክፍሊ መስመር
@@ -100,7 +96,6 @@ noun =
     .diamond = ኣልማዝ
     .cross = መስቀል
     .plus = ምልክት ምድማር
-
 # Tigrinya folds the side count into the head, in front of the noun, the way
 # English does — «5 ጎድኒ ዘለዎ ስሩዕ ፖሊጎን» — so there is no tail.
 noun-regular-polygon =
@@ -108,7 +103,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } ጎድኒ ዘለዎ ስሩዕ ፖሊጎን
     }
-
 noun-gender =
     { $noun ->
         [point] f
@@ -119,7 +113,6 @@ noun-gender =
         [background] f
        *[other] m
     }
-
 
 ## Style composition
 
@@ -133,26 +126,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The adjectives lead and the noun follows, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word =
     { $gender ->
         [f] ምልእቲ
        *[m] ምሉእ
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ምስ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } ምስ { $pattern }
@@ -160,7 +149,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } ምስ { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ዶብ» is masculine and leads its own adjectives, so the border's words agree
 # with it and not with the shape it surrounds. Tigrinya has no indefinite
 # article, so the two `-article` branches read like the two without.
@@ -171,35 +159,28 @@ style-border-clause =
         [and-article] ከምኡ'ውን { $border } ዶብ
        *[with] ምስ { $border } ዶብ
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ዘይመልአ
-
 style-text =
     { $parts ->
         [background] { $color } ምስ { $background } ድሕረ-ባይታ
        *[plain] { $color }
     }
-
 style-background-none = የልቦን
-
 
 ## Boolean words
 
 boolean-true = ሓቂ
 boolean-false = ሓሶት
 
-
 ## Answer buttons
 
 answer-submit-label = ስራሕ ኣረጋግጽ
 answer-submit-label-no-correctness = መልሲ ልኣኽ
-
 
 ## Sectional blocks
 
@@ -224,7 +205,6 @@ section-name =
     .solution = መፍትሒ
     .task = ዕማም
     .theorem = ቲዮረም
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -234,9 +214,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ፍንጪ
-
 
 ## Tables and figures
 
@@ -247,7 +225,6 @@ table-name =
         [unnumbered-title] ሰንጠረዥ{ ": " }
        *[unnumbered] ሰንጠረዥ
     }
-
 figure-name =
     { $parts ->
         [numbered] ስእሊ { $enumeration }
@@ -256,22 +233,18 @@ figure-name =
        *[unnumbered] ስእሊ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ዝሓለፈ
 paginator-next = ዝቕጽል
 paginator-page = ገጽ
-
 paginator-page-status = { $pageLabel } { $currentPage } ካብ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ወይ
 piecewise-condition-if = እንተ
 piecewise-condition-otherwise = እንተዘይኮይኑ
-
 
 ## Chemistry
 
@@ -283,6 +256,5 @@ piecewise-condition-otherwise = እንተዘይኮይኑ
 # check against the English beside it, would be worse than the English. A
 # speaker adding a list should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ዘይቅቡል ኬሚካላዊ ምልክት
 chemistry-invalid-ionic-compound = ዘይቅቡል ኣዮናዊ ውህደት

--- a/packages/i18n/locales/tiv/chrome.ftl
+++ b/packages/i18n/locales/tiv/chrome.ftl
@@ -12,74 +12,55 @@
 
 answer-checking = I ngu tôôn…
 answer-submitting = I ngu tindin…
-
 answer-checking-status = I ngu tôôn mlumun la
 answer-submitting-status = I ngu tindin mlumun la
-
 answer-correct = Ka mimi
 answer-incorrect = Ka mimi ga
-
 answer-response-saved = I Kura Mlumun la
-
 answer-percent-credit = { $percent }% mba upoyint
 answer-percent-correct = { $percent }% mimi
 answer-percent-short = { $percent } %
-
 max-credit-available = Upoyint mba kpishi mba ve lu: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] mtsen ma shi ga
         [one] mtsen { $count } u shi
        *[other] amtsen { $count } a shi
     }
-
 validation-correct = (Ka mimi)
 validation-incorrect = (Ka mimi ga)
 validation-partially-correct = (Ka mimi sha ikyar igen)
-
 answer-show-responses =
     { $count ->
         [one] Tese mlumun { $count } u { $answerId }
        *[other] Tese amlumun { $count } a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Mkaanem
-
 collapsible-click-to-open = (nyanger u bughun)
 collapsible-click-to-close = (nyanger u kuran)
-
 collapsible-initializing = I ngu hiin…
-
 footnote-show = Tese mngerem ma sha inya
 footnote-hide = Yer mngerem ma sha inya
-
 description-more-information = akaa agen
-
 
 ## Controls
 
 slider-previous = U karen
 slider-next = U dondon
-
 keyboard-open = Bugh Kiiboodu
 keyboard-close = Kur Kiiboodu
-
 choice-input-remove-choice = Dugh { $choice }
-
 matrix-remove-row = Dugh layin
 matrix-add-row = Seer layin
 matrix-remove-column = Dugh kolum
 matrix-add-column = Seer kolum
-
 subset-add-remove-points = Seer/Dugh upoyint
 subset-toggle-points-intervals = Gema upoyint man akyar
 subset-move-points = Mough Upoyint
 subset-clear = Dugh cii
-
 orbital-add-row = Seer Layin
 orbital-remove-row = Dugh Layin
 orbital-add-box = Seer Ikpe
@@ -87,13 +68,9 @@ orbital-remove-box = Dugh Ikpe
 orbital-add-up-arrow = Seer Ityôgh i Sha
 orbital-add-down-arrow = Seer Ityôgh i Inya
 orbital-remove-arrow = Dugh Ityôgh
-
 orbital-row-label = Iti i layin { $row }
-
 pretzel-answer = Mlumun
-
 summary-statistics-caption = Mkuran u aeren a { $column }
-
 
 ## Math input
 
@@ -101,34 +78,25 @@ math-input-preview-region = mnenge u hiihii u akaa a mbamsen
 math-input-preview = Mnenge u hiihii
 math-input-invalid-expression = Mkaanem ma ma doo ga:
 
-
 ## Document status
 
 viewer-initializing = I ngu hiin…
 
-
 ## Errors
 
 error-heading = Mtev
-
 error-found-at =
     { $span ->
         [line] I zua a mi sha layin { $startLine }.
        *[lines] I zua a mi sha ulayin { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Takerada ne ngu a mtev!
-
 diagnostic-heading-error = Mtev
 diagnostic-heading-warning = Mtaver
 diagnostic-heading-information = Kwaghôron
 diagnostic-heading-hint = Mtesen
-
 accessibility-heading-level-1 = Mkar u WCAG AA u mzough
 accessibility-heading-level-2 = Mtaver u mzough
-
 something-went-wrong = Kwagh ugen er dedoo ga.
-
 renderer-load-failed = ortesen va ga. Er sar we yô, hide a peji la.
-
 core-start-failed = Ortesen u takerada hii ga. Er sar we yô, hide a peji la.

--- a/packages/i18n/locales/tiv/content.ftl
+++ b/packages/i18n/locales/tiv/content.ftl
@@ -77,7 +77,6 @@ color =
     .purple = papul
     .pink = pinki
     .brown = buraun
-
 line-width =
     .thick =
         { $gender ->
@@ -91,14 +90,12 @@ line-width =
             [c2] i kiryan
            *[c3] a kiryan
         }
-
 # Written as invariable «man …» phrases rather than as quality verbs, so that
 # they take no particle and can close the description. `style-stroke` puts them
 # last.
 line-style =
     .dashed = man ubaajir
     .dotted = man utindi
-
 fill-style =
     .horizontal = ulayin mba ve tsa
     .vertical = ulayin mba ve tile
@@ -106,7 +103,6 @@ fill-style =
     .backdiagonal = ulayin mba ve gbe ken ijime i ugen
     .dots = utindi
     .diamonds = udayamon
-
 noun =
     .line = layin
     .line-segment = ikyar i layin
@@ -126,7 +122,6 @@ noun =
     .diamond = dayamon
     .cross = korosu
     .plus = ikyav i seer
-
 # The side count is a relative and closes the noun phrase behind the describing
 # words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -134,7 +129,6 @@ noun-regular-polygon =
         [tail] i a lu a atser { $numSides }
        *[head] poligon i a kuma
     }
-
 # The noun class. `c3` is the default and the class a loanword joins, which is
 # what an author's own `markerStyleWord` is as far as this catalog is
 # concerned.
@@ -159,7 +153,6 @@ noun-gender =
        *[other] c3
     }
 
-
 ## Style composition
 
 # The dash pattern is a «man …» phrase and closes the description, so it moves
@@ -176,26 +169,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c1] u iv
         [c2] i iv
        *[c3] a iv
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } man { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } man { $pattern }
@@ -203,7 +192,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } man { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «igbenda» is the border and leads its own describing words, so they agree
 # with it rather than with the shape it surrounds. Tiv has no article and joins
 # this clause with the invariable «man», so all four branches read alike.
@@ -214,35 +202,28 @@ style-border-clause =
         [and-article] man igbenda { $border }
        *[with] man igbenda { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = i iv ga
-
 style-text =
     { $parts ->
         [background] { $color } sha ijime { $background }
        *[plain] { $color }
     }
-
 style-background-none = ma kwagh ngu ga
-
 
 ## Boolean words
 
 boolean-true = mimi
 boolean-false = aie
 
-
 ## Answer buttons
 
 answer-submit-label = Tôô Tom
 answer-submit-label-no-correctness = Tindi Mlumun
-
 
 ## Sectional blocks
 
@@ -267,7 +248,6 @@ section-name =
     .solution = Mbem
     .task = Tom
     .theorem = Tiyorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -277,9 +257,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Mtesen
-
 
 ## Tables and figures
 
@@ -290,7 +268,6 @@ table-name =
         [unnumbered-title] Tebur{ ": " }
        *[unnumbered] Tebur
     }
-
 figure-name =
     { $parts ->
         [numbered] Ikyav { $enumeration }
@@ -299,25 +276,18 @@ figure-name =
        *[unnumbered] Ikyav
     }
 
-
 ## Paginator controls
 
 paginator-previous = U karen
 paginator-next = U dondon
-
 paginator-page = Peji
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = shin
-
 piecewise-condition-if = aluer
-
 piecewise-condition-otherwise = hen ajiir agen cii
-
 
 ## Chemistry
 ##
@@ -330,6 +300,5 @@ piecewise-condition-otherwise = hen ajiir agen cii
 ## give from the same ministry.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ikyav i Kemistiri i i Doo Ga
 chemistry-invalid-ionic-compound = Mkohol u Ayon u u Doo Ga

--- a/packages/i18n/locales/tk/chrome.ftl
+++ b/packages/i18n/locales/tk/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Barlanýar…
 answer-submitting = Iberilýär…
-
 answer-checking-status = Jogap barlanýar
 answer-submitting-status = Jogap iberilýär
-
 answer-correct = Dogry
 answer-incorrect = Nädogry
-
 answer-response-saved = Jogap saklandy
-
 answer-percent-credit = { $percent }% bal
 answer-percent-correct = { $percent }% dogry
 answer-percent-short = { $percent } %
-
 max-credit-available = Mümkin bolan iň ýokary bal: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] synanyşyk galmady
         [one] { $count } synanyşyk galdy
        *[other] { $count } synanyşyk galdy
     }
-
 validation-correct = (Dogry)
 validation-incorrect = (Nädogry)
 validation-partially-correct = (Bölekleýin dogry)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } üçin { $count } jogaby görkez
        *[other] { $answerId } üçin { $count } jogaby görkez
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Seslenme
-
 collapsible-click-to-open = (açmak üçin basyň)
 collapsible-click-to-close = (ýapmak üçin basyň)
-
 collapsible-initializing = Taýýarlanýar…
-
 footnote-show = Belligi görkez
 footnote-hide = Belligi gizle
-
 description-more-information = goşmaça maglumat
-
 
 ## Controls
 
 slider-previous = Öňki
 slider-next = Indiki
-
 keyboard-open = Klawiaturany aç
 keyboard-close = Klawiaturany ýap
-
 choice-input-remove-choice = { $choice } saýlawyny aýyr
-
 matrix-remove-row = Setiri aýyr
 matrix-add-row = Setir goş
 matrix-remove-column = Sütüni aýyr
 matrix-add-column = Sütün goş
-
 subset-add-remove-points = Nokat goş/aýyr
 subset-toggle-points-intervals = Nokatlar bilen aralyklaryň arasynda çalyş
 subset-move-points = Nokatlary geçir
 subset-clear = Arassala
-
 orbital-add-row = Setir goş
 orbital-remove-row = Setiri aýyr
 orbital-add-box = Öýjük goş
@@ -92,13 +73,9 @@ orbital-remove-box = Öýjügi aýyr
 orbital-add-up-arrow = Ýokary ok goş
 orbital-add-down-arrow = Aşak ok goş
 orbital-remove-arrow = Oky aýyr
-
 orbital-row-label = { $row } setiriniň belgisi
-
 pretzel-answer = Jogap
-
 summary-statistics-caption = { $column } sütüniniň jemleýji statistikasy
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = matematiki aňlatmanyň deslapky görnüşi
 math-input-preview = Deslapky görnüş
 math-input-invalid-expression = Nädogry aňlatma:
 
-
 ## Document status
 
 viewer-initializing = Taýýarlanýar…
 
-
 ## Errors
 
 error-heading = Ýalňyşlyk
-
 error-found-at =
     { $span ->
         [line] { $startLine } setirde tapyldy.
        *[lines] { $startLine }–{ $endLine } setirlerde tapyldy.
     }
-
 document-contains-errors = Bu resminamada ýalňyşlyklar bar!
-
 diagnostic-heading-error = Ýalňyşlyk
 diagnostic-heading-warning = Duýduryş
 diagnostic-heading-information = Maglumat
 diagnostic-heading-hint = Maslahat
-
 accessibility-heading-level-1 = WCAG AA elýeterlilik bozulmasy
 accessibility-heading-level-2 = Elýeterlilik habary
-
 something-went-wrong = Bir zat nädogry gitdi.
-
 renderer-load-failed = şekillendirijini ýüklemek başartmady. Sahypany täzeläň.
-
 core-start-failed = Resminama görkezijisini işe girizmek başartmady. Sahypany täzeläň.

--- a/packages/i18n/locales/tk/content.ftl
+++ b/packages/i18n/locales/tk/content.ftl
@@ -31,15 +31,12 @@ color =
     .purple = benewşe
     .pink = gülgüne
     .brown = goňur
-
 line-width =
     .thick = ýogyn
     .thin = inçe
-
 line-style =
     .dashed = kesik-kesik
     .dotted = nokatly
-
 # Noun phrases: they stand in front of «nagyşly» and modify nothing.
 fill-style =
     .horizontal = keseligine çyzyk
@@ -48,7 +45,6 @@ fill-style =
     .backdiagonal = ters diagonal çyzyk
     .dots = nokat
     .diamonds = romb
-
 noun =
     .line = göni çyzyk
     .line-segment = kesim
@@ -68,7 +64,6 @@ noun =
     .diamond = romb
     .cross = haç
     .plus = plýus
-
 # Turkmen builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -76,11 +71,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] dogry { $numSides }-burçluk
     }
-
 # Turkmen has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -94,21 +87,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = boýalan
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } nagyşly { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } nagyşly { $color } { $filled } { $noun }
@@ -116,7 +105,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } nagyşly { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «gyraly» — "bordered" — carries the "with a border" sense in its own suffix,
 # so neither a preposition nor an article is wanted, and all four branches read
 # alike except for the connective English needs and Turkmen does not.
@@ -127,15 +115,12 @@ style-border-clause =
         [and-article] we { $border } gyraly
        *[with] { $border } gyraly
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } nagyşly { $color } boýag
        *[plain] { $color } boýag
     }
-
 style-unfilled = boýalmadyk
-
 # «fonda» is the locative of «fon» and says "on the background" by itself, so
 # nothing stands between the two colours.
 style-text =
@@ -143,21 +128,17 @@ style-text =
         [background] { $background } fonda { $color }
        *[plain] { $color }
     }
-
 style-background-none = ýok
-
 
 ## Boolean words
 
 boolean-true = dogry
 boolean-false = ýalňyş
 
-
 ## Answer buttons
 
 answer-submit-label = Barla
 answer-submit-label-no-correctness = Jogaby iber
-
 
 ## Sectional blocks
 
@@ -182,7 +163,6 @@ section-name =
     .solution = Çözgüt
     .task = Ýumuş
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -192,9 +172,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Maslahat
-
 
 ## Tables and figures
 
@@ -205,7 +183,6 @@ table-name =
         [unnumbered-title] Tablisa{ ". " }
        *[unnumbered] Tablisa
     }
-
 figure-name =
     { $parts ->
         [numbered] Surat { $enumeration }
@@ -214,22 +191,18 @@ figure-name =
        *[unnumbered] Surat
     }
 
-
 ## Paginator controls
 
 paginator-previous = Öňki
 paginator-next = Indiki
 paginator-page = Sahypa
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ýa-da
 piecewise-condition-if = eger
 piecewise-condition-otherwise = bolmasa
-
 
 ## Chemistry
 
@@ -352,7 +325,6 @@ element-name =
     .lv = Liwermoriý
     .ts = Tennessin
     .og = Oganeson
-
 element-anion-name =
     .h = Gidrid
     .c = Karbid
@@ -366,8 +338,6 @@ element-anion-name =
     .i = Ýodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Nädogry himiki belgi
 chemistry-invalid-ionic-compound = Nädogry ion birleşmesi

--- a/packages/i18n/locales/tlh/chrome.ftl
+++ b/packages/i18n/locales/tlh/chrome.ftl
@@ -44,23 +44,17 @@
 
 answer-checking = chovlu'taH…
 answer-submitting = ngeHlu'taH…
-
 answer-checking-status = jang chovlu'taH
 answer-submitting-status = jang ngeHlu'taH
-
 answer-correct = lugh
 answer-incorrect = lughbe'
-
 # «pol» is «keep, save»; «-ta'» marks it done on purpose.
 answer-response-saved = pollu'ta'
-
 # «pop» is «reward», which is what credit is.
 answer-percent-credit = { $percent }% pop
 answer-percent-correct = { $percent }% lugh
 answer-percent-short = { $percent } %
-
 max-credit-available = Suqlu'laHbogh pop: { $percent }%
-
 # No select. Klingon marks no number on a noun after a numeral, so one form of
 # «nID» serves every count, and «ratlh» (remain) puts its subject after it.
 # «nID» is canon as the verb «attempt, try» and there is no noun for an
@@ -71,38 +65,30 @@ attempts-remaining =
         [0] ratlh pagh nID
        *[other] ratlh { $count } nID
     }
-
 validation-correct = (lugh)
 validation-incorrect = (lughbe')
 validation-partially-correct = ('op lugh)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated; «-vaD» sits on it unchanged, which is what
 # `content.ftl`'s header means about Klingon suffixes having one shape each.
 answer-show-responses = { $answerId }vaD { $count } jang yI'ang
-
 
 ## Disclosure panels
 
 # «qeS» is «advice». `hint-title` in `content.ftl` takes «boQ» (aid) so that the
 # two headings stay apart.
 feedback-heading = qeS
-
 # «yuv» is «push», which is what a click is; «-meH» opens the purpose clause
 # that says what pushing is for.
 collapsible-click-to-open = (poSmoHmeH yIyuv)
 collapsible-click-to-close = (SoQmoHmeH yIyuv)
-
 # «tagh» is «begin» and «-lI'» marks it under way toward a known end.
 collapsible-initializing = taghlI'…
-
 # «bIng QIn» — «the message below» — is this file's own compound for a
 # footnote, from two canon words.
 footnote-show = bIng QIn yI'ang
 footnote-hide = bIng QIn yISo'
-
 description-more-information = De' latlh
-
 
 ## Controls
 
@@ -111,14 +97,11 @@ description-more-information = De' latlh
 # longer do either.
 slider-previous = vorgh
 slider-next = veb
-
 # «nItlh 'echlet» — «finger board» — is Okrand's own word for a computer
 # keyboard, from the `qepHom'a'` list of 2014 rather than from TKD.
 keyboard-open = nItlh 'echlet yIpoSmoH
 keyboard-close = nItlh 'echlet yISoQmoH
-
 choice-input-remove-choice = { $choice } yIteq
-
 # «wev» and «war» are Okrand's words for a row and a column of a table or
 # spreadsheet (`qepHom'a'` 2015), which is what a matrix is made of.
 matrix-remove-row = wev yIteq
@@ -141,11 +124,8 @@ orbital-remove-box = ngaSwI' yIteq
 orbital-add-up-arrow = Dung tIH yIchel
 orbital-add-down-arrow = bIng tIH yIchel
 orbital-remove-arrow = tIH yIteq
-
 orbital-row-label = { $row } wev pong
-
 pretzel-answer = jang
-
 
 ## Math input
 
@@ -154,16 +134,13 @@ pretzel-answer = jang
 # English: *preview* is a root, not a description.
 math-input-invalid-expression = mujbogh mu'tlhegh:
 
-
 ## Document status
 
 viewer-initializing = taghlI'…
 
-
 ## Errors
 
 error-heading = Qagh
-
 # «tu'lu'» is «one finds it», Klingon's way of saying *was found*; the locative
 # «-Daq» sits on «tlhegh» rather than on the line number, and the verb comes
 # last as it does in every Klingon sentence.
@@ -172,9 +149,7 @@ error-found-at =
         [line] { $startLine } tlheghDaq tu'lu'.
        *[lines] { $startLine }–{ $endLine } tlheghmeyDaq tu'lu'.
     }
-
 document-contains-errors = Qaghmey ngaS ghItlhvam!
-
 # «ghuHmoHwI'» — «that which warns» — is this file's own, from the TKD
 # «ghuHmoH» (warn). The two accessibility headings are left to English: nothing
 # published names accessibility, and WCAG AA is the standard's name and would
@@ -183,11 +158,8 @@ diagnostic-heading-error = Qagh
 diagnostic-heading-warning = ghuHmoHwI'
 diagnostic-heading-information = De'
 diagnostic-heading-hint = boQ
-
 something-went-wrong = qaS wanI' muj.
-
 # «'angwI'» is «that which shows», for the renderer; «HaSta» is a visual
 # display, and «chu'qa'» is «activate it again».
 renderer-load-failed = taghbe' 'angwI'. HaSta yIchu'qa'.
-
 core-start-failed = taghlaHbe' ghItlh 'angwI'. HaSta yIchu'qa'.

--- a/packages/i18n/locales/tlh/content.ftl
+++ b/packages/i18n/locales/tlh/content.ftl
@@ -163,20 +163,17 @@ color =
     .purple = Doq
     .pink = Doq
     .brown = Doq
-
 # «jeD» is «be thick, be dense» (KGT) and «lang» is «be thin, be narrow» (TKD)
 # — published verbs of quality, so «-bogh» welds onto them as onto any other.
 line-width =
     .thick = jeD
     .thin = lang
-
 # Both are verbs, so that «-bogh» can weld on: «pe'lu'» is «one cuts it», and
 # «nagHommey ngaS» is «it contains dots» — an object and its verb, which takes
 # the suffix on the verb exactly as a bare one does.
 line-style =
     .dashed = pe'lu'
     .dotted = nagHommey ngaS
-
 # Nouns, placed after the colour by `style-fill`. «yav» (ground) and «chal»
 # (sky) carry the horizontal/vertical contrast, and «nIH» (right) and «poS»
 # (left) which way a diagonal leans; all four are TKD entries, and the compounds
@@ -188,7 +185,6 @@ fill-style =
     .diagonal = nIH tlheghmey
     .backdiagonal = poS tlheghmey
     .dots = nagHommey
-
 # Fourteen of the eighteen, and all fourteen are Okrand's rather than this
 # file's — but they are not all Okrand's in the same way, so this table is where
 # the three classes in the header have to be read off word by word.
@@ -245,10 +241,8 @@ noun =
     .square = meyrI'
     .cross = me'cheD
     .plus = me'cheD
-
 # One answer for every noun; see the note on noun class in the header.
 noun-gender = neuter
-
 
 ## Style composition
 ##
@@ -269,16 +263,13 @@ style-stroke =
         [style] { $lineStyle }bogh
        *[color] { $color }bogh
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # «buy'» is «be full», the nearest canon verb to *filled*.
 style-filled-word = buy'
-
 # A pattern is a noun, so it joins the chain as «X ngaSbogh» — «which contains
 # X» — rather than as another quality verb.
 style-filled =
@@ -286,7 +277,6 @@ style-filled =
         [pattern] { $filled }bogh 'ej { $color }bogh 'ej { $pattern } ngaSbogh
        *[plain] { $filled }bogh 'ej { $color }bogh
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled }bogh 'ej { $color }bogh 'ej { $pattern } ngaSbogh { $noun }
@@ -294,7 +284,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled }bogh 'ej { $color }bogh 'ej { $pattern } ngaSbogh { $noun } { $nounTail }
        *[plain] { $filled }bogh 'ej { $color }bogh { $noun }
     }
-
 # «HeH» is «edge, border» and «je» is the noun conjunction, which follows what
 # it joins. Klingon has no article and «je» opens no clause, so all four
 # branches say the same thing — English's first-clause-against-further-clause
@@ -306,15 +295,12 @@ style-border-clause =
         [and-article] { $border } HeH je
        *[with] { $border } HeH je
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color }bogh { $pattern }
        *[plain] { $color }bogh
     }
-
 style-unfilled = buy'be'
-
 # «'em» is «the area behind», and «ghaj» is «have»: «{ $background }bogh 'em
 # ghajbogh» is «which has a background that is ⟨colour⟩», with the object in
 # front of its verb as Klingon puts it.
@@ -323,9 +309,7 @@ style-text =
         [background] { $color }bogh 'ej { $background }bogh 'em ghajbogh
        *[plain] { $color }bogh
     }
-
 style-background-none = pagh
-
 
 ## Boolean words
 
@@ -334,13 +318,11 @@ style-background-none = pagh
 boolean-true = teH
 boolean-false = teHbe'
 
-
 ## Answer buttons
 
 # «chov» is «evaluate», which is what checking work is; «ngeH» is «send».
 answer-submit-label = yIchov
 answer-submit-label-no-correctness = yIngeH
-
 
 ## Sectional blocks
 ##
@@ -357,7 +339,6 @@ section-name =
     .task = Qu'
     .objectives = ngoQmey
     .note = QIn
-
 # Klingon puts a number after what it counts, which is the order English uses
 # here too, so only the punctuation moves.
 section-title-prefix =
@@ -369,12 +350,10 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 # «boQ» is «assist, aid». `diagnostics.ftl` has no competing word for it, and
 # `feedback-heading` in `chrome.ftl` takes «qeS» (advice) so that the two stay
 # apart.
 hint-title = boQ
-
 
 ## Tables and figures
 ##
@@ -393,7 +372,6 @@ table-name =
        *[unnumbered] wa'chaw
     }
 
-
 ## Paginator controls
 
 # «veb» is «be next» (KGT) and «vorgh» is «be previous» (`qep'a'` 23); an
@@ -403,11 +381,9 @@ table-name =
 paginator-previous = vorgh
 paginator-next = veb
 paginator-page = tenwal
-
 # Klingon has no partitive «of». «Hoch» is «all», so the count of pages is named
 # as a whole beside the page being read rather than as a fraction of it.
 paginator-page-status = { $pageLabel } { $currentPage }, Hoch { $numPages }
-
 
 ## Piecewise functions
 
@@ -424,7 +400,6 @@ piecewise-condition-or = pagh
 piecewise-condition-if = qaSchugh
 piecewise-condition-otherwise = latlhDaq
 
-
 ## Chemistry
 ##
 ## The 118 element names, the 12 anion names and the two error messages are all
@@ -436,3 +411,4 @@ piecewise-condition-otherwise = latlhDaq
 ## own length, and the missing eighty-eight are exactly the coinage
 ## `locales/oj` refuses. Filling in the thirty is real work a corrector can do,
 ## and it is the largest single gap left in this catalog.
+

--- a/packages/i18n/locales/tn/chrome.ftl
+++ b/packages/i18n/locales/tn/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = E a tlhatlhoba...
 answer-submitting = E a romela...
-
 answer-checking-status = E tlhatlhoba karabo
 answer-submitting-status = E romela karabo
-
 answer-correct = E siame
 answer-incorrect = Ga e a siama
-
 answer-response-saved = Karabo e Bolokilwe
-
 answer-percent-credit = Matshwao { $percent }%
 answer-percent-correct = { $percent }% E siame
 answer-percent-short = { $percent } %
-
 max-credit-available = Matshwao a magolo a a leng teng: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ga go na teko e e setseng
         [one] teko e le { $count } e setse
        *[other] diteko tse { $count } di setse
     }
-
 validation-correct = (E siame)
 validation-incorrect = (Ga e a siama)
 validation-partially-correct = (E siame ka bontlhanngwe)
-
 answer-show-responses =
     { $count ->
         [one] Bontsha karabo e le { $count } ya { $answerId }
        *[other] Bontsha dikarabo tse { $count } tsa { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Kakgelo
-
 collapsible-click-to-open = (tobetsa go bula)
 collapsible-click-to-close = (tobetsa go tswala)
-
 collapsible-initializing = E a simolola...
-
 footnote-show = Bontsha tlhaloso ya kwa tlase
 footnote-hide = Fitlha tlhaloso ya kwa tlase
-
 description-more-information = tshedimosetso e nngwe
-
 
 ## Controls
 
 slider-previous = E e fetileng
 slider-next = E e latelang
-
 keyboard-open = Bula Keyboard
 keyboard-close = Tswala Keyboard
-
 choice-input-remove-choice = Ntsha { $choice }
-
 matrix-remove-row = Ntsha mola o o rapameng
 matrix-add-row = Oketsa mola o o rapameng
 matrix-remove-column = Ntsha mola o o emeng
 matrix-add-column = Oketsa mola o o emeng
-
 subset-add-remove-points = Oketsa/Ntsha dintlha
 subset-toggle-points-intervals = Fetola fa gare ga dintlha le dikgaoganyo
 subset-move-points = Sutisa Dintlha
 subset-clear = Phimola
-
 # A `box` here is one orbital, drawn as a square: «lebokoso».
 orbital-add-row = Oketsa Mola
 orbital-remove-row = Ntsha Mola
@@ -95,13 +76,9 @@ orbital-remove-box = Ntsha Lebokoso
 orbital-add-up-arrow = Oketsa Sekai se se Lebileng Godimo
 orbital-add-down-arrow = Oketsa Sekai se se Lebileng Tlase
 orbital-remove-arrow = Ntsha Sekai
-
 orbital-row-label = Leina la mola { $row }
-
 pretzel-answer = Karabo
-
 summary-statistics-caption = Tshobokanyo ya dipalopalo tsa { $column }
-
 
 ## Math input
 
@@ -109,34 +86,25 @@ math-input-preview-region = ponelopele ya polelo ya dipalo
 math-input-preview = Ponelopele
 math-input-invalid-expression = Polelo ga e a siama:
 
-
 ## Document status
 
 viewer-initializing = E a simolola...
 
-
 ## Errors
 
 error-heading = Phoso
-
 error-found-at =
     { $span ->
         [line] E fitlhetswe mo moleng wa { $startLine }.
        *[lines] E fitlhetswe mo melaneng ya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Lokwalo lo lo na le diphoso!
-
 diagnostic-heading-error = Phoso
 diagnostic-heading-warning = Tlhagiso
 diagnostic-heading-information = Tshedimosetso
 diagnostic-heading-hint = Kgakololo
-
 accessibility-heading-level-1 = Tlolo ya WCAG AA ya Tsenogo
 accessibility-heading-level-2 = Tlhagiso ya tsenogo
-
 something-went-wrong = Go na le se se sa tsamayang sentle.
-
 renderer-load-failed = mmontshi o le mongwe ga o a kgona go tsena. Tsweetswee ntshafatsa tsebe.
-
 core-start-failed = Mmontshi wa lokwalo ga a a kgona go simolola. Tsweetswee ntshafatsa tsebe.

--- a/packages/i18n/locales/tn/content.ftl
+++ b/packages/i18n/locales/tn/content.ftl
@@ -83,7 +83,6 @@ color =
     .purple = phepolo
     .pink = pinki
     .brown = borokwa
-
 line-width =
     .thick =
         { $gender ->
@@ -99,14 +98,12 @@ line-width =
             [c7] sesesane
            *[c9] sesane
         }
-
 # Written as invariable «ka …» phrases rather than as adjectives, so that they
 # agree with nothing and can close the description. `style-stroke` puts them
 # last for that reason.
 line-style =
     .dashed = ka dikgaotso
     .dotted = ka dintlha
-
 fill-style =
     .horizontal = mela e e rapameng
     .vertical = mela e e emeng
@@ -114,7 +111,6 @@ fill-style =
     .backdiagonal = mela e e sekameng morago
     .dots = dintlha
     .diamonds = ditaemane
-
 noun =
     .line = mola
     .line-segment = karolo ya mola
@@ -134,7 +130,6 @@ noun =
     .diamond = taemane
     .cross = sefapaano
     .plus = letshwao la go oketsa
-
 # The side count goes in the tail, behind the adjectives, because «e e nang le
 # matlhakore a le 5» is a relative clause and Setswana closes a noun phrase
 # with one rather than opening one.
@@ -143,7 +138,6 @@ noun-regular-polygon =
         [tail] e e nang le matlhakore a le { $numSides }
        *[head] polikone e e lekalekanang
     }
-
 noun-gender =
     { $noun ->
         [line] c3
@@ -159,7 +153,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -172,13 +165,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] o o tletseng
@@ -186,13 +177,11 @@ style-filled-word =
         [c7] se se tletseng
        *[c9] e e tletseng
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ka { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ka { $pattern }
@@ -200,7 +189,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ka { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «moedi» is class 3 and leads its own adjectives, so the border's words agree
 # with it and not with the shape it surrounds. Setswana has no article, so the
 # two `-article` branches read like the two without, and the complement is
@@ -213,35 +201,28 @@ style-border-clause =
         [and-article] ka moedi { $border }
        *[with] ka moedi { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = e e sa tlalang
-
 style-text =
     { $parts ->
         [background] { $color } mo godimo ga bokamorago { $background }
        *[plain] { $color }
     }
-
 style-background-none = ga go na sepe
-
 
 ## Boolean words
 
 boolean-true = boammaaruri
 boolean-false = maaka
 
-
 ## Answer buttons
 
 answer-submit-label = Tlhatlhoba Tiro
 answer-submit-label-no-correctness = Romela Karabo
-
 
 ## Sectional blocks
 
@@ -266,7 +247,6 @@ section-name =
     .solution = Tharabololo
     .task = Tiro
     .theorem = Thiorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -276,9 +256,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Kgakololo
-
 
 ## Tables and figures
 
@@ -289,7 +267,6 @@ table-name =
         [unnumbered-title] Tafole{ ": " }
        *[unnumbered] Tafole
     }
-
 figure-name =
     { $parts ->
         [numbered] Setshwantsho { $enumeration }
@@ -298,22 +275,18 @@ figure-name =
        *[unnumbered] Setshwantsho
     }
 
-
 ## Paginator controls
 
 paginator-previous = E e fetileng
 paginator-next = E e latelang
 paginator-page = Tsebe
-
 paginator-page-status = { $pageLabel } { $currentPage } mo go { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kgotsa
 piecewise-condition-if = fa
 piecewise-condition-otherwise = fa go sa nna jalo
-
 
 ## Chemistry
 
@@ -323,6 +296,5 @@ piecewise-condition-otherwise = fa go sa nna jalo
 # words meets them in English already; the seed has no settled Setswana list to
 # reproduce. A speaker adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Letshwao la Khemisi le le sa Siamang
 chemistry-invalid-ionic-compound = Motswako wa Ione o o sa Siamang

--- a/packages/i18n/locales/to/chrome.ftl
+++ b/packages/i18n/locales/to/chrome.ftl
@@ -25,21 +25,15 @@
 
 answer-checking = ʻOku sivi…
 answer-submitting = ʻOku ʻave…
-
 answer-checking-status = ʻOku sivi ʻa e tali
 answer-submitting-status = ʻOku ʻave ʻa e tali
-
 answer-correct = Totonu
 answer-incorrect = Hala
-
 answer-response-saved = Kuo tauhi ʻa e tali
-
 answer-percent-credit = { $percent }% ʻo e mataʻitohi
 answer-percent-correct = { $percent }% totonu
 answer-percent-short = { $percent } %
-
 max-credit-available = Mataʻitohi lahi taha ʻe lava ʻo maʻu: { $percent }%
-
 # No select: «feinga» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -47,51 +41,38 @@ attempts-remaining =
         [0] ʻoku ʻikai toe ʻi ai ha feinga
        *[other] ʻoku toe ʻi ai ʻa e feinga ʻe { $count }
     }
-
 validation-correct = (Totonu)
 validation-incorrect = (Hala)
 validation-partially-correct = (Totonu fakakonga)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Fakahā ʻa e tali ʻe { $count } ki he { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Fakamatala
-
 collapsible-click-to-open = (lomiʻi ke fakaava)
 collapsible-click-to-close = (lomiʻi ke tāpuni)
-
 collapsible-initializing = ʻOku kamata…
-
 footnote-show = Fakahā ʻa e footnote
 footnote-hide = Fufū ʻa e footnote
-
 description-more-information = fakamatala lahi ange
-
 
 ## Controls
 
 slider-previous = Kimuʻa
 slider-next = Hoko
-
 keyboard-open = Fakaava ʻa e kīpoti
 keyboard-close = Tāpuni ʻa e kīpoti
-
 choice-input-remove-choice = Toʻo ʻa e { $choice }
-
 matrix-remove-row = Toʻo ʻa e laine
 matrix-add-row = Tānaki ha laine
 matrix-remove-column = Toʻo ʻa e kolomu
 matrix-add-column = Tānaki ha kolomu
-
 subset-add-remove-points = Tānaki/Toʻo ʻa e ngaahi poini
 subset-toggle-points-intervals = Liliu ʻa e ngaahi poini mo e vahaʻa
 subset-move-points = Hiki ʻa e ngaahi poini
 subset-clear = Fakamaʻa
-
 orbital-add-row = Tānaki ha laine
 orbital-remove-row = Toʻo ʻa e laine
 orbital-add-box = Tānaki ha puha
@@ -99,13 +80,9 @@ orbital-remove-box = Toʻo ʻa e puha
 orbital-add-up-arrow = Tānaki ha ngahau ki ʻolunga
 orbital-add-down-arrow = Tānaki ha ngahau ki lalo
 orbital-remove-arrow = Toʻo ʻa e ngahau
-
 orbital-row-label = Fakaʻilonga ki he laine { $row }
-
 pretzel-answer = Tali
-
 summary-statistics-caption = Fakanounou fakafuainoa ʻo e { $column }
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = fakahā muʻa ʻo e fakamatala fika
 math-input-preview = Fakahā muʻa
 math-input-invalid-expression = Fakamatala fika taʻetotonu:
 
-
 ## Document status
 
 viewer-initializing = ʻOku kamata…
 
-
 ## Errors
 
 error-heading = Hala
-
 error-found-at =
     { $span ->
         [line] Naʻe maʻu ʻi he laine { $startLine }.
        *[lines] Naʻe maʻu ʻi he ngaahi laine { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = ʻOku ʻi ai ha hala ʻi he pepa ni!
-
 diagnostic-heading-error = Hala
 diagnostic-heading-warning = Fakatokanga
 diagnostic-heading-information = Fakamatala
 diagnostic-heading-hint = Fakahinohino
-
 accessibility-heading-level-1 = Maumauʻi ʻo e aʻusia WCAG AA
 accessibility-heading-level-2 = Fakatokanga fekauʻaki mo e aʻusia
-
 something-went-wrong = Naʻe ʻi ai ha meʻa naʻe hala.
-
 renderer-load-failed = naʻe ʻikai lava ʻo hū mai ha renderer. Kātaki ʻo toe fakaake ʻa e peesi.
-
 core-start-failed = Naʻe ʻikai lava ʻo kamata ʻa e mata sio ki he pepa. Kātaki ʻo toe fakaake ʻa e peesi.

--- a/packages/i18n/locales/to/content.ftl
+++ b/packages/i18n/locales/to/content.ftl
@@ -45,15 +45,12 @@ color =
     .purple = vaioleti
     .pink = pingi
     .brown = melo
-
 line-width =
     .thick = matolu
     .thin = manifinifi
-
 line-style =
     .dashed = motumotu
     .dotted = tuʻitongi
-
 # Noun phrases. Tongan marks no plural on the noun, so «laine» is the word for
 # one line and for many alike.
 fill-style =
@@ -63,7 +60,6 @@ fill-style =
     .backdiagonal = laine fakahekeheke fakafoki
     .dots = tongi
     .diamonds = taimane
-
 noun =
     .line = laine
     .line-segment = konga laine
@@ -83,7 +79,6 @@ noun =
     .diamond = taimane
     .cross = kolosi
     .plus = tānaki
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -91,10 +86,8 @@ noun-regular-polygon =
         [tail] ʻoku tapa { $numSides }
        *[head] polikoni tatau
     }
-
 # One answer for every noun: Tongan has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -108,22 +101,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = fonu
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } mo e { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } mo e { $pattern }
@@ -131,7 +120,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } mo e { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Tongan's article is «ha» for an indefinite and «e» for a definite, and neither
 # is what English's "a" is doing here, so all four branches read alike but for
 # the connective: «mo e» opens the first clause and «pea mo e» a further one.
@@ -142,35 +130,28 @@ style-border-clause =
         [and-article] pea mo e kapa { $border }
        *[with] mo e kapa { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = taʻefonu
-
 style-text =
     { $parts ->
         [background] { $color } mo e tuʻunga { $background }
        *[plain] { $color }
     }
-
 style-background-none = ʻikai ha taha
-
 
 ## Boolean words
 
 boolean-true = moʻoni
 boolean-false = loi
 
-
 ## Answer buttons
 
 answer-submit-label = Sivi ʻa e ngāue
 answer-submit-label-no-correctness = ʻAve ʻa e tali
-
 
 ## Sectional blocks
 
@@ -197,7 +178,6 @@ section-name =
     .solution = Fakalelei
     .task = Ngāue
     .theorem = Tioleme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -207,9 +187,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Fakahinohino
-
 
 ## Tables and figures
 
@@ -220,7 +198,6 @@ table-name =
         [unnumbered-title] Tēpile{ ": " }
        *[unnumbered] Tēpile
     }
-
 figure-name =
     { $parts ->
         [numbered] Fakatātā { $enumeration }
@@ -229,22 +206,18 @@ figure-name =
        *[unnumbered] Fakatātā
     }
 
-
 ## Paginator controls
 
 paginator-previous = Kimuʻa
 paginator-next = Hoko
 paginator-page = Peesi
-
 paginator-page-status = { $pageLabel } { $currentPage } ʻo e { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = pe
 piecewise-condition-if = kapau
 piecewise-condition-otherwise = kapau ʻoku ʻikai
-
 
 ## Chemistry
 ##
@@ -256,6 +229,5 @@ piecewise-condition-otherwise = kapau ʻoku ʻikai
 ## not a table.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Fakaʻilonga kemikale taʻetotonu
 chemistry-invalid-ionic-compound = Fefiofi ʻaioniki taʻetotonu

--- a/packages/i18n/locales/tpi/chrome.ftl
+++ b/packages/i18n/locales/tpi/chrome.ftl
@@ -27,21 +27,15 @@
 
 answer-checking = Skelim i stap…
 answer-submitting = Salim i stap…
-
 answer-checking-status = Skelim bekim
 answer-submitting-status = Salim bekim
-
 answer-correct = Stret
 answer-incorrect = I no stret
-
 answer-response-saved = Bekim i stap sef
-
 answer-percent-credit = { $percent }% mak
 answer-percent-correct = { $percent }% stret
 answer-percent-short = { $percent } %
-
 max-credit-available = Bikpela mak yu inap kisim: { $percent }%
-
 # No select: «traim» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -49,51 +43,38 @@ attempts-remaining =
         [0] i no gat traim i stap yet
        *[other] { $count } traim i stap yet
     }
-
 validation-correct = (Stret)
 validation-incorrect = (I no stret)
 validation-partially-correct = (Stret liklik)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Soim { $count } bekim bilong { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Toktok bek
-
 collapsible-click-to-open = (klikim bilong opim)
 collapsible-click-to-close = (klikim bilong pasim)
-
 collapsible-initializing = Kirapim i stap…
-
 footnote-show = Soim footnote
 footnote-hide = Haitim footnote
-
 description-more-information = moa tok save
-
 
 ## Controls
 
 slider-previous = Bipo
 slider-next = Neks
-
 keyboard-open = Opim kibot
 keyboard-close = Pasim kibot
-
 choice-input-remove-choice = Rausim { $choice }
-
 matrix-remove-row = Rausim lain
 matrix-add-row = Putim wanpela lain
 matrix-remove-column = Rausim kolam
 matrix-add-column = Putim wanpela kolam
-
 subset-add-remove-points = Putim/Rausim ol poin
 subset-toggle-points-intervals = Senisim ol poin na ol namel
 subset-move-points = Muvim ol poin
 subset-clear = Klinim
-
 orbital-add-row = Putim wanpela lain
 orbital-remove-row = Rausim lain
 orbital-add-box = Putim wanpela bokis
@@ -101,13 +82,9 @@ orbital-remove-box = Rausim bokis
 orbital-add-up-arrow = Putim wanpela spia i go antap
 orbital-add-down-arrow = Putim wanpela spia i go daun
 orbital-remove-arrow = Rausim spia
-
 orbital-row-label = Nem bilong lain { $row }
-
 pretzel-answer = Bekim
-
 summary-statistics-caption = Sotpela ripot namba bilong { $column }
-
 
 ## Math input
 
@@ -115,34 +92,25 @@ math-input-preview-region = lukluk pastaim long tok matematik
 math-input-preview = Lukluk pastaim
 math-input-invalid-expression = Tok i no stret:
 
-
 ## Document status
 
 viewer-initializing = Kirapim i stap…
 
-
 ## Errors
 
 error-heading = Asua
-
 error-found-at =
     { $span ->
         [line] Painim long lain { $startLine }.
        *[lines] Painim long ol lain { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dispela dokumen i gat asua!
-
 diagnostic-heading-error = Asua
 diagnostic-heading-warning = Tok lukaut
 diagnostic-heading-information = Tok save
 diagnostic-heading-hint = Tok helpim
-
 accessibility-heading-level-1 = Brukim lo bilong akses WCAG AA
 accessibility-heading-level-2 = Tok lukaut long akses
-
 something-went-wrong = Wanpela samting i no orait.
-
 renderer-load-failed = wanpela renderer i no lodim. Plis lodim gen dispela pes.
-
 core-start-failed = Luk bilong dokumen i no inap kirap. Plis lodim gen dispela pes.

--- a/packages/i18n/locales/tpi/content.ftl
+++ b/packages/i18n/locales/tpi/content.ftl
@@ -52,15 +52,12 @@ color =
     .purple = purpelpela
     .pink = pingpela
     .brown = braunpela
-
 line-width =
     .thick = patpela
     .thin = tinpela
-
 line-style =
     .dashed = brukbruk
     .dotted = tikitiki
-
 # Noun phrases. Tok Pisin marks no plural on the noun, so «lain» is the word for
 # one line and for many alike; «ol» before it is the plural and a description
 # does not carry it.
@@ -71,7 +68,6 @@ fill-style =
     .backdiagonal = ol lain i go krungut long narapela sait
     .dots = ol tiki
     .diamonds = ol daimon
-
 noun =
     .line = lain
     .line-segment = hap lain
@@ -91,7 +87,6 @@ noun =
     .diamond = daimon
     .cross = kruse
     .plus = plas
-
 # The side count follows the noun as a complement, because «-pela» adjectives
 # must sit directly in front of it and a counted phrase in front of them would
 # read as a comment on the sides.
@@ -100,10 +95,8 @@ noun-regular-polygon =
         [tail] i gat { $numSides } sait wankain
        *[head] poligon
     }
-
 # One answer for every noun: Tok Pisin has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -117,21 +110,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = pulapela
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } wantaim { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } wantaim { $pattern }
@@ -139,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wantaim { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # Tok Pisin has no article, so the two `-article` branches say what the other
 # two say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «wantaim» against «na».
@@ -150,35 +138,28 @@ style-border-clause =
         [and-article] na { $border } arere
        *[with] wantaim { $border } arere
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = i no pulap
-
 style-text =
     { $parts ->
         [background] { $color } wantaim { $background } baksait
        *[plain] { $color }
     }
-
 style-background-none = i no gat
-
 
 ## Boolean words
 
 boolean-true = tru
 boolean-false = giaman
 
-
 ## Answer buttons
 
 answer-submit-label = Skelim wok
 answer-submit-label-no-correctness = Salim bekim
-
 
 ## Sectional blocks
 
@@ -206,7 +187,6 @@ section-name =
     .solution = Rot bilong bekim
     .task = Wok
     .theorem = Tiorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -216,9 +196,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Tok helpim
-
 
 ## Tables and figures
 
@@ -229,7 +207,6 @@ table-name =
         [unnumbered-title] Tebol{ ": " }
        *[unnumbered] Tebol
     }
-
 figure-name =
     { $parts ->
         [numbered] Piksa { $enumeration }
@@ -238,22 +215,18 @@ figure-name =
        *[unnumbered] Piksa
     }
 
-
 ## Paginator controls
 
 paginator-previous = Bipo
 paginator-next = Neks
 paginator-page = Pes
-
 paginator-page-status = { $pageLabel } { $currentPage } bilong { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = sapos
 piecewise-condition-otherwise = sapos nogat
-
 
 ## Chemistry
 ##
@@ -265,6 +238,5 @@ piecewise-condition-otherwise = sapos nogat
 ## than the whole 118, are where a speaker should start.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Simbol kemikol i no stret
 chemistry-invalid-ionic-compound = Kompaun aionik i no stret

--- a/packages/i18n/locales/tr/chrome.ftl
+++ b/packages/i18n/locales/tr/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Denetleniyor...
 answer-submitting = Gönderiliyor...
-
 answer-checking-status = Yanıt denetleniyor
 answer-submitting-status = Yanıt gönderiliyor
-
 answer-correct = Doğru
 answer-incorrect = Yanlış
-
 answer-response-saved = Yanıt kaydedildi
-
 answer-percent-credit = %{ $percent } puan
 answer-percent-correct = %{ $percent } doğru
 answer-percent-short = %{ $percent }
-
 max-credit-available = Alınabilecek en yüksek puan: %{ $percent }
-
 attempts-remaining =
     { $count ->
         [0] deneme hakkı kalmadı
        *[other] { $count } deneme hakkı kaldı
     }
-
 validation-correct = (Doğru)
 validation-incorrect = (Yanlış)
 validation-partially-correct = (Kısmen doğru)
-
 answer-show-responses = { $answerId } için { $count } yanıtı göster
-
 
 ## Disclosure panels
 
 feedback-heading = Geri bildirim
-
 collapsible-click-to-open = (açmak için tıklayın)
 collapsible-click-to-close = (kapatmak için tıklayın)
-
 collapsible-initializing = Hazırlanıyor...
-
 footnote-show = Dipnotu göster
 footnote-hide = Dipnotu gizle
-
 description-more-information = daha fazla bilgi
-
 
 ## Controls
 
 slider-previous = Önceki
 slider-next = Sonraki
-
 keyboard-open = Klavyeyi aç
 keyboard-close = Klavyeyi kapat
-
 choice-input-remove-choice = { $choice } sil
-
 matrix-remove-row = Satır sil
 matrix-add-row = Satır ekle
 matrix-remove-column = Sütun sil
 matrix-add-column = Sütun ekle
-
 subset-add-remove-points = Nokta ekle/sil
 subset-toggle-points-intervals = Noktalar ve aralıklar arasında geçiş yap
 subset-move-points = Noktaları taşı
 subset-clear = Temizle
-
 # A `box` here is one orbital, drawn as a square: kutu.
 orbital-add-row = Satır ekle
 orbital-remove-row = Satır sil
@@ -91,13 +72,9 @@ orbital-remove-box = Kutu sil
 orbital-add-up-arrow = Yukarı ok ekle
 orbital-add-down-arrow = Aşağı ok ekle
 orbital-remove-arrow = Ok sil
-
 orbital-row-label = { $row }. satırın etiketi
-
 pretzel-answer = Yanıt
-
 summary-statistics-caption = { $column } için betimsel istatistikler
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = matematiksel ifade önizlemesi
 math-input-preview = Önizleme
 math-input-invalid-expression = Geçersiz ifade:
 
-
 ## Document status
 
 viewer-initializing = Hazırlanıyor...
 
-
 ## Errors
 
 error-heading = Hata
-
 error-found-at =
     { $span ->
         [line] { $startLine }. satırda bulundu.
        *[lines] { $startLine }–{ $endLine }. satırlarda bulundu.
     }
-
 document-contains-errors = Bu belge hatalar içeriyor!
-
 diagnostic-heading-error = Hata
 diagnostic-heading-warning = Uyarı
 diagnostic-heading-information = Bilgi
 diagnostic-heading-hint = İpucu
-
 accessibility-heading-level-1 = WCAG AA erişilebilirlik ihlali
 accessibility-heading-level-2 = Erişilebilirlik uyarısı
-
 something-went-wrong = Bir şeyler ters gitti.
-
 renderer-load-failed = bir işleyici bileşeni yüklenemedi. Lütfen sayfayı yeniden yükleyin.
-
 core-start-failed = Belge görüntüleyici başlatılamadı. Lütfen sayfayı yeniden yükleyin.

--- a/packages/i18n/locales/tr/content.ftl
+++ b/packages/i18n/locales/tr/content.ftl
@@ -30,15 +30,12 @@ color =
     .purple = mor
     .pink = pembe
     .brown = kahverengi
-
 line-width =
     .thick = kalın
     .thin = ince
-
 line-style =
     .dashed = kesikli
     .dotted = noktalı
-
 # Noun phrases: they precede `desenli` and modify nothing.
 fill-style =
     .horizontal = yatay çizgi
@@ -47,7 +44,6 @@ fill-style =
     .backdiagonal = ters çapraz çizgi
     .dots = nokta
     .diamonds = baklava dilimi
-
 noun =
     .line = doğru
     .line-segment = doğru parçası
@@ -67,7 +63,6 @@ noun =
     .diamond = eşkenar dörtgen
     .cross = çarpı
     .plus = artı
-
 # Turkish builds the word from the side count itself — düzgün beşgen — so the
 # whole thing is one head and there is no tail.
 noun-regular-polygon =
@@ -75,11 +70,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] düzgün { $numSides }-gen
     }
-
 # Turkish has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -93,21 +86,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = dolgulu
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } desenli { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } desenli { $color } { $filled } { $noun }
@@ -115,7 +104,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } desenli { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # `kenarlıklı` carries the "with a border" sense in its own suffix, so no
 # preposition and no article is needed — which makes all four branches the same
 # except for the connective English needs and Turkish does not.
@@ -126,35 +114,28 @@ style-border-clause =
         [and-article] ve { $border } kenarlıklı
        *[with] { $border } kenarlıklı
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = dolgusuz
-
 style-text =
     { $parts ->
         [background] { $background } zemin üzerinde { $color }
        *[plain] { $color }
     }
-
 style-background-none = yok
-
 
 ## Boolean words
 
 boolean-true = doğru
 boolean-false = yanlış
 
-
 ## Answer buttons
 
 answer-submit-label = Kontrol et
 answer-submit-label-no-correctness = Yanıtı gönder
-
 
 ## Sectional blocks
 
@@ -179,7 +160,6 @@ section-name =
     .solution = Çözüm
     .task = Görev
     .theorem = Teorem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -189,9 +169,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = İpucu
-
 
 ## Tables and figures
 
@@ -202,7 +180,6 @@ table-name =
         [unnumbered-title] Tablo{ ": " }
        *[unnumbered] Tablo
     }
-
 figure-name =
     { $parts ->
         [numbered] Şekil { $enumeration }
@@ -211,22 +188,18 @@ figure-name =
        *[unnumbered] Şekil
     }
 
-
 ## Paginator controls
 
 paginator-previous = Önceki
 paginator-next = Sonraki
 paginator-page = Sayfa
-
 paginator-page-status = { $numPages } { $pageLabel } içinden { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = veya
 piecewise-condition-if = eğer
 piecewise-condition-otherwise = aksi halde
-
 
 ## Chemistry
 
@@ -349,7 +322,6 @@ element-name =
     .lv = Livermoryum
     .ts = Tennessin
     .og = Oganesson
-
 element-anion-name =
     .h = Hidrür
     .c = Karbür
@@ -363,8 +335,6 @@ element-anion-name =
     .i = İyodür
     .at = Astatür
     .ts = Tennessür
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Geçersiz kimyasal sembol
 chemistry-invalid-ionic-compound = Geçersiz iyonik bileşik

--- a/packages/i18n/locales/ts/chrome.ftl
+++ b/packages/i18n/locales/ts/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Ku kambeliwa…
 answer-submitting = Ku rhumeriwa…
-
 answer-checking-status = Nhlamulo ya kambeliwa
 answer-submitting-status = Nhlamulo ya rhumeriwa
-
 answer-correct = Swi lulamile
 answer-incorrect = A swi lulamanga
-
 answer-response-saved = Nhlamulo yi Hlayisiwile
-
 answer-percent-credit = { $percent }% wa Tinhlayo
 answer-percent-correct = { $percent }% swi Lulamile
 answer-percent-short = { $percent } %
-
 max-credit-available = Tinhlayo letikulu leti kumekaka: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] a ku na ku ringeta loku saleke
         [one] ku sale ku ringeta ka { $count }
        *[other] ku sale ku ringeta ka { $count }
     }
-
 validation-correct = (Swi lulamile)
 validation-incorrect = (A swi lulamanga)
 validation-partially-correct = (Swi lulamile hi xiphemu)
-
 answer-show-responses =
     { $count ->
         [one] Kombisa nhlamulo { $count } eka { $answerId }
        *[other] Kombisa tinhlamulo { $count } eka { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Nhlamulo ya Mudyondzisi
-
 collapsible-click-to-open = (tshikilela ku pfula)
 collapsible-click-to-close = (tshikilela ku pfala)
-
 collapsible-initializing = Ku sungula…
-
 footnote-show = Kombisa xitsundzuxo xa le hansi
 footnote-hide = Tumbeta xitsundzuxo xa le hansi
-
 description-more-information = vuxokoxoko lebyin'wana
-
 
 ## Controls
 
 slider-previous = Leswi hundzeke
 slider-next = Leswi landzelaka
-
 keyboard-open = Pfula Khibodo
 keyboard-close = Pfala Khibodo
-
 choice-input-remove-choice = Susa { $choice }
-
 matrix-remove-row = Susa ntila
 matrix-add-row = Engetela ntila
 matrix-remove-column = Susa khumbi
 matrix-add-column = Engetela khumbi
-
 subset-add-remove-points = Engetela/Susa tipoyinti
 subset-toggle-points-intervals = Cinca tipoyinti ni swikhati
 subset-move-points = Susumeta Tipoyinti
 subset-clear = Sula
-
 orbital-add-row = Engetela Ntila
 orbital-remove-row = Susa Ntila
 orbital-add-box = Engetela Bokisi
@@ -86,13 +67,9 @@ orbital-remove-box = Susa Bokisi
 orbital-add-up-arrow = Engetela Nseve wa le Henhla
 orbital-add-down-arrow = Engetela Nseve wa le Hansi
 orbital-remove-arrow = Susa Nseve
-
 orbital-row-label = Vito ra ntila { $row }
-
 pretzel-answer = Nhlamulo
-
 summary-statistics-caption = Nkatsakanyo wa tinhlayo ta { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = ku languta ka xivulwa xa tinhlayo
 math-input-preview = Ku languta
 math-input-invalid-expression = Xivulwa lexi hoxeke:
 
-
 ## Document status
 
 viewer-initializing = Ku sungula…
 
-
 ## Errors
 
 error-heading = Xihoxo
-
 error-found-at =
     { $span ->
         [line] Xi kumeke eka layini { $startLine }.
        *[lines] Xi kumeke eka tilayini { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tsalwa leri ri na swihoxo!
-
 diagnostic-heading-error = Xihoxo
 diagnostic-heading-warning = Xilemukiso
 diagnostic-heading-information = Vuxokoxoko
 diagnostic-heading-hint = Xiletelo
-
 accessibility-heading-level-1 = Ku Tluriwa ka WCAG AA ka Ku Fikeleleka
 accessibility-heading-level-2 = Xilemukiso xa ku fikeleleka
-
 something-went-wrong = Ku na leswi nga fambangiki kahle.
-
 renderer-load-failed = xikombisi a xi kotanga ku layicha. Hi kombela u layicha tluka nakambe.
-
 core-start-failed = Xikombisi xa tsalwa a xi kotanga ku sungula. Hi kombela u layicha tluka nakambe.

--- a/packages/i18n/locales/ts/content.ftl
+++ b/packages/i18n/locales/ts/content.ftl
@@ -60,7 +60,6 @@ color =
     .purple = phepuli
     .pink = phinki
     .brown = ntsvuku wa misava
-
 # The two true adjectives. With `style-filled-word` below, these are the only
 # places in this file where a class concord moves.
 line-width =
@@ -76,13 +75,11 @@ line-width =
             [c7] lexitsongo
            *[c9] leyitsongo
         }
-
 # Written as an invariable «hi …» phrase, so that it agrees with nothing and
 # can close the phrase. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = hi swiphemu
     .dotted = hi swikoloto
-
 fill-style =
     .horizontal = mintila yo etlela
     .vertical = mintila yo yima
@@ -90,7 +87,6 @@ fill-style =
     .backdiagonal = mintila yo rhembelela hi ku hundzuluxa
     .dots = swikoloto
     .diamonds = madayimani
-
 noun =
     .line = ntila
     .line-segment = xiphemu xa ntila
@@ -110,7 +106,6 @@ noun =
     .diamond = dayimani
     .cross = xihambano
     .plus = xikombiso xo hlanganisa
-
 # The side count is a possessive complement and closes the noun phrase behind
 # the describing words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -118,7 +113,6 @@ noun-regular-polygon =
         [tail] xa matlhelo ya { $numSides }
        *[head] xivumbeko lexi ringanaka
     }
-
 # The noun class. `c9` is the default and the class of every loanword,
 # including a word an author supplies.
 noun-gender =
@@ -142,7 +136,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «hi …» phrase and closes the description, so it moves
@@ -157,26 +150,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] lowu tateriweke
         [c7] lexi tateriweke
        *[c9] leyi tateriweke
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } hi { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } hi { $pattern }
@@ -184,7 +173,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } hi { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «ndzilakano» is class 3 and leads its own describing words, so the border's
 # words agree with it rather than with the shape it surrounds. Xitsonga has no
 # article and joins this clause with the invariable «ni», so all four branches
@@ -196,35 +184,28 @@ style-border-clause =
         [and-article] ni ndzilakano { $border }
        *[with] ni ndzilakano { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = a swi tateriwanga
-
 style-text =
     { $parts ->
         [background] { $color } ehenhla ka xitshuriwa { $background }
        *[plain] { $color }
     }
-
 style-background-none = a ku na nchumu
-
 
 ## Boolean words
 
 boolean-true = ntiyiso
 boolean-false = mavunwa
 
-
 ## Answer buttons
 
 answer-submit-label = Kambela Ntirho
 answer-submit-label-no-correctness = Rhumela Nhlamulo
-
 
 ## Sectional blocks
 
@@ -249,7 +230,6 @@ section-name =
     .solution = Ntlhantlho
     .task = Ntirho
     .theorem = Thiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -259,9 +239,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Xiletelo
-
 
 ## Tables and figures
 
@@ -272,7 +250,6 @@ table-name =
         [unnumbered-title] Tafula{ ": " }
        *[unnumbered] Tafula
     }
-
 figure-name =
     { $parts ->
         [numbered] Xifaniso { $enumeration }
@@ -281,24 +258,18 @@ figure-name =
        *[unnumbered] Xifaniso
     }
 
-
 ## Paginator controls
 
 paginator-previous = Leswi hundzeke
 paginator-next = Leswi landzelaka
 paginator-page = Tluka
-
 paginator-page-status = { $pageLabel } { $currentPage } eka { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kumbe
-
 piecewise-condition-if = loko
-
 piecewise-condition-otherwise = handle ka sweswo
-
 
 ## Chemistry
 ##
@@ -312,6 +283,5 @@ piecewise-condition-otherwise = handle ka sweswo
 ## language.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Xikombiso xa Khemikhali lexi Hoxeke
 chemistry-invalid-ionic-compound = Nhlanganiso wa Ayoni lowu Hoxeke

--- a/packages/i18n/locales/tt/chrome.ftl
+++ b/packages/i18n/locales/tt/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Тикшерелә…
 answer-submitting = Җибәрелә…
-
 answer-checking-status = Җавап тикшерелә
 answer-submitting-status = Җавап җибәрелә
-
 answer-correct = Дөрес
 answer-incorrect = Ялгыш
-
 answer-response-saved = Җавап сакланды
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% дөрес
 answer-percent-short = { $percent } %
-
 max-credit-available = Мөмкин булган иң югары балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] омтылыш калмады
         [one] { $count } омтылыш калды
        *[other] { $count } омтылыш калды
     }
-
 validation-correct = (Дөрес)
 validation-incorrect = (Ялгыш)
 validation-partially-correct = (Өлешчә дөрес)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } өчен { $count } җавап күрсәтү
        *[other] { $answerId } өчен { $count } җавап күрсәтү
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Кире бәйләнеш
-
 collapsible-click-to-open = (ачу өчен басыгыз)
 collapsible-click-to-close = (ябу өчен басыгыз)
-
 collapsible-initializing = Әзерләнә…
-
 footnote-show = Искәрмәне күрсәтү
 footnote-hide = Искәрмәне яшерү
-
 description-more-information = өстәмә мәгълүмат
-
 
 ## Controls
 
 slider-previous = Алдагы
 slider-next = Киләсе
-
 keyboard-open = Клавиатураны ачу
 keyboard-close = Клавиатураны ябу
-
 choice-input-remove-choice = { $choice } сайлавын бетерү
-
 matrix-remove-row = Юлны бетерү
 matrix-add-row = Юл өстәү
 matrix-remove-column = Баганны бетерү
 matrix-add-column = Баган өстәү
-
 subset-add-remove-points = Нокта өстәү/бетерү
 subset-toggle-points-intervals = Нокталар белән аралыклар арасында алмаштыру
 subset-move-points = Нокталарны күчерү
 subset-clear = Чистарту
-
 orbital-add-row = Юл өстәү
 orbital-remove-row = Юлны бетерү
 orbital-add-box = Күзәнәк өстәү
@@ -92,13 +73,9 @@ orbital-remove-box = Күзәнәкне бетерү
 orbital-add-up-arrow = Өскә ук өстәү
 orbital-add-down-arrow = Аска ук өстәү
 orbital-remove-arrow = Укны бетерү
-
 orbital-row-label = { $row } юлының тамгасы
-
 pretzel-answer = Җавап
-
 summary-statistics-caption = { $column } баганының йомгаклау статистикасы
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = математик аңлатманың алдан �
 math-input-preview = Алдан каралыш
 math-input-invalid-expression = Дөрес булмаган аңлатма:
 
-
 ## Document status
 
 viewer-initializing = Әзерләнә…
 
-
 ## Errors
 
 error-heading = Хата
-
 error-found-at =
     { $span ->
         [line] Табылган юл: { $startLine }.
        *[lines] Табылган юллар: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Бу документта хаталар бар!
-
 diagnostic-heading-error = Хата
 diagnostic-heading-warning = Кисәтү
 diagnostic-heading-information = Мәгълүмат
 diagnostic-heading-hint = Киңәш
-
 accessibility-heading-level-1 = WCAG AA үтемлелек бозуы
 accessibility-heading-level-2 = Үтемлелек хәбәре
-
 something-went-wrong = Нәрсәдер дөрес булмады.
-
 renderer-load-failed = сурәтләүчене йөкләп булмады. Битне яңартыгыз.
-
 core-start-failed = Документ карагычын эшләтеп җибәреп булмады. Битне яңартыгыз.

--- a/packages/i18n/locales/tt/content.ftl
+++ b/packages/i18n/locales/tt/content.ftl
@@ -31,15 +31,12 @@ color =
     .purple = шәмәхә
     .pink = алсу
     .brown = көрән
-
 line-width =
     .thick = юан
     .thin = нечкә
-
 line-style =
     .dashed = өзек
     .dotted = нокталы
-
 # Noun phrases: they stand in front of «бизәкле» and modify nothing.
 fill-style =
     .horizontal = горизонталь сызык
@@ -48,7 +45,6 @@ fill-style =
     .backdiagonal = кире диагональ сызык
     .dots = нокта
     .diamonds = ромб
-
 noun =
     .line = туры сызык
     .line-segment = кисемтә
@@ -68,7 +64,6 @@ noun =
     .diamond = ромб
     .cross = кисешү тамгасы
     .plus = плюс
-
 # Tatar builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -76,11 +71,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] дөрес { $numSides } мөйешлек
     }
-
 # Tatar has no grammatical gender, so every noun answers the same and the answer
 # goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -94,21 +87,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = буялган
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } бизәкле { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } бизәкле { $color } { $filled } { $noun }
@@ -116,7 +105,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } бизәкле { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «кырыйлы» — "bordered" — carries the "with a border" sense in its own suffix,
 # so neither a preposition nor an article is wanted, and all four branches read
 # alike except for the connective English needs and Tatar does not.
@@ -127,15 +115,12 @@ style-border-clause =
         [and-article] һәм { $border } кырыйлы
        *[with] { $border } кырыйлы
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } бизәкле { $color } буяу
        *[plain] { $color } буяу
     }
-
 style-unfilled = буялмаган
-
 # «фонда» is the locative of «фон» and says "on the background" by itself, so
 # nothing stands between the two colours.
 style-text =
@@ -143,21 +128,17 @@ style-text =
         [background] { $background } фонда { $color }
        *[plain] { $color }
     }
-
 style-background-none = юк
-
 
 ## Boolean words
 
 boolean-true = дөрес
 boolean-false = ялгыш
 
-
 ## Answer buttons
 
 answer-submit-label = Тикшерү
 answer-submit-label-no-correctness = Җавапны җибәрү
-
 
 ## Sectional blocks
 
@@ -182,7 +163,6 @@ section-name =
     .solution = Чишелеш
     .task = Бирем
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -192,9 +172,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Киңәш
-
 
 ## Tables and figures
 
@@ -205,7 +183,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Рәсем { $enumeration }
@@ -214,22 +191,18 @@ figure-name =
        *[unnumbered] Рәсем
     }
 
-
 ## Paginator controls
 
 paginator-previous = Алдагы
 paginator-next = Киләсе
 paginator-page = Бит
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = яки
 piecewise-condition-if = әгәр
 piecewise-condition-otherwise = юкса
-
 
 ## Chemistry
 
@@ -352,7 +325,6 @@ element-name =
     .lv = Ливерморий
     .ts = Теннессин
     .og = Оганесон
-
 element-anion-name =
     .h = Гидрид
     .c = Карбид
@@ -366,8 +338,6 @@ element-anion-name =
     .i = Йодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Дөрес булмаган химик билге
 chemistry-invalid-ionic-compound = Дөрес булмаган ион кушылмасы

--- a/packages/i18n/locales/ty/chrome.ftl
+++ b/packages/i18n/locales/ty/chrome.ftl
@@ -25,21 +25,15 @@
 
 answer-checking = Te hiʻopoʻa nei…
 answer-submitting = Te hōpoi nei…
-
 answer-checking-status = Te hiʻopoʻa nei i te pāhonoraʻa
 answer-submitting-status = Te hōpoi nei i te pāhonoraʻa
-
 answer-correct = Tano
 answer-incorrect = Tano ʻore
-
 answer-response-saved = Ua tāpeʻahia te pāhonoraʻa
-
 answer-percent-credit = { $percent }% o te tāpuraʻa
 answer-percent-correct = { $percent }% tano
 answer-percent-short = { $percent } %
-
 max-credit-available = Tāpuraʻa rahi roa e nehenehe e noaʻa: { $percent }%
-
 # No select: «tāmataraʻa» is the same word for one and for many. The `[0]`
 # branch stays, because it names none rather than counting.
 attempts-remaining =
@@ -47,51 +41,38 @@ attempts-remaining =
         [0] ʻaita ʻe tāmataraʻa i toe
        *[other] e { $count } tāmataraʻa i toe
     }
-
 validation-correct = (Tano)
 validation-incorrect = (Tano ʻore)
 validation-partially-correct = (Tano i te tahi tuhaʻa)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Faʻaʻite i te { $count } pāhonoraʻa nō te { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Manaʻo faʻahou
-
 collapsible-click-to-open = (pāto no te ʻiriti)
 collapsible-click-to-close = (pāto no te ʻōpani)
-
 collapsible-initializing = Te haʻamata nei…
-
 footnote-show = Faʻaʻite i te footnote
 footnote-hide = Hunā i te footnote
-
 description-more-information = haʻamāramaramaraʻa hau
-
 
 ## Controls
 
 slider-previous = I mua
 slider-next = I muri
-
 keyboard-open = ʻIriti i te papa taio
 keyboard-close = ʻŌpani i te papa taio
-
 choice-input-remove-choice = Iriti ê i te { $choice }
-
 matrix-remove-row = Iriti ê i te ʻāfata roa
 matrix-add-row = Tuʻu i te tahi ʻāfata roa
 matrix-remove-column = Iriti ê i te tīʻā
 matrix-add-column = Tuʻu i te tahi tīʻā
-
 subset-add-remove-points = Tuʻu/Iriti ê i te mau poini
 subset-toggle-points-intervals = Taui i te mau poini ʻe te mau ārearea
 subset-move-points = Faʻanehenehe i te mau poini
 subset-clear = Tāmā
-
 orbital-add-row = Tuʻu i te tahi ʻāfata roa
 orbital-remove-row = Iriti ê i te ʻāfata roa
 orbital-add-box = Tuʻu i te tahi ʻāfata
@@ -99,13 +80,9 @@ orbital-remove-box = Iriti ê i te ʻāfata
 orbital-add-up-arrow = Tuʻu i te tahi ʻōfaʻi i niʻa
 orbital-add-down-arrow = Tuʻu i te tahi ʻōfaʻi i raro
 orbital-remove-arrow = Iriti ê i te ʻōfaʻi
-
 orbital-row-label = Tāpaʻo nō te ʻāfata roa { $row }
-
 pretzel-answer = Pāhonoraʻa
-
 summary-statistics-caption = Haʻapotoraʻa numera o te { $column }
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = hiʻoraʻa nā mua o te parau numera
 math-input-preview = Hiʻoraʻa nā mua
 math-input-invalid-expression = Parau numera tano ʻore:
 
-
 ## Document status
 
 viewer-initializing = Te haʻamata nei…
 
-
 ## Errors
 
 error-heading = Hape
-
 error-found-at =
     { $span ->
         [line] Ua ʻitehia i te reni { $startLine }.
        *[lines] Ua ʻitehia i te mau reni { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tē vai nei te hape i roto i teie papaʻiraʻa!
-
 diagnostic-heading-error = Hape
 diagnostic-heading-warning = Faʻaararaʻa
 diagnostic-heading-information = Haʻamāramaramaraʻa
 diagnostic-heading-hint = Aratairaʻa
-
 accessibility-heading-level-1 = Ofatiraʻa i te ture ʻāravehi WCAG AA
 accessibility-heading-level-2 = Faʻaararaʻa nō te ʻāravehi
-
 something-went-wrong = Ua tupu te tahi hape.
-
 renderer-load-failed = ʻaita te tahi renderer i hōhoʻahia. A tāmata faʻahou i te ʻāpī.
-
 core-start-failed = ʻAita te hiʻoraʻa o te papaʻiraʻa i haʻamatahia. A tāmata faʻahou i te ʻāpī.

--- a/packages/i18n/locales/ty/content.ftl
+++ b/packages/i18n/locales/ty/content.ftl
@@ -41,15 +41,12 @@ color =
     .purple = vaiorete
     .pink = roze
     .brown = parauri
-
 line-width =
     .thick = mātotoru
     .thin = rairai
-
 line-style =
     .dashed = motumotu
     .dotted = tāpaʻo iti
-
 # Noun phrases. Tahitian marks no plural on the noun, so «reni» is the word for
 # one line and for many alike.
 fill-style =
@@ -59,7 +56,6 @@ fill-style =
     .backdiagonal = reni pīʻao huri
     .dots = tāpaʻo iti
     .diamonds = tiamane
-
 noun =
     .line = reni
     .line-segment = tuhaʻa reni
@@ -79,7 +75,6 @@ noun =
     .diamond = tiamane
     .cross = ʻafaʻifaʻi
     .plus = tāpiʻi
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -87,10 +82,8 @@ noun-regular-polygon =
         [tail] e { $numSides } hiti tōna
        *[head] poligone ʻaifaito
     }
-
 # One answer for every noun: Tahitian has no grammatical gender.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -104,22 +97,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun first and the adjectives behind it, which is the opposite of English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ʻī
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } e { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } e { $pattern }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } e { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Tahitian's «te» is the article and is not what English's "a" is doing here, so
 # all four branches read alike but for the connective: «e» opens the first
 # clause and «ʻe» a further one.
@@ -138,35 +126,28 @@ style-border-clause =
         [and-article] ʻe hiti { $border }
        *[with] e hiti { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ʻī ʻore
-
 style-text =
     { $parts ->
         [background] { $color } e niʻa { $background }
        *[plain] { $color }
     }
-
 style-background-none = ʻaita
-
 
 ## Boolean words
 
 boolean-true = mau
 boolean-false = hape
 
-
 ## Answer buttons
 
 answer-submit-label = Hiʻopoʻa i te ʻohipa
 answer-submit-label-no-correctness = Hōpoi i te pāhonoraʻa
-
 
 ## Sectional blocks
 
@@ -193,7 +174,6 @@ section-name =
     .solution = Ravaʻi
     .task = ʻOhipa rave
     .theorem = Teoreme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -203,9 +183,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Aratairaʻa
-
 
 ## Tables and figures
 
@@ -216,7 +194,6 @@ table-name =
         [unnumbered-title] Tāpura{ ": " }
        *[unnumbered] Tāpura
     }
-
 figure-name =
     { $parts ->
         [numbered] Hōhoʻa { $enumeration }
@@ -225,22 +202,18 @@ figure-name =
        *[unnumbered] Hōhoʻa
     }
 
-
 ## Paginator controls
 
 paginator-previous = I mua
 paginator-next = I muri
 paginator-page = ʻĀpī
-
 paginator-page-status = { $pageLabel } { $currentPage } nō roto i te { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = aore rā
 piecewise-condition-if = mai te mea
 piecewise-condition-otherwise = mai te mea ʻaita
-
 
 ## Chemistry
 ##
@@ -253,6 +226,5 @@ piecewise-condition-otherwise = mai te mea ʻaita
 ## of it.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Tāpaʻo tāʻiʻaʻi tano ʻore
 chemistry-invalid-ionic-compound = Faʻaʻamuraʻa ionika tano ʻore

--- a/packages/i18n/locales/tyv/chrome.ftl
+++ b/packages/i18n/locales/tyv/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = Хынап турар…
 answer-submitting = Чорудуп турар…
-
 answer-checking-status = Харыыны хынап турар
 answer-submitting-status = Харыыны чорудуп турар
-
 answer-correct = Шын
 answer-incorrect = Меге
-
 answer-response-saved = Харыы шыгжаттынган
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% шын
 answer-percent-short = { $percent } %
-
 max-credit-available = Ап болур эң улуг балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] оралдажыышкын арталбаан
         [one] { $count } оралдажыышкын арткан
        *[other] { $count } оралдажыышкын арткан
     }
-
 validation-correct = (Шын)
 validation-incorrect = (Меге)
 validation-partially-correct = (Кезии-биле шын)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } дээш { $count } харыыны көргүзер
        *[other] { $answerId } дээш { $count } харыыны көргүзер
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Дедир харыы
-
 collapsible-click-to-open = (ажарда базыңар)
 collapsible-click-to-close = (хаарда базыңар)
-
 collapsible-initializing = Белеткенип турар…
-
 footnote-show = Демдеглелди көргүзер
 footnote-hide = Демдеглелди чажырар
-
 description-more-information = немелде медээ
-
 
 ## Controls
 
 slider-previous = Мурнунда
 slider-next = Дараазында
-
 keyboard-open = Клавиатураны ажар
 keyboard-close = Клавиатураны хаар
-
 choice-input-remove-choice = { $choice } шилилгезин ужулдурар
-
 matrix-remove-row = Одуругну ужулдурар
 matrix-add-row = Одуруг немээр
 matrix-remove-column = Баганны ужулдурар
 matrix-add-column = Баган немээр
-
 subset-add-remove-points = Точка немээр/ужулдурар
 subset-toggle-points-intervals = Точкалар биле аразын солуштурар
 subset-move-points = Точкаларны шимчедир
 subset-clear = Арыглаар
-
 orbital-add-row = Одуруг немээр
 orbital-remove-row = Одуругну ужулдурар
 orbital-add-box = Куду немээр
@@ -94,13 +75,9 @@ orbital-remove-box = Кудуну ужулдурар
 orbital-add-up-arrow = Өрү согун немээр
 orbital-add-down-arrow = Куду согун немээр
 orbital-remove-arrow = Согунну ужулдурар
-
 orbital-row-label = { $row } одуругнуң демдээ
-
 pretzel-answer = Харыы
-
 summary-statistics-caption = { $column } баганның түңнел статистиказы
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = математиктиг илередиишкинн�
 math-input-preview = Мурнунда көрүүшкүн
 math-input-invalid-expression = Шын эвес илередиишкин:
 
-
 ## Document status
 
 viewer-initializing = Белеткенип турар…
 
-
 ## Errors
 
 error-heading = Частырыг
-
 error-found-at =
     { $span ->
         [line] Тывылган одуруг: { $startLine }.
        *[lines] Тывылган одуруглар: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Бо документиде частырыглар бар!
-
 diagnostic-heading-error = Частырыг
 diagnostic-heading-warning = Сагындырыг
 diagnostic-heading-information = Медээ
 diagnostic-heading-hint = Сүме
-
 accessibility-heading-level-1 = WCAG AA ажыглаар аргазының үрелиишкини
 accessibility-heading-level-2 = Ажыглаар арга дугайында медээ
-
 something-went-wrong = Бир-ле чүве шын эвес болган.
-
 renderer-load-failed = чуруктаарны чүдүрүп шыдаваан. Арынны катап ажыдыңар.
-
 core-start-failed = Документ көрүкчүзүн эгелеп шыдаваан. Арынны катап ажыдыңар.

--- a/packages/i18n/locales/tyv/content.ftl
+++ b/packages/i18n/locales/tyv/content.ftl
@@ -35,15 +35,12 @@ color =
     .purple = фиолет
     .pink = розовый
     .brown = хүрең
-
 line-width =
     .thick = кылын
     .thin = чуга
-
 line-style =
     .dashed = үзүктелген
     .dotted = точкалыг
-
 # Noun phrases: they stand in front of «чурумалдыг» and modify nothing.
 fill-style =
     .horizontal = горизонталь шугум
@@ -52,7 +49,6 @@ fill-style =
     .backdiagonal = удурланышкак диагональ шугум
     .dots = точка
     .diamonds = ромб
-
 noun =
     .line = дорт шугум
     .line-segment = кезек
@@ -72,7 +68,6 @@ noun =
     .diamond = ромб
     .cross = крест
     .plus = плюс
-
 # Tuvan builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -80,11 +75,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] дең { $numSides } булуңнуг
     }
-
 # Tuvan has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -98,21 +91,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = будаан
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } чурумалдыг { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } чурумалдыг { $color } { $filled } { $noun }
@@ -120,7 +109,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } чурумалдыг { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «кыдыглыг» — "having an edge" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
@@ -130,15 +118,12 @@ style-border-clause =
         [and-article] база { $border } кыдыглыг
        *[with] { $border } кыдыглыг
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } чурумалдыг { $color } будуг
        *[plain] { $color } будуг
     }
-
 style-unfilled = будаваан
-
 # «кырында» — "on top of" — is a postposition and follows the background
 # colour, so nothing stands between the two words.
 style-text =
@@ -146,21 +131,17 @@ style-text =
         [background] { $background } фон кырында { $color }
        *[plain] { $color }
     }
-
 style-background-none = чок
-
 
 ## Boolean words
 
 boolean-true = шын
 boolean-false = меге
 
-
 ## Answer buttons
 
 answer-submit-label = Хынаар
 answer-submit-label-no-correctness = Харыыны чорудар
-
 
 ## Sectional blocks
 
@@ -185,7 +166,6 @@ section-name =
     .solution = Шиитпир
     .task = Онаалга
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -195,9 +175,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Сүме
-
 
 ## Tables and figures
 
@@ -208,7 +186,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Чурук { $enumeration }
@@ -217,15 +194,12 @@ figure-name =
        *[unnumbered] Чурук
     }
 
-
 ## Paginator controls
 
 paginator-previous = Мурнунда
 paginator-next = Дараазында
 paginator-page = Арын
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -238,7 +212,6 @@ piecewise-condition-or = азы
 piecewise-condition-if = болза
 piecewise-condition-otherwise = өске таварылгада
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -247,6 +220,5 @@ piecewise-condition-otherwise = өске таварылгада
 ## ones — the school-system case this whole batch shares.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Шын эвес химиктиг демдек
 chemistry-invalid-ionic-compound = Шын эвес ион каттыжыышкыны

--- a/packages/i18n/locales/udm/chrome.ftl
+++ b/packages/i18n/locales/udm/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Эскериське…
 answer-submitting = Ыстӥське…
-
 answer-checking-status = Ответ эскериське
 answer-submitting-status = Ответ ыстӥське
-
 answer-correct = Шонер
 answer-incorrect = Янгыш
-
 answer-response-saved = Ответ утемын
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% шонер
 answer-percent-short = { $percent } %
-
 max-credit-available = Басьтыны луонлыко бадӟым балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] выремлык кылемын ӧвӧл
         [one] { $count } выремлык кылемын
        *[other] { $count } выремлык кылемын
     }
-
 validation-correct = (Шонер)
 validation-incorrect = (Янгыш)
 validation-partially-correct = (Люкетэн шонер)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } понна { $count } ответэз возьматыны
        *[other] { $answerId } понна { $count } ответэз возьматыны
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Берыктэт
-
 collapsible-click-to-open = (усьтон понна зӥбе)
 collapsible-click-to-close = (ворсан понна зӥбе)
-
 collapsible-initializing = Дасяське…
-
 footnote-show = Пусъёнэз возьматыны
 footnote-hide = Пусъёнэз ватыны
-
 description-more-information = ватсаса ивортэт
-
 
 ## Controls
 
 slider-previous = Азьло
 slider-next = Собере
-
 keyboard-open = Клавиатураез усьтыны
 keyboard-close = Клавиатураез ворсаны
-
 choice-input-remove-choice = { $choice } быръёнэз палэнтыны
-
 matrix-remove-row = Чурез палэнтыны
 matrix-add-row = Чур ватсаны
 matrix-remove-column = Юбоез палэнтыны
 matrix-add-column = Юбо ватсаны
-
 subset-add-remove-points = Пус ватсаны/палэнтыны
 subset-toggle-points-intervals = Пусъёсты но кусыпъёсты воштыны
 subset-move-points = Пусъёсты выретыны
 subset-clear = Сузяны
-
 orbital-add-row = Чур ватсаны
 orbital-remove-row = Чурез палэнтыны
 orbital-add-box = Клетка ватсаны
@@ -92,13 +73,9 @@ orbital-remove-box = Клеткаез палэнтыны
 orbital-add-up-arrow = Вылӥе ньӧл ватсаны
 orbital-add-down-arrow = Улӥе ньӧл ватсаны
 orbital-remove-arrow = Ньӧлэз палэнтыны
-
 orbital-row-label = { $row } чурлэн пусэз
-
 pretzel-answer = Ответ
-
 summary-statistics-caption = { $column } юболэн йылпумъян статистикаез
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = математической валэктонлэн 
 math-input-preview = Азьло учкон
 math-input-invalid-expression = Янгыш валэктон:
 
-
 ## Document status
 
 viewer-initializing = Дасяське…
 
-
 ## Errors
 
 error-heading = Янгыш
-
 error-found-at =
     { $span ->
         [line] Шедьтэм чур: { $startLine }.
        *[lines] Шедьтэм чуръёс: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Та документын янгышъёс вань!
-
 diagnostic-heading-error = Янгыш
 diagnostic-heading-warning = Сак кариськон
 diagnostic-heading-information = Ивортэт
 diagnostic-heading-hint = Юрттэт
-
 accessibility-heading-level-1 = WCAG AA вуонлык тӥян
 accessibility-heading-level-2 = Вуонлык сярысь ивортэт
-
 something-went-wrong = Мар ке янгыш потӥз.
-
 renderer-load-failed = суредасез пыртыны ӧз луы. Бамез выльдэ.
-
 core-start-failed = Документэз учконэз кутскытыны ӧз луы. Бамез выльдэ.

--- a/packages/i18n/locales/udm/content.ftl
+++ b/packages/i18n/locales/udm/content.ftl
@@ -37,15 +37,12 @@ color =
     .purple = фиолетовой
     .pink = лемлет
     .brown = коричневой
-
 line-width =
     .thick = зӧк
     .thin = векчи
-
 line-style =
     .dashed = чигем
     .dotted = пусъем
-
 # Noun phrases: they stand in front of «чеберъямен» and modify nothing.
 fill-style =
     .horizontal = горизонтальной чур
@@ -54,7 +51,6 @@ fill-style =
     .backdiagonal = пумит диагональной чур
     .dots = пус
     .diamonds = ромб
-
 noun =
     .line = шонер чур
     .line-segment = висъет
@@ -74,7 +70,6 @@ noun =
     .diamond = ромб
     .cross = перекрест
     .plus = плюс
-
 # Udmurt builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -82,11 +77,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] шонер { $numSides } сэрего
     }
-
 # Udmurt has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -100,21 +93,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = буям
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } чеберъямен { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } чеберъямен { $color } { $filled } { $noun }
@@ -122,7 +111,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } чеберъямен { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «дуроен» is the instrumental of «дур», "edge", and carries the whole of "with
 # a border" in its own suffix — so neither a preposition nor an article is
 # wanted, and the suffix sits on a noun this catalog writes rather than on a
@@ -134,15 +122,12 @@ style-border-clause =
         [and-article] но { $border } дуроен
        *[with] { $border } дуроен
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } чеберъямен { $color } буям
        *[plain] { $color } буям
     }
-
 style-unfilled = буямтэ
-
 # «вылын» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.
 style-text =
@@ -150,21 +135,17 @@ style-text =
         [background] { $background } фон вылын { $color }
        *[plain] { $color }
     }
-
 style-background-none = ӧвӧл
-
 
 ## Boolean words
 
 boolean-true = зэм
 boolean-false = зэм ӧвӧл
 
-
 ## Answer buttons
 
 answer-submit-label = Эскерыны
 answer-submit-label-no-correctness = Ответэз ыстыны
-
 
 ## Sectional blocks
 
@@ -189,7 +170,6 @@ section-name =
     .solution = Шедьтон
     .task = Уж
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -199,9 +179,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Юрттэт
-
 
 ## Tables and figures
 
@@ -212,7 +190,6 @@ table-name =
         [unnumbered-title] Таблица{ ". " }
        *[unnumbered] Таблица
     }
-
 figure-name =
     { $parts ->
         [numbered] Суред { $enumeration }
@@ -221,15 +198,12 @@ figure-name =
        *[unnumbered] Суред
     }
 
-
 ## Paginator controls
 
 paginator-previous = Азьло
 paginator-next = Собере
 paginator-page = Бам
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -246,7 +220,6 @@ piecewise-condition-or = яке
 piecewise-condition-if = ке
 piecewise-condition-otherwise = мукет учыре
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -255,6 +228,5 @@ piecewise-condition-otherwise = мукет учыре
 ## ones — the school-system case this batch shares throughout.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Янгыш химической пус
 chemistry-invalid-ionic-compound = Янгыш ион герӟет

--- a/packages/i18n/locales/ug/chrome.ftl
+++ b/packages/i18n/locales/ug/chrome.ftl
@@ -21,72 +21,54 @@
 
 answer-checking = تەكشۈرۈۋاتىدۇ...
 answer-submitting = يوللاۋاتىدۇ...
-
 answer-checking-status = جاۋاب تەكشۈرۈلۈۋاتىدۇ
 answer-submitting-status = جاۋاب يوللىنىۋاتىدۇ
-
 answer-correct = توغرا
 answer-incorrect = خاتا
-
 answer-response-saved = جاۋاب ساقلاندى
-
 answer-percent-credit = { $percent }% نومۇر
 answer-percent-correct = { $percent }% توغرا
 answer-percent-short = { $percent }%
-
 max-credit-available = ئەڭ يۇقىرى ئېرىشكىلى بولىدىغان نومۇر: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] سىناش پۇرسىتى قالمىدى
        *[other] { $count } سىناش پۇرسىتى قالدى
     }
-
 validation-correct = (توغرا جاۋاب)
 validation-incorrect = (خاتا جاۋاب)
 validation-partially-correct = (قىسمەن توغرا جاۋاب)
-
 answer-show-responses = { $answerId } غا يوللانغان { $count } جاۋابنى كۆرسىتىش
-
 
 ## Disclosure panels
 
 feedback-heading = ئىنكاس
-
 collapsible-click-to-open = (ئېچىش ئۈچۈن چېكىش)
 collapsible-click-to-close = (يېپىش ئۈچۈن چېكىش)
 collapsible-initializing = تەييارلىنىۋاتىدۇ...
-
 footnote-show = بەت ئىزاھاتىنى كۆرسىتىش
 footnote-hide = بەت ئىزاھاتىنى يوشۇرۇش
-
 description-more-information = تېخىمۇ كۆپ ئۇچۇر
-
 
 ## Controls
 
 slider-previous = ئالدىنقى
 slider-next = كېيىنكى
-
 keyboard-open = ھەرپتاختىنى ئېچىش
 keyboard-close = ھەرپتاختىنى يېپىش
-
 # The accusative «نى» is written detached after the placeable, as it is after
 # `{ $shortcut }` in `editor.ftl` and as Uyghur writes a case ending against a
 # foreign word. `$choice` is the choice's own text, in whatever language the
 # document is written in, so it is exactly that case.
 choice-input-remove-choice = { $choice } نى ئۆچۈرۈش
-
 matrix-remove-row = قۇر ئۆچۈرۈش
 matrix-add-row = قۇر قوشۇش
 matrix-remove-column = ئىستون ئۆچۈرۈش
 matrix-add-column = ئىستون قوشۇش
-
 subset-add-remove-points = نۇقتا قوشۇش/ئۆچۈرۈش
 subset-toggle-points-intervals = نۇقتا بىلەن ئارىلىق ئارىسىدا ئالماشتۇرۇش
 subset-move-points = نۇقتىلارنى يۆتكەش
 subset-clear = تازىلاش
-
 orbital-add-row = قۇر قوشۇش
 orbital-remove-row = قۇر ئۆچۈرۈش
 orbital-add-box = رامكا قوشۇش
@@ -94,13 +76,9 @@ orbital-remove-box = رامكا ئۆچۈرۈش
 orbital-add-up-arrow = ئۈستىگە قارىغان يا ئوق قوشۇش
 orbital-add-down-arrow = ئاستىغا قارىغان يا ئوق قوشۇش
 orbital-remove-arrow = يا ئوق ئۆچۈرۈش
-
 orbital-row-label = { $row } - قۇرنىڭ ئىسمى
-
 pretzel-answer = جاۋاب
-
 summary-statistics-caption = { $column } ئىستوننىڭ ستاتىستىكا خۇلاسىسى
-
 
 ## Math input
 
@@ -108,37 +86,28 @@ math-input-preview-region = ماتېماتىكىلىق ئىپادىنىڭ ئال
 math-input-preview = ئالدىن كۆرۈش
 math-input-invalid-expression = ئىناۋەتسىز ئىپادە:
 
-
 ## Document status
 
 viewer-initializing = تەييارلىنىۋاتىدۇ...
 
-
 ## Errors
 
 error-heading = خاتالىق
-
 error-found-at =
     { $span ->
         [line] { $startLine } - قۇردا بايقالدى.
        *[lines] { $startLine } - { $endLine } قۇرلاردا بايقالدى.
     }
-
 document-contains-errors = بۇ ھۆججەتتە خاتالىق بار!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = خاتالىق
 diagnostic-heading-warning = ئاگاھلاندۇرۇش
 diagnostic-heading-information = ئۇچۇر
 diagnostic-heading-hint = كۆرسەتمە
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = WCAG AA بويىچە زىيارەت قۇلايلىقى بۇزۇلۇشى
 accessibility-heading-level-2 = زىيارەت قۇلايلىقى ئەسكەرتىشى
-
 something-went-wrong = بىر يەردە خاتالىق كۆرۈلدى.
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = بىر بۆلەك يۈكلەنمىدى. بەتنى قايتا يۈكلەش كېرەك.
-
 core-start-failed = ھۆججەت كۆرگۈچنى قوزغاتقىلى بولمىدى. بەتنى قايتا يۈكلەش كېرەك.

--- a/packages/i18n/locales/ug/content.ftl
+++ b/packages/i18n/locales/ug/content.ftl
@@ -40,15 +40,12 @@ color =
     .purple = بىنەپشە
     .pink = ھالرەڭ
     .brown = قوڭۇر
-
 line-width =
     .thick = قېلىن
     .thin = ئىنچىكە
-
 line-style =
     .dashed = ئۈزۈك
     .dotted = چېكىتلىك
-
 fill-style =
     .horizontal = توغرا سىزىقلار
     .vertical = تىك سىزىقلار
@@ -56,7 +53,6 @@ fill-style =
     .backdiagonal = تەتۈر يانتۇ سىزىقلار
     .dots = چېكىتلەر
     .diamonds = رومبىلار
-
 noun =
     .line = سىزىق
     .line-segment = سىزىق بۆلىكى
@@ -76,7 +72,6 @@ noun =
     .diamond = رومبا
     .cross = كرېست
     .plus = قوشۇش بەلگىسى
-
 # Uyghur keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -84,11 +79,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } تەرەپلىك مۇنتىزىم كۆپ بۇلۇڭلۇق
     }
-
 # Uyghur has no grammatical gender. The token is defined anyway rather than
 # left to fall back, so that this catalog says so on purpose.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -102,16 +95,13 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = تولدۇرۇلغان
-
 # «بىلەن» is a postposition and a word of its own, so it can follow a
 # placeable where a case suffix could not.
 style-filled =
@@ -119,7 +109,6 @@ style-filled =
         [pattern] { $color } { $filled }، { $pattern } بىلەن
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $color } { $filled } { $noun }، { $pattern } بىلەن
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $color } { $filled } { $noun } { $nounTail }، { $pattern } بىلەن
        *[plain] { $color } { $filled } { $noun }
     }
-
 # Uyghur has no article, so the two `-article` branches say what their plain
 # counterparts do.
 style-border-clause =
@@ -137,7 +125,6 @@ style-border-clause =
         [and-article] ۋە { $border } گىرۋەك بىلەن
        *[with] { $border } گىرۋەك بىلەن
     }
-
 # The pattern is a plural noun and the colour an adjective in front of it, so
 # the two fall in the same order they do in English.
 style-fill =
@@ -145,29 +132,23 @@ style-fill =
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = تولدۇرۇلمىغان
-
 style-text =
     { $parts ->
         [background] { $color }، { $background } تەگلىك بىلەن
        *[plain] { $color }
     }
-
 style-background-none = يوق
-
 
 ## Boolean words
 
 boolean-true = راست
 boolean-false = يالغان
 
-
 ## Answer buttons
 
 answer-submit-label = جاۋابنى تەكشۈرۈش
 answer-submit-label-no-correctness = جاۋابنى يوللاش
-
 
 ## Sectional blocks
 
@@ -192,7 +173,6 @@ section-name =
     .solution = يېشىم
     .task = ۋەزىپە
     .theorem = تېئورېما
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -202,9 +182,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = كۆرسەتمە
-
 
 ## Tables and figures
 
@@ -215,7 +193,6 @@ table-name =
         [unnumbered-title] جەدۋەل{ ": " }
        *[unnumbered] جەدۋەل
     }
-
 figure-name =
     { $parts ->
         [numbered] رەسىم { $enumeration }
@@ -224,28 +201,21 @@ figure-name =
        *[unnumbered] رەسىم
     }
 
-
 ## Paginator controls
 
 paginator-previous = ئالدىنقى
 paginator-next = كېيىنكى
 paginator-page = بەت
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ياكى
-
 piecewise-condition-if = ئەگەر
-
 piecewise-condition-otherwise = بولمىسا
-
 
 ## Chemistry
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ئىناۋەتسىز خىمىيىلىك بەلگە
 chemistry-invalid-ionic-compound = ئىناۋەتسىز ئىئون بىرىكمىسى

--- a/packages/i18n/locales/uk/chrome.ftl
+++ b/packages/i18n/locales/uk/chrome.ftl
@@ -21,21 +21,15 @@
 
 answer-checking = Перевірка…
 answer-submitting = Надсилання…
-
 answer-checking-status = Перевірка відповіді
 answer-submitting-status = Надсилання відповіді
-
 answer-correct = Правильно
 answer-incorrect = Неправильно
-
 answer-response-saved = Відповідь збережено
-
 answer-percent-credit = { $percent }% зарахування
 answer-percent-correct = { $percent }% правильно
 answer-percent-short = { $percent } %
-
 max-credit-available = Максимально можливе зарахування: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] спроб не залишилося
@@ -44,11 +38,9 @@ attempts-remaining =
         [many] залишилося { $count } спроб
        *[other] залишилося { $count } спроби
     }
-
 validation-correct = (Правильно)
 validation-incorrect = (Неправильно)
 validation-partially-correct = (Частково правильно)
-
 answer-show-responses =
     { $count ->
         [one] Показати { $count } відповідь на { $answerId }
@@ -57,42 +49,31 @@ answer-show-responses =
        *[other] Показати { $count } відповіді на { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Відгук
-
 collapsible-click-to-open = (натисніть, щоб відкрити)
 collapsible-click-to-close = (натисніть, щоб закрити)
-
 collapsible-initializing = Ініціалізація…
-
 footnote-show = Показати виноску
 footnote-hide = Сховати виноску
-
 description-more-information = докладніше
-
 
 ## Controls
 
 slider-previous = Назад
 slider-next = Далі
-
 keyboard-open = Відкрити клавіатуру
 keyboard-close = Закрити клавіатуру
-
 choice-input-remove-choice = Вилучити { $choice }
-
 matrix-remove-row = Вилучити рядок
 matrix-add-row = Додати рядок
 matrix-remove-column = Вилучити стовпець
 matrix-add-column = Додати стовпець
-
 subset-add-remove-points = Додати/вилучити точки
 subset-toggle-points-intervals = Перемкнути точки та проміжки
 subset-move-points = Пересунути точки
 subset-clear = Очистити
-
 orbital-add-row = Додати рядок
 orbital-remove-row = Вилучити рядок
 orbital-add-box = Додати комірку
@@ -100,13 +81,9 @@ orbital-remove-box = Вилучити комірку
 orbital-add-up-arrow = Додати стрілку вгору
 orbital-add-down-arrow = Додати стрілку вниз
 orbital-remove-arrow = Вилучити стрілку
-
 orbital-row-label = Підпис рядка { $row }
-
 pretzel-answer = Відповідь
-
 summary-statistics-caption = Зведена статистика для { $column }
-
 
 ## Math input
 
@@ -114,16 +91,13 @@ math-input-preview-region = попередній перегляд математ
 math-input-preview = Перегляд
 math-input-invalid-expression = Некоректний вираз:
 
-
 ## Document status
 
 viewer-initializing = Ініціалізація…
 
-
 ## Errors
 
 error-heading = Помилка
-
 # Ukrainian has no article and needs none of English's; the sentence is the
 # same shape either way, so the two branches differ only in the number of line
 # numbers they name.
@@ -132,19 +106,13 @@ error-found-at =
         [line] Виявлено в рядку { $startLine }.
        *[lines] Виявлено в рядках { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Цей документ містить помилки!
-
 diagnostic-heading-error = Помилка
 diagnostic-heading-warning = Попередження
 diagnostic-heading-information = Інформація
 diagnostic-heading-hint = Підказка
-
 accessibility-heading-level-1 = Порушення доступності WCAG AA
 accessibility-heading-level-2 = Зауваження щодо доступності
-
 something-went-wrong = Щось пішло не так.
-
 renderer-load-failed = не вдалося завантажити модуль відображення. Перезавантажте сторінку.
-
 core-start-failed = Не вдалося запустити переглядач документа. Перезавантажте сторінку.

--- a/packages/i18n/locales/uk/content.ftl
+++ b/packages/i18n/locales/uk/content.ftl
@@ -171,7 +171,6 @@ color =
                    *[m] коричневий
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -197,7 +196,6 @@ line-width =
                    *[m] тонкий
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -223,7 +221,6 @@ line-style =
                    *[m] пунктирний
                 }
         }
-
 # Noun phrases in the accusative plural, which is the case «у» takes when it
 # names a pattern — «у ромби», the way Ukrainian describes patterned cloth.
 # The accusative plural of an inanimate noun is spelled like the nominative,
@@ -235,7 +232,6 @@ fill-style =
     .backdiagonal = зворотні діагональні лінії
     .dots = крапки
     .diamonds = ромби
-
 noun =
     .line = пряма
     .line-segment = відрізок
@@ -255,7 +251,6 @@ noun =
     .diamond = ромб
     .cross = хрестик
     .plus = плюс
-
 # Ukrainian counts the sides after the noun, so the count closes the phrase
 # behind the adjectives: «товстий червоний правильний многокутник із 5
 # сторонами».
@@ -264,7 +259,6 @@ noun-regular-polygon =
         [tail] із { $numSides } сторонами
        *[head] правильний многокутник
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (многокутник, m) or
 # the head of a phrase the description never names: `border` (рамка, f), `fill`
 # (заливка, f), `text` (текст, m), `background` (тло, n).
@@ -284,7 +278,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -297,14 +290,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, and the complement closes the phrase.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -313,13 +304,11 @@ style-filled-word =
         [n] заповнене
        *[m] заповнений
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } у { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } у { $pattern }
@@ -327,7 +316,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } у { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «з» governs the instrumental, which the `border-clause` branch of every
 # adjective supplies. Ukrainian has no article, so the `-article` branches read
 # the same as the ones without.
@@ -343,15 +331,12 @@ style-border-clause =
         [and-article] і з { $border } рамкою
        *[with] з { $border } рамкою
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = незаповнений
-
 # «на» governs the locative, which is what the `background-clause` branch of
 # every adjective supplies — «на чорному тлі».
 style-text =
@@ -359,21 +344,17 @@ style-text =
         [background] { $color } на { $background } тлі
        *[plain] { $color }
     }
-
 style-background-none = немає
-
 
 ## Boolean words
 
 boolean-true = істина
 boolean-false = хиба
 
-
 ## Answer buttons
 
 answer-submit-label = Перевірити
 answer-submit-label-no-correctness = Надіслати відповідь
-
 
 ## Sectional blocks
 
@@ -398,7 +379,6 @@ section-name =
     .solution = Розв'язання
     .task = Завдання
     .theorem = Теорема
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -408,9 +388,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Підказка
-
 
 ## Tables and figures
 
@@ -421,7 +399,6 @@ table-name =
         [unnumbered-title] Таблиця{ ": " }
        *[unnumbered] Таблиця
     }
-
 figure-name =
     { $parts ->
         [numbered] Рисунок { $enumeration }
@@ -430,22 +407,18 @@ figure-name =
        *[unnumbered] Рисунок
     }
 
-
 ## Paginator controls
 
 paginator-previous = Попередня
 paginator-next = Наступна
 paginator-page = Сторінка
-
 paginator-page-status = { $pageLabel } { $currentPage } з { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = або
 piecewise-condition-if = якщо
 piecewise-condition-otherwise = інакше
-
 
 ## Chemistry
 ##
@@ -574,7 +547,6 @@ element-name =
     .lv = Ліверморій
     .ts = Теннессін
     .og = Оганесон
-
 element-anion-name =
     .h = Гідрид
     .c = Карбід
@@ -588,8 +560,6 @@ element-anion-name =
     .i = Йодид
     .at = Астатид
     .ts = Теннессид
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Некоректний хімічний символ
 chemistry-invalid-ionic-compound = Некоректна йонна сполука

--- a/packages/i18n/locales/umb/chrome.ftl
+++ b/packages/i18n/locales/umb/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Oku konomboloya…
 answer-submitting = Oku tuma…
-
 answer-checking-status = Etambululo li kasi oku konomboloyiwa
 answer-submitting-status = Etambululo li kasi oku tumiwa
-
 answer-correct = Cocili
 answer-incorrect = Ka cocili
-
 answer-response-saved = Etambululo Lya Vikiwa
-
 answer-percent-credit = { $percent }% Yolonoso
 answer-percent-correct = { $percent }% Cocili
 answer-percent-short = { $percent } %
-
 max-credit-available = Olonoso vinene o pondola oku tambula: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kaku sialele elilongiso
         [one] elilongiso { $count } lya sialele
        *[other] alilongiso { $count } a sialele
     }
-
 validation-correct = (Cocili)
 validation-incorrect = (Ka cocili)
 validation-partially-correct = (Cocili konepa)
-
 answer-show-responses =
     { $count ->
         [one] Lekisa etambululo { $count } lya { $answerId }
        *[other] Lekisa atambululo { $count } a { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Etambululo
-
 collapsible-click-to-open = (yeta oco ci yulule)
 collapsible-click-to-close = (yeta oco ci yike)
-
 collapsible-initializing = Oku fetika…
-
 footnote-show = Lekisa esapulo lyokemehi
 footnote-hide = Seluka esapulo lyokemehi
-
 description-more-information = ovina vikwavo
-
 
 ## Controls
 
 slider-previous = Yipita
 slider-next = Yikwãma
-
 keyboard-open = Yulula Otekiladu
 keyboard-close = Yika Otekiladu
-
 choice-input-remove-choice = Pindula { $choice }
-
 matrix-remove-row = Pindula ongoli
 matrix-add-row = Vokiya ongoli
 matrix-remove-column = Pindula okoluna
 matrix-add-column = Vokiya okoluna
-
 subset-add-remove-points = Vokiya/Pindula olondimbu
 subset-toggle-points-intervals = Pongolola olondimbu lolotembo
 subset-move-points = Nyingisa Olondimbu
 subset-clear = Yepisa
-
 orbital-add-row = Vokiya Ongoli
 orbital-remove-row = Pindula Ongoli
 orbital-add-box = Vokiya Ocikuta
@@ -86,13 +67,9 @@ orbital-remove-box = Pindula Ocikuta
 orbital-add-up-arrow = Vokiya Oseta Yokilu
 orbital-add-down-arrow = Vokiya Oseta Yokemehi
 orbital-remove-arrow = Pindula Oseta
-
 orbital-row-label = Onduko yongoli { $row }
-
 pretzel-answer = Etambululo
-
 summary-statistics-caption = Elomboloko lyovialua vya { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = oku tala tete ondaka yomatematika
 math-input-preview = Tala tete
 math-input-invalid-expression = Ondaka ka ya sungulukile:
 
-
 ## Document status
 
 viewer-initializing = Oku fetika…
 
-
 ## Errors
 
 error-heading = Eviho
-
 error-found-at =
     { $span ->
         [line] Lya sangiwa kongoli { $startLine }.
        *[lines] Lya sangiwa kolongoli { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Elivulu lilo li kwete oviho!
-
 diagnostic-heading-error = Eviho
 diagnostic-heading-warning = Elungulo
 diagnostic-heading-information = Esapulo
 diagnostic-heading-hint = Ekwatiso
-
 accessibility-heading-level-1 = Elueyo lya WCAG AA Kokupitĩla
 accessibility-heading-level-2 = Elungulo lyokupitĩla
-
 something-went-wrong = Cimwe ka ca lingile ciwa.
-
 renderer-load-failed = ulekisi umwe ka weyile. Tu ku pinga, tiukulula etapa.
-
 core-start-failed = Ulekisi welivulu ka wa tẽlele oku fetika. Tu ku pinga, tiukulula etapa.

--- a/packages/i18n/locales/umb/content.ftl
+++ b/packages/i18n/locales/umb/content.ftl
@@ -79,7 +79,6 @@ color =
     .purple = roxu
     .pink = rosa
     .brown = kastanyu
-
 line-width =
     .thick =
         { $gender ->
@@ -95,13 +94,11 @@ line-width =
             [c10] vitito
            *[c7] citito
         }
-
 # Written as «lo …» phrases rather than as prefixed qualifiers, so that they
 # take no concord and can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = lo olongoli vitito
     .dotted = lo olondimbu
-
 fill-style =
     .horizontal = olongoli vi kasi vokati
     .vertical = olongoli vi kasi voku talama
@@ -109,7 +106,6 @@ fill-style =
     .backdiagonal = olongoli vi kasi voku pita konele yikwavo
     .dots = olondimbu
     .diamonds = olodiamanti
-
 noun =
     .line = ongoli
     .line-segment = ocinepa congoli
@@ -129,7 +125,6 @@ noun =
     .diamond = odiamanti
     .cross = ekulusu
     .plus = ondimbukiso yoku vokiya
-
 # The side count is a complement and closes the noun phrase behind the
 # describing words, so it goes in the tail.
 #
@@ -142,7 +137,6 @@ noun-regular-polygon =
         [tail] lo olonele { $numSides }
        *[head] poligonu cisokisa
     }
-
 # The noun class. `c7` is the default, which is what an author's own
 # `markerStyleWord` is as far as this catalog is concerned. Every noun with an
 # overt `oci-` — «ocilinganya», «ocitumãlo», «ocinepa» — falls to it unlisted,
@@ -164,7 +158,6 @@ noun-gender =
        *[other] c7
     }
 
-
 ## Style composition
 
 # The dash pattern is a «lo …» phrase and closes the description, so it moves
@@ -179,13 +172,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c5] liyukisiwa
@@ -193,13 +184,11 @@ style-filled-word =
         [c10] viyukisiwa
        *[c7] ciyukisiwa
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } lo { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } lo { $pattern }
@@ -207,7 +196,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } lo { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «onele» is the border and leads its own describing words, so they agree with
 # it rather than with the shape it surrounds — which is why `border` answers
 # `c9` in `noun-gender`. Umbundu has no article and joins this clause with the
@@ -219,35 +207,28 @@ style-border-clause =
         [and-article] lo onele { $border }
        *[with] lo onele { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = ka ciyukisiwa
-
 style-text =
     { $parts ->
         [background] { $color } lo konyima { $background }
        *[plain] { $color }
     }
-
 style-background-none = kalimwe
-
 
 ## Boolean words
 
 boolean-true = ocili
 boolean-false = uhembi
 
-
 ## Answer buttons
 
 answer-submit-label = Konomboloya Upange
 answer-submit-label-no-correctness = Tuma Etambululo
-
 
 ## Sectional blocks
 
@@ -272,7 +253,6 @@ section-name =
     .solution = Etetulwilo
     .task = Upange
     .theorem = Teoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -282,9 +262,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ekwatiso
-
 
 ## Tables and figures
 
@@ -295,7 +273,6 @@ table-name =
         [unnumbered-title] Otabela{ ": " }
        *[unnumbered] Otabela
     }
-
 figure-name =
     { $parts ->
         [numbered] Ocifwa { $enumeration }
@@ -304,25 +281,18 @@ figure-name =
        *[unnumbered] Ocifwa
     }
 
-
 ## Paginator controls
 
 paginator-previous = Yipita
 paginator-next = Yikwãma
-
 paginator-page = Etapa
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ale
-
 piecewise-condition-if = nda
-
 piecewise-condition-otherwise = kovina vikwavo viosi
-
 
 ## Chemistry
 ##
@@ -345,6 +315,5 @@ piecewise-condition-otherwise = kovina vikwavo viosi
 ## is recorded here so #1521 can find it.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ondimbukiso ya Kimika ka Yisungulukile
 chemistry-invalid-ionic-compound = Elikongelo lya Ioni ka Lyasungulukile

--- a/packages/i18n/locales/ur/chrome.ftl
+++ b/packages/i18n/locales/ur/chrome.ftl
@@ -23,68 +23,50 @@
 
 answer-checking = جانچا جا رہا ہے...
 answer-submitting = بھیجا جا رہا ہے...
-
 answer-checking-status = جواب جانچا جا رہا ہے
 answer-submitting-status = جواب بھیجا جا رہا ہے
-
 answer-correct = صحیح
 answer-incorrect = غلط
-
 answer-response-saved = جواب محفوظ ہو گیا
-
 answer-percent-credit = { $percent }% نمبر
 answer-percent-correct = { $percent }% صحیح
 answer-percent-short = { $percent }%
-
 max-credit-available = زیادہ سے زیادہ ممکنہ نمبر: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] کوئی کوشش باقی نہیں
        *[other] { $count } کوشش باقی
     }
-
 validation-correct = (صحیح جواب)
 validation-incorrect = (غلط جواب)
 validation-partially-correct = (جزوی طور پر صحیح جواب)
-
 answer-show-responses = { $answerId } کو بھیجے گئے { $count } جواب دکھائیں
-
 
 ## Disclosure panels
 
 feedback-heading = رائے
-
 collapsible-click-to-open = (کھولنے کے لیے کلک کریں)
 collapsible-click-to-close = (بند کرنے کے لیے کلک کریں)
 collapsible-initializing = تیار کیا جا رہا ہے...
-
 footnote-show = حاشیہ دکھائیں
 footnote-hide = حاشیہ چھپائیں
-
 description-more-information = مزید معلومات
-
 
 ## Controls
 
 slider-previous = پچھلا
 slider-next = اگلا
-
 keyboard-open = کی بورڈ کھولیں
 keyboard-close = کی بورڈ بند کریں
-
 choice-input-remove-choice = { $choice } ہٹائیں
-
 matrix-remove-row = سطر ہٹائیں
 matrix-add-row = سطر شامل کریں
 matrix-remove-column = کالم ہٹائیں
 matrix-add-column = کالم شامل کریں
-
 subset-add-remove-points = نقطے شامل کریں/ہٹائیں
 subset-toggle-points-intervals = نقطوں اور وقفوں کے درمیان بدلیں
 subset-move-points = نقطے حرکت دیں
 subset-clear = صاف کریں
-
 orbital-add-row = سطر شامل کریں
 orbital-remove-row = سطر ہٹائیں
 orbital-add-box = خانہ شامل کریں
@@ -92,13 +74,9 @@ orbital-remove-box = خانہ ہٹائیں
 orbital-add-up-arrow = اوپر کا تیر شامل کریں
 orbital-add-down-arrow = نیچے کا تیر شامل کریں
 orbital-remove-arrow = تیر ہٹائیں
-
 orbital-row-label = سطر { $row } کا عنوان
-
 pretzel-answer = جواب
-
 summary-statistics-caption = کالم { $column } کا شماریاتی خلاصہ
-
 
 ## Math input
 
@@ -106,37 +84,28 @@ math-input-preview-region = ریاضیاتی اظہار کا پیش نظارہ
 math-input-preview = پیش نظارہ
 math-input-invalid-expression = نامعتبر اظہار:
 
-
 ## Document status
 
 viewer-initializing = تیار کیا جا رہا ہے...
 
-
 ## Errors
 
 error-heading = خرابی
-
 error-found-at =
     { $span ->
         [line] سطر { $startLine } پر ملی۔
        *[lines] سطر { $startLine } تا { $endLine } پر ملی۔
     }
-
 document-contains-errors = اس دستاویز میں خرابیاں ہیں!
-
 # Headings of the tooltip the editor shows over a squiggle.
 diagnostic-heading-error = خرابی
 diagnostic-heading-warning = تنبیہ
 diagnostic-heading-information = معلومات
 diagnostic-heading-hint = اشارہ
-
 # `WCAG AA` is the standard's own name and is not translated.
 accessibility-heading-level-1 = WCAG AA کے مطابق رسائی کی خلاف ورزی
 accessibility-heading-level-2 = رسائی سے متعلق تنبیہ
-
 something-went-wrong = کچھ غلط ہو گیا۔
-
 # Follows `error-heading` and a colon.
 renderer-load-failed = ایک جزو لوڈ نہیں ہو سکا۔ براہِ کرم صفحہ دوبارہ لوڈ کریں۔
-
 core-start-failed = دستاویز کا ناظر شروع نہیں ہو سکا۔ براہِ کرم صفحہ دوبارہ لوڈ کریں۔

--- a/packages/i18n/locales/ur/content.ftl
+++ b/packages/i18n/locales/ur/content.ftl
@@ -95,7 +95,6 @@ color =
                    *[m] بھورا
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -119,12 +118,10 @@ line-width =
                    *[m] پتلا
                 }
         }
-
 # Both are unmarked, so neither inflects.
 line-style =
     .dashed = منقطع
     .dotted = نقطہ دار
-
 # Noun phrases in the oblique plural, because their other use is in front of
 # «والا» — a postposition that governs the oblique and inflects like a marked
 # adjective itself. They agree with nothing, so `style-fill` has to give them
@@ -136,7 +133,6 @@ fill-style =
     .backdiagonal = مخالف ترچھی لکیروں
     .dots = نقطوں
     .diamonds = معینوں
-
 noun =
     .line = لکیر
     .line-segment = قطعہ خط
@@ -156,7 +152,6 @@ noun =
     .diamond = معین
     .cross = کراس
     .plus = جمع کا نشان
-
 # Urdu keeps the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -164,7 +159,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] { $numSides } اضلاع والا باقاعدہ کثیر الاضلاع
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (کثیر الاضلاع, m)
 # or the head of a phrase the description never names: `border` (کنارہ, m),
 # `fill` (بھراؤ, m), `text` (متن, m), `background` (پس منظر, m). Urdu parts
@@ -179,7 +173,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -192,14 +185,12 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # Adjectives precede the noun, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -207,7 +198,6 @@ style-filled-word =
         [f] بھری ہوئی
        *[m] بھرا ہوا
     }
-
 # «والا» is a marked adjective itself, and it agrees with the shape rather than
 # with the pattern in front of it: «نقطوں والی لکیر», «نقطوں والا مربع». It is
 # always said of the shape, so the direct form is the only one needed here —
@@ -215,27 +205,28 @@ style-filled-word =
 # there is «بھراؤ», which is always masculine.
 style-filled =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] والی
-           *[m] والا
-        } { $color } { $filled }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] والی
+               *[m] والا
+            } { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
-        [pattern] { $pattern } { $gender ->
-            [f] والی
-           *[m] والا
-        } { $color } { $filled } { $noun }
+        [pattern]
+            { $pattern } { $gender ->
+                [f] والی
+               *[m] والا
+            } { $color } { $filled } { $noun }
         [plain-tail] { $color } { $filled } { $noun } { $nounTail }
-        [pattern-tail] { $pattern } { $gender ->
-            [f] والی
-           *[m] والا
-        } { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail]
+            { $pattern } { $gender ->
+                [f] والی
+               *[m] والا
+            } { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «کے ساتھ» is a postposition, so «کنارہ» takes the oblique «کنارے» and so do
 # its adjectives — which is what the `border-clause` branch supplies. Urdu has
 # no article, so the `-article` branches read the same as the ones without.
@@ -246,7 +237,6 @@ style-border-clause =
         [and-article] اور { $border } کنارے کے ساتھ
        *[with] { $border } کنارے کے ساتھ
     }
-
 # The fill-pattern words are oblique plurals, so this message supplies a noun
 # for them to hang off — «بھراؤ», masculine, which is the gender `noun-gender`
 # already answers for `fill`, so the colour agrees with it in both variants.
@@ -255,29 +245,23 @@ style-fill =
         [pattern] { $pattern } والا { $color } بھراؤ
        *[plain] { $color } بھراؤ
     }
-
 style-unfilled = بغیر بھراؤ
-
 style-text =
     { $parts ->
         [background] { $background } پس منظر پر { $color }
        *[plain] { $color }
     }
-
 style-background-none = کوئی نہیں
-
 
 ## Boolean words
 
 boolean-true = صحیح
 boolean-false = غلط
 
-
 ## Answer buttons
 
 answer-submit-label = جواب جانچیں
 answer-submit-label-no-correctness = جواب بھیجیں
-
 
 ## Sectional blocks
 
@@ -302,7 +286,6 @@ section-name =
     .solution = حل
     .task = کام
     .theorem = نظریہ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -312,9 +295,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = اشارہ
-
 
 ## Tables and figures
 
@@ -325,7 +306,6 @@ table-name =
         [unnumbered-title] جدول{ ": " }
        *[unnumbered] جدول
     }
-
 figure-name =
     { $parts ->
         [numbered] شکل { $enumeration }
@@ -334,24 +314,18 @@ figure-name =
        *[unnumbered] شکل
     }
 
-
 ## Paginator controls
 
 paginator-previous = پچھلا
 paginator-next = اگلا
 paginator-page = صفحہ
-
 paginator-page-status = { $numPages } میں سے { $pageLabel } { $currentPage }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = یا
-
 piecewise-condition-if = اگر
-
 piecewise-condition-otherwise = بصورت دیگر
-
 
 ## Chemistry
 
@@ -474,7 +448,6 @@ element-name =
     .lv = لیورموریم
     .ts = ٹینیسین
     .og = اوگنیسون
-
 element-anion-name =
     .h = ہائیڈرائیڈ
     .c = کاربائیڈ
@@ -488,8 +461,6 @@ element-anion-name =
     .i = آیوڈائیڈ
     .at = ایسٹاٹائیڈ
     .ts = ٹینیسائیڈ
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = نامعتبر کیمیائی علامت
 chemistry-invalid-ionic-compound = نامعتبر آئنی مرکب

--- a/packages/i18n/locales/urh/chrome.ftl
+++ b/packages/i18n/locales/urh/chrome.ftl
@@ -29,73 +29,55 @@
 
 answer-checking = Ọ yẹn chek…
 answer-submitting = Ọ yẹn sọmit…
-
 answer-checking-status = Ọ yẹn chek ẹkpahọnphiyọ
 answer-submitting-status = Ọ yẹn sọmit ẹkpahọnphiyọ
-
 answer-correct = Ọ rugba
 answer-incorrect = Ọ rugba-e
-
 answer-response-saved = A vwo sevu ẹkpahọnphiyọ na
-
 answer-percent-credit = { $percent }% kirediti
 answer-percent-correct = { $percent }% rugba
 answer-percent-short = { $percent } %
-
 max-credit-available = Kirediti ro kpo họhọ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] i vwo utuja ọvo-o
         [one] utuja { $count } che dje
        *[other] utuja { $count } che dje
     }
-
 validation-correct = (Ọ rugba)
 validation-incorrect = (Ọ rugba-e)
 validation-partially-correct = (Ọ rugba vwẹ ẹkpọvo)
-
 answer-show-responses =
     { $count ->
         [one] Djro ẹkpahọnphiyọ { $count } rẹ { $answerId }
        *[other] Djro ẹkpahọnphiyọ { $count } rẹ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ota
-
 collapsible-click-to-open = (te kẹ e vwo ke)
 collapsible-click-to-close = (te kẹ e vwo vọnrẹ)
-
 collapsible-initializing = Ọ yẹn tọtọre…
-
 footnote-show = Djro ẹbe-egodo
 footnote-hide = Vọnrẹ ẹbe-egodo
-
 description-more-information = odjekọ vwe je
 
 ## Controls
 
 slider-previous = Ọsiẹvwin
 slider-next = Ọrhirie
-
 keyboard-open = Ke Kibọdi
 keyboard-close = Vọnrẹ Kibọdi
-
 choice-input-remove-choice = Werhie { $choice } phrẹ
-
 matrix-remove-row = Werhie eka phrẹ
 matrix-add-row = Kobọrọ eka
 matrix-remove-column = Werhie ọfẹ phrẹ
 matrix-add-column = Kobọrọ ọfẹ
-
 subset-add-remove-points = Kobọrọ/Werhie ẹkpo phrẹ
 subset-toggle-points-intervals = Nrhirhie ẹkpo vẹ ẹkẹ
 subset-move-points = Werhie Ẹkpo
 subset-clear = Ye Ovwan
-
 orbital-add-row = Kobọrọ Eka
 orbital-remove-row = Werhie Eka phrẹ
 orbital-add-box = Kobọrọ Bọkisi
@@ -103,13 +85,9 @@ orbital-remove-box = Werhie Bọkisi phrẹ
 orbital-add-up-arrow = Kobọrọ Arọ ro Kpo Ubru
 orbital-add-down-arrow = Kobọrọ Arọ ro Kpo Otọ
 orbital-remove-arrow = Werhie Arọ phrẹ
-
 orbital-row-label = Odẹ kẹ eka { $row }
-
 pretzel-answer = Ẹkpahọnphiyọ
-
 summary-statistics-caption = Ẹmwemwu ọkiyọvwi rẹ { $column }
-
 
 ## Math input
 
@@ -117,34 +95,25 @@ math-input-preview-region = odjro rẹ mathematiki
 math-input-preview = Odjro
 math-input-invalid-expression = Otọfa ro fioma:
 
-
 ## Document status
 
 viewer-initializing = Ọ yẹn tọtọre…
 
-
 ## Errors
 
 error-heading = Otọfa
-
 error-found-at =
     { $span ->
         [line] A mrẹ o vwẹ layin { $startLine }.
        *[lines] A mrẹ o vwẹ eyin layin { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ẹbe nana vwo otọfa!
-
 diagnostic-heading-error = Otọfa
 diagnostic-heading-warning = Ophariẹ
 diagnostic-heading-information = Odjekọ
 diagnostic-heading-hint = Uphiudu
-
 accessibility-heading-level-1 = Ophariẹ WCAG AA
 accessibility-heading-level-2 = Ophariẹ rẹ Iruemu-erhirhie
-
 something-went-wrong = Ihwo dje otọfa.
-
 renderer-load-failed = odjro-oma na vwo tobọ ke-e. Djovwo vwẹ ẹbe na.
-
 core-start-failed = A sa vwo se odjro rẹ ẹbe na-a. Djovwo vwẹ ẹbe na.

--- a/packages/i18n/locales/urh/content.ftl
+++ b/packages/i18n/locales/urh/content.ftl
@@ -47,15 +47,12 @@ color =
     .purple = pọpol
     .pink = pinki
     .brown = brawun
-
 line-width =
     .thick = ro gbanro
     .thin = ro dinrin
-
 line-style =
     .dashed = ro vwo edaesi
     .dotted = ro vwo ẹkpo
-
 fill-style =
     .horizontal = eyin ro fẹẹ
     .vertical = eyin ro tọtọ
@@ -63,7 +60,6 @@ fill-style =
     .backdiagonal = eyin ro krisikrọsi ephiare
     .dots = ẹkpo
     .diamonds = daimọn
-
 noun =
     .line = layin
     .line-segment = ẹkpẹrọ layin
@@ -83,15 +79,12 @@ noun =
     .diamond = daimọn
     .cross = krọsi
     .plus = plọsi
-
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] poligọn ro dogba, vwo eyin { $numSides }
     }
-
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,21 +98,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = ro vwo evwo vwẹrhọ
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } vwẹ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } vwẹ { $pattern }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $filled } { $color } { $nounTail } vwẹ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 style-border-clause =
     { $parts ->
         [with-article] vwẹ ẹkpẹrọ { $border }
@@ -135,35 +123,28 @@ style-border-clause =
         [and-article] vẹ ẹkpẹrọ { $border }
        *[with] vwẹ ẹkpẹrọ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ro vwo evwo vwẹrhọ-e
-
 style-text =
     { $parts ->
         [background] { $color } vwẹ ẹkẹ-otọ { $background }
        *[plain] { $color }
     }
-
 style-background-none = ovwan
-
 
 ## Boolean words
 
 boolean-true = true
 boolean-false = false
 
-
 ## Answer buttons
 
 answer-submit-label = Chek Iruo
 answer-submit-label-no-correctness = Sọmit Ẹkpahọnphiyọ
-
 
 ## Sectional blocks
 
@@ -188,7 +169,6 @@ section-name =
     .solution = Efejorin
     .task = Iruo
     .theorem = Iyẹrẹ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -198,9 +178,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Uphiudu
-
 
 ## Tables and figures
 
@@ -211,7 +189,6 @@ table-name =
         [unnumbered-title] Tebul{ ": " }
        *[unnumbered] Tebul
     }
-
 figure-name =
     { $parts ->
         [numbered] Fọtọ { $enumeration }
@@ -220,24 +197,18 @@ figure-name =
        *[unnumbered] Fọtọ
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ọsiẹvwin
 paginator-next = Ọrhirie
 paginator-page = Pej
-
 paginator-page-status = { $pageLabel } { $currentPage } vwẹ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = yẹrẹ
-
 piecewise-condition-if = wọ da nẹ
-
 piecewise-condition-otherwise = ọvo ọfa
-
 
 ## Chemistry
 ##
@@ -245,8 +216,6 @@ piecewise-condition-otherwise = ọvo ọfa
 ## including in Delta State, is taught in English, and this seed found no
 ## settled Urhobo chemical nomenclature to draw on.
 
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ami-Kemistri ro Fioma
 chemistry-invalid-ionic-compound = Ọbọ-Aiọni ro Fioma

--- a/packages/i18n/locales/uz/chrome.ftl
+++ b/packages/i18n/locales/uz/chrome.ftl
@@ -17,74 +17,55 @@
 
 answer-checking = Tekshirilmoqda…
 answer-submitting = Yuborilmoqda…
-
 answer-checking-status = Javob tekshirilmoqda
 answer-submitting-status = Javob yuborilmoqda
-
 answer-correct = Toʻgʻri
 answer-incorrect = Notoʻgʻri
-
 answer-response-saved = Javob saqlandi
-
 answer-percent-credit = { $percent }% ball
 answer-percent-correct = { $percent }% toʻgʻri
 answer-percent-short = { $percent } %
-
 max-credit-available = Mumkin boʻlgan eng yuqori ball: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] urinish qolmadi
         [one] { $count } urinish qoldi
        *[other] { $count } urinish qoldi
     }
-
 validation-correct = (Toʻgʻri)
 validation-incorrect = (Notoʻgʻri)
 validation-partially-correct = (Qisman toʻgʻri)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } uchun { $count } javobni koʻrsatish
        *[other] { $answerId } uchun { $count } javobni koʻrsatish
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Fikr-mulohaza
-
 collapsible-click-to-open = (ochish uchun bosing)
 collapsible-click-to-close = (yopish uchun bosing)
-
 collapsible-initializing = Tayyorlanmoqda…
-
 footnote-show = Izohni koʻrsatish
 footnote-hide = Izohni yashirish
-
 description-more-information = qoʻshimcha maʼlumot
-
 
 ## Controls
 
 slider-previous = Oldingi
 slider-next = Keyingi
-
 keyboard-open = Klaviaturani ochish
 keyboard-close = Klaviaturani yopish
-
 choice-input-remove-choice = { $choice } tanlovini olib tashlash
-
 matrix-remove-row = Qatorni oʻchirish
 matrix-add-row = Qator qoʻshish
 matrix-remove-column = Ustunni oʻchirish
 matrix-add-column = Ustun qoʻshish
-
 subset-add-remove-points = Nuqta qoʻshish/oʻchirish
 subset-toggle-points-intervals = Nuqtalar va oraliqlar orasida almashtirish
 subset-move-points = Nuqtalarni koʻchirish
 subset-clear = Tozalash
-
 orbital-add-row = Qator qoʻshish
 orbital-remove-row = Qatorni oʻchirish
 orbital-add-box = Katak qoʻshish
@@ -92,13 +73,9 @@ orbital-remove-box = Katakni oʻchirish
 orbital-add-up-arrow = Yuqoriga strelka qoʻshish
 orbital-add-down-arrow = Pastga strelka qoʻshish
 orbital-remove-arrow = Strelkani oʻchirish
-
 orbital-row-label = { $row } qatorining yorligʻi
-
 pretzel-answer = Javob
-
 summary-statistics-caption = { $column } ustunining jamlovchi statistikasi
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = matematik ifodani oldindan koʻrish
 math-input-preview = Oldindan koʻrish
 math-input-invalid-expression = Yaroqsiz ifoda:
 
-
 ## Document status
 
 viewer-initializing = Tayyorlanmoqda…
 
-
 ## Errors
 
 error-heading = Xato
-
 error-found-at =
     { $span ->
         [line] { $startLine }-qatorda topildi.
        *[lines] { $startLine }–{ $endLine }-qatorlarda topildi.
     }
-
 document-contains-errors = Bu hujjatda xatolar bor!
-
 diagnostic-heading-error = Xato
 diagnostic-heading-warning = Ogohlantirish
 diagnostic-heading-information = Maʼlumot
 diagnostic-heading-hint = Maslahat
-
 accessibility-heading-level-1 = WCAG AA foydalanuvchanlik buzilishi
 accessibility-heading-level-2 = Foydalanuvchanlik bildirishnomasi
-
 something-went-wrong = Nimadir notoʻgʻri ketdi.
-
 renderer-load-failed = tasvirlagichni yuklab boʻlmadi. Sahifani yangilang.
-
 core-start-failed = Hujjat koʻruvchisini ishga tushirib boʻlmadi. Sahifani yangilang.

--- a/packages/i18n/locales/uz/content.ftl
+++ b/packages/i18n/locales/uz/content.ftl
@@ -34,15 +34,12 @@ color =
     .purple = binafsha
     .pink = pushti
     .brown = jigarrang
-
 line-width =
     .thick = qalin
     .thin = ingichka
-
 line-style =
     .dashed = uzuq-uzuq
     .dotted = nuqtali
-
 # Noun phrases: they stand in front of «naqshli» and modify nothing.
 fill-style =
     .horizontal = gorizontal chiziq
@@ -51,7 +48,6 @@ fill-style =
     .backdiagonal = teskari diagonal chiziq
     .dots = nuqta
     .diamonds = romb
-
 noun =
     .line = toʻgʻri chiziq
     .line-segment = kesma
@@ -71,7 +67,6 @@ noun =
     .diamond = romb
     .cross = xoch
     .plus = plyus
-
 # Uzbek builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -79,11 +74,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] muntazam { $numSides }-burchak
     }
-
 # Uzbek has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English and Turkish.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -97,21 +90,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = boʻyalgan
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } naqshli { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } naqshli { $color } { $filled } { $noun }
@@ -119,7 +108,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } naqshli { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «hoshiyali» — "bordered" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted, and all four
 # branches read alike except for the connective English needs and Uzbek does
@@ -131,15 +119,12 @@ style-border-clause =
         [and-article] va { $border } hoshiyali
        *[with] { $border } hoshiyali
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } naqshli { $color } boʻyoq
        *[plain] { $color } boʻyoq
     }
-
 style-unfilled = boʻyalmagan
-
 # «fonda» is the locative of «fon» and says "on the background" by itself, so
 # nothing stands between the two colours.
 style-text =
@@ -147,21 +132,17 @@ style-text =
         [background] { $background } fonda { $color }
        *[plain] { $color }
     }
-
 style-background-none = yoʻq
-
 
 ## Boolean words
 
 boolean-true = rost
 boolean-false = yolgʻon
 
-
 ## Answer buttons
 
 answer-submit-label = Tekshirish
 answer-submit-label-no-correctness = Javobni yuborish
-
 
 ## Sectional blocks
 
@@ -186,7 +167,6 @@ section-name =
     .solution = Yechim
     .task = Topshiriq
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -196,9 +176,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Maslahat
-
 
 ## Tables and figures
 
@@ -209,7 +187,6 @@ table-name =
         [unnumbered-title] Jadval{ ". " }
        *[unnumbered] Jadval
     }
-
 figure-name =
     { $parts ->
         [numbered] { $enumeration }-rasm
@@ -218,22 +195,18 @@ figure-name =
        *[unnumbered] Rasm
     }
 
-
 ## Paginator controls
 
 paginator-previous = Oldingi
 paginator-next = Keyingi
 paginator-page = Sahifa
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = yoki
 piecewise-condition-if = agar
 piecewise-condition-otherwise = aks holda
-
 
 ## Chemistry
 
@@ -356,7 +329,6 @@ element-name =
     .lv = Livermoriy
     .ts = Tennessin
     .og = Oganeson
-
 element-anion-name =
     .h = Gidrid
     .c = Karbid
@@ -370,8 +342,6 @@ element-anion-name =
     .i = Yodid
     .at = Astatid
     .ts = Tennessid
-
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Yaroqsiz kimyoviy belgi
 chemistry-invalid-ionic-compound = Yaroqsiz ion birikma

--- a/packages/i18n/locales/ve/chrome.ftl
+++ b/packages/i18n/locales/ve/chrome.ftl
@@ -11,74 +11,55 @@
 
 answer-checking = Hu khou sedzwa…
 answer-submitting = Hu khou rumelwa…
-
 answer-checking-status = Phindulo i khou sedzwa
 answer-submitting-status = Phindulo i khou rumelwa
-
 answer-correct = Zwo luga
 answer-incorrect = A zwo ngo luga
-
 answer-response-saved = Phindulo yo Vhulungwa
-
 answer-percent-credit = { $percent }% ya Mavhege
 answer-percent-correct = { $percent }% zwo Luga
 answer-percent-short = { $percent } %
-
 max-credit-available = Mavhege mahulwane a wanalaho: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] a hu na u lingedza ho salaho
         [one] ho sala u lingedza ha { $count }
        *[other] ho sala u lingedza ha { $count }
     }
-
 validation-correct = (Zwo luga)
 validation-incorrect = (A zwo ngo luga)
 validation-partially-correct = (Zwo luga nga tshipiḓa)
-
 answer-show-responses =
     { $count ->
         [one] Sumbedza phindulo { $count } kha { $answerId }
        *[other] Sumbedza dziphindulo { $count } kha { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Mbuyedzedzo
-
 collapsible-click-to-open = (puṱedza u vula)
 collapsible-click-to-close = (puṱedza u vala)
-
 collapsible-initializing = Hu khou thoma…
-
 footnote-show = Sumbedza ṋowuthu ya fhasi
 footnote-hide = Dzumba ṋowuthu ya fhasi
-
 description-more-information = mafhungo manzhi
-
 
 ## Controls
 
 slider-previous = Zwo fhiraho
 slider-next = Zwi tevhelaho
-
 keyboard-open = Vula Khiibodo
 keyboard-close = Vala Khiibodo
-
 choice-input-remove-choice = Bvisa { $choice }
-
 matrix-remove-row = Bvisa mutalo
 matrix-add-row = Engedza mutalo
 matrix-remove-column = Bvisa kholomo
 matrix-add-column = Engedza kholomo
-
 subset-add-remove-points = Engedza/Bvisa dziphoinnti
 subset-toggle-points-intervals = Shandukisa dziphoinnti na zwifhinga
 subset-move-points = Pfulusa Dziphoinnti
 subset-clear = Phumula
-
 orbital-add-row = Engedza Mutalo
 orbital-remove-row = Bvisa Mutalo
 orbital-add-box = Engedza Bogisi
@@ -86,13 +67,9 @@ orbital-remove-box = Bvisa Bogisi
 orbital-add-up-arrow = Engedza Musevhe wa Nṱha
 orbital-add-down-arrow = Engedza Musevhe wa Fhasi
 orbital-remove-arrow = Bvisa Musevhe
-
 orbital-row-label = Dzina ḽa mutalo { $row }
-
 pretzel-answer = Phindulo
-
 summary-statistics-caption = Manweledzo a tshivhalo tsha { $column }
-
 
 ## Math input
 
@@ -100,34 +77,25 @@ math-input-preview-region = u sedza hu saathu ha mubvumo wa mbalo
 math-input-preview = U sedza hu saathu
 math-input-invalid-expression = Mubvumo wo khakheaho:
 
-
 ## Document status
 
 viewer-initializing = Hu khou thoma…
 
-
 ## Errors
 
 error-heading = Vhukhakhi
-
 error-found-at =
     { $span ->
         [line] Ho wanala kha mutalo { $startLine }.
        *[lines] Ho wanala kha mitalo { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Ḽiṅwalo iḽi ḽi na vhukhakhi!
-
 diagnostic-heading-error = Vhukhakhi
 diagnostic-heading-warning = Tsevho
 diagnostic-heading-information = Mafhungo
 diagnostic-heading-hint = Nyeletshedzo
-
 accessibility-heading-level-1 = U Pfuka ha WCAG AA ha U Swikelela
 accessibility-heading-level-2 = Tsevho ya u swikelela
-
 something-went-wrong = Hu na tshine tsha si tshimbile zwavhuḓi.
-
 renderer-load-failed = tshisumbedzi a tsho ngo kona u lodiwa. Ri humbela ni lode siaṱari hafhu.
-
 core-start-failed = Tshisumbedzi tsha ḽiṅwalo a tsho ngo kona u thoma. Ri humbela ni lode siaṱari hafhu.

--- a/packages/i18n/locales/ve/content.ftl
+++ b/packages/i18n/locales/ve/content.ftl
@@ -82,7 +82,6 @@ color =
     .purple = phephuḽi
     .pink = phinngi
     .brown = buraweni
-
 line-width =
     .thick =
         { $gender ->
@@ -96,13 +95,11 @@ line-width =
             [c7] tshiṱuku
            *[c9] nṱuku
         }
-
 # Written as an invariable «nga …» phrase, so that it agrees with nothing and
 # can close the phrase. `style-stroke` puts it last for that reason.
 line-style =
     .dashed = nga zwipiḓa
     .dotted = nga thodzi
-
 fill-style =
     .horizontal = mitalo yo lalaho
     .vertical = mitalo yo imaho
@@ -110,7 +107,6 @@ fill-style =
     .backdiagonal = mitalo yo sendamaho nga u fhambana
     .dots = thodzi
     .diamonds = daimonde
-
 noun =
     .line = mutalo
     .line-segment = tshipiḓa tsha mutalo
@@ -130,7 +126,6 @@ noun =
     .diamond = daimonde
     .cross = tshifhambano
     .plus = tshiga tsha u engedza
-
 # The side count is a possessive complement and closes the noun phrase behind
 # the describing words rather than opening it, so it goes in the tail.
 noun-regular-polygon =
@@ -138,7 +133,6 @@ noun-regular-polygon =
         [tail] tsha masia a { $numSides }
        *[head] tshivhumbeo tsho linganaho
     }
-
 # The noun class. `c9` is the default and the class of every loanword.
 noun-gender =
     { $noun ->
@@ -158,7 +152,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a «nga …» phrase and closes the description, so it moves
@@ -173,26 +166,22 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] wo ḓadzwaho
         [c7] tsho ḓadzwaho
        *[c9] yo ḓadzwaho
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } nga { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } nga { $pattern }
@@ -200,7 +189,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nga { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «mukano» is class 3 and leads its own describing words, so the border's words
 # agree with it rather than with the shape it surrounds. Tshivenḓa has no
 # article and joins this clause with the invariable «na», so all four branches
@@ -212,35 +200,28 @@ style-border-clause =
         [and-article] na mukano { $border }
        *[with] na mukano { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = a yo ngo ḓadzwa
-
 style-text =
     { $parts ->
         [background] { $color } nṱha ha muvhala wa murahu { $background }
        *[plain] { $color }
     }
-
 style-background-none = a hu na tshithu
-
 
 ## Boolean words
 
 boolean-true = ngoho
 boolean-false = mazwifhi
 
-
 ## Answer buttons
 
 answer-submit-label = Sedza Mushumo
 answer-submit-label-no-correctness = Rumela Phindulo
-
 
 ## Sectional blocks
 
@@ -265,7 +246,6 @@ section-name =
     .solution = Tandululo
     .task = Mushumo
     .theorem = Thiyoreme
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -275,9 +255,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Nyeletshedzo
-
 
 ## Tables and figures
 
@@ -288,7 +266,6 @@ table-name =
         [unnumbered-title] Ṱhefula{ ": " }
        *[unnumbered] Ṱhefula
     }
-
 figure-name =
     { $parts ->
         [numbered] Tshifanyiso { $enumeration }
@@ -297,24 +274,18 @@ figure-name =
        *[unnumbered] Tshifanyiso
     }
 
-
 ## Paginator controls
 
 paginator-previous = Zwo fhiraho
 paginator-next = Zwi tevhelaho
 paginator-page = Siaṱari
-
 paginator-page-status = { $pageLabel } { $currentPage } kha { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = kana
-
 piecewise-condition-if = arali
-
 piecewise-condition-otherwise = nga nnḓa ha zwenezwo
-
 
 ## Chemistry
 ##
@@ -327,6 +298,5 @@ piecewise-condition-otherwise = nga nnḓa ha zwenezwo
 ## table in one of those and the fallback *is* the curriculum.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Tshiga tsha Khemikhala tsho Khakheaho
 chemistry-invalid-ionic-compound = Ṱhanganelo ya Ayoni yo Khakheaho

--- a/packages/i18n/locales/vi/chrome.ftl
+++ b/packages/i18n/locales/vi/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Đang kiểm tra...
 answer-submitting = Đang gửi...
-
 answer-checking-status = Đang kiểm tra câu trả lời
 answer-submitting-status = Đang gửi câu trả lời
-
 answer-correct = Đúng
 answer-incorrect = Sai
-
 answer-response-saved = Đã lưu câu trả lời
-
 answer-percent-credit = { $percent }% điểm
 answer-percent-correct = { $percent }% đúng
 answer-percent-short = { $percent }%
-
 max-credit-available = Điểm tối đa có thể đạt: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] không còn lượt thử nào
        *[other] còn { $count } lượt thử
     }
-
 validation-correct = (Đúng)
 validation-incorrect = (Sai)
 validation-partially-correct = (Đúng một phần)
-
 answer-show-responses = Hiển thị { $count } câu trả lời cho { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Phản hồi
-
 collapsible-click-to-open = (nhấn để mở)
 collapsible-click-to-close = (nhấn để đóng)
-
 collapsible-initializing = Đang khởi tạo...
-
 footnote-show = Hiện chú thích
 footnote-hide = Ẩn chú thích
-
 description-more-information = thêm thông tin
-
 
 ## Controls
 
 slider-previous = Trước
 slider-next = Sau
-
 keyboard-open = Mở bàn phím
 keyboard-close = Đóng bàn phím
-
 choice-input-remove-choice = Xóa { $choice }
-
 matrix-remove-row = Xóa hàng
 matrix-add-row = Thêm hàng
 matrix-remove-column = Xóa cột
 matrix-add-column = Thêm cột
-
 subset-add-remove-points = Thêm/Xóa điểm
 subset-toggle-points-intervals = Chuyển giữa điểm và khoảng
 subset-move-points = Di chuyển điểm
 subset-clear = Xóa hết
-
 # A `box` here is one orbital, drawn as a square: ô.
 orbital-add-row = Thêm hàng
 orbital-remove-row = Xóa hàng
@@ -91,13 +72,9 @@ orbital-remove-box = Xóa ô
 orbital-add-up-arrow = Thêm mũi tên lên
 orbital-add-down-arrow = Thêm mũi tên xuống
 orbital-remove-arrow = Xóa mũi tên
-
 orbital-row-label = Nhãn cho hàng { $row }
-
 pretzel-answer = Đáp án
-
 summary-statistics-caption = Thống kê mô tả của { $column }
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = xem trước biểu thức toán
 math-input-preview = Xem trước
 math-input-invalid-expression = Biểu thức không hợp lệ:
 
-
 ## Document status
 
 viewer-initializing = Đang khởi tạo...
 
-
 ## Errors
 
 error-heading = Lỗi
-
 error-found-at =
     { $span ->
         [line] Tìm thấy ở dòng { $startLine }.
        *[lines] Tìm thấy ở các dòng { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Tài liệu này có lỗi!
-
 diagnostic-heading-error = Lỗi
 diagnostic-heading-warning = Cảnh báo
 diagnostic-heading-information = Thông tin
 diagnostic-heading-hint = Gợi ý
-
 accessibility-heading-level-1 = Vi phạm khả năng tiếp cận WCAG AA
 accessibility-heading-level-2 = Cảnh báo về khả năng tiếp cận
-
 something-went-wrong = Đã xảy ra lỗi.
-
 renderer-load-failed = một bộ hiển thị không tải được. Vui lòng tải lại trang.
-
 core-start-failed = Không thể khởi động trình xem tài liệu. Vui lòng tải lại trang.

--- a/packages/i18n/locales/vi/content.ftl
+++ b/packages/i18n/locales/vi/content.ftl
@@ -28,15 +28,12 @@ color =
     .purple = màu tím
     .pink = màu hồng
     .brown = màu nâu
-
 line-width =
     .thick = đậm
     .thin = mảnh
-
 line-style =
     .dashed = nét đứt
     .dotted = nét chấm
-
 # Noun phrases: they follow "với" and modify nothing.
 fill-style =
     .horizontal = đường kẻ ngang
@@ -45,7 +42,6 @@ fill-style =
     .backdiagonal = đường kẻ chéo ngược
     .dots = chấm tròn
     .diamonds = hình thoi
-
 noun =
     .line = đường thẳng
     .line-segment = đoạn thẳng
@@ -65,7 +61,6 @@ noun =
     .diamond = hình thoi
     .cross = dấu nhân
     .plus = dấu cộng
-
 # The side count is part of the noun phrase and sits immediately after it —
 # "đa giác đều 5 cạnh" — before any adjective, so it folds into the head and
 # there is no tail. Putting it after the adjectives would separate "cạnh" from
@@ -75,11 +70,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] đa giác đều { $numSides } cạnh
     }
-
 # Vietnamese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -93,22 +86,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: "đường thẳng đậm nét đứt màu đỏ".
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = được tô
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } với { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } với { $pattern }
@@ -116,7 +105,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } với { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Vietnamese needs no article, so the `-article` branches read the same as the
 # ones without.
 style-border-clause =
@@ -126,36 +114,29 @@ style-border-clause =
         [and-article] và viền { $border }
        *[with] với viền { $border }
     }
-
 # The pattern is a noun and the colour follows it, as everywhere else.
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = không tô
-
 style-text =
     { $parts ->
         [background] { $color } trên nền { $background }
        *[plain] { $color }
     }
-
 style-background-none = không có
-
 
 ## Boolean words
 
 boolean-true = đúng
 boolean-false = sai
 
-
 ## Answer buttons
 
 answer-submit-label = Kiểm tra
 answer-submit-label-no-correctness = Gửi câu trả lời
-
 
 ## Sectional blocks
 
@@ -180,7 +161,6 @@ section-name =
     .solution = Lời giải
     .task = Nhiệm vụ
     .theorem = Định lý
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -190,9 +170,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Gợi ý
-
 
 ## Tables and figures
 
@@ -203,7 +181,6 @@ table-name =
         [unnumbered-title] Bảng{ ": " }
        *[unnumbered] Bảng
     }
-
 figure-name =
     { $parts ->
         [numbered] Hình { $enumeration }
@@ -212,15 +189,12 @@ figure-name =
        *[unnumbered] Hình
     }
 
-
 ## Paginator controls
 
 paginator-previous = Trước
 paginator-next = Sau
 paginator-page = Trang
-
 paginator-page-status = { $pageLabel } { $currentPage } trên { $numPages }
-
 
 ## Piecewise functions
 
@@ -228,8 +202,8 @@ piecewise-condition-or = hoặc
 piecewise-condition-if = nếu
 piecewise-condition-otherwise = trường hợp còn lại
 
-
 ## Chemistry
+
 
 # `element-name` and `element-anion-name` are deliberately omitted, and the 130
 # keys fall back to English.
@@ -243,6 +217,5 @@ piecewise-condition-otherwise = trường hợp còn lại
 # document can add these keys, and `lint:i18n` reports the gap until then.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Ký hiệu hóa học không hợp lệ
 chemistry-invalid-ionic-compound = Hợp chất ion không hợp lệ

--- a/packages/i18n/locales/war/chrome.ftl
+++ b/packages/i18n/locales/war/chrome.ftl
@@ -29,21 +29,15 @@
 
 answer-checking = Ginsususi…
 answer-submitting = Ginpapadara…
-
 answer-checking-status = Ginsususi an baton
 answer-submitting-status = Ginpapadara an baton
-
 answer-correct = Husto
 answer-incorrect = Diri husto
-
 answer-response-saved = Natipigan an baton
-
 answer-percent-credit = { $percent }% nga kredito
 answer-percent-correct = { $percent }% nga husto
 answer-percent-short = { $percent } %
-
 max-credit-available = Pinakahitaas nga kredito nga makukuha: { $percent }%
-
 # No select: «pagsari» is the same word for one and for many. The `[0]` branch
 # stays, because it names none rather than counting.
 attempts-remaining =
@@ -51,51 +45,38 @@ attempts-remaining =
         [0] waray na nahabilin nga pagsari
        *[other] { $count } nga pagsari an nahabilin
     }
-
 validation-correct = (Husto)
 validation-incorrect = (Diri husto)
 validation-partially-correct = (Husto ha bahin)
-
 # No select, for the reason above. `$answerId` is the author's own name for the
 # answer and is never translated.
 answer-show-responses = Ipakita an { $count } nga baton para ha { $answerId }
 
-
 ## Disclosure panels
 
 feedback-heading = Komento
-
 collapsible-click-to-open = (i-klik basi maabrihan)
 collapsible-click-to-close = (i-klik basi masarhan)
-
 collapsible-initializing = Nagtitikang…
-
 footnote-show = Ipakita an footnote
 footnote-hide = Itago an footnote
-
 description-more-information = dugang nga impormasyon
-
 
 ## Controls
 
 slider-previous = Nahiuna
 slider-next = Sunod
-
 keyboard-open = Abrihi an teklado
 keyboard-close = Sarhi an teklado
-
 choice-input-remove-choice = Kuhaa an { $choice }
-
 matrix-remove-row = Kuhaa an linya
 matrix-add-row = Dugangi hin linya
 matrix-remove-column = Kuhaa an kolum
 matrix-add-column = Dugangi hin kolum
-
 subset-add-remove-points = Pagdugang/Pagkuha hin mga punto
 subset-toggle-points-intervals = Pagbalyo hin mga punto ngan interbalo
 subset-move-points = Ibalhin an mga punto
 subset-clear = Limpyohi
-
 orbital-add-row = Dugangi hin linya
 orbital-remove-row = Kuhaa an linya
 orbital-add-box = Dugangi hin kahon
@@ -103,13 +84,9 @@ orbital-remove-box = Kuhaa an kahon
 orbital-add-up-arrow = Dugangi hin pana nga pasaka
 orbital-add-down-arrow = Dugangi hin pana nga palugsad
 orbital-remove-arrow = Kuhaa an pana
-
 orbital-row-label = Etiketa para ha linya { $row }
-
 pretzel-answer = Baton
-
 summary-statistics-caption = Sumaryo nga estadistika han { $column }
-
 
 ## Math input
 
@@ -117,34 +94,25 @@ math-input-preview-region = pahiuna nga pagkita han ekspresyon nga matematika
 math-input-preview = Pahiuna nga pagkita
 math-input-invalid-expression = Imbalido nga ekspresyon:
 
-
 ## Document status
 
 viewer-initializing = Nagtitikang…
 
-
 ## Errors
 
 error-heading = Sayop
-
 error-found-at =
     { $span ->
         [line] Nakit-an ha linya { $startLine }.
        *[lines] Nakit-an ha mga linya { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = May-ada sayop ini nga dokumento!
-
 diagnostic-heading-error = Sayop
 diagnostic-heading-warning = Pahamangno
 diagnostic-heading-information = Impormasyon
 diagnostic-heading-hint = Giya
-
 accessibility-heading-level-1 = Paglapas ha aksesibilidad nga WCAG AA
 accessibility-heading-level-2 = Pahamangno mahitungod ha aksesibilidad
-
 something-went-wrong = May-ada nasayop.
-
 renderer-load-failed = may renderer nga waray ma-load. Alayon i-reload an pahina.
-
 core-start-failed = Diri natikang an pagkita han dokumento. Alayon i-reload an pahina.

--- a/packages/i18n/locales/war/content.ftl
+++ b/packages/i18n/locales/war/content.ftl
@@ -39,15 +39,12 @@ color =
     .purple = lila
     .pink = rosas
     .brown = kape
-
 line-width =
     .thick = baga
     .thin = manipis
-
 line-style =
     .dashed = putol-putol
     .dotted = tulbok-tulbok
-
 # Noun phrases. Waray marks no plural on the noun, so «badlis» is the word for
 # one line and for many alike.
 fill-style =
@@ -57,7 +54,6 @@ fill-style =
     .backdiagonal = baliskad nga hilis nga badlis
     .dots = tulbok
     .diamonds = diyamante
-
 noun =
     .line = linya
     .line-segment = segmento
@@ -77,7 +73,6 @@ noun =
     .diamond = diyamante
     .cross = krus
     .plus = plus
-
 # The side count follows the adjectives as a complement, so that they stay
 # beside the noun they describe.
 noun-regular-polygon =
@@ -85,11 +80,9 @@ noun-regular-polygon =
         [tail] nga may { $numSides } nga kilid
        *[head] regular nga poligono
     }
-
 # One answer for every noun: Waray has no grammatical gender, so nothing
 # downstream has anything to agree with.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -103,21 +96,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } nga { $noun } { $nounTail }
        *[noun] { $description } nga { $noun }
     }
-
 style-filled-word = puno
-
 style-filled =
     { $parts ->
         [pattern] { $filled } nga { $color } nga may { $pattern }
        *[plain] { $filled } nga { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } nga { $color } nga { $noun } nga may { $pattern }
@@ -125,7 +114,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } nga { $color } nga { $noun } { $nounTail } nga may { $pattern }
        *[plain] { $filled } nga { $color } nga { $noun }
     }
-
 # Waray has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «nga may» against «ngan».
@@ -136,35 +124,28 @@ style-border-clause =
         [and-article] ngan { $border } nga ligid
        *[with] nga may { $border } nga ligid
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } nga { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = diri puno
-
 style-text =
     { $parts ->
         [background] { $color } nga may { $background } nga background
        *[plain] { $color }
     }
-
 style-background-none = waray
-
 
 ## Boolean words
 
 boolean-true = tinuod
 boolean-false = buwa
 
-
 ## Answer buttons
 
 answer-submit-label = Susiha an baton
 answer-submit-label-no-correctness = Ipadara an baton
-
 
 ## Sectional blocks
 
@@ -192,7 +173,6 @@ section-name =
     .solution = Solusyon
     .task = Buruhaton
     .theorem = Teorema
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -202,9 +182,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Giya
-
 
 ## Tables and figures
 
@@ -215,7 +193,6 @@ table-name =
         [unnumbered-title] Talaan{ ": " }
        *[unnumbered] Talaan
     }
-
 figure-name =
     { $parts ->
         [numbered] Pigura { $enumeration }
@@ -224,22 +201,18 @@ figure-name =
        *[unnumbered] Pigura
     }
 
-
 ## Paginator controls
 
 paginator-previous = Nahiuna
 paginator-next = Sunod
 paginator-page = Pahina
-
 paginator-page-status = { $pageLabel } { $currentPage } ha { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = o
 piecewise-condition-if = kon
 piecewise-condition-otherwise = kon diri
-
 
 ## Chemistry
 ##
@@ -249,6 +222,5 @@ piecewise-condition-otherwise = kon diri
 ## one — the same reason `locales/fil` and `locales/ceb` leave these keys out.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Imbalido nga simbolo nga kemikal
 chemistry-invalid-ionic-compound = Imbalido nga kompuwesto nga ioniko

--- a/packages/i18n/locales/wo/chrome.ftl
+++ b/packages/i18n/locales/wo/chrome.ftl
@@ -20,69 +20,50 @@
 
 answer-checking = Mu ngi seetlu...
 answer-submitting = Mu ngi yónnee...
-
 answer-checking-status = Mu ngi seetlu tontu bi
 answer-submitting-status = Mu ngi yónnee tontu bi
-
 answer-correct = Baax na
 answer-incorrect = Baaxul
-
 answer-response-saved = Tontu bi Denc Nañu ko
-
 answer-percent-credit = { $percent }% Njariñ
 answer-percent-correct = { $percent }% Baax na
 answer-percent-short = { $percent } %
-
 max-credit-available = Njariñ gi gën a kawe: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] amul jéego bu des
        *[other] { $count } jéego a des
     }
-
 validation-correct = (Baax na)
 validation-incorrect = (Baaxul)
 validation-partially-correct = (Baax na ci lenn)
-
 answer-show-responses = Wone { $count } tontu ci { $answerId }
-
 
 ## Disclosure panels
 
 feedback-heading = Ndigal
-
 collapsible-click-to-open = (bësal ngir ubbi)
 collapsible-click-to-close = (bësal ngir tëj)
-
 collapsible-initializing = Mu ngi tàmbali...
-
 footnote-show = Wone nataalu suuf
 footnote-hide = Nëbb nataalu suuf
-
 description-more-information = xibaar yu gën a bare
-
 
 ## Controls
 
 slider-previous = Bi jiitu
 slider-next = Bi ci topp
-
 keyboard-open = Ubbi Klaawiye bi
 keyboard-close = Tëj Klaawiye bi
-
 choice-input-remove-choice = Dindi { $choice }
-
 matrix-remove-row = Dindi ab rëdd
 matrix-add-row = Yokk ab rëdd
 matrix-remove-column = Dindi ab poto
 matrix-add-column = Yokk ab poto
-
 subset-add-remove-points = Yokk/Dindi ay poñ
 subset-toggle-points-intervals = Soppi diggante poñ ak enterwal
 subset-move-points = Toxal Poñ yi
 subset-clear = Far
-
 # A `box` here is one orbital, drawn as a square: «kees».
 orbital-add-row = Yokk Rëdd
 orbital-remove-row = Dindi Rëdd
@@ -91,13 +72,9 @@ orbital-remove-box = Dindi Kees
 orbital-add-up-arrow = Yokk Fetal bu Kaw
 orbital-add-down-arrow = Yokk Fetal bu Suuf
 orbital-remove-arrow = Dindi Fetal
-
 orbital-row-label = Turu rëdd { $row }
-
 pretzel-answer = Tontu
-
 summary-statistics-caption = Statistik yu gàttu yu { $column }
-
 
 ## Math input
 
@@ -105,34 +82,25 @@ math-input-preview-region = wonewaatu ekspresiyoŋu matematik
 math-input-preview = Wonewaat
 math-input-invalid-expression = Ekspresiyoŋ bi baaxul:
 
-
 ## Document status
 
 viewer-initializing = Mu ngi tàmbali...
 
-
 ## Errors
 
 error-heading = Njumte
-
 error-found-at =
     { $span ->
         [line] Gis nañu ko ci rëdd { $startLine }.
        *[lines] Gis nañu ko ci rëdd { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Dokimaan bii am na ay njumte!
-
 diagnostic-heading-error = Njumte
 diagnostic-heading-warning = Artu
 diagnostic-heading-information = Xibaar
 diagnostic-heading-hint = Xelal
-
 accessibility-heading-level-1 = Moytu Jotewaay bu WCAG AA
 accessibility-heading-level-2 = Artu ci jotewaay
-
 something-went-wrong = Am na lu demul ni mu ware.
-
 renderer-load-failed = benn wonekaay yeggul. Nga jëmmali xët bi.
-
 core-start-failed = Wonekaayu dokimaan bi mënul tàmbali. Nga jëmmali xët bi.

--- a/packages/i18n/locales/wo/content.ftl
+++ b/packages/i18n/locales/wo/content.ftl
@@ -51,17 +51,14 @@ color =
     .purple = wiyole
     .pink = roos
     .brown = maroo
-
 line-width =
     .thick = réy
     .thin = sew
-
 # Written as «ak …» phrases rather than as adjectives, so that they take no
 # linker and can close the description. `style-stroke` puts them last.
 line-style =
     .dashed = ak ay tiret
     .dotted = ak ay poñ
-
 fill-style =
     .horizontal = ay rëdd yu tëdd
     .vertical = ay rëdd yu taxaw
@@ -69,7 +66,6 @@ fill-style =
     .backdiagonal = ay rëdd yu jeng gannaaw
     .dots = ay poñ
     .diamonds = ay losaas
-
 noun =
     .line = rëdd
     .line-segment = dogu rëdd
@@ -89,7 +85,6 @@ noun =
     .diamond = losaas
     .cross = kruwaa
     .plus = màndarga plus
-
 # The side count follows the adjectives, behind «bu am», because Wolof closes a
 # noun phrase with a relative rather than opening one: «poligon bu yem bu xonq
 # bu am 5 wet».
@@ -98,10 +93,8 @@ noun-regular-polygon =
         [tail] bu am { $numSides } wet
        *[head] poligon bu yem
     }
-
 # Unused: the class lives on the determiner, not on the adjective.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -115,7 +108,6 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow, with the noun's own relative
 # complement closing the phrase.
 style-with-noun =
@@ -123,15 +115,12 @@ style-with-noun =
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = feesal
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } ak { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ak { $pattern }
@@ -139,7 +128,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ak { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # Wolof has no article, and the complement is joined with the invariable «ak»,
 # so all four branches read alike.
 style-border-clause =
@@ -149,35 +137,28 @@ style-border-clause =
         [and-article] ak wetu { $border }
        *[with] ak wetu { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = feesalul
-
 style-text =
     { $parts ->
         [background] { $color } ci kaw ginnaaw { $background }
        *[plain] { $color }
     }
-
 style-background-none = amul
-
 
 ## Boolean words
 
 boolean-true = dëgg
 boolean-false = fen
 
-
 ## Answer buttons
 
 answer-submit-label = Seetlu Liggéey bi
 answer-submit-label-no-correctness = Yónnee Tontu bi
-
 
 ## Sectional blocks
 
@@ -202,7 +183,6 @@ section-name =
     .solution = Saafara
     .task = Liggéey
     .theorem = Teyoreem
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -212,9 +192,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Xelal
-
 
 ## Tables and figures
 
@@ -225,7 +203,6 @@ table-name =
         [unnumbered-title] Tabal{ ": " }
        *[unnumbered] Tabal
     }
-
 figure-name =
     { $parts ->
         [numbered] Nataal { $enumeration }
@@ -234,22 +211,18 @@ figure-name =
        *[unnumbered] Nataal
     }
 
-
 ## Paginator controls
 
 paginator-previous = Bi jiitu
 paginator-next = Bi ci topp
 paginator-page = Xët
-
 paginator-page-status = { $pageLabel } { $currentPage } ci { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = walla
 piecewise-condition-if = su
 piecewise-condition-otherwise = su dul loolu
-
 
 ## Chemistry
 
@@ -259,6 +232,5 @@ piecewise-condition-otherwise = su dul loolu
 # these words meets them in a European language already — and the seed has no
 # settled Wolof list to reproduce. A speaker adding one should add it here.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Màndarga Simi bu Baaxul
 chemistry-invalid-ionic-compound = Konpose Iyonik bu Baaxul

--- a/packages/i18n/locales/xal/chrome.ftl
+++ b/packages/i18n/locales/xal/chrome.ftl
@@ -19,74 +19,55 @@
 
 answer-checking = Шинҗлгдҗәнә…
 answer-submitting = Илгәгдҗәнә…
-
 answer-checking-status = Хәрү шинҗлгдҗәнә
 answer-submitting-status = Хәрү илгәгдҗәнә
-
 answer-correct = Зөв
 answer-incorrect = Буру
-
 answer-response-saved = Хәрү хадһлгдв
-
 answer-percent-credit = { $percent }% балл
 answer-percent-correct = { $percent }% зөв
 answer-percent-short = { $percent } %
-
 max-credit-available = Авч болх хамгин ик балл: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] эрлһн үлдсн уга
         [one] { $count } эрлһн үлдв
        *[other] { $count } эрлһн үлдв
     }
-
 validation-correct = (Зөв)
 validation-incorrect = (Буру)
 validation-partially-correct = (Хүвәр зөв)
-
 answer-show-responses =
     { $count ->
         [one] { $answerId } деер { $count } хәрү үзүлх
        *[other] { $answerId } деер { $count } хәрү үзүлх
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Хәрү медәллт
-
 collapsible-click-to-open = (секхин төлә даргтн)
 collapsible-click-to-close = (хаахин төлә даргтн)
-
 collapsible-initializing = Белдгдҗәнә…
-
 footnote-show = Темдг үзүлх
 footnote-hide = Темдг нүүх
-
 description-more-information = немр медәлл
-
 
 ## Controls
 
 slider-previous = Өмнк
 slider-next = Дару
-
 keyboard-open = Клавиатур секх
 keyboard-close = Клавиатур хаах
-
 choice-input-remove-choice = { $choice } суңһврыг уга кех
-
 matrix-remove-row = Мөр уга кех
 matrix-add-row = Мөр немх
 matrix-remove-column = Багана уга кех
 matrix-add-column = Багана немх
-
 subset-add-remove-points = Цег немх/уга кех
 subset-toggle-points-intervals = Цегүд болн зәәс сольх
 subset-move-points = Цегүдиг нүүлһх
 subset-clear = Цеврлх
-
 orbital-add-row = Мөр немх
 orbital-remove-row = Мөр уга кех
 orbital-add-box = Нүкн немх
@@ -94,13 +75,9 @@ orbital-remove-box = Нүкн уга кех
 orbital-add-up-arrow = Өөдән сумн немх
 orbital-add-down-arrow = Дор сумн немх
 orbital-remove-arrow = Сумн уга кех
-
 orbital-row-label = { $row } мөрин темдг
-
 pretzel-answer = Хәрү
-
 summary-statistics-caption = { $column } баганан дүңцүлгч статистик
-
 
 ## Math input
 
@@ -108,34 +85,25 @@ math-input-preview-region = математическ илдкврин урдас
 math-input-preview = Урдаснь үзлт
 math-input-invalid-expression = Буру илдквр:
 
-
 ## Document status
 
 viewer-initializing = Белдгдҗәнә…
 
-
 ## Errors
 
 error-heading = Эндү
-
 error-found-at =
     { $span ->
         [line] Олгдсн мөр: { $startLine }.
        *[lines] Олгдсн мөрмүд: { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Эн бичгт эндүс бәәнә!
-
 diagnostic-heading-error = Эндү
 diagnostic-heading-warning = Селвг
 diagnostic-heading-information = Медәлл
 diagnostic-heading-hint = Зәәсн
-
 accessibility-heading-level-1 = WCAG AA күрх аргин эвдлт
 accessibility-heading-level-2 = Күрх аргин тускар медәлл
-
 something-went-wrong = Юмн буру болв.
-
 renderer-load-failed = зурачиг ачлҗ чадсн уга. Халхциг шинрүлтн.
-
 core-start-failed = Бичг үзгчиг эклҗ чадсн уга. Халхциг шинрүлтн.

--- a/packages/i18n/locales/xal/content.ftl
+++ b/packages/i18n/locales/xal/content.ftl
@@ -42,15 +42,12 @@ color =
     .purple = ниил яһан
     .pink = яһан
     .brown = хүрң
-
 line-width =
     .thick = зузан
     .thin = нимгн
-
 line-style =
     .dashed = тасрха
     .dotted = цегтә
-
 # Noun phrases: they stand in front of «кеермжтә» and modify nothing.
 fill-style =
     .horizontal = хөндлң зурас
@@ -59,7 +56,6 @@ fill-style =
     .backdiagonal = өөрхә диагональ зурас
     .dots = цег
     .diamonds = ромб
-
 noun =
     .line = шулун зурас
     .line-segment = хәәрцг
@@ -79,7 +75,6 @@ noun =
     .diamond = ромб
     .cross = крест
     .plus = плюс
-
 # Kalmyk builds the word from the side count in front of the noun, so the whole
 # of it is one head and there is no tail.
 noun-regular-polygon =
@@ -87,11 +82,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] дүңцү { $numSides } талта
     }
-
 # Kalmyk has no grammatical gender, so every noun answers the same and the
 # answer goes unused.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -105,21 +98,17 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 style-filled-word = буддгсн
-
 style-filled =
     { $parts ->
         [pattern] { $pattern } кеермжтә { $color } { $filled }
        *[plain] { $color } { $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $pattern } кеермжтә { $color } { $filled } { $noun }
@@ -127,7 +116,6 @@ style-filled-with-noun =
         [pattern-tail] { $pattern } кеермжтә { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
-
 # «кеҗгтә» — "having an edge" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
@@ -137,15 +125,12 @@ style-border-clause =
         [and-article] болн { $border } кеҗгтә
        *[with] { $border } кеҗгтә
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } кеермжтә { $color } буд
        *[plain] { $color } буд
     }
-
 style-unfilled = буддго
-
 # «деер» — "on top of" — is a postposition and follows the background colour,
 # so nothing stands between the two words.
 style-text =
@@ -153,21 +138,17 @@ style-text =
         [background] { $background } ора деер { $color }
        *[plain] { $color }
     }
-
 style-background-none = уга
-
 
 ## Boolean words
 
 boolean-true = үнн
 boolean-false = худл
 
-
 ## Answer buttons
 
 answer-submit-label = Шинҗлх
 answer-submit-label-no-correctness = Хәрүг илгәх
-
 
 ## Sectional blocks
 
@@ -192,7 +173,6 @@ section-name =
     .solution = Шиидвр
     .task = Даалһвр
     .theorem = Теорем
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -202,9 +182,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Зәәсн
-
 
 ## Tables and figures
 
@@ -215,7 +193,6 @@ table-name =
         [unnumbered-title] Хүсңт{ ". " }
        *[unnumbered] Хүсңт
     }
-
 figure-name =
     { $parts ->
         [numbered] Зург { $enumeration }
@@ -224,15 +201,12 @@ figure-name =
        *[unnumbered] Зург
     }
 
-
 ## Paginator controls
 
 paginator-previous = Өмнк
 paginator-next = Дару
 paginator-page = Халхц
-
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
-
 
 ## Piecewise functions
 ##
@@ -244,7 +218,6 @@ piecewise-condition-or = эсвл
 piecewise-condition-if = кемр
 piecewise-condition-otherwise = нань бәәдлд
 
-
 ## Chemistry
 ##
 ## `element-name` and `element-anion-name` are deliberately left out, so their
@@ -255,6 +228,5 @@ piecewise-condition-otherwise = нань бәәдлд
 ## unreviewed coinages would be the least defensible thing in it.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Буру химическ темдг
 chemistry-invalid-ionic-compound = Буру ионы ниилвр

--- a/packages/i18n/locales/xh/chrome.ftl
+++ b/packages/i18n/locales/xh/chrome.ftl
@@ -20,74 +20,55 @@
 
 answer-checking = Iyajonga...
 answer-submitting = Iyangenisa...
-
 answer-checking-status = Ijonga impendulo
 answer-submitting-status = Ingenisa impendulo
-
 answer-correct = Ichanekile
 answer-incorrect = Ayichanekanga
-
 answer-response-saved = Impendulo Igciniwe
-
 answer-percent-credit = Amanqaku angu-{ $percent }%
 answer-percent-correct = { $percent }% Ichanekile
 answer-percent-short = { $percent }%
-
 max-credit-available = Amanqaku aphezulu afumanekayo: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] akukho malinge ashiyekileyo
         [one] kushiyeke ilinge elingu-{ $count }
        *[other] kushiyeke amalinge angu-{ $count }
     }
-
 validation-correct = (Ichanekile)
 validation-incorrect = (Ayichanekanga)
 validation-partially-correct = (Ichaneke ngokuyinxenye)
-
 answer-show-responses =
     { $count ->
         [one] Bonisa impendulo engu-{ $count } ku-{ $answerId }
        *[other] Bonisa iimpendulo ezingu-{ $count } ku-{ $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Ingxelo
-
 collapsible-click-to-open = (cofa ukuze uvule)
 collapsible-click-to-close = (cofa ukuze uvale)
-
 collapsible-initializing = Iyaqalisa...
-
 footnote-show = Bonisa inqaku elingezantsi
 footnote-hide = Fihla inqaku elingezantsi
-
 description-more-information = ulwazi olungakumbi
-
 
 ## Controls
 
 slider-previous = Emva
 slider-next = Phambili
-
 keyboard-open = Vula Ikhibhodi
 keyboard-close = Vala Ikhibhodi
-
 choice-input-remove-choice = Susa { $choice }
-
 matrix-remove-row = Susa umqolo
 matrix-add-row = Yongeza umqolo
 matrix-remove-column = Susa ikholam
 matrix-add-column = Yongeza ikholam
-
 subset-add-remove-points = Yongeza/Susa amanqaku
 subset-toggle-points-intervals = Tshintsha phakathi kwamanqaku nezithuba
 subset-move-points = Shukumisa Amanqaku
 subset-clear = Sula
-
 # A `box` here is one orbital, drawn as a square: ibhokisi.
 orbital-add-row = Yongeza Umqolo
 orbital-remove-row = Susa Umqolo
@@ -96,13 +77,9 @@ orbital-remove-box = Susa Ibhokisi
 orbital-add-up-arrow = Yongeza Utolo Olujonge Phezulu
 orbital-add-down-arrow = Yongeza Utolo Olujonge Ezantsi
 orbital-remove-arrow = Susa Utolo
-
 orbital-row-label = Ilebhile yomqolo { $row }
-
 pretzel-answer = Impendulo
-
 summary-statistics-caption = Amanani ashwankathelweyo e-{ $column }
-
 
 ## Math input
 
@@ -110,34 +87,25 @@ math-input-preview-region = ukubona kwangaphambili kwentetho yezibalo
 math-input-preview = Bona Kwangaphambili
 math-input-invalid-expression = Intetho engasebenziyo:
 
-
 ## Document status
 
 viewer-initializing = Iyaqalisa...
 
-
 ## Errors
 
 error-heading = Impazamo
-
 error-found-at =
     { $span ->
         [line] Ifunyenwe kumgca { $startLine }.
        *[lines] Ifunyenwe kwimigca { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Olu xwebhu luneempazamo!
-
 diagnostic-heading-error = Impazamo
 diagnostic-heading-warning = Isilumkiso
 diagnostic-heading-information = Ulwazi
 diagnostic-heading-hint = Icebiso
-
 accessibility-heading-level-1 = Ukwaphulwa Kokufikeleleka kwe-WCAG AA
 accessibility-heading-level-2 = Isilumkiso sokufikeleleka
-
 something-went-wrong = Kukho into engahambanga kakuhle.
-
 renderer-load-failed = esinye isibonisi asikwazanga ukulayisha. Nceda ulayishe iphepha kwakhona.
-
 core-start-failed = Isibonisi soxwebhu asikwazanga ukuqaliswa. Nceda ulayishe iphepha kwakhona.

--- a/packages/i18n/locales/xh/content.ftl
+++ b/packages/i18n/locales/xh/content.ftl
@@ -112,7 +112,6 @@ color =
             [c7] esintsundu
            *[c9] entsundu
         }
-
 # These two are true adjectives and take the adjective concord, not the
 # relative one the colours take.
 line-width =
@@ -130,14 +129,12 @@ line-width =
             [c7] esincinci
            *[c9] encinci
         }
-
 # Written as an invariable "having …" phrase rather than as a describing word,
 # so that it agrees with nothing and can close the phrase. `style-stroke` puts
 # it last for that reason.
 line-style =
     .dashed = onemigcana
     .dotted = onamachokoza
-
 fill-style =
     .horizontal = imigca ethe tyaba
     .vertical = imigca emileyo
@@ -145,7 +142,6 @@ fill-style =
     .backdiagonal = imigca ejikelezileyo ngokuchasene
     .dots = amachokoza
     .diamonds = amadayimani
-
 noun =
     .line = umgca
     .line-segment = isiqwenga somgca
@@ -165,7 +161,6 @@ noun =
     .diamond = idayimani
     .cross = umnqamlezo
     .plus = uphawu lokudibanisa
-
 # The side count goes in the tail, behind the describing words: Xhosa closes a
 # noun phrase with a relative clause rather than opening one with it.
 noun-regular-polygon =
@@ -173,7 +168,6 @@ noun-regular-polygon =
         [tail] esinamacala angu-{ $numSides }
        *[head] isakhelo esilinganayo
     }
-
 noun-gender =
     { $noun ->
         [line] c3
@@ -194,7 +188,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -207,13 +200,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] ozalisiweyo
@@ -221,13 +212,11 @@ style-filled-word =
         [c7] esizalisiweyo
        *[c9] ezalisiweyo
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kunye ne-{ $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kunye ne-{ $pattern }
@@ -235,7 +224,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kunye ne-{ $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «umda» is class 3, so the border's words agree with it and not with the shape
 # it surrounds. Xhosa has no article and joins a complement with the invariable
 # «kunye no-», so all four branches read alike.
@@ -246,35 +234,28 @@ style-border-clause =
         [and-article] kunye nomda { $border }
        *[with] kunye nomda { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = akuzaliswanga
-
 style-text =
     { $parts ->
         [background] { $color } kumva { $background }
        *[plain] { $color }
     }
-
 style-background-none = akukho
-
 
 ## Boolean words
 
 boolean-true = inyaniso
 boolean-false = ubuxoki
 
-
 ## Answer buttons
 
 answer-submit-label = Jonga Umsebenzi
 answer-submit-label-no-correctness = Ngenisa Impendulo
-
 
 ## Sectional blocks
 
@@ -299,7 +280,6 @@ section-name =
     .solution = Isisombululo
     .task = Umsebenzi
     .theorem = Ithiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -309,9 +289,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Icebiso
-
 
 ## Tables and figures
 
@@ -322,7 +300,6 @@ table-name =
         [unnumbered-title] Itheyibhile{ ": " }
        *[unnumbered] Itheyibhile
     }
-
 figure-name =
     { $parts ->
         [numbered] Umfanekiso { $enumeration }
@@ -331,15 +308,12 @@ figure-name =
        *[unnumbered] Umfanekiso
     }
 
-
 ## Paginator controls
 
 paginator-previous = Ephelileyo
 paginator-next = Elandelayo
 paginator-page = Iphepha
-
 paginator-page-status = { $pageLabel } { $currentPage } kwangama-{ $numPages }
-
 
 ## Piecewise functions
 
@@ -347,8 +321,8 @@ piecewise-condition-or = okanye
 piecewise-condition-if = ukuba
 piecewise-condition-otherwise = ngaphandle koko
 
-
 ## Chemistry
+
 
 # Xhosa is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English, for the
@@ -357,6 +331,5 @@ piecewise-condition-otherwise = ngaphandle koko
 # classroom to seed from.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Uphawu Lweekhemikhali Olungasebenziyo
 chemistry-invalid-ionic-compound = Umxube Weayoni Ongasebenziyo

--- a/packages/i18n/locales/yi/chrome.ftl
+++ b/packages/i18n/locales/yi/chrome.ftl
@@ -24,74 +24,55 @@
 
 answer-checking = קאָנטראָלירן…
 answer-submitting = שיקן…
-
 answer-checking-status = קאָנטראָלירן דעם ענטפֿער
 answer-submitting-status = שיקן דעם ענטפֿער
-
 answer-correct = ריכטיק
 answer-incorrect = ניט ריכטיק
-
 answer-response-saved = דער ענטפֿער איז אייַנגעהיט
-
 answer-percent-credit = { $percent }% קרעדיט
 answer-percent-correct = { $percent }% ריכטיק
 answer-percent-short = { $percent } %
-
 max-credit-available = מאַקסימאַלער מעגלעכער קרעדיט: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] קיין פּרוּוון זייַנען ניט געבליבן
         [one] עס איז געבליבן { $count } פּרוּוו
        *[other] עס זייַנען געבליבן { $count } פּרוּוון
     }
-
 validation-correct = (ריכטיק)
 validation-incorrect = (ניט ריכטיק)
 validation-partially-correct = (טיילווייַז ריכטיק)
-
 answer-show-responses =
     { $count ->
         [one] ווייַז { $count } ענטפֿער אויף { $answerId }
        *[other] ווייַז { $count } ענטפֿערס אויף { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = אָפּרוף
-
 collapsible-click-to-open = (קליק צו עפֿענען)
 collapsible-click-to-close = (קליק צו פֿאַרמאַכן)
-
 collapsible-initializing = אָנהייבן…
-
 footnote-show = ווייַז די פֿוסנאָטע
 footnote-hide = באַהאַלט די פֿוסנאָטע
-
 description-more-information = מער אינפֿאָרמאַציע
-
 
 ## Controls
 
 slider-previous = צוריק
 slider-next = ווייַטער
-
 keyboard-open = עפֿן די קלאַוויאַטור
 keyboard-close = פֿאַרמאַך די קלאַוויאַטור
-
 choice-input-remove-choice = נעם אַרויס { $choice }
-
 matrix-remove-row = נעם אַרויס אַ רייע
 matrix-add-row = גיב צו אַ רייע
 matrix-remove-column = נעם אַרויס אַ זייַל
 matrix-add-column = גיב צו אַ זייַל
-
 subset-add-remove-points = גיב צו/נעם אַרויס פּונקטן
 subset-toggle-points-intervals = בייַט צווישן פּונקטן און אינטערוואַלן
 subset-move-points = רוק די פּונקטן
 subset-clear = רייניק אויס
-
 orbital-add-row = גיב צו אַ רייע
 orbital-remove-row = נעם אַרויס אַ רייע
 orbital-add-box = גיב צו אַ קעסטל
@@ -99,13 +80,9 @@ orbital-remove-box = נעם אַרויס אַ קעסטל
 orbital-add-up-arrow = גיב צו אַ פֿייַל אַרויף
 orbital-add-down-arrow = גיב צו אַ פֿייַל אַראָפּ
 orbital-remove-arrow = נעם אַרויס אַ פֿייַל
-
 orbital-row-label = צייכן פֿאַר רייע { $row }
-
 pretzel-answer = ענטפֿער
-
 summary-statistics-caption = סטאַטיסטישער סך-הכּל פֿון { $column }
-
 
 ## Math input
 
@@ -113,34 +90,25 @@ math-input-preview-region = פֿאָרויסבליק פֿונעם מאַטעמא
 math-input-preview = פֿאָרויסבליק
 math-input-invalid-expression = אומגילטיקער אויסדרוק:
 
-
 ## Document status
 
 viewer-initializing = אָנהייבן…
 
-
 ## Errors
 
 error-heading = טעות
-
 error-found-at =
     { $span ->
         [line] געפֿונען אויף ליניע { $startLine }.
        *[lines] געפֿונען אויף ליניעס { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = דער דאָקומענט אַנטהאַלט טעותן!
-
 diagnostic-heading-error = טעות
 diagnostic-heading-warning = וואָרענונג
 diagnostic-heading-information = אינפֿאָרמאַציע
 diagnostic-heading-hint = אָנווייַז
-
 accessibility-heading-level-1 = איבערטרעטונג פֿון צוטריטלעכקייט לויט WCAG AA
 accessibility-heading-level-2 = וואָרענונג וועגן צוטריטלעכקייט
-
 something-went-wrong = עפּעס איז ניט געגאַנגען ווי געהעריק.
-
 renderer-load-failed = אַ מאָדול פֿאַרן ווייַזן האָט זיך ניט אַרויפֿגעלאָדן. לאָדט איבער די בלאַט.
-
 core-start-failed = דער דאָקומענט־ווייַזער האָט זיך ניט געקענט אָנהייבן. לאָדט איבער די בלאַט.

--- a/packages/i18n/locales/yi/content.ftl
+++ b/packages/i18n/locales/yi/content.ftl
@@ -171,7 +171,6 @@ color =
                    *[m] ברוינער
                 }
         }
-
 line-width =
     .thick =
         { $role ->
@@ -195,7 +194,6 @@ line-width =
                    *[m] דינער
                 }
         }
-
 line-style =
     .dashed =
         { $role ->
@@ -219,7 +217,6 @@ line-style =
                    *[m] געפּינטלטער
                 }
         }
-
 # Plural noun phrases, which is what follows «מיט» in `style-filled`. They agree
 # with nothing.
 fill-style =
@@ -229,7 +226,6 @@ fill-style =
     .backdiagonal = פֿאַרקערטע דיאַגאָנאַלע ליניעס
     .dots = פּינטלעך
     .diamonds = ראָמבן
-
 noun =
     .line = ליניע
     .line-segment = אָפּשניט
@@ -249,7 +245,6 @@ noun =
     .diamond = ראָמב
     .cross = קרייץ
     .plus = פּלוס
-
 # Yiddish keeps the side count in front of the noun, so the whole of it is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -257,7 +252,6 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] רעגולערער { $numSides }-זייַטיקער פּאָליגאָן
     }
-
 # Besides the nouns above, `$noun` can be `regular-polygon` (פּאָליגאָן, m) or the
 # head of a phrase the description never names: `border` (ראַנד, m), `fill`
 # (אָנפֿיל, m), `text` (טעקסט, m), `background` (הינטערגרונט, m).
@@ -272,7 +266,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -285,13 +278,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
        *[noun] { $description } { $noun }
     }
-
 # Only ever said of the shape itself, so it is standalone in every description
 # and takes no `$role` branch.
 style-filled-word =
@@ -299,13 +290,11 @@ style-filled-word =
         [f] אָנגעפֿילטע
        *[m] אָנגעפֿילטער
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } מיט { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $filled } { $color } { $noun } מיט { $pattern }
@@ -313,7 +302,6 @@ style-filled-with-noun =
         [pattern-tail] { $filled } { $color } { $noun } { $nounTail } מיט { $pattern }
        *[plain] { $filled } { $color } { $noun }
     }
-
 # «ראַנד» is masculine, so the border's adjectives agree with it and not with
 # the shape it surrounds, and they are in the dative, which «מיט» governs.
 # Yiddish has an indefinite article, «אַ», so the two `-article` branches really
@@ -325,7 +313,6 @@ style-border-clause =
         [and-article] און אַ { $border } ראַנד
        *[with] מיט { $border } ראַנד
     }
-
 # The fill-pattern words are plurals, because their other use is the
 # «מיט { $pattern }» clause in `style-filled`. So this message supplies a noun
 # for them to hang off — «אָנפֿיל», masculine, which is the gender `noun-gender`
@@ -335,29 +322,23 @@ style-fill =
         [pattern] { $color } אָנפֿיל מיט { $pattern }
        *[plain] { $color } אָנפֿיל
     }
-
 style-unfilled = ניט אָנגעפֿילט
-
 style-text =
     { $parts ->
         [background] { $color } אויף אַ { $background } הינטערגרונט
        *[plain] { $color }
     }
-
 style-background-none = קיינער
-
 
 ## Boolean words
 
 boolean-true = אמת
 boolean-false = פֿאַלש
 
-
 ## Answer buttons
 
 answer-submit-label = קאָנטראָליר די אַרבעט
 answer-submit-label-no-correctness = שיק דעם ענטפֿער
-
 
 ## Sectional blocks
 
@@ -382,7 +363,6 @@ section-name =
     .solution = לייזונג
     .task = אויפֿטו
     .theorem = טעאָרעם
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -392,9 +372,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = אָנווייַז
-
 
 ## Tables and figures
 
@@ -405,7 +383,6 @@ table-name =
         [unnumbered-title] טאַבעלע{ ": " }
        *[unnumbered] טאַבעלע
     }
-
 figure-name =
     { $parts ->
         [numbered] פֿיגור { $enumeration }
@@ -414,22 +391,18 @@ figure-name =
        *[unnumbered] פֿיגור
     }
 
-
 ## Paginator controls
 
 paginator-previous = פֿריִערדיקע
 paginator-next = קומענדיקע
 paginator-page = זייַט
-
 paginator-page-status = { $pageLabel } { $currentPage } פֿון { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = אָדער
 piecewise-condition-if = אויב
 piecewise-condition-otherwise = אַנדערש
-
 
 ## Chemistry
 ##
@@ -441,6 +414,5 @@ piecewise-condition-otherwise = אַנדערש
 ## the English. This is where a speaker should look first.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = אומגילטיקער כעמישער סימבאָל
 chemistry-invalid-ionic-compound = אומגילטיקע יאָנישע פֿאַרבינדונג

--- a/packages/i18n/locales/yo/chrome.ftl
+++ b/packages/i18n/locales/yo/chrome.ftl
@@ -21,69 +21,50 @@
 
 answer-checking = Ń ṣàyẹ̀wò...
 answer-submitting = Ń fi ránṣẹ́...
-
 answer-checking-status = Ń ṣàyẹ̀wò ìdáhùn
 answer-submitting-status = Ń fi ìdáhùn ránṣẹ́
-
 answer-correct = Ó tọ́
 answer-incorrect = Kò tọ́
-
 answer-response-saved = A Ti Fi Ìdáhùn Pamọ́
-
 answer-percent-credit = Àmì { $percent }%
 answer-percent-correct = { $percent }% Tọ́
 answer-percent-short = { $percent }%
-
 max-credit-available = Àmì gíga jùlọ tí ó wà: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] kò sí ìgbìyànjú tí ó kù
        *[other] ìgbìyànjú { $count } ló kù
     }
-
 validation-correct = (Ó tọ́)
 validation-incorrect = (Kò tọ́)
 validation-partially-correct = (Ó tọ́ ní apá kan)
-
 answer-show-responses = Fi ìdáhùn { $count } sí { $answerId } hàn
-
 
 ## Disclosure panels
 
 feedback-heading = Èsì
-
 collapsible-click-to-open = (tẹ̀ láti ṣí)
 collapsible-click-to-close = (tẹ̀ láti tì)
-
 collapsible-initializing = Ń bẹ̀rẹ̀...
-
 footnote-show = Fi àkíyèsí ìsàlẹ̀ hàn
 footnote-hide = Fi àkíyèsí ìsàlẹ̀ pamọ́
-
 description-more-information = ìsọfúnni sí i
-
 
 ## Controls
 
 slider-previous = Ẹ̀yìn
 slider-next = Iwájú
-
 keyboard-open = Ṣí Bọ́tìnì Ìkọ̀wé
 keyboard-close = Ti Bọ́tìnì Ìkọ̀wé
-
 choice-input-remove-choice = Yọ { $choice } kúrò
-
 matrix-remove-row = Yọ ilà kúrò
 matrix-add-row = Fi ilà kún
 matrix-remove-column = Yọ ọ̀wọ̀n kúrò
 matrix-add-column = Fi ọ̀wọ̀n kún
-
 subset-add-remove-points = Fi ààmì kún / Yọ ààmì kúrò
 subset-toggle-points-intervals = Yípadà láàárín ààmì àti àlàfo
 subset-move-points = Gbé Àwọn Ààmì
 subset-clear = Nù
-
 # A `box` here is one orbital, drawn as a square: àpótí.
 orbital-add-row = Fi Ilà Kún
 orbital-remove-row = Yọ Ilà Kúrò
@@ -92,13 +73,9 @@ orbital-remove-box = Yọ Àpótí Kúrò
 orbital-add-up-arrow = Fi Ọfà Òkè Kún
 orbital-add-down-arrow = Fi Ọfà Ìsàlẹ̀ Kún
 orbital-remove-arrow = Yọ Ọfà Kúrò
-
 orbital-row-label = Àmì ìdámọ̀ fún ilà { $row }
-
 pretzel-answer = Ìdáhùn
-
 summary-statistics-caption = Àkópọ̀ ìṣirò ti { $column }
-
 
 ## Math input
 
@@ -106,34 +83,25 @@ math-input-preview-region = àwòtẹ́lẹ̀ ọ̀rọ̀ ìṣirò
 math-input-preview = Àwòtẹ́lẹ̀
 math-input-invalid-expression = Ọ̀rọ̀ tí kò tọ́:
 
-
 ## Document status
 
 viewer-initializing = Ń bẹ̀rẹ̀...
 
-
 ## Errors
 
 error-heading = Àṣìṣe
-
 error-found-at =
     { $span ->
         [line] A rí i ní ilà { $startLine }.
        *[lines] A rí i ní àwọn ilà { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Àkọsílẹ̀ yìí ní àwọn àṣìṣe nínú!
-
 diagnostic-heading-error = Àṣìṣe
 diagnostic-heading-warning = Ìkìlọ̀
 diagnostic-heading-information = Ìsọfúnni
 diagnostic-heading-hint = Ìtọ́ka
-
 accessibility-heading-level-1 = Ìrúfin Ìwọlé WCAG AA
 accessibility-heading-level-2 = Ìkìlọ̀ ìwọlé
-
 something-went-wrong = Nǹkan kan kò lọ dáadáa.
-
 renderer-load-failed = ohun ìṣàfihàn kan kò ṣàṣeyọrí láti gbé. Jọ̀wọ́ tún ojú-ìwé náà gbé.
-
 core-start-failed = Ohun ìṣàfihàn àkọsílẹ̀ kò lè bẹ̀rẹ̀. Jọ̀wọ́ tún ojú-ìwé náà gbé.

--- a/packages/i18n/locales/yo/content.ftl
+++ b/packages/i18n/locales/yo/content.ftl
@@ -31,15 +31,12 @@ color =
     .purple = aláwọ̀ àlùkò
     .pink = aláwọ̀ pìǹkì
     .brown = aláwọ̀ aró
-
 line-width =
     .thick = nípọn
     .thin = tínrín
-
 line-style =
     .dashed = onípínyà
     .dotted = oníààmì
-
 # Noun phrases: they follow «pẹ̀lú» and modify nothing.
 fill-style =
     .horizontal = àwọn ìlà ìbú
@@ -48,7 +45,6 @@ fill-style =
     .backdiagonal = àwọn ìlà ìkọjá ẹ̀yìn
     .dots = àwọn ààmì
     .diamonds = àwọn dáyámọ́ǹdì
-
 noun =
     .line = ìlà
     .line-segment = apá ìlà
@@ -68,7 +64,6 @@ noun =
     .diamond = dáyámọ́ǹdì
     .cross = àgbélébùú
     .plus = àmì àfikún
-
 # The side count goes in the tail, behind the adjectives: «oníhà dọ́gba pupa
 # oníhà 5». Putting it in the head would separate «oníhà» from the number
 # counting it only to reunite them at the far end of the phrase.
@@ -77,11 +72,9 @@ noun-regular-polygon =
         [tail] oníhà { $numSides }
        *[head] oníhà dọ́gba
     }
-
 # Yoruba has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -95,22 +88,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # The noun leads and its adjectives follow: «ìlà nípọn onípínyà pupa».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word = kíkún
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } pẹ̀lú { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } pẹ̀lú { $pattern }
@@ -118,7 +107,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } pẹ̀lú { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «ìlà ẹ̀gbẹ́» leads its own adjectives, the same way every noun here does.
 style-border-clause =
     { $parts ->
@@ -127,35 +115,28 @@ style-border-clause =
         [and-article] àti ìlà ẹ̀gbẹ́ { $border }
        *[with] pẹ̀lú ìlà ẹ̀gbẹ́ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = àìkún
-
 style-text =
     { $parts ->
         [background] { $color } lórí ẹ̀yìn { $background }
        *[plain] { $color }
     }
-
 style-background-none = kò sí
-
 
 ## Boolean words
 
 boolean-true = òótọ́
 boolean-false = irọ́
 
-
 ## Answer buttons
 
 answer-submit-label = Ṣàyẹ̀wò Iṣẹ́
 answer-submit-label-no-correctness = Fi Ìdáhùn Ránṣẹ́
-
 
 ## Sectional blocks
 
@@ -180,7 +161,6 @@ section-name =
     .solution = Ìdáhùn Kíkún
     .task = Iṣẹ́
     .theorem = Ìlànà
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -190,9 +170,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Ìtọ́ka
-
 
 ## Tables and figures
 
@@ -203,7 +181,6 @@ table-name =
         [unnumbered-title] Tábìlì{ ": " }
        *[unnumbered] Tábìlì
     }
-
 figure-name =
     { $parts ->
         [numbered] Àwòrán { $enumeration }
@@ -212,15 +189,12 @@ figure-name =
        *[unnumbered] Àwòrán
     }
 
-
 ## Paginator controls
 
 paginator-previous = Tẹ́lẹ̀
 paginator-next = Tókàn
 paginator-page = Ojú-ìwé
-
 paginator-page-status = { $pageLabel } { $currentPage } nínú { $numPages }
-
 
 ## Piecewise functions
 
@@ -228,8 +202,8 @@ piecewise-condition-or = tàbí
 piecewise-condition-if = bí
 piecewise-condition-otherwise = bí bẹ́ẹ̀ kọ́
 
-
 ## Chemistry
+
 
 # Yoruba is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. Nigerian
@@ -239,6 +213,5 @@ piecewise-condition-otherwise = bí bẹ́ẹ̀ kọ́
 # prints.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Àmì Kẹ́mìkà Tí Kò Tọ́
 chemistry-invalid-ionic-compound = Àdàpọ̀ Áyọ́nì Tí Kò Tọ́

--- a/packages/i18n/locales/zgh/chrome.ftl
+++ b/packages/i18n/locales/zgh/chrome.ftl
@@ -14,74 +14,55 @@
 
 answer-checking = ⴰⵙⵏⵇⴻⴷ…
 answer-submitting = ⵜⵓⵣⵏⴰ…
-
 answer-checking-status = ⵜⵉⵔⵉⵔⵉⵜ ⵜⴻⵜⵜⵡⴰⵙⵏⵇⴰⴷ
 answer-submitting-status = ⵜⵉⵔⵉⵔⵉⵜ ⵜⴻⵜⵜⵡⴰⵣⴻⵏ
-
 answer-correct = ⴷ ⵜⵉⴷⴻⵜ
 answer-incorrect = ⵎⴰⵛⵛⵉ ⴷ ⵜⵉⴷⴻⵜ
-
 answer-response-saved = ⵜⵉⵔⵉⵔⵉⵜ ⵜⴻⵜⵜⵡⴰⵃⴹⴰ
-
 answer-percent-credit = { $percent }% ⵏ ⵜⴻⵏⵇⵉⴹⵉⵏ
 answer-percent-correct = { $percent }% ⴷ ⵜⵉⴷⴻⵜ
 answer-percent-short = { $percent } %
-
 max-credit-available = ⵜⵉⵏⵇⵉⴹⵉⵏ ⵓⴳⴰⵔ ⵉ ⵢⴻⵍⵍⴰⵏ: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ⵓⵍⴰⵛ ⴰⵄⵔⴰⴹ ⵉ ⴷ-ⵢⴻⵇⵇⵉⵎⴻⵏ
         [one] ⵢⴻⵇⵇⵉⵎ-ⴷ { $count } ⵏ ⵓⵄⵔⴰⴹ
        *[other] ⵇⵇⵉⵎⴻⵏ-ⴷ { $count } ⵏ ⵢⵉⵄⵔⴰⴹⴻⵏ
     }
-
 validation-correct = (ⴷ ⵜⵉⴷⴻⵜ)
 validation-incorrect = (ⵎⴰⵛⵛⵉ ⴷ ⵜⵉⴷⴻⵜ)
 validation-partially-correct = (ⴷ ⵜⵉⴷⴻⵜ ⵙ ⵓⵃⵔⵉⵛ)
-
 answer-show-responses =
     { $count ->
         [one] ⵙⴽⴻⵏ { $count } ⵏ ⵜⵔⵉⵔⵉⵜ ⵉ { $answerId }
        *[other] ⵙⴽⴻⵏ { $count } ⵏ ⵜⵔⵉⵔⵉⵢⵉⵏ ⵉ { $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = ⵉⵡⴻⵏⵏⵉⵜⴻⵏ
-
 collapsible-click-to-open = (ⵙⵉⵜ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⴻⵍⴷⵉⴷ)
 collapsible-click-to-close = (ⵙⵉⵜ ⴰⴽⴽⴻⵏ ⴰⴷ ⵜⵎⴻⴷⵍⴻⴷ)
-
 collapsible-initializing = ⴰⵙⴻⵏⴽⴻⵔ…
-
 footnote-show = ⵙⴽⴻⵏ ⵜⴰⵣⵎⵉⵍⵜ ⵏ ⵡⴰⴷⴷⴰ
 footnote-hide = ⴼⴼⴻⵔ ⵜⴰⵣⵎⵉⵍⵜ ⵏ ⵡⴰⴷⴷⴰ
-
 description-more-information = ⵓⴳⴰⵔ ⵏ ⵜⴻⵍⵖⵓⵜ
-
 
 ## Controls
 
 slider-previous = ⴰⵣⵡⵉⵔ
 slider-next = ⴰⴹⴼⵉⵔ
-
 keyboard-open = ⵍⴷⵉ ⴰⵏⴰⵙⵉⵡ
 keyboard-close = ⵎⴷⴻⵍ ⴰⵏⴰⵙⵉⵡ
-
 choice-input-remove-choice = ⴽⴽⴻⵙ { $choice }
-
 matrix-remove-row = ⴽⴽⴻⵙ ⵉⵣⵉⵔⵉⴳ
 matrix-add-row = ⵔⵏⵓ ⵉⵣⵉⵔⵉⴳ
 matrix-remove-column = ⴽⴽⴻⵙ ⵜⴰⴳⴻⵊⴷⵉⵜ
 matrix-add-column = ⵔⵏⵓ ⵜⴰⴳⴻⵊⴷⵉⵜ
-
 subset-add-remove-points = ⵔⵏⵓ/ⴽⴽⴻⵙ ⵜⵉⵏⵇⵉⴹⵉⵏ
 subset-toggle-points-intervals = ⴱⴻⴷⴷⴻⵍ ⵜⵉⵏⵇⵉⴹⵉⵏ ⴷ ⵡⴰⴽⵓⴷⴻⵏ
 subset-move-points = ⵙⵎⵓⵜⵜⵉ ⵜⵉⵏⵇⵉⴹⵉⵏ
 subset-clear = ⵙⴼⴻⴹ
-
 orbital-add-row = ⵔⵏⵓ ⵉⵣⵉⵔⵉⴳ
 orbital-remove-row = ⴽⴽⴻⵙ ⵉⵣⵉⵔⵉⴳ
 orbital-add-box = ⵔⵏⵓ ⵜⴰⵏⴰⴽⴰ
@@ -89,13 +70,9 @@ orbital-remove-box = ⴽⴽⴻⵙ ⵜⴰⵏⴰⴽⴰ
 orbital-add-up-arrow = ⵔⵏⵓ ⵜⴰⵏⴻⵛⵛⴰⴱⵜ ⵙ ⵓⴼⴻⵍⵍⴰ
 orbital-add-down-arrow = ⵔⵏⵓ ⵜⴰⵏⴻⵛⵛⴰⴱⵜ ⵙ ⵡⴰⴷⴷⴰ
 orbital-remove-arrow = ⴽⴽⴻⵙ ⵜⴰⵏⴻⵛⵛⴰⴱⵜ
-
 orbital-row-label = ⵜⴰⴱⵣⵉⵎⵜ ⵏ ⵢⵉⵣⵉⵔⵉⴳ { $row }
-
 pretzel-answer = ⵜⵉⵔⵉⵔⵉⵜ
-
 summary-statistics-caption = ⴰⴳⵣⵓⵍ ⵏ ⵜⵙⵉⴹⴰ ⵏ { $column }
-
 
 ## Math input
 
@@ -103,34 +80,25 @@ math-input-preview-region = ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵣⵡⴰⵔⴰⵏⵜ �
 math-input-preview = ⵜⴰⵎⵓⵖⵍⵉ ⵜⴰⵣⵡⴰⵔⴰⵏⵜ
 math-input-invalid-expression = ⵜⴰⵏⴼⴰⵍⵉⵜ ⵜⴰⵔⴰⵎⴻⵖⵜⵓⵜ:
 
-
 ## Document status
 
 viewer-initializing = ⴰⵙⴻⵏⴽⴻⵔ…
 
-
 ## Errors
 
 error-heading = ⵜⵓⵛⵛⴹⴰ
-
 error-found-at =
     { $span ->
         [line] ⵜⴻⵜⵜⵡⴰⴼ ⴷⴻⴳ ⵢⵉⵣⵉⵔⵉⴳ { $startLine }.
        *[lines] ⵜⴻⵜⵜⵡⴰⴼ ⴷⴻⴳ ⵢⵉⵣⵉⵔⵉⴳⴻⵏ { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = ⴰⵙⴻⵎⵍⵉ-ⴰ ⵢⴻⵙⵄⴰ ⵜⵓⵛⵛⴹⵉⵡⵉⵏ!
-
 diagnostic-heading-error = ⵜⵓⵛⵛⴹⴰ
 diagnostic-heading-warning = ⴰⵍⵖⵓ
 diagnostic-heading-information = ⵜⴰⵍⵖⵓⵜ
 diagnostic-heading-hint = ⵜⴰⵏⴻⵖⵔⵓⴼⵜ
-
 accessibility-heading-level-1 = ⴰⵣⴳⴰⵔ WCAG AA ⵏ ⵡⴰⵏⴻⴽⵛⵓⵎ
 accessibility-heading-level-2 = ⴰⵍⵖⵓ ⵏ ⵡⴰⵏⴻⴽⵛⵓⵎ
-
 something-went-wrong = ⵢⴻⵍⵍⴰ ⵡⴰⵢⴻⵏ ⵓⵔ ⵏⵜⴻⴷⴷⵓ ⴰⵔⴰ ⴰⴽⴽⴻⵏ ⵉⵡⴰⵜⴰ.
-
 renderer-load-failed = ⴰⵎⵙⴽⴻⵏ ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⴷ-ⵢⴰⵍⵉ. ⵜⵜⵅⵉⵍ-ⴽ ⴰⵍⴻⵙ ⴰⵙⴰⵍⵉ ⵏ ⵓⵙⴻⴱⵜⴻⵔ.
-
 core-start-failed = ⴰⵎⵙⴽⴻⵏ ⵏ ⵓⵙⴻⵎⵍⵉ ⵓⵔ ⵢⴻⵣⵎⵉⵔ ⴰⵔⴰ ⴰⴷ ⵢⴻⴽⴽⴻⵔ. ⵜⵜⵅⵉⵍ-ⴽ ⴰⵍⴻⵙ ⴰⵙⴰⵍⵉ ⵏ ⵓⵙⴻⴱⵜⴻⵔ.

--- a/packages/i18n/locales/zgh/content.ftl
+++ b/packages/i18n/locales/zgh/content.ftl
@@ -81,7 +81,6 @@ color =
     .purple = ⴰⵕⴳⵡⴰⵏⵉ
     .pink = ⵡⴰⵔⴷⵉ
     .brown = ⵇⴰⵀⵡⵉ
-
 line-width =
     .thick =
         { $gender ->
@@ -93,13 +92,11 @@ line-width =
             [f] ⵜⴰⵔⵇⴰⵇⵜ
            *[m] ⴰⵔⵇⴰⵇ
         }
-
 # Prepositional phrases rather than adjectives, so that they agree with nothing
 # and can close the description.
 line-style =
     .dashed = ⵙ ⵜⴻⴳⵣⵓⵎⵉⵏ
     .dotted = ⵙ ⵜⴻⵏⵇⵉⴹⵉⵏ
-
 # Written in the annexed state, because every place these words are placed puts
 # them behind ⵙ; see this file's header.
 fill-style =
@@ -109,7 +106,6 @@ fill-style =
     .backdiagonal = ⵢⵉⵣⵉⵔⵉⴳⴻⵏ ⵉⵣⴳⴻⵏ ⵙ ⵜⴰⵎⴰ ⵢⴰⴹⵏⵉⵏ
     .dots = ⵜⴻⵏⵇⵉⴹⵉⵏ
     .diamonds = ⵜⴻⵍⵎⴰⵙⵉⵏ
-
 noun =
     .line = ⵉⵣⵉⵔⵉⴳ
     .line-segment = ⴰⴳⵣⵓⵎ ⵏ ⵢⵉⵣⵉⵔⵉⴳ
@@ -129,7 +125,6 @@ noun =
     .diamond = ⵜⴰⵍⵎⴰⵙⵜ
     .cross = ⴰⵎⴳⵔⵉⴷ
     .plus = ⴰⵣⴰⵎⵓⵍ ⵏ ⵓⵔⵏⵓ
-
 # The side count is a complement introduced by ⵙ, so it follows the whole
 # phrase rather than opening it.
 noun-regular-polygon =
@@ -137,7 +132,6 @@ noun-regular-polygon =
         [tail] ⵙ { $numSides } ⵏ ⵢⵉⴷⵉⵙⴰⵏ
        *[head] ⴰⵎⴻⴳⴳⴻⵜⵙⴷⵉⵙ ⴰⵎⴻⵛⵜⵓ
     }
-
 # The grammatical gender of the noun being described. Masculine is the default
 # and the gender a loanword takes.
 noun-gender =
@@ -152,7 +146,6 @@ noun-gender =
        *[other] m
     }
 
-
 ## Style composition
 
 style-stroke =
@@ -165,19 +158,16 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [f] ⵜⴻⵛⵛⵓⵔ
        *[m] ⵉⵛⵛⵓⵔ
     }
-
 # Every branch that places `$pattern` puts it behind ⵙ, which is what lets
 # `fill-style` write one annexed form apiece.
 style-filled =
@@ -185,7 +175,6 @@ style-filled =
         [pattern] { $filled } { $color } ⵙ { $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } ⵙ { $pattern }
@@ -193,7 +182,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ⵙ { $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # ⵜⴰⵎⴰ is feminine, so the border's adjectives agree with it rather than with
 # the shape it surrounds. Tamazight has no indefinite article, so the two
 # `-article` branches read like their neighbours.
@@ -204,35 +192,28 @@ style-border-clause =
         [and-article] ⴷ ⵜⴻⵎⴰ { $border }
        *[with] ⵙ ⵜⴻⵎⴰ { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color } ⵙ { $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = ⵓⵔ ⵉⵛⵛⵓⵔ
-
 style-text =
     { $parts ->
         [background] { $color } ⵅⴼ ⵓⴳⵉⵍⴰⵍ { $background }
        *[plain] { $color }
     }
-
 style-background-none = ⵓⵍⴰⵛ
-
 
 ## Boolean words
 
 boolean-true = ⵜⵉⴷⴻⵜ
 boolean-false = ⵜⴰⴽⴻⵕⴹⵉⵜ
 
-
 ## Answer buttons
 
 answer-submit-label = ⵙⵏⵇⴻⴷ ⵜⴰⵡⵓⵔⵉ
 answer-submit-label-no-correctness = ⴰⵣⴻⵏ ⵜⵉⵔⵉⵔⵉⵜ
-
 
 ## Sectional blocks
 
@@ -257,7 +238,6 @@ section-name =
     .solution = ⵜⵉⴼⵔⴰⵜ
     .task = ⵜⴰⵡⵓⵔⵉ
     .theorem = ⵜⴰⵎⴰⵎⴽⵜ
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -267,9 +247,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = ⵜⴰⵍⵖⵓⵜ
-
 
 ## Tables and figures
 
@@ -280,7 +258,6 @@ table-name =
         [unnumbered-title] ⵜⴰⴼⴻⵍⵡⵉⵜ{ ": " }
        *[unnumbered] ⵜⴰⴼⴻⵍⵡⵉⵜ
     }
-
 figure-name =
     { $parts ->
         [numbered] ⵜⵓⴳⵏⴰ { $enumeration }
@@ -289,24 +266,18 @@ figure-name =
        *[unnumbered] ⵜⵓⴳⵏⴰ
     }
 
-
 ## Paginator controls
 
 paginator-previous = ⴰⵣⵡⵉⵔ
 paginator-next = ⴰⴹⴼⵉⵔ
 paginator-page = ⴰⵙⴻⴱⵜⴻⵔ
-
 paginator-page-status = { $pageLabel } { $currentPage } ⵙⴻⴳ { $numPages }
-
 
 ## Piecewise functions
 
 piecewise-condition-or = ⵏⴻⵖ
-
 piecewise-condition-if = ⵎⴽ
-
 piecewise-condition-otherwise = ⵏⴻⵖ ⵎⵓⵍⴰⵛ
-
 
 ## Chemistry
 ##
@@ -320,6 +291,5 @@ piecewise-condition-otherwise = ⵏⴻⵖ ⵎⵓⵍⴰⵛ
 ## border: three Berber catalogs, two school systems, one answer.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = ⴰⵣⴰⵎⵓⵍ ⴰⴽⵉⵎⵢⴰⵏ ⴰⵔⴰⵎⴻⵖⵜⵓ
 chemistry-invalid-ionic-compound = ⴰⵙⴷⵓⴽⴽⴻⵍ ⴰⵢⵓⵏⴰⵏ ⴰⵔⴰⵎⴻⵖⵜⵓ

--- a/packages/i18n/locales/zh-Hans/chrome.ftl
+++ b/packages/i18n/locales/zh-Hans/chrome.ftl
@@ -33,69 +33,50 @@
 
 answer-checking = 正在检查……
 answer-submitting = 正在提交……
-
 answer-checking-status = 正在检查答案
 answer-submitting-status = 正在提交答案
-
 answer-correct = 正确
 answer-incorrect = 错误
-
 answer-response-saved = 回答已保存
-
 answer-percent-credit = { $percent }% 得分
 answer-percent-correct = { $percent }% 正确
 answer-percent-short = { $percent }%
-
 max-credit-available = 最高可得分数：{ $percent }%
-
 attempts-remaining =
     { $count ->
         [0] 没有剩余尝试次数
        *[other] 还剩 { $count } 次尝试
     }
-
 validation-correct = （正确）
 validation-incorrect = （错误）
 validation-partially-correct = （部分正确）
-
 answer-show-responses = 显示 { $answerId } 的 { $count } 条回答
-
 
 ## Disclosure panels
 
 feedback-heading = 反馈
-
 collapsible-click-to-open = （点击展开）
 collapsible-click-to-close = （点击收起）
-
 collapsible-initializing = 正在初始化……
-
 footnote-show = 显示脚注
 footnote-hide = 隐藏脚注
-
 description-more-information = 更多信息
-
 
 ## Controls
 
 slider-previous = 上一个
 slider-next = 下一个
-
 keyboard-open = 打开键盘
 keyboard-close = 关闭键盘
-
 choice-input-remove-choice = 删除 { $choice }
-
 matrix-remove-row = 删除行
 matrix-add-row = 添加行
 matrix-remove-column = 删除列
 matrix-add-column = 添加列
-
 subset-add-remove-points = 添加/删除点
 subset-toggle-points-intervals = 切换点与区间
 subset-move-points = 移动点
 subset-clear = 清除
-
 # A `box` here is one orbital, drawn as a square: 方框.
 orbital-add-row = 添加行
 orbital-remove-row = 删除行
@@ -104,13 +85,9 @@ orbital-remove-box = 删除方框
 orbital-add-up-arrow = 添加向上箭头
 orbital-add-down-arrow = 添加向下箭头
 orbital-remove-arrow = 删除箭头
-
 orbital-row-label = 第 { $row } 行的标签
-
 pretzel-answer = 答案
-
 summary-statistics-caption = { $column } 的描述统计量
-
 
 ## Math input
 
@@ -118,34 +95,25 @@ math-input-preview-region = 数学表达式预览
 math-input-preview = 预览
 math-input-invalid-expression = 无效的表达式：
 
-
 ## Document status
 
 viewer-initializing = 正在初始化……
 
-
 ## Errors
 
 error-heading = 错误
-
 error-found-at =
     { $span ->
         [line] 位于第 { $startLine } 行。
        *[lines] 位于第 { $startLine }–{ $endLine } 行。
     }
-
 document-contains-errors = 本文档包含错误！
-
 diagnostic-heading-error = 错误
 diagnostic-heading-warning = 警告
 diagnostic-heading-information = 信息
 diagnostic-heading-hint = 提示
-
 accessibility-heading-level-1 = 违反 WCAG AA 无障碍标准
 accessibility-heading-level-2 = 无障碍提醒
-
 something-went-wrong = 出错了。
-
 renderer-load-failed = 某个渲染组件加载失败。请重新加载页面。
-
 core-start-failed = 无法启动文档查看器。请重新加载页面。

--- a/packages/i18n/locales/zh-Hans/content.ftl
+++ b/packages/i18n/locales/zh-Hans/content.ftl
@@ -30,15 +30,12 @@ color =
     .purple = 紫色
     .pink = 粉色
     .brown = 棕色
-
 line-width =
     .thick = 粗
     .thin = 细
-
 line-style =
     .dashed = 虚线
     .dotted = 点线
-
 # Noun phrases: they follow 带 and modify nothing.
 fill-style =
     .horizontal = 水平线
@@ -47,7 +44,6 @@ fill-style =
     .backdiagonal = 反向斜线
     .dots = 圆点
     .diamonds = 菱形
-
 noun =
     .line = 直线
     .line-segment = 线段
@@ -67,7 +63,6 @@ noun =
     .diamond = 菱形
     .cross = 十字
     .plus = 加号
-
 # Chinese puts the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -75,11 +70,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] 正 { $numSides } 边形
     }
-
 # Chinese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -93,22 +86,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # No space between a modifier and the noun it modifies.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description }{ $noun }{ $nounTail }
        *[noun] { $description }{ $noun }
     }
-
 style-filled-word = 填充
-
 style-filled =
     { $parts ->
         [pattern] 带{ $pattern }的{ $color }{ $filled }
        *[plain] { $color }{ $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] 带{ $pattern }的{ $color }{ $filled }{ $noun }
@@ -116,7 +105,6 @@ style-filled-with-noun =
         [pattern-tail] 带{ $pattern }的{ $color }{ $filled }{ $noun }{ $nounTail }
        *[plain] { $color }{ $filled }{ $noun }
     }
-
 # The code appends this clause to the description with a plain space, which is
 # the one join no catalog owns, so Chinese gets a space it would not write:
 # 带圆点的蓝色填充圆 和红色边框. Closing it means the code passing the join to
@@ -128,35 +116,28 @@ style-border-clause =
         [and-article] 和{ $border }边框
        *[with] 带{ $border }边框
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color }{ $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = 未填充
-
 style-text =
     { $parts ->
         [background] { $color }，{ $background }背景
        *[plain] { $color }
     }
-
 style-background-none = 无
-
 
 ## Boolean words
 
 boolean-true = 真
 boolean-false = 假
 
-
 ## Answer buttons
 
 answer-submit-label = 检查
 answer-submit-label-no-correctness = 提交回答
-
 
 ## Sectional blocks
 
@@ -181,7 +162,6 @@ section-name =
     .solution = 解答
     .task = 任务
     .theorem = 定理
-
 # A space separates the word from its number, because the number is Latin
 # digits, and a title follows the full-width colon Chinese punctuates with. A
 # bare number keeps the ASCII period, which is the punctuation the number
@@ -195,9 +175,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ "：" }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = 提示
-
 
 ## Tables and figures
 
@@ -208,7 +186,6 @@ table-name =
         [unnumbered-title] 表{ "：" }
        *[unnumbered] 表
     }
-
 figure-name =
     { $parts ->
         [numbered] 图 { $enumeration }
@@ -217,26 +194,22 @@ figure-name =
        *[unnumbered] 图
     }
 
-
 ## Paginator controls
 
 paginator-previous = 上一页
 paginator-next = 下一页
 paginator-page = 页
-
 # Chinese counts pages with the label on both halves — 第 3 页，共 5 页 — so
 # `$pageLabel` appears twice. It is the `pageLabel` attribute, which an author
 # may have written themselves, and a word they chose has to be the word in
 # both halves.
 paginator-page-status = 第 { $currentPage } { $pageLabel }，共 { $numPages } { $pageLabel }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = 或
 piecewise-condition-if = 当
 piecewise-condition-otherwise = 其他情况
-
 
 ## Chemistry
 
@@ -359,7 +332,6 @@ element-name =
     .lv = 𫟷
     .ts = 鿬
     .og = 鿫
-
 element-anion-name =
     .h = 氢化物
     .c = 碳化物
@@ -373,8 +345,6 @@ element-anion-name =
     .i = 碘化物
     .at = 砹化物
     .ts = 鿬化物
-
 ion-name-oxidation-state = { $name }（{ $numeral }）
-
 chemistry-invalid-symbol = 无效的化学符号
 chemistry-invalid-ionic-compound = 无效的离子化合物

--- a/packages/i18n/locales/zh-Hant/chrome.ftl
+++ b/packages/i18n/locales/zh-Hant/chrome.ftl
@@ -38,70 +38,51 @@
 
 answer-checking = 正在檢查……
 answer-submitting = 正在提交……
-
 answer-checking-status = 正在檢查答案
 answer-submitting-status = 正在提交答案
-
 answer-correct = 正確
 answer-incorrect = 錯誤
-
 answer-response-saved = 作答已儲存
-
 answer-percent-credit = { $percent }% 得分
 answer-percent-correct = { $percent }% 正確
 answer-percent-short = { $percent }%
-
 max-credit-available = 最高可得分數：{ $percent }%
-
 attempts-remaining =
     { $count ->
         [0] 沒有剩餘的嘗試次數
        *[other] 還剩 { $count } 次嘗試
     }
-
 validation-correct = （正確）
 validation-incorrect = （錯誤）
 validation-partially-correct = （部分正確）
-
 answer-show-responses = 顯示 { $answerId } 的 { $count } 筆作答
-
 
 ## Disclosure panels
 
 feedback-heading = 回饋
-
 collapsible-click-to-open = （點擊展開）
 collapsible-click-to-close = （點擊收合）
-
 collapsible-initializing = 正在初始化……
-
 footnote-show = 顯示註腳
 footnote-hide = 隱藏註腳
-
 description-more-information = 更多資訊
-
 
 ## Controls
 
 slider-previous = 上一個
 slider-next = 下一個
-
 keyboard-open = 開啟鍵盤
 keyboard-close = 關閉鍵盤
-
 choice-input-remove-choice = 刪除 { $choice }
-
 # 列 is the row and 欄 the column — see the note on rows and columns above.
 matrix-remove-row = 刪除列
 matrix-add-row = 新增列
 matrix-remove-column = 刪除欄
 matrix-add-column = 新增欄
-
 subset-add-remove-points = 新增/刪除點
 subset-toggle-points-intervals = 切換點與區間
 subset-move-points = 移動點
 subset-clear = 清除
-
 # A `box` here is one orbital, drawn as a square: 方框.
 orbital-add-row = 新增列
 orbital-remove-row = 刪除列
@@ -110,13 +91,9 @@ orbital-remove-box = 刪除方框
 orbital-add-up-arrow = 新增向上箭頭
 orbital-add-down-arrow = 新增向下箭頭
 orbital-remove-arrow = 刪除箭頭
-
 orbital-row-label = 第 { $row } 列的標籤
-
 pretzel-answer = 答案
-
 summary-statistics-caption = { $column } 的描述統計量
-
 
 ## Math input
 
@@ -124,16 +101,13 @@ math-input-preview-region = 數學式預覽
 math-input-preview = 預覽
 math-input-invalid-expression = 無效的數學式：
 
-
 ## Document status
 
 viewer-initializing = 正在初始化……
 
-
 ## Errors
 
 error-heading = 錯誤
-
 # A line of source text, which Taiwan counts with 行 exactly as the mainland
 # does. Only a table's rows and columns swap — see the note above.
 error-found-at =
@@ -141,19 +115,13 @@ error-found-at =
         [line] 位於第 { $startLine } 行。
        *[lines] 位於第 { $startLine }–{ $endLine } 行。
     }
-
 document-contains-errors = 本文件包含錯誤！
-
 diagnostic-heading-error = 錯誤
 diagnostic-heading-warning = 警告
 diagnostic-heading-information = 資訊
 diagnostic-heading-hint = 提示
-
 accessibility-heading-level-1 = 違反 WCAG AA 無障礙標準
 accessibility-heading-level-2 = 無障礙提醒
-
 something-went-wrong = 發生錯誤。
-
 renderer-load-failed = 某個繪製元件載入失敗。請重新載入頁面。
-
 core-start-failed = 無法啟動文件檢視器。請重新載入頁面。

--- a/packages/i18n/locales/zh-Hant/content.ftl
+++ b/packages/i18n/locales/zh-Hant/content.ftl
@@ -39,15 +39,12 @@ color =
     .purple = 紫色
     .pink = 粉紅色
     .brown = 棕色
-
 line-width =
     .thick = 粗
     .thin = 細
-
 line-style =
     .dashed = 虛線
     .dotted = 點線
-
 # Noun phrases: they follow 帶 and modify nothing.
 fill-style =
     .horizontal = 水平線
@@ -56,7 +53,6 @@ fill-style =
     .backdiagonal = 反向斜線
     .dots = 圓點
     .diamonds = 菱形
-
 noun =
     .line = 直線
     .line-segment = 線段
@@ -76,7 +72,6 @@ noun =
     .diamond = 菱形
     .cross = 十字
     .plus = 加號
-
 # Chinese puts the side count in front of the noun, so the whole thing is one
 # head and there is no tail.
 noun-regular-polygon =
@@ -84,11 +79,9 @@ noun-regular-polygon =
         [tail] { "" }
        *[head] 正 { $numSides } 邊形
     }
-
 # Chinese has no grammatical gender, so every noun answers the same and the
 # answer goes unused — as in English.
 noun-gender = neuter
-
 
 ## Style composition
 
@@ -102,22 +95,18 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 # No space between a modifier and the noun it modifies.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description }{ $noun }{ $nounTail }
        *[noun] { $description }{ $noun }
     }
-
 style-filled-word = 填充
-
 style-filled =
     { $parts ->
         [pattern] 帶{ $pattern }的{ $color }{ $filled }
        *[plain] { $color }{ $filled }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] 帶{ $pattern }的{ $color }{ $filled }{ $noun }
@@ -125,7 +114,6 @@ style-filled-with-noun =
         [pattern-tail] 帶{ $pattern }的{ $color }{ $filled }{ $noun }{ $nounTail }
        *[plain] { $color }{ $filled }{ $noun }
     }
-
 # The code appends this clause to the description with a plain space, which is
 # the one join no catalog owns, so Chinese gets a space it would not write:
 # 帶圓點的藍色填充圓 和紅色邊框. Closing it means the code passing the join to
@@ -137,35 +125,28 @@ style-border-clause =
         [and-article] 和{ $border }邊框
        *[with] 帶{ $border }邊框
     }
-
 style-fill =
     { $parts ->
         [pattern] { $color }{ $pattern }
        *[plain] { $color }
     }
-
 style-unfilled = 未填充
-
 style-text =
     { $parts ->
         [background] { $color }，{ $background }背景
        *[plain] { $color }
     }
-
 style-background-none = 無
-
 
 ## Boolean words
 
 boolean-true = 真
 boolean-false = 假
 
-
 ## Answer buttons
 
 answer-submit-label = 檢查
 answer-submit-label-no-correctness = 提交作答
-
 
 ## Sectional blocks
 
@@ -190,7 +171,6 @@ section-name =
     .solution = 解答
     .task = 任務
     .theorem = 定理
-
 # A space separates the word from its number, because the number is Latin
 # digits, and a title follows the full-width colon Chinese punctuates with. A
 # bare number keeps the ASCII period, which is the punctuation the number
@@ -204,9 +184,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ "：" }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = 提示
-
 
 ## Tables and figures
 
@@ -217,7 +195,6 @@ table-name =
         [unnumbered-title] 表{ "：" }
        *[unnumbered] 表
     }
-
 figure-name =
     { $parts ->
         [numbered] 圖 { $enumeration }
@@ -226,26 +203,22 @@ figure-name =
        *[unnumbered] 圖
     }
 
-
 ## Paginator controls
 
 paginator-previous = 上一頁
 paginator-next = 下一頁
 paginator-page = 頁
-
 # Chinese counts pages with the label on both halves — 第 3 頁，共 5 頁 — so
 # `$pageLabel` appears twice. It is the `pageLabel` attribute, which an author
 # may have written themselves, and a word they chose has to be the word in
 # both halves.
 paginator-page-status = 第 { $currentPage } { $pageLabel }，共 { $numPages } { $pageLabel }
 
-
 ## Piecewise functions
 
 piecewise-condition-or = 或
 piecewise-condition-if = 當
 piecewise-condition-otherwise = 其他情況
-
 
 ## Chemistry
 
@@ -368,7 +341,6 @@ element-name =
     .lv = 鉝
     .ts = 鿬
     .og = 鿫
-
 element-anion-name =
     .h = 氫化物
     .c = 碳化物
@@ -382,8 +354,6 @@ element-anion-name =
     .i = 碘化物
     .at = 砈化物
     .ts = 鿬化物
-
 ion-name-oxidation-state = { $name }（{ $numeral }）
-
 chemistry-invalid-symbol = 無效的化學符號
 chemistry-invalid-ionic-compound = 無效的離子化合物

--- a/packages/i18n/locales/zu/chrome.ftl
+++ b/packages/i18n/locales/zu/chrome.ftl
@@ -21,74 +21,55 @@
 
 answer-checking = Iyahlola...
 answer-submitting = Iyathumela...
-
 answer-checking-status = Ihlola impendulo
 answer-submitting-status = Ithumela impendulo
-
 answer-correct = Kulungile
 answer-incorrect = Akulungile
-
 answer-response-saved = Impendulo Ilondoloziwe
-
 answer-percent-credit = Amamaki angu-{ $percent }%
 answer-percent-correct = { $percent }% Kulungile
 answer-percent-short = { $percent }%
-
 max-credit-available = Amamaki aphezulu atholakalayo: { $percent }%
-
 attempts-remaining =
     { $count ->
         [0] ayikho imizamo esele
         [one] kusele umzamo ongu-{ $count }
        *[other] kusele imizamo engu-{ $count }
     }
-
 validation-correct = (Kulungile)
 validation-incorrect = (Akulungile)
 validation-partially-correct = (Kulungile ngokwengxenye)
-
 answer-show-responses =
     { $count ->
         [one] Bonisa impendulo engu-{ $count } ku-{ $answerId }
        *[other] Bonisa izimpendulo ezingu-{ $count } ku-{ $answerId }
     }
 
-
 ## Disclosure panels
 
 feedback-heading = Impendulo Yokuqondisa
-
 collapsible-click-to-open = (chofoza ukuze uvule)
 collapsible-click-to-close = (chofoza ukuze uvale)
-
 collapsible-initializing = Iyaqalisa...
-
 footnote-show = Bonisa inothi elingezansi
 footnote-hide = Fihla inothi elingezansi
-
 description-more-information = olunye ulwazi
-
 
 ## Controls
 
 slider-previous = Emuva
 slider-next = Phambili
-
 keyboard-open = Vula Ikhibhodi
 keyboard-close = Vala Ikhibhodi
-
 choice-input-remove-choice = Susa { $choice }
-
 matrix-remove-row = Susa umugqa
 matrix-add-row = Engeza umugqa
 matrix-remove-column = Susa ikholomu
 matrix-add-column = Engeza ikholomu
-
 subset-add-remove-points = Engeza/Susa amaphuzu
 subset-toggle-points-intervals = Shintsha phakathi kwamaphuzu nezikhala
 subset-move-points = Hambisa Amaphuzu
 subset-clear = Sula
-
 # A `box` here is one orbital, drawn as a square: ibhokisi.
 orbital-add-row = Engeza Umugqa
 orbital-remove-row = Susa Umugqa
@@ -97,13 +78,9 @@ orbital-remove-box = Susa Ibhokisi
 orbital-add-up-arrow = Engeza Umcibisholo Obhekise Phezulu
 orbital-add-down-arrow = Engeza Umcibisholo Obhekise Phansi
 orbital-remove-arrow = Susa Umcibisholo
-
 orbital-row-label = Ilebula lomugqa { $row }
-
 pretzel-answer = Impendulo
-
 summary-statistics-caption = Izibalo ezifingqiwe ze-{ $column }
-
 
 ## Math input
 
@@ -111,34 +88,25 @@ math-input-preview-region = ukubuka kuqala kwenkulumo yezibalo
 math-input-preview = Buka Kuqala
 math-input-invalid-expression = Inkulumo engavumelekile:
 
-
 ## Document status
 
 viewer-initializing = Iyaqalisa...
 
-
 ## Errors
 
 error-heading = Iphutha
-
 error-found-at =
     { $span ->
         [line] Litholakale emugqeni { $startLine }.
        *[lines] Litholakale emigqeni { $startLine }–{ $endLine }.
     }
-
 document-contains-errors = Lo mbhalo unamaphutha!
-
 diagnostic-heading-error = Iphutha
 diagnostic-heading-warning = Isixwayiso
 diagnostic-heading-information = Ulwazi
 diagnostic-heading-hint = Isexwayiso
-
 accessibility-heading-level-1 = Ukwephulwa Kokufinyeleleka Kwe-WCAG AA
 accessibility-heading-level-2 = Isixwayiso sokufinyeleleka
-
 something-went-wrong = Kukhona okungahambanga kahle.
-
 renderer-load-failed = esinye isibonisi sehlulekile ukulayisha. Sicela ulayishe ikhasi kabusha.
-
 core-start-failed = Isibonisi sombhalo asikwazanga ukuqalwa. Sicela ulayishe ikhasi kabusha.

--- a/packages/i18n/locales/zu/content.ftl
+++ b/packages/i18n/locales/zu/content.ftl
@@ -120,7 +120,6 @@ color =
             [c7] esinsundu
            *[c9] ensundu
         }
-
 # These two are true adjectives and take the adjective concord, not the
 # relative one the colours take.
 line-width =
@@ -138,14 +137,12 @@ line-width =
             [c7] esincane
            *[c9] encane
         }
-
 # Written as an invariable «one-…» phrase — "having …" — rather than as a
 # describing word, so that it agrees with nothing and can close the phrase.
 # `style-stroke` puts it last for that reason.
 line-style =
     .dashed = onemidwa
     .dotted = onamachashazi
-
 # Noun phrases: they follow «kanye ne-» and modify nothing.
 fill-style =
     .horizontal = imigqa evundlile
@@ -154,7 +151,6 @@ fill-style =
     .backdiagonal = imigqa etshekile ngokuphambene
     .dots = amachashazi
     .diamonds = amadayimane
-
 noun =
     .line = umugqa
     .line-segment = isiqephu somugqa
@@ -174,7 +170,6 @@ noun =
     .diamond = idayimane
     .cross = isiphambano
     .plus = uphawu lokuhlanganisa
-
 # The side count goes in the tail, behind the describing words, because
 # «esinezinhlangothi ezingu-5» is a relative phrase and Zulu closes a noun
 # phrase with one rather than opening it.
@@ -183,7 +178,6 @@ noun-regular-polygon =
         [tail] esinezinhlangothi ezingu-{ $numSides }
        *[head] isakhiwo esilingene
     }
-
 # The noun class, which is what a describing word agrees with. `c9` is the
 # default and the class of every loanword.
 noun-gender =
@@ -206,7 +200,6 @@ noun-gender =
        *[other] c9
     }
 
-
 ## Style composition
 
 # The dash pattern is a relative phrase of its own and closes the description,
@@ -221,13 +214,11 @@ style-stroke =
         [style] { $lineStyle }
        *[color] { $color }
     }
-
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
        *[noun] { $noun } { $description }
     }
-
 style-filled-word =
     { $gender ->
         [c3] ogcwalisiwe
@@ -235,13 +226,11 @@ style-filled-word =
         [c7] esigcwalisiwe
        *[c9] egcwalisiwe
     }
-
 style-filled =
     { $parts ->
         [pattern] { $filled } { $color } kanye ne-{ $pattern }
        *[plain] { $filled } { $color }
     }
-
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $filled } { $color } kanye ne-{ $pattern }
@@ -249,7 +238,6 @@ style-filled-with-noun =
         [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kanye ne-{ $pattern }
        *[plain] { $noun } { $filled } { $color }
     }
-
 # «umngcele» is class 3, so the border's words agree with it and not with the
 # shape it surrounds. Zulu has no article, and it joins a complement with the
 # invariable «kanye no-» rather than with a concording relative, so all four
@@ -261,35 +249,28 @@ style-border-clause =
         [and-article] kanye nomngcele { $border }
        *[with] kanye nomngcele { $border }
     }
-
 style-fill =
     { $parts ->
         [pattern] { $pattern } { $color }
        *[plain] { $color }
     }
-
 style-unfilled = akugcwalisiwe
-
 style-text =
     { $parts ->
         [background] { $color } engemuva { $background }
        *[plain] { $color }
     }
-
 style-background-none = lutho
-
 
 ## Boolean words
 
 boolean-true = kuyiqiniso
 boolean-false = akulona iqiniso
 
-
 ## Answer buttons
 
 answer-submit-label = Hlola Umsebenzi
 answer-submit-label-no-correctness = Thumela Impendulo
-
 
 ## Sectional blocks
 
@@ -314,7 +295,6 @@ section-name =
     .solution = Isixazululo
     .task = Umsebenzi
     .theorem = Ithiyoremu
-
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }
@@ -324,9 +304,7 @@ section-title-prefix =
         [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
        *[name-number] { $sectionName } { $sectionNumber }
     }
-
 hint-title = Isexwayiso
-
 
 ## Tables and figures
 
@@ -337,7 +315,6 @@ table-name =
         [unnumbered-title] Ithebula{ ": " }
        *[unnumbered] Ithebula
     }
-
 figure-name =
     { $parts ->
         [numbered] Umfanekiso { $enumeration }
@@ -346,15 +323,12 @@ figure-name =
        *[unnumbered] Umfanekiso
     }
 
-
 ## Paginator controls
 
 paginator-previous = Okwedlule
 paginator-next = Okulandelayo
 paginator-page = Ikhasi
-
 paginator-page-status = { $pageLabel } { $currentPage } kwangu-{ $numPages }
-
 
 ## Piecewise functions
 
@@ -362,8 +336,8 @@ piecewise-condition-or = noma
 piecewise-condition-if = uma
 piecewise-condition-otherwise = kwenye indawo
 
-
 ## Chemistry
+
 
 # Zulu is one of the catalogs that leaves `element-name` and
 # `element-anion-name` out, so those 130 keys fall back to English. South
@@ -374,6 +348,5 @@ piecewise-condition-otherwise = kwenye indawo
 # textbook in front of them.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
-
 chemistry-invalid-symbol = Uphawu Lwamakhemikhali Olungavumelekile
 chemistry-invalid-ionic-compound = Inhlanganisela Ye-ayoni Engavumelekile


### PR DESCRIPTION
Drains the backlog that had accumulated in Weblate since the trial hosting was set up — 428 commits, reduced here to two reviewable commits.

Weblate itself could not push these: its components had no working GitHub credential, so the queue sat unsent and the components auto-locked with a "Could not push the repository" alert. That is being fixed separately; this PR gets the content into `main` in the meantime.

## What's in it

| Commit | Extent | What it is |
|---|---|---|
| `chore(l10n): normalize .ftl formatting…` | 421 files, ~13,000 lines | Pure reformat — no content change |
| `feat(l10n): Khmer translation updates…` | 7 files, 79 insertions | The only real translation work |

### The reformat commit

Weblate re-serializes every Fluent file it writes, and its serializer drops the blank lines between messages. Adopting that output once means future translation PRs carry only translation changes instead of repeating this 13,000-line diff every time.

Review it as a no-op: `git diff --ignore-blank-lines c39ee379..8193c316c` produces nothing across all 421 files. Section comments (`## Disclosure panels`) still delimit the groups, so the structure stays legible.

### The translation commit

Khmer (`km`) improvements contributed through Weblate by **SeyhaLite**: reworked wording for `attempts-remaining`, and `answer-show-responses` promoted from a flat string to a proper plural selector.

The other six files (`fil`, `gd`, `hi`, `ps`, `sd`, `ur`) contain no wording change — Weblate reindents selectors nested inside a variant onto their own line. Fluent parses both spellings identically. They are here rather than in the reformat commit because the change is not blank-line-only.

## Scope and verification

- English sources and the `en-XA`/`en-XB` pseudo-locales: **untouched**
- Nothing outside `packages/i18n/locales/`
- No files added, deleted, or renamed
- Resulting tree is byte-identical to Weblate's `chrome` export at `b5ba4de5`
- `npm run build -w @doenet/i18n` succeeds
- `npm run lint:i18n -w @doenet/i18n` passes — 571 keys across 215 locales, 371 call sites
- Prettier does not claim `.ftl` (`inferredParser: null`), so the reformat cannot trip `prettier --check`

## No changeset

Every consumer of `@doenet/i18n` is private, so changesets cannot trace this to a published package on its own, and ongoing Weblate PRs will not carry changesets either. Add one if you want the Khmer fix called out in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3rQdnR58BwSrd3doEMDoH
