### PR TITLE
Add the MathJax units extension

### DIFF
--- a/.changeset/mathjax-units-extension.md
+++ b/.changeset/mathjax-units-extension.md
@@ -20,6 +20,7 @@ Documents embedded in a page that provides its own MathJax now render the same
 way they do on doenet.org. Doenet reuses such an engine rather than clobbering
 it, which previously meant none of Doenet's configuration applied there — the
 `units` macros above, and macros such as `\var`, typeset as their own names
-instead. Doenet now teaches a reused engine those macros and packages before
-rendering. Embeddings where Doenet loads MathJax itself, including every iframe
-embedding, are unaffected.
+instead. Doenet now teaches such an engine those macros and packages before
+rendering, as it does one that booted on a MathJax configuration the host staged
+for itself. Embeddings where Doenet's own configuration reaches the engine,
+including every iframe embedding, render as they did.

--- a/.changeset/mathjax-units-extension.md
+++ b/.changeset/mathjax-units-extension.md
@@ -1,0 +1,25 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Math can now be written with MathJax's `units` extension.
+
+`\units` typesets a quantity beside its unit with the spacing a typesetter
+would use, instead of leaving authors to approximate it with `\,` and
+`\mathrm`. The same extension supplies `\unitfrac` and `\nicefrac`.
+
+```
+<m>\units{9.8}{\text{m}/\text{s}^2}</m>
+```
+
+Documents embedded in a page that provides its own MathJax now render the same
+way they do on doenet.org. Doenet reuses such an engine rather than clobbering
+it, which previously meant none of Doenet's configuration applied there — the
+`units` macros above, and macros such as `\var`, typeset as their own names
+instead. Doenet now teaches a reused engine those macros and packages before
+rendering. Embeddings where Doenet loads MathJax itself, including every iframe
+embedding, are unaffected.

--- a/.changeset/mathjax-units-extension.md
+++ b/.changeset/mathjax-units-extension.md
@@ -18,9 +18,6 @@ would use, instead of leaving authors to approximate it with `\,` and
 
 Documents embedded in a page that provides its own MathJax now render the same
 way they do on doenet.org. Doenet reuses such an engine rather than clobbering
-it, which previously meant none of Doenet's configuration applied there — the
-`units` macros above, and macros such as `\var`, typeset as their own names
-instead. Doenet now teaches such an engine those macros and packages before
-rendering, as it does one that booted on a MathJax configuration the host staged
-for itself. Embeddings where Doenet's own configuration reaches the engine,
-including every iframe embedding, render as they did.
+it, which meant none of Doenet's configuration applied there — `\units` and
+macros such as `\var` typeset as their own names. Doenet now teaches that engine
+its macros and packages before rendering.

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-1-writing-mathematics.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-1-writing-mathematics.mdx
@@ -72,6 +72,16 @@ The `<m>` and `<me>` tags do not recognize strings such as "sqrt" or "sin" as ma
 <me>\sin{(a+b)}</me>
 ```
 
+Quantities with units are typeset with the [`units` extension](https://docs.mathjax.org/en/latest/input/tex/extensions/units.html), which spaces a number and its unit the way a typesetter would, so you don't have to reach for `\,` and `\mathrm` by hand. It supplies `\units`, along with `\unitfrac` and `\nicefrac` for the fractions that units tend to bring with them:
+
+```doenet-editor-horiz
+<p>The ball fell at <m>\units{9.8}{\text{m}/\text{s}^2}</m>.</p>
+
+<me>c = \units{3 \times 10^8}{\text{m}/\text{s}}</me>
+
+<p>A rate of <m>\unitfrac[60]{\text{mi}}{\text{hr}}</m> is <m>\nicefrac{1}{60}</m> of a mile per second.</p>
+```
+
 A full LaTeX introduction is beyond the scope of this tutorial. If you're not familiar with LaTeX, we highly encourage you to search online for an introduction to typing mathematics in LaTeX, such as [this guide](https://overleaf.com/learn/latex/Mathematical_expressions) from Overleaf.
 
 ### Lists and other HTML Tags

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-1-writing-mathematics.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-1-writing-mathematics.mdx
@@ -75,7 +75,7 @@ The `<m>` and `<me>` tags do not recognize strings such as "sqrt" or "sin" as ma
 Quantities with units are typeset with the [`units` extension](https://docs.mathjax.org/en/latest/input/tex/extensions/units.html), which spaces a number and its unit the way a typesetter would, so you don't have to reach for `\,` and `\mathrm` by hand. It supplies `\units`, along with `\unitfrac` and `\nicefrac` for the fractions that units tend to bring with them:
 
 ```doenet-editor-horiz
-<p>The ball fell at <m>\units{9.8}{\text{m}/\text{s}^2}</m>.</p>
+<p>The ball accelerated at <m>\units{9.8}{\text{m}/\text{s}^2}</m>.</p>
 
 <me>c = \units{3 \times 10^8}{\text{m}/\text{s}}</me>
 

--- a/packages/test-cypress/cypress/e2e/standalone/hostMathJaxPriming.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/hostMathJaxPriming.cy.js
@@ -5,9 +5,10 @@ import { normalizeMathTextForComparison } from "../../../src/util/mathDisplay";
 // stock: no Doenet macros, no `units` package. Without priming, `\units` and
 // `\var` reach MathJax's `noundefined` handler and typeset as the macro names
 // themselves — the "works on doenet.org, breaks when embedded" divergence.
-// The page also has the host typeset its own math through the same engine
-// afterwards, so a regression that primed by breaking the host would fail here
-// too rather than pass quietly.
+// The page also has the host typeset its own math through the same engine,
+// after Doenet's math has rendered and so after priming has written to it, so a
+// regression that primed by breaking the host would fail here too rather than
+// pass quietly.
 
 describe(
     "standalone priming of a host-provided MathJax",
@@ -45,8 +46,8 @@ describe(
                 expect(el.text()).eq("x");
             });
 
-            // Priming writes to the host's engine; the host's own math must
-            // still typeset through it.
+            // Priming writes to the host's engine; the host's own math, typeset
+            // through it after priming, must still come out right.
             cy.window()
                 .its("__hostMathJaxProbe.hostTypesetDone")
                 .should("be.true");

--- a/packages/test-cypress/cypress/e2e/standalone/hostMathJaxPriming.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/hostMathJaxPriming.cy.js
@@ -1,0 +1,58 @@
+import { normalizeMathTextForComparison } from "../../../src/util/mathDisplay";
+
+// E2E proof that a document renders the same on a host's MathJax as on one
+// Doenet loaded itself (public/host-mathjax-page.html). The host's engine is
+// stock: no Doenet macros, no `units` package. Without priming, `\units` and
+// `\var` reach MathJax's `noundefined` handler and typeset as the macro names
+// themselves — the "works on doenet.org, breaks when embedded" divergence.
+// The page also has the host typeset its own math through the same engine
+// afterwards, so a regression that primed by breaking the host would fail here
+// too rather than pass quietly.
+
+describe(
+    "standalone priming of a host-provided MathJax",
+    { tags: ["@group1"], retries: 1 },
+    () => {
+        it("renders Doenet's macros and TeX packages on an engine the host configured", () => {
+            cy.visit("/host-mathjax-page.html");
+
+            // Guard the premise: everything below would also pass if Doenet had
+            // ignored the host's engine and loaded its own configured copy, and
+            // the test would then prove nothing about priming. Exactly one
+            // MathJax is on the page and it is the host's.
+            cy.get("script[data-doenet-mathjax]").should("not.exist");
+            cy.get('script[src*="mathjax"]').should("have.length", 1);
+
+            // Sanity: ordinary math renders, so we are reading a live engine
+            // and not an empty page.
+            cy.get("#plain").should((el) => {
+                expect(normalizeMathTextForComparison(el.text())).eq("y2");
+            });
+
+            // From the `units` package, which the host's engine never loaded.
+            cy.get("#units").should((el) => {
+                expect(normalizeMathTextForComparison(el.text())).eq("9.8m/s2");
+            });
+            cy.get("#nicefrac").should((el) => {
+                expect(normalizeMathTextForComparison(el.text())).eq("1/2");
+            });
+
+            // From Doenet's `macros`, which the host's engine never saw.
+            // `\var{x}` is `\mathrm{x}`: upright "x", not the italic 𝑥 that an
+            // unstyled x would render as, and not the literal "\varx" that an
+            // unprimed engine produces.
+            cy.get("#macro").should((el) => {
+                expect(el.text()).eq("x");
+            });
+
+            // Priming writes to the host's engine; the host's own math must
+            // still typeset through it.
+            cy.window()
+                .its("__hostMathJaxProbe.hostTypesetDone")
+                .should("be.true");
+            cy.get("#host-math").should((el) => {
+                expect(normalizeMathTextForComparison(el.text())).eq("a2+b2");
+            });
+        });
+    },
+);

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathdisplay.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathdisplay.cy.js
@@ -1,5 +1,8 @@
 import { cesc } from "@doenet/utils";
