### PR TITLE
Paint a legend's swatches in the theme's colors

### DIFF
--- a/.changeset/legend-swatch-dark-mode.md
+++ b/.changeset/legend-swatch-dark-mode.md
@@ -11,6 +11,6 @@ A legend's swatches now follow the document's theme.
 Every swatch was painted with the light-mode color of the object it stands for,
 whatever the theme, so in dark mode a legend could disagree with the objects it
 describes: a curve drawn in its dark-mode color beside a swatch drawn in its
-light-mode one. Each legend entry now carries both colors and the swatch is
-painted with the one the current theme calls for, alongside the box and the
+light-mode one. A swatch is now painted with the color the current theme calls
+for, and is repainted when the theme is switched, alongside the box and the
 labels, which already were.

--- a/.changeset/legend-swatch-dark-mode.md
+++ b/.changeset/legend-swatch-dark-mode.md
@@ -1,0 +1,16 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+A legend's swatches now follow the document's theme.
+
+Every swatch was painted with the light-mode color of the object it stands for,
+whatever the theme, so in dark mode a legend could disagree with the objects it
+describes: a curve drawn in its dark-mode color beside a swatch drawn in its
+light-mode one. Each legend entry now carries both colors and the swatch is
+painted with the one the current theme calls for, alongside the box and the
+labels, which already were.

--- a/packages/docs-nextra/pages/reference/legend.mdx
+++ b/packages/docs-nextra/pages/reference/legend.mdx
@@ -189,9 +189,9 @@ from the style of the object it stands for. Labels are drawn in the style's
 `<styleDefinition>{:dn}` or an active style palette says otherwise, so a box
 painted a color of its own can be given label text that reads against it.
 
-Note that a swatch takes the *light-mode* color of the object it stands for, so
-in dark mode it can differ from the color that object is actually drawn in. The
-box and the labels do follow the theme.
+Swatches follow the document's theme alongside the box and the labels: in dark
+mode a swatch takes the dark-mode color of the object it stands for, so it is
+drawn in the color that object is actually drawn in.
 
 
 

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -106,6 +106,13 @@ export default class Legend extends GraphicalComponent {
             },
         };
 
