### PR TITLE
Give the legend a layer and an opaque box

### DIFF
--- a/.changeset/legend-layer-and-boxed.md
+++ b/.changeset/legend-layer-and-boxed.md
@@ -8,12 +8,18 @@
 
 `<legend>` honors its `layer` attribute and can draw an opaque box behind itself.
 
-Every piece of a legend — its swatches and its labels — is now drawn at the
-DoenetML `layer` the legend asks for, offset the same way the rest of a graph's
-contents are. `<legend layer="3">` therefore sits above a `layer="2"` rectangle,
-where before it was painted underneath one. A legend now defaults to `layer="1"`
-rather than `layer="0"`, so that it still sits above everything on the default
-layer, as its labels and marker swatches did before.
+A legend's swatches, and its box, are now drawn at the DoenetML `layer` the
+legend asks for, offset the same way the rest of a graph's contents are.
+`<legend layer="3">` therefore sits above a `layer="2"` rectangle, where before
+it was painted underneath one. A legend now defaults to `layer="1"` rather than
+`layer="0"`, so that it still sits above everything on the default layer, as its
+marker swatches did before.
+
+Its labels are a different matter, and the `layer` does less for them: they are
+drawn as HTML overlaid on the board, so they paint above the graph's contents
+whatever layer is asked for. Lowering a legend's layer sends its swatches behind
+a curve but leaves its labels in front — the same asymmetry that made the
+opaque-rectangle workaround look half-broken.
 
 The new `boxed` attribute draws an opaque box behind the legend, so a curve
 passing behind it is hidden rather than tangled up with the labels. The box

--- a/.changeset/legend-layer-and-boxed.md
+++ b/.changeset/legend-layer-and-boxed.md
@@ -1,0 +1,24 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+`<legend>` honors its `layer` attribute and can draw an opaque box behind itself.
+
+Every piece of a legend — its swatches and its labels — is now drawn at the
+DoenetML `layer` the legend asks for, offset the same way the rest of a graph's
+contents are. `<legend layer="3">` therefore sits above a `layer="2"` rectangle
+instead of underneath it, as it did before. A legend now defaults to `layer="1"`
+so that it still sits above everything on the default layer, which is where the
+JSXGraph defaults used to put it.
+
+The new `boxed` attribute draws an opaque box behind the legend, so a curve
+passing behind it is hidden rather than tangled up with the labels. The box
+paints the graph's background color, or the `backgroundColor` of the legend's
+`<styleDefinition>` when one is set, and is bordered so it reads as a panel in
+both light and dark presentation.
+
+Closes #1717.

--- a/.changeset/legend-layer-and-boxed.md
+++ b/.changeset/legend-layer-and-boxed.md
@@ -30,4 +30,9 @@ A `<legend>` inside a `<graph>` also honors `hide` at last: it was drawn whether
 or not it was hidden, which `boxed` would have made plain, since a hidden legend
 would still have painted an opaque box over the graph.
 
+Legend labels are also kept on one line. A label too long for the room beside
+its swatch used to wrap, which made it taller than the single row the legend
+gives each entry — overlapping the entry below it and overflowing the box drawn
+around them. It now runs past the graph's edge instead.
+
 Closes #1717.

--- a/.changeset/legend-layer-and-boxed.md
+++ b/.changeset/legend-layer-and-boxed.md
@@ -21,6 +21,11 @@ paints the graph's background color, or the `backgroundColor` of the legend's
 `<styleDefinition>` when one is set, and is bordered so it reads as a panel in
 both light and dark presentation.
 
+Legend labels now follow the theme, and the legend's `<styleDefinition>`, rather
+than being painted black whatever the theme was: they read white on a dark canvas
+and take the style definition's `textColor` when one is set, so an author who
+paints the box a color of their own can name the text color that reads against it.
+
 A `<legend>` inside a `<graph>` also honors `hide` at last: it was drawn whether
 or not it was hidden, which `boxed` would have made plain, since a hidden legend
 would still have painted an opaque box over the graph.

--- a/.changeset/legend-layer-and-boxed.md
+++ b/.changeset/legend-layer-and-boxed.md
@@ -21,4 +21,8 @@ paints the graph's background color, or the `backgroundColor` of the legend's
 `<styleDefinition>` when one is set, and is bordered so it reads as a panel in
 both light and dark presentation.
 
+A `<legend>` inside a `<graph>` also honors `hide` at last: it was drawn whether
+or not it was hidden, which `boxed` would have made plain, since a hidden legend
+would still have painted an opaque box over the graph.
+
 Closes #1717.

--- a/.changeset/legend-layer-and-boxed.md
+++ b/.changeset/legend-layer-and-boxed.md
@@ -10,10 +10,10 @@
 
 Every piece of a legend — its swatches and its labels — is now drawn at the
 DoenetML `layer` the legend asks for, offset the same way the rest of a graph's
-contents are. `<legend layer="3">` therefore sits above a `layer="2"` rectangle
-instead of underneath it, as it did before. A legend now defaults to `layer="1"`
-so that it still sits above everything on the default layer, which is where the
-JSXGraph defaults used to put it.
+contents are. `<legend layer="3">` therefore sits above a `layer="2"` rectangle,
+where before it was painted underneath one. A legend now defaults to `layer="1"`
+rather than `layer="0"`, so that it still sits above everything on the default
+layer, as its labels and marker swatches did before.
 
 The new `boxed` attribute draws an opaque box behind the legend, so a curve
 passing behind it is hidden rather than tangled up with the labels. The box

--- a/packages/docs-nextra/pages/reference/legend.mdx
+++ b/packages/docs-nextra/pages/reference/legend.mdx
@@ -218,6 +218,11 @@ it above everything on the default layer. Raise the `layer` to lift it above
 graphical components that set a layer of their own — here the legend asks for
 layer 3, above the rectangle's layer 2, so the swatch stays visible.
 
+The `layer` governs the legend's swatches and its box. A legend's labels are
+drawn as text laid over the graph, so they stay in front of the graph's contents
+whatever layer the legend is given: lowering a legend's `layer` will send its
+swatches behind a curve but not its labels.
+
 
 
 ---

--- a/packages/docs-nextra/pages/reference/legend.mdx
+++ b/packages/docs-nextra/pages/reference/legend.mdx
@@ -182,6 +182,15 @@ legend's `<styleDefinition>{:dn}` names a `backgroundColor`:
 
 
 
+A `<legend>{:dn}`'s own `styleNumber` says how the legend itself is drawn — the
+background of its box, and the color of its labels — while each swatch keeps the
+style of the object it stands for. Labels are drawn in the style's `textColor`,
+which is black on light and white on dark unless a `<styleDefinition>{:dn}` or an
+active style palette says otherwise, so a box painted a color of its own can be
+given label text that reads against it.
+
+
+
 ---
 
 ### Attribute Example: layer

--- a/packages/docs-nextra/pages/reference/legend.mdx
+++ b/packages/docs-nextra/pages/reference/legend.mdx
@@ -183,11 +183,15 @@ legend's `<styleDefinition>{:dn}` names a `backgroundColor`:
 
 
 A `<legend>{:dn}`'s own `styleNumber` says how the legend itself is drawn — the
-background of its box, and the color of its labels — while each swatch keeps the
-style of the object it stands for. Labels are drawn in the style's `textColor`,
-which is black on light and white on dark unless a `<styleDefinition>{:dn}` or an
-active style palette says otherwise, so a box painted a color of its own can be
-given label text that reads against it.
+background of its box, and the color of its labels — while each swatch is drawn
+from the style of the object it stands for. Labels are drawn in the style's
+`textColor`, which is black on light and white on dark unless a
+`<styleDefinition>{:dn}` or an active style palette says otherwise, so a box
+painted a color of its own can be given label text that reads against it.
+
+Note that a swatch takes the *light-mode* color of the object it stands for, so
+in dark mode it can differ from the color that object is actually drawn in. The
+box and the labels do follow the theme.
 
 
 

--- a/packages/docs-nextra/pages/reference/legend.mdx
+++ b/packages/docs-nextra/pages/reference/legend.mdx
@@ -144,6 +144,71 @@ are: `upperright`, `upperleft`, `lowerright` and `lowerleft`.
 
 ---
 