-import { toMathJaxString } from "../../../src/util/mathDisplay";
+import {
+    normalizeMathTextForComparison,
+    toMathJaxString,
+} from "../../../src/util/mathDisplay";
 
 describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
     beforeEach(() => {
@@ -872,5 +875,35 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
         cy.get("#bcancel").should("have.text", toMathJaxString("y"));
         cy.get("#bbox").should("have.text", toMathJaxString("R"));
         cy.get("#circle").should("have.text", toMathJaxString("1"));
+    });
+
+    it("mathjax has the units extension", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+
+    <m name="units">\\units{5}{\\text{m}/\\text{s}}</m>
+    <m name="unitfrac">\\unitfrac[5]{\\text{m}}{\\text{s}}</m>
+    <m name="nicefrac">\\nicefrac{1}{2}</m>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // `units` is not one of the packages the combined MathJax component
+        // carries, nor one `autoload` knows about, so it renders only if our
+        // configuration actually asked for it. Without it, `noundefined` would
+        // typeset the macro names themselves — `\units5m/s` rather than `5m/s`.
+        cy.get("#units").should((el) => {
+            expect(normalizeMathTextForComparison(el.text())).eq("5m/s");
+        });
+        cy.get("#unitfrac").should((el) => {
+            expect(normalizeMathTextForComparison(el.text())).eq("5m/s");
+        });
+        cy.get("#nicefrac").should((el) => {
+            expect(normalizeMathTextForComparison(el.text())).eq("1/2");
+        });
     });
 });

--- a/packages/test-cypress/public/host-mathjax-page.html
+++ b/packages/test-cypress/public/host-mathjax-page.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<!-- A page that already owns MathJax before Doenet boots — the React-app and
+     PreTeXt-style embeddings that load the standalone bundle inline rather than
+     through an iframe. The engine here is configured the way a host would
+     configure it: it knows nothing of Doenet's macros and carries no `units`
+     package. Doenet finds a live engine, reuses it rather than clobbering it,
+     and primes it so the document still renders as it does on doenet.org.
+     Asserted by e2e/standalone/hostMathJaxPriming.cy.js. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script>
+            // A stock host configuration. Deliberately NOT Doenet's: no
+            // `macros`, no `packages`. `typeset: false` only stops the initial
+            // page sweep, so what renders below is what someone asked for.
+            window.MathJax = { startup: { typeset: false } };
+        </script>
+        <script src="https://cdn.jsdelivr.net/npm/mathjax@4.1.3/tex-mml-chtml.js"></script>
+        <script type="module">
+            // Boot the host's engine FIRST, so `window.MathJax` is a live
+            // engine by the time the bundle looks — the reuse path.
+            await window.MathJax.startup.promise;
+            await import("/standalone/doenet-standalone.js");
+            window.renderDoenetViewerToContainer(
+                document.querySelector(".doenetml-applet"),
+            );
+            // The host's own math, typeset by the host through the same engine
+            // Doenet just primed. It must be unaffected.
+            await window.MathJax.typesetPromise([
+                document.getElementById("host-math"),
+            ]);
+            window.__hostMathJaxProbe = { hostTypesetDone: true };
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+                <p name="units"><m>\units{9.8}{\text{m}/\text{s}^2}</m></p>
+                <p name="nicefrac"><m>\nicefrac{1}{2}</m></p>
+                <p name="macro"><m>\var{x}</m></p>
+                <p name="plain"><m>y^2</m></p>
+            </script>
+        </div>
+        <div id="host-math">\(a^2+b^2\)</div>
+    </body>
+</html>

--- a/packages/test-cypress/public/host-mathjax-page.html
+++ b/packages/test-cypress/public/host-mathjax-page.html
@@ -25,6 +25,21 @@
             window.renderDoenetViewerToContainer(
                 document.querySelector(".doenetml-applet"),
             );