+        // Each element carries both the light-mode and the dark-mode color of
+        // the object it stands for, and the renderer picks between them. Dark
+        // mode is a document-level concern the renderer holds and the worker
+        // has no view of, so a swatch whose color were flattened here would be
+        // painted in one theme's color whatever theme the document is read in
+        // — disagreeing with the object it labels, which is the one job a
+        // legend has.
         stateVariableDefinitions.legendElements = {
             forRenderer: true,
             stateVariablesDeterminingDependencies: ["graphicalElementNames"],
@@ -361,6 +368,8 @@ export default class Legend extends GraphicalComponent {
                                     swatchType: "marker",
                                     markerStyle: selectedStyle.markerStyle,
                                     markerColor: selectedStyle.markerColor,
+                                    markerColorDarkMode:
+                                        selectedStyle.markerColorDarkMode,
                                     markerSize: selectedStyle.markerSize,
                                     lineOpacity: selectedStyle.lineOpacity,
                                     label: label.labelInfo,
@@ -376,9 +385,13 @@ export default class Legend extends GraphicalComponent {
                                     swatchType: "rectangle",
                                     lineStyle: selectedStyle.lineStyle,
                                     lineColor: selectedStyle.lineColor,
+                                    lineColorDarkMode:
+                                        selectedStyle.lineColorDarkMode,
                                     lineWidth: selectedStyle.lineWidth,
                                     lineOpacity: selectedStyle.lineOpacity,
                                     fillColor: selectedStyle.fillColor,
+                                    fillColorDarkMode:
+                                        selectedStyle.fillColorDarkMode,
                                     filled: componentForLabel.stateValues
                                         .filled,
                                     fillOpacity: selectedStyle.fillOpacity,
@@ -390,6 +403,8 @@ export default class Legend extends GraphicalComponent {
                                     swatchType: "line",
                                     lineStyle: selectedStyle.lineStyle,
                                     lineColor: selectedStyle.lineColor,
+                                    lineColorDarkMode:
+                                        selectedStyle.lineColorDarkMode,
                                     lineWidth: selectedStyle.lineWidth,
                                     lineOpacity: selectedStyle.lineOpacity,
                                     label: label.labelInfo,

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -107,12 +107,10 @@ export default class Legend extends GraphicalComponent {
         };
 
         // Each element carries both the light-mode and the dark-mode color of
-        // the object it stands for, and the renderer picks between them. Dark
-        // mode is a document-level concern the renderer holds and the worker
-        // has no view of, so a swatch whose color were flattened here would be
-        // painted in one theme's color whatever theme the document is read in
-        // — disagreeing with the object it labels, which is the one job a
-        // legend has.
+        // the object it stands for, and the renderer picks between them. The
+        // theme is a document-level concern the renderer holds and the worker
+        // has no view of, so a color flattened to one theme here would leave
+        // the swatch disagreeing with the object it labels in the other.
         stateVariableDefinitions.legendElements = {
             forRenderer: true,
             stateVariablesDeterminingDependencies: ["graphicalElementNames"],

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/legend.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/legend.test.ts
@@ -11,18 +11,22 @@ const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
 vi.mock("hyperformula");
 
+// The `*DarkMode` colors are checked on their own, since a legend element
+// carries both themes' colors and most of the cases below author neither.
 type LineLegendItem = {
     swatchType: "line";
     label: string;
     hasLatex: boolean;
     lineStyle?: string;
     lineColor?: string;
+    lineColorDarkMode?: string;
     lineWidth?: number;
     lineOpacity?: number;
 };
 type RectangleLegendItem = Omit<LineLegendItem, "swatchType"> & {
     swatchType: "rectangle";
     fillColor?: string;
+    fillColorDarkMode?: string;
     filled?: boolean;
     fillOpacity?: number;
 };
@@ -32,6 +36,7 @@ type MarkerLegendItem = {
     hasLatex: boolean;
     markerStyle?: string;
     markerColor?: string;
+    markerColorDarkMode?: string;
     markerSize?: number;
 };
 
@@ -77,6 +82,11 @@ async function check_legend({
                 expect(element.markerColor).eq(item.markerColor);
                 expect(element.markerSize).eq(item.markerSize);
             }
+            if (item.markerColorDarkMode !== undefined) {
+                expect(element.markerColorDarkMode).eq(
+                    item.markerColorDarkMode,
+                );
+            }
         } else {
             if (item.lineStyle !== undefined) {
                 expect(element.lineStyle).eq(item.lineStyle);
@@ -88,6 +98,15 @@ async function check_legend({
                     expect(element.filled).eq(item.filled);
                     expect(element.fillOpacity).eq(item.fillOpacity);
                 }
+            }
+            if (item.lineColorDarkMode !== undefined) {
+                expect(element.lineColorDarkMode).eq(item.lineColorDarkMode);
+            }
+            if (
+                item.swatchType === "rectangle" &&
+                item.fillColorDarkMode !== undefined
+            ) {
+                expect(element.fillColorDarkMode).eq(item.fillColorDarkMode);
             }
         }
     }
@@ -484,6 +503,68 @@ describe("Legend tag tests @group3", async () => {
             core,
         });
         await check_items(true);
+    });
+
+    it("legend elements carry both themes' colors", async () => {
+        // Which of the two a swatch is painted with is the renderer's to
+        // decide, since the worker has no view of the document's theme. A
+        // legend element that named only one color would be a swatch that
+        // disagreed with the object it labels in the other theme.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <setup>
+        <styleDefinition styleNumber="1" lineColor="#1f5dff" lineColorDarkMode="#ffcc00" markerColor="#1f5dff" markerColorDarkMode="#ffcc00" fillColor="#c0d0ff" fillColorDarkMode="#553300" />
+    </setup>
+
+    <graph>
+      <function name="f" styleNumber="1">x^2</function>
+      <point name="P" styleNumber="1">(1,2)</point>
+      <circle name="c" styleNumber="1" filled />
+
+      <legend name="legend1" displayClosedSwatches>
+        <label forObject="$f">parabola</label>
+        <label forObject="$P">point</label>
+        <label forObject="$c">circle</label>
+      </legend>
+    </graph>
+    `,
+        });
+
+        await check_legend({
+            core,
+            resolvePathToNodeIdx,
+            legendItems: [
+                {
+                    swatchType: "line",
+                    label: "parabola",
+                    hasLatex: false,
+                    lineColorDarkMode: "#ffcc00",
+                },
+                {
+                    swatchType: "marker",
+                    label: "point",
+                    hasLatex: false,
+                    markerColorDarkMode: "#ffcc00",
+                },
+                {
+                    swatchType: "rectangle",
+                    label: "circle",
+                    hasLatex: false,
+                    lineColorDarkMode: "#ffcc00",
+                    fillColorDarkMode: "#553300",
+                },
+            ],
+        });
+
+        // The light-mode colors are still there beside them.
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const legendElements =
+            stateVariables[await resolvePathToNodeIdx("legend1")].stateValues
+                .legendElements;
+        expect(legendElements[0].lineColor).eq("#1f5dff");
+        expect(legendElements[1].markerColor).eq("#1f5dff");
+        expect(legendElements[2].lineColor).eq("#1f5dff");
+        expect(legendElements[2].fillColor).eq("#c0d0ff");
     });
 
     it("legend defaults to layer 1 and an unboxed background", async () => {

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -20,6 +20,7 @@ import {
     detachAnchoredGraphElement,
 } from "./utils/useAnchoredGraphDragHandler";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import { resolveBackgroundColor, resolveTextColor } from "./utils/styleColors";
 import { computeLabelMaskCssStyle } from "./utils/labelMaskStyle";
 
 interface LabelSVs {
@@ -76,14 +77,11 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             return null;
         }
 
-        let textColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.textColorDarkMode
-                : SVs.selectedStyle.textColor;
-        let backgroundColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.backgroundColorDarkMode
-                : SVs.selectedStyle.backgroundColor;
+        let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+        let backgroundColor = resolveBackgroundColor(
+            SVs.selectedStyle,
+            darkMode,
+        );
 
         let { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
             layer: SVs.layer,
@@ -255,14 +253,11 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 labelJXG.current.setAttribute({ layer });
             }
 
-            let textColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.textColorDarkMode
-                    : SVs.selectedStyle.textColor;
-            let backgroundColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.backgroundColorDarkMode
-                    : SVs.selectedStyle.backgroundColor;
+            let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+            let backgroundColor = resolveBackgroundColor(
+                SVs.selectedStyle,
+                darkMode,
+            );
             let { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
                 layer: SVs.layer,
                 backgroundColor,

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -21,8 +21,12 @@ import {
 import { styleToDash } from "./utils/styleToDash";
 import { DocContext } from "../DocViewer";
 import {
+    DarkMode,
     resolveBackgroundColor,
     resolveCanvasColor,
+    resolveFillColor,
+    resolveLineColor,
+    resolveMarkerColor,
     resolvePanelBorderColor,
     resolveTextColor,
 } from "./utils/styleColors";
@@ -33,20 +37,50 @@ interface LegendLabel {
     value: string;
 }
 
-interface LegendElement {
+/**
+ * One row of the legend, as the worker describes it: a label and the style of
+ * the object that label stands for. Every color comes as a light-mode and a
+ * dark-mode value, since which of the two a swatch takes is settled here and
+ * not in the worker, which has no view of the document's theme.
+ *
+ * Which style keys an element carries follows from its `swatchType`, so the
+ * three kinds are separate types rather than one type of optional fields:
+ * only a marker names a marker color, only a rectangle a fill.
+ */
+interface LegendElementBase {
     label?: LegendLabel;
-    swatchType: "marker" | "rectangle" | "line";
-    markerColor?: string;
-    markerStyle?: string;
-    markerSize?: number;
-    lineColor?: string;
-    lineWidth?: number;
-    lineStyle?: string;
-    lineOpacity?: number;
-    fillColor?: string;
-    fillOpacity?: number;
-    filled?: boolean;
+    lineOpacity: number;
 }
+
+interface MarkerLegendElement extends LegendElementBase {
+    swatchType: "marker";
+    markerColor: string;
+    markerColorDarkMode: string;
+    markerStyle: string;
+    markerSize: number;
+}
+
+interface LineLegendElement extends LegendElementBase {
+    swatchType: "line";
+    lineColor: string;
+    lineColorDarkMode: string;
+    lineWidth: number;
+    lineStyle: string;
+}
+
+interface RectangleLegendElement extends Omit<LineLegendElement, "swatchType"> {
+    swatchType: "rectangle";
+    fillColor: string;
+    fillColorDarkMode: string;
+    fillOpacity: number;
+    filled: boolean;
+}
+
+type LegendElement =
+    MarkerLegendElement | LineLegendElement | RectangleLegendElement;
+
+/** The elements whose swatch is drawn with a stroke: a line, and a rectangle's border. */
+type StrokedLegendElement = LineLegendElement | RectangleLegendElement;
 
 interface GraphLimits {
     xMin: number;
@@ -276,7 +310,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
         if (element.swatchType === "marker") {
             return board.create("point", ORIGIN, {
-                ...markerAttributes(element),
+                ...markerAttributes(element, darkMode),
                 strokeColor: "none",
                 fixed: true,
                 highlight: false,
@@ -288,13 +322,13 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
 
         if (element.swatchType === "rectangle") {
             return board.create("polygon", [ORIGIN, ORIGIN, ORIGIN, ORIGIN], {
-                ...fillAttributes(element),
+                ...fillAttributes(element, darkMode),
                 fixed: true,
                 highlight: false,
                 layer: lineSwatchLayer,
                 vertices: { visible: false },
                 borders: {
-                    ...strokeAttributes(element),
+                    ...strokeAttributes(element, darkMode),
                     fixed: true,
                     highlight: false,
                     layer: lineSwatchLayer,
@@ -305,7 +339,7 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         // The endpoints are distinct because a segment between coincident
         // points has no direction to be drawn along.
         return board.create("segment", [ORIGIN, [1, 0]], {
-            ...strokeAttributes(element),
+            ...strokeAttributes(element, darkMode),
             fixed: true,
             highlight: false,
             layer: lineSwatchLayer,
@@ -412,23 +446,23 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     function applySwatchStyle(swatch: Swatch, element: LegendElement) {
         if (element.swatchType === "marker") {
             swatch.setAttribute({
-                ...markerAttributes(element),
+                ...markerAttributes(element, darkMode),
                 layer: markerSwatchLayer,
             });
         } else if (element.swatchType === "rectangle") {
             swatch.setAttribute({
-                ...fillAttributes(element),
+                ...fillAttributes(element, darkMode),
                 layer: lineSwatchLayer,
             });
             for (const border of (swatch as JXGPolygon).borders) {
                 border.setAttribute({
-                    ...strokeAttributes(element),
+                    ...strokeAttributes(element, darkMode),
                     layer: lineSwatchLayer,
                 });
             }
         } else {
             swatch.setAttribute({
-                ...strokeAttributes(element),
+                ...strokeAttributes(element, darkMode),
                 layer: lineSwatchLayer,
             });
         }
@@ -680,6 +714,15 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             boxFillColor,
             boxBorderColor,
             labelTextColor,
+            // A legend element carries both of its colors and the swatch
+            // picks between them here, so toggling the theme leaves the
+            // elements themselves untouched while every swatch drawn from
+            // them wants repainting. The resolved colors above would usually
+            // catch that, but only because they happen to differ between the
+            // themes — an author who names one color for both would leave
+            // them equal, and the swatches unrepainted. The theme itself is
+            // what the swatches actually turn on.
+            darkMode,
         };
 
         if (!deepCompare(previousDependencies.current, dependencies)) {
@@ -713,27 +756,38 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
     );
 });
 
-function markerAttributes(element: LegendElement): Record<string, any> {
+function markerAttributes(
+    element: MarkerLegendElement,
+    darkMode: DarkMode,
+): Record<string, any> {
     return {
-        fillColor: element.markerColor,
+        fillColor: resolveMarkerColor(element, darkMode),
         fillOpacity: element.lineOpacity,
         size: element.markerSize,
         face: normalizeStyle(element.markerStyle),
     };
 }
 
-function strokeAttributes(element: LegendElement): Record<string, any> {
+function strokeAttributes(
+    element: StrokedLegendElement,
+    darkMode: DarkMode,
+): Record<string, any> {
     return {
-        strokeColor: element.lineColor,
+        strokeColor: resolveLineColor(element, darkMode),
         strokeWidth: element.lineWidth,
         strokeOpacity: element.lineOpacity,
         dash: styleToDash(element.lineStyle),
     };
 }
 
-function fillAttributes(element: LegendElement): Record<string, any> {
+function fillAttributes(
+    element: RectangleLegendElement,
+    darkMode: DarkMode,
+): Record<string, any> {
     return {
-        fillColor: element.filled ? element.fillColor : "none",
+        fillColor: element.filled
+            ? resolveFillColor(element, darkMode)
+            : "none",
         fillOpacity: element.fillOpacity,
     };
 }

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -843,12 +843,9 @@ function boxCorners(
     ];
 }
 
-function normalizeStyle(style: string | undefined): string | undefined {
-    if (style === "triangle") {
-        return "triangleup";
-    } else {
-        return style;
-    }
+/** A marker style under the name JSXGraph knows it by. */
+function normalizeStyle(style: string): string {
+    return style === "triangle" ? "triangleup" : style;
 }
 
 /**

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -37,16 +37,7 @@ interface LegendLabel {
     value: string;
 }
 
-/**
- * One row of the legend, as the worker describes it: a label and the style of
- * the object that label stands for. Every color comes as a light-mode and a
- * dark-mode value, since which of the two a swatch takes is settled here and
- * not in the worker, which has no view of the document's theme.
- *
- * Which style keys an element carries follows from its `swatchType`, so the
- * three kinds are separate types rather than one type of optional fields:
- * only a marker names a marker color, only a rectangle a fill.
- */
+/** What every legend element carries, whatever its swatch is drawn as. */
 interface LegendElementBase {
     label?: LegendLabel;
     lineOpacity: number;
@@ -76,10 +67,23 @@ interface RectangleLegendElement extends Omit<LineLegendElement, "swatchType"> {
     filled: boolean;
 }
 
+/**
+ * One row of the legend, as the worker describes it: a label and the style of
+ * the object that label stands for. Every color comes as a light-mode and a
+ * dark-mode value, since which of the two a swatch takes is settled here and
+ * not in the worker, which has no view of the document's theme.
+ *
+ * Which style keys an element carries follows from its `swatchType`, so the
+ * three kinds are separate types rather than one type of optional fields:
+ * only a marker names a marker color, only a rectangle a fill.
+ */
 type LegendElement =
     MarkerLegendElement | LineLegendElement | RectangleLegendElement;
 
-/** The elements whose swatch is drawn with a stroke: a line, and a rectangle's border. */
+/**
+ * The elements whose swatch is drawn with a stroke: a line, and a rectangle's
+ * border.
+ */
 type StrokedLegendElement = LineLegendElement | RectangleLegendElement;
 
 interface GraphLimits {
@@ -717,11 +721,11 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
             // A legend element carries both of its colors and the swatch
             // picks between them here, so toggling the theme leaves the
             // elements themselves untouched while every swatch drawn from
-            // them wants repainting. The resolved colors above would usually
-            // catch that, but only because they happen to differ between the
-            // themes — an author who names one color for both would leave
-            // them equal, and the swatches unrepainted. The theme itself is
-            // what the swatches actually turn on.
+            // them wants repainting. The theme is named directly rather than
+            // left to the resolved colors above, which catch a toggle only
+            // incidentally: `boxBorderColor` happens to differ between the
+            // themes today, but it is the box's color, and the swatches
+            // should not depend on it to be repainted.
             darkMode,
         };
 

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -40,6 +40,13 @@ interface LegendLabel {
 /** What every legend element carries, whatever its swatch is drawn as. */
 interface LegendElementBase {
     label?: LegendLabel;
+    /**
+     * The opacity every swatch is drawn at, a marker's fill included: the
+     * worker sends the described object's `lineOpacity` for all three kinds.
+     * A point is drawn from `markerOpacity` instead, so a marker swatch and
+     * the point it stands for differ in opacity wherever a style definition
+     * names the two apart.
+     */
     lineOpacity: number;
 }
 

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -20,6 +20,7 @@ import {
     detachAnchoredGraphElement,
 } from "./utils/useAnchoredGraphDragHandler";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import { resolveBackgroundColor, resolveTextColor } from "./utils/styleColors";
 
 interface MathSVs {
     [key: string]: any;
@@ -91,14 +92,11 @@ export default React.memo(function MathComponent(
             return null;
         }
 
-        let textColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.textColorDarkMode
-                : SVs.selectedStyle.textColor;
-        let backgroundColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.backgroundColorDarkMode
-                : SVs.selectedStyle.backgroundColor;
+        let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+        let backgroundColor = resolveBackgroundColor(
+            SVs.selectedStyle,
+            darkMode,
+        );
 
         let cssStyle = ``;
         if (backgroundColor) {
@@ -264,14 +262,11 @@ export default React.memo(function MathComponent(
                 mathJXG.current.setAttribute({ layer });
             }
 
-            let textColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.textColorDarkMode
-                    : SVs.selectedStyle.textColor;
-            let backgroundColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.backgroundColorDarkMode
-                    : SVs.selectedStyle.backgroundColor;
+            let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+            let backgroundColor = resolveBackgroundColor(
+                SVs.selectedStyle,
+                darkMode,
+            );
             let cssStyle = ``;
             if (backgroundColor) {
                 cssStyle += `background-color: ${backgroundColor}`;

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -21,6 +21,7 @@ import {
     detachAnchoredGraphElement,
 } from "./utils/useAnchoredGraphDragHandler";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import { resolveBackgroundColor, resolveTextColor } from "./utils/styleColors";
 
 interface NumberSVs {
     hidden: boolean;
@@ -75,14 +76,11 @@ export default React.memo(function NumberComponent(
             return null;
         }
 
-        let textColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.textColorDarkMode
-                : SVs.selectedStyle.textColor;
-        let backgroundColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.backgroundColorDarkMode
-                : SVs.selectedStyle.backgroundColor;
+        let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+        let backgroundColor = resolveBackgroundColor(
+            SVs.selectedStyle,
+            darkMode,
+        );
 
         let cssStyle = ``;
         if (backgroundColor) {
@@ -229,14 +227,11 @@ export default React.memo(function NumberComponent(
                 numberJXG.current.setAttribute({ layer });
             }
 
-            let textColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.textColorDarkMode
-                    : SVs.selectedStyle.textColor;
-            let backgroundColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.backgroundColorDarkMode
-                    : SVs.selectedStyle.backgroundColor;
+            let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+            let backgroundColor = resolveBackgroundColor(
+                SVs.selectedStyle,
+                darkMode,
+            );
             let cssStyle = ``;
             if (backgroundColor) {
                 cssStyle += `background-color: ${backgroundColor}`;

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -19,6 +19,7 @@ import {
     detachAnchoredGraphElement,
 } from "./utils/useAnchoredGraphDragHandler";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import { resolveBackgroundColor, resolveTextColor } from "./utils/styleColors";
 
 interface TextSVs {
     hidden: boolean;
@@ -70,14 +71,11 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
             return null;
         }
 
-        let textColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.textColorDarkMode
-                : SVs.selectedStyle.textColor;
-        let backgroundColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.backgroundColorDarkMode
-                : SVs.selectedStyle.backgroundColor;
+        let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+        let backgroundColor = resolveBackgroundColor(
+            SVs.selectedStyle,
+            darkMode,
+        );
 
         let cssStyle = ``;
         if (backgroundColor) {
@@ -225,14 +223,11 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
                 textJXG.current.setAttribute({ layer });
             }
 
-            let textColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.textColorDarkMode
-                    : SVs.selectedStyle.textColor;
-            let backgroundColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.backgroundColorDarkMode
-                    : SVs.selectedStyle.backgroundColor;
+            let textColor = resolveTextColor(SVs.selectedStyle, darkMode);
+            let backgroundColor = resolveBackgroundColor(
+                SVs.selectedStyle,
+                darkMode,
+            );
             let cssStyle = ``;
             if (backgroundColor) {
                 cssStyle += `background-color: ${backgroundColor}`;

--- a/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/legend.cy.js
@@ -694,6 +694,83 @@ describe("Legend Tag Tests", { tags: ["@group2"] }, function () {
         });
     });
 
+    it("swatches agree with their objects in both themes", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <function name="f" styleNumber="10">x^2</function>
+        <point name="P" styleNumber="11">(1,2)</point>
+        <circle name="c" center="(5,5)" filled styleNumber="12" />
+        <legend displayClosedSwatches>
+            <label forObject="$f">a curve</label>
+            <label forObject="$P">a point</label>
+            <label forObject="$c">a circle</label>
+        </legend>
+    </graph>
+
+    <setup>
+        <styleDefinition styleNumber="10" lineColor="#ff0000" lineColorDarkMode="#ffcc00" lineOpacity="1" />
+        <styleDefinition styleNumber="11" markerColor="#00ff00" markerColorDarkMode="#00ffff" markerStyle="square" lineOpacity="1" />
+        <styleDefinition styleNumber="12" fillColor="#0000ff" fillColorDarkMode="#ff00ff" fillOpacity="1"
+            lineColor="#996633" lineColorDarkMode="#663399" lineOpacity="1" />
+    </setup>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains(".jxgbox .JXGtext", "a circle").should("be.visible");
+
+        // Two elements stroked the curve's light-mode color: the curve itself
+        // and the line swatch that stands for it. That they are both there is
+        // the assertion — a legend whose swatch disagreed with its object
+        // would leave one of each color.
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("have.length", 2);
+
+        // The marker swatch is the only fully opaque green element; the point
+        // it stands for is drawn translucent. The rectangle swatch is the only
+        // blue polygon; the circle it stands for is an ellipse.
+        const ids = {};
+        cy.get(".jxgbox svg [fill='#00ff00'][fill-opacity='1']")
+            .should("have.length", 1)
+            .then(($marker) => {
+                ids.marker = $marker.attr("id");
+            });
+        cy.get(".jxgbox svg polygon[fill='#0000ff']")
+            .should("have.length", 1)
+            .then(($rectangle) => {
+                ids.rectangle = $rectangle.attr("id");
+            });
+
+        // Switch the document into dark mode. Every swatch takes the dark-mode
+        // color of the object it labels, and does so by being repainted rather
+        // than rebuilt: each is still the object it was.
+        cy.window().then((win) => {
+            win.postMessage({ darkMode: "dark" }, "*");
+        });
+        cy.get('[data-theme="dark"]').should("exist");
+
+        cy.get(".jxgbox svg [stroke='#ffcc00']").should("have.length", 2);
+        cy.get(".jxgbox svg [stroke='#ff0000']").should("not.exist");
+
+        cy.then(() => {
+            cy.get(`.jxgbox svg #${ids.marker}`)
+                .should("have.length", 1)
+                .and("have.attr", "fill", "#00ffff");
+            cy.get(`.jxgbox svg polygon#${ids.rectangle}`)
+                .should("have.length", 1)
+                .and("have.attr", "fill", "#ff00ff");
+        });
+
+        // The rectangle swatch's border follows the theme alongside its fill:
+        // the circle's outline and the swatch's are drawn the same color.
+        cy.get(".jxgbox svg [stroke='#663399']").should("have.length.gte", 2);
+        cy.get(".jxgbox svg [stroke='#996633']").should("not.exist");
+    });
+
     it("a legend follows entries being added and removed", () => {
         cy.window().then(async (win) => {
             win.postMessage(


### PR DESCRIPTION
A `<legend>` swatch was painted with the **light-mode** color of the object it stood for whatever the theme, so in dark mode a legend could disagree with the objects it describes — a curve drawn in its dark-mode color beside a swatch drawn in its light-mode one. Every other graphical renderer resolves per theme through `styleColors.ts`; the legend could not, because the worker flattened the color before the renderer saw it, in the one place with no view of the document's theme.

## What changed

`Legend.js` now carries both variants on each legend element — `lineColorDarkMode`, `markerColorDarkMode`, `fillColorDarkMode` alongside the keys that were already there — and `legend.tsx` picks between them with the `darkMode` it already reads from `DocContext`, through the same `resolveLineColor` / `resolveMarkerColor` / `resolveFillColor` helpers the other renderers use. A rectangle swatch's fill and its border's stroke are resolved together.

The theme joins the set that triggers a redraw. A toggle already reached that set through the box's border color, which is a fixed pair of neutrals and so always differs between the themes — but that is the box's color, and the swatches should not depend on it to be repainted. Naming the theme itself says what they actually turn on. The legend updates in place, so this is a restyle rather than a rebuild: the swatch objects survive the toggle.

The renderer's `LegendElement` becomes a discriminated union on `swatchType`. Which style keys an element carries follows from its kind — only a marker names a marker color, only a rectangle a fill — and the helpers want a color pair that is actually there rather than one of optional fields. Every style field is required, matching `ResolvedStyleDefinition`, from which the worker fills all three branches.

The `<legend>` reference page said in as many words that a swatch takes the light-mode color of its object; it now says swatches follow the theme.

## Also here: #1749

`styleColors.ts` exists so that dark-mode color resolution lives in one place, but `math.tsx`, `label.tsx`, `number.tsx` and `text.tsx` each wrote the text and background ternary out by hand, once on the create path and once on the update path. All eight are now `resolveTextColor` and `resolveBackgroundColor` calls. No behavior change — the helpers are the same ternary, and `resolveBackgroundColor` keeps the `""`-means-unauthored contract those call sites rely on. It is the second commit, and stands alone.

## Testing

- **`legend.cy.js`: swatches agree with their objects in both themes** — a curve, a point and a filled circle, each with a style definition naming both a light and a dark color, and a legend drawing all three swatch kinds. In light mode two elements are stroked the curve's light color: the curve and the swatch that stands for it. Switching the document to dark mode leaves two stroked the *dark* color and none the light one, and the marker's and rectangle's swatches are still the SVG nodes they were, now filled with their dark-mode colors. The rectangle's border is checked alongside its fill.

  It fails without the renderer half of this change: `Not enough elements found. Found '1', expected '2'` — the curve repaints and the swatch does not. I checked that by building with the fix backed out.

- **`legend.test.ts`: legend elements carry both themes' colors** — the worker half, on its own: a style definition naming both variants for a line, a marker and a fill, asserting each pairs its dark-mode color with the light-mode one it already had. `check_legend` gained the dark-mode keys, checked separately since most of the cases in the file author neither.

`legend.cy.js`, `legend.test.ts` and `DoenetViewer.legendMathJaxLayout.cy.tsx` all pass. For the four renderers in the second commit: `math.cy.js`, `text.cy.js`, `labelMask.cy.js`, `mathdisplay.cy.js`, and the `darkModeRendererAccessibility`, `darkModeVisibilityRegressions` and `styleDefinitionAccessibility` specs.

## Known gaps

- (#1750) A label kept on one line can run past the graph's right edge, and a legend positioned on the left can draw its box wider than the graph. Untouched here.
- Colors are what a swatch takes from its object; opacity is not. The worker sends the object's `lineOpacity` for every swatch kind, so a marker swatch is drawn at the point's *line* opacity rather than its `markerOpacity` — the two agree at their defaults and part company where a style definition names them apart. Longstanding, and left alone here; the renderer's `LegendElementBase` now says so where the field is declared.
- Line and fill colors are still resolved by hand in `curve.tsx`, `regionBetweenCurves.tsx`, `regionBetweenCurveXAxis.tsx` and `useFieldCurve.ts`. #1749 scopes itself to the text/background pairs, so those eight sites are left for a follow-up rather than folded in here.

Closes #1748.
Closes #1749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