+### Attribute Example: boxed
+
+
+```doenet-example
+<graph xmin="-2" ymin="-2" size="small">
+  <shortDescription>graph of two functions with a legend drawn over an opaque box</shortDescription>
+  <function name="f">x^2</function>
+  <function name="g" styleNumber="2">x</function>
+  <legend boxed>
+    <label forObject="$f"><m>f(x)</m></label>
+    <label forObject="$g"><m>g(x)</m></label>
+  </legend>
+</graph>
+```
+
+
+
+By default a `<legend>{:dn}` has no background of its own, so graph contents
+passing behind it show through. The `boxed` attribute draws an opaque box behind
+the legend instead. The box paints the graph's background color unless the
+legend's `<styleDefinition>{:dn}` names a `backgroundColor`:
+
+```doenet-example
+<graph xmin="-2" ymin="-2" size="small">
+  <shortDescription>graph of a function with a legend on a pale yellow box</shortDescription>
+  <function name="f">x^2</function>
+  <legend boxed styleNumber="10">
+    <label forObject="$f"><m>f(x)</m></label>
+  </legend>
+</graph>
+
+<setup>
+  <styleDefinition styleNumber="10" backgroundColor="#fff8c4" backgroundColorDarkMode="#3b3410" />
+</setup>
+```
+
+
+
+---
+
+### Attribute Example: layer
+
+
+```doenet-example
+<graph xmin="-2" ymin="-2" size="small">
+  <shortDescription>graph of a function, a filled rectangle, and a legend drawn above the rectangle</shortDescription>
+  <function name="f">x^2</function>
+  <rectangle vertices="(4,6) (9.5,9.5)" filled styleNumber="2" layer="2" fixLocation />
+  <legend layer="3">
+    <label forObject="$f"><m>f(x)</m></label>
+  </legend>
+</graph>
+```
+
+
+
+A `<legend>{:dn}` is drawn on `layer="1"{:dn}` unless told otherwise, which puts
+it above everything on the default layer. Raise the `layer` to lift it above
+graphical components that set a layer of their own — here the legend asks for
+layer 3, above the rectangle's layer 2, so the swatch stays visible.
+
+
+
+---
+
 ### Attribute Example: displayClosedSwatches
 
 

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -11,11 +11,13 @@ export default class Legend extends GraphicalComponent {
 
         // A legend describes the rest of the graph, so it belongs on top of it.
         // Layer 1 puts every piece of the legend above the whole of layer 0,
-        // where graphical components sit unless an author says otherwise. That
-        // is where JSXGraph's own element defaults happened to put the swatches
-        // back when the renderer ignored `layer`, so honoring `layer` with a
-        // default of 0 would instead have dropped the legend into the band it
-        // used to sit above.
+        // where graphical components sit unless an author says otherwise.
+        // Honoring `layer` with the inherited default of 0 would instead have
+        // interleaved the legend with the components it describes, and would
+        // have lowered its labels and marker swatches: while the renderer
+        // ignored `layer` those took JSXGraph's own element defaults, which
+        // draw text and points at layer 9, above the 0-6 band that Doenet's
+        // layer 0 occupies.
         attributes.layer.defaultValue = 1;
 
         attributes.position = {

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -11,9 +11,11 @@ export default class Legend extends GraphicalComponent {
 
         // A legend describes the rest of the graph, so it belongs on top of it.
         // Layer 1 puts every piece of the legend above the whole of layer 0,
-        // where graphical components sit unless an author says otherwise,
-        // which is where JSXGraph's own element defaults used to put the
-        // swatches before the legend honored `layer` at all.
+        // where graphical components sit unless an author says otherwise. That
+        // is where JSXGraph's own element defaults happened to put the swatches
+        // back when the renderer ignored `layer`, so honoring `layer` with a
+        // default of 0 would instead have dropped the legend into the band it
+        // used to sit above.
         attributes.layer.defaultValue = 1;
 
         attributes.position = {

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -9,6 +9,13 @@ export default class Legend extends GraphicalComponent {
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
 
+        // A legend describes the rest of the graph, so it belongs on top of it.
+        // Layer 1 puts every piece of the legend above the whole of layer 0,
+        // where graphical components sit unless an author says otherwise,
+        // which is where JSXGraph's own element defaults used to put the
+        // swatches before the legend honored `layer` at all.
+        attributes.layer.defaultValue = 1;
+
         attributes.position = {
             description: "Position of the legend on the graph.",
             createComponentOfType: "text",
@@ -35,6 +42,16 @@ export default class Legend extends GraphicalComponent {
                     description: "Place the legend in the lower-left corner.",
                 },
             ],
+        };
+
+        attributes.boxed = {
+            description:
+                "Whether to draw an opaque box behind the legend so that graph contents passing behind it stay hidden.",
+            createComponentOfType: "boolean",
+            createStateVariable: "boxed",
+            defaultValue: false,
+            public: true,
+            forRenderer: true,
         };
 
         attributes.displayClosedSwatches = {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/legend.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/legend.test.ts
@@ -486,6 +486,43 @@ describe("Legend tag tests @group3", async () => {
         await check_items(true);
     });
 
+    it("legend defaults to layer 1 and an unboxed background", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <graph>
+      <point name="p">(3,4)</point>
+      <legend name="default"><label>point p</label></legend>
+    </graph>
+    <graph>
+      <point name="q">(3,4)</point>
+      <legend name="boxed" boxed layer="3"><label>point q</label></legend>
+    </graph>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        // A legend sits above everything on layer 0, where graphical
+        // components land unless an author says otherwise.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("default")].stateValues
+                .layer,
+        ).eq(1);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("default")].stateValues
+                .boxed,
+        ).eq(false);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("boxed")].stateValues
+                .layer,
+        ).eq(3);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("boxed")].stateValues
+                .boxed,
+        ).eq(true);
+    });
+
     it("legend with forObject, use names of shadow sources", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -301,9 +301,19 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             }
         }
 
