### PR TITLE
Report a self-referential attribute instead of hanging on it

### DIFF
--- a/.changeset/circular-attribute-reference.md
+++ b/.changeset/circular-attribute-reference.md
@@ -1,0 +1,23 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+An attribute that refers back to the component it is on is reported as a
+circular dependency instead of hanging the page.
+
+`<selectFromSequence name="a" from="1" to="10" numToSelect="2" exclude="2$a[1]"/>`
+asks for a selection that cannot be made until the exclusion is known, and an
+exclusion that cannot be evaluated until the selection is made. The two chased
+each other — no warning, no error, the tab growing until it ran out of memory —
+and the same happened for any sequence attribute written in terms of the
+sequence's own values, `<sequence exclude="$a[1]"/>` and `to="$a[1]"` among them.
+
+Doenet already recognizes a cycle like this one and says which components are
+involved; it just never got the chance here, because the resolution of the two
+sides never came back to ask. Resolving an item that is already being resolved
+now puts the question to the same check, so these documents report the circular
+dependency the way `<math name="m">$m</math>` always has.

--- a/.changeset/circular-attribute-reference.md
+++ b/.changeset/circular-attribute-reference.md
@@ -17,10 +17,11 @@ and the same happened for any sequence attribute written in terms of the
 sequence's own values, `<sequence exclude="$a[1]"/>` and `to="$a[1]"` among them.
 
 Doenet already recognizes a cycle like this one and says which components are
-involved; it just never got the chance here, because the resolution of the two
-sides never came back to ask. Resolving an item that is already being resolved
-now puts the question to that check, and the document reports a circular
-dependency naming the components instead of consuming the tab.
+involved; the check was simply never run here, because it fires only as a new
+dependency is registered and this cycle closed without one. Resolving something
+that is already being resolved now puts the question to that same check, and the
+document reports a circular dependency naming the components instead of
+consuming the tab.
 
 The report arrives as the document's failure, which is what a circular
 reference has always done — `<math name="m">$m</math>` fails a document the

--- a/.changeset/circular-attribute-reference.md
+++ b/.changeset/circular-attribute-reference.md
@@ -19,5 +19,10 @@ sequence's own values, `<sequence exclude="$a[1]"/>` and `to="$a[1]"` among them
 Doenet already recognizes a cycle like this one and says which components are
 involved; it just never got the chance here, because the resolution of the two
 sides never came back to ask. Resolving an item that is already being resolved
-now puts the question to the same check, so these documents report the circular
-dependency the way `<math name="m">$m</math>` always has.
+now puts the question to that check, and the document reports a circular
+dependency naming the components instead of consuming the tab.
+
+The report arrives as the document's failure rather than as an error on the
+offending component, which is how a cycle found while the document is being
+built — `<math extend="$m" name="m"/>` and the like — is reported. Confining
+this one the same way is left for later.

--- a/.changeset/circular-attribute-reference.md
+++ b/.changeset/circular-attribute-reference.md
@@ -22,7 +22,7 @@ sides never came back to ask. Resolving an item that is already being resolved
 now puts the question to that check, and the document reports a circular
 dependency naming the components instead of consuming the tab.
 
-The report arrives as the document's failure rather than as an error on the
-offending component, which is how a cycle found while the document is being
-built — `<math extend="$m" name="m"/>` and the like — is reported. Confining
-this one the same way is left for later.
+The report arrives as the document's failure, which is what a circular
+reference has always done — `<math name="m">$m</math>` fails a document the
+same way. Confining the report to the component at fault, as a composite that
+reports a cycle in its own replacements manages to, is left for later.

--- a/.changeset/circular-attribute-reference.md
+++ b/.changeset/circular-attribute-reference.md
@@ -13,15 +13,14 @@ circular dependency instead of hanging the page.
 asks for a selection that cannot be made until the exclusion is known, and an
 exclusion that cannot be evaluated until the selection is made. The two chased
 each other — no warning, no error, the tab growing until it ran out of memory —
-and the same happened for any sequence attribute written in terms of the
-sequence's own values, `<sequence exclude="$a[1]"/>` and `to="$a[1]"` among them.
+and the same happened for any attribute written in terms of the component's own
+values: `<sequence exclude="$a[1]"/>` and `to="$a[1]"` among them, and the
+matching shapes on `<select>`, `<repeat>`, and `<conditionalContent>`.
 
-Doenet already recognizes a cycle like this one and says which components are
-involved; the check was simply never run here, because it fires only as a new
-dependency is registered and this cycle closed without one. Resolving something
-that is already being resolved now puts the question to that same check, and the
-document reports a circular dependency naming the components instead of
-consuming the tab.
+Doenet had recognized the cycle all along and raised its usual error naming the
+components involved; the error was being dropped rather than reported, because
+the step that raised it was started and never waited for. It is waited for now,
+so the cycle is reported.
 
 The report arrives as the document's failure, which is what a circular
 reference has always done — `<math name="m">$m</math>` fails a document the

--- a/.changeset/circular-attribute-reference.md
+++ b/.changeset/circular-attribute-reference.md
@@ -14,8 +14,8 @@ asks for a selection that cannot be made until the exclusion is known, and an
 exclusion that cannot be evaluated until the selection is made. The two chased
 each other — no warning, no error, the tab growing until it ran out of memory —
 and the same happened for any attribute written in terms of the component's own
