### PR TITLE
Redraw the legend in place instead of rebuilding it

### DIFF
--- a/.changeset/legend-update-in-place.md
+++ b/.changeset/legend-update-in-place.md
@@ -18,6 +18,6 @@ The legend now keeps its objects and updates them: a label whose text changed is
 given the new text, a swatch takes the new colors, and everything moves to the
 new geometry. Objects are only created or removed when the legend gains or loses
 an entry, an entry changes what kind of swatch it draws, or a label gains or
-loses latex.
+loses latex or moves to a new layer.
 
 Closes #402.

--- a/.changeset/legend-update-in-place.md
+++ b/.changeset/legend-update-in-place.md
@@ -16,8 +16,11 @@ visibly flashed and shifted.
 
 The legend now keeps its objects and updates them: a label whose text changed is
 given the new text, a swatch takes the new colors, and everything moves to the
-new geometry. Objects are only created or removed when the legend gains or loses
-an entry, an entry changes what kind of swatch it draws, or a label gains or
-loses latex or moves to a new layer.
+new geometry. What still has to be built or thrown away is only what cannot be
+carried over — an entry the legend gains or loses, an entry that changes what
+kind of swatch it draws, a label that gains or loses latex or moves to a new
+layer, the backing box as `boxed` is switched on or off, and everything at once
+when the legend is hidden. Switching the box on no longer takes the swatches and
+labels with it, which is the difference.
 
 Closes #402.

--- a/.changeset/legend-update-in-place.md
+++ b/.changeset/legend-update-in-place.md
@@ -1,0 +1,23 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+A legend is now redrawn in place instead of being rebuilt from scratch.
+
+Every change to a `<graph>`'s legend — a label whose text depends on something
+the student changes, a style, the graph being panned or zoomed, the position or
+the box — used to delete every swatch and label and create them again. With
+MathJax labels that meant a fresh typesetting pass each time, and the legend
+visibly flashed and shifted.
+
+The legend now keeps its objects and updates them: a label whose text changed is
+given the new text, a swatch takes the new colors, and everything moves to the
+new geometry. Objects are only created or removed when the legend gains or loses
+an entry, an entry changes what kind of swatch it draws, or a label gains or
+loses latex.
+
+Closes #402.

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -93,6 +93,13 @@ interface LegendEntry {
     /** Null when the element has no label. */
     label: JXGText | null;
     /**
+     * The layer `label` was created at. JSXGraph turns a text's layer into
+     * its node's `z-index` when it draws it, and that cannot be re-set
+     * afterwards (see `syncLabel`), so a label whose layer has changed is
+     * replaced rather than updated. Null alongside a null `label`.
+     */
+    labelLayer: number | null;
+    /**
      * What `label` was last given. Kept here because JSXGraph rewrites the
      * text it is handed (`plaintext` is the processed form), so the object
      * cannot be asked whether its text is still current — and re-setting the
@@ -316,22 +323,29 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         board: JXGBoard,
         previous: LegendEntry | null,
         element: LegendElement,
-    ): Pick<LegendEntry, "label" | "labelContent"> {
+    ): Pick<LegendEntry, "label" | "labelContent" | "labelLayer"> {
         const label = element.label;
         const hasLatex = label?.hasLatex ?? false;
         const shown = previous?.labelContent ?? null;
         let txt = previous?.label ?? null;
 
-        // Whether a label is typeset by MathJax is fixed when its JSXGraph
-        // text is created, so a label that gains or loses latex needs a new
-        // one; a label whose text alone changed does not.
-        if (txt && (!label || shown?.hasLatex !== hasLatex)) {
+        // Two things about a label are fixed when its JSXGraph text is
+        // created: whether MathJax typesets it, and the layer it is drawn at.
+        // A label that gains or loses latex, or whose legend has changed
+        // layer, therefore needs a new text; one whose text alone changed does
+        // not.
+        if (
+            txt &&
+            (!label ||
+                shown?.hasLatex !== hasLatex ||
+                previous?.labelLayer !== labelLayer)
+        ) {
             board.removeObject(txt);
             txt = null;
         }
 
         if (!label) {
-            return { label: null, labelContent: null };
+            return { label: null, labelContent: null, labelLayer: null };
         }
 
         if (txt) {
@@ -346,12 +360,12 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                 strokeColor: labelTextColor,
                 highlightStrokeColor: labelTextColor,
             });
-            // The layer is deliberately not re-set here. JSXGraph renders
+            // The layer is not re-set here, and cannot be: JSXGraph renders
             // these labels as HTML overlaid on the board, and setting a layer
             // on an existing element moves its node into that SVG layer's
-            // group — where an HTML div renders nothing at all. Nothing is
-            // lost: the overlay sits above every SVG layer whatever layer the
-            // label claims.
+            // group — where an HTML div renders nothing at all. A label whose
+            // layer changed was replaced above instead, so what is left here
+            // is always already drawn at the current one.
         } else {
             const textAttrs: Record<string, any> = {
                 fixed: true,
@@ -383,7 +397,11 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             ) as JXGText;
         }
 
-        return { label: txt, labelContent: { value: label.value, hasLatex } };
+        return {
+            label: txt,
+            labelContent: { value: label.value, hasLatex },
+            labelLayer,
+        };
     }
 
     /**

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -12,7 +12,7 @@ import {
 } from "./graph";
 import { deepCompare, loadMathJax } from "@doenet/utils";
 import {
-    JXGElement,
+    JXGBoard,
     JXGLine,
     JXGPoint,
     JXGPolygon,
@@ -28,8 +28,13 @@ import {
 } from "./utils/styleColors";
 import { UnlabeledGraphicalSVs } from "./utils/graphicalSVs";
 
+interface LegendLabel {
+    hasLatex: boolean;
+    value: string;
+}
+
 interface LegendElement {
-    label?: { hasLatex: boolean; value: string };
+    label?: LegendLabel;
     swatchType: "marker" | "rectangle" | "line";
     markerColor?: string;
     markerStyle?: string;
@@ -57,12 +62,67 @@ interface LegendSVs extends UnlabeledGraphicalSVs {
     legendElements: LegendElement[];
 }
 
-type Swatch = JXGPoint | JXGPolygon | JXGLine | JXGElement;
+type SwatchType = LegendElement["swatchType"];
+
+type Swatch = JXGPoint | JXGPolygon | JXGLine;
 
 type Corner = [number, number];
 
-/** The four corners of the backing box, clockwise from the top left. */
-type BoxCorners = [Corner, Corner, Corner, Corner];
+/**
+ * The corners of one of the legend's rectangles — its backing box, or a
+ * rectangle swatch — clockwise from the top left.
+ */
+type Corners = [Corner, Corner, Corner, Corner];
+
+/**
+ * Where every legend object is created. Which coordinates a swatch or a label
+ * takes depends on how wide the labels turn out to be, so no object is created
+ * at its own coordinates: {@link Legend}'s `positionLegend` moves them all once
+ * the labels have been measured, before the browser paints either placement.
+ */
+const ORIGIN: Corner = [0, 0];
+
+/**
+ * The JSXGraph objects drawing one legend element, held from one layout to the
+ * next so that the next layout can update them instead of building them again.
+ */
+interface LegendEntry {
+    swatch: Swatch;
+    /** The kind of swatch `swatch` was built as. */
+    swatchType: SwatchType;
+    /** Null when the element has no label. */
+    label: JXGText | null;
+    /**
+     * What `label` was last given. Kept here because JSXGraph rewrites the
+     * text it is handed (`plaintext` is the processed form), so the object
+     * cannot be asked whether its text is still current — and re-setting the
+     * text of a MathJax label costs a typesetting pass, the very flash this
+     * renderer is avoiding.
+     */
+    labelContent: LegendLabel | null;
+}
+
+/**
+ * The placement of the legend that does not depend on how wide its labels
+ * turn out to be. Everything here follows from the graph's limits and the
+ * legend's position, so it can be computed before a single label is measured.
+ */
+interface Geometry {
+    /** The graph's right edge, which a right-aligned legend is measured from. */
+    xMax: number;
+    /** Vertical distance between one legend row and the next. */
+    legendDy: number;
+    /** Length of a line or rectangle swatch. */
+    legendLineLength: number;
+    /** Horizontal gap between a swatch and its label. */
+    legendDx: number;
+    /** Left edge of the swatches before any right-alignment is applied. */
+    baseLegendX: number;
+    /** Vertical center of the first row. */
+    legendY: number;
+    /** Whether the legend is pushed against the graph's right edge. */
+    atRight: boolean;
+}
 
 export default React.memo(function Legend(props: UseDoenetRendererProps) {
     let { id, SVs } = useDoenetRenderer<LegendSVs>(props);
@@ -71,18 +131,19 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
     const { darkMode } = useContext(DocContext) || {};
 
-    let swatches = useRef<Swatch[]>([]);
-    let labels = useRef<JXGText[]>([]);
-    let box = useRef<JXGPolygon | null>(null);
+    // One entry per legend element, in the same order, so an entry and the
+    // element it draws always share an index.
+    const entries = useRef<LegendEntry[]>([]);
+    const box = useRef<JXGPolygon | null>(null);
 
-    let previousDependencies = useRef<Record<string, any> | null>(null);
+    const previousDependencies = useRef<Record<string, any> | null>(null);
 
-    // Stamps each drawing of the legend, so the layout pass that runs once
-    // MathJax has started can tell whether the legend it was scheduled for is
-    // still the one on the board. It closes over the geometry of its own
-    // drawing but reaches the objects through the refs above, which by then
-    // may hold a legend drawn from different graph limits — or nothing at
-    // all, the legend having been hidden or unmounted.
+    // Stamps each layout of the legend, so the pass that runs once MathJax
+    // has started can tell whether the legend it was scheduled for is still
+    // the one on the board. It closes over the geometry of its own layout but
+    // reaches the objects through the refs above, which by then may hold a
+    // legend laid out from different graph limits — or nothing at all, the
+    // legend having been hidden or unmounted.
     const layoutGeneration = useRef(0);
 
     // The box paints the graph's own background unless the legend's style
@@ -130,324 +191,437 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         };
     }, []);
 