+            // Wait for Doenet's math to be on the page before the host typesets
+            // any of its own. Doenet renders only after priming has written to
+            // this engine, so this is what makes the host's typesetting below
+            // unambiguously *after* priming — typesetting straight away could
+            // win the race and prove nothing about priming's effect on a host.
+            await new Promise((resolve) => {
+                function poll() {
+                    if (document.querySelector("#units mjx-container")) {
+                        resolve();
+                    } else {
+                        setTimeout(poll, 50);
+                    }
+                }
+                poll();
+            });
             // The host's own math, typeset by the host through the same engine
             // Doenet just primed. It must be unaffected.
             await window.MathJax.typesetPromise([

--- a/packages/utils/src/math/math.ts
+++ b/packages/utils/src/math/math.ts
@@ -4,8 +4,10 @@
  * When a host page already provides MathJax, Doenet reuses that engine rather
  * than clobbering it, so this object is never staged there. The `macros` and the
  * `tex.packages` added below are applied to such an engine after the fact
- * instead, by the priming step in `loadMathJax`; the remaining options
- * (`tags`, `displayMath`, `output`) stay the host's to decide.
+ * instead, by the priming step in `loadMathJax` — whose `\require` both fetches
+ * an added package and enables it, covering the `loader.load` entry too. The
+ * remaining options (`tags`, `displayMath`, `output`) stay the host's to decide,
+ * so e.g. long displayed equations do not line-break on a host engine.
  */
 export const mathjaxConfig = {
     loader: {

--- a/packages/utils/src/math/math.ts
+++ b/packages/utils/src/math/math.ts
@@ -1,6 +1,25 @@
+/**
+ * Configuration staged as `window.MathJax` for the MathJax copy Doenet loads.
+ *
+ * Note that this only governs *our* engine: when a host page already provides
+ * MathJax, Doenet reuses it and this configuration is not applied (see
+ * `loadMathJax`). Authors on such a page can still reach the extensions below
+ * with MathJax's `\require`, e.g. `\require{units}`.
+ */
 export const mathjaxConfig = {
+    loader: {
+        // The `units` package is neither bundled into the combined component
+        // we load nor reachable through `autoload`, so it has to be requested
+        // by name. MathJax fetches it during startup, from the same place it
+        // gets the rest of its components.
+        load: ["[tex]/units"],
+    },
     tex: {
         tags: "ams",
+        // `[+]` adds to MathJax's default package list rather than replacing
+        // it. `units` supplies `\units`, `\unitfrac`, and `\nicefrac`, so that
+        // units can be typeset semantically instead of hand-spaced.
+        packages: { "[+]": ["units"] },
         macros: {
             lt: "<",
             gt: ">",

--- a/packages/utils/src/math/math.ts
+++ b/packages/utils/src/math/math.ts
@@ -1,10 +1,11 @@
 /**
  * Configuration staged as `window.MathJax` for the MathJax copy Doenet loads.
  *
- * Note that this only governs *our* engine: when a host page already provides
- * MathJax, Doenet reuses it and this configuration is not applied (see
- * `loadMathJax`). Authors on such a page can still reach the extensions below
- * with MathJax's `\require`, e.g. `\require{units}`.
+ * When a host page already provides MathJax, Doenet reuses that engine rather
+ * than clobbering it, so this object is never staged there. The `macros` and the
+ * `tex.packages` added below are applied to such an engine after the fact
+ * instead, by the priming step in `loadMathJax`; the remaining options
+ * (`tags`, `displayMath`, `output`) stay the host's to decide.
  */
 export const mathjaxConfig = {
     loader: {

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -479,6 +479,19 @@ describe("priming a host-provided MathJax", () => {
         ]);
     });
 
+    it("leaves an engine with no TeX input jax alone", async () => {
+        // `tex2mmlPromise` is defined only once a TeX input jax is in play, so
+        // a MathML-only host engine has none. There is nothing to prime through
+        // and nothing priming could rescue; it must simply not throw.
+        const engine = makeEngine();
+        delete (engine as any).tex2mmlPromise;
+        (globalThis as any).window.MathJax = engine;
+
+        await expect(loadMathJax({ config })).resolves.toBe(engine);
+
+        expect(engine.converted).toEqual([]);
+    });
+
     it("primes nothing when there is no configuration to reproduce", async () => {
         const engine = makeEngine();
         (globalThis as any).window.MathJax = engine;

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -489,6 +489,30 @@ describe("priming a host-provided MathJax", () => {
         }
     });
 
+    it("primes the copy it injects when a host config already claimed the global", async () => {
+        const win = (globalThis as any).window;
+        // A host staged a config of its own but has not added a script yet. We
+        // load MathJax without clobbering that config, so the engine boots on
+        // the host's terms and is as short of our macros as the host's own
+        // engine would have been.
+        const hostConfig = { tex: { macros: {} } };
+        win.MathJax = hostConfig;
+
+        const promise = loadMathJax({ config });
+        expect(appendedScripts).toHaveLength(1);
+        expect(win.MathJax).toBe(hostConfig);
+
+        const engine = makeEngine();
+        win.MathJax = engine;
+        appendedScripts[0]._fire("load");
+        await expect(promise).resolves.toBe(engine);
+
+        expect(engine.typeset).toEqual([
+            "\\(\\def\\lt{<}\\def\\var#1{\\mathrm{#1}}\\)",
+            "\\(\\require{units}\\)",
+        ]);
+    });
+
     it("primes nothing when there is no configuration to reproduce", async () => {
         const engine = makeEngine();
         (globalThis as any).window.MathJax = engine;

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -45,18 +45,50 @@ function makeScript(src = ""): FakeScript {
     };
 }
 
+/**
+ * The offscreen element priming typesets into. Only the handful of members
+ * `typesetForSideEffect` touches are modelled.
+ */
+type FakeElement = {
+    textContent: string;
+    style: { cssText: string };
+    setAttribute: (name: string, value: string) => void;
+    remove: () => void;
+    _removed: boolean;
+};
+
+function makeElement(): FakeElement {
+    return {
+        textContent: "",
+        style: { cssText: "" },
+        setAttribute() {},
+        remove() {
+            this._removed = true;
+        },
+        _removed: false,
+    };
+}
+
 let appendedScripts: FakeScript[];
 let domScripts: FakeScript[];
+let bodyChildren: FakeElement[];
 
 function installFakeDom() {
     appendedScripts = [];
     domScripts = [];
+    bodyChildren = [];
     const fakeDocument = {
-        createElement: (_tag: string) => makeScript(),
+        createElement: (tag: string) =>
+            tag === "script" ? makeScript() : makeElement(),
         head: {
             appendChild: (script: FakeScript) => {
                 appendedScripts.push(script);
                 domScripts.push(script);
+            },
+        },
+        body: {
+            appendChild: (element: FakeElement) => {
+                bodyChildren.push(element);
             },
         },
         querySelectorAll: (_selector: string) =>
@@ -78,13 +110,25 @@ function installFakeDom() {
  * with an object `startup` hid the bug where `isMathJaxEngine` rejected every
  * MathJax 4 host engine.
  */
-function makeEngine() {
+function makeEngine(
+    options: { failTypesetting?: (tex: string) => boolean } = {},
+) {
     const startup: any = () => {};
     startup.promise = Promise.resolve();
+    // Everything the engine was asked to typeset, in order — which for a primed
+    // host engine is exactly the priming fragments.
+    const typeset: string[] = [];
     return {
         version: "4.1.3",
         startup,
-        typesetPromise: () => Promise.resolve(),
+        typeset,
+        typesetPromise: (elements: FakeElement[]) => {
+            const tex = elements[0]?.textContent ?? "";
+            typeset.push(tex);
+            return options.failTypesetting?.(tex)
+                ? Promise.reject(new Error(`cannot typeset ${tex}`))
+                : Promise.resolve();
+        },
         typesetClear: () => {},
     };
 }
@@ -322,5 +366,135 @@ describe("loadMathJax", () => {
         win.MathJax = engine;
         appendedScripts[1]._fire("load");
         await expect(second).resolves.toBe(engine);
+    });
+});
+
+/**
+ * Priming is what makes a document render the same on a host's engine as on one
+ * Doenet loaded: the engine never saw our config, so we teach it the macros and
+ * TeX packages that config would have given it. These tests pin down both that
+ * it happens where it must, and that it does *not* happen where our own config
+ * is already in effect — the common case, which must pay nothing for it.
+ */
+describe("priming a host-provided MathJax", () => {
+    const config = {
+        tex: {
+            macros: {
+                lt: "<",
+                var: ["\\mathrm{#1}", 1],
+                // A `\def` cannot express an optional argument, and control
+                // sequences are letters-only; both are skipped, not approximated.
+                withOptional: ["\\tfrac{#1}{#2}", 2, "1"],
+                "not-a-name": "\\alpha",
+            },
+            packages: { "[+]": ["units"] },
+        },
+    };
+
+    beforeEach(() => {
+        installFakeDom();
+    });
+
+    it("teaches a reused host engine our macros and added packages", async () => {
+        const engine = makeEngine();
+        (globalThis as any).window.MathJax = engine;
+
+        await expect(loadMathJax({ config })).resolves.toBe(engine);
+
+        expect(engine.typeset).toEqual([
+            "\\(\\def\\lt{<}\\def\\var#1{\\mathrm{#1}}\\)",
+            "\\(\\require{units}\\)",
+        ]);
+        // Every offscreen host is cleaned up, however the typeset went.
+        expect(bodyChildren).toHaveLength(2);
+        expect(bodyChildren.every((element) => element._removed)).toBe(true);
+    });
+
+    it("keeps \\require in its own typeset so an unavailable package cannot take the macros down with it", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // A host whose MathJax has no `units` package to load.
+            const engine = makeEngine({
+                failTypesetting: (tex) => tex.includes("\\require"),
+            });
+            (globalThis as any).window.MathJax = engine;
+
+            await expect(loadMathJax({ config })).resolves.toBe(engine);
+
+            // The definitions were typeset before — and separately from — the
+            // package that failed, so they still took effect.
+            expect(engine.typeset[0]).toContain("\\def\\var#1{\\mathrm{#1}}");
+            expect(engine.typeset).toHaveLength(2);
+            expect(warnSpy).toHaveBeenCalled();
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    it("still resolves the engine when priming fails outright", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const engine = makeEngine({ failTypesetting: () => true });
+            (globalThis as any).window.MathJax = engine;
+
+            // Priming is best-effort on an engine we do not own; a failure must
+            // degrade to "renders as the host would" rather than to no math.
+            await expect(loadMathJax({ config })).resolves.toBe(engine);
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    it("does not prime an engine it loaded and configured itself", async () => {
+        const win = (globalThis as any).window;
+
+        const promise = loadMathJax({ config });
+        expect(appendedScripts).toHaveLength(1);
+
+        const engine = makeEngine();
+        win.MathJax = engine;
+        appendedScripts[0]._fire("load");
+        await expect(promise).resolves.toBe(engine);
+
+        // `config` was staged on this engine before it booted, so its macros and
+        // packages are already in effect — priming it would be pure overhead.
+        expect(engine.typeset).toEqual([]);
+        expect(bodyChildren).toHaveLength(0);
+    });
+
+    it("does not prime the takeover copy loaded after a host engine never appears", async () => {
+        vi.useFakeTimers();
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const win = (globalThis as any).window;
+            const promise = loadMathJax({
+                useExistingMathJax: true,
+                timeoutMs: 1000,
+                config,
+            });
+            await vi.advanceTimersByTimeAsync(1100);
+
+            // The fallback stages `config` on the copy it injects, so this
+            // engine is ours despite having started down the host branch.
+            expect(appendedScripts).toHaveLength(1);
+            const engine = makeEngine();
+            win.MathJax = engine;
+            appendedScripts[0]._fire("load");
+            await expect(promise).resolves.toBe(engine);
+
+            expect(engine.typeset).toEqual([]);
+        } finally {
+            warnSpy.mockRestore();
+            vi.useRealTimers();
+        }
+    });
+
+    it("primes nothing when there is no configuration to reproduce", async () => {
+        const engine = makeEngine();
+        (globalThis as any).window.MathJax = engine;
+
+        await expect(loadMathJax()).resolves.toBe(engine);
+
+        expect(engine.typeset).toEqual([]);
     });
 });

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -45,50 +45,18 @@ function makeScript(src = ""): FakeScript {
     };
 }
 
-/**
- * The offscreen element priming typesets into. Only the handful of members
- * `typesetForSideEffect` touches are modelled.
- */
-type FakeElement = {
-    textContent: string;
-    style: { cssText: string };
-    setAttribute: (name: string, value: string) => void;
-    remove: () => void;
-    _removed: boolean;
-};
-
-function makeElement(): FakeElement {
-    return {
-        textContent: "",
-        style: { cssText: "" },
-        setAttribute() {},
-        remove() {
-            this._removed = true;
-        },
-        _removed: false,
-    };
-}
-
 let appendedScripts: FakeScript[];
 let domScripts: FakeScript[];
-let bodyChildren: FakeElement[];
 
 function installFakeDom() {
     appendedScripts = [];
     domScripts = [];
-    bodyChildren = [];
     const fakeDocument = {
-        createElement: (tag: string) =>
-            tag === "script" ? makeScript() : makeElement(),
+        createElement: (_tag: string) => makeScript(),
         head: {
             appendChild: (script: FakeScript) => {
                 appendedScripts.push(script);
                 domScripts.push(script);
-            },
-        },
-        body: {
-            appendChild: (element: FakeElement) => {
-                bodyChildren.push(element);
             },
         },
         querySelectorAll: (_selector: string) =>
@@ -111,25 +79,27 @@ function installFakeDom() {
  * MathJax 4 host engine.
  */
 function makeEngine(
-    options: { failTypesetting?: (tex: string) => boolean } = {},
+    options: { failConversion?: (tex: string) => boolean } = {},
 ) {
     const startup: any = () => {};
     startup.promise = Promise.resolve();
-    // Everything the engine was asked to typeset, in order — which for a primed
+    // Everything the engine was asked to convert, in order — which for a primed
     // host engine is exactly the priming fragments.
-    const typeset: string[] = [];
+    const converted: string[] = [];
     return {
         version: "4.1.3",
         startup,
-        typeset,
-        typesetPromise: (elements: FakeElement[]) => {
-            const tex = elements[0]?.textContent ?? "";
-            typeset.push(tex);
-            return options.failTypesetting?.(tex)
-                ? Promise.reject(new Error(`cannot typeset ${tex}`))
-                : Promise.resolve();
-        },
+        converted,
+        typesetPromise: () => Promise.resolve(),
         typesetClear: () => {},
+        // Priming reaches the TeX input jax through this rather than through the
+        // page, so it is what records what was primed.
+        tex2mmlPromise: (tex: string) => {
+            converted.push(tex);
+            return options.failConversion?.(tex)
+                ? Promise.reject(new Error(`cannot convert ${tex}`))
+                : Promise.resolve("<math/>");
+        },
     };
 }
 
@@ -401,30 +371,27 @@ describe("priming a host-provided MathJax", () => {
 
         await expect(loadMathJax({ config })).resolves.toBe(engine);
 
-        expect(engine.typeset).toEqual([
-            "\\(\\def\\lt{<}\\def\\var#1{\\mathrm{#1}}\\)",
-            "\\(\\require{units}\\)",
+        expect(engine.converted).toEqual([
+            "\\def\\lt{<}\\def\\var#1{\\mathrm{#1}}",
+            "\\require{units}",
         ]);
-        // Every offscreen host is cleaned up, however the typeset went.
-        expect(bodyChildren).toHaveLength(2);
-        expect(bodyChildren.every((element) => element._removed)).toBe(true);
     });
 
-    it("keeps \\require in its own typeset so an unavailable package cannot take the macros down with it", async () => {
+    it("keeps \\require in its own conversion so an unavailable package cannot take the macros down with it", async () => {
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         try {
             // A host whose MathJax has no `units` package to load.
             const engine = makeEngine({
-                failTypesetting: (tex) => tex.includes("\\require"),
+                failConversion: (tex) => tex.includes("\\require"),
             });
             (globalThis as any).window.MathJax = engine;
 
             await expect(loadMathJax({ config })).resolves.toBe(engine);
 
-            // The definitions were typeset before — and separately from — the
+            // The definitions were converted before — and separately from — the
             // package that failed, so they still took effect.
-            expect(engine.typeset[0]).toContain("\\def\\var#1{\\mathrm{#1}}");
-            expect(engine.typeset).toHaveLength(2);
+            expect(engine.converted[0]).toContain("\\def\\var#1{\\mathrm{#1}}");
+            expect(engine.converted).toHaveLength(2);
             expect(warnSpy).toHaveBeenCalled();
         } finally {
             warnSpy.mockRestore();
@@ -434,7 +401,7 @@ describe("priming a host-provided MathJax", () => {
     it("still resolves the engine when priming fails outright", async () => {
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         try {
-            const engine = makeEngine({ failTypesetting: () => true });
+            const engine = makeEngine({ failConversion: () => true });
             (globalThis as any).window.MathJax = engine;
 
             // Priming is best-effort on an engine we do not own; a failure must
@@ -458,8 +425,7 @@ describe("priming a host-provided MathJax", () => {
 
         // `config` was staged on this engine before it booted, so its macros and
         // packages are already in effect — priming it would be pure overhead.
-        expect(engine.typeset).toEqual([]);
-        expect(bodyChildren).toHaveLength(0);
+        expect(engine.converted).toEqual([]);
     });
 
     it("does not prime the takeover copy loaded after a host engine never appears", async () => {
@@ -482,7 +448,7 @@ describe("priming a host-provided MathJax", () => {
             appendedScripts[0]._fire("load");
             await expect(promise).resolves.toBe(engine);
 
-            expect(engine.typeset).toEqual([]);
+            expect(engine.converted).toEqual([]);
         } finally {
             warnSpy.mockRestore();
             vi.useRealTimers();
@@ -507,9 +473,9 @@ describe("priming a host-provided MathJax", () => {
         appendedScripts[0]._fire("load");
         await expect(promise).resolves.toBe(engine);
 
-        expect(engine.typeset).toEqual([
-            "\\(\\def\\lt{<}\\def\\var#1{\\mathrm{#1}}\\)",
-            "\\(\\require{units}\\)",
+        expect(engine.converted).toEqual([
+            "\\def\\lt{<}\\def\\var#1{\\mathrm{#1}}",
+            "\\require{units}",
         ]);
     });
 
@@ -519,6 +485,6 @@ describe("priming a host-provided MathJax", () => {
 
         await expect(loadMathJax()).resolves.toBe(engine);
 
-        expect(engine.typeset).toEqual([]);
+        expect(engine.converted).toEqual([]);
     });
 });

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -27,10 +27,11 @@
  * TeX packages Doenet's documents rely on are simply absent there — an author's
  * `\units{9.8}{...}` renders as a bare `\units` on a host page and correctly on
  * doenet.org. To close that gap, such an engine is *primed*: before the shared
- * promise resolves, we typeset a hidden expression that reproduces our
- * configured macros as `\def`s and pulls in our added TeX packages with
- * `\require`. MathJax keeps such definitions for the life of the document, so
- * this happens once rather than per expression. See
+ * promise resolves, we run an expression through its TeX input jax that
+ * reproduces our configured macros as `\def`s and pulls in our added TeX
+ * packages with `\require`. Nothing is rendered or added to the page; the point
+ * is the state that expression leaves behind in the jax, which MathJax keeps for
+ * the life of the document, so this happens once rather than per expression. See
  * {@link primeUnconfiguredEngine} for what that costs the host.
  *
  * Priming is deliberately skipped whenever the engine booted on our own
@@ -66,6 +67,12 @@ export interface MathJaxEngine {
     startup?: { promise?: Promise<unknown> } & Record<string, unknown>;
     typesetPromise?: (...args: unknown[]) => Promise<unknown>;
     typesetClear?: (...args: unknown[]) => unknown;
+    /**
+     * Direct TeX-to-MathML conversion, added by MathJax's startup when a TeX
+     * input jax is loaded. Used by priming to reach that jax without going
+     * through the page (see {@link primeUnconfiguredEngine}).
+     */
+    tex2mmlPromise?: (...args: unknown[]) => Promise<unknown>;
     version?: string;
     [key: string]: unknown;
 }
@@ -342,48 +349,37 @@ function texPackagesFromConfig(config: object | undefined): string[] {
 }
 
 /**
- * Typesets `tex` into a throwaway offscreen element purely for its side effect
- * on the engine, and resolves whether or not that worked.
+ * Runs `tex` through the engine's TeX input jax purely for the state it leaves
+ * behind there — a macro table entry, a loaded package — and resolves whether or
+ * not that worked.
+ *
+ * Direct conversion rather than typesetting a hidden element: it reaches the
+ * same input jax the engine renders everything else with, so the definitions
+ * persist, while depending on neither the host's math delimiters (which a host
+ * is free to redefine, and `\(`…`\)` need not survive) nor its ignored-element
+ * rules, and putting nothing into the page.
  *
  * Never rejects: priming is a best-effort improvement on an engine we did not
  * configure, and a failure here must not stop the math that follows from
  * rendering.
  */
-async function typesetForSideEffect(
+async function convertForSideEffect(
     engine: MathJaxEngine,
     tex: string,
 ): Promise<void> {
-    if (typeof engine.typesetPromise !== "function") {
+    // Defined by MathJax's startup once a TeX input jax is in play, so absent
+    // exactly when there are no TeX macros to teach in the first place.
+    if (typeof engine.tex2mmlPromise !== "function") {
         return;
     }
-    const parent = document.body ?? document.documentElement;
-    if (!parent) {
-        return;
-    }
-    const host = document.createElement("div");
-    host.setAttribute("aria-hidden", "true");
-    host.style.cssText =
-        "position:absolute;left:-9999px;top:0;width:0;height:0;overflow:hidden;visibility:hidden";
-    // Offscreen rather than `display: none`, because the output jax measures
-    // what it typesets and an undisplayed subtree has no metrics to measure.
-    host.textContent = `\\(${tex}\\)`;
-    parent.appendChild(host);
     try {
-        await engine.typesetPromise([host]);
+        await engine.tex2mmlPromise(tex);
     } catch (reason) {
         console.warn(
             `DoenetViewer: could not prime MathJax with "${tex}"; ` +
                 "math relying on it may not render as it does on doenet.org.",
             reason,
         );
-    } finally {
-        try {
-            engine.typesetClear?.([host]);
-        } catch {
-            // `typesetClear` only drops bookkeeping for an element we are about
-            // to discard; if the host engine dislikes it, nothing is lost.
-        }
-        host.remove();
     }
 }
 
@@ -401,7 +397,7 @@ async function typesetForSideEffect(
  *    means a host that defines any of the same names gets ours instead. The
  *    names come from Doenet's own configuration, so the exposure is limited to
  *    what a Doenet document could already have relied on.
- *  - Each fragment is typeset separately. `\require` throws when a package
+ *  - Each fragment is converted separately. `\require` throws when a package
  *    cannot be loaded, and MathJax abandons the rest of the expression when it
  *    does; batching would let one unavailable package silently take the macro
  *    definitions down with it.
@@ -413,15 +409,15 @@ async function primeUnconfiguredEngine(
     try {
         await engine.startup?.promise;
     } catch {
-        // An engine that reports a failed startup may still typeset; let the
+        // An engine that reports a failed startup may still convert; let the
         // priming attempts below find out rather than deciding here.
     }
     const defs = texDefsFromConfig(config);
     if (defs) {
-        await typesetForSideEffect(engine, defs);
+        await convertForSideEffect(engine, defs);
     }
     for (const packageName of texPackagesFromConfig(config)) {
-        await typesetForSideEffect(engine, `\\require{${packageName}}`);
+        await convertForSideEffect(engine, `\\require{${packageName}}`);
     }
     return engine;
 }

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -23,19 +23,19 @@
  *  - Otherwise, inject our own copy — and only stage `window.MathJax = config`
  *    when nothing else has claimed that global.
  *
- * When we end up on someone else's engine, our configuration never reaches it,
- * so the macros and TeX packages Doenet's documents rely on are simply absent
- * there — an author's `\\units{9.8}{...}` renders as a red `\\units` on a host
- * page and correctly on doenet.org. To close that gap, a foreign engine is
- * *primed*: before the shared promise resolves, we typeset a hidden expression
- * that reproduces our configured macros as `\\def`s and pulls in our added TeX
- * packages with `\\require`. MathJax keeps such definitions for the life of the
- * document, so this happens once rather than per expression. See
- * {@link primeForeignEngine} for what that costs the host.
+ * Whenever our configuration does not reach the engine in play, the macros and
+ * TeX packages Doenet's documents rely on are simply absent there — an author's
+ * `\units{9.8}{...}` renders as a bare `\units` on a host page and correctly on
+ * doenet.org. To close that gap, such an engine is *primed*: before the shared
+ * promise resolves, we typeset a hidden expression that reproduces our
+ * configured macros as `\def`s and pulls in our added TeX packages with
+ * `\require`. MathJax keeps such definitions for the life of the document, so
+ * this happens once rather than per expression. See
+ * {@link primeUnconfiguredEngine} for what that costs the host.
  *
- * Priming is deliberately skipped whenever the engine is one we configured
- * ourselves — the common case, including every iframe embedding — so the usual
- * path pays nothing for it.
+ * Priming is deliberately skipped whenever the engine booted on our own
+ * configuration — the common case, including every iframe embedding — so the
+ * usual path pays nothing for it.
  *
  * The resulting promise is memoized on `window` so that every viewer, editor,
  * and virtual-keyboard tray in the realm shares a single MathJax, regardless of
@@ -85,7 +85,9 @@ export interface LoadMathJaxOptions {
      * script loads. Left unset while a host MathJax engine or script is in play,
      * so a host's configuration is never overwritten — unless that host engine
      * never becomes usable and the timeout fallback takes over (see
-     * {@link loadMathJax}), in which case this config is staged instead.
+     * {@link loadMathJax}), in which case this config is staged instead. Where
+     * it cannot be staged, its macros and added TeX packages are instead applied
+     * to the resulting engine by priming (see {@link loadMathJax}).
      */
     config?: object;
     /**
@@ -218,6 +220,10 @@ function waitForExistingMathJax(timeoutMs: number): Promise<MathJaxEngine> {
  * never became usable. Overwriting the stale global with our config (as
  * Doenet ≤0.7.20 always did) is what lets our own engine initialize cleanly,
  * rather than colliding with a half-loaded or unrecognized host engine.
+ *
+ * When a host config was left in place, the engine we load boots on *its* terms
+ * rather than ours, so the result is primed exactly as a host's own engine
+ * would be (see {@link primeUnconfiguredEngine}).
  */
 function injectMathJax(
     src: string,
@@ -225,7 +231,10 @@ function injectMathJax(
     { force = false }: { force?: boolean } = {},
 ): Promise<MathJaxEngine> {
     return new Promise((resolve, reject) => {
-        if (config && (force || window.MathJax == null)) {
+        // True also when there is no config at all: there is then nothing our
+        // configuration could have taught the engine that it is missing.
+        const bootsOnOurConfig = !config || force || window.MathJax == null;
+        if (config && bootsOnOurConfig) {
             window.MathJax = config;
         }
         const script = document.createElement("script");
@@ -234,7 +243,12 @@ function injectMathJax(
         script.async = true;
         script.setAttribute(DOENET_MATHJAX_SCRIPT_ATTR, "true");
         script.addEventListener("load", () => {
-            resolve(window.MathJax as MathJaxEngine);
+            const engine = window.MathJax as MathJaxEngine;
+            resolve(
+                bootsOnOurConfig
+                    ? engine
+                    : primeUnconfiguredEngine(engine, config),
+            );
         });
         script.addEventListener("error", () => {
             reject(
@@ -243,6 +257,20 @@ function injectMathJax(
         });
         document.head.appendChild(script);
     });
+}
+
+/**
+ * The `tex` section of a MathJax configuration, whose shape we cannot rely on:
+ * `config` is whatever the caller passed, and a host may have staged one of its
+ * own. Every field is read defensively by the helpers below.
+ */
+function texConfig(
+    config: object | undefined,
+): Record<string, unknown> | undefined {
+    const tex = (config as { tex?: unknown } | undefined)?.tex;
+    return tex && typeof tex === "object"
+        ? (tex as Record<string, unknown>)
+        : undefined;
 }
 
 /**
@@ -255,8 +283,7 @@ function injectMathJax(
  * cannot take (control sequences are letters-only).
  */
 function texDefsFromConfig(config: object | undefined): string {
-    const macros = (config as { tex?: { macros?: unknown } } | undefined)?.tex
-        ?.macros;
+    const macros = texConfig(config)?.macros;
     if (!macros || typeof macros !== "object") {
         return "";
     }
@@ -297,11 +324,10 @@ function texDefsFromConfig(config: object | undefined): string {
  * The TeX packages `config` *adds* to MathJax's defaults — the `{"[+]": [...]}`
  * form. A bare array is ignored on purpose: that form replaces the default list
  * outright and so describes the base set of the engine we build ourselves, not
- * something a host engine is necessarily missing.
+ * something an unconfigured engine is necessarily missing.
  */
 function texPackagesFromConfig(config: object | undefined): string[] {
-    const packages = (config as { tex?: { packages?: unknown } } | undefined)
-        ?.tex?.packages;
+    const packages = texConfig(config)?.packages;
     if (!packages || typeof packages !== "object" || Array.isArray(packages)) {
         return [];
     }
@@ -319,8 +345,9 @@ function texPackagesFromConfig(config: object | undefined): string[] {
  * Typesets `tex` into a throwaway offscreen element purely for its side effect
  * on the engine, and resolves whether or not that worked.
  *
- * Never rejects: priming is a best-effort improvement on an engine we do not
- * own, and a failure here must not stop the math that follows from rendering.
+ * Never rejects: priming is a best-effort improvement on an engine we did not
+ * configure, and a failure here must not stop the math that follows from
+ * rendering.
  */
 async function typesetForSideEffect(
     engine: MathJaxEngine,
@@ -345,7 +372,7 @@ async function typesetForSideEffect(
         await engine.typesetPromise([host]);
     } catch (reason) {
         console.warn(
-            `DoenetViewer: could not prime a host-provided MathJax with "${tex}"; ` +
+            `DoenetViewer: could not prime MathJax with "${tex}"; ` +
                 "math relying on it may not render as it does on doenet.org.",
             reason,
         );
@@ -361,12 +388,13 @@ async function typesetForSideEffect(
 }
 
 /**
- * Teaches a host-provided engine the macros and TeX packages our configuration
- * would have given it, so a document renders the same there as on an engine we
- * loaded ourselves.
+ * Teaches an engine our configuration never reached — a host's, or one we
+ * injected onto a host-staged config — the macros and TeX packages that
+ * configuration would have given it, so a document renders the same there as on
+ * an engine we configured ourselves.
  *
  * Two things are worth being explicit about, because this writes to state the
- * host owns:
+ * host shares:
  *
  *  - The definitions are document-wide and outlive this call, which is what
  *    makes priming a one-time cost instead of a per-expression one. It also
@@ -378,15 +406,15 @@ async function typesetForSideEffect(
  *    does; batching would let one unavailable package silently take the macro
  *    definitions down with it.
  */
-async function primeForeignEngine(
+async function primeUnconfiguredEngine(
     engine: MathJaxEngine,
     config: object | undefined,
 ): Promise<MathJaxEngine> {
     try {
         await engine.startup?.promise;
     } catch {
-        // A host engine that reports a failed startup may still typeset; let
-        // the priming attempts below find out rather than deciding here.
+        // An engine that reports a failed startup may still typeset; let the
+        // priming attempts below find out rather than deciding here.
     }
     const defs = texDefsFromConfig(config);
     if (defs) {
@@ -411,7 +439,7 @@ function createMathJaxPromise(
     // A live engine is already present — reuse it and never touch window.MathJax.
     // It is not ours and never saw `config`, so prime it before anyone uses it.
     if (isMathJaxEngine(window.MathJax)) {
-        return primeForeignEngine(window.MathJax, config);
+        return primeUnconfiguredEngine(window.MathJax, config);
     }
 
     // A MathJax script is already on the page (possibly deferred), or the host
@@ -423,7 +451,7 @@ function createMathJaxPromise(
     if (useExistingMathJax || findMathJaxScript()) {
         return waitForExistingMathJax(timeoutMs).then(
             // The host's engine: ours to use, not ours to have configured.
-            (engine) => primeForeignEngine(engine, config),
+            (engine) => primeUnconfiguredEngine(engine, config),
             // The takeover copy is one we load and stage `config` on ourselves,
             // so it needs no priming. Handling the rejection here rather than in
             // a trailing `.catch` also keeps a priming failure above — which is
@@ -440,8 +468,9 @@ function createMathJaxPromise(
         );
     }
 
-    // Nothing else provides MathJax — we load it and stage `config` on it, so
-    // everything in that config is already in effect. No priming needed.
+    // Nothing else provides MathJax — load our own copy. `injectMathJax` stages
+    // `config` on it unless a host has already claimed the global with a config
+    // of its own, in which case it primes what it could not stage.
     return injectMathJax(src, config);
 }
 

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -23,6 +23,20 @@
  *  - Otherwise, inject our own copy — and only stage `window.MathJax = config`
  *    when nothing else has claimed that global.
  *
+ * When we end up on someone else's engine, our configuration never reaches it,
+ * so the macros and TeX packages Doenet's documents rely on are simply absent
+ * there — an author's `\\units{9.8}{...}` renders as a red `\\units` on a host
+ * page and correctly on doenet.org. To close that gap, a foreign engine is
+ * *primed*: before the shared promise resolves, we typeset a hidden expression
+ * that reproduces our configured macros as `\\def`s and pulls in our added TeX
+ * packages with `\\require`. MathJax keeps such definitions for the life of the
+ * document, so this happens once rather than per expression. See
+ * {@link primeForeignEngine} for what that costs the host.
+ *
+ * Priming is deliberately skipped whenever the engine is one we configured
+ * ourselves — the common case, including every iframe embedding — so the usual
+ * path pays nothing for it.
+ *
  * The resulting promise is memoized on `window` so that every viewer, editor,
  * and virtual-keyboard tray in the realm shares a single MathJax, regardless of
  * how many (possibly separately-bundled) copies of this module are loaded.
@@ -231,6 +245,159 @@ function injectMathJax(
     });
 }
 
+/**
+ * Reproduces `config.tex.macros` as a string of `\def`s.
+ *
+ * MathJax's macro config accepts a bare replacement string, or `[replacement,
+ * argCount]`, or `[replacement, argCount, defaultForOptionalArg]`. A plain
+ * `\def` expresses the first two; the optional-argument form has no `\def`
+ * equivalent and is skipped rather than approximated, as is any name `\def`
+ * cannot take (control sequences are letters-only).
+ */
+function texDefsFromConfig(config: object | undefined): string {
+    const macros = (config as { tex?: { macros?: unknown } } | undefined)?.tex
+        ?.macros;
+    if (!macros || typeof macros !== "object") {
+        return "";
+    }
+    const defs: string[] = [];
+    for (const [name, value] of Object.entries(
+        macros as Record<string, unknown>,
+    )) {
+        if (!/^[A-Za-z]+$/.test(name)) {
+            continue;
+        }
+        let replacement: string;
+        let argCount = 0;
+        if (typeof value === "string") {
+            replacement = value;
+        } else if (
+            Array.isArray(value) &&
+            value.length <= 2 &&
+            typeof value[0] === "string"
+        ) {
+            replacement = value[0];
+            argCount = typeof value[1] === "number" ? value[1] : 0;
+        } else {
+            continue;
+        }
+        if (!Number.isInteger(argCount) || argCount < 0 || argCount > 9) {
+            continue;
+        }
+        const parameters = Array.from(
+            { length: argCount },
+            (_unused, index) => `#${index + 1}`,
+        ).join("");
+        defs.push(`\\def\\${name}${parameters}{${replacement}}`);
+    }
+    return defs.join("");
+}
+
+/**
+ * The TeX packages `config` *adds* to MathJax's defaults — the `{"[+]": [...]}`
+ * form. A bare array is ignored on purpose: that form replaces the default list
+ * outright and so describes the base set of the engine we build ourselves, not
+ * something a host engine is necessarily missing.
+ */
+function texPackagesFromConfig(config: object | undefined): string[] {
+    const packages = (config as { tex?: { packages?: unknown } } | undefined)
+        ?.tex?.packages;
+    if (!packages || typeof packages !== "object" || Array.isArray(packages)) {
+        return [];
+    }
+    const added = (packages as Record<string, unknown>)["[+]"];
+    if (!Array.isArray(added)) {
+        return [];
+    }
+    return added.filter(
+        (name): name is string =>
+            typeof name === "string" && /^[\w-]+$/.test(name),
+    );
+}
+
+/**
+ * Typesets `tex` into a throwaway offscreen element purely for its side effect
+ * on the engine, and resolves whether or not that worked.
+ *
+ * Never rejects: priming is a best-effort improvement on an engine we do not
+ * own, and a failure here must not stop the math that follows from rendering.
+ */
+async function typesetForSideEffect(
+    engine: MathJaxEngine,
+    tex: string,
+): Promise<void> {
+    if (typeof engine.typesetPromise !== "function") {
+        return;
+    }
+    const parent = document.body ?? document.documentElement;
+    if (!parent) {
+        return;
+    }
+    const host = document.createElement("div");
+    host.setAttribute("aria-hidden", "true");
+    host.style.cssText =
+        "position:absolute;left:-9999px;top:0;width:0;height:0;overflow:hidden;visibility:hidden";
+    // Offscreen rather than `display: none`, because the output jax measures
+    // what it typesets and an undisplayed subtree has no metrics to measure.
+    host.textContent = `\\(${tex}\\)`;
+    parent.appendChild(host);
+    try {
+        await engine.typesetPromise([host]);
+    } catch (reason) {
+        console.warn(
+            `DoenetViewer: could not prime a host-provided MathJax with "${tex}"; ` +
+                "math relying on it may not render as it does on doenet.org.",
+            reason,
+        );
+    } finally {
+        try {
+            engine.typesetClear?.([host]);
+        } catch {
+            // `typesetClear` only drops bookkeeping for an element we are about
+            // to discard; if the host engine dislikes it, nothing is lost.
+        }
+        host.remove();
+    }
+}
+
+/**
+ * Teaches a host-provided engine the macros and TeX packages our configuration
+ * would have given it, so a document renders the same there as on an engine we
+ * loaded ourselves.
+ *
+ * Two things are worth being explicit about, because this writes to state the
+ * host owns:
+ *
+ *  - The definitions are document-wide and outlive this call, which is what
+ *    makes priming a one-time cost instead of a per-expression one. It also
+ *    means a host that defines any of the same names gets ours instead. The
+ *    names come from Doenet's own configuration, so the exposure is limited to
+ *    what a Doenet document could already have relied on.
+ *  - Each fragment is typeset separately. `\require` throws when a package
+ *    cannot be loaded, and MathJax abandons the rest of the expression when it
+ *    does; batching would let one unavailable package silently take the macro
+ *    definitions down with it.
+ */
+async function primeForeignEngine(
+    engine: MathJaxEngine,
+    config: object | undefined,
+): Promise<MathJaxEngine> {
+    try {
+        await engine.startup?.promise;
+    } catch {
+        // A host engine that reports a failed startup may still typeset; let
+        // the priming attempts below find out rather than deciding here.
+    }
+    const defs = texDefsFromConfig(config);
+    if (defs) {
+        await typesetForSideEffect(engine, defs);
+    }
+    for (const packageName of texPackagesFromConfig(config)) {
+        await typesetForSideEffect(engine, `\\require{${packageName}}`);
+    }
+    return engine;
+}
+
 function createMathJaxPromise(
     options: LoadMathJaxOptions,
 ): Promise<MathJaxEngine> {
@@ -242,8 +409,9 @@ function createMathJaxPromise(
     } = options;
 
     // A live engine is already present — reuse it and never touch window.MathJax.
+    // It is not ours and never saw `config`, so prime it before anyone uses it.
     if (isMathJaxEngine(window.MathJax)) {
-        return Promise.resolve(window.MathJax);
+        return primeForeignEngine(window.MathJax, config);
     }
 
     // A MathJax script is already on the page (possibly deferred), or the host
@@ -253,17 +421,27 @@ function createMathJaxPromise(
     // loading — and taking over with — our own copy, so math still renders. This
     // is what makes a mis-detected host non-fatal instead of blanking all math.
     if (useExistingMathJax || findMathJaxScript()) {
-        return waitForExistingMathJax(timeoutMs).catch((reason) => {
-            console.warn(
-                "DoenetViewer: a host-provided MathJax did not become usable in " +
-                    "time; falling back to loading Doenet's own copy.",
-                reason,
-            );
-            return injectMathJax(src, config, { force: true });
-        });
+        return waitForExistingMathJax(timeoutMs).then(
+            // The host's engine: ours to use, not ours to have configured.
+            (engine) => primeForeignEngine(engine, config),
+            // The takeover copy is one we load and stage `config` on ourselves,
+            // so it needs no priming. Handling the rejection here rather than in
+            // a trailing `.catch` also keeps a priming failure above — which is
+            // never fatal — from being mistaken for a host that never loaded,
+            // and answered by injecting a second engine over the host's.
+            (reason) => {
+                console.warn(
+                    "DoenetViewer: a host-provided MathJax did not become usable in " +
+                        "time; falling back to loading Doenet's own copy.",
+                    reason,
+                );
+                return injectMathJax(src, config, { force: true });
+            },
+        );
     }
 
-    // Nothing else provides MathJax — load our own copy.
+    // Nothing else provides MathJax — we load it and stage `config` on it, so
+    // everything in that config is already in effect. No priming needed.
     return injectMathJax(src, config);
 }
 

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -36,12 +36,10 @@
  *
  * Priming is best-effort by design: each fragment is allowed to fail on its own
  * (an engine with no TeX input jax, a `\require` the host's MathJax cannot
- * honor) and the worst outcome is that the host renders the document the way it
- * would have before — never that math stops rendering.
- *
- * Priming is deliberately skipped whenever the engine booted on our own
- * configuration — the common case, including every iframe embedding — so the
- * usual path pays nothing for it.
+ * honor) and the worst outcome is that the host renders the document as it would
+ * have unprimed — never that math stops rendering. It is skipped altogether
+ * whenever the engine booted on our own configuration — the common case,
+ * including every iframe embedding — so the usual path pays nothing for it.
  *
  * The resulting promise is memoized on `window` so that every viewer, editor,
  * and virtual-keyboard tray in the realm shares a single MathJax, regardless of
@@ -58,9 +56,8 @@
  *
  * Priming reaches only as far as the host's version allows. `units` is a
  * MathJax 4 package, so on a host still running 3.x the `\require{units}`
- * fragment fails, priming logs a warning, and the macros still land — `\units`
- * typesets as its own name there, exactly as it did before this existed, while
- * everything else is unaffected.
+ * fragment fails and priming logs a warning; the macros still land, and `\units`
+ * typesets as its own name there.
  */
 
 /**

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -27,12 +27,17 @@
  * TeX packages Doenet's documents rely on are simply absent there — an author's
  * `\units{9.8}{...}` renders as a bare `\units` on a host page and correctly on
  * doenet.org. To close that gap, such an engine is *primed*: before the shared
- * promise resolves, we run an expression through its TeX input jax that
- * reproduces our configured macros as `\def`s and pulls in our added TeX
- * packages with `\require`. Nothing is rendered or added to the page; the point
- * is the state that expression leaves behind in the jax, which MathJax keeps for
- * the life of the document, so this happens once rather than per expression. See
+ * promise resolves, we run expressions through its TeX input jax that reproduce
+ * our configured macros as `\def`s and pull in our added TeX packages with
+ * `\require`. Nothing is rendered or added to the page; the point is the state
+ * those expressions leave behind in the jax, which MathJax keeps for the life of
+ * the document, so this happens once rather than per expression. See
  * {@link primeUnconfiguredEngine} for what that costs the host.
+ *
+ * Priming is best-effort by design: each fragment is allowed to fail on its own
+ * (an engine with no TeX input jax, a `\require` the host's MathJax cannot
+ * honor) and the worst outcome is that the host renders the document the way it
+ * would have before — never that math stops rendering.
  *
  * Priming is deliberately skipped whenever the engine booted on our own
  * configuration — the common case, including every iframe embedding — so the
@@ -47,9 +52,15 @@
  * Doenet renders with MathJax 4 and pins {@link DEFAULT_MATHJAX_SRC} for the
  * copy it injects. When reusing a host-provided engine, the host's version
  * governs typesetting. MathJax 3 and 4 share the component-tex/typeset API this
- * code relies on (`startup.promise`, `typesetPromise`, `typesetClear`), so a
- * host engine in the 3.x–4.x range works; MathJax 2 (which exposes `Hub`
- * instead) is not supported for reuse.
+ * code relies on (`startup.promise`, `typesetPromise`, `typesetClear`, and the
+ * `tex2mmlPromise` that priming uses), so a host engine in the 3.x–4.x range
+ * works; MathJax 2 (which exposes `Hub` instead) is not supported for reuse.
+ *
+ * Priming reaches only as far as the host's version allows. `units` is a
+ * MathJax 4 package, so on a host still running 3.x the `\require{units}`
+ * fragment fails, priming logs a warning, and the macros still land — `\units`
+ * typesets as its own name there, exactly as it did before this existed, while
+ * everything else is unaffected.
  */
 
 /**
@@ -367,8 +378,9 @@ async function convertForSideEffect(
     engine: MathJaxEngine,
     tex: string,
 ): Promise<void> {
-    // Defined by MathJax's startup once a TeX input jax is in play, so absent
-    // exactly when there are no TeX macros to teach in the first place.
+    // Defined by MathJax's startup only once a TeX input jax is in play. An
+    // engine without one cannot render Doenet's TeX at all, primed or not, so
+    // there is nothing priming could rescue here — leave the host alone.
     if (typeof engine.tex2mmlPromise !== "function") {
         return;
     }
@@ -475,6 +487,13 @@ function createMathJaxPromise(
  * returns a promise for the live engine. The promise is memoized on `window`,
  * so repeated calls (from multiple viewers/editors/keyboard trays) share a
  * single MathJax and the first caller's options win.
+ *
+ * "The first caller's options win" is why callers that only need the engine
+ * (renderers reaching for `startup.promise`) call this bare: they run inside a
+ * viewer, whose `MathJaxContext` has already made the call carrying `config`.
+ * A bare call that got there first would settle the memo with no configuration
+ * to stage *or* to prime, leaving Doenet's macros absent everywhere — so a new
+ * caller that could run before a viewer mounts must pass `config`.
  */
 export function loadMathJax(
     options: LoadMathJaxOptions = {},


### PR DESCRIPTION
## What

Two related changes, so that `\units` works and keeps working wherever a document is used.

### 1. Add the MathJax `units` extension

`units` is neither bundled into the combined MathJax component we load nor reachable through `autoload`, so it is requested by name in `loader.load` and added to the TeX package list with the `[+]` merge form (which keeps MathJax's defaults). That brings `\units`, `\unitfrac`, and `\nicefrac`.

```
<m>\units{9.8}{\text{m}/\text{s}^2}</m>
```

### 2. Prime an engine our configuration never reached

Configuration alone only fixes the case where Doenet loads MathJax on its own terms. When a page already provides its own, `loadMathJax` reuses that engine and never applies our config — so Doenet's macros and TeX packages are absent there. `\units{9.8}{...}` renders correctly on doenet.org and as a bare `\units` when embedded inline.

That divergence is not new to this PR: `\var`, `\amp`, `\csch`, `\sech`, and `\erf` have behaved that way for as long as the reuse path has existed. Adding `units` would have made the list longer.

Reuse itself is the right call — injecting a second copy of the component distribution replaces `window.MathJax` and breaks the host's own math — so instead such an engine is now *primed*: before the shared promise resolves, an expression reproducing the configured macros as `\def`s, and pulling in each added package with `\require`, is run through the engine's TeX input jax. Nothing is rendered and nothing is added to the page; the point is the state that expression leaves behind in the jax, which MathJax keeps for the life of the document. So this is a one-time cost, not a per-expression one.

The same treatment covers the other way our config can miss the engine: a host that staged a MathJax configuration of its own without yet adding a script. We leave that config in place rather than clobbering it and load MathJax ourselves, so the engine boots on the host's terms and arrives as short of Doenet's macros as a host's own engine would have been. It is now primed too.

## Design notes

- **Priming converts rather than typesets.** Going through `tex2mmlPromise` reaches the same input jax the engine renders everything else with, without depending on the host's math delimiters (a host is free to redefine `inlineMath`, and `\(`…`\)` need not survive) or its ignored-element rules, and without putting a hidden element in the host's page.
- **`\require` is converted separately from the `\def`s.** `\require` throws when a package cannot be loaded, and MathJax abandons the rest of the expression when it does. Batching would let one unavailable package silently take the macro definitions down with it. Verified against a host engine with no such package: the definitions still land.
- **Priming is skipped whenever the engine booted on our own configuration**, which is the common case and includes every iframe embedding — those pay nothing. The distinction is drawn by whether our config actually reached the engine, not by who loaded it: the timeout fallback begins on the host branch but ends up staging our config on a copy we load, so it needs no priming, while a copy we load onto a host-staged config does.
- **The preamble is derived from the config object** rather than written out beside it, so the two cannot drift. Macro forms `\def` cannot express (optional arguments, non-letter names) are skipped rather than approximated.
- **Priming writes to state the host shares.** The definitions are document-wide, so a host defining any of the same names gets Doenet's. The names come from Doenet's own configuration, so the exposure is limited to what a Doenet document could already have relied on. Documented in the module.

## Known limits

- `units` does not exist in MathJax 3 — it is a v4 addition. On a host still running v3, `\require{units}` fails, priming logs a warning, and the macros still land. Everything else is unaffected.
- `output.displayOverflow: "linebreak"` is a rendering option rather than a macro, so priming cannot carry it to a host engine; long displayed equations will not line-break there. A host that wants full parity can import `mathjaxConfig` from `@doenet/doenetml` and merge it into their own MathJax configuration.

## Documentation

The introductory tutorial's "writing mathematics" page now covers `\units`, `\unitfrac`, and `\nicefrac`, with a runnable example.

## Testing

- `mathjax-loader.test.ts`: new tests covering what gets primed, that `\require` stays in its own conversion, that a priming failure still resolves the engine, that an engine with no TeX input jax is left alone, that a copy loaded onto a host-staged config is primed, and that neither a self-configured engine nor the timeout-fallback copy is.
- `hostMathJaxPriming.cy.js` + `public/host-mathjax-page.html`: a page that boots a stock MathJax 4 before loading the standalone bundle. Asserts `\units`, `\nicefrac`, and `\var` all render, and that the host's own math still typesets through the engine Doenet wrote to.
  - The spec first asserts no Doenet-injected MathJax is on the page, so it cannot pass by way of Doenet quietly loading its own configured engine instead.
  - The page waits for Doenet's math to appear before typesetting its own, so the host's typesetting is unambiguously after priming rather than racing it.
  - Confirmed to fail without the change: `\units9.8m/s2` rather than `9.8m/s2`.
- `mathdisplay.cy.js`: new test that the `units` macros render on Doenet's own engine.
- `math.cy.js` re-run as a regression check on the shared loader.

Closes #1648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