-values: `<sequence exclude="$a[1]"/>` and `to="$a[1]"` among them, and the
-matching shapes on `<select>`, `<repeat>`, and `<conditionalContent>`.
+values: `<sequence name="a" from="1" to="10" exclude="$a[1]"/>` among them, and
+the matching shapes on `<select>`, `<repeat>`, and `<conditionalContent>`.
 
 Doenet had recognized the cycle all along and raised its usual error naming the
 components involved; the error was being dropped rather than reported, because

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -1377,6 +1377,11 @@ export class Dependency {
     /**
      * Add a resolve blocker to this dependency based on `composite`
      * not yet being expanded.
+     *
+     * Must be awaited. `addBlocker` checks the blocker graph for a cycle and
+     * throws when it finds one; left unawaited, that becomes a floating
+     * rejection and resolution goes on around the cycle until the worker runs
+     * out of memory (Doenet/DoenetML#1665).
      */
     async addBlockerForUnexpandedComposite(composite: any) {
         for (const varName of this.upstreamVariableNames) {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -1283,6 +1283,9 @@ export class Dependency {
      * Add resolve blockers to this dependency due to the component with `componentIdx`
      * not existing as well as update triggers that will attempt to resolve
      * this dependency when the component is created.
+     *
+     * Must be awaited, for the reason given on
+     * {@link Dependency.addBlockerForUnexpandedComposite}.
      */
     async addBlockerUpdateTriggerForMissingComponent(componentIdx: number) {
         this.addUpdateTriggerForMissingComponent(componentIdx);

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -2714,8 +2714,18 @@ export class DependencyHandler {
 
     /**
      * Resolve `item`, resolving whatever blocks it first. `_resolveItem` does
-     * that work and defines the parameters and the result; this wrapper only
-     * keeps a cycle in the blockers from being chased forever.
+     * that work and defines the parameters and the result; this wrapper is a
+     * backstop against a cycle in the blockers being chased forever.
+     *
+     * A cycle is normally caught the moment its last edge goes in: `addBlocker`
+     * ends by running `checkForCircularResolveBlocker` on the item it has just
+     * blocked, and that throws. What went wrong in Doenet/DoenetML#1665 is that
+     * the throw was dropped — five `addBlockerForUnexpandedComposite` calls
+     * were left unawaited, so the rejection floated and resolution went on
+     * around the cycle until the worker ran out of memory. Those five are
+     * awaited now, and every `addBlocker` call in `src/core` is; no input we
+     * know of reaches the check below. It is here so that the next dropped
+     * rejection costs an error message rather than the tab.
      *
      * Note: even if expandComposites=false and force=false we still might
      * expand composites and force evaluate, as resolving a determineDependency
@@ -2734,36 +2744,36 @@ export class DependencyHandler {
             });
         }
 
-        const identifier = resolveItemIdentifier(item);
-        const inProgressCount =
-            this.resolveItemsInProgress.get(identifier) ?? 0;
+        let identifier: string;
+        let inProgressCount: number;
+        try {
+            identifier = resolveItemIdentifier(item);
+            inProgressCount = this.resolveItemsInProgress.get(identifier) ?? 0;
 
-        if (inProgressCount > 0) {
-            // A resolve of this item is already underway, so — when this call
-            // is nested inside it, as a cycle makes it — the item is among its
-            // own blockers. Whether that is a cycle the author has to fix or a
-            // step that will still resolve is a question for the blocker graph,
-            // which throws naming the components when the cycle is real. Left
-            // unasked, a real cycle is chased until the worker runs out of
-            // memory (Doenet/DoenetML#1665).
-            try {
+            if (inProgressCount > 0) {
+                // A resolve of this item is already underway, so — when this
+                // call is nested inside it, as a cycle makes it — the item is
+                // among its own blockers. Re-entry is not itself an error:
+                // re-resolving the same item is an ordinary step for collected
+                // and extended components. Only the blocker graph can tell the
+                // two apart, so put the question to it. It throws naming the
+                // components when the cycle is real and returns when it is not.
                 this.recheckForCircularResolveBlocker(item);
-            } catch (e) {
-                // Every other failure out of `resolveItem` reaches the caller
-                // as a rejected promise, from inside `_resolveItem`. This one
-                // is raised before that call, and `resolveItem` is not async,
-                // so hand it back in the same shape rather than throwing into
-                // the caller's own frame.
-                this.resolveDepth--;
-                return Promise.reject(e);
             }
+        } catch (e) {
+            // Every other failure out of `resolveItem` reaches the caller as a
+            // rejected promise, from inside `_resolveItem`. Anything raised
+            // above happens before that call, and `resolveItem` is not async,
+            // so hand it back in the same shape rather than throwing into the
+            // caller's own frame — and undo the depth this call took.
+            this.resolveDepth--;
+            return Promise.reject(e);
         }
 
         this.resolveItemsInProgress.set(identifier, inProgressCount + 1);
         return this._resolveItem(item).finally(() => {
             this.resolveDepth--;
-            const remaining =
-                (this.resolveItemsInProgress.get(identifier) ?? 1) - 1;
+            const remaining = this.resolveItemsInProgress.get(identifier)! - 1;
             if (remaining > 0) {
                 this.resolveItemsInProgress.set(identifier, remaining);
             } else {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -32,50 +32,6 @@ import { dependencyTypeClasses } from "./registry";
 const EMPTY_BLOCKERS: Record<string, any> = Object.freeze({});
 
 /**
- * The number of unsettled `resolveItem` calls past which each further call is
- * recorded so that a cycle in the blockers can be recognized. Set above the
- * count ordinary resolution reaches — the heaviest documents in the test suite
- * reach around 30 — so that the common case pays only a counter. A document
- * that goes past it is not treated as suspect; it just starts being recorded.
- */
-const RESOLVE_DEPTH_TO_TRACK = 50;
-
-/**
- * One thing resolution can be asked for: a state variable, a component's
- * expansion, a dependency's downstream components, and so on. The four fields
- * below identify it; callers pass further options (`force`, `expandComposites`,
- * …) alongside them, which `_resolveItem` destructures.
- */
-type ResolvableItem = {
-    componentIdx: ComponentIdx | string;
-    type: string;
-    stateVariable?: string;
-    dependency?: string;
-    [option: string]: any;
-};
-
-/**
- * The key identifying one resolvable item. Used both to memoize the
- * circular-blocker check and, in `resolveItem`, to recognize that an item is
- * already being resolved.
- */
-function resolveItemIdentifier({
-    componentIdx,
-    type,
-    stateVariable,
-    dependency,
-}: ResolvableItem) {
-    let code = componentIdx.toString();
-    if (stateVariable) {
-        code += "|" + stateVariable;
-        if (dependency) {
-            code += "|" + dependency;
-        }
-    }
-    return code + "|" + type;
-}
-
-/**
  * The 9 trigger tables that `DependencyHandler` exposes for cross-component
  * change propagation. Each is an index over component identifiers or names
  * pointing at the dependent dependency records; the records themselves are
@@ -128,19 +84,6 @@ export class DependencyHandler {
 
     circularCheckPassed: Record<string, boolean>;
     circularResolveBlockedCheckPassed: Record<string, boolean>;
-    /**
-     * How many `resolveItem` calls for each identifier have yet to settle, so
-     * a call can tell that it is resolving an item already being resolved.
-     * Only calls made past `RESOLVE_DEPTH_TO_TRACK` are recorded.
-     */
-    resolveItemsInProgress: Map<string, number>;
-    /**
-     * How many `resolveItem` calls have yet to settle. Resolution nests
-     * — resolving an item means resolving what blocks it — so this tracks
-     * nesting depth, except that concurrent resolutions also count toward it.
-     * Either way, a large value only turns on the bookkeeping in `resolveItem`.
-     */
-    resolveDepth: number;
 
     dependencyTypes: Record<string, any>;
     updateTriggers: DependencyUpdateTriggers;
@@ -228,8 +171,6 @@ export class DependencyHandler {
 
         this.circularCheckPassed = {};
         this.circularResolveBlockedCheckPassed = {};
-        this.resolveItemsInProgress = new Map();
-        this.resolveDepth = 0;
 
         this.dependencyTypes = {};
         dependencyTypeClasses.forEach(
@@ -2712,99 +2653,7 @@ export class DependencyHandler {
         return result;
     }
 
-    /**
-     * Resolve `item`, resolving whatever blocks it first. `_resolveItem` does
-     * that work and defines the parameters and the result; this wrapper is a
-     * backstop against a cycle in the blockers being chased forever.
-     *
-     * A cycle is normally caught the moment its last edge goes in: `addBlocker`
-     * ends by running `checkForCircularResolveBlocker` on the item it has just
-     * blocked, and that throws. What went wrong in Doenet/DoenetML#1665 is that
-     * the throw was dropped — five `addBlockerForUnexpandedComposite` calls
-     * were left unawaited, so the rejection floated and resolution went on
-     * around the cycle until the worker ran out of memory. Those five are
-     * awaited now, and every `addBlocker` call in `src/core` is; no input we
-     * know of reaches the check below. It is here so that the next dropped
-     * rejection costs an error message rather than the tab.
-     *
-     * Note: even if expandComposites=false and force=false we still might
-     * expand composites and force evaluate, as resolving a determineDependency
-     * will call updateDependencies, and updateDependencies calls the getters on
-     * the state variables determining dependencies.
-     */
-    resolveItem(item: ResolvableItem): Promise<any> {
-        // Resolving one item routinely means resolving the handful of items
-        // blocking it, so only the calls made past a depth no ordinary
-        // document reaches are worth the bookkeeping below. A cycle keeps
-        // nesting, so it is always caught once past that depth.
-        this.resolveDepth++;
-        if (this.resolveDepth <= RESOLVE_DEPTH_TO_TRACK) {
-            return this._resolveItem(item).finally(() => {
-                this.resolveDepth--;
-            });
-        }
-
-        let identifier: string;
-        let inProgressCount: number;
-        try {
-            identifier = resolveItemIdentifier(item);
-            inProgressCount = this.resolveItemsInProgress.get(identifier) ?? 0;
-
-            if (inProgressCount > 0) {
-                // A resolve of this item is already underway, so — when this
-                // call is nested inside it, as a cycle makes it — the item is
-                // among its own blockers. Re-entry is not itself an error:
-                // re-resolving the same item is an ordinary step for collected
-                // and extended components. Only the blocker graph can tell the
-                // two apart, so put the question to it. It throws naming the
-                // components when the cycle is real and returns when it is not.
-                this.recheckForCircularResolveBlocker(item);
-            }
-        } catch (e) {
-            // Every other failure out of `resolveItem` reaches the caller as a
-            // rejected promise, from inside `_resolveItem`. Anything raised
-            // above happens before that call, and `resolveItem` is not async,
-            // so hand it back in the same shape rather than throwing into the
-            // caller's own frame — and undo the depth this call took.
-            this.resolveDepth--;
-            return Promise.reject(e);
-        }
-
-        this.resolveItemsInProgress.set(identifier, inProgressCount + 1);
-        return this._resolveItem(item).finally(() => {
-            this.resolveDepth--;
-            const remaining = this.resolveItemsInProgress.get(identifier)! - 1;
-            if (remaining > 0) {
-                this.resolveItemsInProgress.set(identifier, remaining);
-            } else {
-                this.resolveItemsInProgress.delete(identifier);
-            }
-        });
-    }
-
-    /**
-     * Run `checkForCircularResolveBlocker` on an item that an earlier
-     * traversal may already have cleared, against an empty set of memos: a
-     * memo left from that traversal would stop the walk before it reaches a
-     * cycle formed since. The memos the rest of the resolve is relying on are
-     * put back either way. Throws naming the components when the cycle is real.
-     */
-    recheckForCircularResolveBlocker(item: ResolvableItem) {
-        const memos = this.circularResolveBlockedCheckPassed;
-        this.circularResolveBlockedCheckPassed = {};
-        try {
-            this.checkForCircularResolveBlocker(item);
-        } finally {
-            this.circularResolveBlockedCheckPassed = memos;
-        }
-    }
-
-    /**
-     * The body of `resolveItem`, which is the only caller. Recursing into the
-     * blockers it finds goes back through `resolveItem`, so every step of the
-     * descent passes the guard there.
-     */
-    async _resolveItem({
+    async resolveItem({
         componentIdx,
         type,
         stateVariable,
@@ -2814,6 +2663,19 @@ export class DependencyHandler {
         expandComposites = true,
         numPreviouslyNeeded,
     }: any): Promise<any> {
+        // if (!this.resolveLevels) {
+        //   this.resolveLevels = 0;
+        // }
+        // this.resolveLevels++;
+
+        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. resolve item ${componentIdx}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
+
+        // Note: even if expandComposites=false and force=false
+        // we still might expand composites and force evaluate
+        // as resolving a determineDependency will call updateDependencies
+        // and updateDependencies calls the getters on
+        // the state variables determining dependencies
+
         if (type === "stateVariable") {
             // Set up this variable's dependencies now (if not yet built) so
             // the peek below sees the real blockers — including the
@@ -2857,6 +2719,8 @@ export class DependencyHandler {
                 });
 
                 if (!result.success) {
+                    // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
+                    // this.resolveLevels--;
                     return result;
                 }
             }
@@ -2921,6 +2785,8 @@ export class DependencyHandler {
                         if (force) {
                             nFailures++;
                         } else {
+                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
+                            // this.resolveLevels--;
                             return result;
                         }
                     }
@@ -2966,6 +2832,8 @@ export class DependencyHandler {
                         });
 
                         if (!result.success) {
+                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
+                            // this.resolveLevels--;
                             return result;
                         }
                     }
@@ -3022,6 +2890,9 @@ export class DependencyHandler {
             }
         }
 
+        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. done resolving item ${componentIdx}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
+        // this.resolveLevels--;
+
         return finalResult;
     }
 
@@ -3031,22 +2902,21 @@ export class DependencyHandler {
         stateVariable,
         dependency,
         previouslyVisited = [],
-    }: ResolvableItem) {
-        let identifier = resolveItemIdentifier({
-            componentIdx,
-            type,
-            stateVariable,
-            dependency,
-        });
+    }: any) {
+        let code = componentIdx.toString();
+        if (stateVariable) {
+            code += "|" + stateVariable;
+            if (dependency) {
+                code += "|" + dependency;
+            }
+        }
+
+        let identifier = code + "|" + type;
 
         if (previouslyVisited.includes(identifier)) {
             // Found circular dependency
             // Create error message with list of component types and names involved
 
-            // Kept deliberately: the message built below names the components
-            // involved, while this path through the blockers also carries the
-            // blocker types and state variables that a cycle is actually
-            // diagnosed from.
             console.log("found circular", identifier, previouslyVisited);
 
             let componentNameRe = /^([^|]*)\|/;
@@ -3195,13 +3065,16 @@ export class DependencyHandler {
         type,
         stateVariable,
         dependency,
-    }: ResolvableItem) {
-        let identifier = resolveItemIdentifier({
-            componentIdx,
-            type,
-            stateVariable,
-            dependency,
-        });
+    }: any) {
+        let code = componentIdx.toString();
+        if (stateVariable) {
+            code += "|" + stateVariable;
+            if (dependency) {
+                code += "|" + dependency;
+            }
+        }
+
+        let identifier = code + "|" + type;
 
         if (this.circularResolveBlockedCheckPassed[identifier]) {
             delete this.circularResolveBlockedCheckPassed[identifier];

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -32,18 +32,18 @@ import { dependencyTypeClasses } from "./registry";
 const EMPTY_BLOCKERS: Record<string, any> = Object.freeze({});
 
 /**
- * The `resolveItem` nesting depth past which each call is recorded so that a
- * cycle in the blockers can be recognized. Set above the depth ordinary
- * resolution reaches — the heaviest documents in the test suite nest around
- * 30 — so that the common case pays only a counter. A document that nests
- * deeper than this is not treated as suspect; it just starts being recorded.
+ * The number of unsettled `resolveItem` calls past which each further call is
+ * recorded so that a cycle in the blockers can be recognized. Set above the
+ * count ordinary resolution reaches — the heaviest documents in the test suite
+ * reach around 30 — so that the common case pays only a counter. A document
+ * that goes past it is not treated as suspect; it just starts being recorded.
  */
 const RESOLVE_DEPTH_TO_TRACK = 50;
 
 /**
- * The key `resolveItem` uses to recognize that it is already resolving an
- * item further up the stack. Matches the identifiers of
- * `checkForCircularResolveBlocker` so the two can be read side by side.
+ * The key identifying one resolvable item — a state variable, a component's
+ * expansion, and so on. Used both to memoize the circular-blocker check and,
+ * in `resolveItem`, to recognize that an item is already being resolved.
  */
 function resolveItemIdentifier({
     componentIdx,
@@ -120,12 +120,17 @@ export class DependencyHandler {
     circularCheckPassed: Record<string, boolean>;
     circularResolveBlockedCheckPassed: Record<string, boolean>;
     /**
-     * How many `resolveItem` calls for each identifier are on the stack, so a
-     * call can tell that it is resolving an item it is already resolving.
-     * Only the calls nested deeper than `RESOLVE_DEPTH_TO_TRACK` are recorded.
+     * How many `resolveItem` calls for each identifier have yet to settle, so
+     * a call can tell that it is resolving an item already being resolved.
+     * Only calls made past `RESOLVE_DEPTH_TO_TRACK` are recorded.
      */
     resolveItemsInProgress: Map<string, number>;
-    /** How many `resolveItem` calls are on the stack. */
+    /**
+     * How many `resolveItem` calls have yet to settle. Resolution nests
+     * — resolving an item means resolving what blocks it — so this tracks
+     * nesting depth, except that concurrent resolutions also count toward it.
+     * Either way, a large value only turns on the bookkeeping in `resolveItem`.
+     */
     resolveDepth: number;
 
     dependencyTypes: Record<string, any>;
@@ -2698,123 +2703,84 @@ export class DependencyHandler {
         return result;
     }
 
-    resolveItem({
-        componentIdx,
-        type,
-        stateVariable,
-        dependency,
-        force = false,
-        recurseUpstream = false,
-        expandComposites = true,
-        numPreviouslyNeeded,
-    }: any): Promise<any> {
-        // if (!this.resolveLevels) {
-        //   this.resolveLevels = 0;
-        // }
-        // this.resolveLevels++;
-
-        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. resolve item ${componentIdx}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
-
-        // Note: even if expandComposites=false and force=false
-        // we still might expand composites and force evaluate
-        // as resolving a determineDependency will call updateDependencies
-        // and updateDependencies calls the getters on
-        // the state variables determining dependencies
-
+    /**
+     * Resolve `item`, resolving whatever blocks it first. See `_resolveItem`
+     * for the parameters and the returned result; this half only guards
+     * against a cycle in the blockers being chased forever.
+     *
+     * Note: even if expandComposites=false and force=false we still might
+     * expand composites and force evaluate, as resolving a determineDependency
+     * will call updateDependencies, and updateDependencies calls the getters on
+     * the state variables determining dependencies.
+     */
+    resolveItem(item: any): Promise<any> {
         // Resolving one item routinely means resolving the handful of items
-        // blocking it, so only the calls nested past a depth no ordinary
+        // blocking it, so only the calls made past a depth no ordinary
         // document reaches are worth the bookkeeping below. A cycle keeps
         // nesting, so it is always caught once past that depth.
         this.resolveDepth++;
         if (this.resolveDepth <= RESOLVE_DEPTH_TO_TRACK) {
-            return this._resolveItem({
-                componentIdx,
-                type,
-                stateVariable,
-                dependency,
-                force,
-                recurseUpstream,
-                expandComposites,
-                numPreviouslyNeeded,
-            }).finally(() => {
+            return this._resolveItem(item).finally(() => {
                 this.resolveDepth--;
             });
         }
 
-        const inProgressIdentifier = resolveItemIdentifier({
-            componentIdx,
-            type,
-            stateVariable,
-            dependency,
-        });
-
+        const identifier = resolveItemIdentifier(item);
         const inProgressCount =
-            this.resolveItemsInProgress.get(inProgressIdentifier) ?? 0;
+            this.resolveItemsInProgress.get(identifier) ?? 0;
 
         if (inProgressCount > 0) {
-            // We are already resolving this item further up the stack, so it
-            // is now among its own blockers. Whether that is a cycle the
+            // A resolve of this item is already underway, so — when this call
+            // is nested inside it, as a cycle makes it — the item is among its
+            // own blockers. Whether that is a cycle the
             // author has to fix or a step that will still resolve is a
             // question for the blocker graph, which throws with the components
             // involved when the cycle is real. Left unasked, a real cycle is
             // chased until the worker runs out of memory (Doenet/DoenetML#1665).
-            // The check runs against an empty set of memos, since a memo left
-            // from an earlier traversal would stop it before it reaches the
-            // cycle. The memos the rest of the resolve is relying on are put
-            // back either way.
-            const memos = this.circularResolveBlockedCheckPassed;
-            this.circularResolveBlockedCheckPassed = {};
             try {
-                this.checkForCircularResolveBlocker({
-                    componentIdx,
-                    type,
-                    stateVariable,
-                    dependency,
-                });
+                this.recheckForCircularResolveBlocker(item);
             } catch (e) {
                 // `resolveItem` hands back a promise rather than being async,
                 // so a caller that never awaits it sees a rejection here and
                 // not an exception thrown out of its own frame.
                 this.resolveDepth--;
                 return Promise.reject(e);
-            } finally {
-                this.circularResolveBlockedCheckPassed = memos;
             }
         }
 
-        this.resolveItemsInProgress.set(
-            inProgressIdentifier,
-            inProgressCount + 1,
-        );
-        return this._resolveItem({
-            componentIdx,
-            type,
-            stateVariable,
-            dependency,
-            force,
-            recurseUpstream,
-            expandComposites,
-            numPreviouslyNeeded,
-        }).finally(() => {
+        this.resolveItemsInProgress.set(identifier, inProgressCount + 1);
+        return this._resolveItem(item).finally(() => {
             this.resolveDepth--;
             const remaining =
-                (this.resolveItemsInProgress.get(inProgressIdentifier) ?? 1) -
-                1;
+                (this.resolveItemsInProgress.get(identifier) ?? 1) - 1;
             if (remaining > 0) {
-                this.resolveItemsInProgress.set(
-                    inProgressIdentifier,
-                    remaining,
-                );
+                this.resolveItemsInProgress.set(identifier, remaining);
             } else {
-                this.resolveItemsInProgress.delete(inProgressIdentifier);
+                this.resolveItemsInProgress.delete(identifier);
             }
         });
     }
 
     /**
-     * The body of `resolveItem`, which is the only caller: it holds the guard
-     * that keeps a cycle in the blockers from being chased forever, and this
-     * half is free to recurse into the blockers it finds.
+     * Run `checkForCircularResolveBlocker` on an item that an earlier
+     * traversal may already have cleared, against an empty set of memos: a
+     * memo left from that traversal would stop the walk before it reaches a
+     * cycle formed since. The memos the rest of the resolve is relying on are
+     * put back either way. Throws naming the components when the cycle is real.
+     */
+    recheckForCircularResolveBlocker(item: any) {
+        const memos = this.circularResolveBlockedCheckPassed;
+        this.circularResolveBlockedCheckPassed = {};
+        try {
+            this.checkForCircularResolveBlocker(item);
+        } finally {
+            this.circularResolveBlockedCheckPassed = memos;
+        }
+    }
+
+    /**
+     * The body of `resolveItem`, which is the only caller. Unlike that half,
+     * this one is free to recurse into the blockers it finds.
      */
     async _resolveItem({
         componentIdx,
@@ -2869,8 +2835,6 @@ export class DependencyHandler {
                 });
 
                 if (!result.success) {
-                    // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
-                    // this.resolveLevels--;
                     return result;
                 }
             }
@@ -2935,8 +2899,6 @@ export class DependencyHandler {
                         if (force) {
                             nFailures++;
                         } else {
-                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
-                            // this.resolveLevels--;
                             return result;
                         }
                     }
@@ -2982,8 +2944,6 @@ export class DependencyHandler {
                         });
 
                         if (!result.success) {
-                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
-                            // this.resolveLevels--;
                             return result;
                         }
                     }
@@ -3040,9 +3000,6 @@ export class DependencyHandler {
             }
         }
 
-        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. done resolving item ${componentIdx}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
-        // this.resolveLevels--;
-
         return finalResult;
     }
 
@@ -3053,21 +3010,16 @@ export class DependencyHandler {
         dependency,
         previouslyVisited = [],
     }: any) {
-        let code = componentIdx.toString();
-        if (stateVariable) {
-            code += "|" + stateVariable;
-            if (dependency) {
-                code += "|" + dependency;
-            }
-        }
-
-        let identifier = code + "|" + type;
+        let identifier = resolveItemIdentifier({
+            componentIdx,
+            type,
+            stateVariable,
+            dependency,
+        });
 
         if (previouslyVisited.includes(identifier)) {
             // Found circular dependency
             // Create error message with list of component types and names involved
-
-            console.log("found circular", identifier, previouslyVisited);
 
             let componentNameRe = /^([^|]*)\|/;
 
@@ -3216,15 +3168,12 @@ export class DependencyHandler {
         stateVariable,
         dependency,
     }: any) {
-        let code = componentIdx.toString();
-        if (stateVariable) {
-            code += "|" + stateVariable;
-            if (dependency) {
-                code += "|" + dependency;
-            }
-        }
-
-        let identifier = code + "|" + type;
+        let identifier = resolveItemIdentifier({
+            componentIdx,
+            type,
+            stateVariable,
+            dependency,
+        });
 
         if (this.circularResolveBlockedCheckPassed[identifier]) {
             delete this.circularResolveBlockedCheckPassed[identifier];

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -32,6 +32,41 @@ import { dependencyTypeClasses } from "./registry";
 const EMPTY_BLOCKERS: Record<string, any> = Object.freeze({});
 
 /**
+ * The `resolveItem` nesting depth past which each call is recorded so that a
+ * cycle in the blockers can be recognized. Set above the depth ordinary
+ * resolution reaches — the heaviest documents in the test suite nest around
+ * 30 — so that the common case pays only a counter. A document that nests
+ * deeper than this is not treated as suspect; it just starts being recorded.
+ */
+const RESOLVE_DEPTH_TO_TRACK = 50;
+
+/**
+ * The key `resolveItem` uses to recognize that it is already resolving an
+ * item further up the stack. Matches the identifiers of
+ * `checkForCircularResolveBlocker` so the two can be read side by side.
+ */
+function resolveItemIdentifier({
+    componentIdx,
+    type,
+    stateVariable,
+    dependency,
+}: {
+    componentIdx: ComponentIdx | string;
+    type: string;
+    stateVariable?: string;
+    dependency?: string;
+}) {
+    let code = componentIdx.toString();
+    if (stateVariable) {
+        code += "|" + stateVariable;
+        if (dependency) {
+            code += "|" + dependency;
+        }
+    }
+    return code + "|" + type;
+}
+
+/**
  * The 9 trigger tables that `DependencyHandler` exposes for cross-component
  * change propagation. Each is an index over component identifiers or names
  * pointing at the dependent dependency records; the records themselves are
@@ -84,6 +119,14 @@ export class DependencyHandler {
 
     circularCheckPassed: Record<string, boolean>;
     circularResolveBlockedCheckPassed: Record<string, boolean>;
+    /**
+     * How many `resolveItem` calls for each identifier are on the stack, so a
+     * call can tell that it is resolving an item it is already resolving.
+     * Only the calls nested deeper than `RESOLVE_DEPTH_TO_TRACK` are recorded.
+     */
+    resolveItemsInProgress: Map<string, number>;
+    /** How many `resolveItem` calls are on the stack. */
+    resolveDepth: number;
 
     dependencyTypes: Record<string, any>;
     updateTriggers: DependencyUpdateTriggers;
@@ -171,6 +214,8 @@ export class DependencyHandler {
 
         this.circularCheckPassed = {};
         this.circularResolveBlockedCheckPassed = {};
+        this.resolveItemsInProgress = new Map();
+        this.resolveDepth = 0;
 
         this.dependencyTypes = {};
         dependencyTypeClasses.forEach(
@@ -2653,7 +2698,7 @@ export class DependencyHandler {
         return result;
     }
 
-    async resolveItem({
+    resolveItem({
         componentIdx,
         type,
         stateVariable,
@@ -2676,6 +2721,111 @@ export class DependencyHandler {
         // and updateDependencies calls the getters on
         // the state variables determining dependencies
 
+        // Resolving one item routinely means resolving the handful of items
+        // blocking it, so only the calls nested past a depth no ordinary
+        // document reaches are worth the bookkeeping below. A cycle keeps
+        // nesting, so it is always caught once past that depth.
+        this.resolveDepth++;
+        if (this.resolveDepth <= RESOLVE_DEPTH_TO_TRACK) {
+            return this._resolveItem({
+                componentIdx,
+                type,
+                stateVariable,
+                dependency,
+                force,
+                recurseUpstream,
+                expandComposites,
+                numPreviouslyNeeded,
+            }).finally(() => {
+                this.resolveDepth--;
+            });
+        }
+
+        const inProgressIdentifier = resolveItemIdentifier({
+            componentIdx,
+            type,
+            stateVariable,
+            dependency,
+        });
+
+        const inProgressCount =
+            this.resolveItemsInProgress.get(inProgressIdentifier) ?? 0;
+
+        if (inProgressCount > 0) {
+            // We are already resolving this item further up the stack, so it
+            // is now among its own blockers. Whether that is a cycle the
+            // author has to fix or a step that will still resolve is a
+            // question for the blocker graph, which throws with the components
+            // involved when the cycle is real. Left unasked, a real cycle is
+            // chased until the worker runs out of memory (Doenet/DoenetML#1665).
+            // The check runs against an empty set of memos, since a memo left
+            // from an earlier traversal would stop it before it reaches the
+            // cycle. The memos the rest of the resolve is relying on are put
+            // back either way.
+            const memos = this.circularResolveBlockedCheckPassed;
+            this.circularResolveBlockedCheckPassed = {};
+            try {
+                this.checkForCircularResolveBlocker({
+                    componentIdx,
+                    type,
+                    stateVariable,
+                    dependency,
+                });
+            } catch (e) {
+                // `resolveItem` hands back a promise rather than being async,
+                // so a caller that never awaits it sees a rejection here and
+                // not an exception thrown out of its own frame.
+                this.resolveDepth--;
+                return Promise.reject(e);
+            } finally {
+                this.circularResolveBlockedCheckPassed = memos;
+            }
+        }
+
+        this.resolveItemsInProgress.set(
+            inProgressIdentifier,
+            inProgressCount + 1,
+        );
+        return this._resolveItem({
+            componentIdx,
+            type,
+            stateVariable,
+            dependency,
+            force,
+            recurseUpstream,
+            expandComposites,
+            numPreviouslyNeeded,
+        }).finally(() => {
+            this.resolveDepth--;
+            const remaining =
+                (this.resolveItemsInProgress.get(inProgressIdentifier) ?? 1) -
+                1;
+            if (remaining > 0) {
+                this.resolveItemsInProgress.set(
+                    inProgressIdentifier,
+                    remaining,
+                );
+            } else {
+                this.resolveItemsInProgress.delete(inProgressIdentifier);
+            }
+        });
+    }
+
+    /**
+     * The body of `resolveItem`, which is the only caller: it holds the guard
+     * that keeps a cycle in the blockers from being chased forever, and this
+     * half is free to recurse into the blockers it finds.
+     */
+    async _resolveItem({
+        componentIdx,
+        type,
+        stateVariable,
+        dependency,
+        force = false,
+        recurseUpstream = false,
+        expandComposites = true,
+        numPreviouslyNeeded,
+    }: any): Promise<any> {
         if (type === "stateVariable") {
             // Set up this variable's dependencies now (if not yet built) so
             // the peek below sees the real blockers — including the

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -41,21 +41,30 @@ const EMPTY_BLOCKERS: Record<string, any> = Object.freeze({});
 const RESOLVE_DEPTH_TO_TRACK = 50;
 
 /**
- * The key identifying one resolvable item — a state variable, a component's
- * expansion, and so on. Used both to memoize the circular-blocker check and,
- * in `resolveItem`, to recognize that an item is already being resolved.
+ * One thing resolution can be asked for: a state variable, a component's
+ * expansion, a dependency's downstream components, and so on. The four fields
+ * below identify it; callers pass further options (`force`, `expandComposites`,
+ * …) alongside them, which `_resolveItem` destructures.
+ */
+type ResolvableItem = {
+    componentIdx: ComponentIdx | string;
+    type: string;
+    stateVariable?: string;
+    dependency?: string;
+    [option: string]: any;
+};
+
+/**
+ * The key identifying one resolvable item. Used both to memoize the
+ * circular-blocker check and, in `resolveItem`, to recognize that an item is
+ * already being resolved.
  */
 function resolveItemIdentifier({
     componentIdx,
     type,
     stateVariable,
     dependency,
-}: {
-    componentIdx: ComponentIdx | string;
-    type: string;
-    stateVariable?: string;
-    dependency?: string;
-}) {
+}: ResolvableItem) {
     let code = componentIdx.toString();
     if (stateVariable) {
         code += "|" + stateVariable;
@@ -2704,16 +2713,16 @@ export class DependencyHandler {
     }
 
     /**
-     * Resolve `item`, resolving whatever blocks it first. See `_resolveItem`
-     * for the parameters and the returned result; this half only guards
-     * against a cycle in the blockers being chased forever.
+     * Resolve `item`, resolving whatever blocks it first. `_resolveItem` does
+     * that work and defines the parameters and the result; this wrapper only
+     * keeps a cycle in the blockers from being chased forever.
      *
      * Note: even if expandComposites=false and force=false we still might
      * expand composites and force evaluate, as resolving a determineDependency
      * will call updateDependencies, and updateDependencies calls the getters on
      * the state variables determining dependencies.
      */
-    resolveItem(item: any): Promise<any> {
+    resolveItem(item: ResolvableItem): Promise<any> {
         // Resolving one item routinely means resolving the handful of items
         // blocking it, so only the calls made past a depth no ordinary
         // document reaches are worth the bookkeeping below. A cycle keeps
@@ -2732,17 +2741,19 @@ export class DependencyHandler {
         if (inProgressCount > 0) {
             // A resolve of this item is already underway, so — when this call
             // is nested inside it, as a cycle makes it — the item is among its
-            // own blockers. Whether that is a cycle the
-            // author has to fix or a step that will still resolve is a
-            // question for the blocker graph, which throws with the components
-            // involved when the cycle is real. Left unasked, a real cycle is
-            // chased until the worker runs out of memory (Doenet/DoenetML#1665).
+            // own blockers. Whether that is a cycle the author has to fix or a
+            // step that will still resolve is a question for the blocker graph,
+            // which throws naming the components when the cycle is real. Left
+            // unasked, a real cycle is chased until the worker runs out of
+            // memory (Doenet/DoenetML#1665).
             try {
                 this.recheckForCircularResolveBlocker(item);
             } catch (e) {
-                // `resolveItem` hands back a promise rather than being async,
-                // so a caller that never awaits it sees a rejection here and
-                // not an exception thrown out of its own frame.
+                // Every other failure out of `resolveItem` reaches the caller
+                // as a rejected promise, from inside `_resolveItem`. This one
+                // is raised before that call, and `resolveItem` is not async,
+                // so hand it back in the same shape rather than throwing into
+                // the caller's own frame.
                 this.resolveDepth--;
                 return Promise.reject(e);
             }
@@ -2768,7 +2779,7 @@ export class DependencyHandler {
      * cycle formed since. The memos the rest of the resolve is relying on are
      * put back either way. Throws naming the components when the cycle is real.
      */
-    recheckForCircularResolveBlocker(item: any) {
+    recheckForCircularResolveBlocker(item: ResolvableItem) {
         const memos = this.circularResolveBlockedCheckPassed;
         this.circularResolveBlockedCheckPassed = {};
         try {
@@ -2779,8 +2790,9 @@ export class DependencyHandler {
     }
 
     /**
-     * The body of `resolveItem`, which is the only caller. Unlike that half,
-     * this one is free to recurse into the blockers it finds.
+     * The body of `resolveItem`, which is the only caller. Recursing into the
+     * blockers it finds goes back through `resolveItem`, so every step of the
+     * descent passes the guard there.
      */
     async _resolveItem({
         componentIdx,
@@ -3009,7 +3021,7 @@ export class DependencyHandler {
         stateVariable,
         dependency,
         previouslyVisited = [],
-    }: any) {
+    }: ResolvableItem) {
         let identifier = resolveItemIdentifier({
             componentIdx,
             type,
@@ -3021,8 +3033,9 @@ export class DependencyHandler {
             // Found circular dependency
             // Create error message with list of component types and names involved
 
-            // The path through the blockers, which carries the types and state
-            // variables the message below leaves out, and is what a cycle is
+            // Kept deliberately: the message built below names the components
+            // involved, while this path through the blockers also carries the
+            // blocker types and state variables that a cycle is actually
             // diagnosed from.
             console.log("found circular", identifier, previouslyVisited);
 
@@ -3172,7 +3185,7 @@ export class DependencyHandler {
         type,
         stateVariable,
         dependency,
-    }: any) {
+    }: ResolvableItem) {
         let identifier = resolveItemIdentifier({
             componentIdx,
             type,

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -3021,6 +3021,11 @@ export class DependencyHandler {
             // Found circular dependency
             // Create error message with list of component types and names involved
 
+            // The path through the blockers, which carries the types and state
+            // variables the message below leaves out, and is what a cycle is
+            // diagnosed from.
+            console.log("found circular", identifier, previouslyVisited);
+
             let componentNameRe = /^([^|]*)\|/;
 
             let componentsInvolved = previouslyVisited.map(

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -88,7 +88,7 @@ export class RefResolutionIndexDependencies extends Dependency {
 
                     if (haveComposite) {
                         if (!indexComponent.isExpanded) {
-                            this.addBlockerForUnexpandedComposite(
+                            await this.addBlockerForUnexpandedComposite(
                                 indexComponent,
                             );
 
@@ -234,7 +234,7 @@ export class RefResolutionDependency extends Dependency {
             }
 
             if (!compositeCreating.isExpanded) {
-                this.addBlockerForUnexpandedComposite(compositeCreating);
+                await this.addBlockerForUnexpandedComposite(compositeCreating);
 
                 return {
                     success: false,
@@ -293,7 +293,7 @@ export class RefResolutionDependency extends Dependency {
         if (haveComposite) {
             // make sure that the composite refComponent is expanded
             if (!refComponent.isExpanded) {
-                this.addBlockerForUnexpandedComposite(refComponent);
+                await this.addBlockerForUnexpandedComposite(refComponent);
 
                 return {
                     success: false,
@@ -441,7 +441,7 @@ export class RefResolutionDependency extends Dependency {
             // We ended on a composite component with the next unresolved path being an index.
             // If the composite isn't expanded, that's the next blocker for resolving the reference.
             if (!newRefComponent.isExpanded) {
-                this.addBlockerForUnexpandedComposite(newRefComponent);
+                await this.addBlockerForUnexpandedComposite(newRefComponent);
 
                 return {
                     success: false,
@@ -556,7 +556,7 @@ export class RefResolutionDependency extends Dependency {
 
                     if (haveComposite) {
                         if (!indexComponent.isExpanded) {
-                            this.addBlockerForUnexpandedComposite(
+                            await this.addBlockerForUnexpandedComposite(
                                 indexComponent,
                             );
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -28,7 +28,9 @@ export class RefResolutionIndexDependencies extends Dependency {
         let composite = this.dependencyHandler._components[this.compositeIdx];
 
         if (!composite) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.compositeIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.compositeIdx,
+            );
             this.missingComponentBlockers.push(this.compositeIdx);
 
             return {
@@ -196,7 +198,9 @@ export class RefResolutionDependency extends Dependency {
         let composite = this.dependencyHandler._components[this.compositeIdx];
 
         if (!composite) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.compositeIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.compositeIdx,
+            );
             this.missingComponentBlockers.push(this.compositeIdx);
 
             return {
@@ -676,7 +680,9 @@ export class AttributeRefResolutions extends Dependency {
         let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.parentIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.parentIdx,
+            );
             this.missingComponentBlockers.push(this.parentIdx);
 
             return {
@@ -838,7 +844,9 @@ export class ComponentsReferencingAttributeDependency extends Dependency {
             this.dependencyHandler._components[this.referencedIdx];
 
         if (!referencedComponent) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.referencedIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.referencedIdx,
+            );
             this.missingComponentBlockers.push(this.referencedIdx);
 
             return {
@@ -943,7 +951,9 @@ export class StringsFromReferenceAttribute extends Dependency {
         let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.parentIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.parentIdx,
+            );
             this.missingComponentBlockers.push(this.parentIdx);
 
             return {
@@ -1010,7 +1020,9 @@ export class RendererId extends Dependency {
         this.component = this.dependencyHandler._components[this.componentIdx];
 
         if (!this.component) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.componentIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.componentIdx,
+            );
             this.missingComponentBlockers.push(this.componentIdx);
 
             return {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/stateVariableDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/stateVariableDependencies.ts
@@ -46,7 +46,9 @@ export class StateVariableDependency extends Dependency {
         let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.componentIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.componentIdx,
+            );
 
             return {
                 success: false,
@@ -114,7 +116,9 @@ export class StateVariableFromUnresolvedPathDependency extends Dependency {
         const component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
-            this.addBlockerUpdateTriggerForMissingComponent(this.componentIdx);
+            await this.addBlockerUpdateTriggerForMissingComponent(
+                this.componentIdx,
+            );
 
             return {
                 success: false,

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/circularReferences.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/circularReferences.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+/**
+ * Doenet/DoenetML#1665: an attribute written in terms of the values its own
+ * component has yet to produce cannot be evaluated until the component is
+ * expanded, and the component cannot be expanded until the attribute is
+ * evaluated. Doenet recognized the cycle all along, but the error was raised
+ * from a blocker registration nobody awaited, so it was dropped and resolution
+ * went on around the cycle until the worker ran out of memory. Each case below
+ * exhausted the heap before the fix.
+ *
+ * The shapes are gathered here rather than spread over the component suites
+ * because none of them is about the component: they all fail at the same step
+ * of reference resolution.
+ */
+describe("Circular reference tests @group2", async () => {
+    const circularError = "Circular dependency involving these components";
+
+    const selfReferentialAttributes: [string, string][] = [
+        [
+            "selectFromSequence exclude (the reported case)",
+            `<selectFromSequence name="a" from="1" to="10" numToSelect="2" exclude="2$a[1]"/>`,
+        ],
+        [
+            "selectFromSequence from",
+            `<selectFromSequence name="a" from="$a[1]" to="10" numToSelect="2"/>`,
+        ],
+        [
+            "selectFromSequence numToSelect",
+            `<selectFromSequence name="a" from="1" to="10" numToSelect="$a[1]"/>`,
+        ],
+        ["sequence step", `<sequence name="a" from="1" to="10" step="$a[1]"/>`],
+        ["sequence length", `<sequence name="a" from="1" length="$a[1]"/>`],
+        [
+            "select numToSelect",
+            `<select name="a" numToSelect="$a[1]"><option><math>1</math></option><option><math>2</math></option></select>`,
+        ],
+        [
+            "repeat for",
+            `<repeat name="r" valueName="v" for="$r[1]"><number>$v</number></repeat>`,
+        ],
+        [
+            "conditionalContent condition",
+            `<conditionalContent name="c" condition="$c[1] > 0"><number>1</number></conditionalContent>`,
+        ],
+    ];
+
+    for (const [description, doenetML] of selfReferentialAttributes) {
+        it(`${description} is reported as circular`, async () => {
+            await expect(createTestCore({ doenetML })).rejects.toThrow(
+                circularError,
+            );
+        });
+    }
+
+    // Two components, each excluding a value the other has yet to produce:
+    // the same cycle, drawn across a pair rather than closed on one component.
+    it("mutually referential excludes are reported as circular", async () => {
+        await expect(
+            createTestCore({
+                doenetML: `
+    <selectFromSequence name="a" from="1" to="10" exclude="$b[1]"/>
+    <selectFromSequence name="b" from="1" to="10" exclude="$a[1]"/>
+    `,
+            }),
+        ).rejects.toThrow(circularError);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/circularReferences.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/circularReferences.test.ts
@@ -58,8 +58,22 @@ describe("Circular reference tests @group2", async () => {
         });
     }
 
+    // The message is worth checking on one case: reporting the cycle is only
+    // useful if it says where to look. It goes on to name the components the
+    // attribute expanded into, which are an implementation detail, so only the
+    // authored component is asserted.
+    it("the report names the component the attribute is on", async () => {
+        await expect(
+            createTestCore({
+                doenetML: `<selectFromSequence name="a" from="1" to="10" numToSelect="2" exclude="2$a[1]"/>`,
+            }),
+        ).rejects.toThrow(`${circularError}: <selectFromSequence> (line 1)`);
+    });
+
     // Two components, each excluding a value the other has yet to produce:
     // the same cycle, drawn across a pair rather than closed on one component.
+    // Both ends should be named, which is what distinguishes this from the
+    // cases above.
     it("mutually referential excludes are reported as circular", async () => {
         await expect(
             createTestCore({
@@ -68,6 +82,11 @@ describe("Circular reference tests @group2", async () => {
     <selectFromSequence name="b" from="1" to="10" exclude="$a[1]"/>
     `,
             }),
-        ).rejects.toThrow(circularError);
+        ).rejects.toThrow(
+            new RegExp(
+                `${circularError}:.*<selectFromSequence> \\(line 2\\).*<selectFromSequence> \\(line 3\\)`,
+                "s",
+            ),
+        );
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2264,7 +2264,9 @@ describe("SelectFromSequence tag tests @group4", async () => {
     // Doenet/DoenetML#1665: an attribute that refers back to the selection
     // cannot be evaluated until the selection is made, which in turn needs the
     // attribute. Before the resolve machinery recognized that, the two chased
-    // each other until the worker ran out of memory.
+    // each other until the worker ran out of memory. The cycle is found partway
+    // through resolution, so it fails the document rather than being reported
+    // as an error on the component the way a cycle found while building is.
     it("self-referential exclude is reported as circular", async () => {
         await expect(
             createTestCore({

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2263,9 +2263,10 @@ describe("SelectFromSequence tag tests @group4", async () => {
 
     // Doenet/DoenetML#1665: an attribute that refers back to the selection
     // cannot be evaluated until the selection is made, which in turn needs the
-    // attribute. Before the resolve machinery recognized that, the two chased
-    // each other until the worker ran out of memory. The document now fails the
-    // way any circular reference fails one, `<math name="m">$m</math>` included.
+    // attribute. Both cases exhausted the worker's heap before the fix; the
+    // document now fails the way any circular reference fails one. The wider
+    // family of self-referential attributes is in
+    // `src/test/diagnostics/circularReferences.test.ts`.
     it("self-referential exclude is reported as circular", async () => {
         await expect(
             createTestCore({

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2260,4 +2260,24 @@ describe("SelectFromSequence tag tests @group4", async () => {
         // sort with no value should produce consistent results
         expect(secondNumbers).eqls(originalNumbers);
     });
+
+    // Doenet/DoenetML#1665: an attribute that refers back to the selection
+    // cannot be evaluated until the selection is made, which in turn needs the
+    // attribute. Before the resolve machinery recognized that, the two chased
+    // each other until the worker ran out of memory.
+    it("self-referential exclude is reported as circular", async () => {
+        await expect(
+            createTestCore({
+                doenetML: `<selectFromSequence name="a" from="1" to="10" numToSelect="2" exclude="2$a[1]"/>`,
+            }),
+        ).rejects.toThrow("Circular dependency involving these components");
+    });
+
+    it("self-referential sequence bound is reported as circular", async () => {
+        await expect(
+            createTestCore({
+                doenetML: `<selectFromSequence name="a" from="1" to="$a[1]" numToSelect="2"/>`,
+            }),
+        ).rejects.toThrow("Circular dependency involving these components");
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2264,9 +2264,8 @@ describe("SelectFromSequence tag tests @group4", async () => {
     // Doenet/DoenetML#1665: an attribute that refers back to the selection
     // cannot be evaluated until the selection is made, which in turn needs the
     // attribute. Before the resolve machinery recognized that, the two chased
-    // each other until the worker ran out of memory. The cycle is found partway
-    // through resolution, so it fails the document rather than being reported
-    // as an error on the component the way a cycle found while building is.
+    // each other until the worker ran out of memory. The document now fails the
+    // way any circular reference fails one, `<math name="m">$m</math>` included.
     it("self-referential exclude is reported as circular", async () => {
         await expect(
             createTestCore({

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sequence.test.ts
@@ -2314,4 +2314,14 @@ describe("Sequence tag tests @group1", async () => {
             ).lessThan(1e-14);
         }
     });
+
+    // The same cycle `<selectFromSequence>` hits in Doenet/DoenetML#1665: the
+    // exclusion is one of the values the sequence has yet to produce.
+    it("self-referential exclude is reported as circular", async () => {
+        await expect(
+            createTestCore({
+                doenetML: `<sequence name="a" from="1" to="10" exclude="$a[1]"/>`,
+            }),
+        ).rejects.toThrow("Circular dependency involving these components");
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sequence.test.ts
@@ -2316,7 +2316,8 @@ describe("Sequence tag tests @group1", async () => {
     });
 
     // The same cycle `<selectFromSequence>` hits in Doenet/DoenetML#1665: the
-    // exclusion is one of the values the sequence has yet to produce.
+    // exclusion is one of the values the sequence has yet to produce. See
+    // `src/test/diagnostics/circularReferences.test.ts` for the wider family.
     it("self-referential exclude is reported as circular", async () => {
         await expect(
             createTestCore({


### PR DESCRIPTION
Closes #1665.

## The bug

```xml
<selectFromSequence name="a" from="1" to="10" numToSelect="2" exclude="2$a[1]"/>
```

asks for a selection that cannot be made until the exclusion is known, and an exclusion that cannot be evaluated until the selection is made. Loading it produced no warning and no error — the tab grew until it ran out of memory. A trace before the crash shows `resolveItem` recursing 2.3M times around a 16-step loop:

```
2|stateVariable|extendIdx                              ($a[1])
2|recalculateDownstreamComponents|extendIdx|refResolution
1|expandComposite                                      (selectFromSequence a)
1|readyToExpandWhenResolved → from → specifiedExclude
4|values → 7|value → 8|value → 8|unnormalizedValue
8|recalculateDownstreamComponents|unnormalizedValue|mathChildren
8|childMatches|unnormalizedValue → back to 2|readyToExpandWhenResolved
```

Nothing here is specific to `exclude` or to `<selectFromSequence>`. The same hang came from `from`, `to`, `numToSelect`, `<sequence step>` and `length`, `<select numToSelect>`, `<repeat for>`, and `<conditionalContent condition>` — any attribute written in terms of the values its own component has yet to produce.

## The cause

Doenet had recognized the cycle all along. `addBlocker` ends by running `checkForCircularResolveBlocker`, which walks the blocker graph and throws the usual `Circular dependency involving these components: …` naming what is involved.

It threw here too. The error was simply dropped: `RefResolutionDependency` registers the blocker for an unexpanded composite with a call it never awaited, so the rejection floated away and resolution carried on around the cycle until the heap was gone.

## The fix

Await the registration.

Five `await`s do it — the `addBlockerForUnexpandedComposite` calls in `refResolutionDependencies.ts`. With only those, every case in the new suite reports its cycle, and without them every one of the new tests exhausts the heap.

Eight more are awaited alongside them: `addBlockerUpdateTriggerForMissingComponent`, six in `refResolutionDependencies.ts` and two in `stateVariableDependencies.ts`. It is `async`, it ends in the same `addBlocker`, and it sits in the same `if (!component) { …; return { success: false } }` shape — the identical defect. They are closed by inspection rather than by a failing test: twelve probe documents built to route a cycle through a not-yet-created component resolve the same way with and without those eight, so nothing in the suite distinguishes them. Drop them if you would rather keep this to the five; nothing else depends on them.

`addBlockerForUnexpandedComposite` carries a comment saying why it must be awaited, and `addBlockerUpdateTriggerForMissingComponent` points at it, so the regression does not come back.

The first version of this PR also added a guard in `DependencyHandler.resolveItem` that recognized an item among its own blockers and put the question to the same check. Bisecting the two halves showed the guard carries none of the fix, and no test distinguished it, so it is not in this PR. What it offered — a backstop for a cycle whose error is swallowed somewhere else — is filed as #1756, with the design, the benchmark numbers, and the 13-test failure that taught it re-entry is not a cycle.

## Behavior

The document fails with the circular-dependency error, which is what a circular reference has always done: `<math name="m">$m</math>` and `<math extend="$m" name="m"/>` both reject core creation with the same kind of message. Confining the report to the component at fault — as a composite that catches a cycle in its own replacements manages to (`doenet-e0005`) — is left for later; the `it.skip`ped circular-dependency cases in `errors.test.ts` are waiting on that, not on this.

## Testing

- New `src/test/diagnostics/circularReferences.test.ts`: ten cases. Nine cover the family — gathered rather than spread across component suites because none is about the component, they all fail at the same step of reference resolution. The tenth pins the message, since reporting a cycle is only useful if it says where to look: it must name `<selectFromSequence> (line 1)`, and the mutually referential case must name both ends. Two cases stay in `selectfromsequence.test.ts` and one in `sequence.test.ts` for discoverability.
- Twelve of the thirteen new cycle tests were run individually against a tree with the five `await`s removed, at node's default heap: all twelve die with `JavaScript heap out of memory`. The thirteenth, the one that pins the message, loads the same document as the first. They are regression tests, not documentation.
- Full `@doenet/doenetml-worker-javascript` suite green: 168 files, 3551 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