-    function createLegend() {
-        if (board === null) {
-            return;
-        }
+    /** The current {@link Geometry}, read off the graph limits and position. */
+    function baseGeometry(): Geometry {
+        const { xMin, xMax, yMin, yMax } = SVs.graphLimits;
 
-        const generation = ++layoutGeneration.current;
-
-        let { xMin, xMax, yMin, yMax } = SVs.graphLimits;
-
-        let legendDy = (yMax - yMin) * 0.06;
-        let legendLineLength = (xMax - xMin) * 0.05;
-        let legendDx = (xMax - xMin) * 0.02;
-
-        // Where the legend sits before any right-alignment. Both this pass
-        // and the one after typesetting bound the alignment below by it, so
-        // that the second computes the same function of the measured width as
-        // the first rather than only ever ratcheting the legend rightwards.
+        const legendDy = (yMax - yMin) * 0.06;
+        const legendLineLength = (xMax - xMin) * 0.05;
+        const legendDx = (xMax - xMin) * 0.02;
         const baseLegendX = xMin + (xMax - xMin) * 0.05;
 
-        let legendX = baseLegendX;
+        const legendY =
+            SVs.position.slice(0, 5) === "upper"
+                ? yMin + (yMax - yMin) * 0.95
+                : yMin +
+                  (yMax - yMin) * 0.05 +
+                  legendDy * SVs.legendElements.length;
 
-        let legendY: number;
+        return {
+            xMax,
+            legendDy,
+            legendLineLength,
+            legendDx,
+            baseLegendX,
+            legendY,
+            atRight: SVs.position.slice(-5) === "right",
+        };
+    }
 
-        if (SVs.position.slice(0, 5) === "upper") {
-            legendY = yMin + (yMax - yMin) * 0.95;
-        } else {
-            legendY =
-                yMin +
-                (yMax - yMin) * 0.05 +
-                legendDy * SVs.legendElements.length;
+    /**
+     * Bring the legend's objects in line with the current legend elements,
+     * reusing every object that still suits the element it draws. Coordinates
+     * are left to {@link positionLegend}, which needs the label widths this
+     * does not have. Returns whether any label is typeset by MathJax, and so
+     * will only reach its final width some time after this returns.
+     */
+    function syncEntries(): boolean {
+        if (board === null) {
+            return false;
         }
-
-        let atRight =
-            SVs.position.slice(SVs.position.length - 5, SVs.position.length) ===
-            "right";
-
-        swatches.current = [];
-        labels.current = [];
-
-        let maxTextWidth = 0;
 
         let usedMathJax = false;
 
-        for (let [ind, element] of SVs.legendElements.entries()) {
-            if (element.label) {
-                let y = legendY - ind * legendDy;
+        for (const [ind, element] of SVs.legendElements.entries()) {
+            const previous = entries.current[ind] ?? null;
+            const entry = {
+                swatch: syncSwatch(board, previous, element),
+                swatchType: element.swatchType,
+                ...syncLabel(board, previous, element),
+            };
+            usedMathJax ||= entry.labelContent?.hasLatex ?? false;
+            entries.current[ind] = entry;
+        }
 
-                let textAttrs: Record<string, any> = {
-                    fixed: true,
-                    highlight: false,
-                    layer: labelLayer,
-                    strokeColor: labelTextColor,
-                    highlightStrokeColor: labelTextColor,
-                    // A label is an absolutely positioned div inside the
-                    // board, so left to itself it is only as wide as the room
-                    // beside it and wraps to fit. The legend gives each entry
-                    // one row, and the box is drawn around those rows, so a
-                    // label that wraps is taller than the row it was given: it
-                    // overlaps the entry below and overflows the box. Kept on
-                    // one line it runs past the graph's edge instead, which is
-                    // the lesser of the two (see #1750).
-                    cssStyle: "white-space: nowrap",
-                };
+        removeEntries(SVs.legendElements.length);
 
-                if (element.label.hasLatex) {
-                    textAttrs.useMathJax = true;
-                    textAttrs.parse = false;
-                    usedMathJax = true;
-                }
+        return usedMathJax;
+    }
 
-                let txt = board.create(
-                    "text",
-                    [
-                        legendX + legendLineLength + legendDx,
-                        y,
-                        element.label.value,
-                    ],
-                    textAttrs,
-                ) as JXGText;
-
-                labels.current.push(txt);
-
-                maxTextWidth = Math.max(maxTextWidth, txt.rendNode.offsetWidth);
+    /**
+     * The JSXGraph object drawing `element`'s swatch: the one `previous` holds
+     * if it is of the right kind, restyled, and a newly created one otherwise.
+     * A new swatch is placed at the origin, and given its coordinates by
+     * {@link positionLegend} before anything is painted.
+     */
+    function syncSwatch(
+        board: JXGBoard,
+        previous: LegendEntry | null,
+        element: LegendElement,
+    ): Swatch {
+        if (previous) {
+            if (previous.swatchType === element.swatchType) {
+                applySwatchStyle(previous.swatch, element);
+                return previous.swatch;
             }
+            board.removeObject(previous.swatch);
         }
 
-        maxTextWidth /= board.unitX;
-
-        if (atRight) {
-            legendX = Math.max(
-                baseLegendX,
-                xMax - legendLineLength - 3 * legendDx - maxTextWidth,
-            );
-        }
-
-        /** Where the box goes for the geometry computed so far. */
-        function currentBoxCorners(): BoxCorners {
-            const padX = legendDx / 2;
-            const padY = legendDy / 4;
-            const left = legendX - padX;
-            const right =
-                legendX + legendLineLength + legendDx + maxTextWidth + padX;
-            const top = legendY + legendDy / 2 + padY;
-            const bottom =
-                legendY -
-                (SVs.legendElements.length - 1) * legendDy -
-                legendDy / 2 -
-                padY;
-            return [
-                [left, top],
-                [right, top],
-                [right, bottom],
-                [left, bottom],
-            ];
-        }
-
-        if (SVs.boxed && SVs.legendElements.length > 0) {
-            box.current = board.create("polygon", currentBoxCorners(), {
-                fillColor: boxFillColor,
-                fillOpacity: 1,
+        if (element.swatchType === "marker") {
+            return board.create("point", ORIGIN, {
+                ...markerAttributes(element),
+                strokeColor: "none",
                 fixed: true,
                 highlight: false,
-                layer: boxLayer,
+                withLabel: false,
+                showInfoBox: false,
+                layer: markerSwatchLayer,
+            }) as JXGPoint;
+        }
+
+        if (element.swatchType === "rectangle") {
+            return board.create("polygon", [ORIGIN, ORIGIN, ORIGIN, ORIGIN], {
+                ...fillAttributes(element),
+                fixed: true,
+                highlight: false,
+                layer: lineSwatchLayer,
                 vertices: { visible: false },
                 borders: {
-                    strokeColor: boxBorderColor,
-                    strokeWidth: 1,
-                    strokeOpacity: 1,
+                    ...strokeAttributes(element),
                     fixed: true,
                     highlight: false,
-                    layer: boxLayer,
+                    layer: lineSwatchLayer,
                 },
             }) as JXGPolygon;
         }
 
-        for (let [ind, element] of SVs.legendElements.entries()) {
-            let y = legendY - ind * legendDy;
-            if (element.swatchType === "marker") {
-                let pointStyle: Record<string, any> = {
-                    fillColor: element.markerColor,
-                    fillOpacity: element.lineOpacity,
-                    strokeColor: "none",
-                    size: element.markerSize,
-                    face: normalizeStyle(element.markerStyle),
-                    fixed: true,
-                    highlight: false,
-                    withLabel: false,
-                    showInfoBox: false,
-                    layer: markerSwatchLayer,
-                };
-                let point = board.create(
-                    "point",
-                    [legendX + legendLineLength / 2, y],
-                    pointStyle,
-                ) as JXGPoint;
-                swatches.current.push(point);
-            } else if (element.swatchType === "rectangle") {
-                let rectangleStyle: Record<string, any> = {
-                    fillColor: element.filled ? element.fillColor : "none",
-                    fillOpacity: element.fillOpacity,
-                    fixed: true,
-                    highlight: false,
-                    layer: lineSwatchLayer,
-                    vertices: { visible: false },
-                    borders: {
-                        strokeColor: element.lineColor,
-                        strokeWidth: element.lineWidth,
-                        strokeOpacity: element.lineOpacity,
-                        dash: styleToDash(element.lineStyle),
-                        fixed: true,
-                        highlight: false,
-                        layer: lineSwatchLayer,
-                    },
-                };
+        // The endpoints are distinct because a segment between coincident
+        // points has no direction to be drawn along.
+        return board.create("segment", [ORIGIN, [1, 0]], {
+            ...strokeAttributes(element),
+            fixed: true,
+            highlight: false,
+            layer: lineSwatchLayer,
+        }) as JXGLine;
+    }
 
-                let seg = board.create(
-                    "polygon",
-                    [
-                        [legendX, y + legendDy / 4],
-                        [legendX + legendLineLength, y + legendDy / 4],
-                        [legendX + legendLineLength, y - legendDy / 4],
-                        [legendX, y - legendDy / 4],
-                    ],
-                    rectangleStyle,
-                ) as JXGPolygon;
-                swatches.current.push(seg);
-            } else {
-                let lineStyle: Record<string, any> = {
-                    strokeColor: element.lineColor,
-                    strokeWidth: element.lineWidth,
-                    strokeOpacity: element.lineOpacity,
-                    dash: styleToDash(element.lineStyle),
+    /**
+     * The JSXGraph text drawing `element`'s label, if it has one: the one
+     * `previous` holds if it can still show this label — given the new text if
+     * that changed — and a newly created one otherwise. A new text is placed
+     * at the origin, and given its coordinates by {@link positionLegend}
+     * before anything is painted.
+     */
+    function syncLabel(
+        board: JXGBoard,
+        previous: LegendEntry | null,
+        element: LegendElement,
+    ): Pick<LegendEntry, "label" | "labelContent"> {
+        const label = element.label;
+        const hasLatex = label?.hasLatex ?? false;
+        const shown = previous?.labelContent ?? null;
+        let txt = previous?.label ?? null;
+
+        // Whether a label is typeset by MathJax is fixed when its JSXGraph
+        // text is created, so a label that gains or loses latex needs a new
+        // one; a label whose text alone changed does not.
+        if (txt && (!label || shown?.hasLatex !== hasLatex)) {
+            board.removeObject(txt);
+            txt = null;
+        }
+
+        if (!label) {
+            return { label: null, labelContent: null };
+        }
+
+        if (txt) {
+            if (shown?.value !== label.value) {
+                txt.setText(label.value);
+            }
+            // The text color can change under a reused label — the theme is
+            // toggled, or the legend's style number changes — and unlike the
+            // layer below it is safe to re-set: it becomes a CSS color on the
+            // node rather than moving the node anywhere.
+            txt.setAttribute({
+                strokeColor: labelTextColor,
+                highlightStrokeColor: labelTextColor,
+            });
+            // The layer is deliberately not re-set here. JSXGraph renders
+            // these labels as HTML overlaid on the board, and setting a layer
+            // on an existing element moves its node into that SVG layer's
+            // group — where an HTML div renders nothing at all. Nothing is
+            // lost: the overlay sits above every SVG layer whatever layer the
+            // label claims.
+        } else {
+            const textAttrs: Record<string, any> = {
+                fixed: true,
+                highlight: false,
+                layer: labelLayer,
+                strokeColor: labelTextColor,
+                highlightStrokeColor: labelTextColor,
+                // A label is an absolutely positioned div inside the board, so
+                // left to itself it is only as wide as the room left between
+                // where it sits and the board's right edge, and wraps to fit.
+                // Its width is what the legend is laid out from, and it is
+                // measured wherever the label happens to be standing at the
+                // time, so a label that may wrap measures differently
+                // depending on where it is measured. Kept on one line, its
+                // width is its own.
+                cssStyle: "white-space: nowrap",
+            };
+
+            if (hasLatex) {
+                textAttrs.useMathJax = true;
+                textAttrs.parse = false;
+            }
+
+            txt = board.create(
+                "text",
+                [...ORIGIN, label.value],
+                textAttrs,
+            ) as JXGText;
+        }
+
+        return { label: txt, labelContent: { value: label.value, hasLatex } };
+    }
+
+    /**
+     * Give a swatch that is being kept the colors, widths and layer its
+     * element now calls for. Only ever handed a swatch of `element`'s own
+     * kind, so which attributes it takes is settled by `element.swatchType`.
+     */
+    function applySwatchStyle(swatch: Swatch, element: LegendElement) {
+        if (element.swatchType === "marker") {
+            swatch.setAttribute({
+                ...markerAttributes(element),
+                layer: markerSwatchLayer,
+            });
+        } else if (element.swatchType === "rectangle") {
+            swatch.setAttribute({
+                ...fillAttributes(element),
+                layer: lineSwatchLayer,
+            });
+            for (const border of (swatch as JXGPolygon).borders) {
+                border.setAttribute({
+                    ...strokeAttributes(element),
+                    layer: lineSwatchLayer,
+                });
+            }
+        } else {
+            swatch.setAttribute({
+                ...strokeAttributes(element),
+                layer: lineSwatchLayer,
+            });
+        }
+    }
+
+    /** Create, remove or restyle the backing box to match `boxed`. */
+    function syncBox() {
+        if (board === null) {
+            return;
+        }
+
+        const wanted = SVs.boxed && SVs.legendElements.length > 0;
+
+        if (!wanted) {
+            if (box.current) {
+                board.removeObject(box.current);
+                box.current = null;
+            }
+            return;
+        }
+
+        const boxAttributes = {
+            fillColor: boxFillColor,
+            fillOpacity: 1,
+            layer: boxLayer,
+        };
+        const borderAttributes = {
+            strokeColor: boxBorderColor,
+            strokeWidth: 1,
+            strokeOpacity: 1,
+            layer: boxLayer,
+        };
+
+        if (box.current) {
+            box.current.setAttribute(boxAttributes);
+            for (const border of box.current.borders) {
+                border.setAttribute(borderAttributes);
+            }
+            return;
+        }
+
+        box.current = board.create(
+            "polygon",
+            [ORIGIN, ORIGIN, ORIGIN, ORIGIN],
+            {
+                ...boxAttributes,
+                fixed: true,
+                highlight: false,
+                vertices: { visible: false },
+                borders: {
+                    ...borderAttributes,
                     fixed: true,
                     highlight: false,
-                    layer: lineSwatchLayer,
-                };
-                let seg = board.create(
-                    "segment",
-                    [
-                        [legendX, y],
-                        [legendX + legendLineLength, y],
-                    ],
-                    lineStyle,
-                ) as JXGLine;
-                swatches.current.push(seg);
+                },
+            },
+        ) as JXGPolygon;
+    }
+
+    /**
+     * Measure the labels and move every piece of the legend to where that
+     * measurement puts it. Run once the objects exist and again once MathJax
+     * has typeset any label it is responsible for.
+     */
+    function positionLegend(geometry: Geometry) {
+        if (board === null) {
+            return;
+        }
+
+        const {
+            xMax,
+            legendDx,
+            legendDy,
+            legendLineLength,
+            legendY,
+            baseLegendX,
+            atRight,
+        } = geometry;
+
+        let maxTextWidth = 0;
+        for (const { label } of entries.current) {
+            if (label) {
+                maxTextWidth = Math.max(
+                    maxTextWidth,
+                    label.rendNode.offsetWidth,
+                );
             }
-            if (atRight && element.label) {
-                labels.current[ind].coords.setCoordinates(JXG.COORDS_BY_USER, [
+        }
+        maxTextWidth /= board.unitX;
+
+        const legendX = atRight
+            ? Math.max(
+                  baseLegendX,
+                  xMax - legendLineLength - 3 * legendDx - maxTextWidth,
+              )
+            : baseLegendX;
+
+        if (box.current) {
+            movePolygon(
+                box.current,
+                boxCorners(
+                    geometry,
+                    legendX,
+                    maxTextWidth,
+                    entries.current.length,
+                ),
+            );
+        }
+
+        for (const [ind, entry] of entries.current.entries()) {
+            const y = legendY - ind * legendDy;
+
+            if (entry.swatchType === "marker") {
+                movePoint(entry.swatch as JXGPoint, [
+                    legendX + legendLineLength / 2,
+                    y,
+                ]);
+            } else if (entry.swatchType === "rectangle") {
+                movePolygon(
+                    entry.swatch as JXGPolygon,
+                    rectangleSwatchCorners(geometry, legendX, y),
+                );
+            } else {
+                const line = entry.swatch as JXGLine;
+                movePoint(line.point1, [legendX, y]);
+                movePoint(line.point2, [legendX + legendLineLength, y]);
+                line.needsUpdate = true;
+                line.update();
+            }
+
+            if (entry.label) {
+                movePoint(entry.label, [
                     legendX + legendLineLength + legendDx,
                     y,
                 ]);
             }
         }
+    }
+
+    /**
+     * Bring the whole legend up to date: the objects it is drawn from, their
+     * styles, and where they sit. The one place a change to the legend is
+     * acted on.
+     */
+    function layoutLegend() {
+        if (board === null) {
+            return;
+        }
+
+        const generation = ++layoutGeneration.current;
+        const geometry = baseGeometry();
+
+        const usedMathJax = syncEntries();
+        syncBox();
+
+        // A label is measured from the node the renderer drew it into, so
+        // every label — one just created, and one reused that has just been
+        // given new text — has to be rendered before it can be measured.
+        board.updateRenderer();
+
+        positionLegend(geometry);
+        board.updateRenderer();
 
         // The right-aligned position and the width of the box are both
         // measured from the labels, so both are wrong if a latex label has
-        // not been typeset by the time it is measured above.
+        // not been typeset by the time it is measured just above.
         //
         // Usually it has been: JSXGraph typesets with the synchronous
-        // `MathJax.typeset`, inside the `board.create` calls above rather
-        // than after them. What this covers is the board being drawn before
-        // MathJax has finished loading, when that call throws and JSXGraph's
-        // own try/catch swallows it, leaving the label showing raw latex.
-        // Waiting for the engine and then for its startup is what suits that
-        // case; waiting on a per-label typesetting instead would not, since
-        // the call that would have reported it is the one that failed.
+        // `MathJax.typeset`, inside the `updateRenderer` above rather than
+        // after it, for a label it has just created and for one it has just
+        // been given new text for alike. What this covers is the board being
+        // drawn before MathJax has finished loading, when that call throws
+        // and JSXGraph's own try/catch swallows it, leaving the label showing
+        // raw latex. Waiting for the engine and then for its startup is what
+        // suits that case; waiting on a per-label typesetting instead would
+        // not, since the call that would have reported it is the one that
+        // failed.
         //
-        // `loadMathJax()` rather than `window.MathJax` directly, because
-        // that global holds a plain config object until the engine's script
-        // has run (see `isMathJaxEngine`) — reaching for `startup.promise`
-        // on it would throw, and throw synchronously, out of a render, in
-        // precisely the cold load this pass is here for.
-        if (usedMathJax && (atRight || box.current)) {
+        // `loadMathJax()` rather than `window.MathJax` directly, because that
+        // global holds a plain config object until the engine's script has
+        // run (see `isMathJaxEngine`) — reaching for `startup.promise` on it
+        // would throw, and throw synchronously, out of a render, in precisely
+        // the cold load this pass is here for.
+        if (usedMathJax) {
             layOutAfterTypesetting()
                 .then(() => {
                     if (layoutGeneration.current !== generation) {
                         return;
                     }
-
-                    maxTextWidth = 0;
-                    for (let txt of labels.current) {
-                        maxTextWidth = Math.max(
-                            maxTextWidth,
-                            txt.rendNode.offsetWidth,
-                        );
-                    }
-
-                    maxTextWidth /= board!.unitX;
-
-                    if (atRight) {
-                        legendX = Math.max(
-                            baseLegendX,
-                            xMax -
-                                legendLineLength -
-                                3 * legendDx -
-                                maxTextWidth,
-                        );
-
-                        for (let [ind, swatch] of swatches.current.entries()) {
-                            let y = legendY - ind * legendDy;
-                            if (swatch.elType === "point") {
-                                (swatch as JXGPoint).coords.setCoordinates(
-                                    JXG.COORDS_BY_USER,
-                                    [legendX + legendLineLength / 2, y],
-                                );
-                                swatch.needsUpdate = true;
-                                swatch.update();
-                            } else if (swatch.elType === "polygon") {
-                                movePolygon(swatch as JXGPolygon, [
-                                    [legendX, y + legendDy / 4],
-                                    [
-                                        legendX + legendLineLength,
-                                        y + legendDy / 4,
-                                    ],
-                                    [
-                                        legendX + legendLineLength,
-                                        y - legendDy / 4,
-                                    ],
-                                    [legendX, y - legendDy / 4],
-                                ]);
-                            } else {
-                                const line = swatch as JXGLine;
-                                line.point1.coords.setCoordinates(
-                                    JXG.COORDS_BY_USER,
-                                    [legendX, y],
-                                );
-                                line.point2.coords.setCoordinates(
-                                    JXG.COORDS_BY_USER,
-                                    [legendX + legendLineLength, y],
-                                );
-                                line.needsUpdate = true;
-                                line.update();
-                            }
-
-                            if (labels.current[ind]) {
-                                labels.current[ind].coords.setCoordinates(
-                                    JXG.COORDS_BY_USER,
-                                    [legendX + legendLineLength + legendDx, y],
-                                );
-                                labels.current[ind].needsUpdate = true;
-                                labels.current[ind].update();
-                            }
-                        }
-                    }
-
-                    if (box.current) {
-                        movePolygon(box.current, currentBoxCorners());
-                    }
-
-                    board!.updateRenderer();
+                    positionLegend(geometry);
+                    board.updateRenderer();
                 })
                 .catch((e: unknown) => {
                     console.error(
-                        "Failed to lay out legend after typesetting",
+                        "Failed to lay out the legend after typesetting",
                         e,
                     );
                 });
         }
+    }
+
+    /**
+     * Remove the JSXGraph objects of the entries held past `length`, and drop
+     * those entries.
+     */
+    function removeEntries(length: number) {
+        for (const entry of entries.current.slice(length)) {
+            board?.removeObject(entry.swatch);
+            if (entry.label) {
+                board?.removeObject(entry.label);
+            }
+        }
+        entries.current.length = length;
     }
 
     /**
@@ -466,24 +640,17 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         // so schedules no pass to correct what a stale one did.
         layoutGeneration.current++;
 
-        for (let swatch of swatches.current) {
-            board?.removeObject(swatch);
-        }
-        for (let txt of labels.current) {
-            board?.removeObject(txt);
-        }
+        removeEntries(0);
         if (box.current) {
             board?.removeObject(box.current);
             box.current = null;
         }
-        swatches.current = [];
-        labels.current = [];
     }
 
     if (board) {
-        // Whether the legend is drawn at all, and everything that is baked
-        // into its JSXGraph objects at creation. Any change here means tearing
-        // the legend down and, unless it is now hidden, drawing it again.
+        // Whether the legend is drawn at all, and everything it is drawn
+        // from. Laying it out again when none of this changed would re-render
+        // the whole board for nothing.
         const dependencies = {
             hidden: SVs.hidden,
             legendElements: [...SVs.legendElements],
@@ -498,10 +665,11 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
         if (!deepCompare(previousDependencies.current, dependencies)) {
             // A hidden legend puts nothing on the board, so none of it is
-            // drawn — box included — and it reappears intact when unhidden.
-            deleteLegend();
-            if (!SVs.hidden) {
-                createLegend();
+            // drawn — box included — and it is drawn afresh when unhidden.
+            if (SVs.hidden) {
+                deleteLegend();
+            } else {
+                layoutLegend();
             }
         }
 
@@ -526,6 +694,71 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     );
 });
 
+function markerAttributes(element: LegendElement): Record<string, any> {
+    return {
+        fillColor: element.markerColor,
+        fillOpacity: element.lineOpacity,
+        size: element.markerSize,
+        face: normalizeStyle(element.markerStyle),
+    };
+}
+
+function strokeAttributes(element: LegendElement): Record<string, any> {
+    return {
+        strokeColor: element.lineColor,
+        strokeWidth: element.lineWidth,
+        strokeOpacity: element.lineOpacity,
+        dash: styleToDash(element.lineStyle),
+    };
+}
+
+function fillAttributes(element: LegendElement): Record<string, any> {
+    return {
+        fillColor: element.filled ? element.fillColor : "none",
+        fillOpacity: element.fillOpacity,
+    };
+}
+
+/** Where a rectangle swatch goes on the row centered on `y`. */
+function rectangleSwatchCorners(
+    geometry: Geometry,
+    legendX: number,
+    y: number,
+): Corners {
+    const { legendDy, legendLineLength } = geometry;
+    return [
+        [legendX, y + legendDy / 4],
+        [legendX + legendLineLength, y + legendDy / 4],
+        [legendX + legendLineLength, y - legendDy / 4],
+        [legendX, y - legendDy / 4],
+    ];
+}
+
+/**
+ * Where the backing box goes around `rowCount` rows of swatches whose labels
+ * are at most `maxTextWidth` wide, with a margin of its own around them.
+ */
+function boxCorners(
+    geometry: Geometry,
+    legendX: number,
+    maxTextWidth: number,
+    rowCount: number,
+): Corners {
+    const { legendDx, legendDy, legendLineLength, legendY } = geometry;
+    const padX = legendDx / 2;
+    const padY = legendDy / 4;
+    const left = legendX - padX;
+    const right = legendX + legendLineLength + legendDx + maxTextWidth + padX;
+    const top = legendY + legendDy / 2 + padY;
+    const bottom = legendY - (rowCount - 1) * legendDy - legendDy / 2 - padY;
+    return [
+        [left, top],
+        [right, top],
+        [right, bottom],
+        [left, bottom],
+    ];
+}
+
 function normalizeStyle(style: string | undefined): string | undefined {
     if (style === "triangle") {
         return "triangleup";
@@ -535,18 +768,26 @@ function normalizeStyle(style: string | undefined): string | undefined {
 }
 
 /**
- * Move a four-cornered polygon to new coordinates. JSXGraph draws a polygon's
- * fill and each of its borders from its vertices, so all three have to be told
- * they are stale for the move to reach the renderer.
+ * Move anything that carries its own coordinates — a point, a polygon vertex,
+ * a line endpoint, a text — and tell it that it is stale so the move reaches
+ * the renderer.
  */
-function movePolygon(polygon: JXGPolygon, corners: Corner[]) {
+function movePoint(
+    object: { coords: any; needsUpdate: boolean; update: () => void },
+    coords: Corner,
+) {
+    object.coords.setCoordinates(JXG.COORDS_BY_USER, coords);
+    object.needsUpdate = true;
+    object.update();
+}
+
+/**
+ * Move a polygon to new corners. JSXGraph draws a polygon's fill and each of
+ * its borders from its vertices, so all three have to be told they are stale.
+ */
+function movePolygon(polygon: JXGPolygon, corners: Corners) {
     for (let i = 0; i < corners.length; i++) {
-        polygon.vertices[i].coords.setCoordinates(
-            JXG.COORDS_BY_USER,
-            corners[i],
-        );
-        polygon.vertices[i].needsUpdate = true;
-        polygon.vertices[i].update();
+        movePoint(polygon.vertices[i], corners[i]);
         polygon.borders[i].needsUpdate = true;
         polygon.borders[i].update();
     }

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -366,7 +366,8 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
                 // measured wherever the label happens to be standing at the
                 // time, so a label that may wrap measures differently
                 // depending on where it is measured. Kept on one line, its
-                // width is its own.
+                // width is its own — and it runs past the graph's edge rather
+                // than wrapping into the row below it (see #1750).
                 cssStyle: "white-space: nowrap",
             };
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -747,6 +747,45 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         );
     });
 
+    it("a legend's labels follow a layer that changes", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <mathInput name="lay" prefill="1" />
+    <graph>
+        <function name="f">x^2</function>
+        <legend layer="$lay"><label forObject="$f">a label</label></legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // JSXGraph draws these labels as HTML overlaid on the board and turns
+        // the layer into the node's z-index — `10 * layer + TEXT_LAYER_OFFSET`,
+        // the same arithmetic the swatches use. A reused label cannot be given
+        // a new layer, so a legend whose layer changed has to be given a new
+        // label, or its labels would keep ordering by the old one while its
+        // swatches moved to the new.
+        cy.contains(".jxgbox .JXGtext", "a label").should(
+            "have.css",
+            "z-index",
+            "16",
+        );
+
+        cy.get("#lay textarea").type("{end}{backspace}3{enter}", {
+            force: true,
+        });
+
+        cy.contains(".jxgbox .JXGtext", "a label").should(
+            "have.css",
+            "z-index",
+            "36",
+        );
+    });
+
     it("an unboxed legend draws no box", () => {
         cy.window().then(async (win) => {
             win.postMessage(

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -38,6 +38,11 @@ function assertBoxContainsLabel(getLabel) {
     });
 }
 
+/** {@link assertBoxContainsLabel} for the label showing `labelText`. */
+function assertLabelInsideBox(labelText) {
+    assertBoxContainsLabel(() => cy.contains(".jxgbox .JXGtext", labelText));
+}
+
 describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -381,6 +386,365 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
                 },
             );
         });
+    });
+
+    it("a changed legend keeps its swatches and labels", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <mathInput name="mi" prefill="2" />
+    <graph>
+        <function name="f" styleNumber="10">x^$mi</function>
+        <legend boxed><label forObject="$f">power $mi</label></legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" lineColor="#ff0000" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(".jxgbox").should("contain.text", "power 2");
+
+        // The legend's swatch, above the curve of the same color, and the box.
+        const idsBefore = {};
+        cy.get(".jxgbox svg [stroke='#ff0000']")
+            .eq(1)
+            .then(($swatch) => {
+                idsBefore.swatch = $swatch.attr("id");
+                expect(idsBefore.swatch).to.be.a("string").and.not.be.empty;
+            });
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").then(($box) => {
+            idsBefore.box = $box.attr("id");
+        });
+
+        cy.get("#mi textarea").type("{end}{backspace}3{enter}", {
+            force: true,
+        });
+
+        cy.get(".jxgbox").should("contain.text", "power 3");
+        cy.contains(".jxgbox .JXGtext", "power 3").should("be.visible");
+
+        // The legend is redrawn in place, so its JSXGraph objects — and hence
+        // the SVG nodes they render to — are the same ones as before.
+        cy.get(".jxgbox svg [stroke='#ff0000']")
+            .eq(1)
+            .should(($swatch) => {
+                expect($swatch.attr("id")).to.eq(idsBefore.swatch);
+            });
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            ($box) => {
+                expect($box.attr("id")).to.eq(idsBefore.box);
+            },
+        );
+    });
+
+    it("a latex label keeps its text object when it changes", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <mathInput name="mi" prefill="2" />
+    <graph>
+        <function name="f">x^$mi</function>
+        <legend boxed><label forObject="$f"><m>k = $mi</m></label></legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        let labelId;
+        cy.contains(".jxgbox .JXGtext", toMathJaxString("k =2")).then(
+            ($label) => {
+                labelId = $label.attr("id");
+                expect(labelId).to.be.a("string").and.not.be.empty;
+            },
+        );
+
+        cy.get("#mi textarea").type("{end}{backspace}3{enter}", {
+            force: true,
+        });
+
+        // The text is given to the object that was already showing the old
+        // one, so MathJax typesets the new label in place rather than the
+        // legend building a second text to typeset from scratch.
+        cy.contains(".jxgbox .JXGtext", toMathJaxString("k =3")).should(
+            ($label) => {
+                expect($label.attr("id")).to.eq(labelId);
+            },
+        );
+    });
+
+    it("a legend lays out from a label's full width", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph xmin="-100" xmax="0" ymin="-10" ymax="10">
+        <function name="f">x^2</function>
+        <legend boxed><label forObject="$f">a fairly long legend label</label></legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // Every legend object is created at the graph's origin, which this
+        // graph puts hard against the board's right edge — where an absolutely
+        // positioned label would have no room to stand at its full width. The
+        // label is kept on one line, so it is measured, and the box around it
+        // drawn, from the width it will actually be drawn at.
+        cy.contains(".jxgbox .JXGtext", "a fairly long legend label").should(
+            "be.visible",
+        );
+        assertLabelInsideBox("a fairly long legend label");
+    });
+
+    it("a legend follows a label that grows where it stands", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <textInput name="ti" prefill="short" />
+    <graph>
+        <function name="f">x^2</function>
+        <legend boxed><label forObject="$f">$ti</label></legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        let labelId;
+        cy.contains(".jxgbox .JXGtext", "short").then(($label) => {
+            labelId = $label.attr("id");
+            expect(labelId).to.be.a("string").and.not.be.empty;
+        });
+
+        const grown = "a considerably longer legend label";
+        cy.get("#ti_input").clear().type(`${grown}{enter}`);
+
+        // The label is the object that was already there, so it is measured
+        // where it was last drawn: hard against the graph's right edge, where
+        // this right-aligned legend had put it while it was short. Kept on one
+        // line it still measures its full width, so the legend moves left to
+        // make room for it instead of being stuck at the width it had.
+        cy.contains(".jxgbox .JXGtext", grown).should(($label) => {
+            expect($label.attr("id")).to.eq(labelId);
+        });
+        assertLabelInsideBox(grown);
+    });
+
+    it("a legend follows a latex label that grows where it stands", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <mathInput name="mi" prefill="x" />
+    <graph>
+        <function name="f">x^2</function>
+        <legend boxed><label forObject="$f"><m>g = $mi</m></label></legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        function latexLabel() {
+            return cy.get(".jxgbox .JXGtext").filter(":has(.MathJax)");
+        }
+
+        let shortWidth;
+        latexLabel().should(($label) => {
+            shortWidth = $label[0].getBoundingClientRect().width;
+            expect(shortWidth, "typeset width").to.be.greaterThan(0);
+        });
+
+        cy.get("#mi textarea").type(
+            "{selectall}{backspace}abcdefghijklmnop{enter}",
+            { force: true },
+        );
+
+        // The label is the text object that was already there, typeset in
+        // place, and it is measured where the short label left it — hard
+        // against the graph's right edge on this right-aligned legend. The
+        // box has to be sized from what MathJax made of the new latex, so it
+        // still encloses the label once the label is several times wider.
+        latexLabel().should(($label) => {
+            expect(
+                $label[0].getBoundingClientRect().width,
+                "typeset width after the label grew",
+            ).to.be.greaterThan(shortWidth * 2);
+        });
+        assertBoxContainsLabel(latexLabel);
+    });
+
+    it("a legend can gain and lose its box while it is shown", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <booleanInput name="bi" prefill="false" />
+    <graph>
+        <function name="f">x^2</function>
+        <legend boxed="$bi"><label forObject="$f">a label</label></legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains(".jxgbox .JXGtext", "a label").should("be.visible");
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "not.exist",
+        );
+
+        cy.get("#bi").click();
+
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+        cy.contains(".jxgbox .JXGtext", "a label").should("be.visible");
+
+        cy.get("#bi").click();
+
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "not.exist",
+        );
+        cy.contains(".jxgbox .JXGtext", "a label").should("be.visible");
+    });
+
+    it("marker and rectangle swatches are restyled in place", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <booleanInput name="bi" prefill="true" />
+    <graph>
+        <point name="P" styleNumber="10">(1,2)</point>
+        <circle name="c" center="(5,5)" filled="$bi" styleNumber="11" />
+        <legend displayClosedSwatches>
+            <label forObject="$P">a point</label>
+            <label forObject="$c">a circle</label>
+        </legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" markerColor="#ff0000" markerStyle="square" lineOpacity="1" />
+        <styleDefinition styleNumber="11" fillColor="#00ff00" fillOpacity="1"
+            lineColor="#0000ff" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains(".jxgbox .JXGtext", "a circle").should("be.visible");
+
+        // The marker swatch is the only fully opaque red element: the point it
+        // stands for is drawn translucent. The rectangle swatch is the only
+        // green polygon; the circle it stands for is an ellipse.
+        const ids = {};
+        cy.get(".jxgbox svg [fill='#ff0000'][fill-opacity='1']")
+            .should("have.length", 1)
+            .then(($marker) => {
+                ids.marker = $marker.attr("id");
+                expect(ids.marker).to.be.a("string").and.not.be.empty;
+            });
+        cy.get(".jxgbox svg polygon[fill='#00ff00']")
+            .should("have.length", 1)
+            .then(($rectangle) => {
+                ids.rectangle = $rectangle.attr("id");
+                expect(ids.rectangle).to.be.a("string").and.not.be.empty;
+            });
+
+        // Unfilling the circle restyles the rectangle swatch, which JSXGraph
+        // draws unfilled by taking its fill opacity to zero. Both swatches are
+        // still the objects they were: only their attributes changed.
+        cy.get("#bi").click();
+
+        cy.then(() => {
+            cy.get(`.jxgbox svg polygon#${ids.rectangle}`)
+                .should("have.length", 1)
+                .and("have.attr", "fill-opacity", "0");
+            cy.get(`.jxgbox svg #${ids.marker}`)
+                .should("have.length", 1)
+                .and("have.attr", "fill", "#ff0000");
+        });
+
+        cy.get("#bi").click();
+
+        cy.then(() => {
+            cy.get(`.jxgbox svg polygon#${ids.rectangle}`)
+                .should("have.length", 1)
+                .and("have.attr", "fill", "#00ff00")
+                .and("have.attr", "fill-opacity", "1");
+        });
+    });
+
+    it("a legend follows entries being added and removed", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <mathInput name="n" prefill="2" />
+    <graph>
+        <repeatForSequence length="$n" indexName="i">
+            <function styleNumber="$i">x^$i</function>
+        </repeatForSequence>
+        <legend boxed>
+            <repeatForSequence length="$n" indexName="i">
+                <label>curve $i</label>
+            </repeatForSequence>
+        </legend>
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains(".jxgbox .JXGtext", "curve 2").should("be.visible");
+        cy.get(".jxgbox").should("not.contain.text", "curve 3");
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+
+        // A third entry: the legend gains a swatch and a label, and its box
+        // grows to hold them.
+        cy.get("#n textarea").type("{end}{backspace}3{enter}", { force: true });
+
+        cy.contains(".jxgbox .JXGtext", "curve 3").should("be.visible");
+        cy.contains(".jxgbox .JXGtext", "curve 1").should("be.visible");
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
+
+        // Down to one entry: the swatches and labels of the other two are
+        // taken off the board rather than left behind.
+        cy.get("#n textarea").type("{end}{backspace}1{enter}", { force: true });
+
+        cy.contains(".jxgbox .JXGtext", "curve 1").should("be.visible");
+        cy.get(".jxgbox").should("not.contain.text", "curve 2");
+        cy.get(".jxgbox").should("not.contain.text", "curve 3");
+        cy.get(".jxgbox svg [fill='white'][fill-opacity='1']").should(
+            "have.length",
+            1,
+        );
     });
 
     it("an unboxed legend draws no box", () => {


### PR DESCRIPTION
A legend's elements were deleted and created again on every change (`legend.tsx:300-321` before this branch). Any change: a label whose text depends on a `<mathInput>` the student is typing in, a style number, the graph being panned or zoomed, the position. With MathJax labels each rebuild also meant a fresh typesetting pass, which is what makes the legend visibly flash and shift.

## What changed

The renderer now holds one `LegendEntry` per legend element — its swatch, the kind of swatch that is, its label, and the text and layer that label was last given — and brings those objects into line with the current state rather than starting over:

- a label whose text changed is given the new text with `setText`; one whose text is unchanged is left entirely alone, so MathJax is not asked to typeset it again;
- a swatch keeps its object and takes the new colors, width and dash;
- everything is moved to the new geometry.

Objects are created or removed only when the legend actually gains or loses one: an entry added or dropped, an entry that changes what kind of swatch it draws, or a label that gains or loses latex or moves to a new layer — whether a text is typeset by MathJax, and the layer it is drawn at, are both fixed when it is created.

The work is split so that the two things that have to happen in order still do. `syncEntries` (through `syncSwatch` and `syncLabel`) and `syncBox` bring the objects and their styles up to date; `positionLegend` then measures the labels and moves everything, and is the one piece the post-MathJax pass repeats. Since where a swatch or a label goes depends on how wide the labels turn out to be, no object is created at its own coordinates: everything is created at the origin and placed by `positionLegend` before the browser paints either placement.

Because that post-MathJax pass measures for a particular geometry, it is stamped with a layout generation. Laying the legend out again, or tearing it down, bumps the generation, so a callback whose geometry has been superseded — or that arrives after the legend is hidden or unmounted — does nothing.

Creating everything at a shared origin puts new weight on the `white-space: nowrap` that labels already carry on `main`. A label is an absolutely positioned div inside the board, so left to itself it is only as wide as the room between where it stands and the board's right edge, and wraps to fit. Its width is what the legend and its box are laid out from, and it is measured wherever it happens to be standing — at the origin when it has just been created, at its previous position when it is being reused. Two of the specs below pin that down.

## Labels and the layer

A label's layer is fixed when its JSXGraph text is created and cannot be re-set afterwards: `setAttribute({ layer })` moves the node into an SVG layer group, where an HTML div renders nothing at all. I hit that the honest way — the labels vanished the first time a boxed legend was toggled on — so the update path leaves the layer alone. Setting it at creation is fine; the renderer never moves the node then.

Leaving it alone is only safe if nothing is left behind by it, and at first this branch assumed nothing was: the HTML overlay sits above every SVG layer whatever layer a label claims, so the layer buys no ordering against the graph's contents. But it does order a label against the board's *other* HTML — another legend's labels, say — because JSXGraph turns the layer into the node's `z-index`. A legend whose `layer` changed would have kept its labels ordered by the old one while its swatches and box moved to the new, which the rebuild this PR replaces had never let happen.

So a label the layer change invalidates is *replaced*, exactly as one that gains or loses latex already was, and the entry records the layer its label was built at so the change can be seen. That keeps `setAttribute({ layer })` off labels while still giving them the new layer.

A label's `strokeColor` *is* re-set on the update path, since the theme can be toggled or the style number changed under a legend whose labels are being kept. Re-setting the color is safe in the way re-setting the layer is not: it becomes a CSS color on the node rather than moving the node into an SVG group.

## Testing

Nine specs added to `legend.cy.js`, bringing the file to nineteen:

- **a changed legend keeps its swatches and labels** — drives a label's text from a `<mathInput>` and asserts the swatch's and the box's SVG node ids are unchanged after the edit, and that the label is still visible. It fails on `main`, where the objects are rebuilt and the ids change.
- **a latex label keeps its text object when it changes** — the same for a `<m>` label: the JSXGraph text showing it is given the new latex rather than replaced, which is the case the whole change is aimed at.
- **a legend lays out from a label's full width** — a graph whose origin sits hard against the board's right edge, which is where this branch creates every label. Asserts the label is drawn inside the box drawn for it.
- **a legend follows a label that grows where it stands** — the other half of that: a right-aligned legend whose label is replaced with a much longer one, so the reused text is measured at the far-right position the short label had left it in. Asserts the text object is the same one and that the grown label is still inside its box.
- **a legend can gain and lose its box while it is shown** — toggles `boxed` from a `<booleanInput>` in both directions, checking the box appears and disappears and the label survives both.
- **marker and rectangle swatches are restyled in place** — the two swatch kinds the specs above do not reach. Unfilling the circle behind a rectangle swatch restyles that swatch in place: it is still the same SVG node, now drawn with zero fill opacity, and filling the circle again brings its color back.
- **a legend follows entries being added and removed** — the number of legend entries is driven by a `<mathInput>`, so entries are created and taken off the board at runtime. This is the path that creates and removes objects rather than reusing them.
- **a legend follows a latex label that grows where it stands** — two of the above at once: a right-aligned `<m>` label, typeset in place, that grows to several times its width. Asserts the box is sized from what MathJax made of the new latex, not from the width the old label had.
- **a legend's labels follow a layer that changes** — the one thing redrawing in place lost that the rebuild had. A reused label cannot be given a new layer, so a legend whose layer changes gets new labels; the spec drives the layer from a `<mathInput>` and asserts the label's `z-index` follows it. Backing the replacement clause out again fails that spec and only that spec.

All nineteen specs in the file pass locally, as do the six `legend.test.ts` Vitest cases. The generation stamp is covered by the component spec `DoenetViewer.legendMathJaxLayout.cy.tsx`, which lives on `main` rather than in this diff: it fails on this branch too if the stamp check is removed — the legend lands 80% of the way down the board instead of staying at the top. Both of its cases pass here.

## On the post-typesetting layout pass

A review comment asked whether `MathJax.startup.promise` is the right thing to wait on, since it resolves when the MathJax engine has initialized and not when a particular label has been typeset — which would leave a growing latex label laid out from a stale width.

It is not a problem here, because JSXGraph does not typeset asynchronously. (The engine is reached through the memoized `loadMathJax()` rather than `window.MathJax` directly, which could still be the loader's staged config object.) `JXG.SVGRenderer.updateInternal` calls the **synchronous** `MathJax.typeset([el.rendNode])` (MathJax v3; `jsxgraphsrc.js:53412-53417`), and that runs inside the `board.updateRenderer()` that this renderer performs *before* it measures — for a label it has just created and for one it has just been given new text for alike. So a reused label is already typeset at the point its width is read, and there is nothing outstanding for a promise to wait on.

The pass on `startup.promise` earns its keep in the other case: a board drawn while MathJax is still loading, where JSXGraph's typeset call throws and is swallowed by its own `try`/`catch`. Once startup completes, the legend measures again. That is a load race there is no way to provoke from Cypress, so the latex spec above pins down the reachable half — and would start failing if JSXGraph ever moved to `typesetPromise`.

## Known gaps

- (#1748) Legend swatches are painted with the light-mode color of the object they stand for whatever the theme, because the worker flattens the color before the renderer sees it. Untouched here; the new specs identify the box by that light-mode fill color for the same reason.
- (#1750) A label kept on one line can run past the graph's right edge instead of wrapping, and a legend positioned on the left can draw its box wider than the graph. Laying a genuinely long label out over several rows is a separate piece of work.

Closes #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