-        // A label's width is only known once MathJax has typeset it, and both
-        // the right-aligned position and the width of the box are measured
-        // from it, so both have to be recomputed after typesetting.
+        // The right-aligned position and the width of the box are both
+        // measured from the labels, so both are wrong if a latex label has
+        // not been typeset by the time it is measured above.
+        //
+        // Usually it has been: JSXGraph typesets with the synchronous
+        // `MathJax.typeset`, inside the `board.create` calls above rather
+        // than after them. What this covers is the board being drawn before
+        // MathJax has finished loading, when that call throws and JSXGraph's
+        // own try/catch swallows it, leaving the label showing raw latex.
+        // Waiting on `startup.promise` is what suits that case — it resolves
+        // once MathJax exists and has typeset the document — and waiting on a
+        // per-label typesetting instead would not, since the call that would
+        // have reported it is the one that failed.
         if (usedMathJax && (atRight || box.current)) {
             MathJax.startup.promise
                 .then(() => {

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -10,7 +10,7 @@ import {
     POINT_LAYER_OFFSET,
     TEXT_LAYER_OFFSET,
 } from "./graph";
-import { deepCompare } from "@doenet/utils";
+import { deepCompare, loadMathJax } from "@doenet/utils";
 import {
     JXGElement,
     JXGLine,
@@ -24,10 +24,9 @@ import {
     resolveBackgroundColor,
     resolveCanvasColor,
     resolvePanelBorderColor,
+    resolveTextColor,
 } from "./utils/styleColors";
 import { UnlabeledGraphicalSVs } from "./utils/graphicalSVs";
-
-declare const MathJax: any;
 
 interface LegendElement {
     label?: { hasLatex: boolean; value: string };
@@ -98,6 +97,14 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         resolveCanvasColor(darkMode);
     const boxBorderColor = resolvePanelBorderColor(darkMode);
 
+    // JSXGraph paints a text with a fixed color of its own — black, unless
+    // told otherwise — rather than letting it inherit one from the page, so a
+    // legend label has to be given the theme's text color or it stays black
+    // against a dark canvas and a dark box alike. Taking it from the legend's
+    // own style definition also means an author who paints the box a color of
+    // their own can name the text color that reads against it.
+    const labelTextColor = resolveTextColor(SVs.selectedStyle, darkMode);
+
     // Each piece of the legend is offset from the DoenetML layer the same way
     // the rest of the graph's renderers offset theirs, so `<legend layer="3">`
     // sits above a `layer="2"` rectangle piece for piece. The box takes the
@@ -160,6 +167,8 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                     fixed: true,
                     highlight: false,
                     layer: labelLayer,
+                    strokeColor: labelTextColor,
+                    highlightStrokeColor: labelTextColor,
                 };
 
                 if (element.label.hasLatex) {
@@ -321,12 +330,17 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         // than after them. What this covers is the board being drawn before
         // MathJax has finished loading, when that call throws and JSXGraph's
         // own try/catch swallows it, leaving the label showing raw latex.
-        // Waiting on `startup.promise` is what suits that case — it resolves
-        // once MathJax exists and has typeset the document — and waiting on a
-        // per-label typesetting instead would not, since the call that would
-        // have reported it is the one that failed.
+        // Waiting for the engine and then for its startup is what suits that
+        // case; waiting on a per-label typesetting instead would not, since
+        // the call that would have reported it is the one that failed.
+        //
+        // `loadMathJax()` rather than `window.MathJax` directly, because
+        // that global holds a plain config object until the engine's script
+        // has run (see `isMathJaxEngine`) — reaching for `startup.promise`
+        // on it would throw, and throw synchronously, out of a render, in
+        // precisely the cold load this pass is here for.
         if (usedMathJax && (atRight || box.current)) {
-            MathJax.startup.promise
+            layOutAfterTypesetting()
                 .then(() => {
                     if (layoutGeneration.current !== generation) {
                         return;
@@ -413,6 +427,16 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         }
     }
 
+    /**
+     * Resolves once MathJax has loaded and finished its initial typesetting.
+     * `startup` is optional on the engine type, and awaiting `undefined` is
+     * harmless: an engine without one has no initial typesetting to wait for.
+     */
+    async function layOutAfterTypesetting() {
+        const mathJax = await loadMathJax();
+        await mathJax.startup?.promise;
+    }
+
     function deleteLegend() {
         // Retires any layout pass still pending for the legend being removed,
         // which matters most when its replacement has no latex of its own and
@@ -446,6 +470,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             boxed: SVs.boxed,
             boxFillColor,
             boxBorderColor,
+            labelTextColor,
         };
 
         if (!deepCompare(previousDependencies.current, dependencies)) {

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -135,7 +135,13 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         let legendLineLength = (xMax - xMin) * 0.05;
         let legendDx = (xMax - xMin) * 0.02;
 
-        let legendX = xMin + (xMax - xMin) * 0.05;
+        // Where the legend sits before any right-alignment. Both this pass
+        // and the one after typesetting bound the alignment below by it, so
+        // that the second computes the same function of the measured width as
+        // the first rather than only ever ratcheting the legend rightwards.
+        const baseLegendX = xMin + (xMax - xMin) * 0.05;
+
+        let legendX = baseLegendX;
 
         let legendY: number;
 
@@ -169,6 +175,15 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                     layer: labelLayer,
                     strokeColor: labelTextColor,
                     highlightStrokeColor: labelTextColor,
+                    // A label is an absolutely positioned div inside the
+                    // board, so left to itself it is only as wide as the room
+                    // beside it and wraps to fit. The legend gives each entry
+                    // one row, and the box is drawn around those rows, so a
+                    // label that wraps is taller than the row it was given: it
+                    // overlaps the entry below and overflows the box. Kept on
+                    // one line it runs past the graph's edge instead, which is
+                    // the lesser of the two (see #1750).
+                    cssStyle: "white-space: nowrap",
                 };
 
                 if (element.label.hasLatex) {
@@ -197,7 +212,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
         if (atRight) {
             legendX = Math.max(
-                legendX,
+                baseLegendX,
                 xMax - legendLineLength - 3 * legendDx - maxTextWidth,
             );
         }
@@ -358,7 +373,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
                     if (atRight) {
                         legendX = Math.max(
-                            legendX,
+                            baseLegendX,
                             xMax -
                                 legendLineLength -
                                 3 * legendDx -

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -404,9 +404,11 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     }
 
     if (board) {
-        // Everything below is baked into the JSXGraph objects at creation, so
-        // any change to it means tearing the legend down and drawing it again.
+        // Whether the legend is drawn at all, and everything that is baked
+        // into its JSXGraph objects at creation. Any change here means tearing
+        // the legend down and, unless it is now hidden, drawing it again.
         const dependencies = {
+            hidden: SVs.hidden,
             legendElements: [...SVs.legendElements],
             graphLimits: { ...SVs.graphLimits },
             position: SVs.position,
@@ -417,8 +419,12 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         };
 
         if (!deepCompare(previousDependencies.current, dependencies)) {
+            // A hidden legend puts nothing on the board, so none of it is
+            // drawn — box included — and it reappears intact when unhidden.
             deleteLegend();
-            createLegend();
+            if (!SVs.hidden) {
+                createLegend();
+            }
         }
 
         previousDependencies.current = dependencies;

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -110,6 +110,14 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     // sits above a `layer="2"` rectangle piece for piece. The box takes the
     // base offset so it stays behind the legend's own swatches and labels
     // while covering everything drawn below the legend's layer.
+    //
+    // The label's layer buys less than the others'. JSXGraph renders these
+    // labels as HTML overlaid on the board and turns the layer into the
+    // node's `z-index`, which orders a label against the board's other HTML
+    // but not against its SVG: the overlay is positioned and the board's
+    // `<svg>` is not, so a label paints above the graph's contents at any
+    // layer an author would ask for. It is passed for the ordering it does
+    // buy, and because a label rendered as SVG would honor it in full.
     const boxLayer = 10 * SVs.layer + BASE_LAYER_OFFSET;
     const lineSwatchLayer = 10 * SVs.layer + LINE_LAYER_OFFSET;
     const markerSwatchLayer = 10 * SVs.layer + POINT_LAYER_OFFSET;

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -3,7 +3,13 @@ import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { BoardContext } from "./graph";
+import {
+    BoardContext,
+    BASE_LAYER_OFFSET,
+    LINE_LAYER_OFFSET,
+    POINT_LAYER_OFFSET,
+    TEXT_LAYER_OFFSET,
+} from "./graph";
 import { deepCompare } from "@doenet/utils";
 import {
     JXGElement,
@@ -13,6 +19,13 @@ import {
     JXGText,
 } from "./jsxgraph-distrib/types";
 import { styleToDash } from "./utils/styleToDash";
+import { DocContext } from "../DocViewer";
+import {
+    resolveBackgroundColor,
+    resolveCanvasColor,
+    resolvePanelBorderColor,
+} from "./utils/styleColors";
+import { UnlabeledGraphicalSVs } from "./utils/graphicalSVs";
 
 declare const MathJax: any;
 
@@ -38,26 +51,53 @@ interface GraphLimits {
     yMax: number;
 }
 
-interface LegendSVs {
-    hidden: boolean;
+interface LegendSVs extends UnlabeledGraphicalSVs {
     graphLimits: GraphLimits;
     position: string;
+    boxed: boolean;
     legendElements: LegendElement[];
 }
 
 type Swatch = JXGPoint | JXGPolygon | JXGLine | JXGElement;
+
+type Corner = [number, number];
+
+/** The four corners of the backing box, clockwise from the top left. */
+type BoxCorners = [Corner, Corner, Corner, Corner];
 
 export default React.memo(function Legend(props: UseDoenetRendererProps) {
     let { id, SVs } = useDoenetRenderer<LegendSVs>(props);
 
     const board = useContext(BoardContext);
 
+    const { darkMode } = useContext(DocContext) || {};
+
     let swatches = useRef<Swatch[]>([]);
     let labels = useRef<JXGText[]>([]);
+    let box = useRef<JXGPolygon | null>(null);
 
-    let previousElements = useRef<LegendElement[] | null>(null);
-    let previousPosition = useRef<string | null>(null);
-    let previousLimits = useRef<GraphLimits | null>(null);
+    let previousDependencies = useRef<Record<string, any> | null>(null);
+
+    // The box paints the graph's own background unless the legend's style
+    // definition names one, so an unboxed and a boxed legend look the same
+    // until something passes behind the box. Its border is the neutral panel
+    // color rather than the style definition's line color: the box is chrome
+    // around the legend, not one more piece of graph content, and the line
+    // color belongs to the swatches that stand for the graphed objects.
+    const boxFillColor =
+        resolveBackgroundColor(SVs.selectedStyle, darkMode) ||
+        resolveCanvasColor(darkMode);
+    const boxBorderColor = resolvePanelBorderColor(darkMode);
+
+    // Each piece of the legend is offset from the DoenetML layer the same way
+    // the rest of the graph's renderers offset theirs, so `<legend layer="3">`
+    // sits above a `layer="2"` rectangle piece for piece. The box takes the
+    // base offset so it stays behind the legend's own swatches and labels
+    // while covering everything drawn below the legend's layer.
+    const boxLayer = 10 * SVs.layer + BASE_LAYER_OFFSET;
+    const lineSwatchLayer = 10 * SVs.layer + LINE_LAYER_OFFSET;
+    const markerSwatchLayer = 10 * SVs.layer + POINT_LAYER_OFFSET;
+    const labelLayer = 10 * SVs.layer + TEXT_LAYER_OFFSET;
 
     useEffect(() => {
         //On unmount
@@ -107,6 +147,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                 let textAttrs: Record<string, any> = {
                     fixed: true,
                     highlight: false,
+                    layer: labelLayer,
                 };
 
                 if (element.label.hasLatex) {
@@ -140,6 +181,46 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             );
         }
 
+        /** Where the box goes for the geometry computed so far. */
+        function currentBoxCorners(): BoxCorners {
+            const padX = legendDx / 2;
+            const padY = legendDy / 4;
+            const left = legendX - padX;
+            const right =
+                legendX + legendLineLength + legendDx + maxTextWidth + padX;
+            const top = legendY + legendDy / 2 + padY;
+            const bottom =
+                legendY -
+                (SVs.legendElements.length - 1) * legendDy -
+                legendDy / 2 -
+                padY;
+            return [
+                [left, top],
+                [right, top],
+                [right, bottom],
+                [left, bottom],
+            ];
+        }
+
+        if (SVs.boxed && SVs.legendElements.length > 0) {
+            box.current = board.create("polygon", currentBoxCorners(), {
+                fillColor: boxFillColor,
+                fillOpacity: 1,
+                fixed: true,
+                highlight: false,
+                layer: boxLayer,
+                vertices: { visible: false },
+                borders: {
+                    strokeColor: boxBorderColor,
+                    strokeWidth: 1,
+                    strokeOpacity: 1,
+                    fixed: true,
+                    highlight: false,
+                    layer: boxLayer,
+                },
+            }) as JXGPolygon;
+        }
+
         for (let [ind, element] of SVs.legendElements.entries()) {
             let y = legendY - ind * legendDy;
             if (element.swatchType === "marker") {
@@ -153,6 +234,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                     highlight: false,
                     withLabel: false,
                     showInfoBox: false,
+                    layer: markerSwatchLayer,
                 };
                 let point = board.create(
                     "point",
@@ -166,6 +248,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                     fillOpacity: element.fillOpacity,
                     fixed: true,
                     highlight: false,
+                    layer: lineSwatchLayer,
                     vertices: { visible: false },
                     borders: {
                         strokeColor: element.lineColor,
@@ -174,6 +257,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                         dash: styleToDash(element.lineStyle),
                         fixed: true,
                         highlight: false,
+                        layer: lineSwatchLayer,
                     },
                 };
 
@@ -196,6 +280,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                     dash: styleToDash(element.lineStyle),
                     fixed: true,
                     highlight: false,
+                    layer: lineSwatchLayer,
                 };
                 let seg = board.create(
                     "segment",
@@ -215,85 +300,90 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             }
         }
 
-        if (atRight && usedMathJax) {
-            MathJax.startup.promise.then(() => {
-                maxTextWidth = 0;
-                for (let txt of labels.current) {
-                    maxTextWidth = Math.max(
-                        maxTextWidth,
-                        txt.rendNode.offsetWidth,
-                    );
-                }
+        // A label's width is only known once MathJax has typeset it, and both
+        // the right-aligned position and the width of the box are measured
+        // from it, so both have to be recomputed after typesetting.
+        if (usedMathJax && (atRight || box.current)) {
+            MathJax.startup.promise
+                .then(() => {
+                    maxTextWidth = 0;
+                    for (let txt of labels.current) {
+                        maxTextWidth = Math.max(
+                            maxTextWidth,
+                            txt.rendNode.offsetWidth,
+                        );
+                    }
 
-                maxTextWidth /= board!.unitX;
+                    maxTextWidth /= board!.unitX;
 
-                legendX = Math.max(
-                    legendX,
-                    xMax - legendLineLength - 3 * legendDx - maxTextWidth,
-                );
-
-                for (let [ind, swatch] of swatches.current.entries()) {
-                    let y = legendY - ind * legendDy;
-                    if (swatch.elType === "point") {
-                        (swatch as JXGPoint).coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX + legendLineLength / 2, y],
-                        );
-                        swatch.needsUpdate = true;
-                        swatch.update();
-                    } else if (swatch.elType === "polygon") {
-                        const polygon = swatch as JXGPolygon;
-                        polygon.vertices[0].coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX, y + legendDy / 4],
-                        );
-                        polygon.vertices[1].coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX + legendLineLength, y + legendDy / 4],
-                        );
-                        polygon.vertices[2].coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX + legendLineLength, y - legendDy / 4],
-                        );
-                        polygon.vertices[3].coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX, y - legendDy / 4],
-                        );
-
-                        for (let i = 0; i < 4; i++) {
-                            polygon.vertices[i].needsUpdate = true;
-                            polygon.vertices[i].update();
-                            polygon.borders[i].needsUpdate = true;
-                            polygon.borders[i].update();
-                        }
-                        polygon.needsUpdate = true;
-                        polygon.update();
-                    } else {
-                        const line = swatch as JXGLine;
-                        line.point1.coords.setCoordinates(JXG.COORDS_BY_USER, [
+                    if (atRight) {
+                        legendX = Math.max(
                             legendX,
-                            y,
-                        ]);
-                        line.point2.coords.setCoordinates(JXG.COORDS_BY_USER, [
-                            legendX + legendLineLength,
-                            y,
-                        ]);
-                        line.needsUpdate = true;
-                        line.update();
-                    }
-
-                    if (labels.current[ind]) {
-                        labels.current[ind].coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX + legendLineLength + legendDx, y],
+                            xMax -
+                                legendLineLength -
+                                3 * legendDx -
+                                maxTextWidth,
                         );
-                        labels.current[ind].needsUpdate = true;
-                        labels.current[ind].update();
-                    }
-                }
 
-                board!.updateRenderer();
-            });
+                        for (let [ind, swatch] of swatches.current.entries()) {
+                            let y = legendY - ind * legendDy;
+                            if (swatch.elType === "point") {
+                                (swatch as JXGPoint).coords.setCoordinates(
+                                    JXG.COORDS_BY_USER,
+                                    [legendX + legendLineLength / 2, y],
+                                );
+                                swatch.needsUpdate = true;
+                                swatch.update();
+                            } else if (swatch.elType === "polygon") {
+                                movePolygon(swatch as JXGPolygon, [
+                                    [legendX, y + legendDy / 4],
+                                    [
+                                        legendX + legendLineLength,
+                                        y + legendDy / 4,
+                                    ],
+                                    [
+                                        legendX + legendLineLength,
+                                        y - legendDy / 4,
+                                    ],
+                                    [legendX, y - legendDy / 4],
+                                ]);
+                            } else {
+                                const line = swatch as JXGLine;
+                                line.point1.coords.setCoordinates(
+                                    JXG.COORDS_BY_USER,
+                                    [legendX, y],
+                                );
+                                line.point2.coords.setCoordinates(
+                                    JXG.COORDS_BY_USER,
+                                    [legendX + legendLineLength, y],
+                                );
+                                line.needsUpdate = true;
+                                line.update();
+                            }
+
+                            if (labels.current[ind]) {
+                                labels.current[ind].coords.setCoordinates(
+                                    JXG.COORDS_BY_USER,
+                                    [legendX + legendLineLength + legendDx, y],
+                                );
+                                labels.current[ind].needsUpdate = true;
+                                labels.current[ind].update();
+                            }
+                        }
+                    }
+
+                    if (box.current) {
+                        movePolygon(box.current, currentBoxCorners());
+                    }
+
+                    board!.updateRenderer();
+                })
+                .catch((e: unknown) => {
+                    console.error(
+                        "Failed to lay out legend after typesetting",
+                        e,
+                    );
+                });
         }
     }
 
@@ -304,25 +394,33 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         for (let txt of labels.current) {
             board?.removeObject(txt);
         }
+        if (box.current) {
+            board?.removeObject(box.current);
+            box.current = null;
+        }
         swatches.current = [];
         labels.current = [];
     }
 
     if (board) {
-        if (
-            !deepCompare(previousElements.current, SVs.legendElements) ||
-            !deepCompare(previousLimits.current, SVs.graphLimits) ||
-            previousPosition.current !== SVs.position
-        ) {
-            if (swatches.current.length > 0) {
-                deleteLegend();
-            }
+        // Everything below is baked into the JSXGraph objects at creation, so
+        // any change to it means tearing the legend down and drawing it again.
+        const dependencies = {
+            legendElements: [...SVs.legendElements],
+            graphLimits: { ...SVs.graphLimits },
+            position: SVs.position,
+            layer: SVs.layer,
+            boxed: SVs.boxed,
+            boxFillColor,
+            boxBorderColor,
+        };
+
+        if (!deepCompare(previousDependencies.current, dependencies)) {
+            deleteLegend();
             createLegend();
         }
 
-        previousElements.current = [...SVs.legendElements];
-        previousLimits.current = Object.assign({}, SVs.graphLimits);
-        previousPosition.current = SVs.position;
+        previousDependencies.current = dependencies;
 
         return (
             <>
@@ -349,4 +447,24 @@ function normalizeStyle(style: string | undefined): string | undefined {
     } else {
         return style;
     }
+}
+
+/**
+ * Move a four-cornered polygon to new coordinates. JSXGraph draws a polygon's
+ * fill and each of its borders from its vertices, so all three have to be told
+ * they are stale for the move to reach the renderer.
+ */
+function movePolygon(polygon: JXGPolygon, corners: Corner[]) {
+    for (let i = 0; i < corners.length; i++) {
+        polygon.vertices[i].coords.setCoordinates(
+            JXG.COORDS_BY_USER,
+            corners[i],
+        );
+        polygon.vertices[i].needsUpdate = true;
+        polygon.vertices[i].update();
+        polygon.borders[i].needsUpdate = true;
+        polygon.borders[i].update();
+    }
+    polygon.needsUpdate = true;
+    polygon.update();
 }

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -79,11 +79,12 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     let previousDependencies = useRef<Record<string, any> | null>(null);
 
     // The box paints the graph's own background unless the legend's style
-    // definition names one, so an unboxed and a boxed legend look the same
-    // until something passes behind the box. Its border is the neutral panel
-    // color rather than the style definition's line color: the box is chrome
-    // around the legend, not one more piece of graph content, and the line
-    // color belongs to the swatches that stand for the graphed objects.
+    // definition names one, so all that distinguishes it from the graph behind
+    // it is its border — which is what makes something passing behind the
+    // legend disappear rather than tangle with it. That border is the neutral
+    // panel color rather than the style definition's line color: the box is
+    // chrome around the legend, not one more piece of graph content, and the
+    // line color belongs to the swatches that stand for the graphed objects.
     const boxFillColor =
         resolveBackgroundColor(SVs.selectedStyle, darkMode) ||
         resolveCanvasColor(darkMode);

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -78,6 +78,14 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
     let previousDependencies = useRef<Record<string, any> | null>(null);
 
+    // Stamps each drawing of the legend, so the layout pass that runs once
+    // MathJax has started can tell whether the legend it was scheduled for is
+    // still the one on the board. It closes over the geometry of its own
+    // drawing but reaches the objects through the refs above, which by then
+    // may hold a legend drawn from different graph limits — or nothing at
+    // all, the legend having been hidden or unmounted.
+    const layoutGeneration = useRef(0);
+
     // The box paints the graph's own background unless the legend's style
     // definition names one, so all that distinguishes it from the graph behind
     // it is its border — which is what makes something passing behind the
@@ -111,6 +119,9 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         if (board === null) {
             return;
         }
+
+        const generation = ++layoutGeneration.current;
+
         let { xMin, xMax, yMin, yMax } = SVs.graphLimits;
 
         let legendDy = (yMax - yMin) * 0.06;
@@ -317,6 +328,10 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         if (usedMathJax && (atRight || box.current)) {
             MathJax.startup.promise
                 .then(() => {
+                    if (layoutGeneration.current !== generation) {
+                        return;
+                    }
+
                     maxTextWidth = 0;
                     for (let txt of labels.current) {
                         maxTextWidth = Math.max(
@@ -399,6 +414,11 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     }
 
     function deleteLegend() {
+        // Retires any layout pass still pending for the legend being removed,
+        // which matters most when its replacement has no latex of its own and
+        // so schedules no pass to correct what a stale one did.
+        layoutGeneration.current++;
+
         for (let swatch of swatches.current) {
             board?.removeObject(swatch);
         }

--- a/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
@@ -61,3 +61,31 @@ export function resolveHandleColor(darkMode: DarkMode): string {
 export function resolveCanvasColor(darkMode: DarkMode): string {
     return darkMode === "dark" ? "#121212" : "white";
 }
+
+/**
+ * The authored background color of a style definition, or `""` when none was
+ * authored. Callers treat the empty string as "no explicit color" and fall
+ * back to whatever surface they sit on — usually {@link resolveCanvasColor}.
+ */
+export function resolveBackgroundColor(
+    style: Pick<
+        ResolvedStyleDefinition,
+        "backgroundColor" | "backgroundColorDarkMode"
+    >,
+    darkMode: DarkMode,
+): string {
+    return darkMode === "dark"
+        ? style.backgroundColorDarkMode
+        : style.backgroundColor;
+}
+
+/**
+ * The border color for a panel drawn in the canvas color, which has no fill of
+ * its own to set it apart from the graph behind it. Mirrors the `--panelBorder`
+ * CSS variable, which meets WCAG's 3:1 non-text contrast against the canvas in
+ * both themes, and is resolved rather than passed through as `var(--panelBorder)`
+ * for the same reason as {@link resolveHandleColor}.
+ */
+export function resolvePanelBorderColor(darkMode: DarkMode): string {
+    return darkMode === "dark" ? "#6b6b6b" : "#949494";
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
@@ -89,3 +89,17 @@ export function resolveBackgroundColor(
 export function resolvePanelBorderColor(darkMode: DarkMode): string {
     return darkMode === "dark" ? "#6b6b6b" : "#949494";
 }
+
+/**
+ * The text color of a style definition, resolved for the current theme.
+ * Unlike the background, this always has a value: `DEFAULT_STYLE_VALUES`
+ * pairs `textColor: black` with `textColorDarkMode: white`, so a component
+ * that has authored no text color of its own still reads against the canvas
+ * in both themes.
+ */
+export function resolveTextColor(
+    style: Pick<ResolvedStyleDefinition, "textColor" | "textColorDarkMode">,
+    darkMode: DarkMode,
+): string {
+    return darkMode === "dark" ? style.textColorDarkMode : style.textColor;
+}

--- a/packages/doenetml/test/cypress/component/DoenetViewer.legendMathJaxLayout.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.legendMathJaxLayout.cy.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import { loadMathJax } from "@doenet/utils";
+
+// Component coverage for the two guards on the legend's post-typesetting
+// layout pass (#1751), neither of which the `@doenet/test-cypress` specs can
+// reach: there MathJax is loaded before any DoenetML is posted, and both
+// guards only matter while the engine is still in flight.
+//
+// The pass exists because JSXGraph typesets a latex label with the synchronous
+// `MathJax.typeset`, which throws — and is swallowed by JSXGraph's own
+// try/catch — when the engine has not loaded yet. The label is then left
+// showing raw latex at the wrong width, and the legend, which is laid out from
+// its labels' widths, has to be measured again once MathJax arrives.
+//
+// `loadMathJax` memoizes its promise on `window.__doenetMathJaxPromise`, so
+// putting a deferred promise there is what lets a test decide when that pass
+// runs, and therefore what lets it happen late enough to be wrong.
+
+/** Where `loadMathJax` memoizes its promise (`mathjax-loader.ts`). */
+const MATHJAX_MEMO_KEY = "__doenetMathJaxPromise";
+
+/** Long enough for a cold core boot, short enough to fail rather than hang. */
+const VIEWER_TIMEOUT = 15_000;
+
+/** Long enough to be sure a layout that should not happen has not. */
+const SETTLE = 500;
+
+type Deferred = { promise: Promise<unknown>; release: () => void };
+
+function deferEngine(engine: unknown): Deferred {
+    let release!: () => void;
+    const promise = new Promise((resolve) => {
+        release = () => resolve(engine);
+    });
+    return { promise, release };
+}
+
+function setMathJaxMemo(value: unknown) {
+    (window as unknown as Record<string, unknown>)[MATHJAX_MEMO_KEY] = value;
+}
+
+/**
+ * The legend's label, as a fraction of the board's height measured from its
+ * top. The legend is placed relative to the graph's limits, so this is what
+ * says which limits it was placed from.
+ *
+ * Found by the plain word its label carries beside the latex, since the
+ * board's axis ticks are `.JXGtext` too, and the latex itself reads as one
+ * thing before MathJax has typeset it and another after.
+ */
+function labelHeightFraction(): Cypress.Chainable<number> {
+    return cy.get(".jxgbox").then(($board) => {
+        const board = $board[0].getBoundingClientRect();
+        return cy.contains(".jxgbox .JXGtext", "curve").then(($label) => {
+            const label = $label[0].getBoundingClientRect();
+            return (label.top - board.top) / board.height;
+        });
+    });
+}
+
+/**
+ * A boxed legend with a latex label, on a graph whose top edge a button
+ * raises from 10 to 100.
+ *
+ * An upper legend sits at 95% of the way up whatever the graph's limits are,
+ * so it stays put in pixels when they change — unless it is placed from limits
+ * that are no longer current. Placed from `ymax="10"` on a graph now running
+ * to 100, `legendY` of 9 lands 17% up instead of 95%, which is the difference
+ * these tests read.
+ */
+const LEGEND_DOC = `
+<number name="top">10</number>
+<updateValue name="grow" target="$top" newValue="100" type="number">
+  <label>grow</label>
+</updateValue>
+<graph xmin="-10" xmax="10" ymin="-10" ymax="$top">
+  <function name="f">x^2</function>
+  <legend boxed>
+    <label forObject="$f">curve <m>f(x)</m></label>
+  </legend>
+</graph>
+`;
+
+describe("legend layout across a MathJax load (#1751)", () => {
+    let engine: unknown;
+
+    before(() => {
+        // Load the real engine once, so every test can hand it out on its own
+        // schedule rather than waiting on the network.
+        cy.wrap(null).then(() => loadMathJax().then((mj) => (engine = mj)));
+    });
+
+    afterEach(() => {
+        // The memo is per realm and the component runner reuses this window,
+        // so a deferred promise left behind would stall the next spec's math.
+        setMathJaxMemo(Promise.resolve(engine));
+        (window as unknown as Record<string, unknown>).MathJax = engine;
+    });
+
+    it("draws a legend with latex while MathJax is still loading", () => {
+        cy.wrap(null).then(() => {
+            const deferred = deferEngine(engine);
+            setMathJaxMemo(deferred.promise);
+            // What the loader stages on `window.MathJax` before the engine's
+            // script runs: a plain config object, with no `startup`. Reading
+            // `MathJax.startup.promise` off it throws a TypeError — out of a
+            // render, and ahead of any `.catch` — which used to take the whole
+            // document down rather than leave the legend to be laid out later.
+            (window as unknown as Record<string, unknown>).MathJax = {
+                tex: { inlineMath: [["\\(", "\\)"]] },
+            };
+            cy.mount(
+                <DoenetViewer
+                    doenetML={LEGEND_DOC}
+                    addVirtualKeyboard={false}
+                />,
+            );
+
+            cy.get(".jxgbox", { timeout: VIEWER_TIMEOUT }).should("exist");
+            cy.contains(".jxgbox .JXGtext", "curve").should("be.visible");
+            // The document is still standing, not replaced by an error.
+            cy.get("button").contains("grow").should("be.visible");
+
+            cy.wrap(null).then(() => deferred.release());
+            // And the legend is laid out where an upper legend belongs.
+            labelHeightFraction().should("be.lessThan", 0.4);
+        });
+    });
+
+    it("ignores a layout pass whose graph limits are no longer current", () => {
+        cy.wrap(null).then(() => {
+            const stale = deferEngine(engine);
+            setMathJaxMemo(stale.promise);
+
+            cy.mount(
+                <DoenetViewer
+                    doenetML={LEGEND_DOC}
+                    addVirtualKeyboard={false}
+                />,
+            );
+
+            cy.get(".jxgbox", { timeout: VIEWER_TIMEOUT }).should("exist");
+            cy.contains(".jxgbox .JXGtext", "curve").should("be.visible");
+
+            // Hand the engine straight to every later layout, so the one the
+            // raised graph schedules runs promptly and this test is left
+            // waiting only on the pass held open above.
+            cy.wrap(null).then(() => setMathJaxMemo(Promise.resolve(engine)));
+
+            cy.get("button").contains("grow").click();
+
+            // Redrawn for the raised graph: still 95% of the way up it.
+            labelHeightFraction().should("be.lessThan", 0.4);
+
+            // Now let the pass scheduled for the *old* graph arrive. It closes
+            // over limits that ran to 10, and reaches the legend through refs
+            // that now hold the objects drawn for a graph running to 100, so
+            // applying it would drag the legend down to 17% of the board.
+            cy.wrap(null).then(() => stale.release());
+            cy.wait(SETTLE);
+            labelHeightFraction().should("be.lessThan", 0.4);
+        });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetViewer.legendMathJaxLayout.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.legendMathJaxLayout.cy.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { DoenetViewer } from "../../../src/doenetml-inline-worker";
-import { loadMathJax } from "@doenet/utils";
 
 // Component coverage for the two guards on the legend's post-typesetting
 // layout pass (#1751), neither of which the `@doenet/test-cypress` specs can
@@ -27,6 +26,27 @@ const VIEWER_TIMEOUT = 15_000;
 const SETTLE = 500;
 
 type Deferred = { promise: Promise<unknown>; release: () => void };
+
+/**
+ * Stands in for a loaded MathJax engine.
+ *
+ * Nothing here typesets, and nothing needs to: what these specs assert is
+ * where the legend ends up, and the layout pass only ever waits on the
+ * engine — `await loadMathJax()`, then `await mathJax.startup?.promise`. A
+ * real engine would mean fetching MathJax from a CDN inside a hook, which is
+ * a network dependency and a flake in a spec that is not about the network.
+ *
+ * `typeset` is a no-op rather than absent so that JSXGraph, which calls it
+ * directly on the global when it draws a latex label, finds something to call.
+ * The label is then left showing its latex source, which is what a board drawn
+ * mid-load shows anyway.
+ */
+const FAKE_ENGINE = {
+    startup: { promise: Promise.resolve() },
+    typeset: () => {},
+    typesetPromise: () => Promise.resolve(),
+    typesetClear: () => {},
+};
 
 function deferEngine(engine: unknown): Deferred {
     let release!: () => void;
@@ -85,13 +105,7 @@ const LEGEND_DOC = `
 `;
 
 describe("legend layout across a MathJax load (#1751)", () => {
-    let engine: unknown;
-
-    before(() => {
-        // Load the real engine once, so every test can hand it out on its own
-        // schedule rather than waiting on the network.
-        cy.wrap(null).then(() => loadMathJax().then((mj) => (engine = mj)));
-    });
+    const engine: unknown = FAKE_ENGINE;
 
     afterEach(() => {
         // The memo is per realm and the component runner reuses this window,

--- a/packages/doenetml/test/cypress/component/DoenetViewer.legendMathJaxLayout.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.legendMathJaxLayout.cy.tsx
@@ -66,8 +66,10 @@ function labelHeightFraction(): Cypress.Chainable<number> {
  * An upper legend sits at 95% of the way up whatever the graph's limits are,
  * so it stays put in pixels when they change — unless it is placed from limits
  * that are no longer current. Placed from `ymax="10"` on a graph now running
- * to 100, `legendY` of 9 lands 17% up instead of 95%, which is the difference
- * these tests read.
+ * to 100, `legendY` of 9 lands 17% of the way up instead of 95%. Read the way
+ * {@link labelHeightFraction} reads it — down from the board's top — that is
+ * 0.80 rather than the near-zero an upper legend gives, which is the
+ * difference these tests turn on.
  */
 const LEGEND_DOC = `
 <number name="top">10</number>
@@ -156,7 +158,7 @@ describe("legend layout across a MathJax load (#1751)", () => {
             // Now let the pass scheduled for the *old* graph arrive. It closes
             // over limits that ran to 10, and reaches the legend through refs
             // that now hold the objects drawn for a graph running to 100, so
-            // applying it would drag the legend down to 17% of the board.
+            // applying it would drag the legend 80% of the way down the board.
             cy.wrap(null).then(() => stale.release());
             cy.wait(SETTLE);
             labelHeightFraction().should("be.lessThan", 0.4);

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -144513,6 +144513,13 @@
                         "lowerLeft"
                     ]
                 },
+                "boxed": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayClosedSwatches": {
                     "optional": true,
                     "type": [
@@ -144591,6 +144598,13 @@
                     "type": "text",
                     "isArray": false,
                     "description": "Position of the legend on the graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "boxed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to draw an opaque box behind the legend so that graph contents passing behind it stay hidden.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -117070,7 +117070,7 @@
                 {
                     "name": "layer",
                     "description": "Z-order layer index used to stack graphical components (higher values render on top).",
-                    "defaultValue": 0,
+                    "defaultValue": 1,
                     "type": "integer"
                 },
                 {
@@ -117102,6 +117102,16 @@
                         }
                     ],
                     "type": "keyword"
+                },
+                {
+                    "name": "boxed",
+                    "description": "Whether to draw an opaque box behind the legend so that graph contents passing behind it stay hidden.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
                 },
                 {
                     "name": "displayClosedSwatches",
@@ -117170,6 +117180,13 @@
                     "type": "text",
                     "isArray": false,
                     "description": "Position of the legend on the graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "boxed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to draw an opaque box behind the legend so that graph contents passing behind it stay hidden.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -14,10 +14,13 @@ function assertPaintedAbove($above, $below) {
 }
 
 /**
- * Assert that the legend's box is drawn around the label showing `labelText`.
+ * Assert that the legend's box is drawn around the label `getLabel` yields.
  * It only can be if that label was measured at the width it is drawn at: the
  * box is sized from the widest label, so a label measured narrower than it is
  * drawn spills out of the box that was drawn for it.
+ *
+ * `getLabel` is called rather than passed a value so that the element is
+ * queried inside the assertion, letting Cypress retry it.
  */
 function assertBoxContainsLabel(getLabel, boxFill = "white") {
     cy.get(`.jxgbox svg [fill='${boxFill}'][fill-opacity='1']`).then(($box) => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -164,4 +164,49 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
             "not.exist",
         );
     });
+
+    it("a hidden legend draws nothing", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <booleanInput name="hideLegend" />
+    <graph>
+        <function name="f" styleNumber="10">x^2</function>
+        <legend boxed hide="$hideLegend">
+            <label forObject="$f">f</label>
+        </legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" lineColor="#ff0000" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // Shown: the function's curve plus the legend's swatch, and the box.
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("have.length", 2);
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+
+        // Hidden: only the curve is left, and no box is painted over it.
+        cy.get("#hideLegend").click();
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("have.length", 1);
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "not.exist",
+        );
+
+        // Unhidden: the legend comes back whole.
+        cy.get("#hideLegend").click();
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("have.length", 2);
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -339,6 +339,50 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         );
     });
 
+    it("a legend keeps every label on one row", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f">x^2</function>
+        <point name="P" styleNumber="2">(1,1)</point>
+        <legend boxed>
+            <label forObject="$f">a legend label so long that it cannot possibly fit beside its swatch inside the graphing window at all</label>
+            <label forObject="$P">short</label>
+        </legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains(".jxgbox .JXGtext", "cannot possibly").should("be.visible");
+
+        // A label is an absolutely positioned div, so one too long for the
+        // room beside it wraps — and the legend, which gives each entry a
+        // single row and draws its box around those rows, has no way to hold
+        // it. Both labels stay one line tall, and neither reaches the row the
+        // other is on.
+        cy.contains(".jxgbox .JXGtext", "short").then(($short) => {
+            const rowHeight = $short[0].getBoundingClientRect().height;
+            expect(rowHeight, "a one-line label's height").to.be.greaterThan(0);
+            cy.contains(".jxgbox .JXGtext", "cannot possibly").should(
+                ($long) => {
+                    const long = $long[0].getBoundingClientRect();
+                    expect(long.height, "the long label's height").to.eq(
+                        rowHeight,
+                    );
+                    expect(
+                        long.bottom,
+                        "the long label's bottom edge",
+                    ).to.be.lessThan($short[0].getBoundingClientRect().top);
+                },
+            );
+        });
+    });
+
     it("an unboxed legend draws no box", () => {
         cy.window().then(async (win) => {
             win.postMessage(

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -322,6 +322,28 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
             "not.exist",
         );
+
+        // JSXGraph paints a label a fixed color rather than letting it
+        // inherit one, so a label left alone stays black over the dark box it
+        // now sits on. Both labels take the theme's text color instead.
+        cy.contains(".jxgbox .JXGtext", "canvas background").should(
+            "have.css",
+            "color",
+            "rgb(255, 255, 255)",
+        );
+        cy.contains(".jxgbox .JXGtext", "authored background").should(
+            "have.css",
+            "color",
+            "rgb(255, 255, 255)",
+        );
+
+        cy.setDarkMode("light");
+
+        cy.contains(".jxgbox .JXGtext", "canvas background").should(
+            "have.css",
+            "color",
+            "rgb(0, 0, 0)",
+        );
     });
 
     it("an unboxed legend draws no box", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -14,16 +14,17 @@ function assertPaintedAbove($above, $below) {
 }
 
 /**
- * Assert that the legend's box is drawn around the label `getLabel` yields.
- * It only can be if that label was measured at the width it is drawn at: the
- * box is sized from the widest label, so a label measured narrower than it is
- * drawn spills out of the box that was drawn for it.
+ * Assert that the legend's box — the one painted the light-mode canvas color —
+ * is drawn around the label `getLabel` yields. It only can be if that label was
+ * measured at the width it is drawn at: the box is sized from the widest label,
+ * so a label measured narrower than it is drawn spills out of the box that was
+ * drawn for it.
  *
  * `getLabel` is called rather than passed a value so that the element is
  * queried inside the assertion, letting Cypress retry it.
  */
-function assertBoxContainsLabel(getLabel, boxFill = "white") {
-    cy.get(`.jxgbox svg [fill='${boxFill}'][fill-opacity='1']`).then(($box) => {
+function assertBoxContainsLabel(getLabel) {
+    cy.get(`.jxgbox svg [fill='white'][fill-opacity='1']`).then(($box) => {
         getLabel().should(($label) => {
             const boxRect = $box[0].getBoundingClientRect();
             const labelRect = $label[0].getBoundingClientRect();
@@ -35,14 +36,6 @@ function assertBoxContainsLabel(getLabel, boxFill = "white") {
             );
         });
     });
-}
-
-/** {@link assertBoxContainsLabel} for the label showing `labelText`. */
-function assertLabelInsideBox(labelText, boxFill) {
-    assertBoxContainsLabel(
-        () => cy.contains(".jxgbox .JXGtext", labelText),
-        boxFill,
-    );
 }
 
 describe("Legend Tag Tests", { tags: ["@group2"] }, function () {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -1,5 +1,18 @@
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
+/**
+ * Assert that `$above` is painted on top of `$below`. JSXGraph draws each
+ * layer into its own `<g>`, appended to the board's `<svg>` in increasing
+ * layer order, so the element painted on top comes later in the document.
+ */
+function assertPaintedAbove($above, $below) {
+    const relation = $below[0].compareDocumentPosition($above[0]);
+    expect(
+        relation & Node.DOCUMENT_POSITION_FOLLOWING,
+        "the first element is painted after the second",
+    ).to.be.greaterThan(0);
+}
+
 describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -23,5 +36,132 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(".MathJax").should("contain.text", toMathJaxString("A =2.83"));
+    });
+
+    it("legend swatches honor the layer attribute", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f" styleNumber="10">x^2</function>
+        <rectangle vertices="(6,7) (9.5,9.5)" filled layer="2" fixLocation styleNumber="11" />
+        <legend layer="3"><label forObject="$f">f</label></legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" lineColor="#ff0000" lineOpacity="1" />
+        <styleDefinition styleNumber="11" fillColor="#00ff00" fillOpacity="1"
+            lineColor="#0000ff" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // Two red-stroked elements: the function's curve, on the default
+        // layer, and the legend's line swatch, which takes the function's
+        // color. The legend asks for layer 3, above the rectangle's layer 2,
+        // so its swatch must be painted over the rectangle even though the
+        // curve is painted under it.
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("have.length", 2);
+        cy.get(".jxgbox svg [fill='#00ff00']").should("have.length", 1);
+
+        cy.get(".jxgbox svg [stroke='#ff0000']").then(($strokes) => {
+            cy.get(".jxgbox svg [fill='#00ff00']").then(($rectangle) => {
+                assertPaintedAbove($rectangle, $strokes.eq(0));
+                assertPaintedAbove($strokes.eq(1), $rectangle);
+            });
+        });
+    });
+
+    it("boxed legend is painted over what passes behind it", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f" styleNumber="10">x^2</function>
+        <legend boxed><label forObject="$f">f</label></legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" lineColor="#ff0000" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // With no background in its style definition, the box paints the
+        // canvas color, opaquely.
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").then(($box) => {
+            cy.get(".jxgbox svg [stroke='#ff0000']").then(($strokes) => {
+                // The function's curve is drawn below the box; the
+                // legend's swatch, in the same color, above it.
+                expect($strokes.length).to.eq(2);
+                assertPaintedAbove($box, $strokes.eq(0));
+                assertPaintedAbove($strokes.eq(1), $box);
+            });
+        });
+    });
+
+    it("boxed legend takes its background from a style definition", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f">x^2</function>
+        <legend boxed styleNumber="10"><label forObject="$f">f</label></legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" backgroundColor="#ffff00" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(".jxgbox svg [fill='#ffff00'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+    });
+
+    it("an unboxed legend draws no box", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f" styleNumber="10">x^2</function>
+        <legend><label forObject="$f">f</label></legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" lineColor="#ff0000" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // The curve and the legend's swatch, so the legend has been drawn
+        // before the box is asserted absent.
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("have.length", 2);
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "not.exist",
+        );
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -251,9 +251,9 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         // not at the width of the latex source it was created with.
         //
         // Note what this does not pin down: JSXGraph typesets a latex label
-        // with the synchronous `MathJax.typeset`, inside the same
-        // `updateRenderer` that precedes the measurement, so the box is
-        // already sized correctly without the post-typesetting pass below it.
+        // with the synchronous `MathJax.typeset`, inside the `board.create`
+        // call that makes the label — so by the time the renderer measures it,
+        // the box is already sized correctly without the post-typesetting pass.
         // That pass is the safety net for a board drawn before MathJax has
         // finished loading, when JSXGraph's typeset call throws and is
         // swallowed — a load race there is no way to provoke from here.

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -13,6 +13,35 @@ function assertPaintedAbove($above, $below) {
     ).to.be.greaterThan(0);
 }
 
+/**
+ * Assert that the legend's box is drawn around the label showing `labelText`.
+ * It only can be if that label was measured at the width it is drawn at: the
+ * box is sized from the widest label, so a label measured narrower than it is
+ * drawn spills out of the box that was drawn for it.
+ */
+function assertBoxContainsLabel(getLabel, boxFill = "white") {
+    cy.get(`.jxgbox svg [fill='${boxFill}'][fill-opacity='1']`).then(($box) => {
+        getLabel().should(($label) => {
+            const boxRect = $box[0].getBoundingClientRect();
+            const labelRect = $label[0].getBoundingClientRect();
+            expect(labelRect.left, "label's left edge").to.be.greaterThan(
+                boxRect.left,
+            );
+            expect(labelRect.right, "label's right edge").to.be.lessThan(
+                boxRect.right,
+            );
+        });
+    });
+}
+
+/** {@link assertBoxContainsLabel} for the label showing `labelText`. */
+function assertLabelInsideBox(labelText, boxFill) {
+    assertBoxContainsLabel(
+        () => cy.contains(".jxgbox .JXGtext", labelText),
+        boxFill,
+    );
+}
+
 describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -135,6 +164,160 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         cy.get(".jxgbox svg [fill='#ffff00'][fill-opacity='1']").should(
             "have.length",
             1,
+        );
+    });
+
+    it("marker and rectangle swatches honor the layer attribute", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <point name="P" styleNumber="10">(1,1)</point>
+        <circle name="C" styleNumber="11" center="(3,3)" radius="1" filled />
+        <rectangle vertices="(6,7) (9.5,9.5)" filled layer="2" fixLocation styleNumber="12" />
+        <legend layer="3" displayClosedSwatches>
+            <label forObject="$P">a point</label>
+            <label forObject="$C">a circle</label>
+        </legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" markerColor="#ff0000" lineOpacity="1" />
+        <styleDefinition styleNumber="11" fillColor="#00ffff" fillOpacity="1"
+            lineColor="#ff00ff" lineOpacity="1" />
+        <styleDefinition styleNumber="12" fillColor="#00ff00" fillOpacity="1"
+            lineColor="#0000ff" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // A marker swatch is a JSXGraph point and a closed-shape swatch a
+        // polygon, each placed on its own layer offset, so the line-swatch
+        // spec above says nothing about either. Both take the color of the
+        // object they stand for, and the legend asks for layer 3 — above the
+        // rectangle's layer 2 — so each swatch must be painted over the
+        // rectangle even though the object it stands for is painted under it.
+        //
+        // The point's marker is the one drawn at the style's marker opacity;
+        // the legend's swatch draws the same color at the line opacity, and
+        // the point's hit area at no opacity at all.
+        cy.get(".jxgbox svg [fill='#00ff00']").should("have.length", 1);
+        cy.get(".jxgbox svg [fill='#ff0000'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+        cy.get(".jxgbox svg [fill='#ff0000'][fill-opacity='0.7']").should(
+            "have.length",
+            1,
+        );
+        cy.get(".jxgbox svg [fill='#00ffff']").should("have.length", 2);
+
+        cy.get(".jxgbox svg [fill='#00ff00']").then(($rectangle) => {
+            cy.get(".jxgbox svg [fill='#ff0000'][fill-opacity='0.7']").then(
+                ($point) => {
+                    assertPaintedAbove($rectangle, $point);
+                },
+            );
+            cy.get(".jxgbox svg [fill='#ff0000'][fill-opacity='1']").then(
+                ($markerSwatch) => {
+                    assertPaintedAbove($markerSwatch, $rectangle);
+                },
+            );
+            cy.get(".jxgbox svg [fill='#00ffff']").then(($closed) => {
+                assertPaintedAbove($rectangle, $closed.eq(0));
+                assertPaintedAbove($closed.eq(1), $rectangle);
+            });
+        });
+    });
+
+    it("a boxed legend fits a label that MathJax typesets", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f">x^2</function>
+        <legend boxed>
+            <label forObject="$f"><m>f(x) = x^2 + 3x + 1</m></label>
+        </legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // The box has to enclose the label at the width MathJax leaves it,
+        // not at the width of the latex source it was created with.
+        //
+        // Note what this does not pin down: JSXGraph typesets a latex label
+        // with the synchronous `MathJax.typeset`, inside the same
+        // `updateRenderer` that precedes the measurement, so the box is
+        // already sized correctly without the post-typesetting pass below it.
+        // That pass is the safety net for a board drawn before MathJax has
+        // finished loading, when JSXGraph's typeset call throws and is
+        // swallowed — a load race there is no way to provoke from here.
+        cy.get(".jxgbox .MathJax").should("exist");
+        assertBoxContainsLabel(() =>
+            cy.get(".jxgbox .JXGtext").filter(":has(.MathJax)"),
+        );
+    });
+
+    it("a boxed legend follows the dark-mode background", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f">x^2</function>
+        <legend boxed><label forObject="$f">canvas background</label></legend>
+    </graph>
+    <graph>
+        <function name="g">x^3</function>
+        <legend boxed styleNumber="10">
+            <label forObject="$g">authored background</label>
+        </legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" backgroundColor="#ffff00"
+            backgroundColorDarkMode="#00007f" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+        cy.get(".jxgbox svg [fill='#ffff00'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+        cy.get(".jxgbox svg [stroke='#949494']").should("exist");
+
+        cy.setDarkMode("dark");
+
+        // Both the canvas fallback and an authored background follow the
+        // theme, as does the box's border.
+        cy.get(".jxgbox svg [fill='#121212'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+        cy.get(".jxgbox svg [fill='#00007f'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+        cy.get(".jxgbox svg [stroke='#6b6b6b']").should("exist");
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "not.exist",
         );
     });
 


### PR DESCRIPTION
Community request from Melissa Lynn: a legend that a curve can pass *behind* rather than *through*. https://community.doenet.org/t/adding-a-boxed-legend/289

Her workaround — an opaque `<rectangle>` under the legend, lifted with `layer` — could not work, because `<legend>` never passed a layer to any of the JSXGraph objects it drew. It parsed `layer` (it inherits the attribute from `GraphicalComponent`, `public` and `forRenderer`) and then ignored it, so the swatches landed on stock JSXGraph defaults while a `layer="2"` rectangle landed well above them.

This does both halves of #1717.

## Honor `layer`

Each piece of the legend now goes on `10 * layer + <offset>`, the same arithmetic every other graphical renderer uses: `TEXT_LAYER_OFFSET` for labels, `POINT_LAYER_OFFSET` for marker swatches, `LINE_LAYER_OFFSET` for line and rectangle swatches, and `BASE_LAYER_OFFSET` for the new box, which keeps it behind the legend's own contents.

How far that reaches differs by piece, and the difference is the one #1717 opens with. The swatches and the box are SVG and stack against the graph's contents. A label is HTML overlaid on the board — JSXGraph turns its layer into the node's `z-index`, which orders it against the board's other HTML but not against its SVG, since the overlay is positioned and the board's `<svg>` is not. So a label paints above graph content at any layer an author would ask for: lowering a legend's `layer` sends its swatches behind a curve and leaves its labels in front. Documented in the changeset, on the docs page, and beside the layer constants rather than left to be rediscovered.

A legend now defaults to `layer="1"` rather than `layer="0"`. Its pieces used to land on JSXGraph's own element defaults — text and points at 9, line segments at 7, but polygons (the rectangle swatches) at 3 — so most of the legend sat above the 0–6 band that Doenet's layer 0 occupies, while its rectangle swatches sat inside it. Layer 1 puts the whole legend above the graph contents it describes, rather than dropping it in among them.

## `boxed`

`<legend boxed>` draws an opaque box behind the swatches and the labels, sized from the row geometry the renderer already computes plus the measured width of the widest label, with a little padding. Because a label's width is only known once MathJax has typeset it, the box is resized in the same post-typesetting pass that already repositioned a right-aligned legend.

The box paints the graph's own background color, so all that sets it apart from the graph behind it is its border, and it takes the `backgroundColor` of the legend's `<styleDefinition>` instead when one is set. Its border is `--panelBorder`, the neutral that meets WCAG's 3:1 non-text contrast against the canvas in both themes — the box is chrome around the legend, not another piece of graph content, so it does not take the style definition's line color, which belongs to the swatches.

```xml
<graph>
  <function name="f">x^2</function>
  <function name="g" styleNumber="2">x</function>
  <legend boxed>
    <label forObject="$f"><m>f(x)</m></label>
    <label forObject="$g"><m>g(x)</m></label>
  </legend>
</graph>
```

Three helpers join `styleColors.ts` alongside the existing `resolveLineColor`/`resolveFillColor`/`resolveCanvasColor`: `resolveBackgroundColor`, which picks the light or dark `backgroundColor` off a resolved style definition; `resolvePanelBorderColor`, which mirrors `--panelBorder`; and `resolveTextColor`, which the label change below uses.

## Honor `hide`

A `<legend>` inside a `<graph>` had never honored `hide`: the renderer drew it whether or not `SVs.hidden` was set, so `<legend hide>` still showed. That predates this branch, but `boxed` makes it much worse — a hidden boxed legend would paint an opaque box over the graph contents. The renderer now takes `hidden` into account alongside everything else the legend is built from: a legend that becomes hidden has its objects removed from the board, a hidden legend creates none in the first place, and one that becomes visible again is drawn whole.

## Retiring a superseded layout pass

The pass that re-measures the legend once MathJax has started closes over the geometry of the drawing that scheduled it, but reaches the legend's objects through refs. Redraw the legend before it runs — pan the graph, change the position — and the refs hold the new objects while the closure still holds the old graph limits, so the pass moves the new legend to where the old one belonged. Nothing puts it back if the new legend has no latex of its own and so schedules no pass; the same closure would also call `updateRenderer` on a board the legend has been unmounted from.

Each drawing is now stamped and the pass returns unless its stamp is still current, with the stamp bumped whenever the legend is torn down. This predates the branch, but the branch makes it worse by moving the box in that pass too. It is only reachable when the board is drawn before MathJax has finished loading — a resolved startup promise leaves no room for a redraw between scheduling and running — which is why the `@doenet/test-cypress` harness cannot reach it, and why it is covered by a component test instead (below). #1747 arrived at the same guard independently for the same callback.

## Two more fixes in the same commit

`window.MathJax` holds a plain config object until the engine's script has run — the loader stages it there, and `isMathJaxEngine` exists to tell the two apart. Reaching for `MathJax.startup.promise` on it throws a `TypeError`, synchronously, out of a render, and before the `.catch` on the chain exists, so a legend containing latex would take the document down in precisely the slow load this pass is there to handle. It now goes through `loadMathJax()`, the memoized loader `DynamicMath` already uses, and awaits the engine's startup from there.

JSXGraph also paints a text a fixed color of its own rather than letting it inherit one from the page, so legend labels stayed black whatever the theme — unreadable on a dark canvas, and, once this branch added one, on a dark box too. They now take the text color of the legend's own `<styleDefinition>`, resolved for the theme: black on light and white on dark by default, and an author who paints the box can name the text color that reads against it.

## Covering the cold-MathJax path

Both guards above only matter while the engine is in flight, which the `@doenet/test-cypress` harness cannot reach — it has MathJax loaded before any DoenetML is posted. `loadMathJax` memoizes on `window.__doenetMathJaxPromise`, so a component test can put a deferred promise there and decide when the pass runs, late enough to be wrong. `DoenetViewer.legendMathJaxLayout.cy.tsx` does that, and both specs were checked against the code they cover:

- **a legend with latex draws while MathJax is still loading** — stages a plain config object on `window.MathJax`, as the loader does before the engine's script runs. Restoring the old synchronous dereference at the call site makes this a `TypeError: Cannot read properties of undefined (reading 'promise')` out of `<Legend>`'s render, which the error boundary catches, taking the document with it.
- **a layout pass whose graph limits are no longer current is ignored** — holds one pass open, raises the graph's top edge from 10 to 100, then releases it. An upper legend sits 95% of the way up whatever limits are current, so it must not move; without the generation stamp it lands 80% of the way down the board.

## Labels stay on one row, and the second pass can move left

Two things the box brought to the surface, both from review.

A label is an absolutely positioned div, so one too long for the room beside it wraps — measured here at 28px against a 14px row. The legend gives each entry a single row and draws its box around those rows, so a wrapped label overlaps the entry below and overflows the box. Labels are now kept on one line, which trades that for a long label running past the graph's edge; laying one out over several rows needs the row model to change, and is #1750. Note the everyday case never showed this: the layout picks `legendX` so the text stops short of `xMax`, so there is room by construction, and only a label too long to fit at all reaches the 5% left margin and runs out of board.

The post-typesetting pass recomputed the right-aligned position with the already-adjusted position as its lower bound, so it could only ratchet rightwards. If a label measures wider the second time — a web font swapping in is the everyday way, since typeset math is almost always narrower than its latex source — the smaller position it needs was discarded and the label ran off the board. Both passes now bound by the same named `baseLegendX`. No spec for this one: the reachable trigger is a font swap, which cannot be provoked deterministically from Cypress.

## Docs

`pages/reference/legend.mdx` gains an attribute example for `boxed` — a plain box, and one colored by a `<styleDefinition>` `backgroundColor` — and one for `layer`, showing a legend lifted above a filled `layer="2"` rectangle. It also gains a paragraph on what a legend's own `styleNumber` controls — the background of its box and the color of its labels, while each swatch keeps the style of the object it stands for — which before this branch was nothing an author could see.

## Testing

- `legend.test.ts` covers the `layer` and `boxed` defaults and the values an author sets.
- `legend.cy.js` gains nine specs: the layer attribute lifting a line swatch over a `layer="2"` rectangle while the same-colored curve on the default layer stays under it; the same for a marker swatch (a JSXGraph point) and a closed-shape swatch (a polygon), which take separate layer assignments; a boxed legend painted over the curve behind it and under its own swatch; the `<styleDefinition>` background; a boxed legend enclosing a label MathJax has typeset; the theme toggled to dark, checking the dark canvas fallback, an authored `backgroundColorDarkMode` and the dark panel border; an unboxed legend drawing no box at all; and a boxed legend driven in and out of `hide` by a `<booleanInput>`, leaving neither swatch nor box on the board while hidden. All ten specs in the file pass locally.
- The layer specs were checked to be worth having: dropping the `layer` from the marker and closed-shape swatch creation makes the new spec fail.
- One caveat on the MathJax spec, recorded in the spec itself: it passes with the post-typesetting layout pass disabled, because JSXGraph typesets a latex label with the *synchronous* `MathJax.typeset`, inside the `board.create` call that makes the label — so it is already typeset by the time the renderer measures it. That pass is the safety net for a board drawn before MathJax has finished loading, and a load race like that cannot be provoked from Cypress.
- The dark-mode spec also asserts the label color in both themes; it fails without the `strokeColor`.
- The two component specs were checked the same way: restoring the synchronous `MathJax.startup.promise` dereference at the call site fails the first, and dropping the generation check fails the second (the legend lands 0.80 of the way down the board instead of at its top).
- The schema and RelaxNG schema are regenerated for the new attribute and the changed `layer` default.

## Known gaps, left alone here

- Legend swatch colors still come from the light-mode `lineColor`/`markerColor`/`fillColor` of the described object, with no dark-mode variant — the box and the label text follow the theme, the swatches do not. Tracked in #1748.
- The light/dark ternaries that `resolveBackgroundColor` and `resolveTextColor` now wrap are still written by hand at eight pre-existing sites in `math.tsx`, `label.tsx`, `number.tsx` and `text.tsx`. Tracked in #1749.
- The legend is still torn down and rebuilt wholesale on every change (#402); the follow-up in #1747 rewrites this update path to move the existing objects in place, and carries the `hide` handling forward.
- ~~The two cold-MathJax guards ship without tests.~~ Now covered by `DoenetViewer.legendMathJaxLayout.cy.tsx` — see above.

Closes #1717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)









