### PR TITLE
Seed catalogs for fifteen languages of the Caucasus and the Kurdish-speaking world

### DIFF
--- a/.changeset/seed-caucasus-kurdish-catalogs.md
+++ b/.changeset/seed-caucasus-kurdish-catalogs.md
@@ -1,0 +1,35 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for fifteen more languages of the Caucasus and
+the Kurdish-speaking world: Abkhaz (`ab`), Adyghe (`ady`), Kabardian (`kbd`),
+Avar (`av`), Lezgian (`lez`), Dargwa (`dar`), Lak (`lbe`), Tabasaran (`tab`),
+Ingush (`inh`), Karachay-Balkar (`krc`), Kumyk (`kum`), Nogai (`nog`), Talysh
+(`tly`), Kurmanji Kurdish (`ku`) and Central Kurdish (`ckb`). A document
+declaring one of these languages now renders its style descriptions, section
+headings, boolean words, answer buttons, editor chrome and diagnostics in it
+instead of falling back to English. The chemistry element tables are
+deliberately left out of all fifteen and still fall back to English.
+
+Central Kurdish is written in the Perso-Arabic script and renders right to
+left, the eleventh such catalog. Kurmanji beside it is Latin and renders left
+to right, and a reader arriving under a Southern Kurdish code (`sdh`) or the
+ISO 639-3 code for Kurmanji (`kmr`) now reaches it rather than English; a
+Sorani reader keeps reaching the Sorani catalog rather than being folded onto
+Kurmanji.
+
+Two of the fifteen are locales CLDR has no name for, so Lak and Tabasaran now
+supply their own names to `<document lang>`'s autocomplete instead of appearing
+as bare codes.
+
+Every string is machine-generated and has not been read by a speaker; each
+catalog says so in its header. Three carry an additional confidence caveat
+worth naming: `locales/tly` (Talysh) is the least certain of the fifteen,
+`locales/dar` (Dargwa) records that seven of its colour words are still
+Russian, and `locales/nog` (Nogai) records that its editor vocabulary is
+largely coined. Correcting any of this needs no permission.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -282,9 +282,9 @@ answers.
 
 **All fifteen of the Caucasus and Kurdish batch are partial, and fourteen of
 the fifteen are one school system.** Secondary chemistry across the North
-Caucasus is taught in Russian, so for the eleven Cyrillic catalogs the fallback
+Caucasus is taught in Russian, so for the twelve Cyrillic catalogs the fallback
 *is* the curriculum, exactly as it was for the twelve of the Russian Federation
-batch — one sentence for eleven education ministries that are really one.
+batch — one sentence for twelve education ministries that are really one.
 `locales/tly` is a two-country version of the same case and the only one that
 has to name two: Talysh schooling is Azerbaijani-medium in Azerbaijan and
 Persian-medium in Iran, so there is no single curriculum to point at.
@@ -1406,7 +1406,7 @@ in the file.
 
 Abkhaz, Adyghe, Kabardian, Avar, Lezgian, Dargwa, Lak, Tabasaran, Ingush,
 Karachay-Balkar, Kumyk, Nogai, Talysh, Kurmanji Kurdish and Central Kurdish —
-fifteen catalogs from **six families** (Northwest Caucasian: `ab`, `ady`,
+fifteen catalogs from **five families** (Northwest Caucasian: `ab`, `ady`,
 `kbd`; Northeast Caucasian: `av`, `lez`, `dar`, `lbe`, `tab`; Nakh: `inh`;
 Turkic: `krc`, `kum`, `nog`; Iranian: `tly`, `ku`, `ckb`), and three scripts.
 It picks up where the Russian Federation batch stopped in the most literal way
@@ -1461,9 +1461,12 @@ rewrite.
 and its header says so where a reader who knows the family will look for a fork
 and must not find one. `locales/tab`'s classes survive on numerals, verbs and
 pronouns and never reach an attributive adjective. `locales/ab`'s agreement is
-a verb prefix and nothing the core names is human. The three Turkic catalogs
-and `locales/ckb` never had classes to lose. Six catalogs, six different
-reasons for the same flat `noun-gender`, in one region.
+a verb prefix and nothing the core names is human. `locales/ady`,
+`locales/kbd`, the three Turkic catalogs, `locales/tly` and `locales/ckb` never
+had classes to lose, and each header says so where a reader would look for the
+fork its neighbours have. Thirteen catalogs, five different reasons for the
+same flat `noun-gender`, in one region; `locales/inh` and `locales/ku` are the
+only two whose `noun-gender` answers per noun.
 
 #### The Kurdish pair
 
@@ -1529,11 +1532,11 @@ macrolanguage mapping still gives it a code outside `kur`, so it falls back —
 **The other thirteen filter unaided, so the batch adds no `LANGUAGE_ALIASES`
 entry at all**, and every regional and script tag over them — `ab-GE`,
 `lez-AZ`, `tly-IR`, `ku-SY`, `ckb-IQ`, `ab-Latn`, `ku-Arab`, `tly-Cyrl` —
-reaches its catalog on ICU data alone. Three catalogs carry a script asymmetry
-their headers record: `ku` is Latin and answers `ku-Arab`, `tly` is Latin and
-answers both `tly-Cyrl` and `tly-Arab`, and the eleven Cyrillic ones answer a
-Latin tag with Cyrillic. As ever the answer to a mismatch is a second catalog
-beside the first rather than a rename of it.
+reaches its catalog on ICU data alone. The script asymmetries the headers
+record: `ku` is Latin and answers `ku-Arab`, `tly` is Latin and answers both
+`tly-Cyrl` and `tly-Arab`, `ckb` is Perso-Arabic and answers `ckb-Latn`, and
+the twelve Cyrillic ones answer a Latin tag with Cyrillic. As ever the answer
+to a mismatch is a second catalog beside the first rather than a rename of it.
 
 **`lbe` and `tab` need `LOCALE_NAME_FALLBACKS` entries, and they part company
 over the endonym.** CLDR has no language data for either tag, so without the
@@ -1577,8 +1580,11 @@ branch empty. `locales/kbd` cannot incorporate the numeral into a word it does
 not own — Kabardian would write «къуапитху», and the count arrives as a
 formatted `{ $numSides }` — so it appends «къуапэ 5 иӀэу» behind the
 description; `locales/ckb`'s noun carries its ezafe and takes the count in a
-«بە … ەوە» phrase behind it. Those two are why `$part` is not dead weight, and
-the test names them against the thirteen.
+«بە … ەوە» phrase behind it. Those two are why `$part` is not dead weight.
+`styleDescriptions.test.ts` holds all fifteen to rendering the count exactly
+once, and names `kbd` and `ckb` against `ab`, `ady` and `ku` — the three other
+postnominal catalogs, which are where the tail is what the string ends with and
+so the only group in which the split is visible from the outside.
 
 **`locales/ady` and `locales/kbd` both record a limit the affix rule creates
 from the other direction.** A postnominal adjective in Circassian is normally

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -66,35 +66,37 @@ locales/<locale>/
   editor.ftl        # editor and LSP surfaces                — uiLocale
 ```
 
-English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
-`ar`, `arn`, `as`, `ast`, `ay`, `az`, `ba`, `ban`, `bci`, `be`, `bem`, `bg`,
-`bho`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`, `brx`, `bs`, `bua`, `bum`, `ca`,
-`ce`, `ceb`, `ch`, `chm`, `co`, `cs`, `cv`, `cy`, `da`, `dag`, `de`, `dje`,
-`doi`, `dv`, `dyo`, `dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`,
-`fa`, `ff`, `fi`, `fil`, `fj`, `fo`, `fon`, `fr`, `fy`, `ga`, `gaa`, `gd`,
-`gl`, `gn`, `gu`, `ha`, `haw`, `he`, `hi`, `hil`, `hnj`, `hr`, `ht`, `hu`,
-`hy`, `id`, `ig`, `ilo`, `is`, `it`, `ja`, `jv`, `ka`, `kab`, `kbp`, `kg`,
-`ki`, `kk`, `km`, `kmb`, `kn`, `ko`, `kok`, `kpe`, `kr`, `kri`, `ks`, `ktu`,
-`kv`, `ky`, `lb`, `lg`, `ln`, `lo`, `lom`, `lt`, `lua`, `luo`, `lv`, `mad`,
-`mai`, `men`, `mg`, `mi`, `min`, `mk`, `ml`, `mn`, `mni`, `mnk`, `mos`, `mr`,
-`ms`, `mt`, `my`, `myv`, `nah`, `nb`, `nds`, `ne`, `nl`, `nso`, `ny`, `nyn`,
-`oc`, `oj`, `om`, `or`, `os`, `pa`, `pam`, `pcm`, `pl`, `ps`, `pt`, `qu`,
-`quc`, `rm`, `rn`, `ro`, `ru`, `rw`, `sa`, `sah`, `sat`, `sc`, `scn`, `sd`,
-`se`, `sg`, `shi`, `si`, `sk`, `sl`, `sm`, `sn`, `so`, `sq`, `sr`, `ss`, `st`,
-`su`, `sus`, `sv`, `sw`, `ta`, `te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`,
-`tk`, `tlh`, `tn`, `to`, `tpi`, `tr`, `ts`, `tt`, `ty`, `tyv`, `udm`, `ug`,
-`uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vi`, `war`, `wo`, `xal`, `xh`, `yi`,
-`yo`, `zgh`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed machine-generated
+English is the source of truth. Every translation — `ab`, `ace`, `ady`,
+`af`, `ak`, `am`, `ar`, `arn`, `as`, `ast`, `av`, `ay`, `az`, `ba`, `ban`,
+`bci`, `be`, `bem`, `bg`, `bho`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`,
+`brx`, `bs`, `bua`, `bum`, `ca`, `ce`, `ceb`, `ch`, `chm`, `ckb`, `co`,
+`cs`, `cv`, `cy`, `da`, `dag`, `dar`, `de`, `dje`, `doi`, `dv`, `dyo`,
+`dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`, `fi`,
+`fil`, `fj`, `fo`, `fon`, `fr`, `fy`, `ga`, `gaa`, `gd`, `gl`, `gn`, `gu`,
+`ha`, `haw`, `he`, `hi`, `hil`, `hnj`, `hr`, `ht`, `hu`, `hy`, `id`, `ig`,
+`ilo`, `inh`, `is`, `it`, `ja`, `jv`, `ka`, `kab`, `kbd`, `kbp`, `kg`, `ki`,
+`kk`, `km`, `kmb`, `kn`, `ko`, `kok`, `kpe`, `kr`, `krc`, `kri`, `ks`,
+`ktu`, `ku`, `kum`, `kv`, `ky`, `lb`, `lbe`, `lez`, `lg`, `ln`, `lo`, `lom`,
+`lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `men`, `mg`, `mi`, `min`, `mk`,
+`ml`, `mn`, `mni`, `mnk`, `mos`, `mr`, `ms`, `mt`, `my`, `myv`, `nah`, `nb`,
+`nds`, `ne`, `nl`, `nog`, `nso`, `ny`, `nyn`, `oc`, `oj`, `om`, `or`, `os`,
+`pa`, `pam`, `pcm`, `pl`, `ps`, `pt`, `qu`, `quc`, `rm`, `rn`, `ro`, `ru`,
+`rw`, `sa`, `sah`, `sat`, `sc`, `scn`, `sd`, `se`, `sg`, `shi`, `si`, `sk`,
+`sl`, `sm`, `sn`, `so`, `sq`, `sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`,
+`ta`, `tab`, `te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tlh`,
+`tly`, `tn`, `to`, `tpi`, `tr`, `ts`, `tt`, `ty`, `tyv`, `udm`, `ug`, `uk`,
+`umb`, `ur`, `urh`, `uz`, `ve`, `vi`, `war`, `wo`, `xal`, `xh`, `yi`, `yo`,
+`zgh`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed machine-generated
 seed**, which each file's own header says at the top, and which is what #1521's
 translation platform is for. None has been read by a speaker. Correcting one
 needs no permission and no coordination: a wrong string is just wrong, and the
 English is one key away.
 
-A hundred and forty-one of them are deliberately partial. A hundred and forty
-are partial in the same place — the two chemistry tables — while Klingon is
-partial almost everywhere, for a different reason: see
+A hundred and fifty-six of them are deliberately partial. A hundred and
+fifty-five are partial in the same place — the two chemistry tables — while
+Klingon is partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The hundred
-and forty are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
+and fifty-five are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -110,7 +112,9 @@ Tachelhit, Rundi, Nyankole, Luba-Lulua, Kituba, Mooré, Dagbani, Dyula,
 Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè, Temne,
 Mende, Umbundu, Kimbundu, Zarma, Baoulé, Bini, Bulu, Jola-Fonyi, Efik, Ewondo,
 Kpelle, Loma, Susu, Urhobo, Bashkir, Chuvash, Yakut, Tuvinian, Buriat,
-Kalmyk, Udmurt, Komi, Erzya, Mari, Ossetic and Chechen
+Kalmyk, Udmurt, Komi, Erzya, Mari, Ossetic, Chechen, Abkhazian, Adyghe,
+Kabardian, Avaric, Lezghian, Dargwa, Lak, Tabasaran, Ingush, Karachay-Balkar,
+Kumyk, Nogai, Talysh, Kurdish and Central Kurdish
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -275,6 +279,28 @@ table in English. Nothing about the two languages predicts that, and nothing
 about the medium of instruction is a property of a language. `locales/sw` and
 `locales/ki` are the same pair in Kenya, one education system and two different
 answers.
+
+**All fifteen of the Caucasus and Kurdish batch are partial, and fourteen of
+the fifteen are one school system.** Secondary chemistry across the North
+Caucasus is taught in Russian, so for the eleven Cyrillic catalogs the fallback
+*is* the curriculum, exactly as it was for the twelve of the Russian Federation
+batch — one sentence for eleven education ministries that are really one.
+`locales/tly` is a two-country version of the same case and the only one that
+has to name two: Talysh schooling is Azerbaijani-medium in Azerbaijan and
+Persian-medium in Iran, so there is no single curriculum to point at.
+`locales/ku` is a third variant, Kurmanji-medium secondary schooling barely
+existing at all — Turkish in Turkey, Arabic in Syria.
+
+**`locales/ckb` is the fifteenth and the one claim about a language, and it
+stands beside `locales/ku` the way `locales/bo` stands beside `locales/dz`.**
+Central Kurdish *is* the medium of secondary science teaching in the Kurdistan
+Region of Iraq, and its schools print the periodic table in Sorani — so the
+names exist, and this is the Khmer and Tibetan case rather than the
+school-system one: what is missing is a settled convention this seed could
+reproduce rather than invent, published lists differing in how far they
+transliterate and from which source language. Two catalogs of one
+macrolanguage, two different reasons for the same gap, and the Kurdish pair
+makes the point in two scripts and two directions at once.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -1375,6 +1401,203 @@ error this seed is least able to check. `locales/lom` set the precedent for
 saying that in a file's own header rather than leaving a reader to discover it,
 and 118 unreviewed element coinages would have been the least defensible thing
 in the file.
+
+### Fifteen catalogs across the Caucasus, and the batch that stops agreeing about word order
+
+Abkhaz, Adyghe, Kabardian, Avar, Lezgian, Dargwa, Lak, Tabasaran, Ingush,
+Karachay-Balkar, Kumyk, Nogai, Talysh, Kurmanji Kurdish and Central Kurdish —
+fifteen catalogs from **six families** (Northwest Caucasian: `ab`, `ady`,
+`kbd`; Northeast Caucasian: `av`, `lez`, `dar`, `lbe`, `tab`; Nakh: `inh`;
+Turkic: `krc`, `kum`, `nog`; Iranian: `tly`, `ku`, `ckb`), and three scripts.
+It picks up where the Russian Federation batch stopped in the most literal way
+available: **six of these fifteen were named in that batch's own test** as
+neighbours of `ba` and `ce` that fall back to English rather than being guessed
+at. `krc`, `kum`, `nog`, `ady`, `kbd` and `av` reach a catalog now because one
+was written for them, not because `negotiate.ts` learned to fold a neighbour
+onto a neighbour, and `negotiate.test.ts` says so where those rows used to be.
+
+**This is the first batch that cannot be pinned as one word order.** Every
+earlier one could: the Russian Federation's twelve are prenominal to a catalog,
+and `styleDescriptions.test.ts` asserts that as an identity. Here ten put the
+description in front of the noun and five put it behind — and the five are not
+a group anyone reading a map would predict. All three Northwest Caucasian
+catalogs are postnominal, and so are **both** Kurdish ones, which are Iranian
+and sit at the other end of the batch from them. Northeast Caucasian, Nakh and
+Turkic are prenominal throughout. So a family predicts word order inside this
+batch and the region does not, which is the mirror image of what the batch says
+about agreement below — and the test holds both groups from opposite sides,
+`startsWith` for one and `endsWith` for the other, so that the noun is being
+appended to a description or prefixed to it rather than woven into it.
+
+**Agreement splits four ways, and only two of the four are a fork.**
+
+`locales/inh` and `locales/ku` genuinely agree. Ingush is Chechen's sister and
+forks the в-/й-/б-/д- class system the same way `locales/ce` does — and forks
+one message more: **`line-style.dashed`, which `locales/ce` leaves flat**
+although «кагйина» is the same kind of participle and `describeStroke` hands
+every adjective the same `$gender`. The branch is live rather than decorative,
+and the divergence is a question for a speaker of either language rather than a
+defect in either file; the test pins both forks so nobody flattens one catalog
+to match its neighbour without answering it. `locales/ku` is the other, and its
+mechanism is not a class at all — see [The Kurdish pair](#the-kurdish-pair).
+
+**`locales/av` agrees more than Chechen does and still forks nothing, which is
+the sharpest thing in the batch.** Avar has three singular classes and a
+plural, the marker is a *suffix* rather than a prefix, and — unlike Chechen,
+where the colour and width words take no marker at all — **every attributive
+adjective carries it**. On the face of it every style word in the file should
+fork. None does, because every noun this core names is a thing rather than a
+person and so is class III: `[v]`, `[j]` and `[l]` would be variants nothing
+can select. That is the reachability rule `locales/ve`, `locales/ts`,
+`locales/ki` and `locales/bem` already apply to their unreached Bantu classes,
+arriving for the first time from a language that agrees *more* rather than
+less. `locales/lbe` reaches the same place from four classes. `locales/dar` is
+the one of the three whose select is actually written out — `[v]` вицӀибси,
+`[r]` рицӀибси, `*[b]` бицӀибси, with only the last reachable — left standing
+so that filling in a class table costs a speaker one line rather than a
+rewrite.
+
+**`locales/lez` is the Northeast Caucasian language that lost its classes**,
+and its header says so where a reader who knows the family will look for a fork
+and must not find one. `locales/tab`'s classes survive on numerals, verbs and
+pronouns and never reach an attributive adjective. `locales/ab`'s agreement is
+a verb prefix and nothing the core names is human. The three Turkic catalogs
+and `locales/ckb` never had classes to lose. Six catalogs, six different
+reasons for the same flat `noun-gender`, in one region.
+
+#### The Kurdish pair
+
+`locales/ku` and `locales/ckb` are **one macrolanguage and two catalogs**, and
+they differ in every dimension this package has: script, direction, and whether
+the language agrees.
+
+Kurmanji is Latin (Hawar), left to right, and has masculine and feminine nouns
+linked to their adjectives by an ezafe. The bound ezafe cannot be welded onto
+`{ $noun }` — the constraint [An affix cannot be welded to a
+placeable](#an-affix-cannot-be-welded-to-a-placeable) describes — so
+`locales/ku` writes the free particle «ya» after a feminine noun and «yê» after
+a masculine one, repeating it before each further adjective, and three messages
+fork on `$gender`: `style-stroke`, `style-filled` and `style-filled-with-noun`.
+A line is feminine and a polygon masculine, so one description changes in three
+places and the other does not change at all, which is what the test pins.
+`style-filled-word` is flat, because «dagirtî» is a past participle and does
+not inflect — the agreement beside it is carried entirely by the particle.
+
+Sorani is Perso-Arabic, right to left, and **has no gender at all**, having
+lost the distinction Kurmanji keeps. So `locales/ckb` forks nothing while its
+sibling writes a full gender table. It solved the ezafe problem the other way
+round: rather than a free particle, **every entry in its `noun` table is
+written with its ezafe already on it**, so the composition messages add nothing
+and the adjectives chain with a free «و». Sorani's ezafe is always written,
+where Persian's is an unwritten vowel a space can carry, which is why
+`locales/fa`'s answer was not available to it.
+
+`locales/ckb` is the roster's eleventh right-to-left catalog and needed nothing
+from `direction.ts`: direction is keyed on the script, `ckb` maximizes to
+`ckb-Arab-IQ`, and `ku` maximizes to `ku-Latn-TR`. One macrolanguage rendering
+in both directions is the plainest demonstration this repository has that
+direction is a fact about a script rather than about a language.
+
+#### Negotiation
+
+**`ku` is the first key in `MACROLANGUAGE_MEMBERS` that is the macrolanguage
+and still excludes one of its own members.** ISO 639-3 gives Kurdish three —
+`ckb`, `kmr`, `sdh` — and the map lists two of them. `ckb` is left out because
+it has a catalog of its own, and folding it would serve a Sorani reader
+Kurmanji in a script they do not read. That is `locales/mnk` excluding `bam`
+and `dyu`, arriving for the first time on a key that is the macrolanguage
+rather than a member of one. `kmr` is the member ICU folds unaided; `sdh`
+reaches a catalog only because the map names it.
+
+`sdh` is the batch's **script debt**, and it is recorded rather than fixed:
+Southern Kurdish maximizes to `sdh-Arab-IR`, so CLDR's own data says such a
+reader most likely arrives in the Perso-Arabic script, and what published
+membership hands them is Latin Kurmanji. Routing it to `locales/ckb` on script
+alone would read better and would be exactly the judgement these maps exist to
+avoid — sharing a script is not a membership fact. That is `locales/bua`'s debt
+to `bxu` in Mongolian script and `locales/kr`'s to `kby` in Ajami, and the
+answer to it is a `sdh` catalog.
+
+`lki` (Laki) is the near miss worth naming, because everything except the
+published mapping points the other way: it is written in the same script as
+`ckb`, and it is often described as a variety of Southern Kurdish. ISO 639-3's
+macrolanguage mapping still gives it a code outside `kur`, so it falls back —
+`alq` beside `oj` and `kbl` beside `kr` land the same way. `zza`, `agx`, `ddo`,
+`xmf` and `sva` are the same shape in five other families, and
+`negotiate.test.ts` pins every one.
+
+**The other thirteen filter unaided, so the batch adds no `LANGUAGE_ALIASES`
+entry at all**, and every regional and script tag over them — `ab-GE`,
+`lez-AZ`, `tly-IR`, `ku-SY`, `ckb-IQ`, `ab-Latn`, `ku-Arab`, `tly-Cyrl` —
+reaches its catalog on ICU data alone. Three catalogs carry a script asymmetry
+their headers record: `ku` is Latin and answers `ku-Arab`, `tly` is Latin and
+answers both `tly-Cyrl` and `tly-Arab`, and the eleven Cyrillic ones answer a
+Latin tag with Cyrillic. As ever the answer to a mismatch is a second catalog
+beside the first rather than a rename of it.
+
+**`lbe` and `tab` need `LOCALE_NAME_FALLBACKS` entries, and they part company
+over the endonym.** CLDR has no language data for either tag, so without the
+table `<document lang>`'s autocomplete would offer a reader "lbe" and "tab" and
+nothing else. Lak gets both fields — its own headers name the language «лакку
+маз» and three of the four repeat it — while Tabasaran gets only an English
+name, because no header of its commits to a self-name in any script and a wrong
+endonym is worse than none. Its label therefore reads "Tabasaran (tab)", which
+is `locales/bci`'s and `locales/lom`'s shape rather than a new one.
+
+Four of the batch's CLDR names will look wrong and are not, the
+`ny`-reads-Nyanja rule again: `ab` renders as **Abkhazian**, `av` as
+**Avaric**, `lez` as **Lezghian**, and `ku` — whose endonym ICU gives as
+"kurdî (kurmancî)" — labels itself **"Kurdish (kurdî (kurmancî))"**, nested
+parenthesis and all. `supportedLocales.ts` is derived rather than hand-written,
+which is the whole point: adding fifteen languages cost no per-language prose,
+and the price of that is that ICU's rendering stands even when it reads oddly.
+Each catalog's header says which language it is.
+
+#### What the batch could not do, and says so
+
+**`piecewise-condition-if` splits, and the wall is syntax rather than family.**
+The renderer places the key *before* the mathematics it introduces. Abkhaz,
+Adyghe, Kabardian and Lak all mark a condition on a clause-final verb form and
+have no free word to put in front, so all four record the `locales/sah` shape
+beside the key rather than inventing a workaround — the same limit five
+catalogs of the previous batch recorded. The other eleven land correctly, and
+**nine of the eleven do it with the same borrowed word**: «эгер» in Lezgian,
+Dargwa, Tabasaran, Karachay-Balkar, Kumyk and Nogai, «əqər» in Talysh, «eger»
+in Kurmanji and «ئەگەر» in Sorani, all of them Persian and all of them
+clause-initial in languages whose own conditional is a suffix that would close
+the clause. Avar's «нагагь» and Ingush's «нагахьа» are the two that land on
+native words. Three Northwest Caucasian catalogs and Lak on one side of that
+line, and every Turkic and Iranian one on the other — which is the shape the
+previous batch found too, where two Turkic catalogs fell on each side and the
+wall turned out to be syntax rather than ancestry.
+
+**Two catalogs put a regular polygon's side count in a trailing complement**,
+where thirteen fold it into the noun and leave `noun-regular-polygon`'s `[tail]`
+branch empty. `locales/kbd` cannot incorporate the numeral into a word it does
+not own — Kabardian would write «къуапитху», and the count arrives as a
+formatted `{ $numSides }` — so it appends «къуапэ 5 иӀэу» behind the
+description; `locales/ckb`'s noun carries its ezafe and takes the count in a
+«بە … ەوە» phrase behind it. Those two are why `$part` is not dead weight, and
+the test names them against the thirteen.
+
+**`locales/ady` and `locales/kbd` both record a limit the affix rule creates
+from the other direction.** A postnominal adjective in Circassian is normally
+written *together* with its noun as one word, and the noun is a placeable, so
+both catalogs write it as a separate word one space away from the compound a
+speaker would write. Splitting the key would not help: the affix belongs to
+whichever word lands last, and that word is a placeable too.
+
+Three catalogs are candid about vocabulary rather than grammar, and they are
+where a speaker should start. **`locales/tly` is the least certain catalog in
+the batch** and says so — Talysh is endangered, its written output is small,
+and its Latin orthography is not fully settled even within the tradition this
+catalog writes. **`locales/dar` discloses that seven of its twelve colour slots
+are plain Russian words**, its header naming that the file's most valuable
+edit; that is a decision to leave a visible gap rather than coin seven terms,
+`locales/xal`'s judgement in a different part of a file. **`locales/nog` names
+`editor.ftl` as the file with the most invented vocabulary it contains**, built
+from general Kipchak on the Kazakh and Karakalpak pattern because Nogai has no
+published equivalents. Correcting any of it needs no permission.
 
 ### A language with no word for it
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -281,10 +281,11 @@ about the medium of instruction is a property of a language. `locales/sw` and
 answers.
 
 **All fifteen of the Caucasus and Kurdish batch are partial, and fourteen of
-the fifteen are one school system.** Secondary chemistry across the North
-Caucasus is taught in Russian, so for the twelve Cyrillic catalogs the fallback
-*is* the curriculum, exactly as it was for the twelve of the Russian Federation
-batch — one sentence for twelve education ministries that are really one.
+the fifteen are partial for the school-system reason.** Secondary chemistry
+across the North Caucasus is taught in Russian, so for the twelve Cyrillic
+catalogs the fallback *is* the curriculum, exactly as it was for the twelve of
+the Russian Federation batch — one sentence for twelve education ministries
+that are really one.
 `locales/tly` is a two-country version of the same case and the only one that
 has to name two: Talysh schooling is Azerbaijani-medium in Azerbaijan and
 Persian-medium in Iran, so there is no single curriculum to point at.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2777,19 +2777,18 @@ headers, the graph-controls panel, the editor chrome.
 ### Writing a right-to-left catalog
 
 Eleven ship: `ar`, `fa`, `he`, `ur`, `ps`, `sd`, `ug`, `yi`, `ks`, `dv` and
-`ckb`. Nothing
-about the file format changes for any of them. A `.ftl` pattern is a sequence of
-characters in **logical** order — the order the text is spoken — and `dir`
-decides where each run is drawn, so a translation is written the way it is read
+`ckb`. Nothing about the file format changes for any of them. A `.ftl` pattern
+is a sequence of characters in **logical** order — the order the text is spoken
+— and `dir` decides where each run is drawn, so a translation is written as read
 and never reordered by hand to look right in an editor. Brackets, quotes and
 dashes are the same characters in every one of these scripts and are written
 opening-first; the bidi algorithm turns them around at render time. Digits stay
 Latin, as [everywhere else](#digits-are-latin-separators-are-not), which is why
 an Arabic sentence and the mathematics beside it count in the same characters.
 
-**Direction is not a language family.** These eleven share a writing direction and
-almost nothing else, and the catalogs differ from each other far more than they
-differ from `de` or `es`:
+**Direction is not a language family.** These eleven share a writing direction
+and almost nothing else, and the catalogs differ from each other far more than
+they differ from `de` or `es`:
 
 | | Adjectives | Gender | Plural categories |
 | --- | --- | --- | --- |
@@ -2803,25 +2802,24 @@ differ from `de` or `es`:
 | `dv` | precede the noun | none | two |
 | `ckb` | follow the noun | none | two |
 
-`ur` is the outlier worth knowing about: its grammar is `hi`'s, so
-`locales/hi` is the closest thing to a parallel text for it and a correction to
-one is usually a correction to both. `ug` is Turkic and agrees with nothing,
-and `dv` is Indo-Aryan and agrees with nothing either — the two reach the same
-answer from opposite families. `ks` is the one of the eleven whose catalog
-records a gap rather than a decision: it *does* agree an adjective for gender
-and this seed does not, which its header says outright. `ckb` is the only one
-whose *sibling* is on the roster in the other direction — `locales/ku` is the
-same macrolanguage in Latin, left to right — and the only one that solves the
-affix problem by writing the linker into its `noun` table; see
-[The Kurdish pair](#the-kurdish-pair).
-`yi` is Germanic, and it forks on `$role` for a reason none of the other ten
-does: `ur`, `ps` and `sd` fork because an Indo-Aryan or Iranian adjective takes
-an oblique before a postposition, and Yiddish's adjectives take a **dative**
-after «מיט» and «אויף» — so its catalog has the shape `locales/de` and
-`locales/bs` have rather than `locales/hi`'s, which is the paragraph above put
-as sharply as it goes. Its one spelling convention worth stating is that
-Yiddish's three digraphs are written as **two letters each** — «וו», «וי»,
-«יי» — and never as the precomposed ligatures
+`ur` is the outlier worth knowing about: its grammar is `hi`'s, so `locales/hi`
+is the closest thing to a parallel text for it and a correction to one is
+usually a correction to both. `ug` is Turkic and agrees with nothing, and `dv`
+is Indo-Aryan and agrees with nothing either — the two reach the same answer
+from opposite families. `ks` is the one of the eleven whose catalog records a
+gap rather than a decision: it *does* agree an adjective for gender and this
+seed does not, which its header says outright. `ckb` is the only one whose
+*sibling* is on the roster in the other direction — `locales/ku` is the same
+macrolanguage in Latin, left to right — and the only one that solves the affix
+problem by writing the linker into its `noun` table; see [The Kurdish
+pair](#the-kurdish-pair). `yi` is Germanic, and it forks on `$role` for a
+reason none of the other ten does: `ur`, `ps` and `sd` fork because an
+Indo-Aryan or Iranian adjective takes an oblique before a postposition, and
+Yiddish's adjectives take a **dative** after «מיט» and «אויף» — so its catalog
+has the shape `locales/de` and `locales/bs` have rather than `locales/hi`'s,
+which is the paragraph above put as sharply as it goes. Its one spelling
+convention worth stating is that Yiddish's three digraphs are written as **two
+letters each** — «וו», «וי», «יי» — and never as the precomposed ligatures
 U+05F0–U+05F2, which render identically and compare unequal. CLDR spells the
 endonym «ייִדיש» that way, so the roster's own label and the catalogs match.
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2776,7 +2776,8 @@ headers, the graph-controls panel, the editor chrome.
 
 ### Writing a right-to-left catalog
 
-Ten ship: `ar`, `fa`, `he`, `ur`, `ps`, `sd`, `ug`, `yi`, `ks` and `dv`. Nothing
+Eleven ship: `ar`, `fa`, `he`, `ur`, `ps`, `sd`, `ug`, `yi`, `ks`, `dv` and
+`ckb`. Nothing
 about the file format changes for any of them. A `.ftl` pattern is a sequence of
 characters in **logical** order — the order the text is spoken — and `dir`
 decides where each run is drawn, so a translation is written the way it is read
@@ -2786,7 +2787,7 @@ opening-first; the bidi algorithm turns them around at render time. Digits stay
 Latin, as [everywhere else](#digits-are-latin-separators-are-not), which is why
 an Arabic sentence and the mathematics beside it count in the same characters.
 
-**Direction is not a language family.** These ten share a writing direction and
+**Direction is not a language family.** These eleven share a writing direction and
 almost nothing else, and the catalogs differ from each other far more than they
 differ from `de` or `es`:
 
@@ -2800,15 +2801,20 @@ differ from `de` or `es`:
 | `yi` | precede the noun | m/f/n | two |
 | `ks` | precede the noun | m/f | two |
 | `dv` | precede the noun | none | two |
+| `ckb` | follow the noun | none | two |
 
 `ur` is the outlier worth knowing about: its grammar is `hi`'s, so
 `locales/hi` is the closest thing to a parallel text for it and a correction to
 one is usually a correction to both. `ug` is Turkic and agrees with nothing,
 and `dv` is Indo-Aryan and agrees with nothing either — the two reach the same
-answer from opposite families. `ks` is the one of the ten whose catalog records
-a gap rather than a decision: it *does* agree an adjective for gender and this
-seed does not, which its header says outright.
-`yi` is Germanic, and it forks on `$role` for a reason none of the other nine
+answer from opposite families. `ks` is the one of the eleven whose catalog
+records a gap rather than a decision: it *does* agree an adjective for gender
+and this seed does not, which its header says outright. `ckb` is the only one
+whose *sibling* is on the roster in the other direction — `locales/ku` is the
+same macrolanguage in Latin, left to right — and the only one that solves the
+affix problem by writing the linker into its `noun` table; see
+[The Kurdish pair](#the-kurdish-pair).
+`yi` is Germanic, and it forks on `$role` for a reason none of the other ten
 does: `ur`, `ps` and `sd` fork because an Indo-Aryan or Iranian adjective takes
 an oblique before a postposition, and Yiddish's adjectives take a **dative**
 after «מיט» and «אויף» — so its catalog has the shape `locales/de` and

--- a/packages/i18n/locales/ab/chrome.ftl
+++ b/packages/i18n/locales/ab/chrome.ftl
@@ -1,0 +1,128 @@
+# Abkhaz viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the extended Cyrillic alphabet Abkhazia's schools and publishing
+# use, which is what CLDR fills a bare `ab` in as (`ab` maximizes to
+# `ab-Cyrl-GE`). ԥ is U+0525 and not the older ҧ U+04A7, ә is U+04D9 and not a
+# Latin a; ҟ, ҭ, ҳ, ҵ, ҷ, ҽ, ҿ, ҩ and ҕ are each one letter. A mis-keyed one is
+# not a typo here, it is a different word or no word at all.
+#
+# Abkhaz counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gave it. A noun after a
+# numeral stays in the singular, so the two branches differ in nothing but the
+# number they print — the `[0]` branch of `attempts-remaining` is the only one
+# that says something different, because Abkhaz negates the existential rather
+# than counting to zero.
+#
+# Nothing in this file agrees with a noun class. Abkhaz agreement is a prefix
+# on a verb, and the one place it could have reached the catalog is in
+# `content.ftl`, whose header explains why it does not fork there either.
+#
+# The technical vocabulary is the Russian one where written Abkhaz uses the
+# Russian one — «аклавиатура», «аматрица», «аинтервал», «аинформациа» — rather
+# than a coinage invented for this file.
+
+
+## Answer submission
+
+answer-checking = Агәаҭара…
+answer-submitting = Адәықәҵара…
+answer-checking-status = Аҭак агәаҭара
+answer-submitting-status = Аҭак адәықәҵара
+answer-correct = Иашоуп
+answer-incorrect = Иашаӡам
+answer-response-saved = Аҭак еиқәырхоуп
+answer-percent-credit = { $percent }% абал
+answer-percent-correct = { $percent }% иашоуп
+answer-percent-short = { $percent } %
+max-credit-available = Иахьӡозаалакь абал зегь реиҳа: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] аԥышәара ыҟаӡам
+        [one] иаанхоит { $count } аԥышәара
+       *[other] иаанхоит { $count } аԥышәара
+    }
+validation-correct = (Иашоуп)
+validation-incorrect = (Иашаӡам)
+validation-partially-correct = (Ахәҭала иашоуп)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } азы { $count } аҭак аарԥшра
+       *[other] { $answerId } азы { $count } аҭак аарԥшра
+    }
+
+## Disclosure panels
+
+feedback-heading = Ахәшьара
+collapsible-click-to-open = (аартразы иақәыӷәӷәа)
+collapsible-click-to-close = (аркразы иақәыӷәӷәа)
+collapsible-initializing = Аиқәыршәара…
+footnote-show = Аҵаҟатәи азгәаҭа аарԥшра
+footnote-hide = Аҵаҟатәи азгәаҭа аҵәахра
+description-more-information = еиҳаны аинформациа
+
+## Controls
+
+slider-previous = Аԥхьатәи
+slider-next = Анаҩстәи
+keyboard-open = Аклавиатура аартра
+keyboard-close = Аклавиатура аркра
+choice-input-remove-choice = { $choice } аныхра
+matrix-remove-row = Ацәаҳәа аныхра
+matrix-add-row = Ацәаҳәа ацҵара
+matrix-remove-column = Аколонка аныхра
+matrix-add-column = Аколонка ацҵара
+subset-add-remove-points = Акәаԥқәа рцҵара/рыныхра
+subset-toggle-points-intervals = Акәаԥқәеи аинтервалқәеи реиҭныԥсахлара
+subset-move-points = Акәаԥқәа риагара
+subset-clear = Арыцқьара
+orbital-add-row = Ацәаҳәа ацҵара
+orbital-remove-row = Ацәаҳәа аныхра
+orbital-add-box = Аклетка ацҵара
+orbital-remove-box = Аклетка аныхра
+orbital-add-up-arrow = Хыхьҟатәи ахыц ацҵара
+orbital-add-down-arrow = Ҵаҟаҟатәи ахыц ацҵара
+orbital-remove-arrow = Ахыц аныхра
+orbital-row-label = { $row }-тәи ацәаҳәа ахьӡ
+pretzel-answer = Аҭак
+summary-statistics-caption = { $column } азы астатистикатә ҳасабырба
+
+## Math input
+
+math-input-preview-region = аматематикатә формула аԥхьаԥшра
+math-input-preview = Аԥхьаԥшра
+math-input-invalid-expression = Ииашам аформула:
+
+## Document status
+
+viewer-initializing = Аиқәыршәара…
+
+## Errors
+
+error-heading = Агха
+error-found-at =
+    { $span ->
+        [line] Иԥшаан { $startLine }-тәи ацәаҳәаҿы.
+       *[lines] Иԥшаан ацәаҳәақәа { $startLine }–{ $endLine } рҿы.
+    }
+document-contains-errors = Ари адокумент гхақәа амоуп!
+diagnostic-heading-error = Агха
+diagnostic-heading-warning = Агәаҽанҵара
+diagnostic-heading-information = Аинформациа
+diagnostic-heading-hint = Ацхыраагӡа
+accessibility-heading-level-1 = WCAG AA анеира алшара аеилагара
+accessibility-heading-level-2 = Анеира алшара иазку агәаҽанҵара
+something-went-wrong = Акы гхала ицеит.
+renderer-load-failed = асахьаҭыхга аҭагалара ауам. Адаҟьа еиҭаҭагала.
+core-start-failed = Ари адокумент алагара ауам. Адаҟьа еиҭаҭагала.
+core-start-failed-busy = Ари адокумент алагара ауам. Зныкала документқәак еицалагеит, аиҿартәыра ласымзар уи еиҳа аамҭа адҵахоит. Егьырҭ адокументқәа анхыркәшалак ашьҭахь адаҟьа еиҭаҭагалара ацхыраара ауеит.
+core-start-failed-retry = Ари адокумент алагара ауам.
+core-start-failed-busy-retry = Ари адокумент алагара ауам. Зныкала документқәак еицалагеит, аиҿартәыра ласымзар уи еиҳа аамҭа адҵахоит.
+core-start-retry = Даҽазнык
+saved-state-unavailable = Шәара шәусура еиқәырхоу аҭагалара ауам.

--- a/packages/i18n/locales/ab/content.ftl
+++ b/packages/i18n/locales/ab/content.ftl
@@ -1,0 +1,301 @@
+# Abkhaz content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the extended Cyrillic alphabet Abkhazia's schools and publishing
+# have used since 1954, and what CLDR fills a bare `ab` in as: `ab` maximizes
+# to `ab-Cyrl-GE`. Six of its letters are easy to mis-key and a wrong one turns
+# a word into nothing: ԥ Ԥ is U+0525, **not** the older ҧ Ҧ (U+04A7) and not a
+# Latin p; ә is U+04D9, not a Latin a or e; and ҟ, ҭ, ҳ, ҵ, ҷ, ҽ, ҿ, ҩ, ҕ are
+# each a single letter rather than a Cyrillic base plus a mark. A file that
+# spells «аҟаԥшь» with ҧ or with a Latin p has quietly stopped being Abkhaz.
+#
+# **Abkhaz agrees, and this catalog still forks nowhere — that is the finding,
+# not an omission.** Abkhaz sorts nouns into human and non-human, and splits
+# the human class into masculine and feminine. But the agreement is spelled as
+# a prefix on the *verb*, and an attributive adjective — «ҟаԥшь», «ҭбаа»,
+# «шкәакәа» — never carries it and never changes shape. The one word in the
+# style pipeline that could agree is `style-filled-word` «иҭәу», a relative
+# verb form, whose human counterparts «дҭәу» and the plural «иҭәу» do exist in
+# the language. Nothing the core names is human: every entry in `noun` is a
+# line, a shape or a mark. So a `$gender` fork here would have exactly one
+# reachable branch and would render what the branch underneath it already
+# renders, which is the rule `locales/gu` and the three Berber catalogs each
+# reached from their own direction. `noun-gender` therefore answers one token
+# and no message selects on it. `$role` goes unused for the same reason: what a
+# clause position asks for in Abkhaz lands on a postposition or on the head
+# noun, both of which this catalog writes out itself.
+#
+# **The word order is not English's, and `style-with-noun` is where you see
+# it.** A qualitative adjective *follows* its noun in Abkhaz — «аҩны ду», the
+# big house — so the description comes after the thing described:
+# `{ $noun } { $description }`, not the other way round. A *relational*
+# adjective in -тә goes the other way and precedes, which is why the fill
+# patterns read «адиагоналтә ҵәаӷәа» and the participle «иҭәу» stands in front
+# of the noun in `style-filled-with-noun`. Both orders are in this file on
+# purpose.
+#
+# **The colour table is a set of choices, not a set of translations, and it is
+# the second thing to check.** Abkhaz's inherited «аиаҵәа» covers green and
+# blue together, and the language has no everyday grey. Where the style
+# pipeline needs the terms apart this catalog writes transparent compounds on
+# «аԥштәы», colour: «ажәҩанԥштәы» sky-colour for blue, «ахаҳәԥштәы»
+# stone-colour for grey, «адгьылԥштәы» earth-colour for brown, and «аиаҵәа»
+# kept for green alone. Orange, purple and pink are honest Russian loans in the
+# Abkhaz -тә adjective frame rather than invented natives, which is the reading
+# `locales/sah` took for the same problem in Sakha and `locales/os` for
+# «цъæх» in Ossetian. A speaker may well prefer other words for any of them.
+#
+# **Three further things this seed could not verify, listed loudest first.**
+# (1) The colour words are written in their citation form, with the article
+# а-; in a real attributive phrase the article moves to the head noun and the
+# adjective stands bare, «аҽы ҟаԥшь». This catalog does not attempt the bare
+# forms of the vowel-initial colours, because it could not check them, and
+# `standalone` could not tell the two positions apart even if it had — the
+# limit `locales/tpi` records for Tok Pisin's «-pela». (2) The width pair
+# «аҭбаа» broad and «ахәыҷы» small are stand-ins used as thick and thin; if
+# Abkhaz has proper width adjectives for a drawn stroke, replace them. (3) The
+# geometry nouns built on «акәакь», corner — «акәакьрацәа», «ахԥакәакь»,
+# «аиашакәакь» — are calques on the Russian school terms rather than words
+# read out of an Abkhaz textbook. Abkhaz-medium schooling stops below the
+# grades where this vocabulary is taught, so there was no textbook to read.
+
+
+## Style vocabulary
+##
+## Nothing here takes an agreement prefix, so nothing forks. The words are in
+## their citation form with the article а-; see the note at the top of the file
+## about what an attributive phrase does to it.
+
+color =
+    .black = аиқәаҵәа
+    .white = ашкәакәа
+    .gray = ахаҳәԥштәы
+    .red = аҟаԥшь
+    .orange = аоранжтә
+    .yellow = аҩежь
+    .green = аиаҵәа
+    .cyan = ажәҩанԥштәы лаша
+    .blue = ажәҩанԥштәы
+    .purple = афиолеттә
+    .pink = арозатә
+    .brown = адгьылԥштәы
+# «аҭбаа» is broad and «ахәыҷы» is small; both are stand-ins, and the header
+# says so.
+line-width =
+    .thick = аҭбаа
+    .thin = ахәыҷы
+# Reduplications, which is how Abkhaz builds a distributive: «piece-piece» and
+# «dot-dot». Coinages rather than attested drawing terms.
+line-style =
+    .dashed = ахәҭа-хәҭа
+    .dotted = акәаԥ-кәаԥ
+# Noun phrases, and the one place a relational adjective in -тә stands in front
+# of its noun rather than behind it.
+fill-style =
+    .horizontal = агоризонталтә ҵәаӷәақәа
+    .vertical = авертикалтә ҵәаӷәақәа
+    .diagonal = адиагоналтә ҵәаӷәақәа
+    .backdiagonal = иаҿагылоу адиагоналтә ҵәаӷәақәа
+    .dots = акәаԥқәа
+    .diamonds = аромбқәа
+noun =
+    .line = аҵәаӷәа
+    .line-segment = аҵәаӷәа хәҭа
+    .ray = алуч
+    .vector = авектор
+    .curve = аҵәаӷәа гьежь
+    .function = афункциа
+    .slope-field = анаклонтә поле
+    .vector-field = авектортә поле
+    .parabola = апарабола
+    .polyline = еиԥҟьоу аҵәаӷәа
+    .polygon = акәакьрацәа
+    .triangle = ахԥакәакь
+    .rectangle = аиашакәакь
+    .circle = агьежь
+    .region = аҵакыра
+    .point = акәаԥ
+    .square = аквадрат
+    .diamond = аромб
+    .cross = аџьар
+    .plus = аплиус
+# The side count is a relational adjective in -тә and precedes the noun, while
+# «иаша» — regular, on the Russian «правильный» — follows it. So the whole of
+# the phrase is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides }-кәакьтә акәакьрацәа иаша
+    }
+# Abkhaz agrees a verb with a human/non-human class and, inside human, with
+# masculine and feminine — but an attributive adjective carries none of it, and
+# every noun the core names is non-human. So this answers one token and nothing
+# in the file selects on it. See the header.
+noun-gender = non-human
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun comes first and the describing words follow it, which is Abkhaz's
+# order for a qualitative adjective and the reverse of English's.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+# A relative verb form, "that is full". It is the one word here that could
+# carry a class prefix — «дҭәу» of a person — and no noun the core names is a
+# person, so it is written flat. The header says why at length.
+style-filled-word = иҭәу
+# «змоу» — "which has" — is a free word, so the fill pattern is named without
+# welding a case suffix onto a placeable.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } змоу { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+# The participle precedes the noun and the colour follows it, which is the
+# split the header describes.
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } змоу { $filled } { $noun } { $color }
+        [plain-tail] { $filled } { $noun } { $color } { $nounTail }
+        [pattern-tail] { $pattern } змоу { $filled } { $noun } { $color } { $nounTail }
+       *[plain] { $filled } { $noun } { $color }
+    }
+# «аҳәаа … змоу» — "having a … border". The relative «змоу» stands as a word of
+# its own, so nothing is welded to the description, and Abkhaz wants no
+# article, which is why the two `-article` branches read like the two without.
+style-border-clause =
+    { $parts ->
+        [with-article] аҳәаа { $border } змоу
+        [and] насгьы аҳәаа { $border } змоу
+        [and-article] насгьы аҳәаа { $border } змоу
+       *[with] аҳәаа { $border } змоу
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] аԥштәы { $color }
+    }
+# The negation of «иҭәу». It agrees in the language exactly as the positive
+# form does, and `describeFill` hands this message no noun at all, so there is
+# no `$gender` to select on even if a human shape existed.
+style-unfilled = иҭәым
+# «аҿы» — "on" — is a postposition written as a separate word, so the colour it
+# follows can be a placeable without an ending being welded to it.
+style-text =
+    { $parts ->
+        [background] афон { $background } аҿы { $color }
+       *[plain] { $color }
+    }
+style-background-none = мап
+
+## Boolean words
+
+boolean-true = иаша
+boolean-false = имцу
+
+## Answer buttons
+
+answer-submit-label = Агәаҭара
+answer-submit-label-no-correctness = Аҭак адәықәҵара
+
+## Sectional blocks
+
+section-name =
+    .activity = Аусура
+    .aside = Аганахьтәи азгәаҭа
+    .cascade = Акаскад
+    .definition = Аилыркаара
+    .example = Аҿырԥштәы
+    .exercise = Аҽазыҟаҵага
+    .exercises = Аҽазыҟаҵагақәа
+    .given-answer = Аҭак
+    .note = Азгәаҭа
+    .objectives = Ахықәкқәа
+    .paragraphs = Абзацқәа
+    .part = Ахәҭа
+    .problem = Азадача
+    .problems = Азадачақәа
+    .proof = Ашьақәырӷәӷәара
+    .question = Азҵаара
+    .section = Аҟәша
+    .solution = Аӡбара
+    .task = Адҵа
+    .theorem = Атеорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Ацхыраагӡа
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Атаблица { $enumeration }
+        [numbered-title] Атаблица { $enumeration }{ ". " }
+        [unnumbered-title] Атаблица{ ". " }
+       *[unnumbered] Атаблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Асахьа { $enumeration }
+        [numbered-caption] Асахьа { $enumeration }{ ". " }
+        [unnumbered-caption] Асахьа{ ". " }
+       *[unnumbered] Асахьа
+    }
+
+## Paginator controls
+
+paginator-previous = Аԥхьатәи
+paginator-next = Анаҩстәи
+paginator-page = Адаҟьа
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## `piecewise-condition-if` cannot land correctly here, and the reason is
+## structural rather than lexical. Abkhaz has no free word for "if": a
+## condition is marked by the suffix -зар at the *end* of its own clause, and
+## the renderer places this key *before* the mathematics it introduces. The
+## nearest free-standing form, «акәзар» — "if it is" — is written out so the
+## sentence is at least readable, and it belongs after the inequality rather
+## than in front of it. That is the wall `locales/sah`, `locales/tyv`,
+## `locales/udm`, `locales/kv` and `locales/chm` each record for their own
+## clause-final conditional; no workaround is invented for it here.
+
+piecewise-condition-or = ма
+piecewise-condition-if = акәзар
+piecewise-condition-otherwise = даҽа ҭагылазаашьақәа рҿы
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. This is the school-system case in its
+## sharpest form: Abkhaz-medium schooling stops below the grades where
+## chemistry is taught, and secondary science in Abkhazia is taught in Russian.
+## There is no Abkhaz element list a pupil would recognize, so the English
+## fallback sits nearer their curriculum than an invented Abkhaz table would.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Ииашам ахимиатә дырга
+chemistry-invalid-ionic-compound = Ииашам аионтә еилаҵа

--- a/packages/i18n/locales/ab/diagnostics.ftl
+++ b/packages/i18n/locales/ab/diagnostics.ftl
@@ -1,0 +1,724 @@
+# Abkhaz diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the extended Cyrillic alphabet Abkhazia's schools and publishing
+# use, which is what CLDR fills a bare `ab` in as (`ab-Cyrl-GE`). ԥ is U+0525
+# rather than the older ҧ U+04A7, and ә is U+04D9 rather than a Latin a; ҟ, ҭ,
+# ҳ, ҵ, ҷ, ҽ, ҿ, ҩ and ҕ are each one letter. This is the longest of the four
+# files and so the one where a mis-keyed letter is likeliest to hide.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `styleNumber` — are part of the language rather than
+# prose and stay in English exactly as written, as does anything quoted back
+# from the author's own source.
+#
+# Abkhaz counts in two plural categories, `one` and `other`, so every counted
+# message keeps the shape English gave it, and a noun after a numeral stays
+# singular — which is why the two branches of most of them differ in nothing
+# but the number they print.
+#
+# Abkhaz agreement is a prefix on a verb, and nothing in this file describes a
+# noun the catalog itself supplies, so no message here forks on a class.
+# `content.ftl`'s header works out why the fork is absent there too.
+#
+# **Where a speaker should start.** The technical register below is built out
+# of a small set of recurring formulae rather than idiomatic prose, and if any
+# of them is wrong it is wrong in fifty places at once: «ахархәара амам» for
+# "is ignored", «… ауам» for "cannot", «… акәзароуп» for "must be", «иԥшаам»
+# for "not found", «ииашам» for "invalid" and «избанзар» for "because". Four
+# words are doing more work than they should and are the likeliest to want
+# replacing: «ацәаҳәа» stands for a source line, a matrix row *and* a sequence;
+# «аҽыԥсахуа» for a variable; «алахьынҵатә» for random; and «еицны ипростоу»
+# for coprime. The last two are coinages, not terms read out of an Abkhaz
+# textbook — Abkhaz-medium schooling stops below the grades where this
+# vocabulary is taught.
+
+## `<lineSegment>`
+
+# $attributes is a list of attribute names; $attributesCount is its length.
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] аҵыхәтәантәи ҩ-кәаԥк анарбо, { $attributes } ахархәара амам
+       *[other] аҵыхәтәантәи ҩ-кәаԥк анарбо, { $attributes } ахархәара амам
+    }
+
+# $attributes is a list of attribute names; $attributesCount is its length.
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] аҵыхәтәантәи акәаԥи агәҭантәи акәаԥи анарбо, { $attributes } ахархәара амам
+       *[other] аҵыхәтәантәи акәаԥи агәҭантәи акәаԥи анарбо, { $attributes } ахархәара амам
+    }
+
+line-segment-midpoint-offset-without-midpoint = агәҭантәи акәаԥ ада midpointOffset аҵак амам
+
+## `<line>`
+
+line-points-undetermined-dimensions = Аҵәаӷәа иарбам аҩаӡара змоу акәаԥқәа ирхысуеит.
+
+line-points-too-few-dimensions = Аҵәаӷәа еиҵамкәа ҩ-ҩаӡарак змоу акәаԥқәа ирхыс акәзароуп.
+
+# $variables is a bare enumeration of variable names, not an "and" list.
+line-points-depend-on-variables = Аҵәаӷәа аҽыԥсахуақәа ирыхьыԥшу акәаԥқәа ирхысуеит: { $variables }.
+
+line-equation-invalid-format = { $variable1 } насгьы { $variable2 } змоу аҵәаӷәа аиҟарара аформат ииашам.
+
+## `<ray>`
+
+ray-overprescribed-through = Алуч through, endpoint насгьы direction рыла иарбоуп. Иарбоу through ахархәара амам.
+
+ray-dimension-mismatch = алуч аҿы numDimensions еиқәшәом.
+
+## `<vector>`
+
+vector-overprescribed-head = Авектор head, tail насгьы displacement рыла иарбоуп. Иарбоу head ахархәара амам.
+
+vector-dimension-mismatch = авектор аҿы numDimensions еиқәшәом.
+
+## Attracting and constraining
+
+# $component is the DoenetML tag of the child that was named, e.g. "polygon".
+attract-to-without-nearest-point = `<{ $component }>` иадҳәалара ауам, избанзар уи nearestPoint аҭагылазаашьатә ҽыԥсахуа амам.
+
+constrain-to-without-nearest-point = `<{ $component }>` ала аҳәаақәҵара ауам, избанзар уи nearestPoint аҭагылазаашьатә ҽыԥсахуа амам.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` аҩныҵҟала аҳәаақәҵара ауам, избанзар уи nearestPoint аҭагылазаашьатә ҽыԥсахуа амам.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ацәаҳәаҿы иҟам choiceInput азы labelPosition ахархәара амам
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput азы иарбоу аиндексқәа ахархәара рымам, избанзар риԥхьаӡара choice ахәыҷқәа риԥхьаӡара иақәшәом.
+
+pretzel-indices-count-mismatch = problem азы иарбоу аиндексқәа ахархәара рымам, избанзар риԥхьаӡара problem ахәыҷқәа риԥхьаӡара иақәшәом.
+
+shuffle-indices-count-mismatch = shuffle азы иарбоу аиндексқәа ахархәара рымам, избанзар риԥхьаӡара акомпонентқәа риԥхьаӡара иақәшәом.
+
+# $component is `choiceInput`, `pretzel` or `shuffle` — a DoenetML component
+# name, so it stays in English.
+indices-ignored-out-of-range = { $component } азы иарбоу аиндексқәа ахархәара рымам, избанзар аиндексқәак аҳәаақәа ирҭыҵуеит.
+
+pretzel-indices-repeated = pretzel азы иарбоу аиндексқәа ахархәара рымам, избанзар аиндексқәак еиҭаҳәоуп.
+
+pretzel-circuit-first-index = circuit арежим аҿы pretzel азы иарбоу аиндексқәа ахархәара рымам, избанзар актәи аиндекс 1 акәзароуп.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` астроктә хәыҷқәа рыла аус аруразы `type` атрибут арбатәуп.
+
+invalid-type-defaulting-to-math = { $component } акомпонент азы ииашам атип { $type }. math, text, number ма boolean руакы акәзароуп. math ахь ииасуеит.
+
+# $value is the string child that could not be used.
+string-not-valid-component-to-arrange = Астрока "{ $value }" { $component } азы иашоу акомпонент акәӡам. Ахархәара амам.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Ииашам атип { $type }, атип number ахь ииасуеит.
+
+invalid-variable-value = Аҽыԥсахуа ииашам аҵакы: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Авариант аиндекс { $index } ахыԥхьаӡара акәзароуп
+
+variant-index-must-be-integer = Авариант аиндекс { $index } еибгоу ахыԥхьаӡара акәзароуп
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолиуттә шәагаақәа рзы иҟаҵам. Аҭбаарақәа аиҿырԥшратә ахь ииасуеит.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолиуттә шәагаақәа рзы иҟаҵам. Аҳәаақәа аиҿырԥшратә ахь ииасуеит.
+
+side-by-side-no-block-child = Ииашам `<{ $component }>`: еиҵамкәа аблоктә хәыҷык амазароуп.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Аграфикатә `<label>` аҿы `for` атрибут ахархәара амам.
+
+label-for-must-resolve-to-one = `<label>` аҿы `for` атрибут акомпонент заҵәык иазкызароуп.
+
+label-for-unresolved = `<label>` аҿы `for` атрибут акомпонент аҟынӡа инагӡахом.
+
+label-for-answer-with-authored-inputs = `<label>` аҿы `for` атрибут иарбоу аҭагаларақәа змоу `<answer>` иазхьарԥшуеит; аҭагалара хаҭала иазхьарԥш.
+
+label-for-answer-without-input = `<label>` аҿы `for` атрибут аҭагалара змам `<answer>` иазхьарԥшуеит.
+
+label-for-must-reference-input-or-answer = `<label>` аҿы `for` атрибут аҭагалара ма аҭак иазхьарԥшзароуп.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Анеира алшара азы `<{ $component }>` акьаҿу ахҳәаа амазароуп ма аԥшӡаратә ҳасабла иарбазароуп.
+
+accessibility-video-short-description = Анеира алшара азы `<video>` акьаҿу ахҳәаа амазароуп.
+
+accessibility-input-short-description-or-label = Анеира алшара азы `<{ $component }>` акьаҿу ахҳәаа ма ахьӡ амазароуп.
+
+accessibility-answer-input-short-description-or-label = Анеира алшара азы аҭагалара зыҟанаҵо `<answer>` акьаҿу ахҳәаа ма ахьӡ амазароуп.
+
+accessibility-short-description-contains-math = Акьаҿу ахҳәаақәа `<{ $component }>` еиԥш иҟоу аматематикатә компонентқәа рымазар ауам. Аматематика ажәақәа рыла иаҳәатәуп.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } аҟәша ахы атеқст азы иаҭаху аконтраст амам (аиқәаҵәа арежим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; еиҵамкәа { $threshold }:1 иаҭахуп).
+       *[other] { $colorName } аҟәша ахы атеқст азы иаҭаху аконтраст амам ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; еиҵамкәа { $threshold }:1 иаҭахуп).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = { $count } кәаԥ ирхысуа `<circle>` иҟаҵам, акәаԥқәа ахыԥхьаӡаратә ҵакқәа рымамзар.
+
+circle-too-many-through-points = Хԥа кәаԥ иреиҳаны ирхысуа агьежь аԥхьаӡара ауам.
+
+circle-overprescribed-radius-center-points = Иарбоу арадиуси ацентри ирхысуа акәаԥқәеи змоу агьежь аԥхьаӡара ауам.
+
+circle-center-with-multiple-points = Иарбоу ацентр змоу агьежь акәаԥ заҵәык иреиҳаны ирхыс ауам.
+
+circle-radius-too-small = Агьежь аԥхьаӡара ауам: ҩ-кәаԥк рыбжьара ибжьоу { $distance } акәзар, иарбоу арадиус { $radius } хәыҷуп.
+
+circle-radius-with-many-points = Иарбоу арадиус змоу агьежь ҩ-кәаԥк иреиҳаны ирхыс ауам.
+
+circle-invalid-center-or-through-points = Агьежь ацентр ма ирхысуа акәаԥқәа ииашам.
+
+circle-radius-center-with-multiple-points = Иарбоу ацентр змоу агьежь арадиус аԥхьаӡара ауам, акәаԥ заҵәык иреиҳаны ирхысуазар.
+
+circle-change-radius-non-numerical = Ахыԥхьаӡаратә ҵак змам акәаԥқәа ирхысуа агьежь арадиус аԥсахра ауам
+
+circle-radius-with-points-non-numerical = Ахыԥхьаӡаратә ҵакқәа анымам, иарбоу арадиус змоу, акәаԥ заҵәык иреиҳаны ирхысуа агьежь аԥҵара ауам.
+
+circle-change-center-non-numerical = Ахыԥхьаӡаратә ҵак змам акәаԥқәа ирхысуа агьежь ацентр аԥсахра иҟаҵам.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Афункциа аобласт азы аҩаӡарақәа маҷуп. Аобласт { $intervals } аинтервал амоуп, афункциа иамоуп { $inputs ->
+            [one] { $inputs } аҭагалара
+           *[other] { $inputs } аҭагалара
+        }.
+       *[other] Афункциа аобласт азы аҩаӡарақәа маҷуп. Аобласт { $intervals } аинтервал амоуп, афункциа иамоуп { $inputs ->
+            [one] { $inputs } аҭагалара
+           *[other] { $inputs } аҭагалара
+        }.
+    }
+
+function-domain-invalid-format = Афункциа аобласт аформат ииашам.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Афункциа ахыԥхьаӡаратә ҵак змам амаксимум ахархәара амам.
+        [minimum] Афункциа ахыԥхьаӡаратә ҵак змам аминимум ахархәара амам.
+        [extremum] Афункциа ахыԥхьаӡаратә ҵак змам аекстремум ахархәара амам.
+        [point] Афункциа ахыԥхьаӡаратә ҵак змам акәаԥ ахархәара амам.
+        [slope] Афункциа ахыԥхьаӡаратә ҵак змам анаклон ахархәара амам.
+       *[other] Афункциа ахыԥхьаӡаратә ҵак змам { $type } ахархәара амам.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Афункциа иҭацәу амаксимум ахархәара амам.
+        [minimum] Афункциа иҭацәу аминимум ахархәара амам.
+        [extremum] Афункциа иҭацәу аекстремум ахархәара амам.
+        [point] Афункциа иҭацәу акәаԥ ахархәара амам.
+       *[other] Афункциа иҭацәу { $type } ахархәара амам.
+    }
+
+function-points-too-close = Афункциа иамоуп рҭыԥқәа даара еиқәшәо ҩ-кәаԥк. Афункциа алкаара ауам.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Афункциа аиҭаҟаҵарақәа рылшоит аҭагаларақәа рхыԥхьаӡареи аҭыҵгақәа рхыԥхьаӡареи еиҟарзар мацара. Ари афункциа иамоуп { $inputs } аҭагалара насгьы { $outputs ->
+            [one] { $outputs } аҭыҵга
+           *[other] { $outputs } аҭыҵга
+        }.
+       *[other] Афункциа аиҭаҟаҵарақәа рылшоит аҭагаларақәа рхыԥхьаӡареи аҭыҵгақәа рхыԥхьаӡареи еиҟарзар мацара. Ари афункциа иамоуп { $inputs } аҭагалара насгьы { $outputs ->
+            [one] { $outputs } аҭыҵга
+           *[other] { $outputs } аҭыҵга
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Ацәаҳәа аура ииашам. Ноль еиҵамкәа еибгоу ахыԥхьаӡара акәзароуп.
+
+# $type is a sequence type: number, letters, or math.
+sequence-invalid-step = Ацәаҳәа ашьаҿа ииашам. { $type } атип змоу ацәаҳәа азы ахыԥхьаӡара акәзароуп.
+
+# $attribute is `from` or `to` — an attribute name, so it stays in English.
+sequence-invalid-endpoint-number = Ахыԥхьаӡаратә цәаҳәа "{ $attribute }" ииашам. Ахыԥхьаӡара акәзароуп.
+
+sequence-invalid-endpoint-letters = Анбантә цәаҳәа "{ $attribute }" ииашам. Анбанқәа реилаҵа акәзароуп.
+
+sequence-invalid-endpoint = Ацәаҳәа "{ $attribute }" ииашам.
+
+select-from-sequence-coprime-not-numbers = coprime ахархәара амам, избанзар ахыԥхьаӡарақәа алхӡом
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ахархәара амам, избанзар excludeCombinations арбоуп
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` азы ииашам target: ахықәкы иԥшаам.
+
+# $property is the state variable that was looked for; $component is the tag it
+# was looked for on.
+target-state-variable-not-found = `<{ $source }>` азы ииашам target: `<{ $component }>` аҿы "{ $property }" ахьӡ змоу аҭагылазаашьатә ҽыԥсахуа иԥшаам.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` аҽыԥсахуақәа ихьыԥшым аҽыԥсахуа иақәшәар ауам.
+
+ode-system-duplicate-variable-names = Еиҭаҳәоу ахьӡқәа змоу аҽыԥсахуақәа рыла ОДУ афункциақәа рԥҵара ауам.
+
+ode-system-rhs-function-error = ОДУ афункциа аԥҵара ауам. mathjs афункциа аԥҵараҿы агха.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } ҵәаӷәа рыбжьара акәакь аԥҵара ауам
+
+angle-invalid-through-point = `<angle>` through аҿы ииашам акәаԥ
+
+parabola-vertex-too-many-points = Иарбоу авершина змоу апарабола акәаԥ заҵәык иреиҳаны ирхыс иҟаҵам.
+
+parabola-too-many-points = Хԥа кәаԥ иреиҳаны ирхысуа апарабола иҟаҵам.
+
+intersection-too-many-items = Ҩ-хәҭак иреиҳаны раиԥырҵра иҟаҵам
+
+## Other math components
+
+ionic-compound-not-two-ions = Ҩ-ионк ада егьырҭ рзы аионтә еилаҵа иҟаҵам.
+
+ionic-compound-needs-cation-and-anion = Аионтә еилаҵа акатион заҵәыки анион заҵәыки рзы мацара иҟаҵоуп.
+
+# $equation is the equation as the author wrote it.
+solve-equations-cannot-evaluate = Аиҟарара аӡбара ауам, избанзар аиҟарара аԥхьаӡара ауам: { $equation }
+
+math-operators-operand-number-required = Аматематикатә операнд аныхразы operandNumber арбатәуп.
+
+eigen-decomposition-failed = Аматрица ахатәы ҵакқәа рыԥхьаӡара ауам
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: апараметр { $parameters } ашаблон аҿы иҟаӡам, убри аҟнытә иарбанзаалак аамҭазы иҭацәу иақәшәоит.
+       *[other] `<matchesPattern>`: апараметрқәа { $parameters } ашаблон аҿы иҟаӡам, убри аҟнытә иарбанзаалак аамҭазы иҭацәу ирқәшәоит.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" аилкаара ауам. none, medium, dense ма абжьажәа ала еиҟәшоу ҩ-позитивтә хыԥхьаӡарак акәзароуп, аҿырԥштәыс grid="1 0.5". Асеть ҭыхӡом.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` иаҭахуп афункциа змоу { $expected ->
+        [one] аҭыҵга заҵәык, акәаԥ зегь аҿы анаклон y', аҿырԥштәыс `y - x`
+       *[other] ҩ-ҭыҵгак, акәаԥ зегь аҿы авектор, аҿырԥштәыс `(y, -x)`
+    }, аха иарбоу афункциа иамоуп { $found ->
+        [one] { $found } аҭыҵга
+       *[other] { $found } аҭыҵга
+    }. { $alternative ->
+        [none] Акгьы ҭыхӡом.
+       *[other] Уи афункциа азы `<{ $alternative }>` акомпонент ауп. Акгьы ҭыхӡом.
+    }
+
+# Translators: retired. `function` is an attribute name and stays in English.
+field-function-attribute-ignored-with-child = `function` атрибут ахархәара амам, избанзар афункциа акомпонент аҩныҵҟагьы иарбоуп; ахархәара амоуп аҩныҵҟатәи. Афункциа ҩ-мҩак руакы мацара ала иарба.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибут акомпонент аҩныҵҟа иҩу аформула аҽыԥсахуақәа рырбоит. { $reason ->
+        [function-child] Араҟа афункциа `<function>` хәыҷык ҳасабла иарбоуп, уи ахатә ҽыԥсахуақәа ирбоит, убри аҟнытә `variables` ахархәара амам.
+       *[no-expression] Араҟа уи еиԥш аформула ыҟаӡам, убри аҟнытә `variables` ахархәара амам.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure асахьаҭыхгаҿы xLabelPosition="left" аднагалаӡом; арӷьарахьтәи аҭыԥ ахымҩаԥгашьа ахы иархәоуп.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure асахьаҭыхгаҿы yLabelPosition="bottom" аднагалаӡом; хыхьтәи аҭыԥ ахымҩаԥгашьа ахы иархәоуп.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure ахь аиасразы ааҭгылара аҳәаақәа ииашам; астандарттә bbox (-10,-10,10,10) ахы иархәоуп.
+
+prefigure-invalid-width = `<graph>`: prefigure ахь аиасразы аҭбаара ииашам; астандарттә аҭбаара 425 ахы иархәоуп.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure ахь аиасразы aspectRatio ииашам; астандарттә аҵакы 1 ахы иархәоуп.
+
+prefigure-grid-spacing-too-fine = `<graph>`: асеть абжьаанҵа ааҭгылара аҳәаақәа рзы даара имаҷуп; prefigure асахьаҭыхгаҿы асеть ҭыхӡом.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure асахьаҭыхга ахархәара анымам, азгәаҭарақәа ҭыхӡом.
+
+multiple-annotations-children = `<graph>` аҿы `<annotations>` хәыҷқәа рацәаны иԥшаауп; аҵыхәтәантәи ада егьырҭ зегь ахархәара рымам.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ирдырӡом акомпонент атип аиҵыхра ма акопиа аҟаҵара ауам: { $type }.
+
+copy-prop-not-found = { $component } атип змоу акомпонент аҿы { $property } аҷыдаҟазшьа иԥшаам
+
+collect-no-source = collect азы ахыҵхырҭа иԥшаам.
+
+collect-invalid-component-type = `<{ $component }>` атип змоу акомпонентқәа реизгара ауам, избанзар уи ииашам акомпонент атипуп.
+
+reference-index-unavailable = Аиндекс `{ $reference }` азхьарԥшра ауам
+
+## `<callAction>`
+
+component-action-unavailable = Акомпонент `{ $reference }` аҿы { $action } ааԥхьара ауам
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Адырқәа ииашам аформа рымоуп. Ацәаҳәақәа аура еиқәшәом. Иԥшаауп componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Адырқәа еиҭаҳәоу аколонкақәа рыхьӡқәа рымоуп. Иԥшаауп componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Адырқәа аколонка ахьӡ рымам. Иԥшаауп componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ари аҭак абал арҭара ихьыԥшуп аҭак ихатәы идәықәҵоу аҭак, уи иаԥсам ахымҩаԥгашьа алнагалоит.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` змоу аконтеинер аҩныҵҟа иҟоу `<answer>` аҿы `maxNumAttempts` аҵак амам, избанзар аԥышәарақәа рхыԥхьаӡара аконтеинер иаднакылоит. `maxNumAttempts` аконтеинер аҿы иқәыргыл.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` змоу даҽа контеинерк аҩныҵҟа иҟоу `sectionWideCheckWork` змоу аконтеинер аҿы `maxNumAttempts` аҵак амам, избанзар аԥышәарақәа рхыԥхьаӡара адәныҟатәи аконтеинер иаднакылоит. `maxNumAttempts` адәныҟатәи аконтеинер аҿы иқәыргыл.
+
+# $attributes is a list of attribute names; $attributesCount is its length.
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality ада { $attributes } атрибут аҵак амоуам.
+       *[other] symbolicEquality ада { $attributes } атрибутқәа рҵак рымоуам.
+    }
+
+answer-invalid-type = Аҭак азы ииашам атип: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` акомпонент ахьӡ анамам, амодуль атрибут ҳасабла ахархәара ауам
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` акомпонент амодуль азы атрибут ҳасабла ахархәара ауам, избанзар `<module>` акомпонент атип аҿы "{ $name }" атрибут ыҟоуп.
+
+conditional-content-condition-ignored = case ма else хәыҷқәа змоу `<conditionalContent>` акомпонент аҿы `condition` атрибут ахархәара амам.
+
+slider-markers-type-mismatch = Амаркерқәа ратип аслаидер атип иақәшәом.
+
+pretzel-problem-needs-statement-and-answer = Ииашам pretzel: `<problem>` зегь `<statement>` заҵәыки `<answer>` заҵәыки рымазароуп.
+
+pretzel-circuit-first-problem-distractor = Ииашам pretzel: mode="circuit" аҿы актәи `<problem>` дистрактор акәзар ауам.
+
+## Attribute values
+
+# $values is a list of the values that were rejected, each already in
+# backticks; $valuesCount is how many there were.
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут азы ииашам аҵакы { $values }; ахархәара амам.
+       *[other] `{ $attribute }` атрибут азы ииашам аҵакқәа { $values }; ахархәара рымам.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут азы ииашам аҵакы `{ $value }`. Атрибут `$` ала иалагоу азхьарԥшқәа рыла еиқәыршәазароуп.
+
+# $names is a list of the rejected names, each already in single quotes.
+math-input-invalid-function-names = <mathInput>: { $attribute } аҿы ииашам афункциа ахьӡқәа ахархәара рымам: { $names }. Ахьӡ зегь раарԥшратә хәҭа еиҵамкәа 2 символ (анбанқәа ма адефисқәа) амазароуп; уи ашьҭахь `|<mathspeak alternative>` ацҵазар ауеит.
+
+## Building components from the source
+
+component-type-invalid = Ииашам акомпонент атип: `<{ $componentType }>`
+
+attribute-repeated = Атрибут { $attribute } еиҭаҳәара ауам.
+
+attribute-invalid-for-component = `<{ $componentType }>` атип змоу акомпонент азы ииашам атрибут "{ $attribute }".
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Астиль { $styleNumber } иаҭаху аконтраст амам { $context ->
+        [text-on-background] афон иаҿагылоу атеқст аԥштәы азы
+        [high-contrast] аканва иаҿагылоу иконтрастны иҟоу аԥштәы азы
+        [line] аканва иаҿагылоу аҵәаӷәа аԥштәы азы
+        [marker] аканва иаҿагылоу амаркер аԥштәы азы
+       *[text-on-canvas] аканва иаҿагылоу атеқст аԥштәы азы
+    }{ $mode ->
+        [dark] { " (аиқәаҵәа арежим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; еиҵамкәа { $threshold }:1 иаҭахуп).
+
+style-definition-dark-mode-text-background-contrast =
+    Астиль { $styleNumber } алашара арежим азы иаҭаху аконтраст змоу аԥштәқәа рымазаргьы, урҭ рыла иҟоу аиқәаҵәа арежим аԥштәқәа рҿы афон иаҿагылоу атеқст аԥштәы иаҭаху аконтраст амам ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; еиҵамкәа { $threshold }:1 иаҭахуп). { $suggestion ->
+        [available] Аиқәаҵәа арежим аҿы аконтраст еиӷьхаразы алашара арежим аконтраст еизырҳатәуп (аҿырԥштәыс { $lightAttribute }="{ $lightColor }" аҭаргалара), мамзаргьы аиқәаҵәа арежим аԥштәы ԥсахтәуп (аҿырԥштәыс { $darkAttribute }="{ $darkColor }" аҭаргалара).
+       *[none] Аиқәаҵәа арежим аҿы аконтраст еиӷьхаразы алашара арежим аконтраст еизырҳатәуп, мамзаргьы textColorDarkMode ма backgroundColorDarkMode рыла аԥштәқәа ԥсахтәуп.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Астиль { $styleNumber } алашара арежим азы иаҭаху аконтраст змоу атеқст аԥштәы амазаргьы, уи ала иҟоу аиқәаҵәа арежим атеқст аԥштәы аканва иаҿагыланы иаҭаху аконтраст амам ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; еиҵамкәа { $threshold }:1 иаҭахуп). { $suggestion ->
+        [available] Аиқәаҵәа арежим аҿы аконтраст еиӷьхаразы алашара арежим аконтраст еизырҳатәуп (аҿырԥштәыс textColor="{ $lightColor }" аҭаргалара), мамзаргьы аиқәаҵәа арежим аԥштәы ԥсахтәуп (аҿырԥштәыс textColorDarkMode="{ $darkColor }" аҭаргалара).
+       *[none] Аиқәаҵәа арежим аҿы аконтраст еиӷьхаразы алашара арежим аконтраст еизырҳатәуп, мамзаргьы textColorDarkMode ала аԥштәы ԥсахтәуп.
+    }
+
+section-multiple-style-palettes = Аҟәша <stylePalette> заҵәык алнахуеит; ахархәара амоуп аҵыхәтәантәи.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } аҷыда вариантқәа рылкаара ауам, избанзар numToSelect ноль еиҵамкәа еибгоу ахыԥхьаӡара акәӡам.
+
+variant-num-to-select-not-constant-number = { $component } аҷыда вариантқәа рылкаара ауам, избанзар numToSelect иҭышәынтәалоу ахыԥхьаӡара акәӡам.
+
+variant-with-replacement-not-constant-boolean = { $component } аҷыда вариантқәа рылкаара ауам, избанзар withReplacement иҭышәынтәалоу абулевтә ҵакы акәӡам.
+
+variant-select-weight-disables-unique = select азы аҷыда вариантқәа аанкылоуп, selectWeight ма selectForVariants змоу алхрак анымоу
+
+variant-coprime-undetermined = { $component } аҷыда вариантқәа рылкаара ауам, избанзар coprime еснагь имцу ауп ҳәа алкаара ауам.
+
+# $attribute is an attribute name (`from`, `to`, `step`, `sort`, `length`) and
+# stays as written.
+variant-attribute-not-constant = { $component } аҷыда вариантқәа рылкаара ауам, избанзар { $attribute } иҭышәынтәалам.
+
+variant-attribute-not-number = { $component } аҷыда вариантқәа рылкаара ауам, избанзар { $attribute } ахыԥхьаӡара акәӡам.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } атип змоу { $component } аҷыда вариантқәа рылкаара ауам, избанзар { $attribute } { $expected ->
+        [letters-combination] анбанқәа реилаҵа
+        [math-expression] иашоу аматематикатә формула
+        [integer] еибгоу ахыԥхьаӡара
+       *[number] ахыԥхьаӡара
+    } акәӡам.
+
+variant-length-not-integer = { $component } аҷыда вариантқәа рылкаара ауам, избанзар аура еибгоу ахыԥхьаӡара акәӡам.
+
+variant-sort-not-implemented = sort змоу { $component } аҷыда вариантқәа иҟаҵам
+
+variant-exclude-combinations-not-implemented = excludeCombinations змоу { $component } аҷыда вариантқәа иҟаҵам
+
+variant-math-exclude-not-implemented = exclude змоу math атип змоу { $component } аҷыда вариантқәа иҟаҵам
+
+variant-non-constant-exclude-not-implemented = иҭышәынтәалам exclude змоу { $component } аҷыда вариантқәа иҟаҵам
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: аграфик prefigure асахьаҭыхгаҿы аднагалаӡом; ахылҵ аанрыжьуп.
+
+prefigure-descendant-invalid-geometry = { $subject }: агеометриа ҵыхәтәа змам ма нагӡам; ахылҵ аанрыжьуп.
+
+prefigure-curve-label-omitted = { $subject }: еиҭагоу аҵәаӷәа гьежь аелементқәа рҿы ахьӡқәа аднагалаӡом; ахьӡ аанрыжьуп.
+
+prefigure-curve-unsupported-definition-type = { $subject }: аҵәаӷәа гьежь аилкаара атип '{ $definitionType }' аднагалаӡом; ахылҵ аанрыжьуп.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves аҿы flipFunctions атрибут аднагалаӡом; ахылҵ аанрыжьуп.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves аҿы аформулатә тип змоу ахәыҷқәа рфункциақәа мацара аднагалоит; ахылҵ аанрыжьуп.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] аҵәаӷәатә гәыԥ ахьӡ
+       *[point] акәаԥ ахьӡ
+    } азы labelPosition '{ $labelPosition }' аднагалаӡом; PreFigure астандарттә еиҟаратәра ахы иархәоуп.
+
+prefigure-fill-style-unsupported = { $subject }: аҭәара астиль '{ $fillStyle }' PreFigure иаднагалаӡом; аԥштәы заҵәык ала аҭәара ахь ииасуеит.
+
+prefigure-line-style-unknown = { $subject }: еилкаам аҵәаӷәа астиль '{ $lineStyle }' PreFigure аҭыҵгаҿы аанрыжьуп.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: амаркер астиль '{ $markerStyle }' PreFigure астиль 'diamond' ахь ииасуеит.
+
+prefigure-marker-style-unsupported = { $subject }: амаркер астиль '{ $markerStyle }' PreFigure иаднагалаӡом; астандарттә стиль ахы иархәоуп.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ииашам `ref`; ахықәкы аԥшаара ауам. Азгәаҭа аанрыжьуп.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` хықәкқәа рацәак иазкуп; ахархәара амоуп актәи.
+
+annotation-ref-outside-graph = `<annotation>`: ииашам `ref`; ахықәкы аграфик анҭыҵ иҟоуп. Азгәаҭа аанрыжьуп.
+
+annotation-ref-unsupported-target = `<annotation>`: ииашам `ref`; ахықәкы prefigure ахь аиасраҿы иаднагало графикатә объект акәӡам. Азгәаҭа аанрыжьуп.
+
+annotation-text-missing = `<annotation>`: `text` ыҟаӡам ма иҭацәуп; иҭацәу атеқст аҭыҵуеит.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Агьежьтә хьыԥшра ԥшаауп.
+       *[other] `<{ $componentType }>` акомпонент иадҳәалоу агьежьтә хьыԥшра ԥшаауп.
+    }
+
+reference-no-referent = Азхьарԥш азы иазку акгьы иԥшаам: `{ $reference }`
+
+reference-multiple-referents = Азхьарԥш азы иазку рацәак иԥшааит: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` атрибут { $attribute } аформат ииашам.
+
+# $children is the list of child types that did not match, already joined.
+children-invalid = `<{ $componentType }>` азы ииашам ахәыҷқәа: иԥшаауп ииашам ахәыҷқәа: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут азы ииашам аҵакы `{ $value }`, ахархәара амоуп аҵакы `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML аверсиа { $version } иԥшаам.
+       *[other] DoenetML аверсиа { $version } иԥшаам. Аверсиа { $fallback } ахь ииасуеит
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Ииашам DoenetML: { $content }
+
+parse-tag-missing-close-tag = Ииашам DoenetML: Атег `{ $tag }` аркга тег амам. Хаҭала иаркуа атег ма `</{ $tagName }>` атег иаҭахын.
+
+parse-tag-error = Ииашам DoenetML: Атег `<{ $tagName }>` аҿы агха
+
+parse-attribute-missing-value = Ииашам DoenetML: Ииашам атрибут `{ $attribute }` аҵакы амам ҳәа иҟалоит.
+
+parse-attribute-invalid = Ииашам DoenetML: Ииашам атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Ииашам DoenetML: Ииашам атрибут аҵакы `{ $value }`
+
+# $quote is the quote character that would balance the pair: `"` or `'`.
+parse-attribute-value-quote-mismatch = Ииашам DoenetML: Ииашам атрибут аҵакы `{ $value }`. Акавычкақәа еиқәшәом. `{ $quote }` шәымам ҳәа иҟалоит
+
+parse-open-tag-name-missing = Ииашам DoenetML: Ахьӡ змам атег ԥшаауп, аҿырԥштәыс `<`
+
+parse-tag-not-closed = Ииашам DoenetML: Атег `{ $tag }` аркӡам (`>` ыҟаӡам ҳәа иҟалоит).
+
+parse-self-closing-tag-name-missing = Ииашам DoenetML: Ахьӡ змам атег ԥшаауп `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Ииашам DoenetML: Атег `{ $tag }` аркӡам (`/>` ыҟаӡам ҳәа иҟалоит).
+
+parse-tag-invalid-attributes = Ииашам DoenetML: Атег `{ $tag }` ииашам. Ииашам атрибутқәа амазар ауеит.
+
+parse-close-tag-name-missing = Ииашам DoenetML: Ахьӡ змам аркга тег ԥшаауп, аҿырԥштәыс `</`
+
+parse-attribute-value-unquoted = Атрибут аҵакқәа акавычкақәа рыбжьара иҟазароуп: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Ииашам DoenetML: Аркга тег `{ $tag }` ԥшаауп, аха иақәшәо аартга тег ыҟаӡам
+
+parse-close-tag-mismatched = Ииашам DoenetML: Аркга тег еиқәшәом. Иаҭахын `</{ $expected }>`. Иԥшаауп `{ $found }`
+
+parser-node-unconvertible = Анод { $node } Dast анод ахь аиагара ауам.
+
+## Names
+
+name-attribute-invalid =
+    Ииашам атрибут name='{ $name }'. { $reason ->
+        [characters] Ахьӡқәа анбанқәа, ахыԥхьаӡарақәа, аҵаҟатәи аҵәаӷәақәа ма адефисқәа мацара рымазар ауеит.
+       *[start] Ахьӡқәа анбан ала иалагазароуп.
+    }
+
+component-name-invalid-start = Ииашам акомпонент ахьӡ "{ $name }". Ахьӡқәа анбан ала иалагазароуп.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched атип змоу аҭак video атрибут амазароуп
+
+answer-video-watched-video-not-reference = videoWatched атип змоу аҭак азхьарԥш зкоу video атрибут амазароуп
+
+answer-name-not-single-text = Аҭак name атрибут атеқсттә хәыҷ заҵәык амазароуп
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Адәныҟатәи DoenetML аиура ауам, арекурсиа аҩаӡарақәа рацәоуп. Агьежьтә зхьарԥш ыҟазар акәхап?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" аҟынтә DoenetML аиура ауам
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" аҟынтә иаагоу DoenetML ииашам: акомпонент атип "{ $componentType }" иақәшәом
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Атрибут `{ $from }` ижәытәуп; уи аҭыԥан `{ $to }` шәхы иашәырхәа.
+       *[other] [deprecation] `<{ $component }>` аҿы атрибут `{ $from }` ижәытәуп; уи аҭыԥан `{ $to }` шәхы иашәырхәа.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Атрибут `{ $from }` ижәытәуп, `{ $to }` гьы иарбоуп, убри аҟнытә ахархәара амам.
+       *[other] [deprecation] `<{ $component }>` аҿы атрибут `{ $from }` ижәытәуп, `{ $to }` гьы иарбоуп, убри аҟнытә ахархәара амам.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` аҿы атрибут `{ $attribute }` ижәытәуп, ахархәара амам.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` аҿы атрибут `{ $attribute }` ижәытәуп; уи аҭыԥан `<{ $child }>` хәыҷ шәхы иашәырхәа.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` аҿы атрибут `{ $attribute }` аҵакы `{ $value }` ижәытәуп; уи аҭыԥан `{ $to }` шәхы иашәырхәа.
+
+
+## Language coverage
+
+# $locale is the document's language tag, as declared.
+pluralize-english-only = `<pluralize>` аинглыз бызшәа мацара арацәабатә ахь иагоит, убри аҟнытә { $locale } ала иҩу адокумент аҿы уи атеқст ԥсахда иаанхоит. Арацәабатә хаҭала иҩ, мамзаргьы `pluralForm` атрибут ала иарба.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Аелемент `<{ $tag }>` ирдырхо Doenet елемент акәӡам.
+
+schema-element-not-allowed-at-root = Аелемент `<{ $tag }>` адокумент ахцәа аҿы азин амам.
+
+schema-element-not-allowed-inside = Аелемент `<{ $tag }>` `<{ $parent }>` аҩныҵҟа азин амам.
+
+schema-attribute-unrecognized = Аелемент `<{ $tag }>` `{ $attribute }` ахьӡ змоу атрибут амам.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Аелемент `<{ $tag }>` атрибут `{ $attribute }` ахьӡынҵа акәзароуп, уи ахәҭа зегь ари аҟынтә акәзароуп: { $allowed }
+       *[other] Аелемент `<{ $tag }>` атрибут `{ $attribute }` ари аҟынтә акәзароуп: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select азы ииашам авариант ахьӡ. Авариант ахьӡ { $variantName } { $numOptions } алхраҿы иԥшаауп, алхтәу ракәзар { $numToSelect } ауп.
+
+select-variant-name-without-options = select азы авариантқәа арбоуп, аха иҟалар зылшо авариант ахьӡ азы алхрақәа арбаӡам: { $variantName }.
+
+select-variant-name-not-possible = select азы иарбоу авариант ахьӡ { $variantName } иҟалар зылшо авариант ахьӡ акәӡам.
+
+select-too-few-options = { $numOptions } мацара рҟынтә { $numToSelect } компонент алхра ауам.
+
+select-from-sequence-too-few-values = Аура { $length } змоу ацәаҳәа аҟынтә { $numToSelect } ҵакы алхра ауам.
+
+select-from-sequence-indices-count-mismatch = select азы иарбоу аиндексқәа рхыԥхьаӡара алхтәу рхыԥхьаӡара иақәшәазароуп
+
+select-from-sequence-indices-not-integers = select азы иарбоу аиндексқәа зегь еибгоу ахыԥхьаӡарақәа ракәзароуп
+
+select-from-sequence-index-excluded = selectfromsequence азы иарбоу аиндекс иҭыганы иҟан
+
+select-from-sequence-indices-excluded-combination = selectfromsequence азы иарбоу аиндексқәа иҭыгоу еилаҵаны иҟан
+
+select-from-sequence-coprime-not-positive-integers = Еицны ипростоу еилаҵақәа алхра ауам, избанзар апозитивтә еибгоу хыԥхьаӡарақәа алхӡом.
+
+# Translators: from, to and step are attribute names.
+select-from-sequence-coprime-common-factor = Еицны ипростоу ахыԥхьаӡарақәа алхра ауам. Иҟалар зылшо аҵакқәа зегь еицырзеиԥшу аиҟәшага рымоуп. (Иарбоу "from" ма "to" аҵакқәа "step" ацы еицны ипростозароуп.)
+
+select-from-sequence-coprime-single-number = 1 акәым хыԥхьаӡара заҵәык аҟынтә еицны ипростоу еилаҵақәа алхра ауам.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence аҿы аилаҵақәа 70% инеиҳаны иҭыгоуп
+
+select-from-sequence-coprime-none-found = Еицны ипростоу ахыԥхьаӡарақәа алхра ауам. Иҟалар зылшо аҵакқәа зегь еицырзеиԥшу аиҟәшага рымоуп.
+
+select-from-sequence-too-few-unique-values = Аура { $numPossibleValues } змоу ацәаҳәа аҟынтә { $numToSelect } ҷыда ҵакы алхра ауам
+
+select-prime-numbers-too-few-values = Аура { $numValues } змоу апростатә хыԥхьаӡарақәа рыхьӡынҵа аҟынтә { $numToSelect } ҵакы алхра ауам
+
+select-prime-numbers-values-count-mismatch = select азы иарбоу аҵакқәа рхыԥхьаӡара алхтәу рхыԥхьаӡара иақәшәазароуп
+
+select-prime-numbers-values-not-prime = select prime number азы иарбоу аҵакқәа зегь апростатә хыԥхьаӡарақәа рыхьӡынҵаҿы иҟазароуп
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers азы иарбоу аҵакқәа иҭыгоу еилаҵаны иҟан
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers аҿы аилаҵақәа 70% инеиҳаны иҭыгоуп
+
+select-random-combination-fluke = Даара иҟалар зылшам ҭагылазаашьала алахьынҵатә ҵакқәа реилаҵа алхра ауам
+
+select-random-value-fluke = Даара иҟалар зылшам ҭагылазаашьала алахьынҵатә ҵакы алхра ауам

--- a/packages/i18n/locales/ab/editor.ftl
+++ b/packages/i18n/locales/ab/editor.ftl
@@ -1,0 +1,234 @@
+# Abkhaz editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the extended Cyrillic alphabet Abkhazia's schools and publishing
+# use, which is what CLDR fills a bare `ab` in as (`ab-Cyrl-GE`). ԥ is U+0525
+# rather than the older ҧ U+04A7, and ә is U+04D9 rather than a Latin a; ҟ, ҭ,
+# ҳ, ҵ, ҷ, ҽ, ҿ, ҩ and ҕ are each one letter.
+#
+# Abkhaz counts in two plural categories, `one` and `other`, so the counted
+# messages below keep the shape English gave them. A noun after a numeral stays
+# singular, so the two branches differ only in the number they print.
+#
+# Nothing here agrees with a noun class: Abkhaz spells agreement as a prefix on
+# a verb, and none of these sentences describes a noun the catalog supplies.
+# `content.ftl`'s header is where that is worked out at length.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every element and attribute
+# name are identifiers rather than prose and stay exactly as written.
+#
+# **Where this file most likely reads stiffly.** Abkhaz makes a verbal noun out
+# of nearly every action, and an object stands in front of it — so a button
+# that reads "Update Viewer" in English reads «Ахәаԥшга арҿыцра», viewer first
+# and the action second, throughout. The technical vocabulary is the Russian
+# one where written Abkhaz uses the Russian one, and the coinages a speaker
+# should look at first are «ахәаԥшга» for the viewer, «аԥхьаԥшра» for a
+# preview, and «анеира алшара» for accessibility.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Аиҭашьақәыргылара
+       *[update] Арҿыцра
+    }
+
+# The object stands in front of the verbal noun in Abkhaz, so the viewer is
+# named first and { $word } follows it — the reverse of the English order.
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Ахәаԥшга { $word }
+       *[other] Ахәаԥшга { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Авариант
+editor-variant-filter = Афильтр…
+editor-variant-next = Анаҩстәи авариант алхра
+editor-variant-previous = Аԥхьатәи авариант алхра
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA анеира алшара аеилагара ԥшаауп. Анеира алшара иазку аҳасабырба { $action ->
+            [close] аркразы
+           *[open] аартразы
+        } иақәыӷәӷәа.
+        [advisories] Анеира алшара иазку аҳасабырба { $action ->
+            [close] аркразы
+           *[open] аартразы
+        } иақәыӷәӷәа. WCAG AA аеилагарақәа ԥшаам, аха анеира алшара иазку иацҵоу арекомендациақәа ыҟоуп.
+       *[clean] Анеира алшара иазку аҳасабырба { $action ->
+            [close] аркразы
+           *[open] аартразы
+        } иақәыӷәӷәа. Анеира алшара иазку азҵаарақәа ԥшаам.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA анеира алшара аеилагара ԥшаауп. Иԥшаауп { $count ->
+            [one] WCAG AA { $count } аеилагара
+           *[other] WCAG AA { $count } аеилагара
+        }. Анеира алшара иазку аҳасабырба { $action ->
+            [close] аркразы
+           *[open] аартразы
+        } иақәыӷәӷәа.
+        [advisories] WCAG AA аеилагарақәа ԥшаам. Иԥшаауп анеира алшара иазку иацҵоу { $count ->
+            [one] { $count } арекомендациа
+           *[other] { $count } арекомендациа
+        }. Анеира алшара иазку аҳасабырба { $action ->
+            [close] аркразы
+           *[open] аартразы
+        } иақәыӷәӷәа.
+       *[clean] WCAG AA аеилагарақәа ԥшаам. Анеира алшара иазку аҳасабырба { $action ->
+            [close] аркразы
+           *[open] аартразы
+        } иақәыӷәӷәа.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML аверсиа { $version }
+
+editor-tab-help = Аконтекст иақәыршәоу ацхыраара
+editor-tab-help-short = Аконтекст
+editor-tab-errors = Агхақәа
+editor-tab-warnings = Агәаҽанҵарақәа
+editor-tab-info = Аинформациа
+editor-tab-accessibility = Анеира алшара
+editor-tab-responses = Идәықәҵоу аҭакқәа
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Аредактор апараметрқәа
+editor-format-as-doenetml = DoenetML ала аформатркра
+editor-format-as-xml = XML ала аформатркра
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Ацәаҳәа #{ $line }
+
+editor-no-errors = Гхақәа ыҟаӡам
+editor-no-warnings = Агәаҽанҵарақәа ыҟаӡам
+editor-no-info = Аинформациатә диагностика ыҟаӡам
+
+editor-show-info-annotations = Аинформациатә диагностика аредактор аҿы аарԥшра
+editor-show-accessibility-annotations = Анеира алшара иазку адиагностика аредактор аҿы аарԥшра
+
+editor-accessibility-learn-more = Doenet анеира алшара шазнеиуа шәаԥхьа
+
+editor-accessibility-violations-heading = Анеира алшара аеилагарақәа ({ $standard })
+
+editor-accessibility-other-heading = Анеира алшара иазку егьырҭ азҵаарақәа
+editor-none-found = Акгьы иԥшаам
+
+
+## Submitted responses
+
+editor-no-responses = Ҟаза иахьӡанӡа идәықәҵоу аҭакқәа ыҟаӡам
+editor-response-answer-id = Аҭак аидентификатор
+editor-response-response = Аҭак
+editor-response-credit = Абал
+editor-response-submitted = Идәықәҵоуп
+
+
+## The context-help panel
+
+help-placeholder = Адокументациа азы акурсор атег ахьӡ, атрибут, ма { $ref } иқәыргыл.
+
+help-unsupported-ref-chain = { $example } еиԥш ихәҭа-хәҭоу азхьарԥшқәа рзы ацхыраара ҵыхәтәанӡа иҟаӡам.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Азхьарԥш азы иазку акгьы иԥшаам: { $ref }.
+        [multiple] Азхьарԥш азы иазку рацәак иԥшааит: { $ref }.
+       *[indeterminate] { $ref } иазку иашьашәалоу аилкаара ауам.
+    }
+
+help-learn-about-references = Азхьарԥшқәа ирызкны шәаԥхьа →
+help-reference-page = Азхьарԥш адаҟьа →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } аҩныҵҟа
+       *[top] Хыхьтәи аҩаӡараҿы
+    }{ $allowed ->
+        [none] { " — араҟа акгьы иқәтәом." }
+        [text] { " — араҟа атеқст ишәыҩ." }
+        [text-and-components] { " — араҟа атеқст ишәыҩ, мамзаргьы:" }
+       *[components] { " — ишәыԥышәар илшо:" }
+    }
+
+help-suggestions-footer = Акомпонентқәа зегь { $total } рбаразы { $shortcut } иақәыӷәӷәа.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } { $target } иазку азхьарԥшуп.
+       *[other] { $ref } { $target } иазку азхьарԥшуп (ацәаҳәа { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } { $role } ҳасабла иалагалеит.
+       *[other] { $owner } { $line }-тәи ацәаҳәаҿы { $role } ҳасабла иалагалеит.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } { $element } аҷыдаҟазшьа { $property } иазку азхьарԥшуп.
+       *[other] { $ref } { $element } аҷыдаҟазшьа { $property } иазку азхьарԥшуп (ацәаҳәа { $line }).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = афрагмент
+help-kind-array-entry = амассив аелемент
+
+help-default = Астандарттә ҵакы:
+help-active-default = Иактиву астандарттә ҵакы:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Иаднагало аҵакқәа (хәҭак ала акы):
+       *[other] Иаднагало аҵакқәа:
+    }
+
+help-suggested-values = Ишәыԥышәар илшо аҵакқәа:
+
+help-inserts = Иалнагалоит:
+
+help-coordinates =
+    { $count ->
+        [one] Акоордината:
+       *[other] Акоординатақәа:
+    }
+
+help-type = Атип:
+
+help-resolved-style = Иалкаау астиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Иалкаау афункциақәа рыхьӡқәа:
+help-reset-list = Ари аҭагалараҿы аиҭашьақәыргылара ахьӡынҵа:
+help-added-on-input = Ари аҭагалараҿы иацҵоуп:
+help-removed-on-input = Ари аҭагалараҿы ианыхуп:
+
+help-reset-overrides = { $reset } { $additional } насгьы { $removed } рҭыԥ ааннакылоит.

--- a/packages/i18n/locales/ady/chrome.ftl
+++ b/packages/i18n/locales/ady/chrome.ftl
@@ -1,0 +1,135 @@
+# Adyghe (West Circassian) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Ӏ (palochka), the orthography Adygea's schools and
+# publishing use. The palochka is a letter, not a Latin I and not a digit 1:
+# УплъэкӀун, ӀэпыӀэгъу and ЗэшӀохыгъ are ordinary words, and spelling any of
+# them with `I` or `1` breaks them silently.
+#
+# Adyghe counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular in Adyghe — and the numeral follows the noun, «попыткэ 3» — so the
+# two branches differ in nothing but the number they print, and both were
+# still written out rather than collapsed.
+#
+# Adyghe has no gender and no noun class, so nothing here or in `content.ftl`
+# forks on `$gender`. See `content.ftl`'s header for the word order the style
+# descriptions use and for the colour terms, neither of which this file
+# touches.
+#
+# Two vocabularies are borrowed rather than coined, and a speaker should
+# expect to revisit both: the interface words the Russian-language software an
+# Adyghe reader already uses supplies — «клавиатурэ», «таблицэ», «попыткэ»,
+# «стрелкэ» — and «доступность» for accessibility, which has no settled
+# Adyghe equivalent this seed could check.
+
+
+## Answer submission
+
+answer-checking = УплъэкӀун…
+answer-submitting = ГъэкӀон…
+answer-checking-status = Джэуапыр уплъэкӀун
+answer-submitting-status = Джэуапыр гъэкӀон
+answer-correct = Тэрэз
+answer-incorrect = Мытэрэз
+answer-response-saved = Джэуапыр къэгъэнагъ
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% тэрэз
+answer-percent-short = { $percent } %
+max-credit-available = Балл нахьыбэ дэдэу пшӀошӀыщтыр: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] къэнэжьыгъэ попыткэ щыӀэп
+        [one] попыткэ { $count } къэнэжьыгъ
+       *[other] попыткэ { $count } къэнэжьыгъ
+    }
+validation-correct = (Тэрэз)
+validation-incorrect = (Мытэрэз)
+validation-partially-correct = (ӀахькӀэ тэрэз)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } иджэуап { $count } къэгъэлъэгъон
+       *[other] { $answerId } иджэуап { $count } къэгъэлъэгъон
+    }
+
+
+## Disclosure panels
+
+feedback-heading = ГущыӀэ къэгъэзэжь
+collapsible-click-to-open = (къызэӀухыным фэшӀ тепӀытӀ)
+collapsible-click-to-close = (зэфэшӀыжьыным фэшӀ тепӀытӀ)
+collapsible-initializing = Егъэхьазыры…
+footnote-show = ЧӀэгърыт тхыгъэр къэгъэлъэгъон
+footnote-hide = ЧӀэгърыт тхыгъэр гъэбылъын
+description-more-information = нахьыбэ къэбар
+
+
+## Controls
+
+slider-previous = Ыпэрэ
+slider-next = Ыужырэ
+keyboard-open = Клавиатурэр къызэӀухын
+keyboard-close = Клавиатурэр зэфэшӀыжьын
+choice-input-remove-choice = { $choice } хэгъэкӀын
+matrix-remove-row = Сатыр хэгъэкӀын
+matrix-add-row = Сатыр хэгъэхьан
+matrix-remove-column = Колонкэ хэгъэкӀын
+matrix-add-column = Колонкэ хэгъэхьан
+subset-add-remove-points = Точкэхэр хэгъэхьан/хэгъэкӀын
+subset-toggle-points-intervals = Точкэхэмрэ интервалхэмрэ зэблэхъун
+subset-move-points = Точкэхэр гъэкӀотэн
+subset-clear = Гъэкъэбзэн
+orbital-add-row = Сатыр хэгъэхьан
+orbital-remove-row = Сатыр хэгъэкӀын
+orbital-add-box = Клеткэ хэгъэхьан
+orbital-remove-box = Клеткэ хэгъэкӀын
+orbital-add-up-arrow = ДэкӀоерэ стрелкэ хэгъэхьан
+orbital-add-down-arrow = Къехырэ стрелкэ хэгъэхьан
+orbital-remove-arrow = Стрелкэ хэгъэкӀын
+orbital-row-label = Сатыр { $row } ыцӀэ
+pretzel-answer = Джэуап
+summary-statistics-caption = { $column } изэфэхьысыжь статистикэ
+
+
+## Math input
+
+math-input-preview-region = математическэ выражением иапэрэ теплъ
+math-input-preview = Апэрэ теплъ
+math-input-invalid-expression = Выражение мытэрэз:
+
+
+## Document status
+
+viewer-initializing = Егъэхьазыры…
+
+
+## Errors
+
+error-heading = Щыуагъ
+error-found-at =
+    { $span ->
+        [line] Къыщагъотыгъ: сатыр { $startLine }.
+       *[lines] Къыщагъотыгъэх: сатырхэр { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Мы документым щыуагъэхэр хэтых!
+diagnostic-heading-error = Щыуагъ
+diagnostic-heading-warning = Гъэсакъ
+diagnostic-heading-information = Къэбар
+diagnostic-heading-hint = ӀэпыӀэгъу
+accessibility-heading-level-1 = WCAG AA доступностым икъутэныгъ
+accessibility-heading-level-2 = Доступностым ехьылӀэгъэ гъэсакъ
+something-went-wrong = Зыгорэ тэрэзэу хъугъэп.
+renderer-load-failed = рендерерым къытӀэпӀыгъэп. НэкӀубгъор джыри къэгъэлъэгъожь.
+core-start-failed = Мы документыр рагъэжьэшъугъэп. НэкӀубгъор джыри къэгъэлъэгъожь.
+core-start-failed-busy = Мы документыр рагъэжьэшъугъэп. Документыбэ зэдырагъэжьагъ, ащ къыхэкӀэу компьютер щэрыончъэм нахьыбэрэ фэхьы. АдрэхэмкӀэ аухыгъэ ужым нэкӀубгъор джыри къэгъэлъэгъожьыныр шӀуагъэ къытын.
+core-start-failed-retry = Мы документыр рагъэжьэшъугъэп.
+core-start-failed-busy-retry = Мы документыр рагъэжьэшъугъэп. Документыбэ зэдырагъэжьагъ, ащ къыхэкӀэу компьютер щэрыончъэм нахьыбэрэ фэхьы.
+core-start-retry = Джыри зэ
+saved-state-unavailable = УиӀоф къэгъэнэжьыгъэр къэтӀэпӀыгъэп.

--- a/packages/i18n/locales/ady/content.ftl
+++ b/packages/i18n/locales/ady/content.ftl
@@ -1,0 +1,311 @@
+# Adyghe (West Circassian) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Ӏ (palochka), which is the orthography Adygea's
+# schools, its publishing and CLDR all use — `ady` maximizes to `ady-Cyrl-RU`.
+# The palochka is a letter of the alphabet, not a Latin capital I and not a
+# digit 1, and Adyghe leans on it harder than most: шӀуцӀэ, Ӏужъу, пӀуакӀэ,
+# ӀофшӀэн, УпчӀэ and шхъуантӀэ are all ordinary words. A catalog that spells
+# any of them with `I` or `1` has quietly become unreadable, and the two look
+# alike enough in most editor fonts that nothing on screen would say so.
+#
+# **Adyghe has no grammatical gender and no noun class**, and an attributive
+# adjective does not agree with its head in anything. So `noun-gender` returns
+# one token, nothing forks on `$gender`, and nothing forks on `$role` either —
+# what a clause position asks for in Adyghe lands as a suffix on a *noun*, and
+# every noun a position lands on is one this catalog writes out («гъунэ»,
+# «фон»). That is the flat answer eleven of the twelve Cyrillic catalogs
+# already give; Adyghe is Northwest Caucasian and gives it too, so the Nakh
+# class system in `locales/ce` stays the exception rather than a Caucasian
+# trait.
+#
+# **Word order is where this catalog differs from every Cyrillic one beside
+# it, and it is the thing to check first.** Adyghe splits its modifiers in
+# two:
+#
+#   * a *qualitative* adjective FOLLOWS its noun — «линие занкӀэ», a straight
+#     line; «гъунэ Ӏужъу плъыжьы», a thick red border;
+#   * a *relational* modifier, itself a noun, PRECEDES it as a compound —
+#     «горизонталь линиехэр», «вектор поле».
+#
+# So `style-with-noun` and `style-filled-with-noun` put the noun first and the
+# description after it, which is the reverse of English and of `locales/ba`
+# and `locales/ce`, while `fill-style`'s phrases keep the English order for
+# the opposite reason.
+#
+# **The limit that order runs into is recorded rather than papered over.** A
+# postnominal qualitative adjective in Adyghe is normally written *together*
+# with its noun as one word — «унэшхо», a big house — and the noun here is
+# `{ $noun }`, a placeable this catalog never sees. There is no reaching
+# inside a placeable to weld anything to it, so every description below writes
+# the adjective as a separate word after the noun. That is grammatical and
+# legible, and it is one space away from the compound a speaker would write.
+# Splitting the noun would not fix it either: the affix belongs to whatever
+# word lands last, and that word is a placeable too.
+#
+# **The colour terms are a choice and not a translation.** «шхъуантӀэ» covers
+# green and blue together — the Circassian colour the style pipeline has no
+# single slot for — and «шхъо» covers grey and a pale blue. The pipeline needs
+# green, cyan and blue as three separate words, so this catalog assigns
+# «шхъуантӀэ» to blue and writes the transparent compound «уцышъо»
+# (grass-colour) for green, as `locales/sah` writes «от күөх» for Sakha's
+# «күөх» and `locales/os` writes «кæрдæгхуыз» for Ossetian's «цъæх». Orange,
+# purple and pink are written as two-colour compounds for the same reason.
+# A speaker should expect to change these first.
+#
+# **The geometric vocabulary is the least certain thing in the file.** Adygea
+# teaches secondary mathematics in Russian, so a pupil meets «отрезок»,
+# «вектор» and «парабола» rather than a native coinage, and this catalog
+# writes the Russian term wherever it could not check a native one. Where a
+# native word is confident it is used — «хъурай» for circle, «чӀыпӀэ» for
+# region, «джор» for cross, «лъэныкъуабэ» and «лъэныкъуищ» built on
+# «лъэныкъо», side. Which of those a speaker would actually accept is exactly
+# what this seed could not verify.
+
+
+## Style vocabulary
+##
+## Nothing here agrees with anything, so nothing forks. Qualitative adjectives
+## (colours, widths, dash patterns) are written in the form that follows a
+## noun; the fill patterns are noun phrases and precede nothing.
+
+color =
+    .black = шӀуцӀэ
+    .white = фыжьы
+    .gray = шхъо
+    .red = плъыжьы
+    .orange = гъожьы-плъыжьы
+    .yellow = гъожьы
+    .green = уцышъо
+    .cyan = шхъуантӀэ нэфы
+    .blue = шхъуантӀэ
+    .purple = плъыжьы-шхъуантӀэ
+    .pink = плъыжьы-фыжьы
+    .brown = гъуабжэ
+line-width =
+    .thick = Ӏужъу
+    .thin = пӀуакӀэ
+line-style =
+    .dashed = зэпыугъэ
+    .dotted = точкэ зэхэлъ
+# Noun phrases, not adjectives: the relational word precedes its head here,
+# which is the opposite of what the colours and widths above do.
+fill-style =
+    .horizontal = горизонталь линиехэр
+    .vertical = вертикаль линиехэр
+    .diagonal = диагональ линиехэр
+    .backdiagonal = къэгъэзэжьыгъэ диагональ линиехэр
+    .dots = точкэхэр
+    .diamonds = ромбхэр
+noun =
+    .line = линие занкӀэ
+    .line-segment = отрезок
+    .ray = луч
+    .vector = вектор
+    .curve = кривая
+    .function = функцие
+    .slope-field = наклон поле
+    .vector-field = вектор поле
+    .parabola = парабола
+    .polyline = ломаная
+    .polygon = лъэныкъуабэ
+    .triangle = лъэныкъуищ
+    .rectangle = прямоугольник
+    .circle = хъурай
+    .region = чӀыпӀэ
+    .point = точкэ
+    .square = квадрат
+    .diamond = ромб
+    .cross = джор
+    .plus = плюс
+# The side count folds into the head, so there is no tail. Adyghe normally
+# puts a numeral *after* the noun it counts — «лъэныкъуищ», three sides — and
+# that construction cannot be built around `{ $numSides }`, which arrives as a
+# formatted number rather than as a word this catalog could suffix. So the
+# count is written in front of the noun as a compound, the way a Russian
+# loan-formation would, and «тэрэз» follows the noun as a qualitative
+# adjective should.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides }-лъэныкъуабэ тэрэз
+    }
+# Adyghe has no gender and no noun class, so every noun answers the same and
+# the answer goes unused — as in English, Bashkir and Ossetian, and unlike
+# `locales/ce` beside it.
+noun-gender = neuter
+
+
+## Style composition
+##
+## The noun leads and its adjectives follow, which is the reverse of the
+## English frame. See the note at the top of this file about the compound the
+## adjective would form with the noun if the noun were a word rather than a
+## placeable.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = гъэзыгъэ
+# «теплъэкӀэ» — "in the appearance of" — carries the instrumental suffix on a
+# word this catalog writes, so nothing is welded to `{ $pattern }`.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } теплъэкӀэ { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } теплъэкӀэ { $noun } { $color } { $filled }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $pattern } теплъэкӀэ { $noun } { $nounTail } { $color } { $filled }
+       *[plain] { $noun } { $color } { $filled }
+    }
+# «гъунэ … зиӀэ» — "having an edge that is …" — puts the noun first and the
+# adjectives after it, so the border's description lands in Adyghe's own
+# order and no article is wanted. The four branches differ only in the
+# connective English needs and Adyghe does not.
+style-border-clause =
+    { $parts ->
+        [with-article] гъунэ { $border } зиӀэ
+        [and] ыкӀи гъунэ { $border } зиӀэ
+        [and-article] ыкӀи гъунэ { $border } зиӀэ
+       *[with] гъунэ { $border } зиӀэ
+    }
+# The pattern is the head noun here and the colour follows it, which is why
+# this message reverses English rather than repeating `style-filled`'s shape.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = мыгъэзыгъэ
+# «фон … зиӀэ» is the same construction `style-border-clause` uses, and for
+# the same reason: the suffix falls on «фон», a word this catalog writes.
+style-text =
+    { $parts ->
+        [background] фон { $background } зиӀэ { $color }
+       *[plain] { $color }
+    }
+style-background-none = щыӀэп
+
+
+## Boolean words
+
+boolean-true = шъыпкъ
+boolean-false = пцӀы
+
+
+## Answer buttons
+
+answer-submit-label = УплъэкӀун
+answer-submit-label-no-correctness = Джэуапыр гъэкӀон
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ӀофшӀэн
+    .aside = ГущыӀэ гуадзэ
+    .cascade = Каскад
+    .definition = Гъэнэфэныгъ
+    .example = Щысэ
+    .exercise = Упражнение
+    .exercises = Упражнениехэр
+    .given-answer = Джэуап
+    .note = ХэгъэунэфыкӀыгъ
+    .objectives = Пшъэрылъхэр
+    .paragraphs = Абзацхэр
+    .part = Ӏахь
+    .problem = Задачэ
+    .problems = Задачэхэр
+    .proof = Гъэшъыпкъэжьын
+    .question = УпчӀэ
+    .section = Пычыгъо
+    .solution = ЗэшӀохыгъ
+    .task = Ӏоф
+    .theorem = Теорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = ӀэпыӀэгъу
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблицэ { $enumeration }
+        [numbered-title] Таблицэ { $enumeration }{ ". " }
+        [unnumbered-title] Таблицэ{ ". " }
+       *[unnumbered] Таблицэ
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурэт { $enumeration }
+        [numbered-caption] Сурэт { $enumeration }{ ". " }
+        [unnumbered-caption] Сурэт{ ". " }
+       *[unnumbered] Сурэт
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ыпэрэ
+paginator-next = Ыужырэ
+paginator-page = НэкӀубгъо
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## `piecewise-condition-if` is placed by the renderer *before* the mathematics
+## it introduces, and Adyghe cannot put a word there. The conditional in
+## Adyghe is a verbal suffix, -мэ, and the free form built on it — «хъумэ»,
+## "if it is so" — closes the clause it conditions rather than opening it. So
+## the word below lands on the wrong side of its mathematics, exactly as
+## `locales/sah`, `locales/tyv`, `locales/udm`, `locales/kv` and `locales/chm`
+## record for their own clause-final conditionals. Splitting the key into a
+## prefix and a suffix would fix it; nothing here can, and inventing a
+## clause-initial particle Adyghe does not have would be worse than a limit
+## written down.
+
+piecewise-condition-or = е
+piecewise-condition-if = хъумэ
+piecewise-condition-otherwise = нэмыкӀэу
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Adygea is taught in
+## Russian, so the element names an Adyghe-speaking pupil meets are the
+## Russian ones, and the English fallback beside a Russian textbook is nearer
+## the curriculum than 118 unreviewed coinages would be — the school-system
+## case this batch and the Cyrillic batch before it share throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Химическэ символ мытэрэз
+chemistry-invalid-ionic-compound = Ионнэ зэхэлъ мытэрэз

--- a/packages/i18n/locales/ady/diagnostics.ftl
+++ b/packages/i18n/locales/ady/diagnostics.ftl
@@ -1,0 +1,694 @@
+# Adyghe (West Circassian) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Ӏ (palochka), which is a letter and not a Latin I
+# or a digit 1. See `content.ftl`'s header for the rest of the orthographic
+# note and for the word order the style descriptions use.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Adyghe has no gender and no noun class, so nothing here forks on `$gender`;
+# it counts in two plural categories, so every `{ $count -> … }` keeps both
+# branches. A noun after a numeral stays singular and the numeral follows it,
+# so the two branches of a count usually read alike.
+#
+# **The technical vocabulary is Russian, and deliberately.** Adygea teaches
+# secondary mathematics and computing in Russian, and Adyghe has no settled
+# native terms for most of what this file names — «компонент», «атрибут»,
+# «функцие», «переменнэ», «последовательность», «индекс», «ссылк». Coining a
+# hundred of them for an unreviewed seed would produce a file no Adyghe reader
+# could check against the English beside it. Where a native word is confident
+# it is used: «щыуагъ» for error, «цӀэ» for name, «пчъагъ» for number,
+# «сатыр» for line, «мытэрэз» for invalid.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кӀэух точкитӀу гъэнэфагъэ хъумэ { $attributes } хэлъытагъэ хъурэп
+       *[other] кӀэух точкитӀу гъэнэфагъэ хъумэ { $attributes } хэлъытагъэ хъурэп
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] кӀэух точкэри гузэгу точкэри зэдэгъэнэфагъэ хъумэ { $attributes } хэлъытагъэ хъурэп
+       *[other] кӀэух точкэри гузэгу точкэри зэдэгъэнэфагъэ хъумэ { $attributes } хэлъытагъэ хъурэп
+    }
+
+line-segment-midpoint-offset-without-midpoint = гузэгу точкэ имыӀэу midpointOffset зи къышӀырэп
+
+## `<line>`
+
+line-points-undetermined-dimensions = Линиер измерениехэр зыгъэнэфагъэ мыхъугъэ точкэхэм апхыры кӀуагъэ.
+
+line-points-too-few-dimensions = Линиер измерениитӀумэ анахь макӀэ зимыӀэ точкэхэм апхырыкӀон фае.
+
+line-points-depend-on-variables = Линиер переменнэхэм ялъытыгъэ точкэхэм апхыры кӀуагъэ: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ыкӀи { $variable2 } переменнэхэмкӀэ линием иуравнение иформат мытэрэз.
+
+## `<ray>`
+
+ray-overprescribed-through = Лучыр through, endpoint ыкӀи direction зэдэгъэнэфагъэ. Гъэнэфэгъэ through хэлъытагъэ хъурэп.
+
+ray-dimension-mismatch = Лучым numDimensions зэтефэрэп.
+
+## `<vector>`
+
+vector-overprescribed-head = Векторыр head, tail ыкӀи displacement зэдэгъэнэфагъэ. Гъэнэфэгъэ head хэлъытагъэ хъурэп.
+
+vector-dimension-mismatch = Векторым numDimensions зэтефэрэп.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` фэпщэн плъэкӀыщтэп, nearestPoint зыфиӀорэ гъэуцугъэ имыӀэшъ.
+
+constrain-to-without-nearest-point = `<{ $component }>` къыгъэуцун плъэкӀыщтэп, nearestPoint зыфиӀорэ гъэуцугъэ имыӀэшъ.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` ыкӀоцӀ къыгъэуцун плъэкӀыщтэп, nearestPoint зыфиӀорэ гъэуцугъэ имыӀэшъ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = инлайн мыхъурэ choiceInput-мкӀэ labelPosition хэлъытагъэ хъурэп
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-м фэгъэнэфэгъэ индексхэр хэлъытагъэ хъурэп, индексхэм япчъагъэрэ choice сабыйхэм япчъагъэрэ зэтемыфэшъ.
+
+pretzel-indices-count-mismatch = problem-м фэгъэнэфэгъэ индексхэр хэлъытагъэ хъурэп, индексхэм япчъагъэрэ problem сабыйхэм япчъагъэрэ зэтемыфэшъ.
+
+shuffle-indices-count-mismatch = shuffle-м фэгъэнэфэгъэ индексхэр хэлъытагъэ хъурэп, индексхэм япчъагъэрэ компонентхэм япчъагъэрэ зэтемыфэшъ.
+
+indices-ignored-out-of-range = { $component } фэгъэнэфэгъэ индексхэр хэлъытагъэ хъурэп, заулэмэ гъунапкъэр аухыгъэшъ.
+
+pretzel-indices-repeated = pretzel-м фэгъэнэфэгъэ индексхэр хэлъытагъэ хъурэп, заулэ къыкӀэлъэкӀужьышъ.
+
+pretzel-circuit-first-index = circuit режимым итэу pretzel-м фэгъэнэфэгъэ индексхэр хэлъытагъэ хъурэп, апэрэ индексыр 1 хъун фаешъ.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` строкэ сабыйхэм адэлэжьэным пае `type` атрибутыр гъэнэфагъэ хъун фае.
+
+invalid-type-defaulting-to-math = { $component } компонентым итип { $type } мытэрэз. math, text, number е boolean ащыщ хъун фае. math ашъхьадэкӀы.
+
+string-not-valid-component-to-arrange = "{ $value }" строкэр { $component } зыфэдэ компонент тэрэзэп. Хэлъытагъэ хъурэп.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } тип мытэрэз, типыр number ашъхьадэкӀы.
+
+invalid-variable-value = Переменнэм имэхьанэ мытэрэз: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Вариантым индекс { $index } пчъагъэ хъун фае
+
+variant-index-must-be-integer = Вариантым индекс { $index } целэ пчъагъэ хъун фае
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютнэ мардэхэмкӀэ гъэпсыгъэп. Шъомбгъуагъэхэр относительнэ ашӀых.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютнэ мардэхэмкӀэ гъэпсыгъэп. Гъунапкъэхэр относительнэ ашӀых.
+
+side-by-side-no-block-child = `<{ $component }>` мытэрэз: зы блок сабый нахь мышӀэми иӀэн фае.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>`-м `for` атрибутыр хэлъытагъэ хъурэп.
+
+label-for-must-resolve-to-one = `<label>`-м и `for` атрибут зы компонент ныӀэп къыгъэлъэгъон фае.
+
+label-for-unresolved = `<label>`-м и `for` атрибут компонент горэм фэгъэзэгъэ хъугъэп.
+
+label-for-answer-with-authored-inputs = `<label>`-м и `for` атрибут авторым иӀэкӀэ ытхыгъэ инпутхэр зиӀэ `<answer>` фэгъэзагъ; инпутым занкӀэу фэгъазэ.
+
+label-for-answer-without-input = `<label>`-м и `for` атрибут инпут зимыӀэ `<answer>` фэгъэзагъ.
+
+label-for-must-reference-input-or-answer = `<label>`-м и `for` атрибут инпут е джэуап фэгъэзагъэ хъун фае.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = ДоступностымкӀэ `<{ $component }>` кӀэкӀ гъэнэфэн иӀэн е гъэдэхакӀэу гъэнэфагъэ хъун фае.
+
+accessibility-video-short-description = ДоступностымкӀэ `<video>` кӀэкӀ гъэнэфэн иӀэн фае.
+
+accessibility-input-short-description-or-label = ДоступностымкӀэ `<{ $component }>` кӀэкӀ гъэнэфэн е ярлык иӀэн фае.
+
+accessibility-answer-input-short-description-or-label = ДоступностымкӀэ инпут зыгъэпсырэ `<answer>` кӀэкӀ гъэнэфэн е ярлык иӀэн фае.
+
+accessibility-short-description-contains-math = КӀэкӀ гъэнэфэнхэм `<{ $component }>` фэдэ математическэ компонентхэр ахэмытын фае. Математикэр гущыӀэкӀэ къыӀотэн.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } пычыгъом ишъхьэ тхыгъэ икъурэ контраст фыриӀэп (шӀункӀы режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; анахь макӀэу { $threshold }:1 ищыкӀагъ).
+       *[other] { $colorName } пычыгъом ишъхьэ тхыгъэ икъурэ контраст фыриӀэп ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; анахь макӀэу { $threshold }:1 ищыкӀагъ).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Точкэхэм пчъагъэ мэхьанэ ямыӀэ хъумэ, точкэ { $count } апхырыкӀырэ `<circle>` гъэпсыгъэ хъугъэп.
+
+circle-too-many-through-points = Точкищмэ анахьыбэмэ апхырыкӀырэ хъурай къэлъытэн плъэкӀыщтэп.
+
+circle-overprescribed-radius-center-points = Радиусыр, гупчэр ыкӀи пхырыкӀыпӀэ точкэхэр зэдэгъэнэфагъэу хъурай къэлъытэн плъэкӀыщтэп.
+
+circle-center-with-multiple-points = Гупчэр гъэнэфагъэу зы точкэм анахьыбэмэ апхырыкӀырэ хъурай къэлъытэн плъэкӀыщтэп.
+
+circle-radius-too-small = Хъурайр къэлъытэн плъэкӀыщтэп: точкитӀумэ азыфагу { $distance } зэрэдэлъым тетэу, гъэнэфэгъэ радиус { $radius } макӀэ дэд.
+
+circle-radius-with-many-points = Радиусыр гъэнэфагъэу точкитӀумэ анахьыбэмэ апхырыкӀырэ хъурай гъэпсын плъэкӀыщтэп.
+
+circle-invalid-center-or-through-points = Хъурайм игупчэ е ипхырыкӀыпӀэ точкэхэр мытэрэзых.
+
+circle-radius-center-with-multiple-points = Гупчэр гъэнэфагъэу зы точкэм анахьыбэмэ апхырыкӀырэ хъурайм ирадиус къэлъытэн плъэкӀыщтэп.
+
+circle-change-radius-non-numerical = Пчъагъэ мэхьанэ зимыӀэ точкэхэм апхырыкӀырэ хъурайм ирадиус зэхъокӀын плъэкӀыщтэп
+
+circle-radius-with-points-non-numerical = Пчъагъэ мэхьанэхэр щымыӀэ зыхъукӀэ, радиусыр гъэнэфагъэу зы точкэм анахьыбэмэ апхырыкӀырэ хъурай гъэпсын плъэкӀыщтэп.
+
+circle-change-center-non-numerical = Пчъагъэ мэхьанэ зимыӀэ точкэхэм апхырыкӀырэ хъурайм игупчэ зэхъокӀыныр гъэпсыгъэ хъугъэп.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцием иобласть измерениехэр икъурэп. Областым интервал { $intervals } иӀ, функцием { $inputs ->
+            [one] инпут { $inputs }
+           *[other] инпут { $inputs }
+        } иӀэ хъуми.
+       *[other] Функцием иобласть измерениехэр икъурэп. Областым интервал { $intervals } иӀ, функцием { $inputs ->
+            [one] инпут { $inputs }
+           *[other] инпут { $inputs }
+        } иӀэ хъуми.
+    }
+
+function-domain-invalid-format = Функцием иобласть иформат мытэрэз.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцием ипчъагъэ мыхъурэ максимум хэлъытагъэ хъурэп.
+        [minimum] Функцием ипчъагъэ мыхъурэ минимум хэлъытагъэ хъурэп.
+        [extremum] Функцием ипчъагъэ мыхъурэ экстремум хэлъытагъэ хъурэп.
+        [point] Функцием ипчъагъэ мыхъурэ точкэ хэлъытагъэ хъурэп.
+        [slope] Функцием ипчъагъэ мыхъурэ наклон хэлъытагъэ хъурэп.
+       *[other] Функцием ипчъагъэ мыхъурэ { $type } хэлъытагъэ хъурэп.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцием инэкӀы максимум хэлъытагъэ хъурэп.
+        [minimum] Функцием инэкӀы минимум хэлъытагъэ хъурэп.
+        [extremum] Функцием инэкӀы экстремум хэлъытагъэ хъурэп.
+        [point] Функцием инэкӀы точкэ хэлъытагъэ хъурэп.
+       *[other] Функцием инэкӀы { $type } хэлъытагъэ хъурэп.
+    }
+
+function-points-too-close = Функцием зэпэблэгъэ дэдэ точкитӀу хэт. Функциер гъэнэфэн плъэкӀыщтэп.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцием иитерациехэр хъущтых инпутхэм япчъагъэрэ аутпутхэм япчъагъэрэ зэфэдэ зыхъукӀэ ныӀэп. Мы функцием инпут { $inputs } ыкӀи { $outputs ->
+            [one] аутпут { $outputs }
+           *[other] аутпут { $outputs }
+        } иӀ.
+       *[other] Функцием иитерациехэр хъущтых инпутхэм япчъагъэрэ аутпутхэм япчъагъэрэ зэфэдэ зыхъукӀэ ныӀэп. Мы функцием инпут { $inputs } ыкӀи { $outputs ->
+            [one] аутпут { $outputs }
+           *[other] аутпут { $outputs }
+        } иӀ.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Последовательностым икӀыхьагъэ мытэрэз. Ныкъоу мыхъурэ целэ пчъагъэ хъун фае.
+
+sequence-invalid-step = Последовательностым ишъэхъу мытэрэз. { $type } типым иӀэ последовательностымкӀэ пчъагъэ хъун фае.
+
+sequence-invalid-endpoint-number = Пчъагъэ последовательностым и "{ $attribute }" мытэрэз. Пчъагъэ хъун фае.
+
+sequence-invalid-endpoint-letters = Буквэ последовательностым и "{ $attribute }" мытэрэз. Буквэ зэхэлъ хъун фае.
+
+sequence-invalid-endpoint = Последовательностым и "{ $attribute }" мытэрэз.
+
+select-from-sequence-coprime-not-numbers = пчъагъэхэр къыхэмыхыгъэ зэрэхъурэм пае coprime хэлъытагъэ хъурэп
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations гъэнэфагъэ зэрэхъугъэм пае coprime хэлъытагъэ хъурэп
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>`-м итарget мытэрэз: тарget къэгъотыгъэ хъурэп.
+
+target-state-variable-not-found = `<{ $source }>`-м итарget мытэрэз: `<{ $component }>`-м "{ $property }" зыфиӀорэ гъэуцугъэ къыщыгъотыгъэ хъурэп.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`-м ипеременнэхэр зэхэмылъ переменнэм фэмыдэу щытын фае.
+
+ode-system-duplicate-variable-names = Зэтемыфэ лъытэныгъэ переменнэ цӀэхэр зиӀэ ОДУ ижъабгъу лъэныкъо функциехэр гъэнэфэн плъэкӀыщтэп.
+
+ode-system-rhs-function-error = ОДУ ижъабгъу лъэныкъо функцие гъэнэфэн плъэкӀыщтэп. mathjs функциер гъэпсыгъэ хъумэ щыуагъ.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Линие { $count } зэфагу илъ ку гъэнэфэн плъэкӀыщтэп
+
+angle-invalid-through-point = `<angle>`-м и through-м точкэ мытэрэз хэт
+
+parabola-vertex-too-many-points = Вершинэр иӀэу зы точкэм анахьыбэмэ апхырыкӀырэ параболэ гъэпсыгъэ хъугъэп.
+
+parabola-too-many-points = Точкищмэ анахьыбэмэ апхырыкӀырэ параболэ гъэпсыгъэ хъугъэп.
+
+intersection-too-many-items = ТӀумэ анахьыбэ пкъыгъомэ азэпэуцужьыпӀэ гъэпсыгъэ хъугъэп
+
+## Other math components
+
+ionic-compound-not-two-ions = Ион зэхэлъыр ионитӀумэ нэмыкӀэу гъэпсыгъэ хъугъэп.
+
+ionic-compound-needs-cation-and-anion = Ион зэхэлъыр зы катионрэ зы анионрэ ныӀэп зэрэгъэпсыгъэр.
+
+solve-equations-cannot-evaluate = Уравнениер къэлъытэгъэ мыхъушъутэу зэшӀохын плъэкӀыщтэп: { $equation }
+
+math-operators-operand-number-required = Математическэ операнд къыхэпхыным пае operandNumber гъэнэфагъэ хъун фае.
+
+eigen-decomposition-failed = Матрицэм исобственнэ мэхьанэхэр къэлъытэгъэ хъугъэп
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: параметр { $parameters } шаблоным хэтэп, ащ къыхэкӀэу сыдигъуи нэкӀыгъэм фэдэщт.
+       *[other] `<matchesPattern>`: параметрхэр { $parameters } шаблоным хэтхэп, ащ къыхэкӀэу сыдигъуи нэкӀыгъэм фэдэщтых.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" гурыӀогъошӀу хъурэп. none, medium, dense е зы пробелкӀэ зэпыгъэчыгъэ пчъагъитӀу хъун фае, щысэу grid="1 0.5". Сеткэ къэшӀыгъэ хъурэп.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>`-м { $expected ->
+        [one] зы аутпут — точкэ пэпчъ ынаклон y', щысэу `y - x`
+       *[other] аутпутитӀу — точкэ пэпчъ ивектор, щысэу `(y, -x)`
+    } зиӀэ функцие ищыкӀагъ, ау къыратыгъэ функцием { $found ->
+        [one] аутпут { $found }
+       *[other] аутпут { $found }
+    } иӀ. { $alternative ->
+        [none] Зи къэшӀыгъэ хъурэп.
+       *[other] А функциемкӀэ компонентыр `<{ $alternative }>`. Зи къэшӀыгъэ хъурэп.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибутыр хэлъытагъэ хъурэп, функциер компонентым ыкӀоцӀи къызэрэратыгъэм пае; ыкӀоцӀ илъыр агъэфедэ. Функциер тӀумэ ащыщ зыкӀэ ныӀэп къэптын фаер.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибутым компонентым занкӀэу ыкӀоцӀ итхэгъэ выражением ипеременнэхэр къеӀуалӀэ. { $reason ->
+        [function-child] Мыщ функциер `<function>` сабыеу къэтыгъэ, ащ ежь ипеременнэхэр къеӀуалӀэх, ащ къыхэкӀэу `variables` хэлъытагъэ хъурэп.
+       *[no-expression] Мыщ ащ фэдэ выражение къэтыгъэп, ащ къыхэкӀэу `variables` хэлъытагъэ хъурэп.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure рендерерым xLabelPosition="left" ыдерэп; жъабгъу лъэныкъом ишӀыкӀэ агъэфедэ.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure рендерерым yLabelPosition="bottom" ыдерэп; шъхьагърэ лъэныкъом ишӀыкӀэ агъэфедэ.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure зэрэшӀыгъэным пае осьхэм ягъунапкъэхэр мытэрэзых; ыпэрапшӀэ bbox (-10,-10,10,10) агъэфедэ.
+
+prefigure-invalid-width = `<graph>`: prefigure зэрэшӀыгъэным пае шъомбгъуагъэр мытэрэз; ыпэрапшӀэ диаграммэ шъомбгъуагъэу 425 агъэфедэ.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure зэрэшӀыгъэным пае aspectRatio мытэрэз; ыпэрапшӀэ зэпэлъытыгъэу 1 агъэфедэ.
+
+prefigure-grid-spacing-too-fine = `<graph>`: осьхэм ягъунапкъэхэмкӀэ сеткэм изэфагу цӀыкӀу дэд; prefigure рендерерым сеткэр къыщыхэнэ.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure рендерерыр агъэмыфедэ зыхъукӀэ аннотациехэр къэшӀыгъэ хъущтхэп.
+
+multiple-annotations-children = `<graph>`-м `<annotations>` сабый заулэ къыщагъотыгъ; аужырэм фэшъхьафхэр хэлъытагъэ хъурэп.
+
+## Referring to other components
+
+copy-unrecognized-component-type = ГурыӀогъошӀоу мыхъугъэ компонент тип къэпгъэкӀэрэкӀэн е къэпхын плъэкӀыщтэп: { $type }.
+
+copy-prop-not-found = { $component } типым иӀэ компонентым { $property } проп къыщыгъотыгъэ хъугъэп
+
+collect-no-source = collect-мкӀэ источник къэгъотыгъэ хъугъэп.
+
+collect-invalid-component-type = `<{ $component }>` типым иӀэ компонентхэр зэхэпхьажьын плъэкӀыщтэп, ар компонент тип мытэрэзышъ.
+
+reference-index-unavailable = `{ $reference }` индексым уфэгъэзэн плъэкӀыщтэп
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентым { $action } щыпшӀэн плъэкӀыщтэп
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннэхэм яшӀыкӀэ мытэрэз. Сатырхэм якӀыхьагъэхэр зэтемыфэх. Къыщагъотыгъ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннэхэм зэтефэрэ колонкэ цӀэхэр яӀэх. Къыщагъотыгъ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннэхэм колонкэм ыцӀэ ащыщэп. Къыщагъотыгъ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Мы джэуапым ибалл ежь answer тегым ыгъэкӀогъэ джэуапым тетэу гъэпсыгъ, ащ гухэлъым имыдэ ӀофшӀакӀэ къыхьыщт.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` зиӀэ контейнерым ыкӀоцӀ ит `<answer>`-м `maxNumAttempts` фэбгъэнэфэным зи къышӀырэп, попыткэхэм япчъагъэ контейнерым ыгъэнафэшъ. `maxNumAttempts` контейнерым фэгъэнэфэн.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` зиӀэ нэмыкӀ контейнерым ыкӀоцӀ ит, `sectionWideCheckWork` зиӀэ контейнерым `maxNumAttempts` фэбгъэнэфэным зи къышӀырэп, попыткэхэм япчъагъэ иужьырэ контейнерым ыгъэнафэшъ. `maxNumAttempts` ыкӀыб ит контейнерым фэгъэнэфэн.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality гъэнэфагъэ мыхъумэ { $attributes } атрибутым зи къышӀыщтэп.
+       *[other] symbolicEquality гъэнэфагъэ мыхъумэ { $attributes } атрибутхэм зи къашӀыщтэп.
+    }
+
+answer-invalid-type = Джэуапым итип мытэрэз: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентым ыцӀэ зэрэщымыӀэм пае, модулым иатрибутэу гъэфедагъэ хъун плъэкӀыщтэп
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентыр модулым иатрибутэу гъэфедагъэ хъун плъэкӀыщтэп, `<module>` компонент типым "{ $name }" атрибутыр гъэнэфагъэу иӀэшъ.
+
+conditional-content-condition-ignored = case е else сабыйхэр зиӀэ `<conditionalContent>` компонентым `condition` атрибутыр хэлъытагъэ хъурэп.
+
+slider-markers-type-mismatch = Маркерхэм ятип слайдерым итип зэтефэрэп.
+
+pretzel-problem-needs-statement-and-answer = Pretzel мытэрэз: `<problem>` пэпчъ зы `<statement>` ыкӀи зы `<answer>` хэтын фае.
+
+pretzel-circuit-first-problem-distractor = Pretzel мытэрэз: mode="circuit" зыхъукӀэ, апэрэ `<problem>` дистрактор хъун плъэкӀыщтэп.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутымкӀэ мэхьанэ { $values } мытэрэз; хэлъытагъэ хъурэп.
+       *[other] `{ $attribute }` атрибутымкӀэ мэхьанэхэр { $values } мытэрэзых; хэлъытагъэ хъурэп.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутымкӀэ `{ $value }` мэхьанэр мытэрэз. Атрибутыр `$`-мкӀэ къезыгъажьэрэ ссылкэхэм ахэлъын фае.
+
+math-input-invalid-function-names = <mathInput>: { $attribute }-м хэт мытэрэз функцие цӀэхэр хэлъытагъэ хъугъэхэп: { $names }. ЦӀэ пэпчъ икъэгъэлъэгъон Ӏахьэ анахь макӀэу символитӀу (буквэхэр е дефисхэр) хъун фае; ыуж `|<mathspeak alternative>` кӀэлъыкӀон плъэкӀыщт.
+
+## Building components from the source
+
+component-type-invalid = Компонент тип мытэрэз: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутыр къэпӀожьын плъэкӀыщтэп.
+
+attribute-invalid-for-component = `<{ $componentType }>` типым иӀэ компонентымкӀэ "{ $attribute }" атрибутыр мытэрэз.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Стиль гъэнэфэн { $styleNumber } икъурэ контраст фыриӀэп мыщкӀэ: { $context ->
+        [text-on-background] тхыгъэм ышъо фон шъом дэлъытагъэу
+        [high-contrast] контраст лъагэ зиӀэ шъор канвэм дэлъытагъэу
+        [line] линием ышъо канвэм дэлъытагъэу
+        [marker] маркерым ышъо канвэм дэлъытагъэу
+       *[text-on-canvas] тхыгъэм ышъо канвэм дэлъытагъэу
+    }{ $mode ->
+        [dark] { " (шӀункӀы режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; анахь макӀэу { $threshold }:1 ищыкӀагъ).
+
+style-definition-dark-mode-text-background-contrast =
+    Стиль гъэнэфэн { $styleNumber } нэфы режимымкӀэ икъурэ контраст зиӀэ шъохэр гъэнэфагъэу иӀэ нахь мышӀэми, а мэхьанэхэм къатекӀыгъэ шӀункӀы режим шъохэмкӀэ тхыгъэм ышъо фон шъом икъурэ контраст фыриӀэп ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; анахь макӀэу { $threshold }:1 ищыкӀагъ). { $suggestion ->
+        [available] ШӀункӀы режимым икъурэ контраст щыӀэным пае е нэфы режимым иконтраст гъэпытэн (щысэу { $lightAttribute }="{ $lightColor }" гъэнэфэн), е шӀункӀы режимым ышъо зэблэхъун (щысэу { $darkAttribute }="{ $darkColor }" гъэнэфэн).
+       *[none] ШӀункӀы режимым икъурэ контраст щыӀэным пае нэфы режимым иконтраст гъэпытэн, е къытекӀыгъэ шъохэр textColorDarkMode ыкӀи/е backgroundColorDarkMode-мкӀэ зэблэхъун.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Стиль гъэнэфэн { $styleNumber } нэфы режимымкӀэ икъурэ контраст зиӀэ тхыгъэ шъо гъэнэфагъэу иӀэ нахь мышӀэми, а мэхьанэм къытекӀыгъэ шӀункӀы режим тхыгъэ шъом канвэм дэлъытагъэу икъурэ контраст фыриӀэп ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; анахь макӀэу { $threshold }:1 ищыкӀагъ). { $suggestion ->
+        [available] ШӀункӀы режимым икъурэ контраст щыӀэным пае е нэфы режимым иконтраст гъэпытэн (щысэу textColor="{ $lightColor }" гъэнэфэн), е шӀункӀы режимым ышъо зэблэхъун (щысэу textColorDarkMode="{ $darkColor }" гъэнэфэн).
+       *[none] ШӀункӀы режимым икъурэ контраст щыӀэным пае нэфы режимым иконтраст гъэпытэн, е къытекӀыгъэ шъор textColorDarkMode-мкӀэ зэблэхъун.
+    }
+
+section-multiple-style-palettes = Пычыгъом зы <stylePalette> ныӀэп къыхихын ылъэкӀыщтыр; аужырэр агъэфедэ.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, numToSelect ныкъоу мыхъурэ целэ пчъагъэ мыхъушъ.
+
+variant-num-to-select-not-constant-number = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, numToSelect зэмыхъокӀырэ пчъагъэ мыхъушъ.
+
+variant-with-replacement-not-constant-boolean = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, withReplacement зэмыхъокӀырэ булев мэхьанэ мыхъушъ.
+
+variant-select-weight-disables-unique = selectWeight е selectForVariants гъэнэфагъэу зиӀэ вариант щыӀэ зыхъукӀэ select-м иунэе вариантхэр гъэнэфагъэ хъухэрэп
+
+variant-coprime-undetermined = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, coprime сыдигъуи пцӀы зэрэхъурэр гъэнэфагъэ мыхъушъ.
+
+variant-attribute-not-constant = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, { $attribute } зэмыхъокӀыжьырэ мыхъушъ.
+
+variant-attribute-not-number = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, { $attribute } пчъагъэ мыхъушъ.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } типым иӀэ { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, { $attribute } { $expected ->
+        [letters-combination] буквэ зэхэлъ
+        [math-expression] тэрэз математическэ выражение
+        [integer] целэ пчъагъэ
+       *[number] пчъагъэ
+    } мыхъушъ.
+
+variant-length-not-integer = { $component } иунэе вариантхэр гъэнэфэн плъэкӀыщтэп, length целэ пчъагъэ мыхъушъ.
+
+variant-sort-not-implemented = sort зиӀэ { $component } иунэе вариантхэр гъэпсыгъэ хъугъэхэп
+
+variant-exclude-combinations-not-implemented = excludeCombinations зиӀэ { $component } иунэе вариантхэр гъэпсыгъэ хъугъэхэп
+
+variant-math-exclude-not-implemented = exclude зиӀэ math типым иӀэ { $component } иунэе вариантхэр гъэпсыгъэ хъугъэхэп
+
+variant-non-constant-exclude-not-implemented = зэмыхъокӀырэ мыхъурэ exclude зиӀэ { $component } иунэе вариантхэр гъэпсыгъэ хъугъэхэп
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: график prefigure рендерерым ыдерэп; къытекӀыгъэр къыхэнагъ.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометриер икъурэп е гъунапкъэ иӀэп; къытекӀыгъэр къыхэнагъ.
+
+prefigure-curve-label-omitted = { $subject }: зэблэхъугъэ кривая элементхэм ярлыкхэр адыдэрэп; ярлыкыр къыхэнагъ.
+
+prefigure-curve-unsupported-definition-type = { $subject }: кривая функцием игъэнэфэн тип '{ $definitionType }' ыдерэп; къытекӀыгъэр къыхэнагъ.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-м и flipFunctions атрибут ыдерэп; къытекӀыгъэр къыхэнагъ.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-м формулэ типым иӀэ сабый функциехэр ныӀэп ыдэрэр; къытекӀыгъэр къыхэнагъ.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] линие лъэпкъым иярлык
+       *[point] точкэм иярлык
+    }-мкӀэ labelPosition '{ $labelPosition }' ыдерэп; PreFigure иыпэрапшӀэ зэтегъэуцуакӀэ агъэфедэ.
+
+prefigure-fill-style-unsupported = { $subject }: гъэзын стиль '{ $fillStyle }' PreFigure ыдерэп; зэпыу зимыӀэ гъэзыныр агъэфедэ.
+
+prefigure-line-style-unknown = { $subject }: гурыӀогъошӀу мыхъурэ линие стиль '{ $lineStyle }' PreFigure иаутпут къыхэнагъ.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стиль '{ $markerStyle }' PreFigure истиль 'diamond' фагъэзагъ.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стиль '{ $markerStyle }' PreFigure ыдерэп; ыпэрапшӀэ стилыр агъэфедэ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` мытэрэз; тарget къэгъотыгъэ хъурэп. Аннотациер къыхэнагъ.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` тарget заулэ фэгъэзагъ; апэрэ тарget агъэфедэ.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` мытэрэз; тарget къэзыубытырэ графикым ыкӀыб ит. Аннотациер къыхэнагъ.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` мытэрэз; prefigure зэблэхъунымкӀэ тарget адырэ график пкъыгъо хъурэп. Аннотациер къыхэнагъ.
+
+annotation-text-missing = `<annotation>`: `text` щыӀэп е нэкӀ; нэкӀы текст къатыгъ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Хъурае лъытэныгъэ къэгъотыгъэ хъугъ.
+       *[other] `<{ $componentType }>` компонентыр хэтэу хъурае лъытэныгъэ къэгъотыгъэ хъугъ.
+    }
+
+reference-no-referent = Ссылкэм ызыфигъазэрэр къэгъотыгъэ хъугъэп: `{ $reference }`
+
+reference-multiple-referents = Ссылкэм ызыфигъазэрэ зыбгъупш къэгъотыгъэ хъугъ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>`-м и { $attribute } атрибут иформат мытэрэз.
+
+children-invalid = `<{ $componentType }>`-м исабыйхэр мытэрэзых: мытэрэз сабыйхэр къэгъотыгъэх: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутымкӀэ `{ $value }` мэхьанэр мытэрэз, `{ $default }` мэхьанэр агъэфедэ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML иверсие { $version } къэгъотыгъэ хъугъэп.
+       *[other] DoenetML иверсие { $version } къэгъотыгъэ хъугъэп. Версие { $fallback } агъэфедэ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML мытэрэз: { $content }
+
+parse-tag-missing-close-tag = DoenetML мытэрэз: `{ $tag }` тегым зэфэшӀыжьырэ тег иӀэп. Ежь зызэфэзышӀыжьырэ тег е `</{ $tagName }>` тег щыӀэн фэягъ.
+
+parse-tag-error = DoenetML мытэрэз: `<{ $tagName }>` тегым щыуагъ хэт
+
+parse-attribute-missing-value = DoenetML мытэрэз: `{ $attribute }` атрибут мытэрэзым мэхьанэ иӀэ хъумэ фэд.
+
+parse-attribute-invalid = DoenetML мытэрэз: `{ $attribute }` атрибут мытэрэз
+
+parse-attribute-value-invalid = DoenetML мытэрэз: `{ $value }` атрибут мэхьанэ мытэрэз
+
+parse-attribute-value-quote-mismatch = DoenetML мытэрэз: `{ $value }` атрибут мэхьанэ мытэрэз. Кавычкэхэр зэтефэрэп. `{ $quote }` щыӀэ хъумэ фэд
+
+parse-open-tag-name-missing = DoenetML мытэрэз: тег цӀэ зимыӀэ тег къэгъотыгъэ хъугъ, щысэу `<`
+
+parse-tag-not-closed = DoenetML мытэрэз: `{ $tag }` тегыр зэфэшӀыжьыгъэ хъугъэп (`>` щыӀэ хъумэ фэд).
+
+parse-self-closing-tag-name-missing = DoenetML мытэрэз: тег цӀэ зимыӀэ тег къэгъотыгъэ хъугъ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML мытэрэз: `{ $tag }` тегыр зэфэшӀыжьыгъэ хъугъэп (`/>` щыӀэ хъумэ фэд).
+
+parse-tag-invalid-attributes = DoenetML мытэрэз: `{ $tag }` тегыр тэрэзэп. Атрибут мытэрэзхэр иӀэнхэ ылъэкӀыщт.
+
+parse-close-tag-name-missing = DoenetML мытэрэз: тег цӀэ зимыӀэ зэфэшӀыжьырэ тег къэгъотыгъэ хъугъ, щысэу `</`
+
+parse-attribute-value-unquoted = Атрибут мэхьанэхэр кавычкэхэм ахэлъын фае: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML мытэрэз: `{ $tag }` зэфэшӀыжьырэ тег къэгъотыгъэ хъугъ, ау къезыгъажьэрэ тег иӀэп
+
+parse-close-tag-mismatched = DoenetML мытэрэз: зэфэшӀыжьырэ тегыр зэтефэрэп. `</{ $expected }>` щыӀэн фэягъ. Къэгъотыгъэр `{ $found }`
+
+parser-node-unconvertible = { $node } нодэр Dast нодэ ашӀын плъэкӀыщтэп.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' атрибут цӀэ мытэрэз. { $reason ->
+        [characters] ЦӀэхэм буквэхэр, пчъагъэхэр, чӀэгъ шъуашъохэр е дефисхэр ныӀэп ахэлъын злъэкӀыщтхэр.
+       *[start] ЦӀэхэр буквэмкӀэ къежьэн фае.
+    }
+
+component-name-invalid-start = Компонент цӀэ "{ $name }" мытэрэз. ЦӀэхэр буквэмкӀэ къежьэн фае.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched типым иӀэ джэуапым video атрибут иӀэн фае
+
+answer-video-watched-video-not-reference = videoWatched типым иӀэ джэуапым ссылк зыфэдэ video атрибут иӀэн фае
+
+answer-name-not-single-text = Джэуапым и name атрибут зы текст сабый ныӀэп иӀэн фаер
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ӏэгъо-благъо DoenetML къэхьыгъэ хъурэп, рекурсием илъэгапӀэхэр бэ дэдэшъ. Хъурае ссылк щыӀа?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }"-м DoenetML къыхэхыгъэ хъурэп
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }"-м къыхэхыгъэ DoenetML мытэрэз: "{ $componentType }" компонент типым зэтефагъэп
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибутыр щыӀэжьэп; ащ ычӀыпӀэ `{ $to }` гъэфедэн.
+       *[other] [deprecation] `<{ $component }>`-м и `{ $from }` атрибут щыӀэжьэп; ащ ычӀыпӀэ `{ $to }` гъэфедэн.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибутыр щыӀэжьэп ыкӀи хэлъытагъэ хъурэп, `{ $to }` ащ дэжь гъэнэфагъэшъ.
+       *[other] [deprecation] `<{ $component }>`-м и `{ $from }` атрибут щыӀэжьэп ыкӀи хэлъытагъэ хъурэп, `{ $to }` ащ дэжь гъэнэфагъэшъ.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-м и `{ $attribute }` атрибут щыӀэжьэп ыкӀи хэлъытагъэ хъурэп.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-м и `{ $attribute }` атрибут щыӀэжьэп; ащ ычӀыпӀэ `<{ $child }>` сабый гъэфедэн.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-м и `{ $attribute }` атрибут имэхьанэу `{ $value }` щыӀэжьэп; ащ ычӀыпӀэ `{ $to }` гъэфедэн.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` инджылызыбзэр ныӀэп бэрэ зышӀын ылъэкӀыщтыр, ащ къыхэкӀэу { $locale } бзэмкӀэ тхыгъэ документым итекст зэрэщытэу къэнэ. Бэрэ шӀыгъэ формэр занкӀэу тх, е `pluralForm` атрибуткӀэ гъэнэфэн.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элементыр Doenet иэлемент хъурэп.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементыр документым ылъапсэ дэжь щыгъэфедагъэ хъурэп.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементыр `<{ $parent }>` ыкӀоцӀ ит хъун плъэкӀыщтэп.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементым `{ $attribute }` зыфиӀорэ атрибут иӀэп.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементым и `{ $attribute }` атрибут спискэ хъун фае, ипкъыгъо пэпчъи мыхэм ащыщ: { $allowed }
+       *[other] `<{ $tag }>` элементым и `{ $attribute }` атрибут мыхэм ащыщ хъун фае: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select-мкӀэ вариант цӀэ мытэрэз. Вариант цӀэ { $variantName } опцие { $numOptions } къахэфэ, къыхэпхын фаер { $numToSelect } хъуми.
+
+select-variant-name-without-options = select-м вариант заулэ фэгъэнэфагъ, ау хъун ылъэкӀыщт вариант цӀэ { $variantName } фэдэмкӀэ опцие гъэнэфагъэ щыӀэп.
+
+select-variant-name-not-possible = select-м фэгъэнэфэгъэ вариант цӀэ { $variantName } хъун ылъэкӀыщт вариант цӀэ хъурэп.
+
+select-too-few-options = { $numOptions } ныӀэп щыӀэу компонент { $numToSelect } къыхэпхын плъэкӀыщтэп.
+
+select-from-sequence-too-few-values = КӀыхьагъэу { $length } зиӀэ последовательностым мэхьанэу { $numToSelect } къыхэпхын плъэкӀыщтэп.
+
+select-from-sequence-indices-count-mismatch = select-м фэгъэнэфэгъэ индексхэм япчъагъэ къыхэпхын фаем ыпчъагъэ зэтефэн фае
+
+select-from-sequence-indices-not-integers = select-м фэгъэнэфэгъэ индексхэр зэкӀэ целэ пчъагъэ хъунхэ фае
+
+select-from-sequence-index-excluded = selectfromsequence-м игъэнэфэгъэ индекс хэгъэкӀыгъагъ
+
+select-from-sequence-indices-excluded-combination = selectfromsequence-м игъэнэфэгъэ индексхэр хэгъэкӀыгъэ зэхэлъыгъэх
+
+select-from-sequence-coprime-not-positive-integers = Ныкъоу мыхъурэ целэ пчъагъэхэр къыхэмыхыгъэ зэрэхъурэм пае coprime зэхэлъыгъэхэр къыхэпхын плъэкӀыщтэп.
+
+select-from-sequence-coprime-common-factor = Coprime пчъагъэхэр къыхэпхын плъэкӀыщтэп. Хъун ылъэкӀыщт мэхьанэхэм зэдиӀыгъ множитель яӀ. ("from" е "to"-м ямэхьанэ гъэнэфагъэхэр "step"-м coprime фэхъунхэ фае.)
+
+select-from-sequence-coprime-single-number = 1 мыхъурэ зы пчъагъэм coprime зэхэлъыгъэхэр къыхэпхын плъэкӀыщтэп.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-м зэхэлъыгъэхэм япроцент 70-м нахьыбэ хагъэкӀыгъ
+
+select-from-sequence-coprime-none-found = Coprime пчъагъэхэр къыхэхыгъэ хъугъэхэп. Хъун ылъэкӀыщт мэхьанэхэм зэдиӀыгъ множитель яӀ.
+
+select-from-sequence-too-few-unique-values = КӀыхьагъэу { $numPossibleValues } зиӀэ последовательностым унэе мэхьанэу { $numToSelect } къыхэпхын плъэкӀыщтэп
+
+select-prime-numbers-too-few-values = КӀыхьагъэу { $numValues } зиӀэ простой пчъагъэ спискэм мэхьанэу { $numToSelect } къыхэпхын плъэкӀыщтэп
+
+select-prime-numbers-values-count-mismatch = select-м фэгъэнэфэгъэ мэхьанэхэм япчъагъэ къыхэпхын фаем ыпчъагъэ зэтефэн фае
+
+select-prime-numbers-values-not-prime = select prime number-м фэгъэнэфэгъэ мэхьанэхэр зэкӀэ простой пчъагъэ спискэм хэтын фае
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers-м игъэнэфэгъэ мэхьанэхэр хэгъэкӀыгъэ зэхэлъыгъэх
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-м зэхэлъыгъэхэм япроцент 70-м нахьыбэ хагъэкӀыгъ
+
+select-random-combination-fluke = Хъун зылъэкӀыщтыгъэр макӀэ дэдэу, тхьамыкӀагъокӀэ пчъагъэ зэпэмышӀыжьхэм язэхэлъыгъэ къыхэхыгъэ хъугъэп
+
+select-random-value-fluke = Хъун зылъэкӀыщтыгъэр макӀэ дэдэу, тхьамыкӀагъокӀэ зэпэмышӀыжь мэхьанэ къыхэхыгъэ хъугъэп

--- a/packages/i18n/locales/ady/editor.ftl
+++ b/packages/i18n/locales/ady/editor.ftl
@@ -1,0 +1,227 @@
+# Adyghe (West Circassian) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Ӏ (palochka), which is a letter and not a Latin I
+# or a digit 1 — see `content.ftl`'s header, which says why that matters more
+# in Adyghe than in most Cyrillic orthographies.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Adyghe counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular and
+# the numeral follows it, so the two branches read alike apart from the
+# number. Nothing here agrees with a gender or a noun class; Adyghe has
+# neither.
+#
+# The editor's own vocabulary is where this file is weakest. Adyghe has no
+# settled words for "variant", "diagnostic" or "accessibility", so this seed
+# writes the Russian terms an Adyghe author already meets in the software
+# around the editor — «вариант», «диагностикэ», «доступность» — rather than
+# coining three. A speaker replacing them should replace them everywhere.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ыпэрэм фэдэу гъэуцужьын
+       *[update] ГъэкӀэрэкӀэжьын
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] КъэгъэлъэгъуапӀэр { $word }
+       *[other] КъэгъэлъэгъуапӀэр { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Къыхэхын…
+editor-variant-next = КӀэлъыкӀорэ вариантыр къыхэхын
+editor-variant-previous = Ыпэрэ вариантыр къыхэхын
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA доступностым икъутэныгъ къэгъотыгъэ хъугъэ. Доступностым иотчёт { $action ->
+            [close] зэфэшӀыжьыным
+           *[open] къызэӀухыным
+        } фэшӀ тепӀытӀ.
+        [advisories] Доступностым иотчёт { $action ->
+            [close] зэфэшӀыжьыным
+           *[open] къызэӀухыным
+        } фэшӀ тепӀытӀ. WCAG AA икъутэныгъэхэр къэгъотыгъэхэ хъугъэп, ау доступностымкӀэ нэмыкӀ чэнджэшхэр щыӀэх.
+       *[clean] Доступностым иотчёт { $action ->
+            [close] зэфэшӀыжьыным
+           *[open] къызэӀухыным
+        } фэшӀ тепӀытӀ. ДоступностымкӀэ гумэкӀыгъо къэгъотыгъэ хъугъэп.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA доступностым икъутэныгъ къэгъотыгъэ хъугъэ. { $count ->
+            [one] WCAG AA икъутэныгъ { $count } къагъотыгъ
+           *[other] WCAG AA икъутэныгъ { $count } къагъотыгъ
+        }. Доступностым иотчёт { $action ->
+            [close] зэфэшӀыжьыным
+           *[open] къызэӀухыным
+        } фэшӀ тепӀытӀ.
+        [advisories] WCAG AA икъутэныгъ къэгъотыгъэ хъугъэп. { $count ->
+            [one] ДоступностымкӀэ нэмыкӀ чэнджэш { $count } къагъотыгъ
+           *[other] ДоступностымкӀэ нэмыкӀ чэнджэш { $count } къагъотыгъ
+        }. Доступностым иотчёт { $action ->
+            [close] зэфэшӀыжьыным
+           *[open] къызэӀухыным
+        } фэшӀ тепӀытӀ.
+       *[clean] WCAG AA икъутэныгъ къэгъотыгъэ хъугъэп. Доступностым иотчёт { $action ->
+            [close] зэфэшӀыжьыным
+           *[open] къызэӀухыным
+        } фэшӀ тепӀытӀ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML иверсие { $version }
+
+editor-tab-help = ЧӀыпӀэм ехьылӀэгъэ ӀэпыӀэгъу
+editor-tab-help-short = Контекст
+editor-tab-errors = Щыуагъэхэр
+editor-tab-warnings = Гъэсакъхэр
+editor-tab-info = Къэбар
+editor-tab-accessibility = Доступность
+editor-tab-responses = ГъэкӀуагъэ джэуапхэр
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторым иӀэшӀагъэхэр
+editor-format-as-doenetml = DoenetML фэдэу гъэпсын
+editor-format-as-xml = XML фэдэу гъэпсын
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Сатыр #{ $line }
+
+editor-no-errors = Щыуагъэхэр щыӀэп
+editor-no-warnings = Гъэсакъхэр щыӀэп
+editor-no-info = Къэбар диагностикэхэр щыӀэп
+
+editor-show-info-annotations = Къэбар диагностикэхэр редакторым къыщэгъэлъагъох
+editor-show-accessibility-annotations = Доступностым идиагностикэхэр редакторым къыщэгъэлъагъох
+
+editor-accessibility-learn-more = Doenet доступностым зэрэдэлажьэрэр зэгъашӀ
+
+editor-accessibility-violations-heading = Доступностым икъутэныгъэхэр ({ $standard })
+
+editor-accessibility-other-heading = ДоступностымкӀэ нэмыкӀ гумэкӀыгъохэр
+editor-none-found = Зи къэгъотыгъэ хъугъэп
+
+
+## Submitted responses
+
+editor-no-responses = ГъэкӀуагъэ джэуап джыри щыӀэп
+editor-response-answer-id = Джэуапым иид
+editor-response-response = Джэуап
+editor-response-credit = Балл
+editor-response-submitted = ГъэкӀуагъ
+
+
+## The context-help panel
+
+help-placeholder = Документацием пае курсорыр тегым ыцӀэ, атрибут е { $ref } тегъэуцу.
+
+help-unsupported-ref-chain = { $example } фэдэ Ӏахьыбэ зыхэт ссылкэхэмкӀэ ӀэпыӀэгъур джыри щыӀэп.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ссылкэм ызыфигъазэрэр къэгъотыгъэ хъугъэп: { $ref }.
+        [multiple] Ссылкэм ызыфигъазэрэ зыбгъупш къэгъотыгъэ хъугъ: { $ref }.
+       *[indeterminate] { $ref } ызыфигъазэрэр гъэнэфагъэ хъушъугъэп.
+    }
+
+help-learn-about-references = Ссылкэхэм афэгъэхьыгъэу зэгъашӀ →
+help-reference-page = Справочнэ нэкӀубгъу →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ыкӀоцӀ
+       *[top] ШъхьаӀэ лъэгапӀэм
+    }{ $allowed ->
+        [none] { " — мыщ зи ифэрэп." }
+        [text] { " — мыщ текст тебгъэуцон плъэкӀыщт." }
+        [text-and-components] { " — мыщ текст тебгъэуцон, е мыхэр зэпыплъыхьан плъэкӀыщт:" }
+       *[components] { " — зэпыплъыхьан плъэкӀыщтхэр:" }
+    }
+
+help-suggestions-footer = Компонент { $total } зэкӀэри плъэгъуным пае { $shortcut } тепӀытӀ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } { $target } зыфэзыгъазэрэ ссылк.
+       *[other] { $ref } { $target } зыфэзыгъазэрэ ссылк (сатыр { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } { $role } фэдэу къыхилъхьагъ.
+       *[other] { $owner } { $role } фэдэу къыхилъхьагъ, сатыр { $line }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } { $element } и { $property } свойствэ зыфэзыгъазэрэ ссылк.
+       *[other] { $ref } { $element } и { $property } свойствэ зыфэзыгъазэрэ ссылк (сатыр { $line }).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = сниппет
+help-kind-array-entry = массивым итедзапӀ
+
+help-default = ЫпэрапшӀэу гъэнэфагъэр:
+help-active-default = Джы Ӏоф зышӀэрэ ыпэрапшӀэ гъэнэфагъэр:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Хэлъытэгъэ мэхьанэхэр (зы Ӏахьым — зы):
+       *[other] Хэлъытэгъэ мэхьанэхэр:
+    }
+
+help-suggested-values = Чэнджэшыгъэ мэхьанэхэр:
+
+help-inserts = Хелъхьэ:
+
+help-coordinates =
+    { $count ->
+        [one] Координат:
+       *[other] Координатхэр:
+    }
+
+help-type = Тип:
+
+help-resolved-style = Гъэнэфэгъэ стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Гъэнэфэгъэ функцие цӀэхэр:
+help-reset-list = Мы инпутым итхьапэ зэтегъэуцожьыгъ:
+help-added-on-input = Мы инпутым хэгъэхьагъ:
+help-removed-on-input = Мы инпутым хэгъэкӀыгъ:
+
+help-reset-overrides = { $reset } { $additional } ыкӀи { $removed } акӀэрехьэ.

--- a/packages/i18n/locales/av/chrome.ftl
+++ b/packages/i18n/locales/av/chrome.ftl
@@ -1,0 +1,129 @@
+# Avar viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Avar (авар мацӀ) in the Cyrillic orthography Dagestan's schools and
+# publishing use, which is what CLDR fills a bare `av` in as (`av-Cyrl-RU`).
+# The palochka Ӏ is a letter of the alphabet, not a Latin I and not a digit 1.
+#
+# Avar counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gave it. A noun after a
+# numeral stays singular in Avar, so the two branches differ in nothing but the
+# number they print — which is why they read alike rather than by oversight.
+#
+# Nothing in this file agrees with a noun class. Avar's class agreement is
+# real, and it is a suffix on the agreeing word rather than a prefix; but it
+# needs a noun the catalog itself supplies, and the words here describe the
+# reader's own screen. `content.ftl`'s header is where the class system is
+# written out and where the one place it could have mattered is explained.
+#
+# The interface and mathematical vocabulary is the Russian one wherever written
+# Avar uses it — «клавиатура», «строка», «столбец», «интервал», «статистика»,
+# «выражение» — because that is what an Avar-speaking reader meets on a screen
+# and in a textbook. Where Avar has an everyday word that carries the meaning,
+# that word is used instead: «гьумер» for a page, «жаваб» for an answer,
+# «гъалатӀ» for an error.
+
+
+## Answer submission
+
+answer-checking = Хал гьабулеб буго…
+answer-submitting = БитӀулеб буго…
+answer-checking-status = Жавабалъул хал гьабулеб буго
+answer-submitting-status = Жаваб битӀулеб буго
+answer-correct = БитӀараб
+answer-incorrect = Мекъаб
+answer-response-saved = Жаваб хъвана
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% битӀараб
+answer-percent-short = { $percent } %
+max-credit-available = Босизе бегьулеб бищунго кӀудияб балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] цохӀо гӀуж хутӀун гьечӀо
+        [one] { $count } гӀуж хутӀун буго
+       *[other] { $count } гӀуж хутӀун буго
+    }
+validation-correct = (БитӀараб)
+validation-incorrect = (Мекъаб)
+validation-partially-correct = (БутӀаялъ битӀараб)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } абураб суалалъе { $count } жаваб бихьизабизе
+       *[other] { $answerId } абураб суалалъе { $count } жаваб бихьизабизе
+    }
+
+## Disclosure panels
+
+feedback-heading = Жаваб-калам
+collapsible-click-to-open = (рагьизе хӀапа гьабе)
+collapsible-click-to-close = (къазе хӀапа гьабе)
+collapsible-initializing = ХӀадурулеб буго…
+footnote-show = Гъоркьа бицен бихьизабизе
+footnote-hide = Гъоркьа бицен бахчизе
+description-more-information = цойги хабар
+
+## Controls
+
+slider-previous = Цебесеб
+slider-next = Хадусеб
+keyboard-open = Клавиатура рагьизе
+keyboard-close = Клавиатура къазе
+choice-input-remove-choice = { $choice } нахъе босизе
+matrix-remove-row = Строка нахъе босизе
+matrix-add-row = Строка жубазе
+matrix-remove-column = Столбец нахъе босизе
+matrix-add-column = Столбец жубазе
+subset-add-remove-points = ТӀанкӀал жубазе/нахъе росизе
+subset-toggle-points-intervals = ТӀанкӀалги интервалалги хиси
+subset-move-points = ТӀанкӀал сверизаризе
+subset-clear = БацӀцӀад гьабизе
+orbital-add-row = Строка жубазе
+orbital-remove-row = Строка нахъе босизе
+orbital-add-box = КатӀа жубазе
+orbital-remove-box = КатӀа нахъе босизе
+orbital-add-up-arrow = ТӀасан хӀулу жубазе
+orbital-add-down-arrow = Гъоркьан хӀулу жубазе
+orbital-remove-arrow = ХӀулу нахъе босизе
+orbital-row-label = { $row } абураб строкаялъул цӀар
+pretzel-answer = Жаваб
+summary-statistics-caption = { $column } абураб столбецалъул жамгӀияб статистика
+
+## Math input
+
+math-input-preview-region = математикияб выражениялъул цебесеб балагьи
+math-input-preview = Цебесеб балагьи
+math-input-invalid-expression = Мекъаб выражение:
+
+## Document status
+
+viewer-initializing = ХӀадурулеб буго…
+
+## Errors
+
+error-heading = ГъалатӀ
+error-found-at =
+    { $span ->
+        [line] { $startLine } абураб мухъалда батана.
+       *[lines] { $startLine }–{ $endLine } абурал мухъазда батана.
+    }
+document-contains-errors = Гьаб документалда гъалатӀал руго!
+diagnostic-heading-error = ГъалатӀ
+diagnostic-heading-warning = ХӀинкъи
+diagnostic-heading-information = Хабар
+diagnostic-heading-hint = Ишара
+accessibility-heading-level-1 = WCAG AA щвезабиялъул хисмат
+accessibility-heading-level-2 = Щвезабиялъул хӀинкъи
+something-went-wrong = Жо битӀун ккечӀо.
+renderer-load-failed = сурат бахъулеб компонент бачине кӀвечӀо. Гьумер цӀияб гьабе.
+core-start-failed = Гьаб документ байбихьизе кӀвечӀо. Гьумер цӀияб гьабе.
+core-start-failed-busy = Гьаб документ байбихьизе кӀвечӀо. Цадахъ гӀемерал документал байбихьулел рукӀана, гьеб гӀорхъуда кӀудияб заман босизе бегьула зигараб устройствоялда. Цогидал документал лъугӀараб мехалъ гьумер цӀияб гьабуни, кумек букӀине бегьула.
+core-start-failed-retry = Гьаб документ байбихьизе кӀвечӀо.
+core-start-failed-busy-retry = Гьаб документ байбихьизе кӀвечӀо. Цадахъ гӀемерал документал байбихьулел рукӀана, гьеб гӀорхъуда кӀудияб заман босизе бегьула зигараб устройствоялда.
+core-start-retry = ЦӀияб гӀуж гьабе
+saved-state-unavailable = Дуца хъварабщинаб хӀалтӀи бачине кӀвечӀо.

--- a/packages/i18n/locales/av/content.ftl
+++ b/packages/i18n/locales/av/content.ftl
@@ -1,0 +1,307 @@
+# Avar content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Avar (авар мацӀ, also магӀарул мацӀ) is the largest literary language of
+# Dagestan. Written here in the Cyrillic orthography with the palochka Ӏ — the
+# standard the republic's schools, the Makhachkala publishing houses and the
+# newspaper «ХӀакъикъат» use, and what CLDR fills a bare `av` in as
+# (`av-Cyrl-RU`). The palochka is a letter of the alphabet: it is neither a
+# Latin capital I nor a digit 1, and a file that spells «чӀегӀераб» with either
+# has quietly stopped being Avar.
+#
+# Avar counts in two plural categories, `one` and `other`, so nothing in this
+# file needed a category English does not have.
+#
+# **Avar has a real grammatical class system, it reaches further than Chechen's
+# does, and this catalog still forks nowhere. That combination is the fact
+# worth reading.** Avar nouns fall into three classes in the singular — в for
+# male humans, й for female humans, б for everything else — plus a plural in л,
+# and an agreeing word carries the marker as a *suffix*: «чӀегӀерав чи» a black
+# man, «чӀегӀерай чӀужу» a black woman, «чӀегӀераб мухъ» a black line,
+# «чӀегӀерал мухъал» black lines. That is already two differences from
+# `locales/ce`, which is the nearest catalog on the roster: Chechen carries its
+# class marker at the *front* of the word, and Chechen's colour and width
+# adjectives do not agree at all, so only the participle «дуьзна» forks there.
+# Every adjective written below agrees in Avar.
+#
+# **And every one of them is written flat, because only one class is
+# reachable.** `noun-gender` answers the class of the noun being described, and
+# every noun this core names — a line, a point, a square, a border, a fill, a
+# text, a background — is a thing rather than a person, so all of them are
+# class III and all of them answer `b`. A `{ $gender -> [v] … [j] … *[b] … }`
+# here would be writing three branches nothing can select, which is the
+# reachability rule `locales/ve`, `locales/ts`, `locales/ki` and `locales/bem`
+# already apply to their own unreached noun classes. So the file returns one
+# token and reads like a catalog with no agreement — while the agreement is in
+# fact everywhere, spelled once.
+#
+# What a speaker needs in order to change that is small and worth naming here:
+# the other forms of every adjective below are the same word with -в, -й or -л
+# in place of the final -б (чӀегӀера-в, чӀегӀера-й, чӀегӀера-л), and the
+# participle «цӀураб» is «цӀурав», «цӀурай», «цӀурал». If a class I or II noun
+# ever enters the table above `noun-gender`, that is all the fork costs.
+#
+# **The colour table is the least certain thing in this file.** Avar's basic
+# colour terms are the six written out plainly — чӀегӀераб, хъахӀаб, багӀараб,
+# тӀогьилаб, гӀурччинаб, хъахӀилаб — and the style pipeline asks for twelve. So
+# grey, orange, cyan, purple, pink and brown are written here as transparent
+# two-part compounds. Those are this seed's coinages rather than attested
+# words, they are the first thing a speaker should replace, and replacing one
+# costs a single line.
+#
+# **The geometric nouns are the Russian school terms, and that is deliberate.**
+# Secondary mathematics in Dagestan is taught in Russian, so «квадрат»,
+# «ромб», «треугольник», «многоугольник», «парабола», «вектор», «луч» and
+# «функция» are the words an Avar-speaking pupil actually meets for these
+# shapes — the same argument the chemistry section at the foot of this file
+# makes, applied to geometry. Where Avar has an everyday word that carries the
+# meaning without help — «мухъ» a line, «тӀанкӀ» a point, «бакӀ» a place,
+# «рагӀал» an edge, «кьер» a colour — that word is used instead.
+#
+# Attributive adjectives precede their noun in Avar, as they do in English, and
+# the width–dash–colour order of `style-stroke` is kept as English has it.
+
+
+## Style vocabulary
+##
+## Every adjective here agrees with its noun in Avar, and every one is written
+## in the class III (-б) form, because that is the only class `noun-gender` can
+## answer. See the header: this is one class spelled out, not an absence of
+## agreement.
+
+# The six plain terms are Avar's own basic colours; the six compounds are this
+# seed's coinages and are the least certain lines in the file.
+color =
+    .black = чӀегӀераб
+    .white = хъахӀаб
+    .gray = хъахӀ-чӀегӀераб
+    .red = багӀараб
+    .orange = багӀар-тӀогьилаб
+    .yellow = тӀогьилаб
+    .green = гӀурччинаб
+    .cyan = гӀурччин-хъахӀилаб
+    .blue = хъахӀилаб
+    .purple = багӀар-хъахӀилаб
+    .pink = багӀар-хъахӀаб
+    .brown = чӀегӀер-багӀараб
+# Avar has no specialized pair for the thickness of a drawn line, so the
+# general "big" and "small" adjectives carry it. Both agree, and both are
+# written in class III for the reason the header gives.
+line-width =
+    .thick = кӀудияб
+    .thin = гьитӀинаб
+# «бекараб» is a participle — "broken" — and agrees like an adjective;
+# «тӀанкӀабазул» is a genitive, "of dots", and genitives do not agree in Avar.
+line-style =
+    .dashed = бекараб
+    .dotted = тӀанкӀабазул
+# Noun phrases, not adjectives: they stand in front of «суралгун» in the
+# composing messages below and modify nothing. Their own adjectives agree with
+# a plural head, so they carry -л rather than -б — the one place the plural
+# class is visible in this file.
+fill-style =
+    .horizontal = горизонталиял мухъал
+    .vertical = вертикалиял мухъал
+    .diagonal = диагоналиял мухъал
+    .backdiagonal = данде диагоналиял мухъал
+    .dots = тӀанкӀал
+    .diamonds = ромбал
+noun =
+    .line = мухъ
+    .line-segment = мухъил бутӀа
+    .ray = луч
+    .vector = вектор
+    .curve = гъуркьараб мухъ
+    .function = функция
+    .slope-field = наклоналъул поле
+    .vector-field = векторазул поле
+    .parabola = парабола
+    .polyline = жубарал мухъал
+    .polygon = многоугольник
+    .triangle = треугольник
+    .rectangle = прямоугольник
+    .circle = круг
+    .region = бакӀ
+    .point = тӀанкӀ
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# A numeral is followed by the singular in Avar, so «{ $numSides } рахъ» is
+# right for every side count, and the whole phrase stands in front of the noun.
+# There is nothing left to put after the adjectives, so the tail is empty.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } рахъ бугеб битӀараб многоугольник
+    }
+# The class of the noun being described. Every noun this core names is a thing
+# rather than a person, so every one of them is class III and this answers one
+# token — see the header for what the other three classes would look like and
+# for why writing them as branches here would be writing what nothing can
+# select.
+noun-gender = b
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# Avar's attributive adjectives stand in front of the noun, so the description
+# lands where English puts it.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# «цӀураб» is the participle of «цӀезе», to fill. It agrees in Avar exactly as
+# the colours do — «цӀурав», «цӀурай», «цӀурал» — and is written flat for the
+# same reason they are: only class III is reachable here.
+style-filled-word = цӀураб
+# «суралгун» is "with pictures", the comitative of a word this catalog writes
+# out, so the case ending sits on a word the file owns rather than on the
+# placeable in front of it.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } суралгун { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } суралгун { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } суралгун { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «рагӀалгун» — "with an edge" — puts the comitative on a noun this catalog
+# writes, so nothing is welded to a placeable and Avar wants no article.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } рагӀалгун
+        [and] ва { $border } рагӀалгун
+        [and-article] ва { $border } рагӀалгун
+       *[with] { $border } рагӀалгун
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } суралгун { $color }
+       *[plain] { $color }
+    }
+# The negative participle agrees in Avar as the positive one does — «цӀечӀев»,
+# «цӀечӀей», «цӀечӀел» — but `describeFill` renders this message with no
+# arguments at all, so no noun and no `$gender` ever reach it. The class III
+# form is written flat, as every other agreeing catalog on the roster writes
+# its own.
+style-unfilled = цӀечӀеб
+# «фоналда» is a locative on a word this catalog writes, and the background
+# stands in front of the colour it sits behind.
+style-text =
+    { $parts ->
+        [background] { $background } фоналда { $color }
+       *[plain] { $color }
+    }
+style-background-none = гьечӀо
+
+## Boolean words
+
+boolean-true = битӀараб
+boolean-false = мекъаб
+
+## Answer buttons
+
+answer-submit-label = ХӀалтӀи хал гьабизе
+answer-submit-label-no-correctness = Жаваб битӀизе
+
+## Sectional blocks
+
+section-name =
+    .activity = ХӀалтӀи
+    .aside = Рахъалдаса
+    .cascade = Каскад
+    .definition = Баян
+    .example = Мисал
+    .exercise = Упражнение
+    .exercises = Упражнениял
+    .given-answer = Жаваб
+    .note = Бицен
+    .objectives = Мурадал
+    .paragraphs = Абзацал
+    .part = БутӀа
+    .problem = Масъала
+    .problems = Масъалаби
+    .proof = Бихьизаби
+    .question = Суал
+    .section = БетӀер
+    .solution = Бахъин
+    .task = Иш
+    .theorem = Теорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Ишара
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурат { $enumeration }
+        [numbered-caption] Сурат { $enumeration }{ ". " }
+        [unnumbered-caption] Сурат{ ". " }
+       *[unnumbered] Сурат
+    }
+
+## Paginator controls
+
+paginator-previous = Цебесеб
+paginator-next = Хадусеб
+paginator-page = Гьумер
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## Avar's own conditional is the verb suffix -ни, which closes its clause — but
+## the clause it closes needs a verb, and what this key introduces is
+## mathematics. «нагагь» is the clause-initial particle that normally
+## accompanies that suffix and can stand alone in front of a condition, so this
+## key lands where the renderer puts it, as `locales/ce`'s «нагахь санна» does
+## and unlike the catalogs whose only conditional is clause-final. A speaker
+## writing the sentence out by hand would still mark the verb.
+
+piecewise-condition-or = я
+piecewise-condition-if = нагагь
+piecewise-condition-otherwise = цогидаб мехалъ
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Dagestan is taught in
+## Russian, so the element names an Avar-speaking pupil meets are the Russian
+## ones, and an invented Avar list would be further from the textbook in front
+## of them than the English fallback is.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Мекъаб химиялъул ишара
+chemistry-invalid-ionic-compound = Мекъаб ионалъулаб цолъи

--- a/packages/i18n/locales/av/diagnostics.ftl
+++ b/packages/i18n/locales/av/diagnostics.ftl
@@ -1,0 +1,694 @@
+# Avar diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Avar (авар мацӀ) in the Cyrillic orthography with the palochka Ӏ, which is a
+# letter of the alphabet rather than a Latin I or a digit 1.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Avar counts in two plural categories, `one` and `other`, so every count
+# selection keeps the shape English gave it. A noun after a numeral stays
+# singular in Avar, so a pair of branches often differs in nothing but the
+# number it prints; that is the language rather than an unfinished translation.
+#
+# Nothing in this file agrees with a noun class. Avar's class agreement is
+# real — a suffix -в, -й, -б or -л on the agreeing word — but it needs a noun
+# the catalog itself supplies, and what these messages describe is the author's
+# own document. `content.ftl` is where the class system is written out, and its
+# header is where the reason this seed forks nothing is argued.
+#
+# The technical vocabulary is the Russian one written Avar uses for it —
+# «компонент», «атрибут», «функция», «индекс», «последовательность»,
+# «переменная», «матрица», «контраст» — because mathematics and computing in
+# Dagestan are taught and written in Russian. Where Avar has an everyday word
+# that carries the meaning it is used instead: «мухъ» a line, «тӀанкӀ» a point,
+# «цӀар» a name, «къимат» a value, «гъалатӀ» an error.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кӀиго рагӀалаб тӀанкӀ бихьизабуни { $attributes } хӀисабалде босуларо
+       *[other] кӀиго рагӀалаб тӀанкӀ бихьизабуни { $attributes } хӀисабалде росуларо
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] рагӀалаб тӀанкӀги гьоркьохъеб тӀанкӀги цадахъ бихьизаруни { $attributes } хӀисабалде босуларо
+       *[other] рагӀалаб тӀанкӀги гьоркьохъеб тӀанкӀги цадахъ бихьизаруни { $attributes } хӀисабалде росуларо
+    }
+
+line-segment-midpoint-offset-without-midpoint = гьоркьохъеб тӀанкӀ гьечӀого midpointOffset хӀалтӀуларо
+
+## `<line>`
+
+line-points-undetermined-dimensions = Барам лъачӀел тӀанкӀаздасан унеб мухъ.
+
+line-points-too-few-dimensions = Мухъ камизе гьечӀого кӀиго барам бугел тӀанкӀаздасан ине ккола.
+
+line-points-depend-on-variables = Мухъ гьал переменнаязде мугъчӀвараб тӀанкӀаздасан унеб буго: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ва { $variable2 } абурал переменнаязулаб мухъил уравнениялъул формат мекъаб буго.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint ва direction гьаруна бихьизабун.  Бихьизабураб through хӀисабалде босуларо.
+
+ray-dimension-mismatch = лучалда numDimensions данде ккола гьечӀо.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ва displacement гьаруна бихьизабун.  Бихьизабураб head хӀисабалде босуларо.
+
+vector-dimension-mismatch = векторалда numDimensions данде ккола гьечӀо.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` абуралде цӀазе кӀоларо, гьелъул nearestPoint абураб хӀалалъул переменная гьечӀолъиялъ.
+
+constrain-to-without-nearest-point = `<{ $component }>` абуралда гӀорхъи лъезе кӀоларо, гьелъул nearestPoint абураб хӀалалъул переменная гьечӀолъиялъ.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` абуралъул жаниб гӀорхъи лъезе кӀоларо, гьелъул nearestPoint абураб хӀалалъул переменная гьечӀолъиялъ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition инлайн гуреб choiceInput-алъе хӀисабалде босуларо
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-алъе бихьизарурал индексал хӀисабалде росуларо, гьезул къадар лъималазул къадаралда данде кколеб гьечӀолъиялъ.
+
+pretzel-indices-count-mismatch = масъалаялъе бихьизарурал индексал хӀисабалде росуларо, гьезул къадар масъалаялъул лъималазул къадаралда данде кколеб гьечӀолъиялъ.
+
+shuffle-indices-count-mismatch = shuffle-алъе бихьизарурал индексал хӀисабалде росуларо, гьезул къадар компонентазул къадаралда данде кколеб гьечӀолъиялъ.
+
+indices-ignored-out-of-range = { $component } абуралъе бихьизарурал индексал хӀисабалде росуларо, цоцаязул гӀорхъабаздаса къватӀир рахъиналъ.
+
+pretzel-indices-repeated = pretzel-алъе бихьизарурал индексал хӀисабалде росуларо, цоцаял такрар гьаруналъ.
+
+pretzel-circuit-first-index = circuit режималда pretzel-алъе бихьизарурал индексал хӀисабалде росуларо, тӀоцебесеб индекс 1 букӀине кколелъиялъ.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` строкаязул лъималаздалъун хӀалтӀизе, `type` абураб атрибут бихьизабизе ккола.
+
+invalid-type-defaulting-to-math = { $component } абураб компонентазе { $type } абураб тайпа мекъаб буго. math, text, number яги boolean букӀине ккола. math лъола.
+
+string-not-valid-component-to-arrange = "{ $value }" абураб строка { $component } гьабизе бегьулеб компонент гуро. ХӀисабалде босуларо.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } абураб тайпа мекъаб буго, тайпа number лъола.
+
+invalid-variable-value = Переменнаялъул мекъаб къимат: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } абураб вариантасул индекс число букӀине ккола
+
+variant-index-must-be-integer = { $index } абураб вариантасул индекс бегӀераб число букӀине ккола
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютал барамазе гьабун гьечӀо. Гьоркьохъал барамал относителяллъун рахъулел руго.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютал барамазе гьабун гьечӀо. РагӀалал относителяллъун рахъулел руго.
+
+side-by-side-no-block-child = Мекъаб `<{ $component }>`: гьелъул камизе гьечӀого цо блокияб лъимер букӀине ккола.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Графикияб `<label>` абуралда `for` абураб атрибут хӀисабалде босуларо.
+
+label-for-must-resolve-to-one = `<label>` абуралда бугеб `for` абураб атрибут цо компоненталде бачине ккола.
+
+label-for-unresolved = `<label>` абуралда бугеб `for` абураб атрибут компоненталде бачине кӀвечӀо.
+
+label-for-answer-with-authored-inputs = `<label>` абуралда бугеб `for` абураб атрибуталъ хӀаракатчиясул хъварал инпутал ругеб `<answer>` абуралде ссылка гьабула; инпуталде битӀун ссылка гьабе.
+
+label-for-answer-without-input = `<label>` абуралда бугеб `for` абураб атрибуталъ цӀар кьезе инпут гьечӀеб `<answer>` абуралде ссылка гьабула.
+
+label-for-must-reference-input-or-answer = `<label>` абуралда бугеб `for` абураб атрибуталъ инпуталде яги жавабалде ссылка гьабизе ккола.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Щвезабиялъе `<{ $component }>` абуралъе яги къокъаб баян букӀине ккола, яги гьеб декоративаблъун бихьизабизе ккола.
+
+accessibility-video-short-description = Щвезабиялъе `<video>` абуралъе къокъаб баян букӀине ккола.
+
+accessibility-input-short-description-or-label = Щвезабиялъе `<{ $component }>` абуралъе къокъаб баян яги цӀар букӀине ккола.
+
+accessibility-answer-input-short-description-or-label = Щвезабиялъе инпут гьабулеб `<answer>` абуралъе къокъаб баян яги цӀар букӀине ккола.
+
+accessibility-short-description-contains-math = Къокъал баяназда `<{ $component }>` гӀадал математикиял компонентал рукӀине бегьуларо. Математика рагӀабаздалъун хъвае.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } абуралъул контраст бетӀералъул текстазе гӀоларо (чӀегӀераб режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камизе гьечӀого { $threshold }:1 ккола).
+       *[other] { $colorName } абуралъул контраст бетӀералъул текстазе гӀоларо ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камизе гьечӀого { $threshold }:1 ккола).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = { $count } тӀанкӀалдасан унеб `<circle>` гьабизе гьабун гьечӀо тӀанкӀаздаса числоязулал къиматал гьечӀеб мехалъ.
+
+circle-too-many-through-points = Лъабгоялдаса цӀикӀкӀарал тӀанкӀаздасан унеб круг хӀисабизе кӀоларо.
+
+circle-overprescribed-radius-center-points = Бихьизабураб радиус, бакьулъ ва тӀанкӀал цадахъ ругеб круг хӀисабизе кӀоларо.
+
+circle-center-with-multiple-points = Бихьизабураб бакьулъ бугеб круг цоялдаса цӀикӀкӀарал тӀанкӀаздасан хӀисабизе кӀоларо.
+
+circle-radius-too-small = Круг хӀисабизе кӀоларо: кӀиго тӀанкӀалда гьоркьоб манзил { $distance } бугеб мехалъ, бихьизабураб { $radius } абураб радиус гьитӀинаб буго.
+
+circle-radius-with-many-points = Бихьизабураб радиус бугеб круг кӀиго тӀанкӀалдаса цӀикӀкӀарал тӀанкӀаздасан гьабизе кӀоларо.
+
+circle-invalid-center-or-through-points = Кругалъул бакьулъ яги тӀанкӀал мекъал руго.
+
+circle-radius-center-with-multiple-points = Бихьизабураб бакьулъ бугеб кругалъул радиус цоялдаса цӀикӀкӀарал тӀанкӀаздасан хӀисабизе кӀоларо.
+
+circle-change-radius-non-numerical = Числоязулал къиматал гьечӀел тӀанкӀаздасан унеб кругалъул радиус хисизе кӀоларо
+
+circle-radius-with-points-non-numerical = Числоязулал къиматал гьечӀеб мехалъ бихьизабураб радиусалдалъун цоялдаса цӀикӀкӀарал тӀанкӀаздасан унеб круг гьабизе кӀоларо.
+
+circle-change-center-non-numerical = Числоязулал къиматал гьечӀел тӀанкӀаздасан унеб кругалъул бакьулъ хисизе гьабун гьечӀо.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциялъул областалъе барамал гӀоларо. Областалда { $intervals } интервал буго, амма функциялда { $inputs ->
+            [one] { $inputs } инпут
+           *[other] { $inputs } инпут
+        } буго.
+       *[other] Функциялъул областалъе барамал гӀоларо. Областалда { $intervals } интервал буго, амма функциялда { $inputs ->
+            [one] { $inputs } инпут
+           *[other] { $inputs } инпут
+        } буго.
+    }
+
+function-domain-invalid-format = Функциялъул областалъул формат мекъаб буго.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциялъул числоялъулаб гуреб максимум хӀисабалде босуларо.
+        [minimum] Функциялъул числоялъулаб гуреб минимум хӀисабалде босуларо.
+        [extremum] Функциялъул числоялъулаб гуреб экстремум хӀисабалде босуларо.
+        [point] Функциялъул числоялъулаб гуреб тӀанкӀ хӀисабалде босуларо.
+        [slope] Функциялъул числоялъулаб гуреб наклон хӀисабалде босуларо.
+       *[other] Функциялъул числоялъулаб гуреб { $type } хӀисабалде босуларо.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциялъул чӀобогояб максимум хӀисабалде босуларо.
+        [minimum] Функциялъул чӀобогояб минимум хӀисабалде босуларо.
+        [extremum] Функциялъул чӀобогояб экстремум хӀисабалде босуларо.
+        [point] Функциялъул чӀобогояб тӀанкӀ хӀисабалде босуларо.
+       *[other] Функциялъул чӀобогояб { $type } хӀисабалде босуларо.
+    }
+
+function-points-too-close = Функциялда цоцазде гӀагарлъун ругел кӀиго тӀанкӀ буго. Функция бихьизабизе кӀоларо.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функциялъул итерацияби гьаризе бегьула инпутазул къадар аутпутазул къадаралда данде ккараб мехалъ гурони гьечӀо. Гьаб функциялда { $inputs } инпут ва { $outputs ->
+            [one] { $outputs } аутпут
+           *[other] { $outputs } аутпут
+        } буго.
+       *[other] Функциялъул итерацияби гьаризе бегьула инпутазул къадар аутпутазул къадаралда данде ккараб мехалъ гурони гьечӀо. Гьаб функциялда { $inputs } инпут ва { $outputs ->
+            [one] { $outputs } аутпут
+           *[other] { $outputs } аутпут
+        } буго.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Последовательностасул барам мекъаб буго.  Нулалдаса гъоркье гьечӀеб бегӀераб число букӀине ккола.
+
+sequence-invalid-step = Последовательностасул шаг мекъаб буго.  { $type } тайпаялъул последовательностасе число букӀине ккола.
+
+sequence-invalid-endpoint-number = Числоязул последовательностасул "{ $attribute }" мекъаб буго.  Число букӀине ккола.
+
+sequence-invalid-endpoint-letters = ХӀарпазул последовательностасул "{ $attribute }" мекъаб буго.  ХӀарпазул цолъи букӀине ккола.
+
+sequence-invalid-endpoint = Последовательностасул "{ $attribute }" мекъаб буго.
+
+select-from-sequence-coprime-not-numbers = числоял тӀаса рищулел гьечӀолъиялъ coprime хӀисабалде босуларо
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations бихьизабуралъ coprime хӀисабалде босуларо
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` абуралъул target мекъаб буго: target батичӀо.
+
+target-state-variable-not-found = `<{ $source }>` абуралъул target мекъаб буго: `<{ $component }>` абуралда "{ $property }" абураб цӀар бугеб хӀалалъул переменная батичӀо.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` абуралъул переменнаял мустакъилаб переменнаялдаса батӀиял рукӀине ккола.
+
+ode-system-duplicate-variable-names = Такрар гьарурал переменнаязул цӀараздалъун ОДУ-ялъул рахъалъулал функцияби бихьизаризе кӀоларо.
+
+ode-system-rhs-function-error = ОДУ-ялъул рахъалъулаб функция бихьизабизе кӀоларо.  mathjs функция гьабулаго гъалатӀ ккана.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } мухъалда гьоркьоб угол бихьизабизе кӀоларо
+
+angle-invalid-through-point = `<angle>` абуралъул through абуралда мекъаб тӀанкӀ буго
+
+parabola-vertex-too-many-points = Вершина бугеб парабола цоялдаса цӀикӀкӀарал тӀанкӀаздасан гьабун гьечӀо.
+
+parabola-too-many-points = Лъабгоялдаса цӀикӀкӀарал тӀанкӀаздасан унеб парабола гьабун гьечӀо.
+
+intersection-too-many-items = КӀиго жоялдаса цӀикӀкӀарал жалазе пересечение гьабун гьечӀо
+
+## Other math components
+
+ionic-compound-not-two-ions = КӀиго ион гуреб цогидаб жоялъе ионияб цолъи гьабун гьечӀо.
+
+ionic-compound-needs-cation-and-anion = Ионияб цолъи цо катионалъеги цо анионалъеги гурони гьабун гьечӀо.
+
+solve-equations-cannot-evaluate = Уравнение хӀисабизе кӀвечӀолъиялъ гьеб бахъизе кӀоларо: { $equation }
+
+math-operators-operand-number-required = Математикияб операнд бахъулаго operandNumber бихьизабизе ккола.
+
+eigen-decomposition-failed = Матрицаялъул собственниял къиматал хӀисаризе кӀвечӀо
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } абураб параметр паттерналда гьечӀо, гьелъ киданиги чӀобогояб бакӀ гурони батуларо.
+       *[other] `<matchesPattern>`: { $parameters } абурал параметрал паттерналда гьечӀо, гьез киданиги чӀобогояб бакӀ гурони батуларо.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" бичӀчӀизе кӀоларо. Гьеб none, medium, dense яги пробелалъ ратӀа гьарурал кӀиго позитивияб число букӀине ккола, масала grid="1 0.5". Сетка бахъуларо.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` абуралъе { $expected ->
+        [one] цо аутпут бугеб функция ккола, гьеб щибаб тӀанкӀалда бугеб y' наклон буго, масала `y - x`
+       *[other] кӀиго аутпут бугеб функция ккола, гьеб щибаб тӀанкӀалда бугеб вектор буго, масала `(y, -x)`
+    }, амма кьураб функциялда { $found ->
+        [one] { $found } аутпут
+       *[other] { $found } аутпут
+    } буго. { $alternative ->
+        [none] Щибго бахъуларо.
+       *[other] Гьеб функциялъе `<{ $alternative }>` ккола кколеб компонент. Щибго бахъуларо.
+    }
+
+field-function-attribute-ignored-with-child = `function` абураб атрибут хӀисабалде босуларо, щайгурелъул функция компоненталъул жанибги кьун буго; жанибгиялъ хӀалтӀула. Функция кӀиго къагӀидаялдаса цоялдалъун гурони кьуге.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` абураб атрибуталъ компоненталъул жаниб битӀун хъвараб выражениялъул переменнаязул цӀарал кьола. { $reason ->
+        [function-child] Гьаниб функция `<function>` лъималлъун кьун буго, гьелъ жиндирго переменнаязул цӀарал кьола, гьелъин `variables` хӀисабалде босулареб.
+       *[no-expression] Гьаниб гьедин выражение кьун гьечӀо, гьелъин `variables` хӀисабалде босулареб.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure рендерералда xLabelPosition="left" хӀалтӀуларо; right-позициялъул къагӀида хӀалтӀизабула.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure рендерералда yLabelPosition="bottom" хӀалтӀуларо; top-позициялъул къагӀида хӀалтӀизабула.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure гьабизе осалъул гӀорхъаби мекъал руго; стандартияб bbox (-10,-10,10,10) хӀалтӀизабула.
+
+prefigure-invalid-width = `<graph>`: prefigure гьабизе гьоркьохъеб барам мекъаб буго; стандартияб 425 барам хӀалтӀизабула.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure гьабизе aspectRatio мекъаб буго; стандартияб 1 гьоркьохъеб бащалъи хӀалтӀизабула.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткаялъул гьоркьохъеб манзил осазул гӀорхъабазе бигьаго гьитӀинаб буго; prefigure рендерералда сетка бахъуларо.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure рендерер хӀалтӀизабичӀони аннотацияби бахъуларо.
+
+multiple-annotations-children = `<graph>` абуралъул жаниб гӀемерал `<annotations>` лъимал ратана; ахирисеб гуреб киналго хӀисабалде росуларо.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Лъаларедухъ бугеб компоненталъул тайпа хисизе яги копия гьабизе кӀоларо: { $type }.
+
+copy-prop-not-found = { $component } тайпаялъул компоненталда { $property } абураб проп батичӀо
+
+collect-no-source = collect-алъе источник батичӀо.
+
+collect-invalid-component-type = `<{ $component }>` тайпаялъул компонентал ракӀаризе кӀоларо, гьеб мекъаб тайпа бугелъул.
+
+reference-index-unavailable = `{ $reference }` абураб индексалде ссылка гьабизе кӀоларо
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` абураб компоненталда { $action } гьабизе кӀоларо
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Хазинаялъул шакл мекъаб буго.  Строкабазул барамал данде ккола гьечӀо. Батана componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Хазинаялда столбецазул цӀарал такрар гьарун руго.  Батана componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Хазинаялда цо столбецалъул цӀар гьечӀо.  Батана componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Гьаб жавабалъул award жиндирго битӀараб жавабалда мугъчӀвараб буго, гьелъ хӀисабалде босулареб къагӀидаялде бачина.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` бугеб контейнералъул жаниб бугеб `<answer>` абуралда `maxNumAttempts` лъуни хӀалтӀуларо, гӀужазул къадар контейнералъ бихьизабулелъул. `maxNumAttempts` контейнералда лъе.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` бугеб цогидаб контейнералъул жаниб бугеб `sectionWideCheckWork` бугеб контейнералда `maxNumAttempts` лъуни хӀалтӀуларо, гӀужазул къадар къватӀисеб контейнералъ бихьизабулелъул. `maxNumAttempts` къватӀисеб контейнералда лъе.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality лъечӀого { $attributes } абураб атрибут хӀалтӀуларо.
+       *[other] symbolicEquality лъечӀого { $attributes } абурал атрибутал хӀалтӀуларо.
+    }
+
+answer-invalid-type = Жавабалъе мекъаб тайпа: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` абураб компоненталъе цӀар гьечӀолъиялъ, гьеб модулалъул атрибуталъе хӀалтӀизабизе кӀоларо
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` абураб компонент модулалъул атрибуталъе хӀалтӀизабизе кӀоларо, щайгурелъул `<module>` тайпаялда гьанжего "{ $name }" абураб атрибут буго.
+
+conditional-content-condition-ignored = case яги else лъимал ругеб `<conditionalContent>` компоненталда `condition` абураб атрибут хӀисабалде босуларо.
+
+slider-markers-type-mismatch = Маркеразул тайпа слайдералъул тайпаялда данде ккола гьечӀо.
+
+pretzel-problem-needs-statement-and-answer = Мекъаб pretzel: щибаб `<problem>` абуралъул жаниб цо `<statement>` ва цо `<answer>` букӀине ккола.
+
+pretzel-circuit-first-problem-distractor = Мекъаб pretzel: mode="circuit" бугеб мехалъ тӀоцебесеб `<problem>` дистрактор букӀине бегьуларо.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` абураб атрибуталъе { $values } абураб къимат мекъаб буго; хӀисабалде босуларо.
+       *[other] `{ $attribute }` абураб атрибуталъе { $values } абурал къиматал мекъал руго; хӀисабалде росуларо.
+    }
+
+attribute-must-be-references = `{ $attribute }` абураб атрибуталъе `{ $value }` абураб къимат мекъаб буго. Атрибут `$` абуралдаса байбихьулел ссылкабаздаса гьабизе ккола.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } абуралда рарал мекъал функциязул цӀарал хӀисабалде росулел гьечӀо: { $names }. Щибаб цӀаралъул бихьулеб бутӀаялда камизе гьечӀого 2 хӀарп (хӀарпал яги дефисал) букӀине ккола; хадуб `|<mathspeak alternative>` абураб бутӀа бачине бегьула.
+
+## Building components from the source
+
+component-type-invalid = Мекъаб компоненталъул тайпа: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } абураб атрибут такрар гьабизе кӀоларо.
+
+attribute-invalid-for-component = `<{ $componentType }>` тайпаялъул компоненталъе "{ $attribute }" абураб атрибут мекъаб буго.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } абураб стилалъул контраст { $context ->
+        [text-on-background] текстазул кьералъе фоналъул кьералда данде
+        [high-contrast] кӀудияб контрасталъул кьералъе холсталда данде
+        [line] мухъил кьералъе холсталда данде
+        [marker] маркералъул кьералъе холсталда данде
+       *[text-on-canvas] текстазул кьералъе холсталда данде
+    } гӀоларо{ $mode ->
+        [dark] { " (чӀегӀераб режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камизе гьечӀого { $threshold }:1 ккола).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } абураб стилалда бихьизарурал кьеразул гвангъараб режималъе гӀоларедухъ контраст бугониги, гьезул къиматаздаса бахъарал чӀегӀераб режималъул кьеразда текстазул кьералъе фоналъул кьералда данде контраст гӀоларо ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камизе гьечӀого { $threshold }:1 ккола). { $suggestion ->
+        [available] ЧӀегӀераб режималда контраст гӀезабизе, яги гвангъараб режималъул контраст цӀикӀкӀинабе (масала, { $lightAttribute }="{ $lightColor }" лъе), яги чӀегӀераб режималъул кьер хисе (масала, { $darkAttribute }="{ $darkColor }" лъе).
+       *[none] ЧӀегӀераб режималда контраст гӀезабизе, гвангъараб режималъул контраст цӀикӀкӀинабе яги бахъарал кьерал textColorDarkMode ва/яги backgroundColorDarkMode абуразда хисе.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } абураб стилалда бихьизабураб текстазул кьералъе гвангъараб режималда гӀоларедухъ контраст бугониги, гьеб къиматалдаса бахъараб чӀегӀераб режималъул текстазул кьералъе холсталда данде контраст гӀоларо ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камизе гьечӀого { $threshold }:1 ккола). { $suggestion ->
+        [available] ЧӀегӀераб режималда контраст гӀезабизе, яги гвангъараб режималъул контраст цӀикӀкӀинабе (масала, textColor="{ $lightColor }" лъе), яги чӀегӀераб режималъул кьер хисе (масала, textColorDarkMode="{ $darkColor }" лъе).
+       *[none] ЧӀегӀераб режималда контраст гӀезабизе, гвангъараб режималъул контраст цӀикӀкӀинабе яги бахъараб кьер textColorDarkMode абуралда хисе.
+    }
+
+section-multiple-style-palettes = БетӀералъе цо <stylePalette> гурони тӀаса бищизе кӀоларо; ахирисеб хӀалтӀизабула.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, numToSelect нулалдаса гъоркье гьечӀеб бегӀераб число гьечӀолъиялъ.
+
+variant-num-to-select-not-constant-number = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, numToSelect константияб число гьечӀолъиялъ.
+
+variant-with-replacement-not-constant-boolean = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, withReplacement константияб булев къимат гьечӀолъиялъ.
+
+variant-select-weight-disables-unique = selectWeight яги selectForVariants бихьизабураб вариант бугони, select-алъе батӀиял вариантал хӀалтӀуларо
+
+variant-coprime-undetermined = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, coprime киданиго мекъаб бугилан бихьизабизе кӀвечӀолъиялъ.
+
+variant-attribute-not-constant = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, { $attribute } константа гьечӀолъиялъ.
+
+variant-attribute-not-number = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, { $attribute } число гьечӀолъиялъ.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тайпаялъул { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, { $attribute } { $expected ->
+        [letters-combination] хӀарпазул цолъи
+        [math-expression] бегьулеб математикияб выражение
+        [integer] бегӀераб число
+       *[number] число
+    } гьечӀолъиялъ.
+
+variant-length-not-integer = { $component } абуралъул батӀиял вариантал бихьизаризе кӀоларо, length бегӀераб число гьечӀолъиялъ.
+
+variant-sort-not-implemented = sort бугеб { $component } абуралъул батӀиял вариантал гьабун гьечӀо
+
+variant-exclude-combinations-not-implemented = excludeCombinations бугеб { $component } абуралъул батӀиял вариантал гьабун гьечӀо
+
+variant-math-exclude-not-implemented = exclude бугеб math тайпаялъул { $component } абуралъул батӀиял вариантал гьабун гьечӀо
+
+variant-non-constant-exclude-not-implemented = константияб гуреб exclude бугеб { $component } абуралъул батӀиял вариантал гьабун гьечӀо
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикалъул prefigure рендерералда хӀалтӀуларо; наслу тӀаса бита.
+
+prefigure-descendant-invalid-geometry = { $subject }: гӀорхъи гьечӀеб яги лъугӀичӀеб геометрия; наслу тӀаса бита.
+
+prefigure-curve-label-omitted = { $subject }: хисарал кривая элементазда цӀарал хӀалтӀуларо; цӀар тӀаса бита.
+
+prefigure-curve-unsupported-definition-type = { $subject }: '{ $definitionType }' абураб кривая функция бихьизабиялъул тайпа хӀалтӀуларо; наслу тӀаса бита.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves абуралда flipFunctions абураб атрибут хӀалтӀуларо; наслу тӀаса бита.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves абуралда формулаялъул тайпаялъул лъимал гурони хӀалтӀуларо; наслу тӀаса бита.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] мухъазул тайпаялъул цӀаралъе
+       *[point] тӀанкӀалъул цӀаралъе
+    } '{ $labelPosition }' абураб labelPosition хӀалтӀуларо; PreFigure-ялъул стандартияб бащалъи хӀалтӀизабула.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' абураб цӀезабиялъул стиль PreFigure-алда хӀалтӀуларо; цӀураб кьералде нахъбуссунеб буго.
+
+prefigure-line-style-unknown = { $subject }: лъаларедухъ бугеб '{ $lineStyle }' абураб мухъил стиль PreFigure-алъул аутпуталдаса тӀаса бита.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' абураб маркералъул стиль PreFigure-алъул 'diamond' стилалде сунеб буго.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' абураб маркералъул стиль PreFigure-алда хӀалтӀуларо; стандартияб стиль хӀалтӀизабула.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` мекъаб буго; жиндирго жоялде бачине кӀоларо. Аннотация тӀаса бита.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` гӀемерал жалазде бачана; тӀоцебесеб жо хӀалтӀизабула.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` мекъаб буго; жо жанисеб графикалдаса къватӀиб буго. Аннотация тӀаса бита.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` мекъаб буго; prefigure гьабулаго жо хӀалтӀулеб графикияб объект гуро. Аннотация тӀаса бита.
+
+annotation-text-missing = `<annotation>`: `text` гьечӀо яги чӀобогояб буго; чӀобогояб текст бахъула.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Сверараб мугъчӀвай батана.
+       *[other] `<{ $componentType }>` компонент бугеб сверараб мугъчӀвай батана.
+    }
+
+reference-no-referent = Ссылкаялъе жаваб кколеб жо батичӀо: `{ $reference }`
+
+reference-multiple-referents = Ссылкаялъе жаваб кколел гӀемерал жал ратана: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` абуралъул { $attribute } абураб атрибуталъул формат мекъаб буго.
+
+children-invalid = `<{ $componentType }>` абуралъе лъимал мекъал руго: мекъал лъимал ратана: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` абураб атрибуталъе `{ $value }` абураб къимат мекъаб буго, `{ $default }` абураб къимат хӀалтӀизабула
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версия батичӀо.
+       *[other] DoenetML { $version } версия батичӀо. { $fallback } версиялде нахъбуссунеб буго
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Мекъаб DoenetML: { $content }
+
+parse-tag-missing-close-tag = Мекъаб DoenetML: `{ $tag }` абураб тегалъе къазабулеб тег гьечӀо. Жиндирго къазабулеб тег яги `</{ $tagName }>` тег ккола кколеб.
+
+parse-tag-error = Мекъаб DoenetML: `<{ $tagName }>` абураб тегалда гъалатӀ буго
+
+parse-attribute-missing-value = Мекъаб DoenetML: `{ $attribute }` абураб мекъаб атрибуталъе къимат камун бугилан бихьула.
+
+parse-attribute-invalid = Мекъаб DoenetML: `{ $attribute }` абураб атрибут мекъаб буго
+
+parse-attribute-value-invalid = Мекъаб DoenetML: `{ $value }` абураб атрибуталъул къимат мекъаб буго
+
+parse-attribute-value-quote-mismatch = Мекъаб DoenetML: `{ $value }` абураб атрибуталъул къимат мекъаб буго. Кавычкаби данде ккола гьечӀо. Дуда `{ $quote }` камун бугилан бихьула
+
+parse-open-tag-name-missing = Мекъаб DoenetML: цӀар гьечӀеб тег батана, масала `<`
+
+parse-tag-not-closed = Мекъаб DoenetML: `{ $tag }` абураб тег къан гьечӀо (`>` камун бугилан бихьула).
+
+parse-self-closing-tag-name-missing = Мекъаб DoenetML: цӀар гьечӀеб тег батана `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Мекъаб DoenetML: `{ $tag }` абураб тег къан гьечӀо (`/>` камун бугилан бихьула).
+
+parse-tag-invalid-attributes = Мекъаб DoenetML: `{ $tag }` абураб тег мекъаб буго. Гьелъул атрибутал мекъал ратизе бегьула.
+
+parse-close-tag-name-missing = Мекъаб DoenetML: цӀар гьечӀеб къазабулеб тег батана, масала `</`
+
+parse-attribute-value-unquoted = Атрибутазул къиматал кавычкабазда жаниб рукӀине ккола: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Мекъаб DoenetML: `{ $tag }` абураб къазабулеб тег батана, амма гьелъие данде кколеб рагьулеб тег батичӀо
+
+parse-close-tag-mismatched = Мекъаб DoenetML: къазабулеб тег данде ккола гьечӀо. `</{ $expected }>` ккола кколеб. Батана `{ $found }`
+
+parser-node-unconvertible = { $node } абураб узел Dast узеллъун хисизе кӀвечӀо.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' абураб атрибуталъул цӀар мекъаб буго. { $reason ->
+        [characters] ЦӀаразда хӀарпал, числоял, гъоркьисел мухъалги дефисалги гурони рукӀине бегьуларо.
+       *[start] ЦӀарал хӀарпалдаса байбихьизе ккола.
+    }
+
+component-name-invalid-start = "{ $name }" абураб компоненталъул цӀар мекъаб буго. ЦӀарал хӀарпалдаса байбихьизе ккола.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тайпаялъул жавабалда video абураб атрибут букӀине ккола
+
+answer-video-watched-video-not-reference = videoWatched тайпаялъул жавабалда бугеб video абураб атрибут ссылка букӀине ккола
+
+answer-name-not-single-text = Жавабалъул name абураб атрибуталда цо текстияб лъимер букӀине ккола
+
+## Referencing another document
+
+external-doenetml-recursion-limit = ЦӀикӀкӀараб рекурсиялъул даражаби гьаруналъ къватӀисеб DoenetML босизе кӀвечӀо. Сверараб ссылка бугищ?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" абуралдаса DoenetML босизе кӀвечӀо
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" абуралдаса босараб DoenetML мекъаб буго: гьеб "{ $componentType }" абураб компоненталъул тайпаялда данде ккечӀо
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` абураб атрибут хӀалтӀудаса бахъун буго; гьелъул бакӀалда `{ $to }` хӀалтӀизабе.
+       *[other] [deprecation] `<{ $component }>` абуралда бугеб `{ $from }` абураб атрибут хӀалтӀудаса бахъун буго; гьелъул бакӀалда `{ $to }` хӀалтӀизабе.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` абураб атрибут хӀалтӀудаса бахъун буго ва хӀисабалде босуларо, щайгурелъул `{ $to }` гӀагги бихьизабун буго.
+       *[other] [deprecation] `<{ $component }>` абуралда бугеб `{ $from }` абураб атрибут хӀалтӀудаса бахъун буго ва хӀисабалде босуларо, щайгурелъул `{ $to }` гӀагги бихьизабун буго.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` абуралда бугеб `{ $attribute }` абураб атрибут хӀалтӀудаса бахъун буго ва хӀисабалде босуларо.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` абуралда бугеб `{ $attribute }` абураб атрибут хӀалтӀудаса бахъун буго; гьелъул бакӀалда `<{ $child }>` абураб лъимер хъвае.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` абуралда бугеб `{ $attribute }` абураб атрибуталъул `{ $value }` абураб къимат хӀалтӀудаса бахъун буго; гьелъул бакӀалда `{ $to }` хӀалтӀизабе.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` абуралъ ингилис мацӀалъул рагӀаби гурони гӀемерлъиялде рахъизе кӀоларо, гьелъин { $locale } мацӀалда хъвараб документалда текст хисичӀого тарав. ГӀемерлъиялъул форма жиндирго хъвае, яги `pluralForm` абураб атрибуталдалъун бихьизабе.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` абураб элемент Doenet-алъул лъалеб элемент гуро.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` абураб элемент документалъул кӀалтӀуялда букӀине бегьуларо.
+
+schema-element-not-allowed-inside = `<{ $tag }>` абураб элемент `<{ $parent }>` абуралъул жаниб букӀине бегьуларо.
+
+schema-attribute-unrecognized = `<{ $tag }>` абураб элементалда `{ $attribute }` абураб цӀар бугеб атрибут гьечӀо.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` абураб элементалъул `{ $attribute }` абураб атрибут список букӀине ккола, гьелъул щибаб бутӀа гьазда гьоркьоса цо букӀине ккола: { $allowed }
+       *[other] `<{ $tag }>` абураб элементалъул `{ $attribute }` абураб атрибут гьазда гьоркьоса цо букӀине ккола: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select-алъе вариантасул цӀар мекъаб буго.  { $variantName } абураб вариантасул цӀар { $numOptions } вариантазда буго, амма тӀаса бищизе кколеб къадар { $numToSelect } буго.
+
+select-variant-name-without-options = select-алъе цо-цо вариантал бихьизарун руго, амма { $variantName } абураб бегьулеб вариантасул цӀаралъе вариантал бихьизарун гьечӀо.
+
+select-variant-name-not-possible = select-алъе бихьизабураб { $variantName } абураб вариантасул цӀар бегьулеб вариантасул цӀар гуро.
+
+select-too-few-options = Гурони { $numOptions } бугеб мехалъ { $numToSelect } компонент тӀаса бищизе кӀоларо.
+
+select-from-sequence-too-few-values = { $length } барам бугеб последовательносталдаса { $numToSelect } къимат тӀаса бищизе кӀоларо.
+
+select-from-sequence-indices-count-mismatch = select-алъе бихьизарурал индексазул къадар тӀаса бищизе кколеб къадаралда данде ккезе ккола
+
+select-from-sequence-indices-not-integers = select-алъе бихьизарурал киналго индексал бегӀерал числоял рукӀине ккола
+
+select-from-sequence-index-excluded = selectfromsequence абуралъул къватӀибе бахъараб индекс бихьизабун буго
+
+select-from-sequence-indices-excluded-combination = selectfromsequence абуралъул къватӀибе бахъараб цолъи кколел индексал бихьизарун руго
+
+select-from-sequence-coprime-not-positive-integers = Позитивиял бегӀерал числоял тӀаса рищулел гьечӀолъиялъ coprime цолъаби тӀаса ришизе кӀоларо.
+
+select-from-sequence-coprime-common-factor = Coprime числоял тӀаса ришизе кӀоларо. Киналго бегьулел къиматазда цого умумулаб множитель буго. ("from" яги "to" абуразул бихьизарурал къиматал "step" абуралда coprime рукӀине ккола.)
+
+select-from-sequence-coprime-single-number = 1 гуреб цо числоялдаса coprime цолъаби тӀаса ришизе кӀоларо.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence абуралда цолъабазул 70%-ялдаса цӀикӀкӀараб къватӀибе бахъун буго
+
+select-from-sequence-coprime-none-found = Coprime числоял тӀаса ришизе кӀвечӀо. Киналго бегьулел къиматазда цого умумулаб множитель буго.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } барам бугеб последовательносталдаса { $numToSelect } батӀияб къимат тӀаса бищизе кӀоларо
+
+select-prime-numbers-too-few-values = { $numValues } барам бугеб простой числоязул списокалдаса { $numToSelect } къимат тӀаса бищизе кӀоларо
+
+select-prime-numbers-values-count-mismatch = select-алъе бихьизарурал къиматазул къадар тӀаса бищизе кколеб къадаралда данде ккезе ккола
+
+select-prime-numbers-values-not-prime = select prime number абуралъе бихьизарурал киналго къиматал простой числоязул списокалда рукӀине ккола
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers абуралъул къватӀибе бахъараб цолъи кколел къиматал бихьизарун руго
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers абуралда цолъабазул 70%-ялдаса цӀикӀкӀараб къватӀибе бахъун буго
+
+select-random-combination-fluke = ЦӀакъго камуларедухъ ккараб ишалъ, случайниял къиматазул цолъи тӀаса бищизе кӀвечӀо
+
+select-random-value-fluke = ЦӀакъго камуларедухъ ккараб ишалъ, случайнияб къимат тӀаса бищизе кӀвечӀо

--- a/packages/i18n/locales/av/editor.ftl
+++ b/packages/i18n/locales/av/editor.ftl
@@ -1,0 +1,191 @@
+# Avar editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Avar (авар мацӀ) in the Cyrillic orthography with the palochka Ӏ, which is a
+# letter and not a Latin I or a digit 1. `WCAG AA`, `DoenetML`, `XML`,
+# `styleNumber` and every attribute or element name are identifiers rather than
+# prose and stay exactly as written.
+#
+# Avar counts in the two categories English does, `one` and `other`, so every
+# selection below keeps both branches. A noun after a numeral stays singular,
+# so the two branches of `editor-accessibility-label` and `help-coordinates`
+# differ only in the number they print — deliberately, not by oversight.
+#
+# Nothing here agrees with a noun class. Avar's class agreement is real and is
+# spelled as a suffix, but it needs a noun this catalog supplies, and the
+# things named here are the editor's own panels. The class system is written
+# out in `content.ftl`'s header, which is also where the reason it forks
+# nothing is argued.
+#
+# The editor's technical nouns are the Russian ones written Avar uses —
+# «вариант», «версия», «строка», «атрибут», «ссылка» — as they are throughout
+# this catalog.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Нахъбуссине
+       *[update] ЦӀияб гьабизе
+    }
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Балагьулеб гьумер { $word }
+       *[other] Балагьулеб гьумер { $word } { $shortcut }
+    }
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Балагьи…
+editor-variant-next = Хадусеб вариант тӀаса бищизе
+editor-variant-previous = Цебесеб вариант тӀаса бищизе
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA щвезабиялъул хисмат батана. Щвезабиялъул отчёт { $action ->
+            [close] къазе
+           *[open] рагьизе
+        } хӀапа гьабе.
+        [advisories] Щвезабиялъул отчёт { $action ->
+            [close] къазе
+           *[open] рагьизе
+        } хӀапа гьабе. WCAG AA хисматал ратичӀо, амма щвезабиялъе цойги малъа-хъваял руго.
+       *[clean] Щвезабиялъул отчёт { $action ->
+            [close] къазе
+           *[open] рагьизе
+        } хӀапа гьабе. Щвезабиялъул цониги захӀматлъи батичӀо.
+    }
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA щвезабиялъул хисмат батана. { $count ->
+            [one] { $count } WCAG AA хисмат
+           *[other] { $count } WCAG AA хисмат
+        } батана. Щвезабиялъул отчёт { $action ->
+            [close] къазе
+           *[open] рагьизе
+        } хӀапа гьабе.
+        [advisories] WCAG AA хисматал ратичӀо. { $count ->
+            [one] { $count } щвезабиялъе цойги малъа-хъвай
+           *[other] { $count } щвезабиялъе цойги малъа-хъвай
+        } батана. Щвезабиялъул отчёт { $action ->
+            [close] къазе
+           *[open] рагьизе
+        } хӀапа гьабе.
+       *[clean] WCAG AA хисматал ратичӀо. Щвезабиялъул отчёт { $action ->
+            [close] къазе
+           *[open] рагьизе
+        } хӀапа гьабе.
+    }
+editor-accessibility-badge = WCAG
+
+## The footer
+
+editor-version-title = DoenetML версия { $version }
+editor-tab-help = БакӀалде данде кколеб кумек
+editor-tab-help-short = БакӀ
+editor-tab-errors = ГъалатӀал
+editor-tab-warnings = ХӀинкъаби
+editor-tab-info = Хабар
+editor-tab-accessibility = Щвезаби
+editor-tab-responses = БитӀарал жавабал
+editor-tab-with-count = { $label }: { $count }
+editor-options = Редакторалъул сайлъаби
+editor-format-as-doenetml = DoenetML гӀадин формат гьабе
+editor-format-as-xml = XML гӀадин формат гьабе
+
+## The diagnostics panel
+
+editor-diagnostic-line = Мухъ #{ $line }
+editor-no-errors = ГъалатӀал гьечӀо
+editor-no-warnings = ХӀинкъаби гьечӀо
+editor-no-info = Хабаралъул диагностикаби гьечӀо
+editor-show-info-annotations = Редакторалда хабаралъул диагностикаби рихьизаризе
+editor-show-accessibility-annotations = Редакторалда щвезабиялъул диагностикаби рихьизаризе
+editor-accessibility-learn-more = Doenet щвезабиялде щиб къагӀидаялъ балагьулебали лъазабе
+editor-accessibility-violations-heading = Щвезабиялъул хисматал ({ $standard })
+editor-accessibility-other-heading = Щвезабиялъул цогидал захӀматлъаби
+editor-none-found = Щибго батичӀо
+
+## Submitted responses
+
+editor-no-responses = ГьанжелъизегӀан битӀарал жавабал гьечӀо
+editor-response-answer-id = Жавабалъул Id
+editor-response-response = Жаваб
+editor-response-credit = Балл
+editor-response-submitted = БитӀараб
+
+## The context-help panel
+
+help-placeholder = Документациялъе курсор тегалъул цӀаралда, атрибуталда яги { $ref } абуралда лъе.
+help-unsupported-ref-chain = { $example } гӀадал гӀемерал бутӀабазул ссылкабазе кумек гьанже гьечӀо.
+help-unresolved-ref =
+    { $reason ->
+        [notFound] { $ref } абураб ссылкаялъе жаваб кколеб жо батичӀо.
+        [multiple] { $ref } абураб ссылкаялъе жаваб кколел гӀемерал жал ратана.
+       *[indeterminate] { $ref } абураб ссылкаялъе жаваб кколеб жо бихьизабизе кӀвечӀо.
+    }
+help-learn-about-references = Ссылкабазул хӀакъалъулъ лъазабе →
+help-reference-page = Справочникалъул гьумер →
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } абуралъул жаниб
+       *[top] ТӀадегӀанаб даражаялда
+    }{ $allowed ->
+        [none] { " — гьаниб щибго ккезе бегьуларо." }
+        [text] { " — гьаниб текст хъвае." }
+        [text-and-components] { " — гьаниб текст хъвае, яги гьал рагьае:" }
+       *[components] { " — рагьазе бегьулел жал:" }
+    }
+help-suggestions-footer = Киналго { $total } компонент рихьизе { $shortcut } кьабе.
+help-name-summary = { $name } — { $summary }
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — гьеб { $target } абуралде ссылка буго.
+       *[other] { $ref } — гьеб { $target } абуралде ссылка буго ({ $line } абураб мухъ).
+    }
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } абуралъ { $role } гӀадин лъуна.
+       *[other] { $owner } абуралъ { $line } абураб мухъалда { $role } гӀадин лъуна.
+    }
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — гьеб { $element } абуралъул { $property } абураб свойствоялде ссылка буго.
+       *[other] { $ref } — гьеб { $element } абуралъул { $property } абураб свойствоялде ссылка буго ({ $line } абураб мухъ).
+    }
+help-kind-attribute = атрибут
+help-kind-snippet = сниппет
+help-kind-array-entry = массивалъул бутӀа
+help-default = Стандартияб къимат:
+help-active-default = ХӀалтӀулеб стандартияб къимат:
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+help-allowed-values =
+    { $perItem ->
+        [true] Бегьулел къиматал (кӀиго-лъабго бутӀаялъе цо-цо):
+       *[other] Бегьулел къиматал:
+    }
+help-suggested-values = Малъулел къиматал:
+help-inserts = Лъолеб жо:
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатаби:
+    }
+help-type = Тайпа:
+help-resolved-style = Бихьизабураб стиль (styleNumber { $styleNumber }):
+help-resolved-function-names = Бихьизарурал функциязул цӀарал:
+help-reset-list = Гьаб инпуталда список нахъбуссинаби:
+help-added-on-input = Гьаб инпуталда жубараб:
+help-removed-on-input = Гьаб инпуталда нахъе босараб:
+help-reset-overrides = { $reset } абураб { $additional } ва { $removed } абуразда тӀад ккола.

--- a/packages/i18n/locales/ckb/chrome.ftl
+++ b/packages/i18n/locales/ckb/chrome.ftl
@@ -1,0 +1,137 @@
+# Central Kurdish (Sorani) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Kurdo-Arabic alphabet — the fully vowelled Arabic-script
+# orthography of the Kurdistan Region of Iraq, which is what its schools and
+# its publishing use and what CLDR gives `ckb`. `ckb` maximizes to
+# `ckb-Arab-IQ`, so `directionOf` reports it **right to left**.
+#
+# Northern Kurdish (Kurmanji) has a catalog of its own, `locales/ku`, written
+# left to right in the Latin alphabet. A Sorani reader reaches this file
+# instead: `ckb` is a member of the `ku` macrolanguage, and the roster's
+# `MACROLANGUAGE_MEMBERS` entry deliberately excludes it from the fold onto
+# `ku` for that reason — the same exclusion `locales/mnk` makes for `bam` and
+# `dyu`.
+#
+# Two plural categories, `one` and `other`. A Sorani noun after a numeral
+# stays singular, so almost nothing needs the branch; a message wanting a
+# separate wording for none says `[0]` by number, as the English does.
+#
+# Sorani has no grammatical gender — it lost the masculine/feminine
+# distinction Kurmanji keeps — so nothing here agrees and `noun-gender` in
+# `content.ftl` answers with one token for everything.
+#
+# Numbers reach the reader in Latin digits, which is the repository-wide
+# policy under "Digits are Latin, separators are not" in the README. A Sorani
+# reader would ordinarily expect ٠١٢٣; they are not written anywhere in these
+# four files, and no message names a numbering system.
+#
+# Register: a control is named by a verbal noun («زیادکردنی ڕیز», never
+# «ڕیزێک زیاد بکە»), and a sentence addressed to the reader takes the
+# imperative singular, which is what Kurdish interfaces use.
+
+
+## Answer submission
+
+answer-checking = پشکنین...
+answer-submitting = ناردن...
+answer-checking-status = پشکنینی وەڵام
+answer-submitting-status = ناردنی وەڵام
+answer-correct = ڕاست
+answer-incorrect = هەڵە
+answer-response-saved = وەڵام پاشەکەوت کرا
+answer-percent-credit = { $percent }% لە نمرە
+answer-percent-correct = { $percent }% ڕاست
+answer-percent-short = { $percent }%
+max-credit-available = بەرزترین نمرەی بەردەست: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] هیچ هەوڵێک نەماوە
+       *[other] { $count } هەوڵ ماوە
+    }
+validation-correct = (ڕاست)
+validation-incorrect = (هەڵە)
+validation-partially-correct = (بەشێکی ڕاستە)
+answer-show-responses = پیشاندانی { $count } وەڵامی نێردراو بۆ { $answerId }
+
+## Disclosure panels
+
+feedback-heading = وەڵامدانەوە
+collapsible-click-to-open = (بۆ کردنەوە کلیک بکە)
+collapsible-click-to-close = (بۆ داخستن کلیک بکە)
+collapsible-initializing = ئامادەکردن...
+footnote-show = پیشاندانی پەراوێز
+footnote-hide = شاردنەوەی پەراوێز
+description-more-information = زانیاری زیاتر
+
+## Controls
+
+slider-previous = پێشوو
+slider-next = دواتر
+keyboard-open = کردنەوەی تەختەکلیل
+keyboard-close = داخستنی تەختەکلیل
+choice-input-remove-choice = لابردنی { $choice }
+matrix-remove-row = لابردنی ڕیز
+matrix-add-row = زیادکردنی ڕیز
+matrix-remove-column = لابردنی ستوون
+matrix-add-column = زیادکردنی ستوون
+subset-add-remove-points = زیادکردن/لابردنی خاڵ
+subset-toggle-points-intervals = گۆڕین لە نێوان خاڵ و ماوەدا
+subset-move-points = جوڵاندنی خاڵەکان
+subset-clear = سڕینەوە
+orbital-add-row = زیادکردنی ڕیز
+orbital-remove-row = لابردنی ڕیز
+orbital-add-box = زیادکردنی خانە
+orbital-remove-box = لابردنی خانە
+orbital-add-up-arrow = زیادکردنی تیری سەرەوە
+orbital-add-down-arrow = زیادکردنی تیری خوارەوە
+orbital-remove-arrow = لابردنی تیر
+orbital-row-label = ناونیشانی ڕیزی { $row }
+pretzel-answer = وەڵام
+# «ستوون» names what `$column` is, so that the ezafe joining the phrase to it
+# falls on a word this catalog writes rather than on the placeable.
+summary-statistics-caption = کورتەی ئاماری ستوونی { $column }
+
+## Math input
+
+math-input-preview-region = پێشبینینی دەربڕینی بیرکاری
+math-input-preview = پێشبینین
+math-input-invalid-expression = دەربڕینی نادروست:
+
+## Document status
+
+viewer-initializing = ئامادەکردن...
+
+## Errors
+
+error-heading = هەڵە
+error-found-at =
+    { $span ->
+        [line] لە دێڕی { $startLine } دۆزرایەوە.
+       *[lines] لە دێڕەکانی { $startLine } تا { $endLine } دۆزرایەوە.
+    }
+document-contains-errors = ئەم دۆکیومێنتە هەڵەی تێدایە!
+# Headings of the tooltip the editor shows over a squiggle.
+diagnostic-heading-error = هەڵە
+diagnostic-heading-warning = ئاگاداری
+diagnostic-heading-information = زانیاری
+diagnostic-heading-hint = ڕێنوێنی
+# `WCAG AA` is the standard's own name and is not translated.
+accessibility-heading-level-1 = پێشێلکردنی دەستڕاگەیشتن بەپێی WCAG AA
+accessibility-heading-level-2 = ئاگاداری دەستڕاگەیشتن
+something-went-wrong = شتێک هەڵە بوو.
+# Follows `error-heading` and a colon.
+renderer-load-failed = یەکێک لە پێکهاتەکان بار نەبوو. تکایە پەڕەکە دووبارە بار بکەرەوە.
+core-start-failed = نەتوانرا ئەم دۆکیومێنتە دەست پێ بکات. تکایە پەڕەکە دووبارە بار بکەرەوە.
+core-start-failed-busy = نەتوانرا ئەم دۆکیومێنتە دەست پێ بکات. چەند دۆکیومێنتێک لە یەک کاتدا دەستیان پێ دەکرد، ئەمەش لەسەر ئامێرێکی خاوتر کاتی زیاتر دەبات. دوای تەواوبوونی ئەوانی تر، دووبارە بارکردنەوەی پەڕەکە لەوانەیە یارمەتی بدات.
+core-start-failed-retry = نەتوانرا ئەم دۆکیومێنتە دەست پێ بکات.
+core-start-failed-busy-retry = نەتوانرا ئەم دۆکیومێنتە دەست پێ بکات. چەند دۆکیومێنتێک لە یەک کاتدا دەستیان پێ دەکرد، ئەمەش لەسەر ئامێرێکی خاوتر کاتی زیاتر دەبات.
+core-start-retry = دووبارە هەوڵ بدەرەوە
+saved-state-unavailable = کاری پاشەکەوتکراوت بار نەکرا.

--- a/packages/i18n/locales/ckb/content.ftl
+++ b/packages/i18n/locales/ckb/content.ftl
@@ -1,0 +1,288 @@
+# Central Kurdish (Sorani) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Kurdo-Arabic alphabet, the fully vowelled Arabic-script
+# orthography standardized in the Kurdistan Region of Iraq and the one CLDR
+# gives `ckb`. `ckb` maximizes to `ckb-Arab-IQ` and is **right to left**. See
+# the Direction section of the README for what that does and does not change:
+# nothing about the file format, and the text is written in logical order with
+# no direction marks placed by hand.
+#
+# Northern Kurdish (Kurmanji) is `locales/ku`, left to right in Latin. `ckb`
+# is a member of the `ku` macrolanguage but is deliberately kept out of the
+# roster's fold onto it, because a Sorani reader has this catalog to reach.
+#
+# **Sorani has no grammatical gender.** It lost the masculine/feminine
+# distinction Kurmanji keeps, so `noun-gender` below answers with a single
+# token, nothing forks on `$gender` or `$role`, and `locales/ku` beside it
+# writes a full gender table for the same macrolanguage. Two catalogs of one
+# macrolanguage, one of which agrees and one of which does not.
+#
+# Two plural categories, `one` and `other`. A noun after a numeral stays
+# singular, so no message here needs a count branch.
+#
+# Numbers are Latin digits everywhere, per the README's "Digits are Latin,
+# separators are not". A Sorani reader would ordinarily expect ٠١٢٣ in print;
+# none is written here and no message names a numbering system.
+#
+# **The ezafe is the shape of this file.** An attributive adjective follows
+# its noun and is linked to it by the ezafe, written as a ـی suffix on the
+# noun — «هێڵی سوور», a red line. Unlike Persian's, it is written in every
+# environment rather than being an unspoken vowel a space can carry, so
+# `style-with-noun` cannot simply reverse the two halves and leave the space
+# to do the work. It cannot be welded onto `{ $noun }` either: a placeable is
+# not a word. The way out is the one the Berber catalogs take — make the
+# position uniform, then write the words already inflected for it. `$noun`
+# lands in exactly one place, immediately before the adjectives that describe
+# it, so every entry in the `noun` table below is written **with its ezafe
+# already on it** and the composition messages add nothing. The known cost is
+# an author's own `markerStyleWord`, which the catalog has never seen and
+# which therefore arrives unlinked; that is a real gap and the first thing to
+# check if a description reads wrong.
+#
+# The definiteness suffix ـەکە is the same constraint from the other side and
+# is simply not used: no message here makes a placeable definite, so every
+# description is indefinite or generic. Where English wants an indefinite
+# article — `style-border-clause`'s `-article` branches — Kurdish *can* say
+# it, because the head is «لێوار», a word this catalog writes, so ـێک goes on
+# and the branches genuinely differ.
+
+
+## Style vocabulary
+
+# «شین» historically spans blue and green in Kurdish and «سەوز» is the
+# narrower green; the pair below is the modern split, not the older one. There
+# is no inherited word for cyan, so «فیرۆزەیی» — turquoise — is a coinage
+# chosen the way Persian chose «فیروزه‌ای», and is the least settled word here.
+color =
+    .black = ڕەش
+    .white = سپی
+    .gray = خۆڵەمێشی
+    .red = سوور
+    .orange = پرتەقاڵی
+    .yellow = زەرد
+    .green = سەوز
+    .cyan = فیرۆزەیی
+    .blue = شین
+    .purple = مۆر
+    .pink = پەمەیی
+    .brown = قاوەیی
+line-width =
+    .thick = ئەستوور
+    .thin = باریک
+line-style =
+    .dashed = پچڕپچڕ
+    .dotted = خاڵخاڵ
+fill-style =
+    .horizontal = هێڵی ئاسۆیی
+    .vertical = هێڵی ستوونی
+    .diagonal = هێڵی لار
+    .backdiagonal = هێڵی لاری پێچەوانە
+    .dots = خاڵ
+    .diamonds = لۆزەنگ
+# Every entry carries its ezafe, for the reason the header gives. None of them
+# is rendered on its own — a noun reaches the reader only through
+# `style-with-noun` or `style-filled-with-noun`, and in both it stands
+# immediately in front of the adjectives it is linked to. The words were also
+# chosen to end in a consonant or in ـە, so that the ezafe is a plain ـی
+# everywhere: after a ـی-final noun standard Sorani doubles the letter
+# («کورسیی»), which is written inconsistently in practice and is a wobble this
+# table avoids rather than settles.
+noun =
+    .line = هێڵی
+    .line-segment = پارچەهێڵی
+    .ray = نیوەهێڵی
+    .vector = ڤێکتۆری
+    .curve = چەماوەی
+    .function = فەنکشنی
+    .slope-field = کێڵگەی لاری
+    .vector-field = کێڵگەی ڤێکتۆری
+    .parabola = پارابۆلی
+    .polyline = فرەهێڵی
+    .polygon = فرەلایەنەی
+    .triangle = سێگۆشەی
+    .rectangle = لاکێشەی
+    .circle = بازنەی
+    .region = ناوچەی
+    .point = خاڵی
+    .square = چوارگۆشەی
+    .diamond = لۆزەنگی
+    .cross = خاچی
+    .plus = نیشانەی کۆی
+# The side count follows the adjectives rather than sitting inside the noun,
+# so that they stay against the word they describe: «فرەلایەنەی ڕێکی سوور و
+# ئەستوور بە 5 لایەنەوە». The head carries its ezafe like the table above.
+# Kurdish counts with a singular noun, so nothing here agrees with the count.
+noun-regular-polygon =
+    { $part ->
+        [tail] بە { $numSides } لایەنەوە
+       *[head] فرەلایەنەی ڕێکی
+    }
+# Sorani has no grammatical gender. The token is written out anyway rather
+# than left to fall back, so that this catalog says so on purpose and no
+# adjective above has to carry a branch nothing reads.
+noun-gender = neuter
+
+## Style composition
+
+# The adjectives are chained with «و» rather than with further ezafes: the
+# noun's own ezafe links the first of them, and «و» links the rest without
+# needing to know what word precedes it. The order mirrors English, so the
+# adjective English puts nearest the noun is the one Kurdish puts nearest it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $color } و { $lineStyle } و { $width }
+        [width-color] { $color } و { $width }
+        [style-color] { $color } و { $lineStyle }
+        [width-style] { $lineStyle } و { $width }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = پڕکراو
+style-filled =
+    { $parts ->
+        [pattern] { $filled } و { $color } بە نەخشی { $pattern }
+       *[plain] { $filled } و { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } و { $color } بە نەخشی { $pattern }
+        [plain-tail] { $noun } { $filled } و { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } و { $color } { $nounTail } بە نەخشی { $pattern }
+       *[plain] { $noun } { $filled } و { $color }
+    }
+# «لێوار» is written by this catalog, so the indefinite ـێک and the ezafe both
+# have a word to sit on and the `-article` branches say something the plain
+# ones do not.
+style-border-clause =
+    { $parts ->
+        [with-article] بە لێوارێکی { $border }
+        [and] و لێواری { $border }
+        [and-article] و لێوارێکی { $border }
+       *[with] بە لێواری { $border }
+    }
+# «بە ڕەنگی» — "in the color of" — rather than an adjective against the
+# pattern: the ezafe linking the pattern to a color adjective would have to be
+# written onto `{ $pattern }`, and nothing can be attached to a placeable.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } بە ڕەنگی { $color }
+       *[plain] { $color }
+    }
+# Written flat: `describeFill` calls this with no arguments, so there is no
+# noun to agree with even in a language that agreed.
+style-unfilled = پڕنەکراو
+style-text =
+    { $parts ->
+        [background] { $color } لەسەر پاشبنەمای { $background }
+       *[plain] { $color }
+    }
+style-background-none = هیچ
+
+## Boolean words
+
+boolean-true = ڕاست
+boolean-false = ناڕاست
+
+## Answer buttons
+
+answer-submit-label = پشکنینی کار
+answer-submit-label-no-correctness = ناردنی وەڵام
+
+## Sectional blocks
+
+# Sorani calls both a "part" and a "section" «بەش». They are kept apart here
+# because the two blocks nest, and a heading that read the same word twice
+# would be worse than the slightly narrower «پارچە» for `part`. That choice is
+# this seed's, not the language's.
+section-name =
+    .activity = چالاکی
+    .aside = لاوەکی
+    .cascade = زنجیرە
+    .definition = پێناسە
+    .example = نموونە
+    .exercise = ڕاهێنان
+    .exercises = ڕاهێنانەکان
+    .given-answer = وەڵام
+    .note = تێبینی
+    .objectives = ئامانجەکان
+    .paragraphs = بڕگەکان
+    .part = پارچە
+    .problem = مەسەلە
+    .problems = مەسەلەکان
+    .proof = سەلماندن
+    .question = پرسیار
+    .section = بەش
+    .solution = چارەسەر
+    .task = ئەرک
+    .theorem = تیۆرەم
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = ڕێنوێنی
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] خشتەی { $enumeration }
+        [numbered-title] خشتەی { $enumeration }{ ": " }
+        [unnumbered-title] خشتە{ ": " }
+       *[unnumbered] خشتە
+    }
+figure-name =
+    { $parts ->
+        [numbered] وێنەی { $enumeration }
+        [numbered-caption] وێنەی { $enumeration }{ ": " }
+        [unnumbered-caption] وێنە{ ": " }
+       *[unnumbered] وێنە
+    }
+
+## Paginator controls
+
+paginator-previous = پێشوو
+paginator-next = دواتر
+paginator-page = لاپەڕە
+paginator-page-status = { $pageLabel } { $currentPage } لە { $numPages }
+
+## Piecewise functions
+
+piecewise-condition-or = یان
+# Kurdish «ئەگەر» opens its clause, as English "if" does, so the renderer
+# placing this before the mathematics lands correctly.
+piecewise-condition-if = ئەگەر
+piecewise-condition-otherwise = ئەگەرنا
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, and the
+## reason is not the one the rest of this batch gives. Central Kurdish *is* the
+## medium of secondary science teaching in the Kurdistan Region of Iraq, and
+## its schools print the periodic table in Sorani, so the names exist and a
+## student meets them in their own textbook. What this seed cannot supply is a
+## settled convention rather than an invented one: the published lists differ
+## in how far they transliterate and from which language, and an unreviewed
+## guess written in a script the reader cannot check against the English beside
+## it is worse than the English. So the 130 keys fall back to English and
+## `lint:i18n` reports the gap. This is the first place a Sorani speaker should
+## look, and the one where a correction is worth the most.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = هێمای کیمیایی نادروست
+chemistry-invalid-ionic-compound = پێکهاتەی ئایۆنی نادروست

--- a/packages/i18n/locales/ckb/diagnostics.ftl
+++ b/packages/i18n/locales/ckb/diagnostics.ftl
@@ -1,0 +1,642 @@
+# Central Kurdish (Sorani) warnings and errors. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Kurdo-Arabic alphabet; `ckb` maximizes to `ckb-Arab-IQ` and is
+# right to left. Kurmanji has its own left-to-right Latin catalog in
+# `locales/ku`.
+#
+# `through`, `endpoint`, `midpointOffset`, `numDimensions` and the like are
+# DoenetML attribute names. They are part of the language, not prose, and are
+# left in English exactly as written. Backticks, brackets and quotes are the
+# same characters as in English and are written opening-first, in logical
+# order; the bidi algorithm turns them around when the text is drawn.
+#
+# Where English distinguishes a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — Sorani says one thing, and the select is
+# dropped rather than written out twice identically. The count argument then
+# goes unused, which is harmless: it stays in the English message for the
+# languages that need it. Counts are Latin digits, never ٠١٢٣.
+#
+# Sorani has no grammatical gender, so nothing here agrees with anything.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = کاتێک دوو خاڵی کۆتایی دیاری کرابن، { $attributes } پشتگوێ دەخرێت
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = کاتێک خاڵێکی کۆتایی و خاڵێکی ناوەڕاست پێکەوە دیاری کرابن، { $attributes } پشتگوێ دەخرێت
+
+line-segment-midpoint-offset-without-midpoint = بەبێ خاڵی ناوەڕاست، midpointOffset هیچ کاریگەرییەکی نییە
+
+## `<line>`
+
+line-points-undetermined-dimensions = هێڵێک بەناو خاڵانێکدا کە ڕەهەندیان دیارینییە.
+
+line-points-too-few-dimensions = هێڵ دەبێت بەناو خاڵانێکدا بڕوات کە بەلایەنی کەمەوە دوو ڕەهەندیان هەبێت.
+
+line-points-depend-on-variables = هێڵ بەناو خاڵانێکدا دەڕوات کە بە گۆڕاوەکانەوە بەندن: { $variables }.
+
+line-equation-invalid-format = فۆرمی نادروست بۆ هاوکێشەی هێڵ بە گۆڕاوەکانی { $variable1 } و { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = نیوەهێڵ بە through و endpoint و direction دیاری کراوە. through ـی دیاریکراو پشتگوێ دەخرێت.
+
+ray-dimension-mismatch = نەگونجانی numDimensions لە نیوەهێڵدا.
+
+## `<vector>`
+
+vector-overprescribed-head = ڤێکتۆر بە head و tail و displacement دیاری کراوە. head ـی دیاریکراو پشتگوێ دەخرێت.
+
+vector-dimension-mismatch = نەگونجانی numDimensions لە ڤێکتۆردا.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = ناتوانرێت ڕاکێشان بۆ `<{ $component }>` بکرێت، چونکە گۆڕاوی دۆخی nearestPoint ی نییە.
+
+constrain-to-without-nearest-point = ناتوانرێت سنووردارکردن بۆ `<{ $component }>` بکرێت، چونکە گۆڕاوی دۆخی nearestPoint ی نییە.
+
+constrain-to-interior-without-nearest-point = ناتوانرێت سنووردارکردن بۆ ناوەوەی `<{ $component }>` بکرێت، چونکە گۆڕاوی دۆخی nearestPoint ی نییە.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = لە choiceInput ی نا-inline دا، labelPosition پشتگوێ دەخرێت
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices ی دیاریکراو بۆ choiceInput پشتگوێ دەخرێت، چونکە ژمارەی ئیندێکسەکان لەگەڵ ژمارەی منداڵەکانی choice ناگونجێت.
+
+pretzel-indices-count-mismatch = indices ی دیاریکراو بۆ problem پشتگوێ دەخرێت، چونکە ژمارەی ئیندێکسەکان لەگەڵ ژمارەی منداڵەکانی problem ناگونجێت.
+
+shuffle-indices-count-mismatch = indices ی دیاریکراو بۆ shuffle پشتگوێ دەخرێت، چونکە ژمارەی ئیندێکسەکان لەگەڵ ژمارەی پێکهاتەکان ناگونجێت.
+
+indices-ignored-out-of-range = indices ی دیاریکراو بۆ { $component } پشتگوێ دەخرێت، چونکە هەندێک ئیندێکس لە دەرەوەی مەودان.
+
+pretzel-indices-repeated = indices ی دیاریکراو بۆ pretzel پشتگوێ دەخرێت، چونکە هەندێک ئیندێکس دووبارە بوونەتەوە.
+
+pretzel-circuit-first-index = indices ی دیاریکراو بۆ pretzel لە دۆخی circuit دا پشتگوێ دەخرێت، چونکە یەکەم ئیندێکس دەبێت 1 بێت.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = بۆ ئەوەی `<{ $component }>` لەگەڵ منداڵی دەقیدا کار بکات، دەبێت تایبەتمەندی `type` دیاری بکرێت.
+
+invalid-type-defaulting-to-math = جۆری { $type } بۆ پێکهاتەی { $component } نادروستە. دەبێت یەکێک بێت لە math، text، number یان boolean. math وەک بنەڕەت بەکاردێت.
+
+string-not-valid-component-to-arrange = دەقی "{ $value }" پێکهاتەیەکی دروست نییە بۆ { $component }. پشتگوێ دەخرێت.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = جۆری { $type } نادروستە؛ جۆر دەکرێت بە number.
+
+invalid-variable-value = نرخی نادروستی گۆڕاوێک: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = ئیندێکسی وەشانی { $index } دەبێت ژمارە بێت
+
+variant-index-must-be-integer = ئیندێکسی وەشانی { $index } دەبێت ژمارەی تەواو بێت
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` بۆ پێوانەی ڕەها جێبەجێ نەکراوە. پانییەکان دەکرێن بە ڕێژەیی.
+
+side-by-side-absolute-margins = `<{ $component }>` بۆ پێوانەی ڕەها جێبەجێ نەکراوە. پەراوێزەکان دەکرێن بە ڕێژەیی.
+
+side-by-side-no-block-child = `<{ $component }>` ی نادروست: دەبێت بەلایەنی کەمەوە یەک منداڵی بلۆکی هەبێت.
+
+## `<label>`
+
+label-for-ignored-on-graphical = تایبەتمەندی `for` لەسەر `<label>` ی وێنەیی پشتگوێ دەخرێت.
+
+label-for-must-resolve-to-one = تایبەتمەندی `for` لەسەر `<label>` دەبێت تەنها بۆ یەک پێکهاتە بگەڕێتەوە.
+
+label-for-unresolved = تایبەتمەندی `for` لەسەر `<label>` نەگەیشتە هیچ پێکهاتەیەک.
+
+label-for-answer-with-authored-inputs = تایبەتمەندی `for` لەسەر `<label>` ئاماژە بە `<answer>` ێک دەکات کە خۆی داخڵکراوەکانی نووسراون؛ ڕاستەوخۆ ئاماژە بە داخڵکراوەکە بکە.
+
+label-for-answer-without-input = تایبەتمەندی `for` لەسەر `<label>` ئاماژە بە `<answer>` ێک دەکات کە داخڵکراوی نییە بۆ ناونیشانکردن.
+
+label-for-must-reference-input-or-answer = تایبەتمەندی `for` لەسەر `<label>` دەبێت ئاماژە بە داخڵکراوێک یان بە `<answer>` ێک بکات.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = لە پێناو دەستڕاگەیشتن، `<{ $component }>` دەبێت یان وەسفێکی کورتی هەبێت یان وەک ڕازێنەرەوە دیاری بکرێت.
+
+accessibility-video-short-description = لە پێناو دەستڕاگەیشتن، `<video>` دەبێت وەسفێکی کورتی هەبێت.
+
+accessibility-input-short-description-or-label = لە پێناو دەستڕاگەیشتن، `<{ $component }>` دەبێت وەسفێکی کورت یان ناونیشانێکی هەبێت.
+
+accessibility-answer-input-short-description-or-label = لە پێناو دەستڕاگەیشتن، `<answer>` ێک کە داخڵکراوێک دروست دەکات دەبێت وەسفێکی کورت یان ناونیشانێکی هەبێت.
+
+accessibility-short-description-contains-math = وەسفی کورت نابێت پێکهاتەی بیرکاری وەک `<{ $component }>` لەخۆ بگرێت. بیرکارییەکە بە وشە بنووسە.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } جیاوازی ڕەنگی پێویستی نییە بۆ دەقی سەرناونیشانی بەش (دۆخی تاریک) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ بەلایەنی کەمەوە { $threshold }:1 پێویستە).
+       *[other] { $colorName } جیاوازی ڕەنگی پێویستی نییە بۆ دەقی سەرناونیشانی بەش ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ بەلایەنی کەمەوە { $threshold }:1 پێویستە).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` بەناو { $count } خاڵدا لە حاڵەتێکدا کە خاڵەکان نرخی ژمارەییان نییە، جێبەجێ نەکراوە.
+
+circle-too-many-through-points = ناتوانرێت بازنە بەناو زیاتر لە 3 خاڵدا بژمێردرێت.
+
+circle-overprescribed-radius-center-points = ناتوانرێت بازنە بە تیشک و ناوەند و خاڵی دیاریکراوەوە بژمێردرێت.
+
+circle-center-with-multiple-points = ناتوانرێت بازنە بە ناوەندی دیاریکراو و بەناو زیاتر لە 1 خاڵدا بژمێردرێت.
+
+circle-radius-too-small = ناتوانرێت بازنە بژمێردرێت: بە مەبەستی ئەوەی دووری نێوان دوو خاڵەکە { $distance } ە، تیشکی دیاریکراوی { $radius } زۆر بچووکە.
+
+circle-radius-with-many-points = ناتوانرێت بازنە بەناو زیاتر لە دوو خاڵدا بە تیشکی دیاریکراوەوە دروست بکرێت.
+
+circle-invalid-center-or-through-points = ناوەند یان خاڵەکانی بازنە نادروستن.
+
+circle-radius-center-with-multiple-points = ناتوانرێت تیشکی بازنە بە ناوەندی دیاریکراو و بەناو زیاتر لە 1 خاڵدا بژمێردرێت.
+
+circle-change-radius-non-numerical = ناتوانرێت تیشکی بازنە بگۆڕدرێت کاتێک خاڵەکان ژمارەیی نین
+
+circle-radius-with-points-non-numerical = ناتوانرێت بازنە بەناو زیاتر لە یەک خاڵدا بە تیشکی دیاریکراوەوە دروست بکرێت کاتێک نرخی ژمارەیی نییە.
+
+circle-change-center-non-numerical = گۆڕینی ناوەندی بازنە بەناو خاڵانێکدا کە ژمارەیی نین، جێبەجێ نەکراوە.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = ڕەهەندی پێویست بۆ بواری فەنکشن نییە. بوار { $intervals } ماوەی هەیە بەڵام فەنکشن { $inputs } داخڵکراوی هەیە.
+
+function-domain-invalid-format = فۆرمی نادروست بۆ بواری فەنکشن.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] پشتگوێخستنی بەرزترین نرخی نا-ژمارەیی فەنکشن.
+        [minimum] پشتگوێخستنی نزمترین نرخی نا-ژمارەیی فەنکشن.
+        [extremum] پشتگوێخستنی نرخی سنووریی نا-ژمارەیی فەنکشن.
+        [point] پشتگوێخستنی خاڵی نا-ژمارەیی فەنکشن.
+        [slope] پشتگوێخستنی لاری نا-ژمارەیی فەنکشن.
+       *[other] پشتگوێخستنی { $type } ی نا-ژمارەیی فەنکشن.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] پشتگوێخستنی بەرزترین نرخی بەتاڵی فەنکشن.
+        [minimum] پشتگوێخستنی نزمترین نرخی بەتاڵی فەنکشن.
+        [extremum] پشتگوێخستنی نرخی سنووریی بەتاڵی فەنکشن.
+        [point] پشتگوێخستنی خاڵی بەتاڵی فەنکشن.
+       *[other] پشتگوێخستنی { $type } ی بەتاڵی فەنکشن.
+    }
+
+function-points-too-close = فەنکشن دوو خاڵی تێدایە کە شوێنیان زۆر لە یەک نزیکە. ناتوانرێت فەنکشن پێناسە بکرێت.
+
+function-iterates-input-output-mismatch = دووبارەکردنەوەی فەنکشن تەنها کاتێک دەکرێت کە ژمارەی داخڵکراوەکان لەگەڵ ژمارەی دەرچووەکان یەکسان بێت. ئەم فەنکشنە { $inputs } داخڵکراو و { $outputs } دەرچووی هەیە.
+
+## `<sequence>`
+
+sequence-invalid-length = درێژی زنجیرە نادروستە. دەبێت ژمارەیەکی تەواوی نانەرێنی بێت.
+
+sequence-invalid-step = هەنگاوی زنجیرە نادروستە. بۆ زنجیرەی جۆری { $type } دەبێت ژمارە بێت.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ی زنجیرەی ژمارەیی نادروستە. دەبێت ژمارە بێت.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ی زنجیرەی پیتەکان نادروستە. دەبێت کۆمەڵێک پیت بێت.
+
+sequence-invalid-endpoint = "{ $attribute }" ی زنجیرە نادروستە.
+
+select-from-sequence-coprime-not-numbers = coprime پشتگوێ دەخرێت، چونکە ژمارە هەڵنابژێردرێت
+
+select-from-sequence-coprime-with-exclude-combinations = coprime پشتگوێ دەخرێت، چونکە excludeCombinations دیاری کراوە
+
+## Resolving a `target`
+
+target-not-found = target ی نادروست بۆ `<{ $source }>`: ئامانج نەدۆزرایەوە.
+
+target-state-variable-not-found = target ی نادروست بۆ `<{ $source }>`: گۆڕاوی دۆخێک بەناوی "{ $property }" لەسەر `<{ $component }>` نەدۆزرایەوە.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = گۆڕاوەکانی `<odeSystem>` دەبێت جیاواز بن لە گۆڕاوی سەربەخۆ.
+
+ode-system-duplicate-variable-names = ناتوانرێت فەنکشنەکانی لای ڕاستی ODE بە ناوی گۆڕاوی دووبارەوە پێناسە بکرێن.
+
+ode-system-rhs-function-error = ناتوانرێت فەنکشنی لای ڕاستی ODE پێناسە بکرێت. هەڵە لە دروستکردنی فەنکشنی mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = ناتوانرێت گۆشەیەک لە نێوان { $count } هێڵدا پێناسە بکرێت
+
+angle-invalid-through-point = خاڵی نادروست لە through ی `<angle>` دا
+
+parabola-vertex-too-many-points = پارابۆل بە تەوەرە و بەناو زیاتر لە 1 خاڵدا جێبەجێ نەکراوە.
+
+parabola-too-many-points = پارابۆل بەناو زیاتر لە 3 خاڵدا جێبەجێ نەکراوە.
+
+intersection-too-many-items = پێکدادان بۆ زیاتر لە دوو بڕگە جێبەجێ نەکراوە
+
+## Other math components
+
+ionic-compound-not-two-ions = پێکهاتەی ئایۆنی تەنها بۆ دوو ئایۆن جێبەجێ کراوە.
+
+ionic-compound-needs-cation-and-anion = پێکهاتەی ئایۆنی تەنها بۆ یەک کاتایۆن و یەک ئەنایۆن جێبەجێ کراوە.
+
+solve-equations-cannot-evaluate = ناتوانرێت هاوکێشە شی بکرێتەوە، چونکە نەتوانرا هەڵبسەنگێندرێت: { $equation }
+
+math-operators-operand-number-required = کاتێک ئۆپەراندێکی بیرکاری دەردەهێنرێت، دەبێت operandNumber دیاری بکرێت.
+
+eigen-decomposition-failed = نەتوانرا نرخە ئایگنەکانی ماتریکس بژمێردرێن
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: پارامەتەری { $parameters } لە نەخشەکەدا نایەت، بۆیە هەمیشە لەگەڵ بەتاڵ دەگونجێت.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ناتوانرێت grid="{ $grid }" لێکبدرێتەوە. دەبێت none، medium، dense، یان دوو ژمارەی ئەرێنی بێت کە بە بۆشاییەک جیا کرابنەوە، وەک grid="1 0.5". هیچ تۆڕێک ناکێشرێت.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` فەنکشنێکی پێویستە کە { $expected ->
+        [one] یەک دەرچووی هەبێت، لاری y' لە هەر خاڵێکدا، وەک `y - x`
+       *[other] دوو دەرچووی هەبێت، ڤێکتۆرەکە لە هەر خاڵێکدا، وەک `(y, -x)`
+    }، بەڵام ئەو فەنکشنەی پێی دراوە { $found } دەرچووی هەیە. { $alternative ->
+        [none] هیچ ناکێشرێت.
+       *[other] `<{ $alternative }>` ئەو پێکهاتەیەیە کە بۆ ئەم فەنکشنە دەگونجێت. هیچ ناکێشرێت.
+    }
+
+field-function-attribute-ignored-with-child = تایبەتمەندی `function` پشتگوێ دەخرێت، چونکە فەنکشنەکە لە ناو پێکهاتەکەشدا دراوە؛ ئەوەی ناوەوە بەکاردێت. فەنکشنەکە تەنها بە یەکێک لە دوو ڕێگاکە بدە.
+
+field-variables-ignored =
+    `<{ $component }>`: تایبەتمەندی `variables` ناوی گۆڕاوەکانی دەربڕینێک دەبات کە ڕاستەوخۆ لە ناو پێکهاتەکەدا نووسراوە. { $reason ->
+        [function-child] فەنکشنەکە لێرەدا وەک منداڵێکی `<function>` دراوە کە خۆی ناوی گۆڕاوەکانی خۆی دەبات، بۆیە `variables` پشتگوێ دەخرێت.
+       *[no-expression] هیچ دەربڕینێکی وا لێرەدا نەدراوە، بۆیە `variables` پشتگوێ دەخرێت.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" لە پیشاندەری prefigure دا پشتگیری ناکرێت؛ ڕەفتاری لای ڕاست بەکاردێت.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" لە پیشاندەری prefigure دا پشتگیری ناکرێت؛ ڕەفتاری لای سەرەوە بەکاردێت.
+
+prefigure-invalid-axis-bounds = `<graph>`: سنووری تەوەرەکان بۆ گۆڕینی prefigure نادروستە؛ bbox ی بنەڕەت (-10,-10,10,10) بەکاردێت.
+
+prefigure-invalid-width = `<graph>`: پانی بۆ گۆڕینی prefigure نادروستە؛ پانی بنەڕەتی وێنە 425 بەکاردێت.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio بۆ گۆڕینی prefigure نادروستە؛ ڕێژەی بنەڕەتی 1 بەکاردێت.
+
+prefigure-grid-spacing-too-fine = `<graph>`: بۆشایی نێوان تۆڕەکە بۆ سنووری تەوەرەکان زۆر ورد و بچووکە؛ تۆڕەکە لە پیشاندەری prefigure دا نانووسرێت.
+
+prefigure-annotations-not-rendered = `<graph>`: کاتێک پیشاندەری PreFigure بەکارنەیەت، تێبینییەکان پیشان نادرێن.
+
+multiple-annotations-children = چەند منداڵێکی `<annotations>` لە `<graph>` دا دۆزرایەوە؛ جگە لە دوایینیان هەمووی پشتگوێ دەخرێن.
+
+## Referring to other components
+
+copy-unrecognized-component-type = ناتوانرێت جۆرێکی پێکهاتەی نەناسراو درێژ بکرێتەوە یان لەبەر بگیرێتەوە: { $type }.
+
+copy-prop-not-found = نەتوانرا خاسیەتی { $property } لەسەر پێکهاتەیەکی جۆری { $component } بدۆزرێتەوە
+
+collect-no-source = هیچ سەرچاوەیەک بۆ collect نەدۆزرایەوە.
+
+collect-invalid-component-type = ناتوانرێت پێکهاتەی جۆری `<{ $component }>` کۆبکرێتەوە، چونکە جۆرێکی نادروستی پێکهاتەیە.
+
+reference-index-unavailable = ناتوانرێت ئاماژە بە ئیندێکسی `{ $reference }` بکرێت
+
+## `<callAction>`
+
+component-action-unavailable = ناتوانرێت { $action } لەسەر پێکهاتەی `{ $reference }` بانگ بکرێت
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = شێوەی داتاکە نادروستە. ڕیزەکان درێژی جیاوازیان هەیە. دۆزرایەوە لە componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = داتاکە ناوی ستوونی دووبارەی هەیە. دۆزرایەوە لە componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = ناوی ستوونێک لە داتاکەدا کەمە. دۆزرایەوە لە componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = خەڵاتێکی ئەم وەڵامە پشت بە وەڵامی نێردراوی خودی `<answer>` ەکە دەبەستێت، ئەمەش دەبێتە هۆی ڕەفتارێکی چاوەڕواننەکراو.
+
+answer-max-num-attempts-in-section-wide-check-work = دانانی `maxNumAttempts` لەسەر `<answer>` ێک لە ناو هەڵگرێکدا کە `sectionWideCheckWork` ی هەیە هیچ کاریگەرییەکی نییە، چونکە ژمارەی هەوڵەکان لەلایەن هەڵگرەکەوە کۆنترۆڵ دەکرێت. لەبری ئەوە `maxNumAttempts` لەسەر هەڵگرەکە دابنێ.
+
+nested-section-wide-check-work-max-num-attempts = دانانی `maxNumAttempts` لەسەر هەڵگرێک کە `sectionWideCheckWork` ی هەیە و لە ناو هەڵگرێکی تردایە کە ئەویش `sectionWideCheckWork` ی هەیە، هیچ کاریگەرییەکی نییە، چونکە ژمارەی هەوڵەکان لەلایەن هەڵگری دەرەکییەوە کۆنترۆڵ دەکرێت. لەبری ئەوە `maxNumAttempts` لەسەر هەڵگری دەرەکی دابنێ.
+
+answer-attributes-need-symbolic-equality = تایبەتمەندی { $attributes } بەبێ دانانی symbolicEquality هیچ کاریگەرییەکی نابێت.
+
+answer-invalid-type = جۆری نادروست بۆ وەڵام: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = لەبەر ئەوەی پێکهاتەی `<{ $component }>` ناوی نییە، ناتوانرێت وەک تایبەتمەندییەکی مۆدیوول بەکاربهێنرێت
+
+module-attribute-name-already-defined = پێکهاتەی `<{ $component } name="{ $name }">` ناتوانرێت وەک تایبەتمەندییەک بۆ مۆدیوول بەکاربهێنرێت، چونکە جۆری پێکهاتەی `<module>` پێشتر تایبەتمەندییەکی "{ $name }" ی پێناسە کردووە.
+
+conditional-content-condition-ignored = تایبەتمەندی `condition` پشتگوێ دەخرێت لەسەر پێکهاتەی `<conditionalContent>` ێک کە منداڵی case یان else ی هەیە.
+
+slider-markers-type-mismatch = جۆری نیشانەکان لەگەڵ جۆری سلایدەر ناگونجێت.
+
+pretzel-problem-needs-statement-and-answer = pretzel ی نادروست: هەر `<problem>` ێک دەبێت یەک `<statement>` و یەک `<answer>` ی تێدا بێت.
+
+pretzel-circuit-first-problem-distractor = pretzel ی نادروست: لە mode="circuit" دا، یەکەم `<problem>` ناتوانێت distractor بێت.
+
+## Attribute values
+
+attribute-invalid-values = نرخی نادروستی { $values } بۆ تایبەتمەندی `{ $attribute }`؛ پشتگوێ دەخرێت.
+
+attribute-must-be-references = نرخی نادروستی `{ $value }` بۆ تایبەتمەندی `{ $attribute }`. تایبەتمەندی دەبێت لە ئاماژەکان پێک بێت کە بە `$` دەست پێ دەکەن.
+
+math-input-invalid-function-names = <mathInput>: ناوی فەنکشنی نادروست لە { $attribute } دا پشتگوێ خرا: { $names }. بەشی پیشاندانی هەر ناوێک دەبێت بەلایەنی کەمەوە 2 نووسە بێت (پیت یان بەڕێ)؛ دەکرێت پاشگرێکی هەڵبژاردەی `|<mathspeak alternative>` بەدوایدا بێت.
+
+## Building components from the source
+
+component-type-invalid = جۆری پێکهاتەی نادروست: `<{ $componentType }>`
+
+attribute-repeated = ناتوانرێت تایبەتمەندی { $attribute } دووبارە بکرێتەوە.
+
+attribute-invalid-for-component = تایبەتمەندی "{ $attribute }" بۆ پێکهاتەیەکی جۆری `<{ $componentType }>` نادروستە.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    پێناسەی شێوازی { $styleNumber } جیاوازی ڕەنگی پێویستی نییە بۆ { $context ->
+        [text-on-background] ڕەنگی دەق بەرامبەر بە ڕەنگی پاشبنەما
+        [high-contrast] ڕەنگی جیاوازی بەرز بەرامبەر بە بۆشاییەکە
+        [line] ڕەنگی هێڵ بەرامبەر بە بۆشاییەکە
+        [marker] ڕەنگی نیشانە بەرامبەر بە بۆشاییەکە
+       *[text-on-canvas] ڕەنگی دەق بەرامبەر بە بۆشاییەکە
+    }{ $mode ->
+        [dark] { " (دۆخی تاریک)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ بەلایەنی کەمەوە { $threshold }:1 پێویستە).
+
+style-definition-dark-mode-text-background-contrast =
+    هەرچەندە پێناسەی شێوازی { $styleNumber } ڕەنگی وای دیاری کردووە کە بۆ دۆخی ڕووناک جیاوازی پێویستیان هەیە، ئەو ڕەنگانەی بۆ دۆخی تاریک لێیان دەرهێنراون جیاوازی پێویستیان نییە بۆ ڕەنگی دەق بەرامبەر بە ڕەنگی پاشبنەما ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ بەلایەنی کەمەوە { $threshold }:1 پێویستە). { $suggestion ->
+        [available] بۆ دڵنیابوون لە جیاوازی پێویست لە دۆخی تاریکدا، یان جیاوازی دۆخی ڕووناک زیاد بکە (بۆ نموونە { $lightAttribute }="{ $lightColor }" دابنێ) یان ڕەنگی دۆخی تاریک بگۆڕە (بۆ نموونە { $darkAttribute }="{ $darkColor }" دابنێ).
+       *[none] بۆ دڵنیابوون لە جیاوازی پێویست لە دۆخی تاریکدا، جیاوازی دۆخی ڕووناک زیاد بکە یان ڕەنگە دەرهێنراوەکان بە textColorDarkMode و/یان backgroundColorDarkMode بگۆڕە.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    هەرچەندە پێناسەی شێوازی { $styleNumber } ڕەنگی دەقێکی دیاری کردووە کە بۆ دۆخی ڕووناک جیاوازی پێویستی هەیە، ئەو ڕەنگی دەقەی بۆ دۆخی تاریک لێی دەرهێنراوە جیاوازی پێویستی نییە بەرامبەر بە بۆشاییەکە ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ بەلایەنی کەمەوە { $threshold }:1 پێویستە). { $suggestion ->
+        [available] بۆ دڵنیابوون لە جیاوازی پێویست لە دۆخی تاریکدا، یان جیاوازی دۆخی ڕووناک زیاد بکە (بۆ نموونە textColor="{ $lightColor }" دابنێ) یان ڕەنگی دۆخی تاریک بگۆڕە (بۆ نموونە textColorDarkMode="{ $darkColor }" دابنێ).
+       *[none] بۆ دڵنیابوون لە جیاوازی پێویست لە دۆخی تاریکدا، جیاوازی دۆخی ڕووناک زیاد بکە یان ڕەنگە دەرهێنراوەکە بە textColorDarkMode بگۆڕە.
+    }
+
+section-multiple-style-palettes = بەشێک تەنها دەتوانێت یەک <stylePalette> هەڵبژێرێت؛ دوایینیان بەکاردێت.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە numToSelect ژمارەیەکی تەواوی نانەرێنی نییە.
+
+variant-num-to-select-not-constant-number = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە numToSelect ژمارەیەکی نەگۆڕ نییە.
+
+variant-with-replacement-not-constant-boolean = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە withReplacement بولیانێکی نەگۆڕ نییە.
+
+variant-select-weight-disables-unique = وەشانە بێهاوتاکان بۆ select ناچالاک دەکرێن ئەگەر بژاردەیەک هەبێت کە selectWeight یان selectForVariants ی بۆ دیاری کرابێت
+
+variant-coprime-undetermined = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە ناتوانرێت دیاری بکرێت coprime هەمیشە هەڵەیە.
+
+variant-attribute-not-constant = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە { $attribute } نەگۆڕ نییە.
+
+variant-attribute-not-number = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە { $attribute } ژمارە نییە.
+
+variant-attribute-wrong-type-for-sequence =
+    ناتوانرێت وەشانە بێهاوتاکانی { $component } ی جۆری { $type } دیاری بکرێن، چونکە { $attribute } ئەمە نییە: { $expected ->
+        [letters-combination] کۆمەڵێک پیت
+        [math-expression] دەربڕینێکی بیرکاری دروست
+        [integer] ژمارەیەکی تەواو
+       *[number] ژمارەیەک
+    }.
+
+variant-length-not-integer = ناتوانرێت وەشانە بێهاوتاکانی { $component } دیاری بکرێن، چونکە length ژمارەیەکی تەواو نییە.
+
+variant-sort-not-implemented = وەشانە بێهاوتاکانی { $component } ێک لەگەڵ sort جێبەجێ نەکراون
+
+variant-exclude-combinations-not-implemented = وەشانە بێهاوتاکانی { $component } ێک لەگەڵ excludeCombinations جێبەجێ نەکراون
+
+variant-math-exclude-not-implemented = وەشانە بێهاوتاکانی { $component } ێکی جۆری math لەگەڵ exclude جێبەجێ نەکراون
+
+variant-non-constant-exclude-not-implemented = وەشانە بێهاوتاکانی { $component } ێک لەگەڵ exclude ی ناجێگیر جێبەجێ نەکراون
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: لە پیشاندەری prefigure ی graph دا پشتگیری ناکرێت؛ نەوەکە بەجێهێڵدرا.
+
+prefigure-descendant-invalid-geometry = { $subject }: ئەندازەی ناتەواو یان ناکۆتایی؛ نەوەکە بەجێهێڵدرا.
+
+prefigure-curve-label-omitted = { $subject }: ناونیشان لەسەر توخمە چەماوە گۆڕدراوەکان پشتگیری ناکرێت؛ ناونیشان نانووسرێت.
+
+prefigure-curve-unsupported-definition-type = { $subject }: جۆری پێناسەی فەنکشنی چەماوەی '{ $definitionType }' پشتگیری ناکرێت؛ نەوەکە بەجێهێڵدرا.
+
+prefigure-region-flip-functions-unsupported = { $subject }: تایبەتمەندی flipFunctions لەسەر regionBetweenCurves پشتگیری ناکرێت؛ نەوەکە بەجێهێڵدرا.
+
+prefigure-region-non-formula-child = { $subject }: تەنها فەنکشنی منداڵی جۆری formula لەسەر regionBetweenCurves پشتگیری دەکرێن؛ نەوەکە بەجێهێڵدرا.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition ی '{ $labelPosition }' پشتگیری ناکرێت بۆ { $labelKind ->
+        [line-family] ناونیشانی خێزانی هێڵ
+       *[point] ناونیشانی خاڵ
+    }؛ ڕیزکردنی بنەڕەتی PreFigure بەکارهێنرا.
+
+prefigure-fill-style-unsupported = { $subject }: شێوازی پڕکردنەوەی '{ $fillStyle }' لەلایەن PreFigure ەوە پشتگیری ناکرێت؛ پڕکردنەوەی ڕەق بەکاردێت.
+
+prefigure-line-style-unknown = { $subject }: شێوازی هێڵی نەناسراوی '{ $lineStyle }' لە دەرچووی PreFigure دا نانووسرێت.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: شێوازی نیشانەی '{ $markerStyle }' بۆ شێوازی 'diamond' ی PreFigure گۆڕدرا.
+
+prefigure-marker-style-unsupported = { $subject }: شێوازی نیشانەی '{ $markerStyle }' لەلایەن PreFigure ەوە پشتگیری ناکرێت؛ شێوازی بنەڕەت بەکارهێنرا.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ی نادروست؛ ناتوانرێت ئامانج بدۆزرێتەوە. تێبینییەکە نانووسرێت.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` گەیشتە چەند ئامانجێک؛ یەکەم ئامانج بەکاردێت.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ی نادروست؛ ئامانجەکە لە دەرەوەی ئەو گرافەیە کە لەخۆی گرتووە. تێبینییەکە نانووسرێت.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ی نادروست؛ ئامانجەکە بەرهەمێکی وێنەیی پشتگیریکراو نییە لە گۆڕینی prefigure دا. تێبینییەکە نانووسرێت.
+
+annotation-text-missing = `<annotation>`: `text` نییە یان بەتاڵە؛ دەقێکی بەتاڵ دەنووسرێت.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] پشتبەستنی سووڕاوی دۆزرایەوە.
+       *[other] پشتبەستنی سووڕاوی دۆزرایەوە کە پێکهاتەی `<{ $componentType }>` تێیدایە.
+    }
+
+reference-no-referent = هیچ ئامانجێک بۆ ئاماژەی `{ $reference }` نەدۆزرایەوە
+
+reference-multiple-referents = چەند ئامانجێک بۆ ئاماژەی `{ $reference }` دۆزرایەوە
+
+## Children that do not match
+
+children-invalid-attribute-format = فۆرمی نادروست بۆ تایبەتمەندی { $attribute } ی `<{ $componentType }>`.
+
+children-invalid = منداڵی نادروست بۆ `<{ $componentType }>`: ئەم منداڵە نادروستانە دۆزرانەوە: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = نرخی نادروستی `{ $value }` بۆ تایبەتمەندی `{ $attribute }`، نرخی `{ $default }` بەکاردێت
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] وەشانی DoenetML ی { $version } نەدۆزرایەوە.
+       *[other] وەشانی DoenetML ی { $version } نەدۆزرایەوە. دەگەڕێتەوە بۆ وەشانی { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ی نادروست: { $content }
+
+parse-tag-missing-close-tag = DoenetML ی نادروست: تاگی `{ $tag }` تاگی داخستنی نییە. تاگێکی خۆداخەر یان تاگێکی `</{ $tagName }>` چاوەڕوان دەکرا.
+
+parse-tag-error = DoenetML ی نادروست: هەڵە لە تاگی `<{ $tagName }>` دا
+
+parse-attribute-missing-value = DoenetML ی نادروست: وا دیارە تایبەتمەندی نادروستی `{ $attribute }` نرخی نییە.
+
+parse-attribute-invalid = DoenetML ی نادروست: تایبەتمەندی نادروستی `{ $attribute }`
+
+parse-attribute-value-invalid = DoenetML ی نادروست: نرخی نادروستی تایبەتمەندی `{ $value }`
+
+parse-attribute-value-quote-mismatch = DoenetML ی نادروست: نرخی نادروستی تایبەتمەندی `{ $value }`. نیشانەکانی وتە لەگەڵ یەکتر ناگونجێن. وا دیارە `{ $quote }` ێکت کەمە
+
+parse-open-tag-name-missing = DoenetML ی نادروست: تاگێک بەبێ ناوی تاگ دۆزرایەوە، بۆ نموونە `<`
+
+parse-tag-not-closed = DoenetML ی نادروست: تاگی `{ $tag }` دانەخرا (وا دیارە `>` کەمە).
+
+parse-self-closing-tag-name-missing = DoenetML ی نادروست: تاگێک بەبێ ناوی تاگ دۆزرایەوە `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ی نادروست: تاگی `{ $tag }` دانەخرا (وا دیارە `/>` کەمە).
+
+parse-tag-invalid-attributes = DoenetML ی نادروست: تاگی `{ $tag }` دروست نییە. لەوانەیە تایبەتمەندی هەڵەی هەبێت.
+
+parse-close-tag-name-missing = DoenetML ی نادروست: تاگێکی داخستن بەبێ ناوی تاگ دۆزرایەوە، بۆ نموونە `</`
+
+parse-attribute-value-unquoted = نرخی تایبەتمەندی دەبێت لە نێو وتەنیشانەدا بێت: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ی نادروست: تاگی داخستنی `{ $tag }` دۆزرایەوە، بەڵام هیچ تاگێکی کردنەوەی هاوتای نییە
+
+parse-close-tag-mismatched = DoenetML ی نادروست: تاگی داخستنی نەگونجاو. `</{ $expected }>` چاوەڕوان دەکرا. `{ $found }` دۆزرایەوە
+
+parser-node-unconvertible = نەتوانرا گرێی { $node } بگۆڕدرێت بۆ گرێی Dast.
+
+## Names
+
+name-attribute-invalid =
+    ناوی نادروستی تایبەتمەندی name='{ $name }'. { $reason ->
+        [characters] ناو تەنها دەتوانێت پیت، ژمارە، ژێرهێڵ یان بەڕێ لەخۆ بگرێت.
+       *[start] ناو دەبێت بە پیتێک دەست پێ بکات.
+    }
+
+component-name-invalid-start = ناوی پێکهاتەی نادروستی "{ $name }". ناو دەبێت بە پیتێک دەست پێ بکات.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = وەڵامی جۆری videoWatched دەبێت تایبەتمەندی video ی هەبێت
+
+answer-video-watched-video-not-reference = وەڵامی جۆری videoWatched دەبێت تایبەتمەندی video ی هەبێت کە ئاماژەیەک بێت
+
+answer-name-not-single-text = تایبەتمەندی name ی وەڵام دەبێت یەک منداڵی دەقی هەبێت
+
+## Referencing another document
+
+external-doenetml-recursion-limit = نەتوانرا DoenetML ی دەرەکی وەربگیرێت بەهۆی زۆری ئاستەکانی سووڕانەوە. ئایا ئاماژەیەکی سووڕاوی هەیە؟
+
+external-doenetml-unavailable = نەتوانرا DoenetML وەربگیرێت لە { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ی نادروست لە { $attribute }="{ $uri }" وەرگیرا: لەگەڵ جۆری پێکهاتەی "{ $componentType }" نەگونجا
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] تایبەتمەندی `{ $from }` بەسەرچووە؛ لەبری ئەوە `{ $to }` بەکاربهێنە.
+       *[other] [deprecation] تایبەتمەندی `{ $from }` لەسەر `<{ $component }>` بەسەرچووە؛ لەبری ئەوە `{ $to }` بەکاربهێنە.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] تایبەتمەندی `{ $from }` بەسەرچووە و پشتگوێ دەخرێت، چونکە `{ $to }` یش دیاری کراوە.
+       *[other] [deprecation] تایبەتمەندی `{ $from }` لەسەر `<{ $component }>` بەسەرچووە و پشتگوێ دەخرێت، چونکە `{ $to }` یش دیاری کراوە.
+    }
+
+deprecated-attribute-ignored = [deprecation] تایبەتمەندی `{ $attribute }` لەسەر `<{ $component }>` بەسەرچووە و پشتگوێ دەخرێت.
+
+deprecated-attribute-to-child = [deprecation] تایبەتمەندی `{ $attribute }` لەسەر `<{ $component }>` بەسەرچووە؛ لەبری ئەوە منداڵێکی `<{ $child }>` بەکاربهێنە.
+
+deprecated-attribute-value-renamed = [deprecation] نرخی `{ $value }` ی تایبەتمەندی `{ $attribute }` لەسەر `<{ $component }>` بەسەرچووە؛ لەبری ئەوە `{ $to }` بەکاربهێنە.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` تەنها دەتوانێت ئینگلیزی کۆ بکات، بۆیە دەقەکەی لە دۆکیومێنتێکدا کە بە { $locale } نووسراوە بێگۆڕ دەمێنێتەوە. فۆرمی کۆ ڕاستەوخۆ بنووسە، یان بە تایبەتمەندی `pluralForm` دایبنێ.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = توخمی `<{ $tag }>` توخمێکی ناسراوی Doenet نییە.
+
+schema-element-not-allowed-at-root = توخمی `<{ $tag }>` لە ڕەگی دۆکیومێنتدا ڕێگەپێدراو نییە.
+
+schema-element-not-allowed-inside = توخمی `<{ $tag }>` لە ناو `<{ $parent }>` دا ڕێگەپێدراو نییە.
+
+schema-attribute-unrecognized = توخمی `<{ $tag }>` تایبەتمەندییەکی بەناوی `{ $attribute }` ی نییە.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] تایبەتمەندی `{ $attribute }` ی توخمی `<{ $tag }>` دەبێت لیستێک بێت کە هەر بڕگەیەکی یەکێک بێت لەمانە: { $allowed }
+       *[other] تایبەتمەندی `{ $attribute }` ی توخمی `<{ $tag }>` دەبێت یەکێک بێت لەمانە: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = ناوی وەشانی نادروست بۆ select. ناوی وەشانی { $variantName } لە { $numOptions } بژاردەدا دێت بەڵام ژمارەی هەڵبژاردن { $numToSelect } ە.
+
+select-variant-name-without-options = هەندێک وەشان بۆ select دیاری کراون بەڵام هیچ بژاردەیەک بۆ ناوی وەشانی گونجاو دیاری نەکراوە: { $variantName }.
+
+select-variant-name-not-possible = ناوی وەشانی { $variantName } کە بۆ select دیاری کراوە، ناوێکی وەشانی گونجاو نییە.
+
+select-too-few-options = ناتوانرێت { $numToSelect } پێکهاتە لە تەنها { $numOptions } دا هەڵبژێردرێت.
+
+select-from-sequence-too-few-values = ناتوانرێت { $numToSelect } نرخ لە زنجیرەیەکی بە درێژی { $length } دا هەڵبژێردرێت.
+
+select-from-sequence-indices-count-mismatch = ژمارەی ئیندێکسە دیاریکراوەکان بۆ select دەبێت لەگەڵ ژمارەی هەڵبژاردن بگونجێت
+
+select-from-sequence-indices-not-integers = هەموو ئیندێکسە دیاریکراوەکان بۆ select دەبێت ژمارەی تەواو بن
+
+select-from-sequence-index-excluded = ئیندێکسێکی دیاریکراوی selectfromsequence کە دەرخرابوو
+
+select-from-sequence-indices-excluded-combination = ئیندێکسە دیاریکراوەکانی selectfromsequence کە کۆمەڵەیەکی دەرخراو بوون
+
+select-from-sequence-coprime-not-positive-integers = ناتوانرێت کۆمەڵەی coprime هەڵبژێردرێت، چونکە ژمارەی تەواوی ئەرێنی هەڵنابژێردرێت.
+
+select-from-sequence-coprime-common-factor = ناتوانرێت ژمارەی coprime هەڵبژێردرێت. هەموو نرخە گونجاوەکان فاکتەرێکی هاوبەشیان هەیە. (نرخە دیاریکراوەکانی "from" یان "to" دەبێت لەگەڵ "step" دا coprime بن.)
+
+select-from-sequence-coprime-single-number = ناتوانرێت کۆمەڵەی coprime لە یەک ژمارەدا هەڵبژێردرێت کە 1 نییە.
+
+select-from-sequence-excluded-too-many-combinations = زیاتر لە 70% ی کۆمەڵەکان لە selectFromSequence دا دەرخران
+
+select-from-sequence-coprime-none-found = نەتوانرا ژمارەی coprime هەڵبژێردرێت. هەموو نرخە گونجاوەکان فاکتەرێکی هاوبەشیان هەیە.
+
+select-from-sequence-too-few-unique-values = ناتوانرێت { $numToSelect } نرخی بێهاوتا لە زنجیرەیەکی بە درێژی { $numPossibleValues } دا هەڵبژێردرێت
+
+select-prime-numbers-too-few-values = ناتوانرێت { $numToSelect } نرخ لە لیستێکی ژمارە سەرەتاییەکان بە درێژی { $numValues } دا هەڵبژێردرێت
+
+select-prime-numbers-values-count-mismatch = ژمارەی نرخە دیاریکراوەکان بۆ select دەبێت لەگەڵ ژمارەی هەڵبژاردن بگونجێت
+
+select-prime-numbers-values-not-prime = هەموو نرخە دیاریکراوەکان بۆ هەڵبژاردنی ژمارەی سەرەتایی دەبێت لە لیستی ژمارە سەرەتاییەکاندا بن
+
+select-prime-numbers-values-excluded-combination = نرخە دیاریکراوەکانی selectPrimeNumbers کۆمەڵەیەکی دەرخراو بوون
+
+select-prime-numbers-excluded-too-many-combinations = زیاتر لە 70% ی کۆمەڵەکان لە selectPrimeNumbers دا دەرخران
+
+select-random-combination-fluke = بە ڕێکەوتێکی زۆر دوور، نەتوانرا کۆمەڵەیەکی نرخی هەڕەمەکی هەڵبژێردرێت
+
+select-random-value-fluke = بە ڕێکەوتێکی زۆر دوور، نەتوانرا نرخێکی هەڕەمەکی هەڵبژێردرێت

--- a/packages/i18n/locales/ckb/editor.ftl
+++ b/packages/i18n/locales/ckb/editor.ftl
@@ -1,0 +1,234 @@
+# Central Kurdish (Sorani) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Kurdo-Arabic alphabet, the fully vowelled Arabic-script
+# orthography of the Kurdistan Region of Iraq. `ckb` maximizes to
+# `ckb-Arab-IQ` and is right to left. Northern Kurdish (Kurmanji) has its own
+# left-to-right Latin catalog in `locales/ku`; a Sorani reader reaches this
+# one, which is why `ckb` is kept out of the roster's fold onto `ku`.
+#
+# Sorani has no grammatical gender, so nothing here agrees with anything. Two
+# plural categories, `one` and `other`, and a noun after a numeral stays
+# singular, so no count in this file needs a branch. Numbers are Latin digits;
+# ٠١٢٣ appear nowhere and no message names a numbering system.
+#
+# Register as in `chrome.ftl`: verbal nouns for controls, imperative singular
+# for a sentence addressed to the reader.
+#
+# Where English interpolates a bare verb — "Click to { $action } accessibility
+# report" — the Kurdish verb closes its clause and cannot be dropped into the
+# middle of one, so the selector carries the whole sentence. Fluent does not
+# care where a select sits inside a pattern.
+#
+# The ezafe is written as a ـی suffix and cannot be welded onto a placeable,
+# which is the constraint `content.ftl`'s header describes at length. It
+# reaches this file in three places, each marked below.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ڕێکخستنەوە
+       *[update] نوێکردنەوە
+    }
+
+# «{ $word }ی پیشاندەر» would be the idiomatic phrase, but the ezafe would have
+# to be welded onto the button's own label, which arrives as a placeable. «بۆ»
+# is a free preposition and needs nothing attached to it, so the tooltip reads
+# "Update, for the viewer" rather than "Update of the viewer".
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } بۆ پیشاندەر
+       *[other] { $word } بۆ پیشاندەر { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = وەشان
+editor-variant-filter = پاڵاوتن...
+editor-variant-next = هەڵبژاردنی وەشانی دواتر
+editor-variant-previous = هەڵبژاردنی وەشانی پێشوو
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] پێشێلکردنی دەستڕاگەیشتن بەپێی WCAG AA دۆزرایەوە. { $action ->
+            [close] بۆ داخستنی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+           *[open] بۆ کردنەوەی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+        }
+        [advisories] { $action ->
+            [close] بۆ داخستنی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+           *[open] بۆ کردنەوەی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+        } هیچ پێشێلکردنێکی WCAG AA نەدۆزرایەوە، بەڵام پێشنیاری زیاتری دەستڕاگەیشتن بەردەستە.
+       *[clean] { $action ->
+            [close] بۆ داخستنی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+           *[open] بۆ کردنەوەی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+        } هیچ کێشەیەکی دەستڕاگەیشتن نەدۆزرایەوە.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] پێشێلکردنی دەستڕاگەیشتن بەپێی WCAG AA دۆزرایەوە. { $count } پێشێلکردنی WCAG AA دۆزرایەوە. { $action ->
+            [close] بۆ داخستنی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+           *[open] بۆ کردنەوەی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+        }
+        [advisories] هیچ پێشێلکردنێکی WCAG AA نەدۆزرایەوە. { $count } پێشنیاری زیاتری دەستڕاگەیشتن دۆزرایەوە. { $action ->
+            [close] بۆ داخستنی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+           *[open] بۆ کردنەوەی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+        }
+       *[clean] هیچ پێشێلکردنێکی WCAG AA نەدۆزرایەوە. { $action ->
+            [close] بۆ داخستنی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+           *[open] بۆ کردنەوەی ڕاپۆرتی دەستڕاگەیشتن کلیک بکە.
+        }
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = وەشانی DoenetML { $version }
+
+editor-tab-help = یارمەتی بەپێی چوارچێوە
+editor-tab-help-short = چوارچێوە
+editor-tab-errors = هەڵەکان
+editor-tab-warnings = ئاگادارییەکان
+editor-tab-info = زانیاری
+editor-tab-accessibility = دەستڕاگەیشتن
+editor-tab-responses = وەڵامە نێردراوەکان
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = هەڵبژاردەکانی دەستکاریکەر
+editor-format-as-doenetml = فۆرماتکردن وەک DoenetML
+editor-format-as-xml = فۆرماتکردن وەک XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = دێڕی ژمارە { $line }
+
+editor-no-errors = هیچ هەڵەیەک نییە
+editor-no-warnings = هیچ ئاگادارییەک نییە
+editor-no-info = هیچ دەستنیشانکردنێکی زانیاری نییە
+
+editor-show-info-annotations = پیشاندانی دەستنیشانکردنی زانیاری لە دەستکاریکەردا
+editor-show-accessibility-annotations = پیشاندانی دەستنیشانکردنی دەستڕاگەیشتن لە دەستکاریکەردا
+
+editor-accessibility-learn-more = فێربە Doenet چۆن لە دەستڕاگەیشتن دەڕوانێت
+
+editor-accessibility-violations-heading = پێشێلکردنەکانی دەستڕاگەیشتن ({ $standard })
+
+editor-accessibility-other-heading = کێشەکانی تری دەستڕاگەیشتن
+editor-none-found = هیچ نەدۆزرایەوە
+
+
+## Submitted responses
+
+editor-no-responses = هێشتا هیچ وەڵامێک نەنێردراوە
+editor-response-answer-id = ناسنامەی وەڵام
+editor-response-response = وەڵام
+editor-response-credit = نمرە
+editor-response-submitted = کاتی ناردن
+
+
+## The context-help panel
+
+help-placeholder = بۆ بینینی بەڵگەنامە، نیشاندەر بخە سەر ناوی تاگێک، تایبەتمەندییەک، یان { $ref }.
+
+help-unsupported-ref-chain = یارمەتی بۆ ئاماژەی فرەبەش وەک { $example } هێشتا پشتگیری ناکرێت.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] هیچ ئامانجێک بۆ ئاماژەی { $ref } نەدۆزرایەوە.
+        [multiple] چەند ئامانجێک بۆ ئاماژەی { $ref } دۆزرایەوە.
+       *[indeterminate] نەتوانرا ئامانجێک بۆ { $ref } دیاری بکرێت.
+    }
+
+# The arrow is direction rather than punctuation, and Sorani runs the other
+# way, so it points where the reader is going.
+help-learn-about-references = فێربوون دەربارەی ئاماژەکان ←
+help-reference-page = لاپەڕەی سەرچاوە ←
+
+help-suggestions-header =
+    { $location ->
+        [inside] لە ناو { $element }
+       *[top] لە ئاستی سەرەوە
+    }{ $allowed ->
+        [none] { " — هیچ شتێک لێرە دانانرێت." }
+        [text] { " — لێرەدا دەق بنووسە." }
+        [text-and-components] { " — لێرەدا دەق بنووسە، یان ئەمانە تاقی بکەرەوە:" }
+       *[components] { " — شتانێک بۆ تاقیکردنەوە:" }
+    }
+
+help-suggestions-footer = { $shortcut } دابگرە بۆ بینینی هەموو { $total } پێکهاتەکە.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ئاماژەیەکە بۆ { $target }.
+       *[other] { $ref } ئاماژەیەکە بۆ { $target } (دێڕی { $line }).
+    }
+
+# Kurdish would circumpose «لەلایەن … ەوە» here, and the closing «ەوە» is a
+# suffix on `{ $owner }`. It is left off rather than welded, which is the same
+# choice `content.ftl` makes for the ezafe.
+help-ref-derived-from =
+    { $line ->
+        [none] لەلایەن { $owner } وەک { $role } ناسێنراوە.
+       *[other] لەلایەن { $owner } لە دێڕی { $line } وەک { $role } ناسێنراوە.
+    }
+
+# «خاسیەتی { $property } ی { $element }» would need a second ezafe welded onto
+# `{ $property }`, so the owner is reached with the free preposition «لەسەر»
+# instead.
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ئاماژەیەکە بۆ خاسیەتی { $property } لەسەر { $element }.
+       *[other] { $ref } ئاماژەیەکە بۆ خاسیەتی { $property } لەسەر { $element } (دێڕی { $line }).
+    }
+
+help-kind-attribute = تایبەتمەندی
+help-kind-snippet = پارچەکۆد
+help-kind-array-entry = بڕگەی ڕیزە
+
+help-default = بنەڕەت:
+help-active-default = بنەڕەتی چالاک:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] نرخە ڕێگەپێدراوەکان (یەک بۆ هەر بڕگەیەک):
+       *[other] نرخە ڕێگەپێدراوەکان:
+    }
+
+help-suggested-values = نرخە پێشنیارکراوەکان:
+
+help-inserts = دادەنێت:
+
+# Sorani does not change the noun for the count, so the two English branches
+# would render the same string; the select is dropped rather than written out
+# twice identically. `$count` then goes unused, which is harmless.
+help-coordinates = کۆردینات:
+
+help-type = جۆر:
+
+help-resolved-style = شێوازی دیاریکراو (styleNumber { $styleNumber }):
+
+help-resolved-function-names = ناوە دیاریکراوەکانی فەنکشن:
+help-reset-list = لیستی ڕێکخستنەوە لەسەر ئەم داخڵکراوە:
+help-added-on-input = زیادکراو لەسەر ئەم داخڵکراوە:
+help-removed-on-input = لابراو لەسەر ئەم داخڵکراوە:
+
+help-reset-overrides = { $reset } جێی { $additional } و { $removed } دەگرێتەوە.

--- a/packages/i18n/locales/dar/chrome.ftl
+++ b/packages/i18n/locales/dar/chrome.ftl
@@ -1,0 +1,137 @@
+# Dargwa viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Dargwa is a group of varieties, not one language, and this catalog is the
+# Akusha-based literary standard.** Akusha (Акуша) is what Dagestan's schools
+# teach, what the republic's Dargwa-language press is set in, and what a bare
+# `dar` maximizes to — `dar-Cyrl-RU`. A reader from Kajtag, Kubachi, Itsari,
+# Chirag, Megeb or Sirhwa will find words here that their own variety does not
+# use, and some of those varieties are far enough from Akusha to be counted as
+# separate languages; this file is not addressed to them and does not claim to
+# be.
+#
+# Written in Cyrillic with the palochka Ӏ, which is a letter of the alphabet —
+# not a Latin capital I and not a digit 1. A file that spells «хатӀа» with
+# either has quietly stopped being Dargwa.
+#
+# Dargwa counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gave it. A noun after a
+# numeral stays in the singular, so the two branches differ in nothing but the
+# number they print — that is Dargwa grammar, not a copy-paste slip.
+#
+# Nothing in this file agrees with a noun class. Dargwa has one — see
+# `content.ftl`, where the whole of the class question is worked out — but the
+# words here are not the kind that carry a class prefix.
+#
+# Least certain in this file: «гьаргдеш» for *accessibility* is a transparent
+# coinage from «гьаргси» (open) rather than an attested term, and «балахъни»
+# for *warning* is a stretch of «балахъес» (to announce). The technical nouns
+# are the Russian ones written Dargwa uses in practice — «клавиатура»,
+# «клетка», «стрелка», «столбец», «интервал».
+
+
+## Answer submission
+
+answer-checking = Ахтарбирули…
+answer-submitting = Бархьули…
+answer-checking-status = Жаваб ахтарбирули
+answer-submitting-status = Жаваб бархьули
+answer-correct = Бархьси
+answer-incorrect = Бархьси ахӀен
+answer-response-saved = Жаваб мяхӀкамбарибси
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% бархьси
+answer-percent-short = { $percent } %
+max-credit-available = БегӀлара халаси балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] кализурти попыткаби агара
+        [one] { $count } попытка кализурли саби
+       *[other] { $count } попытка кализурли саби
+    }
+validation-correct = (Бархьси)
+validation-incorrect = (Бархьси ахӀен)
+validation-partially-correct = (БутӀала бархьси)
+# «{ $answerId } жаваблис» — the value is followed by a word this catalog
+# writes, so no case ending is welded onto something the catalog never sees.
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } жаваблис { $count } жаваб чебаахъа
+       *[other] { $answerId } жаваблис { $count } жаваб чебаахъа
+    }
+
+## Disclosure panels
+
+feedback-heading = Пикри
+collapsible-click-to-open = (абхьес кабяхъа)
+collapsible-click-to-close = (кӀапӀбарес кабяхъа)
+collapsible-initializing = ХӀядурбирули…
+footnote-show = Удибси белкӀ чебаахъа
+footnote-hide = Удибси белкӀ кӀапӀбара
+description-more-information = имцӀаси хабар
+
+## Controls
+
+slider-previous = Гьалаб
+slider-next = ГӀергъи
+keyboard-open = Клавиатура абхьа
+keyboard-close = Клавиатура кӀапӀбара
+choice-input-remove-choice = { $choice } ардука
+matrix-remove-row = Жерге ардука
+matrix-add-row = Жерге кабихьа
+matrix-remove-column = Столбец ардука
+matrix-add-column = Столбец кабихьа
+subset-add-remove-points = Точкаби кадихьес/ардукес
+subset-toggle-points-intervals = Точкаби ва интервалуни дарсдарес
+subset-move-points = Точкаби гечдара
+subset-clear = Умубара
+orbital-add-row = Жерге кабихьа
+orbital-remove-row = Жерге ардука
+orbital-add-box = Клетка кабихьа
+orbital-remove-box = Клетка ардука
+orbital-add-up-arrow = Чедиси стрелка кабихьа
+orbital-add-down-arrow = Удиси стрелка кабихьа
+orbital-remove-arrow = Стрелка ардука
+orbital-row-label = { $row } жергела лишан
+pretzel-answer = Жаваб
+summary-statistics-caption = { $column } столбецла статистика
+
+## Math input
+
+math-input-preview-region = математикала выражение гьалаб чебаахъни
+math-input-preview = Гьаларла хӀер
+math-input-invalid-expression = Бархьси ахӀенси выражение:
+
+## Document status
+
+viewer-initializing = ХӀядурбирули…
+
+## Errors
+
+error-heading = ХатӀа
+error-found-at =
+    { $span ->
+        [line] Баргибси жерге: { $startLine }.
+       *[lines] Даргибти жергни: { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Иш документлизир хатӀаби лер!
+diagnostic-heading-error = ХатӀа
+diagnostic-heading-warning = Балахъни
+diagnostic-heading-information = Хабар
+diagnostic-heading-hint = Гьанбушни
+accessibility-heading-level-1 = WCAG AA гьаргдешла дохни
+accessibility-heading-level-2 = Гьаргдешла хӀекьлизибси балахъни
+something-went-wrong = СекӀал бархьли хӀебакӀиб.
+renderer-load-failed = сурат бирнила модуль хӀебилцӀун. БяхӀ гьатӀира абхьа.
+core-start-failed = Иш документ бехӀбихьес хӀебирар. БяхӀ гьатӀира абхьа.
+core-start-failed-busy = Иш документ бехӀбихьес хӀебирар. Цали цала гӀергъи дахъал документуни бехӀбирхьули сарри, гьалакли хӀебирути машинабазиб иш замана имцӀали бетарар. ЦархӀилти документуни таманбиубли гӀергъи бяхӀ гьатӀира абхьалли, кумек бетарес асубирар.
+core-start-failed-retry = Иш документ бехӀбихьес хӀебирар.
+core-start-failed-busy-retry = Иш документ бехӀбихьес хӀебирар. Цали цала гӀергъи дахъал документуни бехӀбирхьули сарри, гьалакли хӀебирути машинабазиб иш замана имцӀали бетарар.
+core-start-retry = ГьатӀира бара
+saved-state-unavailable = ХӀела мяхӀкамбарибси хӀянчи касес хӀебирар.

--- a/packages/i18n/locales/dar/content.ftl
+++ b/packages/i18n/locales/dar/content.ftl
@@ -1,0 +1,302 @@
+# Dargwa content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Dargwa is a diverse group of varieties, and this catalog is the
+# Akusha-based literary standard** — the norm Dagestan's schools teach, the
+# republic's Dargwa press is set in, and CLDR fills a bare `dar` in as
+# (`dar-Cyrl-RU`). Kajtag, Kubachi, Itsari, Chirag, Megeb and Sirhwa Dargwa
+# differ from it far enough that several are counted as separate languages by
+# linguists who work on them; a reader from one of those is being served the
+# Akusha standard here, and this file does not pretend otherwise.
+#
+# Written in Cyrillic. The palochka Ӏ is a letter — not a Latin capital I, not
+# a digit 1.
+#
+# **Dargwa has a grammatical class system, and the interesting thing about it
+# is that this catalog still forks almost nowhere.** Dargwa nouns fall into
+# three singular classes marked by в- (class I, male humans), р- (class II,
+# female humans) and б- (class III, everything else), with б-/д- in the plural.
+# Unlike Chechen's six lexical classes, the Dargwa split is *semantically
+# transparent*: a noun is class III precisely because it is not a person. Every
+# noun the core ever names — a line, a circle, a border, a fill, a background —
+# is a thing, so all of them are class III, and `noun-gender` therefore answers
+# `b` for the whole roster with nothing to select between. It is written flat
+# below for that reason, not because the class system was skipped.
+#
+# **One word here genuinely agrees, and it is the participle, not the
+# adjectives.** Dargwa colour and size adjectives — «цӀудара», «хӀунтӀена»,
+# «халаси» — take no class prefix and hold still in front of any noun, so the
+# style vocabulary forks nowhere. «бицӀибси», *filled*, is a participle of
+# «бицӀес», and its first letter *is* the class marker: «вицӀибси» of a man,
+# «рицӀибси» of a woman, «бицӀибси» of a thing. So `style-filled-word` is
+# written as a real fork on `$gender`, with the understanding that only its
+# `[b]` branch can be reached from this catalog's own `noun-gender` — it is
+# written and waiting, the way `locales/ce` leaves its own table waiting.
+#
+# `style-unfilled` is the message that would agree and cannot: `describeFill`
+# renders it with no arguments at all, so no noun and therefore no `$gender`
+# ever reaches it. The class-III form is written flat, as every other agreeing
+# catalog in the roster does for that message.
+#
+# **Dargwa attributive adjectives stand before the noun** (the language is
+# consistently head-final), so the style descriptions below run in the same
+# order English does — width, dash, colour, noun — and that is Dargwa's own
+# order rather than English's showing through.
+#
+# **The colour table is the least certain thing in this file.** Five of the
+# twelve are native words this seed can stand behind: «цӀудара» black, «цӀуба»
+# white, «хӀунтӀена» red, «шиниша» green and «хьанцӀа» blue. «шиниша» does not
+# split where the style pipeline splits — traditionally it covers the green and
+# blue range together, and «хьанцӀа» is the blue side of it — so the two
+# entries below are a modern narrowing rather than a translation. The other
+# seven are written as the Russian colour words a Dargwa speaker schooled in
+# Russian actually reaches for; a speaker who knows the native terms should
+# replace them, and that is the single most valuable edit this file can
+# receive.
+#
+# The geometric nouns are the Russian ones for the same reason the chemistry
+# table is missing: school mathematics in Dagestan is taught in Russian, so
+# these are the words a Dargwa-speaking pupil has actually met. Where a Dargwa
+# word exists and is ordinary — «мер» for a region, «бутӀа» for a part, «дуб»
+# for an edge — it is used.
+
+
+## Style vocabulary
+##
+## None of these adjectives takes a class prefix, so none of them forks. That
+## is a fact about Dargwa adjectives, not about Dargwa agreement.
+
+color =
+    .black = цӀудара
+    .white = цӀуба
+    .gray = сераси
+    .red = хӀунтӀена
+    .orange = оранжевый
+    .yellow = жёлтый
+    .green = шиниша
+    .cyan = голубой
+    .blue = хьанцӀа
+    .purple = фиолетовый
+    .pink = розовый
+    .brown = коричневый
+line-width =
+    .thick = халаси
+    .thin = биштӀаси
+line-style =
+    .dashed = кӀапӀбикибси
+    .dotted = точкабала
+# Noun phrases: they stand in front of «суратуначил» in the composing messages
+# below and modify nothing, so they carry no agreement of their own.
+fill-style =
+    .horizontal = горизонталла линиуни
+    .vertical = вертикалла линиуни
+    .diagonal = диагоналла линиуни
+    .backdiagonal = гӀелабси диагоналла линиуни
+    .dots = точкаби
+    .diamonds = ромбуни
+noun =
+    .line = линия
+    .line-segment = линияла бутӀа
+    .ray = луч
+    .vector = вектор
+    .curve = кривая
+    .function = функция
+    .slope-field = наклонна майдан
+    .vector-field = векторла майдан
+    .parabola = парабола
+    .polyline = ломаная
+    .polygon = многоугольник
+    .triangle = треугольник
+    .rectangle = прямоугольник
+    .circle = окружность
+    .region = мер
+    .point = точка
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# Dargwa puts the side count in front of the noun, as it puts every other
+# modifier there, so the whole of the phrase is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } дубла бархьси многоугольник
+    }
+# The class of the noun being described. Dargwa's classes are semantic — male
+# human, female human, everything else — and every noun the core names is a
+# thing, so all of them answer class III and there is nothing to select
+# between. Written flat for that reason; see the note at the top of this file.
+noun-gender = b
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# The one word in this catalog whose first letter is a class marker. Only the
+# `[b]` branch is reachable from `noun-gender` above, because everything the
+# core describes is a thing; the other two are written out so that a speaker
+# who extends the table finds them already correct.
+style-filled-word =
+    { $gender ->
+        [v] вицӀибси
+        [r] рицӀибси
+       *[b] бицӀибси
+    }
+# «суратуначил» — "with the figures" — is a word this catalog writes, standing
+# after the pattern name so that the comitative ending lands on it rather than
+# being welded onto a value the catalog never sees.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } суратуначил { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } суратуначил { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } суратуначил { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «дубличил» — "with an edge" — is a case form of a noun this catalog writes,
+# so nothing is welded to a placeable, and Dargwa wants no article.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } дубличил
+        [and] ва { $border } дубличил
+        [and-article] ва { $border } дубличил
+       *[with] { $border } дубличил
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } суратуначил { $color } ранг
+       *[plain] { $color } ранг
+    }
+# The negated participle agrees in the language exactly as the positive one
+# does — «вицӀибси ахӀенси», «рицӀибси ахӀенси» — but this message describes a
+# fill standing on its own, and `describeFill` hands it no noun and therefore
+# no `$gender`. The class-III form is written flat; a fork here could only ever
+# render its own default.
+style-unfilled = бицӀибси ахӀенси
+# «фонничиб» — "on the background" — is a locative on a word this catalog
+# writes, and it precedes the colour because Dargwa modifiers precede.
+style-text =
+    { $parts ->
+        [background] { $background } фонничиб { $color }
+       *[plain] { $color }
+    }
+style-background-none = агара
+
+## Boolean words
+
+boolean-true = бархьси
+boolean-false = къяна
+
+## Answer buttons
+
+answer-submit-label = Ахтарбара
+answer-submit-label-no-correctness = Жаваб бархьа
+
+## Sectional blocks
+
+section-name =
+    .activity = ХӀянчи
+    .aside = Шалила белкӀ
+    .cascade = Каскад
+    .definition = Баян
+    .example = Мисал
+    .exercise = Упражнение
+    .exercises = Упражнениеби
+    .given-answer = Жаваб
+    .note = БелкӀ
+    .objectives = Мурадуни
+    .paragraphs = Абзацуни
+    .part = БутӀа
+    .problem = Масъала
+    .problems = Масъалаби
+    .proof = Далил
+    .question = Суал
+    .section = БекӀ
+    .solution = Решение
+    .task = Задание
+    .theorem = Теорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Гьанбушни
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурат { $enumeration }
+        [numbered-caption] Сурат { $enumeration }{ ". " }
+        [unnumbered-caption] Сурат{ ". " }
+       *[unnumbered] Сурат
+    }
+
+## Paginator controls
+
+paginator-previous = Гьалаб
+paginator-next = ГӀергъи
+paginator-page = БяхӀ
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## Dargwa's own conditional is a *suffix* on the verb — «-алли» — and it closes
+## the clause it conditions, which is the shape `locales/sah`, `locales/tyv`,
+## `locales/udm`, `locales/kv` and `locales/chm` record for their own
+## conditionals. What saves this key is that Dargwa also has the borrowed
+## clause-initial conjunction «эгер», which opens the clause the way the
+## renderer needs and which is what is written below. There is no verb in the
+## mathematics that follows for «-алли» to sit on, so «эгер» is not a
+## workaround here but the only available construction; a speaker should still
+## know that the bare conjunction without its suffix reads as an incomplete
+## conditional in ordinary Dargwa prose.
+
+piecewise-condition-or = яра
+piecewise-condition-if = эгер
+piecewise-condition-otherwise = цархӀилли
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Dagestan is taught in
+## Russian, so a Dargwa-speaking pupil meets the Russian element names in their
+## own textbook and has never met a Dargwa list; inventing 118 coinages here
+## would put something in front of them that no classroom, no dictionary and no
+## examination uses, and would be further from their curriculum than the
+## English fallback is.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Бархьси ахӀенси химияла лишан
+chemistry-invalid-ionic-compound = Бархьси ахӀенси ионтала цалабикни

--- a/packages/i18n/locales/dar/diagnostics.ftl
+++ b/packages/i18n/locales/dar/diagnostics.ftl
@@ -1,0 +1,693 @@
+# Dargwa diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The Akusha-based literary standard, in Cyrillic; see `content.ftl`'s header
+# for what that choice leaves out, since Dargwa is a group of varieties rather
+# than one language. The palochka Ӏ is a letter, not a Latin I and not a
+# digit 1.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Dargwa's class agreement does not reach this file. `content.ftl` explains
+# why the fork lives there and only there: Dargwa classes are semantic (male
+# human, female human, everything else), and nothing described here is a
+# person.
+#
+# Both `{ $count -> … }` shapes keep their two branches, but a Dargwa noun
+# after a numeral stays singular, so the branches differ only in the number
+# they print.
+#
+# The technical vocabulary is the Russian one written Dargwa uses —
+# «компонент», «атрибут», «элемент», «функция», «индекс», «переменная» is
+# rendered as the transparent Dargwa «дарсдируси» where it is prose. Where a
+# plain Dargwa word exists it is used: «хатӀа» error, «кьимат» value, «лугӀи»
+# number, «у» name, «хӀярп» letter, «жерге» line or row, «мер» place.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кӀел ахирла точка гибхӀели { $attributes } пикрилизи хӀебуцу
+       *[other] кӀел ахирла точка гибхӀели { $attributes } пикрилизи хӀебуцу
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] ахирла точка ва бухӀнала точка кӀелра гибхӀели { $attributes } пикрилизи хӀебуцу
+       *[other] ахирла точка ва бухӀнала точка кӀелра гибхӀели { $attributes } пикрилизи хӀебуцу
+    }
+
+line-segment-midpoint-offset-without-midpoint = бухӀнала точка агарли midpointOffset секӀайчи хӀебиркур
+
+## `<line>`
+
+line-points-undetermined-dimensions = Кьадар билгӀабарили ахӀенти точкабазибад башуси линия.
+
+line-points-too-few-dimensions = Линия камлира кӀел кьадар лебти точкабазибад башуси биэс гӀягӀниси саби.
+
+line-points-depend-on-variables = Линия дарсдирути кьиматуначи хӀерси точкабазибад башули саби: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ва { $variable2 } дарсдирутачилси линияла уравнениела формат бархьси ахӀен.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint ва direction сарили гибси саби. Гибси through пикрилизи хӀебуцу.
+
+ray-dimension-mismatch = лучлизиб numDimensions цугхӀебикур.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ва displacement сарили гибси саби. Гибси head пикрилизи хӀебуцу.
+
+vector-dimension-mismatch = векторлизиб numDimensions цугхӀебикур.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементличи битӀакӀес хӀебирар, сенкӀун илала nearestPoint бикӀуси хӀялла кьимат агара.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементличи дозабирес хӀебирар, сенкӀун илала nearestPoint бикӀуси хӀялла кьимат агара.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементла бухӀнализи дозабирес хӀебирар, сенкӀун илала nearestPoint бикӀуси хӀялла кьимат агара.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = жергелизиб ахӀенси choiceInput-лис labelPosition пикрилизи хӀебуцу
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-лис гибти индексуни пикрилизи хӀебуцу, сенкӀун илдала лугӀи choice дурхӀнала лугӀилис цугхӀебикур.
+
+pretzel-indices-count-mismatch = problem-лис гибти индексуни пикрилизи хӀебуцу, сенкӀун илдала лугӀи problem дурхӀнала лугӀилис цугхӀебикур.
+
+shuffle-indices-count-mismatch = shuffle-лис гибти индексуни пикрилизи хӀебуцу, сенкӀун илдала лугӀи компонентунала лугӀилис цугхӀебикур.
+
+indices-ignored-out-of-range = { $component } элементлис гибти индексуни пикрилизи хӀебуцу, сенкӀун цацадехӀ дозализирад дурадулхъан.
+
+pretzel-indices-repeated = pretzel-лис гибти индексуни пикрилизи хӀебуцу, сенкӀун цацадехӀ гьатӀира дучӀули сари.
+
+pretzel-circuit-first-index = circuit режимлизиб pretzel-лис гибти индексуни пикрилизи хӀебуцу, сенкӀун ункъала индекс 1 биэс гӀягӀниси саби.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текстла дурхӀначил хӀянчибирахъес `type` атрибут гес гӀягӀниси саби.
+
+invalid-type-defaulting-to-math = { $component } компонентлис бархьси ахӀенси тип { $type }. Ил math, text, number яра boolean биэс гӀягӀниси саби. math пайдалабиру.
+
+string-not-valid-component-to-arrange = «{ $value }» текст { $component } барес бирути компонент ахӀен. Пикрилизи хӀебуцу.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Бархьси ахӀенси тип { $type }, тип number бирар.
+
+invalid-variable-value = Дарсдирусила бархьси ахӀенси кьимат: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантла индекс лугӀи биэс гӀягӀниси саби
+
+variant-index-must-be-integer = { $index } вариантла индекс бухӀнабуцибси лугӀи биэс гӀягӀниси саби
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютный умцлумас барили ахӀен. Ширина бархбасунсиличи шурбулхъан.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютный умцлумас барили ахӀен. Дубани бархбасунсиличи шурдулхъан.
+
+side-by-side-no-block-child = Бархьси ахӀенси `<{ $component }>`: илала камлира ца блок дурхӀя биэс гӀягӀниси саби.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементла `for` атрибут пикрилизи хӀебуцу.
+
+label-for-must-resolve-to-one = `<label>` элементла `for` атрибут ца компонентличи бен хӀерси биэс гӀягӀниси саби.
+
+label-for-unresolved = `<label>` элементла `for` атрибут компонентличил бархбасахъес хӀебирар.
+
+label-for-answer-with-authored-inputs = `<label>` элементла `for` атрибут авторли делкӀунти чебухъантачилси `<answer>` элементличи хӀерси саби; чебухъанничи гьаннала хӀерси биахъа.
+
+label-for-answer-without-input = `<label>` элементла `for` атрибут лишанбирес чебухъан агарси `<answer>` элементличи хӀерси саби.
+
+label-for-must-reference-input-or-answer = `<label>` элементла `for` атрибут чебухъанничи яра жавабличи хӀерси биэс гӀягӀниси саби.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Гьаргдешлис `<{ $component }>` элементла къантӀси баян биэс гӀягӀниси саби, яра ил жагабирусиличи халбарес гӀягӀниси саби.
+
+accessibility-video-short-description = Гьаргдешлис `<video>` элементла къантӀси баян биэс гӀягӀниси саби.
+
+accessibility-input-short-description-or-label = Гьаргдешлис `<{ $component }>` элементла къантӀси баян яра лишан биэс гӀягӀниси саби.
+
+accessibility-answer-input-short-description-or-label = Гьаргдешлис чебухъан бируси `<answer>` элементла къантӀси баян яра лишан биэс гӀягӀниси саби.
+
+accessibility-short-description-contains-math = КъантӀти баянтазир `<{ $component }>` гъуна математикала компонентуни диэс хӀейгеси саби. Математика девлумачил белкӀа.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } бикӀусилис бекӀла текстлис гӀягӀниси контраст агара (цӀудара режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камлира { $threshold }:1 гӀягӀниси саби).
+       *[other] { $colorName } бикӀусилис бекӀла текстлис гӀягӀниси контраст агара ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камлира { $threshold }:1 гӀягӀниси саби).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Точкабала лугӀила кьиматуни агархӀели { $count } точкализирад башуси `<circle>` барили ахӀен.
+
+circle-too-many-through-points = ХӀябал точкалицад имцӀалирад башуси окружность хӀисаббарес хӀебирар.
+
+circle-overprescribed-radius-center-points = Гибси радиус, юкӀ ва точкаби лерли окружность хӀисаббарес хӀебирар.
+
+circle-center-with-multiple-points = Гибси юкӀличил ца точкалицад имцӀалирад башуси окружность хӀисаббарес хӀебирар.
+
+circle-radius-too-small = Окружность хӀисаббарес хӀебирар: кӀел точкала ургабси гьуни { $distance } биублихӀели, гибси радиус { $radius } бегӀлара биштӀаси саби.
+
+circle-radius-with-many-points = Гибси радиусличил кӀел точкалицад имцӀалирад башуси окружность барес хӀебирар.
+
+circle-invalid-center-or-through-points = Окружностьла юкӀ яра точкаби бархьти ахӀен.
+
+circle-radius-center-with-multiple-points = Гибси юкӀличил ца точкалицад имцӀалирад башуси окружностьла радиус хӀисаббарес хӀебирар.
+
+circle-change-radius-non-numerical = ЛугӀила кьиматуни агарти точкабачилси окружностьла радиус дарсбарес хӀебирар
+
+circle-radius-with-points-non-numerical = ЛугӀила кьиматуни агархӀели гибси радиусличил ца точкалицад имцӀалирад башуси окружность барес хӀебирар.
+
+circle-change-center-non-numerical = ЛугӀила кьиматуни агарти точкабазирад башуси окружностьла юкӀ дарсбирни барили ахӀен.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцияла областьла кьадар камли саби. Областьлизиб { $intervals } интервал леб, функциялизиб биалли { $inputs ->
+            [one] { $inputs } вход
+           *[other] { $inputs } вход
+        } леб.
+       *[other] Функцияла областьла кьадар камли саби. Областьлизиб { $intervals } интервал леб, функциялизиб биалли { $inputs ->
+            [one] { $inputs } вход
+           *[other] { $inputs } вход
+        } леб.
+    }
+
+function-domain-invalid-format = Функцияла областьла формат бархьси ахӀен.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцияла лугӀила ахӀенси максимум пикрилизи хӀебуцу.
+        [minimum] Функцияла лугӀила ахӀенси минимум пикрилизи хӀебуцу.
+        [extremum] Функцияла лугӀила ахӀенси экстремум пикрилизи хӀебуцу.
+        [point] Функцияла лугӀила ахӀенси точка пикрилизи хӀебуцу.
+        [slope] Функцияла лугӀила ахӀенси наклон пикрилизи хӀебуцу.
+       *[other] Функцияла лугӀила ахӀенси { $type } пикрилизи хӀебуцу.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцияла бацӀси максимум пикрилизи хӀебуцу.
+        [minimum] Функцияла бацӀси минимум пикрилизи хӀебуцу.
+        [extremum] Функцияла бацӀси экстремум пикрилизи хӀебуцу.
+        [point] Функцияла бацӀси точка пикрилизи хӀебуцу.
+       *[other] Функцияла бацӀси { $type } пикрилизи хӀебуцу.
+    }
+
+function-points-too-close = Функциялизир цаличи ца бегӀлара гъамли кадиибти кӀел точка лер. Функция билгӀабарес хӀебирар.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцияла итерацияби дирар входунала лугӀи выходунала лугӀилис цугбикибхӀели бен. Иш функциялизиб { $inputs } вход ва { $outputs ->
+            [one] { $outputs } выход
+           *[other] { $outputs } выход
+        } леб.
+       *[other] Функцияла итерацияби дирар входунала лугӀи выходунала лугӀилис цугбикибхӀели бен. Иш функциялизиб { $inputs } вход ва { $outputs ->
+            [one] { $outputs } выход
+           *[other] { $outputs } выход
+        } леб.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Последовательностьла бухъяндеш бархьси ахӀен. Ил минусличил ахӀенси бухӀнабуцибси лугӀи биэс гӀягӀниси саби.
+
+sequence-invalid-step = Последовательностьла шаг бархьси ахӀен. { $type } типла последовательностьлис ил лугӀи биэс гӀягӀниси саби.
+
+sequence-invalid-endpoint-number = ЛугӀила последовательностьла «{ $attribute }» бархьси ахӀен. Ил лугӀи биэс гӀягӀниси саби.
+
+sequence-invalid-endpoint-letters = ХӀярпунала последовательностьла «{ $attribute }» бархьси ахӀен. Ил хӀярпунала цалабикни биэс гӀягӀниси саби.
+
+sequence-invalid-endpoint = Последовательностьла «{ $attribute }» бархьси ахӀен.
+
+select-from-sequence-coprime-not-numbers = лугӀни чердикӀули ахӀенти сабливан coprime пикрилизи хӀебуцу
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations гибси сабливан coprime пикрилизи хӀебуцу
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` элементлис бархьси ахӀенси target: мурад хӀебаргиб.
+
+target-state-variable-not-found = `<{ $source }>` элементлис бархьси ахӀенси target: `<{ $component }>` элементлизиб «{ $property }» бикӀуси хӀялла кьимат хӀебаргиб.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` элементла дарсдирути сунезибадал ахӀенси дарсдирусиличибад декӀарти диэс гӀягӀнити сари.
+
+ode-system-duplicate-variable-names = ГьатӀира дучӀути умани лерти дарсдирутачил ДУ-ла аьтула функцияби билгӀадарес хӀедирар.
+
+ode-system-rhs-function-error = ДУ-ла аьтула функция билгӀабарес хӀебирар. mathjs функция барухӀели хатӀа.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } линияла ургабси угол билгӀабарес хӀебирар
+
+angle-invalid-through-point = `<angle>` элементла through бикӀусилизиб бархьси ахӀенси точка
+
+parabola-vertex-too-many-points = Гибси бекӀличил ца точкалицад имцӀалирад башуси парабола барили ахӀен.
+
+parabola-too-many-points = ХӀябал точкалицад имцӀалирад башуси парабола барили ахӀен.
+
+intersection-too-many-items = КӀел секӀайцад имцӀали секӀайс кабикибси мер барили ахӀен
+
+## Other math components
+
+ionic-compound-not-two-ions = КӀел ионничибад декӀарси ионтала цалабикни барили ахӀен.
+
+ionic-compound-needs-cation-and-anion = Ионтала цалабикни ца катионнис ва ца анионнис бен барили ахӀен.
+
+solve-equations-cannot-evaluate = Уравнение арзес хӀебирар, сенкӀун ил хӀисаббарес хӀебиуб: { $equation }
+
+math-operators-operand-number-required = Математикала операнд касес operandNumber гес гӀягӀниси саби.
+
+eigen-decomposition-failed = Матрицала сунела кьиматуни хӀисабдарес хӀедиуб
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр шаблонализиб агара, гьадила ил даимлис бацӀсиличил цугбикур.
+       *[other] `<matchesPattern>`: { $parameters } параметруни шаблонализир агара, гьадила илди даимлис бацӀсиличил цугдикур.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" бикӀусила мягӀна бургес хӀебирар. Ил none, medium, dense яра мер-мерличил декӀарбарибти кӀел плюсла лугӀи биэс гӀягӀниси саби, масала grid="1 0.5". Сетка хӀебалкьахъу.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` элементлис гӀягӀниси функциялизиб { $expected ->
+        [one] ца выход, гьар точкализибси наклон y', масала `y - x`,
+       *[other] кӀел выход, гьар точкализибси вектор, масала `(y, -x)`,
+    } биэс гӀягӀниси саби, гибси функциялизиб биалли { $found ->
+        [one] { $found } выход
+       *[other] { $found } выход
+    } леб. { $alternative ->
+        [none] СекӀалра хӀебалкьахъу.
+       *[other] Ил функциялис `<{ $alternative }>` компонент саби. СекӀалра хӀебалкьахъу.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибут пикрилизи хӀебуцу, сенкӀун функция компонентла бухӀнабра гибси саби; бухӀнабси пайдалабиру. Функция кӀелрад ца гьунчиб бен ма гу.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибутли компонентла бухӀнаб белкӀунси выражениела дарсдирути умдеш. { $reason ->
+        [function-child] Иш функция `<function>` дурхӀя сабливан гибси саби, илини сунела дарсдирути сунени умдеш, гьадила `variables` пикрилизи хӀебуцу.
+       *[no-expression] ИшбахӀ ил гъуна выражение агара, гьадила `variables` пикрилизи хӀебуцу.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure бирусилизиб xLabelPosition="left" барили ахӀен; аьтула мерла къяйда пайдалабиру.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure бирусилизиб yLabelPosition="bottom" барили ахӀен; чедила мерла къяйда пайдалабиру.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure-личи шурбатес осьла дозани бархьти ахӀен; бехӀбихьудла bbox (-10,-10,10,10) пайдалабиру.
+
+prefigure-invalid-width = `<graph>`: prefigure-личи шурбатес ширина бархьси ахӀен; диаграммала бехӀбихьудла ширина 425 пайдалабиру.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure-личи шурбатес aspectRatio бархьси ахӀен; бехӀбихьудла бяхӀянала кьадар 1 пайдалабиру.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткала шаг осьла дозанас бегӀлара биштӀаси саби; prefigure бирусилизиб сетка хӀебалкьахъу.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure бируси хӀепайдалабирухӀели лишанти хӀедалкьахъу.
+
+multiple-annotations-children = `<graph>` бухӀнаб дахъал `<annotations>` дурхӀни даргиб; ахирличибсиличибад декӀарти лерилра пикрилизи хӀедуцу.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Бевзуси ахӀенси компонентла тип бушбарес яра копия барес хӀебирар: { $type }.
+
+copy-prop-not-found = { $component } типла компонентлизиб { $property } бикӀуси хасдеш хӀебаргиб
+
+collect-no-source = collect-лис хьулчи хӀебаргиб.
+
+collect-invalid-component-type = `<{ $component }>` типла компонентуни цалабирхъес хӀедирар, сенкӀун ил бархьси ахӀенси компонентла тип саби.
+
+reference-index-unavailable = `{ $reference }` бикӀуси индексличи хӀерси барес хӀебирар
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентлизиб { $action } жибарес хӀебирар
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Хабардала кеп бархьси ахӀен. Жергнала бухъяндеш цугхӀебикур. Баргибси componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Хабардализир столбецунала умани гьатӀира дучӀули сари. Баргибси componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Хабардализиб столбецла у агара. Баргибси componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Иш жавабла award сунела answer тегли бархьибси жавабличи хӀерси саби, илини хӀебалуси хӀялличи биркахъес асубирар.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` лебси контейнерла бухӀнабси `<answer>` элементлис `maxNumAttempts` кабизахъни секӀайчи хӀебиркур, сенкӀун попыткабала лугӀи контейнерли билгӀабиру. `maxNumAttempts` контейнерлис кабизахъа.
+
+nested-section-wide-check-work-max-num-attempts = ЦархӀил `sectionWideCheckWork` лебси контейнерла бухӀнабси `sectionWideCheckWork` лебси контейнерлис `maxNumAttempts` кабизахъни секӀайчи хӀебиркур, сенкӀун попыткабала лугӀи дурала контейнерли билгӀабиру. `maxNumAttempts` дурала контейнерлис кабизахъа.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality кабизахъили агарли { $attributes } атрибут секӀайчи хӀебиркур.
+       *[other] symbolicEquality кабизахъили агарли { $attributes } атрибутуни секӀайчи хӀедиркур.
+    }
+
+answer-invalid-type = answer-лис бархьси ахӀенси тип: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентла у агара, гьадила ил модульла атрибут сабливан пайдалабарес хӀебирар
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонент модульла атрибут сабливан пайдалабарес хӀебирар, сенкӀун `<module>` компонентла типлизиб гьаннала «{ $name }» атрибут билгӀабарибси саби.
+
+conditional-content-condition-ignored = case яра else дурхӀни лерти `<conditionalContent>` компонентлизиб `condition` атрибут пикрилизи хӀебуцу.
+
+slider-markers-type-mismatch = Маркертала тип ползунокла типлис цугхӀебикур.
+
+pretzel-problem-needs-statement-and-answer = Бархьси ахӀенси pretzel: гьар `<problem>` бухӀнаб ца `<statement>` ва ца `<answer>` биэс гӀягӀниси саби.
+
+pretzel-circuit-first-problem-distractor = Бархьси ахӀенси pretzel: mode="circuit" режимлизиб ункъала `<problem>` пикри архьуси биэс хӀейгеси саби.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутлис бархьси ахӀенси кьимат { $values }; пикрилизи хӀебуцу.
+       *[other] `{ $attribute }` атрибутлис бархьти ахӀенти кьиматуни { $values }; пикрилизи хӀедуцу.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутлис бархьси ахӀенси кьимат `{ $value }`. Атрибут `$` лишанничибад бехӀбирхьути хӀерсиличибад кабикибси биэс гӀягӀниси саби.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } бухӀнабси бархьти ахӀенти функцияла умани пикрилизи хӀедуциб: { $names }. Гьар ула чебиуси бутӀализиб камлира 2 лишан биэс гӀягӀниси саби (хӀярпани яра дефисуни); илала гӀергъи гӀягӀниси ахӀенси `|<mathspeak альтернатива>` кабиркес асубирар.
+
+## Building components from the source
+
+component-type-invalid = Бархьси ахӀенси компонентла тип: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут гьатӀира белкӀес хӀебирар.
+
+attribute-invalid-for-component = `<{ $componentType }>` типла компонентлис бархьси ахӀенси атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стильла билгӀабарнилизиб { $context ->
+        [text-on-background] текстла ранг ва фонна ранг
+        [high-contrast] халаси контрастла ранг ва суратла мер
+        [line] линияла ранг ва суратла мер
+        [marker] маркерла ранг ва суратла мер
+       *[text-on-canvas] текстла ранг ва суратла мер
+    } ургаб гӀягӀниси контраст агара{ $mode ->
+        [dark] { " (цӀудара режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камлира { $threshold }:1 гӀягӀниси саби).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стильла билгӀабарнилизиб гибти рангани шаласи режимлис гӀягӀниси контраст лугули диалра, илдазирад дурадухъунти цӀудара режимла ранганас текстла ва фонна ургаб гӀягӀниси контраст агара ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камлира { $threshold }:1 гӀягӀниси саби). { $suggestion ->
+        [available] ЦӀудара режимлизиб гӀягӀниси контраст биахъес, яра шаласи режимла контраст имцӀабара (масала { $lightAttribute }="{ $lightColor }" кабизахъа), яра цӀудара режимла ранг дарсбара (масала { $darkAttribute }="{ $darkColor }" кабизахъа).
+       *[none] ЦӀудара режимлизиб гӀягӀниси контраст биахъес шаласи режимла контраст имцӀабара, яра дурадухъунти рангани textColorDarkMode ва/яра backgroundColorDarkMode-личил дарсдара.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стильла билгӀабарнилизиб гибси текстла ранг шаласи режимлис гӀягӀниси контраст лугули биалра, илизирад дурабухъунси цӀудара режимла текстла рангли суратла мерличил гӀягӀниси контраст хӀелугу ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; камлира { $threshold }:1 гӀягӀниси саби). { $suggestion ->
+        [available] ЦӀудара режимлизиб гӀягӀниси контраст биахъес, яра шаласи режимла контраст имцӀабара (масала textColor="{ $lightColor }" кабизахъа), яра цӀудара режимла ранг дарсбара (масала textColorDarkMode="{ $darkColor }" кабизахъа).
+       *[none] ЦӀудара режимлизиб гӀягӀниси контраст биахъес шаласи режимла контраст имцӀабара, яра дурабухъунси ранг textColorDarkMode-личил дарсбара.
+    }
+
+section-multiple-style-palettes = БекӀли ца <stylePalette> бен чеббикӀес хӀебирар; ахирличибси пайдалабиру.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун numToSelect минусличил ахӀенси бухӀнабуцибси лугӀи ахӀен.
+
+variant-num-to-select-not-constant-number = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун numToSelect дарсхӀебируси лугӀи ахӀен.
+
+variant-with-replacement-not-constant-boolean = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун withReplacement дарсхӀебируси логикала кьимат ахӀен.
+
+variant-select-weight-disables-unique = ца харжлизиб selectWeight яра selectForVariants гибси биалли, select-ла декӀар-декӀарти вариантуни хӀедирар
+
+variant-coprime-undetermined = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун coprime даимлис къяна саби или билгӀабарес хӀебирар.
+
+variant-attribute-not-constant = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун { $attribute } дарсхӀебируси ахӀен.
+
+variant-attribute-not-number = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун { $attribute } лугӀи ахӀен.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } типла { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун { $attribute } { $expected ->
+        [letters-combination] хӀярпунала цалабикни
+        [math-expression] бархьси математикала выражение
+        [integer] бухӀнабуцибси лугӀи
+       *[number] лугӀи
+    } ахӀен.
+
+variant-length-not-integer = { $component } элементла декӀар-декӀарти вариантуни билгӀадарес хӀедирар, сенкӀун length бухӀнабуцибси лугӀи ахӀен.
+
+variant-sort-not-implemented = sort лебси { $component } элементла декӀар-декӀарти вариантуни дарили ахӀен
+
+variant-exclude-combinations-not-implemented = excludeCombinations лебси { $component } элементла декӀар-декӀарти вариантуни дарили ахӀен
+
+variant-math-exclude-not-implemented = exclude лебси math типла { $component } элементла декӀар-декӀарти вариантуни дарили ахӀен
+
+variant-non-constant-exclude-not-implemented = дарсбируси exclude лебси { $component } элементла декӀар-декӀарти вариантуни дарили ахӀен
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикла prefigure бирусилизиб барили ахӀен; тухум архьибси саби.
+
+prefigure-descendant-invalid-geometry = { $subject }: ахир агарси яра таманси ахӀенси геометрия; тухум архьибси саби.
+
+prefigure-curve-label-omitted = { $subject }: шурбатурти кривая элементуначир лишанти дарили ахӀен; лишан архьибси саби.
+
+prefigure-curve-unsupported-definition-type = { $subject }: барили ахӀенси кривая функцияла билгӀабарнила тип «{ $definitionType }»; тухум архьибси саби.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементла flipFunctions атрибут барили ахӀен; тухум архьибси саби.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves элементлис формулала типла дурхӀнала функцияби бен хӀедуцу; тухум архьибси саби.
+
+prefigure-label-position-unsupported =
+    { $subject }: барили ахӀенси labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] линиябала тухумла лишанлис
+       *[point] точкала лишанлис
+    }; PreFigure-ла бехӀбихьудла кабизахъни пайдалабиру.
+
+prefigure-fill-style-unsupported = { $subject }: бицӀнила стиль «{ $fillStyle }» PreFigure-ли хӀебуцу; лерилра бицӀуси рангличи шурбулхъан.
+
+prefigure-line-style-unknown = { $subject }: бевзуси ахӀенси линияла стиль «{ $lineStyle }» PreFigure-ла дурабуцнилизирад архьибси саби.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркерла стиль «{ $markerStyle }» PreFigure-ла «diamond» стильличил цугбарибси саби.
+
+prefigure-marker-style-unsupported = { $subject }: маркерла стиль «{ $markerStyle }» PreFigure-ли хӀебуцу; бехӀбихьудла стиль пайдалабиру.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: бархьси ахӀенси `ref`; мурад баргес хӀебирар. Лишан архьибси саби.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` дахъал мурадуначил бархбасунси саби; ункъала мурад пайдалабиру.
+
+annotation-ref-outside-graph = `<annotation>`: бархьси ахӀенси `ref`; мурад сунезибси графикла дураб саби. Лишан архьибси саби.
+
+annotation-ref-unsupported-target = `<annotation>`: бархьси ахӀенси `ref`; мурад prefigure-личи шурбатнилизиб бируси график секӀал ахӀен. Лишан архьибси саби.
+
+annotation-text-missing = `<annotation>`: `text` агара яра бацӀси саби; бацӀси текст дурабулхъан.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Гуми гъуна хӀерси баргибси саби.
+       *[other] `<{ $componentType }>` компонентличилси гуми гъуна хӀерси баргибси саби.
+    }
+
+reference-no-referent = ХӀерсилис мурад хӀебаргиб: `{ $reference }`
+
+reference-multiple-referents = ХӀерсилис дахъал мурадуни даргиб: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементла { $attribute } атрибутла формат бархьси ахӀен.
+
+children-invalid = `<{ $componentType }>` элементлис бархьти ахӀенти дурхӀни: бархьти ахӀенти дурхӀни даргиб: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутлис бархьси ахӀенси кьимат `{ $value }`; `{ $default }` кьимат пайдалабиру
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версия хӀебаргиб.
+       *[other] DoenetML { $version } версия хӀебаргиб. { $fallback } версия пайдалабиру
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Бархьси ахӀенси DoenetML: { $content }
+
+parse-tag-missing-close-tag = Бархьси ахӀенси DoenetML: `{ $tag }` тегла кӀапӀбируси тег агара. Сунени сай кӀапӀбируси тег яра `</{ $tagName }>` тег хӀяжатси сабри.
+
+parse-tag-error = Бархьси ахӀенси DoenetML: `<{ $tagName }>` теглизиб хатӀа
+
+parse-attribute-missing-value = Бархьси ахӀенси DoenetML: `{ $attribute }` атрибутлис кьимат агарсиван саби.
+
+parse-attribute-invalid = Бархьси ахӀенси DoenetML: бархьси ахӀенси атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Бархьси ахӀенси DoenetML: атрибутла бархьси ахӀенси кьимат `{ $value }`
+
+parse-attribute-value-quote-mismatch = Бархьси ахӀенси DoenetML: атрибутла бархьси ахӀенси кьимат `{ $value }`. Кавычкаби цугхӀедикур. `{ $quote }` агарсиван саби
+
+parse-open-tag-name-missing = Бархьси ахӀенси DoenetML: у агарси тег баргибси саби, масала `<`
+
+parse-tag-not-closed = Бархьси ахӀенси DoenetML: `{ $tag }` тег кӀапӀбарили ахӀен (`>` агарсиван саби).
+
+parse-self-closing-tag-name-missing = Бархьси ахӀенси DoenetML: у агарси тег баргибси саби `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Бархьси ахӀенси DoenetML: `{ $tag }` тег кӀапӀбарили ахӀен (`/>` агарсиван саби).
+
+parse-tag-invalid-attributes = Бархьси ахӀенси DoenetML: `{ $tag }` тег бархьси ахӀен. Илала атрибутуни бархьти ахӀенти диэс асубирар.
+
+parse-close-tag-name-missing = Бархьси ахӀенси DoenetML: у агарси кӀапӀбируси тег баргибси саби, масала `</`
+
+parse-attribute-value-unquoted = Атрибутла кьиматуни кавычкабала бухӀнар диэс гӀягӀнити сари: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Бархьси ахӀенси DoenetML: `{ $tag }` кӀапӀбируси тег баргибси саби, амма илис цугбикуси абхьибси тег агара
+
+parse-close-tag-mismatched = Бархьси ахӀенси DoenetML: цугхӀебикуси кӀапӀбируси тег. `</{ $expected }>` хӀяжатси сабри. `{ $found }` баргибси саби
+
+parser-node-unconvertible = { $node } узел Dast узелличи шурбатес хӀебиуб.
+
+## Names
+
+name-attribute-invalid =
+    Бархьси ахӀенси атрибут name='{ $name }'. { $reason ->
+        [characters] Умазир хӀярпани, лугӀни, удила сизри яра дефисуни бен диэс хӀедирар.
+       *[start] Умани хӀярпличибад дехӀдирхьути диэс гӀягӀнити сари.
+    }
+
+component-name-invalid-start = Бархьси ахӀенси компонентла у «{ $name }». Умани хӀярпличибад дехӀдирхьути диэс гӀягӀнити сари.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched типла answer-лизиб video атрибут биэс гӀягӀниси саби
+
+answer-video-watched-video-not-reference = videoWatched типла answer-ла video атрибут хӀерси биэс гӀягӀниси саби
+
+answer-name-not-single-text = answer-ла name атрибутлизиб ца текстла дурхӀя бен биэс хӀейгеси саби
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсияла даражаби бегӀлара дахъал сарливан дурала DoenetML касес хӀебиуб. Гуми гъуна хӀерси лебалав?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" бикӀусилизирад DoenetML касес хӀебиуб
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" бикӀусилизирад бархьси ахӀенси DoenetML касибси саби: ил «{ $componentType }» компонентла типлис цугхӀебикиб
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут гӀелабси саби; илала мерличиб `{ $to }` пайдалабара.
+       *[other] [deprecation] `<{ $component }>` элементла `{ $from }` атрибут гӀелабси саби; илала мерличиб `{ $to }` пайдалабара.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут гӀелабси саби ва пикрилизи хӀебуцу, сенкӀун `{ $to }` бирахъалра гибси саби.
+       *[other] [deprecation] `<{ $component }>` элементла `{ $from }` атрибут гӀелабси саби ва пикрилизи хӀебуцу, сенкӀун `{ $to }` бирахъалра гибси саби.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементла `{ $attribute }` атрибут гӀелабси саби ва пикрилизи хӀебуцу.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементла `{ $attribute }` атрибут гӀелабси саби; илала мерличиб `<{ $child }>` дурхӀя пайдалабара.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементла `{ $attribute }` атрибутла `{ $value }` кьимат гӀелабси саби; илала мерличиб `{ $to }` пайдалабара.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ингилис мезличиб бен дахъалсиличи шурбатес хӀебирар, гьадила { $locale } мезличиб белкӀунси документлизиб илала текст дарсхӀебарили кализур. Дахъалсила кеп сунени белкӀа, яра ил `pluralForm` атрибутличил кабизахъа.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент бевзуси Doenet элемент ахӀен.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементлис документла хьулчилизиб бажардидеш агара.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементлис `<{ $parent }>` бухӀнаб бажардидеш агара.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементлизиб `{ $attribute }` бикӀуси атрибут агара.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементла `{ $attribute }` атрибут гьар секӀал иштазирад цали бируси список биэс гӀягӀниси саби: { $allowed }
+       *[other] `<{ $tag }>` элементла `{ $attribute }` атрибут иштазирад ца биэс гӀягӀниси саби: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select-лис бархьси ахӀенси вариантла у. { $variantName } вариантла у { $numOptions } харжлизиб бургу, чеббикӀес гӀягӀнити биалли { $numToSelect } сари.
+
+select-variant-name-without-options = select-лис цацадехӀ вариантуни гибти сари, амма биэс бируси вариантла улис ца харжра агара: { $variantName }.
+
+select-variant-name-not-possible = select-лис гибси { $variantName } вариантла у биэс бируси вариантла у ахӀен.
+
+select-too-few-options = Ца { $numOptions } секӀайзирад { $numToSelect } компонент чеббикӀес хӀебирар.
+
+select-from-sequence-too-few-values = Бухъяндеш { $length } сабси последовательностьлизирад { $numToSelect } кьимат чеббикӀес хӀебирар.
+
+select-from-sequence-indices-count-mismatch = select-лис гибти индексунала лугӀи чеббикӀес гӀягӀнитала лугӀилис цугбикуси биэс гӀягӀниси саби
+
+select-from-sequence-indices-not-integers = select-лис гибти лерилра индексуни бухӀнабуцибти лугӀни диэс гӀягӀнити сари
+
+select-from-sequence-index-excluded = дурабуцибси selectfromsequence-ла индекс гибси сабри
+
+select-from-sequence-indices-excluded-combination = дурабуцибси цалабикни сабси selectfromsequence-ла индексуни гибти сарри
+
+select-from-sequence-coprime-not-positive-integers = плюсла бухӀнабуцибти лугӀни чердикӀули ахӀенти сабливан цаличи ца хьалхаагарти цалабикни чердикӀес хӀедирар.
+
+select-from-sequence-coprime-common-factor = Цаличи ца хьалхаагарти лугӀни чердикӀес хӀедирар. Биэс бирути лерилра кьиматунас ца цугси бутӀуси леб. (Гибти "from" яра "to" кьиматуни "step"-личи хьалхаагарти диэс гӀягӀнити сари.)
+
+select-from-sequence-coprime-single-number = 1 ахӀенси ца лугӀилизирад цаличи ца хьалхаагарти цалабикни чердикӀес хӀедирар.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence бухӀнаб цалабикнала 70%-личибад имцӀали дурадуциб
+
+select-from-sequence-coprime-none-found = Цаличи ца хьалхаагарти лугӀни чердикӀес хӀедиуб. Биэс бирути лерилра кьиматунас ца цугси бутӀуси леб.
+
+select-from-sequence-too-few-unique-values = Бухъяндеш { $numPossibleValues } сабси последовательностьлизирад { $numToSelect } декӀарси кьимат чеббикӀес хӀебирар
+
+select-prime-numbers-too-few-values = Бухъяндеш { $numValues } сабси ункъала лугӀнала спискализирад { $numToSelect } кьимат чеббикӀес хӀебирар
+
+select-prime-numbers-values-count-mismatch = select-лис гибти кьиматунала лугӀи чеббикӀес гӀягӀнитала лугӀилис цугбикуси биэс гӀягӀниси саби
+
+select-prime-numbers-values-not-prime = select prime number-лис гибти лерилра кьиматуни ункъала лугӀнала спискализир диэс гӀягӀнити сари
+
+select-prime-numbers-values-excluded-combination = дурабуцибси цалабикни сабси selectPrimeNumbers-ла кьиматуни гибти сарри
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers бухӀнаб цалабикнала 70%-личибад имцӀали дурадуциб
+
+select-random-combination-fluke = БегӀлара камли биэс бируси хӀялли хӀебалуси кьиматунала цалабикни чеббикӀес хӀебиуб
+
+select-random-value-fluke = БегӀлара камли биэс бируси хӀялли хӀебалуси кьимат чеббикӀес хӀебиуб

--- a/packages/i18n/locales/dar/editor.ftl
+++ b/packages/i18n/locales/dar/editor.ftl
@@ -1,0 +1,230 @@
+# Dargwa editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The Akusha-based literary standard, in Cyrillic; `content.ftl`'s header says
+# what that choice means for a reader of another Dargwa variety. The palochka Ӏ
+# is a letter, not a Latin I and not a digit 1.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Dargwa counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+#
+# Nothing here agrees with a noun class. Dargwa has one, and `content.ftl`
+# explains why it reaches exactly one message in the whole catalog.
+#
+# `editor-diagnostic-line` prints the line number after a word rather than
+# before it, because a Dargwa ordinal is built with «-ибил» on the numeral
+# itself and the numeral here is a value this catalog never sees.
+#
+# «гьаргдеш» for *accessibility* is the same transparent coinage `chrome.ftl`
+# uses, from «гьаргси» (open); it is not an attested term and a speaker should
+# replace it if one exists.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Чарбара
+       *[update] Сагабара
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Чебиахъуси { $word }
+       *[other] Чебиахъуси { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = ЧердикӀни…
+editor-variant-next = ГӀергъиси вариант чеббикӀа
+editor-variant-previous = Гьалабси вариант чеббикӀа
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA гьаргдешла дохни баргибси саби. Гьаргдешла отчёт { $action ->
+            [close] кӀапӀбарес
+           *[open] абхьес
+        } кабяхъа.
+        [advisories] Гьаргдешла отчёт { $action ->
+            [close] кӀапӀбарес
+           *[open] абхьес
+        } кабяхъа. WCAG AA дохнуби хӀедаргиб, амма цархӀилти гьаргдешла гьанбушнуби лер.
+       *[clean] Гьаргдешла отчёт { $action ->
+            [close] кӀапӀбарес
+           *[open] абхьес
+        } кабяхъа. Гьаргдешла суалти хӀедаргиб.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA гьаргдешла дохни баргибси саби. { $count ->
+            [one] { $count } WCAG AA дохни
+           *[other] { $count } WCAG AA дохни
+        } баргибси саби. Гьаргдешла отчёт { $action ->
+            [close] кӀапӀбарес
+           *[open] абхьес
+        } кабяхъа.
+        [advisories] WCAG AA дохнуби хӀедаргиб. { $count ->
+            [one] { $count } гьаргдешла гьанбушни
+           *[other] { $count } гьаргдешла гьанбушни
+        } баргибси саби. Гьаргдешла отчёт { $action ->
+            [close] кӀапӀбарес
+           *[open] абхьес
+        } кабяхъа.
+       *[clean] WCAG AA дохнуби хӀедаргиб. Гьаргдешла отчёт { $action ->
+            [close] кӀапӀбарес
+           *[open] абхьес
+        } кабяхъа.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML { $version } версия
+
+editor-tab-help = Контекстличи хӀерси кумек
+editor-tab-help-short = Контекст
+editor-tab-errors = ХатӀаби
+editor-tab-warnings = Балахънуби
+editor-tab-info = Хабар
+editor-tab-accessibility = Гьаргдеш
+editor-tab-responses = Бархьибти жавабти
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторла кабизуни
+editor-format-as-doenetml = DoenetML сабливан форматбара
+editor-format-as-xml = XML сабливан форматбара
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Жерге #{ $line }
+
+editor-no-errors = ХатӀаби агара
+editor-no-warnings = Балахънуби агара
+editor-no-info = Хабарла хӀеруди агара
+
+editor-show-info-annotations = Хабарла хӀеруди редакторлизиб чебаахъа
+editor-show-accessibility-annotations = Гьаргдешла хӀеруди редакторлизиб чебаахъа
+
+editor-accessibility-learn-more = Doenet гьаргдешличи сен хӀерхӀерулил бала
+
+editor-accessibility-violations-heading = Гьаргдешла дохнуби ({ $standard })
+
+editor-accessibility-other-heading = ЦархӀилти гьаргдешла суалти
+editor-none-found = СекӀалра хӀебаргиб
+
+
+## Submitted responses
+
+editor-no-responses = Гьачамалра жаваб бархьили ахӀен
+editor-response-answer-id = Жавабла Id
+editor-response-response = Жаваб
+editor-response-credit = Балл
+editor-response-submitted = Бархьибси
+
+
+## The context-help panel
+
+help-placeholder = Документация чебаахъес курсор тегла уличи, атрибутличи яра { $ref } бикӀусиличи кабизахъа.
+
+help-unsupported-ref-chain = { $example } гъуна дахъал бутӀала хӀерсилис кумек гьачамлис агара.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ХӀерсилис мурад хӀебаргиб: { $ref }.
+        [multiple] ХӀерсилис дахъал мурадуни даргиб: { $ref }.
+       *[indeterminate] { $ref } бикӀусила мурад билгӀабарес хӀебиуб.
+    }
+
+help-learn-about-references = ХӀерсила хӀекьлизиб бала →
+help-reference-page = Хасбарибси бяхӀ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } бухӀнаб
+       *[top] Чедила даражаличиб
+    }{ $allowed ->
+        [none] { " — ишбахӀ секӀалра хӀебирар." }
+        [text] { " — ишбахӀ текст белкӀес бирар." }
+        [text-and-components] { " — ишбахӀ текст белкӀес бирар, яра ишди зягӀипдара:" }
+       *[components] { " — ишди зягӀипдара:" }
+    }
+
+help-suggestions-footer = Лерилра { $total } компонент чебаахъес { $shortcut } кабяхъа.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } бикӀусиличи хӀерси саби.
+       *[other] { $ref } — { $target } бикӀусиличи хӀерси саби ({ $line } жерге).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ил { $owner } бикӀусили { $role } сабливан чебуцибси саби.
+       *[other] Ил { $owner } бикӀусили { $line } жергелизиб { $role } сабливан чебуцибси саби.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементла { $property } хасдешличи хӀерси саби.
+       *[other] { $ref } — { $element } элементла { $property } хасдешличи хӀерси саби ({ $line } жерге).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = бутӀа
+help-kind-array-entry = массивла элемент
+
+help-default = БехӀбихьудла кьимат:
+help-active-default = ХӀянчилизибси бехӀбихьудла кьимат:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Бирути кьиматуни (гьар секӀайс цали):
+       *[other] Бирути кьиматуни:
+    }
+
+help-suggested-values = Гьанбушибти кьиматуни:
+
+help-inserts = Кабирхьу:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатаби:
+    }
+
+help-type = Тип:
+
+help-resolved-style = Баргибси стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Даргибти функцияла умани:
+help-reset-list = Иш чебухъанничибси чарбирнила список:
+help-added-on-input = Иш чебухъанничи кабихьибти:
+help-removed-on-input = Иш чебухъанничибад ардукибти:
+
+help-reset-overrides = { $reset } бикӀусили { $additional } ва { $removed } чедидиру.

--- a/packages/i18n/locales/inh/chrome.ftl
+++ b/packages/i18n/locales/inh/chrome.ftl
@@ -1,0 +1,133 @@
+# Ingush viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Ingush (гӀалгӀай мотт), written in Cyrillic with the palochka Ӏ — the
+# orthography Ingushetia's schools and publishing use and what CLDR fills a
+# bare `inh` in as (`inh` maximizes to `inh-Cyrl-RU`). The palochka is a
+# letter, not a Latin capital I and not a digit 1; a catalog that spells
+# «Ӏаьржа» with either has quietly stopped being Ingush.
+#
+# **This catalog's nearest neighbour in the roster is `locales/ce`, and it is
+# one language over rather than a dialect of this one.** Ingush and Chechen are
+# the two Vainakh languages: they share the в-/й-/б-/д- class system, much of
+# the vocabulary and most of the syntax, and a reader who knows one can follow
+# the other. They are still two literary standards with two orthographic
+# habits, so this file was written as Ingush rather than as a respelling —
+# «доаца» where Chechen writes «доцу», «оагӀув» for a page where Chechen writes
+# «агӀо», «кийчду» where Chechen writes «кечдо». Where the two genuinely
+# coincide the coincidence is correct and was left alone. Where this seed was
+# less sure which of the two a word belongs to, the header of `content.ftl`
+# says so.
+#
+# Ingush counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+#
+# Nothing in this file agrees with a noun class — see `content.ftl`, which is
+# where the class fork lives and where the class table a speaker should check
+# first is written out.
+
+
+## Answer submission
+
+answer-checking = Талло…
+answer-submitting = ДӀалуш да…
+answer-checking-status = Жоп талло
+answer-submitting-status = Жоп дӀалу
+answer-correct = Нийса
+answer-incorrect = Нийса дац
+answer-response-saved = Жоп Ӏалашдаьд
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% нийса
+answer-percent-short = { $percent } %
+max-credit-available = Схьаэца йиш йолу лакхара балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] гӀорт йисаяц
+        [one] { $count } гӀорт йисай
+       *[other] { $count } гӀорт йисай
+    }
+validation-correct = (Нийса)
+validation-incorrect = (Нийса дац)
+validation-partially-correct = (Дакъа нийса)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } тӀа { $count } жоп гойта
+       *[other] { $answerId } тӀа { $count } жоп гойта
+    }
+
+## Disclosure panels
+
+feedback-heading = Юхахаам
+collapsible-click-to-open = (даста тӀатаӀае)
+collapsible-click-to-close = (дӀакъовла тӀатаӀае)
+collapsible-initializing = Кийчду…
+footnote-show = Билгалдар гойта
+footnote-hide = Билгалдар къайладаккха
+description-more-information = кхы дола хаам
+
+## Controls
+
+slider-previous = Хьалха
+slider-next = ТӀехьа
+keyboard-open = Клавиатура даста
+keyboard-close = Клавиатура дӀакъовла
+choice-input-remove-choice = { $choice } харжам дӀабаккха
+matrix-remove-row = МогӀа дӀабаккха
+matrix-add-row = МогӀа тӀатоха
+matrix-remove-column = Багана дӀаяккха
+matrix-add-column = Багана тӀатоха
+subset-add-remove-points = ТӀадамаш тӀатоха/дӀабаха
+subset-toggle-points-intervals = ТӀадамаш а, юкъаш а хийца
+subset-move-points = ТӀадамаш дӀаоттаде
+subset-clear = ЦӀенде
+orbital-add-row = МогӀа тӀатоха
+orbital-remove-row = МогӀа дӀабаккха
+orbital-add-box = Клетка тӀатоха
+orbital-remove-box = Клетка дӀаяккха
+orbital-add-up-arrow = Лакхара тӀам тӀатоха
+orbital-add-down-arrow = Лохара тӀам тӀатоха
+orbital-remove-arrow = ТӀам дӀабаккха
+orbital-row-label = { $row } могӀан хьаьрк
+pretzel-answer = Жоп
+summary-statistics-caption = { $column } баганан жамӀа статистика
+
+## Math input
+
+math-input-preview-region = математически билгалдаккхара хьалхара хьажар
+math-input-preview = Хьалхара хьажар
+math-input-invalid-expression = Нийса доаца билгалдаккхар:
+
+## Document status
+
+viewer-initializing = Кийчду…
+
+## Errors
+
+error-heading = ГӀалат
+error-found-at =
+    { $span ->
+        [line] { $startLine }-ча могӀанехь корадаьд.
+       *[lines] { $startLine }–{ $endLine } могӀанашка корадаьд.
+    }
+document-contains-errors = Укх документехь гӀалаташ да!
+diagnostic-heading-error = ГӀалат
+diagnostic-heading-warning = Тергамбар
+diagnostic-heading-information = Хаам
+diagnostic-heading-hint = Хьехам
+accessibility-heading-level-1 = WCAG AA кхачара дохадар
+accessibility-heading-level-2 = Кхачара хьакъехьа хаам
+something-went-wrong = ХӀама нийса ца хиннад.
+renderer-load-failed = сурт дехкархо чуйийла ца делар. ОагӀув керлаяккха.
+core-start-failed = Укх документа хьажархо болабе ца делар. ОагӀув керлаяккха.
+core-start-failed-busy = Укх документа хьажархо болабе ца делар. Дукха документаш цхьана хана йолалуш яра, из ткъа мело болхбеча компьютера тӀа тӀехьадоагӀа. Кхыдола документаш кийчле, тӀаккха оагӀув керлаяккхарах пайда хила мега.
+core-start-failed-retry = Укх документа хьажархо болабе ца делар.
+core-start-failed-busy-retry = Укх документа хьажархо болабе ца делар. Дукха документаш цхьана хана йолалуш яра, из ткъа мело болхбеча компьютера тӀа тӀехьадоагӀа.
+core-start-retry = Юха гӀорта
+saved-state-unavailable = Шун Ӏалашдаь болх чубала ца делар.

--- a/packages/i18n/locales/inh/content.ftl
+++ b/packages/i18n/locales/inh/content.ftl
@@ -1,0 +1,325 @@
+# Ingush content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Ingush (гӀалгӀай мотт), a Nakh language of Ingushetia, written in Cyrillic
+# with the palochka Ӏ — the orthography the republic's schools, its publishing
+# and CLDR all use (`inh` maximizes to `inh-Cyrl-RU`). The palochka is a
+# letter, not a Latin capital I and not a digit 1.
+#
+# **This catalog's exemplar is `locales/ce`, and that is the closest exemplar
+# relationship anywhere in the roster — one language over rather than one
+# family over.** Ingush and Chechen are the two Vainakh languages: partly
+# mutually intelligible, sharing the в-/й-/б-/д- class system and most of the
+# vocabulary a file like this needs. So a reader deserves to be told two
+# things. The first is that where the two coincide here, the coincidence is
+# correct rather than copied: «Ӏаьржа», «можа», «сира», «тӀадам», «сиз» are the
+# word in both languages, and writing something else to look different would
+# have been worse than agreeing. The second is that Ingush's own literary norm
+# is followed wherever it differs — the negative participle is «доаца» and not
+# Chechen's «доцу», the participle "filled" is «дизза» and not «дуьзна», a page
+# is «оагӀув» and not «агӀо», «кийчду» and not «кечдо», «нагахьа» and not
+# «нагахь санна». Some entries below are more confidently Ingush than others,
+# and the two paragraphs after this say which.
+#
+# **Ingush has a real grammatical class system and this catalog forks on it.**
+# Nouns fall into classes marked by в-, й-, б- and д-, and an agreeing word
+# carries the class marker at the *front*. What agrees is a short list, and it
+# is not the same list a Bantu catalog forks: Ingush's colour and width
+# adjectives — «Ӏаьржа», «сийна», «дуькъа», «дораха» — take no class prefix and
+# hold still after every noun, so the colour and width vocabulary below forks
+# nowhere, exactly as `locales/ce` reports for Chechen. What does agree is a
+# *participle*, and there are two of them here rather than one:
+#
+#   * `style-filled-word` — «дизза», filled — forks four ways, which is the
+#     same word `locales/ce` forks.
+#   * `line-style.dashed` — «кагдаь», broken — is a past participle of the same
+#     shape and agrees the same way, so it forks too. **This is the one place
+#     this catalog forks something `locales/ce` leaves flat.** Chechen's
+#     «кагйина» in that slot is the same kind of word and the same argument
+#     reaches it; whether that catalog should fork it as well is a question for
+#     a Chechen speaker rather than something this file changed.
+#
+# `.dotted` beside it is «тӀадамашца», an instrumental noun phrase rather than
+# a participle, so nothing in it can agree and no fork is written. The
+# `fill-style` phrases are nouns for the same reason.
+#
+# `style-unfilled` would agree in the language — «дизза боаца», «дизза йоаца»,
+# «дизза воаца» — and cannot here: `describeFill` renders it with no arguments
+# at all, so no noun exists for `$gender` to come from and a select there could
+# only ever reach its default branch. The д-class form is written flat, which
+# is what every agreeing catalog in the roster does with that message.
+#
+# **`noun-gender`'s table is the least certain thing in this file and is where
+# a speaker should start.** The four class markers and the agreeing forms of
+# both participles are what this seed could check; the class of each individual
+# geometric noun is what it could not. A half-remembered class table is worse
+# than an admitted gap, so only the entries this seed is reasonably confident
+# of are listed and everything else defaults to `d`, the largest class. Filling
+# one in costs a speaker one line, and the forks that read it are already
+# written.
+#
+# **The other soft spots, named so they are not mistaken for settled Ingush.**
+# The polygon vocabulary follows the shared Vainakh «сонера» ("cornered"), and
+# it is the item here most likely to be a Chechen habit rather than an Ingush
+# one. «цӀе-можа», «сийна-цӀе» and «цӀе-кӀай» for orange, purple and pink are
+# transparent compounds written because the style pipeline needs twelve
+# separate colour words and Ingush does not split its colour vocabulary at
+# those twelve points; a speaker may well prefer the Russian loans that school
+# writing uses. `noun.curve` is «нийса доаца сиз», "a line that is not
+# straight" — a description rather than a term, chosen so that it cannot be
+# confused with «нийса сиз» beside it.
+
+
+## Style vocabulary
+##
+## The colour and width words take no class prefix, so none of them forks. That
+## is a fact about Ingush adjectives rather than about Ingush agreement — the
+## agreement is a few lines below, in `line-style`.
+
+color =
+    .black = Ӏаьржа
+    .white = кӀай
+    .gray = сира
+    .red = цӀе
+    .orange = цӀе-можа
+    .yellow = можа
+    .green = баьццара
+    .cyan = сирла сийна
+    .blue = сийна
+    .purple = сийна-цӀе
+    .pink = цӀе-кӀай
+    .brown = мора
+line-width =
+    .thick = дуькъа
+    .thin = дораха
+# «кагдаь» is a past participle and carries the class of what it describes, so
+# it forks; «тӀадамашца» is an instrumental noun and cannot agree, so it does
+# not. See the header for why this is the one fork `locales/ce` does not write.
+line-style =
+    .dashed =
+        { $gender ->
+            [v] кагваь
+            [j] кагйаь
+            [b] кагбаь
+           *[d] кагдаь
+        }
+    .dotted = тӀадамашца
+# Noun phrases: they stand in front of the thing they describe and agree with
+# nothing.
+fill-style =
+    .horizontal = горизонталан сизаш
+    .vertical = вертикалан сизаш
+    .diagonal = диагоналан сизаш
+    .backdiagonal = духьал диагоналан сизаш
+    .dots = тӀадамаш
+    .diamonds = ромбаш
+noun =
+    .line = нийса сиз
+    .line-segment = сизан дакъа
+    .ray = луч
+    .vector = вектор
+    .curve = нийса доаца сиз
+    .function = функци
+    .slope-field = наклонан аре
+    .vector-field = векторан аре
+    .parabola = парабола
+    .polyline = кагдаь сиз
+    .polygon = дукха сонера
+    .triangle = кхо сонера
+    .rectangle = нийса сонера
+    .circle = го
+    .region = моттиг
+    .point = тӀадам
+    .square = квадрат
+    .diamond = ромб
+    .cross = жӀар
+    .plus = плюс
+# Ingush builds the whole word in front of the noun, so all of it is the head
+# and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] нийса { $numSides } сонера
+    }
+# The class of the noun being described, handed to every word that agrees with
+# it. See the header: only the entries this seed could check are written out,
+# and everything else falls to `d`.
+noun-gender =
+    { $noun ->
+        [point] b
+        [cross] b
+        [line] d
+        [line-segment] d
+        [ray] d
+        [border] d
+        [fill] d
+        [text] d
+        [background] d
+       *[other] d
+    }
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# «дизза» — full, filled — carries the class of the shape it fills at the front
+# of the word, which is why `$gender` is read here at all.
+style-filled-word =
+    { $gender ->
+        [v] визза
+        [j] йизза
+        [b] бизза
+       *[d] дизза
+    }
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } сурташца { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } сурташца { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } сурташца { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «йистеца» — "with an edge" — is a case form of a noun this catalog writes, so
+# nothing is welded to a placeable and no article is wanted. Ingush's «а» is an
+# enclitic and follows what it conjoins, so the two `and` branches end in it
+# rather than opening with it — which is where they part from `locales/ce`.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } йистеца
+        [and] { $border } йистеца а
+        [and-article] { $border } йистеца а
+       *[with] { $border } йистеца
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } сурташца { $color } бос
+       *[plain] { $color } бос
+    }
+# The negated participle agrees in the language exactly as the positive one
+# does — «бизза боаца», «йизза йоаца», «визза воаца» — but this message
+# describes a fill standing on its own, with no noun and so no `$gender`
+# reaching it. The д-class form is written flat; a fork here could only ever
+# render its default branch.
+style-unfilled = дизза доаца
+# «тӀа» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон тӀа { $color }
+       *[plain] { $color }
+    }
+style-background-none = дац
+
+## Boolean words
+
+boolean-true = бакъ
+boolean-false = харц
+
+## Answer buttons
+
+answer-submit-label = Таллар
+answer-submit-label-no-correctness = Жоп дӀадала
+
+## Sectional blocks
+
+section-name =
+    .activity = ГӀулакх
+    .aside = ОагӀорара дош
+    .cascade = Каскад
+    .definition = Билгалдаккхар
+    .example = Масал
+    .exercise = Упражнени
+    .exercises = Упражненеш
+    .given-answer = Жоп
+    .note = Билгалдар
+    .objectives = Ӏалашонаш
+    .paragraphs = Абзацаш
+    .part = Дакъа
+    .problem = Задача
+    .problems = Задачаш
+    .proof = ТӀачӀоагӀадар
+    .question = Хаттар
+    .section = Корта
+    .solution = Сацам
+    .task = Дехар
+    .theorem = Теорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Хьехам
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурт { $enumeration }
+        [numbered-caption] Сурт { $enumeration }{ ". " }
+        [unnumbered-caption] Сурт{ ". " }
+       *[unnumbered] Сурт
+    }
+
+## Paginator controls
+
+paginator-previous = Хьалха
+paginator-next = ТӀехьа
+paginator-page = ОагӀув
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## Ingush's conditional «нагахьа» opens the clause it conditions, so this key
+## lands where the renderer puts it — before the mathematics it introduces —
+## and needs none of the caveat `locales/sah`, `locales/tyv`, `locales/udm`,
+## `locales/kv` and `locales/chm` record for a clause-final "if". Chechen's
+## «нагахь санна» is clause-initial too, so the two Vainakh catalogs agree
+## here as well.
+
+piecewise-condition-or = е
+piecewise-condition-if = нагахьа
+piecewise-condition-otherwise = кхыча тайпара
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Ingushetia is taught
+## in Russian, so the element names an Ingush-speaking pupil actually meets are
+## the Russian ones, and the English fallback beside the symbol is nearer that
+## curriculum than 118 invented Ingush coinages would be. This is the
+## school-system case the whole batch shares.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Нийса доаца химин хьаьрк
+chemistry-invalid-ionic-compound = Нийса доаца ионий цхьанкхетар

--- a/packages/i18n/locales/inh/diagnostics.ftl
+++ b/packages/i18n/locales/inh/diagnostics.ftl
@@ -1,0 +1,696 @@
+# Ingush diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Ingush (гӀалгӀай мотт) in Cyrillic with the palochka Ӏ, which is a letter and
+# neither a Latin capital I nor a digit 1.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The exemplar for this catalog is `locales/ce`, the other Vainakh language;
+# `content.ftl`'s header explains what that relationship is and where this file
+# follows Ingush rather than Chechen. In this file the recurring differences
+# are small and constant: «хӀана аьлча» for "because" where Chechen writes
+# «хӀунда аьлча», «мегац» for "cannot", «тидам ца бу» for "is ignored", «цӀи»
+# for a name, «доаца» for the negative participle.
+#
+# Ingush's class agreement does not reach this file: nothing here describes a
+# noun the catalog itself supplies, so no message forks on a class. The fork
+# lives in `content.ftl`, and that file's header says why it lives only there.
+#
+# The technical vocabulary is the Russian one, which is what written Ingush
+# uses for it: «компонент», «атрибут», «функци», «индекс», «формат».
+#
+# Ingush counts in two plural categories, `one` and `other`, so every count
+# below keeps the two branches English gives it. A noun after a numeral stays
+# singular, so in most of them the two branches read alike.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] шиъ йисте билгалбаьча { $attributes } тидам ца бу
+       *[other] шиъ йисте билгалбаьча { $attributes } тидам ца бу
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] йисте а, юкъера тӀадам а билгалбаьча { $attributes } тидам ца бу
+       *[other] йисте а, юкъера тӀадам а билгалбаьча { $attributes } тидам ца бу
+    }
+
+line-segment-midpoint-offset-without-midpoint = юкъера тӀадам боаца midpointOffset хӀаманна тӀа ца кхоач
+
+## `<line>`
+
+line-points-undetermined-dimensions = Барам ца бовзаш болча тӀадамашкахьара доагӀа нийса сиз.
+
+line-points-too-few-dimensions = Нийса сиз кӀезигагӀа шиъ барам болча тӀадамашкахьара даха деза.
+
+line-points-depend-on-variables = Нийса сиз хувцалуча барамашка хьежача тӀадамашкахьара доагӀа: { $variables }.
+
+line-equation-invalid-format = { $variable1 } а, { $variable2 } а хувцалуча барамашца долча нийсача сизан уравнена формат нийса яц.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint а, direction а тӀехьара деннад. Деннача through тидам ца бу.
+
+ray-dimension-mismatch = лучехь numDimensions ца тоъ.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail а, displacement а тӀехьара деннад. Деннача head тидам ца бу.
+
+vector-dimension-mismatch = векторехь numDimensions ца тоъ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементага теда мегац, хӀана аьлча цун nearestPoint яха хьала хувцалу барам бац.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементаца доза де мегац, хӀана аьлча цун nearestPoint яха хьала хувцалу барам бац.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элемента чурчоа доза де мегац, хӀана аьлча цун nearestPoint яха хьала хувцалу барам бац.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = могӀана чу доаца choiceInput тӀа labelPosition тидам ца бу
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput тӀа деннача индексий тидам ца бу, хӀана аьлча царна дукхал choice берий дукхала ца тоъ.
+
+pretzel-indices-count-mismatch = problem тӀа деннача индексий тидам ца бу, хӀана аьлча царна дукхал problem берий дукхала ца тоъ.
+
+shuffle-indices-count-mismatch = shuffle тӀа деннача индексий тидам ца бу, хӀана аьлча царна дукхал компонентий дукхала ца тоъ.
+
+indices-ignored-out-of-range = { $component } тӀа деннача индексий тидам ца бу, хӀана аьлча цхьабараш доза тӀера арадоал.
+
+pretzel-indices-repeated = pretzel тӀа деннача индексий тидам ца бу, хӀана аьлча цхьабараш юха карладоал.
+
+pretzel-circuit-first-index = circuit режиме pretzel тӀа деннача индексий тидам ца бу, хӀана аьлча хьалхара индекс 1 хила еза.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текста берашца болх бе `type` атрибут енна хила еза.
+
+invalid-type-defaulting-to-math = { $component } компонента нийса доаца тайпа { $type }. Из math, text, number е boolean хила деза. math лоаттаду.
+
+string-not-valid-component-to-arrange = «{ $value }» могӀа { $component } де мегача компонент бац. Тидам ца бу.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Нийса доаца тайпа { $type }, тайпа number хургда.
+
+invalid-variable-value = Хувцалуча барама нийса боаца мах: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } варианта индекс терахь хила деза
+
+variant-index-must-be-integer = { $index } варианта индекс дийна терахь хила деза
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютни барамашта дина дац. Шоралла юстара хургья.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютни барамашта дина дац. Йистош юстара хургья.
+
+side-by-side-no-block-child = Нийса доаца `<{ $component }>`: цун кӀезигагӀа цхьа блок бер хила деза.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элемента `for` атрибута тидам ца бу.
+
+label-for-must-resolve-to-one = `<label>` элемента `for` атрибут цхьан компонента тӀа бен хьежаш хила ца деза.
+
+label-for-unresolved = `<label>` элемента `for` атрибут компонентаца тохаде ца делар.
+
+label-for-answer-with-authored-inputs = `<label>` элемента `for` атрибут авторо яздаьча чудаларий моттигаш йолча `<answer>` тӀа хьежа; моттига тӀа нийсса хьажабе.
+
+label-for-answer-without-input = `<label>` элемента `for` атрибут чудаларий моттиг йоаца `<answer>` тӀа хьежа.
+
+label-for-must-reference-input-or-answer = `<label>` элемента `for` атрибут чудаларий моттига е жоапа тӀа хьежаш хила деза.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Кхачара `<{ $component }>` йоацача билгалдаккхарца хила деза, е хозде йоагӀаш я аьнна билгалде деза.
+
+accessibility-video-short-description = Кхачара `<video>` йоацача билгалдаккхарца хила деза.
+
+accessibility-input-short-description-or-label = Кхачара `<{ $component }>` йоацача билгалдаккхарца е хьаьркаца хила деза.
+
+accessibility-answer-input-short-description-or-label = Кхачара чудаларий моттиг кхолла `<answer>` йоацача билгалдаккхарца е хьаьркаца хила деза.
+
+accessibility-short-description-contains-math = Йоацача билгалдаккхарашка `<{ $component }>` санна математически компоненташ хила ца еза. Математика дешашца язъе.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } декъа корта яздеча текста тоаъаш контраст ца ло (Ӏаьржа тайпа) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀезигагӀа { $threshold }:1 деза).
+       *[other] { $colorName } декъа корта яздеча текста тоаъаш контраст ца ло ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀезигагӀа { $threshold }:1 деза).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ТӀадамашта терахьа мах ца хилча { $count } тӀадамашкахьара доагӀа `<circle>` дина дац.
+
+circle-too-many-through-points = 3-ал дукхагӀча тӀадамашкахьара доагӀа го хьисапде мегац.
+
+circle-overprescribed-radius-center-points = Денна радиус, юкъ а, тӀадамаш а долаш го хьисапде мегац.
+
+circle-center-with-multiple-points = Денна юкъаца 1-ал дукхагӀча тӀадамашкахьара доагӀа го хьисапде мегац.
+
+circle-radius-too-small = Го хьисапде мегац: шин тӀадама юкъера геналле { $distance } хилча, денна радиус { $radius } тӀех зӀамига ба.
+
+circle-radius-with-many-points = Денна радиусаца шиъал дукхагӀча тӀадамашкахьара доагӀа го кхолла мегац.
+
+circle-invalid-center-or-through-points = Гон юкъ е тӀадамаш нийса дац.
+
+circle-radius-center-with-multiple-points = Денна юкъаца 1-ал дукхагӀча тӀадамашкахьара доагӀача гон радиус хьисапде мегац.
+
+circle-change-radius-non-numerical = Терахьа боаца тӀадамаш болча гон радиус хувца мегац
+
+circle-radius-with-points-non-numerical = Терахьа мах ца хилча денна радиусаца цхьаннал дукхагӀча тӀадамашкахьара доагӀа го кхолла мегац.
+
+circle-change-center-non-numerical = Терахьа боаца тӀадамашкахьара доагӀача гон юкъ хувцар дина дац.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функца билгалъяьча моттига барам ца тоъ. Моттига чу { $intervals } юкъ я, функце ткъа { $inputs ->
+            [one] { $inputs } чудаккхар
+           *[other] { $inputs } чудаккхар
+        } да.
+       *[other] Функца билгалъяьча моттига барам ца тоъ. Моттига чу { $intervals } юкъ я, функце ткъа { $inputs ->
+            [one] { $inputs } чудаккхар
+           *[other] { $inputs } чудаккхар
+        } да.
+    }
+
+function-domain-invalid-format = Функца билгалъяьча моттига формат нийса яц.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функца терахьа доаца максимума тидам ца бу.
+        [minimum] Функца терахьа доаца минимума тидам ца бу.
+        [extremum] Функца терахьа доаца экстремума тидам ца бу.
+        [point] Функца терахьа боаца тӀадама тидам ца бу.
+        [slope] Функца терахьа доаца наклона тидам ца бу.
+       *[other] Функца терахьа доаца { $type } маха тидам ца бу.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функца ерриг йоаца максимума тидам ца бу.
+        [minimum] Функца ерриг йоаца минимума тидам ца бу.
+        [extremum] Функца ерриг йоаца экстремума тидам ца бу.
+        [point] Функца ерриг боаца тӀадама тидам ца бу.
+       *[other] Функца ерриг йоаца { $type } маха тидам ца бу.
+    }
+
+function-points-too-close = Функце вошта тӀех гаргара шиъ тӀадам ба. Функци билгалъе мегац.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функца итерацеш хул чудаккхарий дукхал арадаккхарий дукхалца цхьатарра хилча бе. Укх функце { $inputs } чудаккхар а, { $outputs ->
+            [one] { $outputs } арадаккхар
+           *[other] { $outputs } арадаккхар
+        } а да.
+       *[other] Функца итерацеш хул чудаккхарий дукхал арадаккхарий дукхалца цхьатарра хилча бе. Укх функце { $inputs } чудаккхар а, { $outputs ->
+            [one] { $outputs } арадаккхар
+           *[other] { $outputs } арадаккхар
+        } а да.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Тайпана деналле нийса яц. Из минус йоаца дийна терахь хила еза.
+
+sequence-invalid-step = Тайпана гӀулакх нийса яц. { $type } тайпан тайпана из терахь хила деза.
+
+sequence-invalid-endpoint-number = Терахьий тайпана «{ $attribute }» мах нийса бац. Из терахь хила деза.
+
+sequence-invalid-endpoint-letters = Элпий тайпана «{ $attribute }» мах нийса бац. Из элпий цхьанкхетар хила деза.
+
+sequence-invalid-endpoint = Тайпана «{ $attribute }» мах нийса бац.
+
+select-from-sequence-coprime-not-numbers = терахьаш ца хоржаш дола дела coprime тидам ца бу
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations денна дола дела coprime тидам ца бу
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` тӀа нийса доаца target: Ӏалашо ца корайо.
+
+target-state-variable-not-found = `<{ $source }>` тӀа нийса доаца target: `<{ $component }>` элементе «{ $property }» яха цӀи йола хьала хувцалу барам ца корабаь.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` хувцалу барамаш шоаш-шоай долча барамах къаьста деза.
+
+ode-system-duplicate-variable-names = Хьежача хувцалуча барамий цӀераш юха карладоалаш ДУ аьттухьара функцеш билгалъе мегац.
+
+ode-system-rhs-function-error = ДУ аьттухьара функци билгалъе мегац. mathjs функци кхолла гӀалат хиннад.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } нийсача сизий юкъера сонера билгалбе мегац
+
+angle-invalid-through-point = `<angle>` элемента through маха чу нийса боаца тӀадам
+
+parabola-vertex-too-many-points = Денна корта болаш 1-ал дукхагӀча тӀадамашкахьара йоагӀа парабола йина яц.
+
+parabola-too-many-points = 3-ал дукхагӀча тӀадамашкахьара йоагӀа парабола йина яц.
+
+intersection-too-many-items = Шиъал дукхагӀча объектий вовшахкхетар дина дац
+
+## Other math components
+
+ionic-compound-not-two-ions = Шин ионах кхы ионий цхьанкхетар дина дац.
+
+ionic-compound-needs-cation-and-anion = Ионий цхьанкхетар цхьан катиона а, цхьан аниона а бе дина дац.
+
+solve-equations-cannot-evaluate = Уравнени яьшта мегац, хӀана аьлча из хьисапе яха ца делар: { $equation }
+
+math-operators-operand-number-required = Математически операнд къаста operandNumber енна хила еза.
+
+eigen-decomposition-failed = Матрица шийна мах хьисапбе ца делар
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр кепе ца корайо, цудухьа из хӀаман даиман ерриг йоацачоа тоаргья.
+       *[other] `<matchesPattern>`: { $parameters } параметраш кепе ца корайо, цудухьа уж даиман ерриг йоацачоа тоаргья.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" маха кхетаде мегац. Из none, medium, dense е моттигаца къаьстта шиъ плюсан терахь хила деза, масала grid="1 0.5". Сеть ца хьокха.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` компонента { $expected ->
+        [one] цхьа арадаккхар дола функци еза — хӀор тӀадама наклон y', масала `y - x`
+       *[other] шиъ арадаккхар дола функци еза — хӀор тӀадама вектор, масала `(y, -x)`
+    }, деннача функце ткъа { $found ->
+        [one] { $found } арадаккхар да
+       *[other] { $found } арадаккхар да
+    }. { $alternative ->
+        [none] ХӀама ца хьокха.
+       *[other] Из функца `<{ $alternative }>` компонент я. ХӀама ца хьокха.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибута тидам ца бу, хӀана аьлча функци компонента чура а еннай; чурчун пайда оал. Функци шин наькъах цхьанне бе ма ле.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибуто компонента чу нийсса яздаьча билгалдаккхара барамашта цӀераш ле. { $reason ->
+        [function-child] Укхаза функци `<function>` бер санна еннай, цо шийна барамашта цӀераш ле, цудухьа `variables` тидам ца бу.
+       *[no-expression] Укхаза из тайпара билгалдаккхар денна дац, цудухьа `variables` тидам ца бу.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure сурт дехкархочунга xLabelPosition="left" дина дац; аьттухьара хӀоттам лоаттабу.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure сурт дехкархочунга yLabelPosition="bottom" дина дац; лакхара хӀоттам лоаттабу.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure дерзадара доза нийса дац; бух болаш bbox (-10,-10,10,10) лоаттабу.
+
+prefigure-invalid-width = `<graph>`: prefigure дерзадара шоралла нийса яц; диаграмма бух болаш шоралла 425 лоаттаю.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure дерзадара aspectRatio нийса дац; бух болаш оагӀонаш барам 1 лоаттабу.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сета гӀулакх дозанашта тӀех зӀамига да; prefigure сурт дехкархочунга сеть ца хьокха.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure сурт дехкархочох пайда ца эцаш билгалдараш ца хьокха.
+
+multiple-annotations-children = `<graph>` чу дукха `<annotations>` бер корадаьд; тӀехьарчунна дӀаэттача кхыдараш тидам ца бу.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ца бовзаш болча компонента тайпа шорде е копи е мегац: { $type }.
+
+copy-prop-not-found = { $component } тайпан компоненте { $property } яха башхал ца корайо
+
+collect-no-source = collect тӀа хьост ца корадаь.
+
+collect-invalid-component-type = `<{ $component }>` тайпан компонентеш гулъе мегац, хӀана аьлча из нийса доаца компонента тайпа да.
+
+reference-index-unavailable = `{ $reference }` индекса тӀа хьажар кхолла мегац
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компоненте { $action } кхайка мегац
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Хаамий кеп нийса яц. МогӀий деналле цхьатарра яц. Корадаьд componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Хаамашка баганай цӀераш юха карладоал. Корадаьд componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Хаамашка баганан цӀи ца тоъ. Корадаьд componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Укх жоапа award мах answer тега шийна дӀаденнача жоапа тӀа хьежа, цо ца хьоахаяьча хьале дала таралу.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` йолча контейнера чурча `<answer>` тӀа `maxNumAttempts` хӀоттадар хӀаманна тӀа ца кхоач, хӀана аьлча гӀортий дукхал контейнеро билгалъю. `maxNumAttempts` мах контейнера тӀа хӀоттабе.
+
+nested-section-wide-check-work-max-num-attempts = Кхыча `sectionWideCheckWork` контейнера чу латта `sectionWideCheckWork` контейнера тӀа `maxNumAttempts` хӀоттадар хӀаманна тӀа ца кхоач, хӀана аьлча гӀортий дукхал арахьарча контейнеро билгалъю. `maxNumAttempts` мах арахьарча контейнера тӀа хӀоттабе.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality хӀоттаяь ца хилча { $attributes } атрибут хӀаманна тӀа ца кхоачаргба.
+       *[other] symbolicEquality хӀоттаяь ца хилча { $attributes } атрибуташ хӀаманна тӀа ца кхоачаргба.
+    }
+
+answer-invalid-type = answer тӀа нийса доаца тайпа: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонента цӀи яц, цудухьа цох модула атрибут де мегац
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентах модула атрибут де мегац, хӀана аьлча `<module>` компонента тайпан «{ $name }» атрибут хӀанзалца билгалъяьй.
+
+conditional-content-condition-ignored = case е else бераш долча `<conditionalContent>` компоненте `condition` атрибута тидам ца бу.
+
+slider-markers-type-mismatch = Маркерий тайпа ползунока тайпана ца тоъ.
+
+pretzel-problem-needs-statement-and-answer = Нийса доаца pretzel: хӀор `<problem>` чу цхьа `<statement>` а, цхьа `<answer>` а хила деза.
+
+pretzel-circuit-first-problem-distractor = Нийса доаца pretzel: mode="circuit" режиме хьалхара `<problem>` тидам дӀабоаккхаш хила ца еза.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибута нийса боаца мах { $values }; тидам ца бу.
+       *[other] `{ $attribute }` атрибута нийса доаца мах { $values }; тидам ца бу.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибута нийса боаца мах `{ $value }`. Атрибут `$` хьаьркаца долалуча хьажарашкара латташ хила деза.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } чура нийса доаца функцешта цӀераш тидаме ца эца: { $names }. ХӀор цӀера гуш дола дакъа кӀезигагӀа 2 хьаьрк хила деза (элпаш е сизаш); цул тӀехьагӀа деза доаца `|<mathspeak альтернатива>` тӀатохар хила таралу.
+
+## Building components from the source
+
+component-type-invalid = Нийса доаца компонента тайпа: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут юха карлаяккха мегац.
+
+attribute-invalid-for-component = `<{ $componentType }>` тайпан компонента нийса доаца атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стила билгалдаккхаре { $context ->
+        [text-on-background] текста бос а, фона бос а
+        [high-contrast] лакха контраст болаш бос а, сурта моттиг а
+        [line] сизан бос а, сурта моттиг а
+        [marker] маркера бос а, сурта моттиг а
+       *[text-on-canvas] текста бос а, сурта моттиг а
+    } юкъе контраст ца тоъ{ $mode ->
+        [dark] { " (Ӏаьржа тайпа)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀезигагӀа { $threshold }:1 деза).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стила билгалдаккхаре денна бесаш сирлача тайпана тоаъаш контраст лу делха а, царах даьнна Ӏаьржача тайпан бесашта текст а, фон а юкъе тоаъаш контраст ца ло ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀезигагӀа { $threshold }:1 деза). { $suggestion ->
+        [available] Ӏаьржача тайпа чу тоаъаш контраст хилийта е сирлача тайпан контраст алсамъяккха (масала { $lightAttribute }="{ $lightColor }"), е Ӏаьржача тайпан бос хувца (масала { $darkAttribute }="{ $darkColor }").
+       *[none] Ӏаьржача тайпа чу тоаъаш контраст хилийта сирлача тайпан контраст алсамъяккха е даьнна бесаш textColorDarkMode а/е backgroundColorDarkMode а тӀехьара хувца.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стила билгалдаккхаре денна текста бос сирлача тайпана тоаъаш контраст лу белха а, цох баьнна Ӏаьржача тайпан текста бос сурта моттигаца тоаъаш контраст ца ло ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀезигагӀа { $threshold }:1 деза). { $suggestion ->
+        [available] Ӏаьржача тайпа чу тоаъаш контраст хилийта е сирлача тайпан контраст алсамъяккха (масала textColor="{ $lightColor }"), е Ӏаьржача тайпан бос хувца (масала textColorDarkMode="{ $darkColor }").
+       *[none] Ӏаьржача тайпа чу тоаъаш контраст хилийта сирлача тайпан контраст алсамъяккха е баьнна бос textColorDarkMode тӀехьара хувца.
+    }
+
+section-multiple-style-palettes = Корто цхьа <stylePalette> бе харжа мегац; тӀехьарчох пайда оал.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча numToSelect минус йоаца дийна терахь яц.
+
+variant-num-to-select-not-constant-number = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча numToSelect хувцалуш йоаца терахь яц.
+
+variant-with-replacement-not-constant-boolean = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча withReplacement хувцалуш боаца логически мах бац.
+
+variant-select-weight-disables-unique = цхьан харжаме selectWeight е selectForVariants денна хилча, select тӀа юха карладоацаш дола варианташ дӀадоах
+
+variant-coprime-undetermined = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча coprime даиман харц йолаш я аьнна билгалде мегац.
+
+variant-attribute-not-constant = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча { $attribute } хувцалуш йоацар яц.
+
+variant-attribute-not-number = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча { $attribute } терахь яц.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тайпан { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча { $attribute } { $expected ->
+        [letters-combination] элпий цхьанкхетар
+        [math-expression] тоаъаш дола математически билгалдаккхар
+        [integer] дийна терахь
+       *[number] терахь
+    } яц.
+
+variant-length-not-integer = { $component } тӀа юха карладоацаш дола варианташ билгалде мегац, хӀана аьлча length дийна терахь яц.
+
+variant-sort-not-implemented = sort йолча { $component } тӀа юха карладоацаш дола варианташ дина дац
+
+variant-exclude-combinations-not-implemented = excludeCombinations йолча { $component } тӀа юха карладоацаш дола варианташ дина дац
+
+variant-math-exclude-not-implemented = exclude йолча math тайпан { $component } тӀа юха карладоацаш дола варианташ дина дац
+
+variant-non-constant-exclude-not-implemented = хувцалуш йоаца exclude йолча { $component } тӀа юха карладоацаш дола варианташ дина дац
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графика prefigure сурт дехкархочунга дина дац; тӀехье дӀатесай.
+
+prefigure-descendant-invalid-geometry = { $subject }: чаккхе йоаца е кхачаза геометри; тӀехье дӀатесай.
+
+prefigure-curve-label-omitted = { $subject }: дерзабаьча сизий элементашка хьаьркаш дина дац; хьаьрк дӀатесай.
+
+prefigure-curve-unsupported-definition-type = { $subject }: дина доаца сизан функца билгалдаккхара тайпа «{ $definitionType }»; тӀехье дӀатесай.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элемента flipFunctions атрибут дина дац; тӀехье дӀатесай.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves тӀа формулаца денна берий функцеш бе ца эца; тӀехье дӀатесай.
+
+prefigure-label-position-unsupported =
+    { $subject }: дина доаца labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] сизий доазала хьаьркана
+       *[point] тӀадама хьаьркана
+    }; PreFigure бух болаш нисдар лоаттаду.
+
+prefigure-fill-style-unsupported = { $subject }: дузара стиль «{ $fillStyle }» PreFigure тӀа дина дац; ерриг дузара доал.
+
+prefigure-line-style-unknown = { $subject }: ца бовзаш болаш сизан стиль «{ $lineStyle }» PreFigure арадаккхарара дӀабаьккхаб.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркера стиль «{ $markerStyle }» PreFigure «diamond» стилаца нисбаьб.
+
+prefigure-marker-style-unsupported = { $subject }: маркера стиль «{ $markerStyle }» PreFigure тӀа дина дац; бух болаш стиль лоаттабу.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: нийса доаца `ref`; Ӏалашо тохае мегац. Билгалдар дӀадаьккхад.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` дукхача Ӏалашонашца тохаяьй; хьалхарчох пайда оал.
+
+annotation-ref-outside-graph = `<annotation>`: нийса доаца `ref`; Ӏалашо чура графикех арахьа я. Билгалдар дӀадаьккхад.
+
+annotation-ref-unsupported-target = `<annotation>`: нийса доаца `ref`; Ӏалашо prefigure дерзадаре дина дола график объект яц. Билгалдар дӀадаьккхад.
+
+annotation-text-missing = `<annotation>`: `text` яц е ерриг яц; ерриг йоаца текст арахьокх.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Гон хьажар корадаьд.
+       *[other] `<{ $componentType }>` компонента чу дола гон хьажар корадаьд.
+    }
+
+reference-no-referent = Хьажарна объект ца корайо: `{ $reference }`
+
+reference-multiple-referents = Хьажарна дукха объекташ корадаь: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элемента { $attribute } атрибута формат нийса яц.
+
+children-invalid = `<{ $componentType }>` тӀа нийса доаца бераш: нийса доаца бераш корадаь: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибута нийса боаца мах `{ $value }`; `{ $default }` махах пайда оал
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } верси ца корайо.
+       *[other] DoenetML { $version } верси ца корайо. { $fallback } версех пайда оал
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Нийса доаца DoenetML: { $content }
+
+parse-tag-missing-close-tag = Нийса доаца DoenetML: `{ $tag }` тега дӀакъовла тег яц. Ше дӀакъовлаш йола тег е `</{ $tagName }>` тег хьоахаяь яр.
+
+parse-tag-error = Нийса доаца DoenetML: `<{ $tagName }>` теге гӀалат
+
+parse-attribute-missing-value = Нийса доаца DoenetML: `{ $attribute }` атрибута мах ца тоъ санна ба.
+
+parse-attribute-invalid = Нийса доаца DoenetML: нийса йоаца атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Нийса доаца DoenetML: атрибута нийса боаца мах `{ $value }`
+
+parse-attribute-value-quote-mismatch = Нийса доаца DoenetML: атрибута нийса боаца мах `{ $value }`. Кавычкаш ца тоъ. `{ $quote }` ца тоъ санна я
+
+parse-open-tag-name-missing = Нийса доаца DoenetML: цӀи йоаца тег корайо, масала `<`
+
+parse-tag-not-closed = Нийса доаца DoenetML: `{ $tag }` тег дӀакъовлаяь яц (`>` ца тоъ санна я).
+
+parse-self-closing-tag-name-missing = Нийса доаца DoenetML: цӀи йоаца тег корайо `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Нийса доаца DoenetML: `{ $tag }` тег дӀакъовлаяь яц (`/>` ца тоъ санна я).
+
+parse-tag-invalid-attributes = Нийса доаца DoenetML: `{ $tag }` тег тоаъаш яц. Цун атрибуташ нийса ца хила таралу.
+
+parse-close-tag-name-missing = Нийса доаца DoenetML: цӀи йоаца дӀакъовла тег корайо, масала `</`
+
+parse-attribute-value-unquoted = Атрибута мах кавычкий чу хила беза: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Нийса доаца DoenetML: `{ $tag }` дӀакъовла тег корайо, бакъда цунна тоаъаш йолалу тег яц
+
+parse-close-tag-mismatched = Нийса доаца DoenetML: ца тоаъ дӀакъовла тег. `</{ $expected }>` хьоахаяь яр. `{ $found }` корайо
+
+parser-node-unconvertible = { $node } узел Dast узела тӀа дерза ца делар.
+
+## Names
+
+name-attribute-invalid =
+    Нийса йоаца атрибут name='{ $name }'. { $reason ->
+        [characters] ЦӀерашка элпаш, терахьаш, кӀалхьара сизаш е сизаш бе хила ца таралу.
+       *[start] ЦӀераш элпаца йолалуш хила еза.
+    }
+
+component-name-invalid-start = Нийса йоаца компонента цӀи «{ $name }». ЦӀераш элпаца йолалуш хила еза.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тайпан answer video атрибутаца хила деза
+
+answer-video-watched-video-not-reference = videoWatched тайпан answer-а video атрибут хьажар хила еза
+
+answer-name-not-single-text = answer-а name атрибута чу цхьа текста бер бе хила ца деза
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурса тӀегӀанаш тӀех дукха да, цудухьа арахьара DoenetML эца ца делар. Гон хьажар яц те?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресара DoenetML эца ца делар
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресара нийса доаца DoenetML эцад: из «{ $componentType }» компонента тайпана ца тийшар
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут йоаяьй; цун метта `{ $to }` лелае.
+       *[other] [deprecation] `<{ $component }>` элемента `{ $from }` атрибут йоаяьй; цун метта `{ $to }` лелае.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут йоаяьй а, цун тидам ца бу а, хӀана аьлча `{ $to }` а еннай.
+       *[other] [deprecation] `<{ $component }>` элемента `{ $from }` атрибут йоаяьй а, цун тидам ца бу а, хӀана аьлча `{ $to }` а еннай.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элемента `{ $attribute }` атрибут йоаяьй а, цун тидам ца бу а.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элемента `{ $attribute }` атрибут йоаяьй; цун метта `<{ $child }>` бер лелае.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элемента `{ $attribute }` атрибута `{ $value }` мах бухбаьнна ба; цун метта `{ $to }` лелае.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` дукхала терахьа тӀа ингалса метта бе де мегац, цудухьа { $locale } метта яздаьча документе цун текст хувцаш дац. Дукхала кеп Ӏа язъе, е из `pluralForm` атрибутаца лаьрхӀае.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент бовзаш болаш Doenet элемент бац.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элемента документа орамехьа бокъо ца ло.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элемента `<{ $parent }>` чу бокъо ца ло.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементе `{ $attribute }` яха цӀи йола атрибут яц.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элемента `{ $attribute }` атрибут хӀор элемент укхарех цхьаъ болаш список хила еза: { $allowed }
+       *[other] `<{ $tag }>` элемента `{ $attribute }` атрибут укхарех цхьаъ хила еза: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select тӀа нийса йоаца варианта цӀи. { $variantName } варианта цӀи { $numOptions } харжаме корайо, харжа езар ткъа { $numToSelect } я.
+
+select-variant-name-without-options = select тӀа варианташ еннай, бакъда хила тарлуча варианта цӀерага цхьа харжам а бац: { $variantName }.
+
+select-variant-name-not-possible = select тӀа денна { $variantName } варианта цӀи хила тарлуча варианта цӀи яц.
+
+select-too-few-options = Дерригаш { $numOptions } юкъера { $numToSelect } компонент харжа мегац.
+
+select-from-sequence-too-few-values = Деналле { $length } йолча тайпанах { $numToSelect } мах харжа мегац.
+
+select-from-sequence-indices-count-mismatch = select тӀа деннача индексий дукхал харжа езача дукхала тоаъ еза
+
+select-from-sequence-indices-not-integers = select тӀа денна масса индексаш дийна терахь хила еза
+
+select-from-sequence-index-excluded = selectfromsequence тӀа денна индекс дӀабаьккха бар
+
+select-from-sequence-indices-excluded-combination = selectfromsequence тӀа денна индексаш дӀадаьккха цхьанкхетар дар
+
+select-from-sequence-coprime-not-positive-integers = Плюсан дийна терахьаш ца хоржаш дола дела вошта хьалха доаца цхьанкхетараш харжа мегац.
+
+select-from-sequence-coprime-common-factor = Вошта хьалха доаца терахьаш харжа мегац. Массаза хила тарлуча маха цхьан декъархо ба. (Денна "from" е "to" мах "step"-аца вошта хьалха боацаш хила беза.)
+
+select-from-sequence-coprime-single-number = 1 йоаца цхьан терахьах вошта хьалха доаца цхьанкхетараш харжа мегац.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence чу цхьанкхетарий 70%-ал дукхагӀчарех дӀадаьхад
+
+select-from-sequence-coprime-none-found = Вошта хьалха доаца терахьаш харжа ца делар. Массаза хила тарлуча маха цхьан декъархо ба.
+
+select-from-sequence-too-few-unique-values = Деналле { $numPossibleValues } йолча тайпанах { $numToSelect } башха мах харжа мегац
+
+select-prime-numbers-too-few-values = Деналле { $numValues } йолча хьалхарча терахьий спискех { $numToSelect } мах харжа мегац
+
+select-prime-numbers-values-count-mismatch = select тӀа деннача махай дукхал харжа езача дукхала тоаъ еза
+
+select-prime-numbers-values-not-prime = select prime number тӀа денна масса мах хьалхарча терахьий списке хила беза
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers тӀа денна мах дӀабаьккха цхьанкхетар дар
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers чу цхьанкхетарий 70%-ал дукхагӀчарех дӀадаьхад
+
+select-random-combination-fluke = ТӀех хила ца тарлуча хӀамаца ца ховча махай цхьанкхетар харжа ца делар
+
+select-random-value-fluke = ТӀех хила ца тарлуча хӀамаца ца ховш бола мах харжа ца делар

--- a/packages/i18n/locales/inh/editor.ftl
+++ b/packages/i18n/locales/inh/editor.ftl
@@ -1,0 +1,222 @@
+# Ingush editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Ingush (гӀалгӀай мотт) in Cyrillic with the palochka Ӏ, which is a letter and
+# neither a Latin capital I nor a digit 1. The catalog's exemplar is
+# `locales/ce` — the other Vainakh language rather than another dialect of this
+# one; `content.ftl`'s header sets out what that means and where this seed is
+# least sure of itself.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Ingush counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike. Nothing here agrees with a noun class: the class fork
+# lives in `content.ftl`, where the noun being described is known.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Юхаяккха
+       *[update] Керлаяккха
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Хьажархо { $word }
+       *[other] Хьажархо { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Хержар…
+editor-variant-next = ТӀехьара вариант харжа
+editor-variant-previous = Хьалхара вариант харжа
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA кхачара дохадар корадаьд. Кхачара отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀатаӀае.
+        [advisories] Кхачара отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀатаӀае. WCAG AA дохадараш ца корадаь, бакъда кхы хьехамаш да.
+       *[clean] Кхачара отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀатаӀае. Кхачара хаттараш ца корадаь.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA кхачара дохадар корадаьд. { $count ->
+            [one] { $count } WCAG AA дохадар
+           *[other] { $count } WCAG AA дохадар
+        } корадаьд. Кхачара отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀатаӀае.
+        [advisories] WCAG AA дохадараш ца корадаь. { $count ->
+            [one] { $count } тӀатоьхача хьехам
+           *[other] { $count } тӀатоьхача хьехам
+        } корадаьд. Кхачара отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀатаӀае.
+       *[clean] WCAG AA дохадараш ца корадаь. Кхачара отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀатаӀае.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML верси { $version }
+
+editor-tab-help = Контекста гӀо
+editor-tab-help-short = Контекст
+editor-tab-errors = ГӀалаташ
+editor-tab-warnings = Тергамбараш
+editor-tab-info = Хаам
+editor-tab-accessibility = Кхачар
+editor-tab-responses = ДӀаденна жоапаш
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редактора нисдараш
+editor-format-as-doenetml = DoenetML санна форматде
+editor-format-as-xml = XML санна форматде
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-ча могӀа
+
+editor-no-errors = ГӀалаташ дац
+editor-no-warnings = Тергамбараш дац
+editor-no-info = Хаама хаамаш дац
+
+editor-show-info-annotations = Хаама хаамаш редактора чу гойта
+editor-show-accessibility-annotations = Кхачара хаамаш редактора чу гойта
+
+editor-accessibility-learn-more = Doenet кхачарга фу тайпара хьожа хьахьовзаде
+
+editor-accessibility-violations-heading = Кхачара дохадараш ({ $standard })
+
+editor-accessibility-other-heading = Кхы дола кхачара хаттараш
+editor-none-found = ХӀама ца корадаь
+
+
+## Submitted responses
+
+editor-no-responses = ХӀанзалца дӀаденна жоапаш дац
+editor-response-answer-id = Жоапа Id
+editor-response-response = Жоп
+editor-response-credit = Балл
+editor-response-submitted = ДӀаденна
+
+
+## The context-help panel
+
+help-placeholder = Документаци гойта курсор тега цӀера тӀа, атрибута тӀа е { $ref } тӀа хӀоттабе.
+
+help-unsupported-ref-chain = { $example } санна дукха дакъа дола хьажараш йолчоа гӀо хӀанза дац.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Хьажарна объект ца корайо: { $ref }.
+        [multiple] Хьажарна дукха объекташ корадаь: { $ref }.
+       *[indeterminate] { $ref } объект билгалде ца делар.
+    }
+
+help-learn-about-references = Хьажарий хьакъехьа хьахьовзаде →
+help-reference-page = Хьисапа оагӀув →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } чу
+       *[top] Лакхарча тӀегӀа тӀа
+    }{ $allowed ->
+        [none] { " — укхаза хӀама ца таралу." }
+        [text] { " — укхаза текст язъе мега." }
+        [text-and-components] { " — укхаза текст язъе мега, е укхарех зехьа:" }
+       *[components] { " — укхарех зехьа:" }
+    }
+
+help-suggestions-footer = Масса { $total } компонент гойта { $shortcut } тӀатаӀае.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объекта тӀа хьажар.
+       *[other] { $ref } — { $target } объекта тӀа хьажар ({ $line }-ча могӀа).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Из { $owner } { $role } санна чудаьккхад.
+       *[other] Из { $owner } { $line }-ча могӀа тӀа { $role } санна чудаьккхад.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элемента { $property } яха башхала тӀа хьажар.
+       *[other] { $ref } — { $element } элемента { $property } яха башхала тӀа хьажар ({ $line }-ча могӀа).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = дакъа
+help-kind-array-entry = массива элемент
+
+help-default = Бух болаш мах:
+help-active-default = ХӀанзара бух болаш мах:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Мега мах (хӀор элемента цхьаъ):
+       *[other] Мега мах:
+    }
+
+help-suggested-values = Хьехам бинна мах:
+
+help-inserts = ТӀатуху:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координаташ:
+    }
+
+help-type = Тайпа:
+
+help-resolved-style = Схьаэцна стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Схьаэцна функцешта цӀераш:
+help-reset-list = Укх моттига юхаяккхара список:
+help-added-on-input = Укх моттига тӀа тӀатоьхад:
+help-removed-on-input = Укх моттигара дӀадаьккхад:
+
+help-reset-overrides = { $reset } — { $additional } а, { $removed } а тӀехьа толаш да.

--- a/packages/i18n/locales/kbd/chrome.ftl
+++ b/packages/i18n/locales/kbd/chrome.ftl
@@ -1,0 +1,138 @@
+# Kabardian (East Circassian) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic literary standard of Kabardino-Balkaria and
+# Karachay-Cherkessia, which is what those republics' schools and publishing
+# use and what CLDR fills a bare `kbd` in as. This is the eastern Circassian
+# standard; `locales/ady` is the western one.
+#
+# The palochka Ӏ is a letter of the alphabet, not a Latin capital I and not a
+# digit 1. U+04C0 is used throughout, inside lowercase words as well.
+#
+# Kabardian counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gives it. A noun after a
+# numeral does not take a plural ending, and the numeral *follows* the noun —
+# «гъэунэхуныгъэ 3», three attempts — so the two branches differ in nothing but
+# the number they print, and the counted messages read noun-first.
+#
+# Kabardian has no grammatical gender and no noun classes, so nothing in this
+# catalog agrees with anything. See `content.ftl` for the whole of that
+# reasoning and for the adjective-after-noun order the descriptions use.
+#
+# Nothing here welds a case ending onto a placeable: Kabardian's oblique is
+# «-м» after a vowel and «-ым» after a consonant, so its shape depends on a
+# word the catalog never sees. Where a case would have fallen on a value the
+# sentence is built around a free word instead.
+#
+# Two verb choices a speaker should look at first. Progressive states —
+# "Checking...", "Initializing..." — are written as masdars in -н, which is the
+# citation form and reads as a label rather than as a report; a speaker may
+# prefer the finite present. And «ЖыӀэгъуэ» for `feedback-heading` is the
+# weakest word in the file: Kabardian has no settled term for feedback in this
+# sense, and this one merely says "remark".
+
+
+## Answer submission
+
+answer-checking = Къэпщытэн…
+answer-submitting = Егъэхьын…
+answer-checking-status = Жэуапыр къэпщытэн
+answer-submitting-status = Жэуапыр егъэхьын
+answer-correct = Тэмэмщ
+answer-incorrect = Тэмэмкъым
+answer-response-saved = Жэуапыр хъумащ
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% тэмэм
+answer-percent-short = { $percent } %
+max-credit-available = Къэпхьыфыну балл нэхъыбэр: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] гъэунэхуныгъэ къэнакъым
+        [one] гъэунэхуныгъэ { $count } къэнащ
+       *[other] гъэунэхуныгъэ { $count } къэнащ
+    }
+validation-correct = (Тэмэмщ)
+validation-incorrect = (Тэмэмкъым)
+validation-partially-correct = (Ӏыхьэу тэмэмщ)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } и жэуап { $count } къэгъэлъэгъуэн
+       *[other] { $answerId } и жэуап { $count } къэгъэлъэгъуэн
+    }
+
+## Disclosure panels
+
+feedback-heading = ЖыӀэгъуэ
+collapsible-click-to-open = (Ӏухын папщӀэ къытеӀуэ)
+collapsible-click-to-close = (зэхуэщӀын папщӀэ къытеӀуэ)
+collapsible-initializing = Къызэгъэпэщын…
+footnote-show = ЩӀэт тхыгъэр къэгъэлъэгъуэн
+footnote-hide = ЩӀэт тхыгъэр гъэпщкӀун
+description-more-information = хъыбар нэхъыбэ
+
+## Controls
+
+slider-previous = Ипэрей
+slider-next = КӀэлъыкӀуэ
+keyboard-open = Клавиатурэр Ӏухын
+keyboard-close = Клавиатурэр зэхуэщӀын
+choice-input-remove-choice = { $choice } хэгъэкӀын
+matrix-remove-row = Сатыр хэгъэкӀын
+matrix-add-row = Сатыр хэгъэхьэн
+matrix-remove-column = Столбец хэгъэкӀын
+matrix-add-column = Столбец хэгъэхьэн
+subset-add-remove-points = Точкэ хэгъэхьэн/хэгъэкӀын
+subset-toggle-points-intervals = Точкэхэмрэ интервалхэмрэ зэхъуэкӀын
+subset-move-points = Точкэхэр гъэӀэпхъуэн
+subset-clear = Гъэкъэбзэн
+orbital-add-row = Сатыр хэгъэхьэн
+orbital-remove-row = Сатыр хэгъэкӀын
+orbital-add-box = Клеткэ хэгъэхьэн
+orbital-remove-box = Клеткэ хэгъэкӀын
+orbital-add-up-arrow = Стрелкэ дэкӀуей хэгъэхьэн
+orbital-add-down-arrow = Стрелкэ ех хэгъэхьэн
+orbital-remove-arrow = Стрелкэ хэгъэкӀын
+orbital-row-label = Сатыр { $row } и фӀэщыгъэцӀэ
+pretzel-answer = Жэуап
+summary-statistics-caption = { $column } и статистикэ зэхуэхьэса
+
+## Math input
+
+math-input-preview-region = математикэ къэгъэлъэгъуэныгъэм и япэ теплъэ
+math-input-preview = Япэ теплъэ
+math-input-invalid-expression = Къэгъэлъэгъуэныгъэ мытэмэм:
+
+## Document status
+
+viewer-initializing = Къызэгъэпэщын…
+
+## Errors
+
+error-heading = Щыуагъэ
+error-found-at =
+    { $span ->
+        [line] Къыщагъуэтар: сатыр { $startLine }.
+       *[lines] Къыщагъуэтар: сатыр { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Мы документым щыуагъэхэр хэтщ!
+diagnostic-heading-error = Щыуагъэ
+diagnostic-heading-warning = Гъэсакъыныгъэ
+diagnostic-heading-information = Хъыбар
+diagnostic-heading-hint = Чэнджэщ
+accessibility-heading-level-1 = WCAG AA Ӏэрыхуагъэм и къутэныгъэ
+accessibility-heading-level-2 = Ӏэрыхуагъэм теухуа гъэсакъыныгъэ
+something-went-wrong = Зыгуэр тэмэму екӀуэкӀакъым.
+renderer-load-failed = къэгъэлъэгъуакӀуэр къэхьын хъуакъым. НапэкӀуэцӀыр къэгъэщӀэрэщӀэж.
+core-start-failed = Мы документыр къэгъэлэжьэн хъуакъым. НапэкӀуэцӀыр къэгъэщӀэрэщӀэж.
+core-start-failed-busy = Мы документыр къэгъэлэжьэн хъуакъым. Зэуэ документ куэд къыщӀидзащ, аращ компьютер хуэмым зэман нэхъыбэ щӀытрагъэкӀуадэр. НэгъуэщӀ документхэр къызэгъэпэща нэужь напэкӀуэцӀыр къэбгъэщӀэрэщӀэжмэ, сэбэп хъунщ.
+core-start-failed-retry = Мы документыр къэгъэлэжьэн хъуакъым.
+core-start-failed-busy-retry = Мы документыр къэгъэлэжьэн хъуакъым. Зэуэ документ куэд къыщӀидзащ, аращ компьютер хуэмым зэман нэхъыбэ щӀытрагъэкӀуадэр.
+core-start-retry = Иджыри зэ епщытэж
+saved-state-unavailable = Уи лэжьыгъэ хъумар къэхьын хъуакъым.

--- a/packages/i18n/locales/kbd/content.ftl
+++ b/packages/i18n/locales/kbd/content.ftl
@@ -1,0 +1,305 @@
+# Kabardian (East Circassian) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic literary standard of Kabardino-Balkaria and
+# Karachay-Cherkessia — the orthography the republics' schools, their
+# newspapers and their textbook publishing use, and what CLDR fills a bare
+# `kbd` in as (`kbd` maximizes to `kbd-Cyrl-RU`). Kabardian and Adyghe are two
+# written standards over one Circassian continuum; this catalog is the eastern
+# one and is not `locales/ady`, which is the western one and was seeded
+# separately.
+#
+# **The palochka Ӏ is a letter of the alphabet.** It is neither a Latin capital
+# I nor a digit 1, and Kabardian cannot be read without it: «фӀыцӀэ» (black),
+# «щхъуантӀэ» (green), «Ӏув» (thick) and «Ӏыхьэ» (part) all turn into different
+# words or into nothing at all if it is typed as `I` or `1`. This file uses
+# U+04C0 throughout, inside lowercase words as well, which is how Kabardian
+# printing sets it.
+#
+# Kabardian counts in two plural categories, `one` and `other`. Nothing in this
+# file selects on a count.
+#
+# **Kabardian has no grammatical gender and no noun classes, and an attributive
+# adjective agrees with nothing** — it takes no prefix, no suffix and no
+# concord. So `noun-gender` answers one token for everything and not a single
+# message below forks on `$gender` or on `$role`. That is the opposite answer
+# from `locales/ce`, the exemplar this catalog was written against: Chechen is
+# Nakh and has a real four-way class system, and Kabardian is Northwest
+# Caucasian and has none. Two Caucasian languages, one script, two answers.
+#
+# **An attributive adjective FOLLOWS its noun in Kabardian** — «хъурей плъыжь»
+# is a red circle, «линэ занщӀэ Ӏув» a thick straight line — so every
+# composition message below puts the noun first and the describing words after
+# it, which is the reverse of the English frame. Among the adjectives
+# themselves the relative order is English's: width, then dash pattern, then
+# colour, the way `locales/ga`, `locales/gd` and `locales/br` run their
+# postnominal strings. A numeral also follows its noun («сатыр 5», line 5),
+# which is why the counted messages in the other three files read noun-first.
+#
+# **Adjective and noun very often form a compound in Kabardian, and this
+# catalog cannot write one.** The tight construction welds the describing word
+# onto the noun's stem, and in `style-with-noun` the noun arrives as
+# `{ $noun }` — a value the catalog never sees. So the loose, juxtaposed
+# construction is written throughout, which is grammatical everywhere and is
+# what a Kabardian technical description uses anyway. This is the README's
+# affix rule reached through a compound rather than through a case ending.
+#
+# **Nothing here welds a case suffix onto a placeable, and Kabardian's oblique
+# is exactly why it must not.** The oblique/ergative marker is «-м» after a
+# vowel and «-ым» after a consonant, so its shape is decided by a word the
+# catalog cannot see. Every place a case would have fallen on a value, the
+# sentence is rebuilt around a free word instead — «иӀэу» (having), «щӀыгъуу»
+# (together with), «тету» (standing on) — which is the README's third and fifth
+# ways out taken together.
+#
+# **What a speaker should check first, in this order.** (1) The colour table:
+# Circassian «щхъуантӀэ» historically covers green *and* blue, and the style
+# pipeline needs those as two separate words, so this catalog splits them as
+# «щхъуантӀэ» green against «къащхъуэ» blue — a choice, not a translation, and
+# the same problem `locales/sah` and `locales/os` record for «күөх» and
+# «цъæх». «гъуэжьыплъ» for orange, «шхъуэплъ» for purple and «плъыжьыфэ» for
+# pink are modern compounds of the same kind; «гъуабжэ» grey and «гъуэплъ»
+# brown are the two this seed is least sure of. (2) The polygon nouns, built on
+# «къуапэ» (corner) with an incorporated numeral — «къуапищ» three-cornered,
+# «къуапиплӀ» four-cornered — which is a real Circassian construction but one
+# whose school-register spelling this seed could not check. (3) Whether the
+# Russian loans naturalized with final -э (точкэ, линэ, функцэ, таблицэ) are the
+# forms the mathematics textbooks print, or whether they keep the Russian -а.
+
+
+## Style vocabulary
+##
+## No word here agrees with anything, so nothing forks. Every describing word
+## is placed after the noun by the composition messages below.
+
+color =
+    .black = фӀыцӀэ
+    .white = хужь
+    .gray = гъуабжэ
+    .red = плъыжь
+    .orange = гъуэжьыплъ
+    .yellow = гъуэжь
+    .green = щхъуантӀэ
+    .cyan = къащхъуэ нэху
+    .blue = къащхъуэ
+    .purple = шхъуэплъ
+    .pink = плъыжьыфэ
+    .brown = гъуэплъ
+line-width =
+    .thick = Ӏув
+    .thin = псыгъуэ
+line-style =
+    .dashed = зэпыуда
+    .dotted = точкэкӀэ гъэпса
+# Noun phrases: they stand in front of «щӀыгъуу» and modify nothing.
+fill-style =
+    .horizontal = горизонталь линэ
+    .vertical = вертикаль линэ
+    .diagonal = диагональ линэ
+    .backdiagonal = мыдрей диагональ линэ
+    .dots = точкэ
+    .diamonds = ромб
+noun =
+    .line = линэ занщӀэ
+    .line-segment = линэ Ӏыхьэ
+    .ray = нэбзий
+    .vector = вектор
+    .curve = линэ гъэша
+    .function = функцэ
+    .slope-field = наклон губгъуэ
+    .vector-field = вектор губгъуэ
+    .parabola = параболэ
+    .polyline = линэ къута
+    .polygon = къуапэкуэд
+    .triangle = къуапищ
+    .rectangle = къуапиплӀ захуэ
+    .circle = хъурей
+    .region = щӀыпӀэ
+    .point = точкэ
+    .square = квадрат
+    .diamond = ромб
+    .cross = жор
+    .plus = плюс
+# Kabardian would say «къуапитху» — five-cornered, with the numeral inside the
+# word — and the count arrives as a placeable, so the numeral cannot be
+# incorporated. The side count is written out as a trailing complement instead,
+# the way `locales/es` writes «de 5 lados», and the composition messages put it
+# behind the adjectives.
+noun-regular-polygon =
+    { $part ->
+        [tail] къуапэ { $numSides } иӀэу
+       *[head] къуапэкуэд захуэ
+    }
+# Kabardian has no grammatical gender and no noun classes, so every noun
+# answers the same and the answer goes unused — as in English, and unlike
+# `locales/ce` beside it.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun leads and the describing words follow it, which is the whole of what
+# Kabardian changes about this message.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+# «из» — full, filled. Nothing agrees with it, so it is written flat.
+style-filled-word = из
+# «щӀыгъуу» — "together with" — is a free word, so the pattern needs no case
+# suffix welded to it.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } щӀыгъуу { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } щӀыгъуу { $noun } { $filled } { $color }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $pattern } щӀыгъуу { $noun } { $filled } { $color } { $nounTail }
+       *[plain] { $noun } { $filled } { $color }
+    }
+# «гъунапкъэ … иӀэу» — "having a … border" — carries the whole of what English
+# says with a preposition and an article, so all four branches differ only in
+# the connective, and «иӀэу» is a free word rather than a suffix on the value.
+style-border-clause =
+    { $parts ->
+        [with-article] гъунапкъэ { $border } иӀэу
+        [and] икӀи гъунапкъэ { $border } иӀэу
+        [and-article] икӀи гъунапкъэ { $border } иӀэу
+       *[with] гъунапкъэ { $border } иӀэу
+    }
+# The pattern is a noun and the colour describes it, so the colour follows —
+# the reverse of English's order.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = изкъым
+# «тету» — "standing on" — is a free postposition, so the background colour
+# takes no ending it would have to agree with.
+style-text =
+    { $parts ->
+        [background] фон { $background } тету { $color }
+       *[plain] { $color }
+    }
+style-background-none = щыӀэкъым
+
+## Boolean words
+
+boolean-true = пэж
+boolean-false = пцӀы
+
+## Answer buttons
+
+answer-submit-label = Лэжьыгъэр къэпщытэн
+answer-submit-label-no-correctness = Жэуапыр егъэхьын
+
+## Sectional blocks
+
+section-name =
+    .activity = Ӏуэхугъуэ
+    .aside = Щхьэхуэ
+    .cascade = Каскад
+    .definition = Убзыхуныгъэ
+    .example = Щапхъэ
+    .exercise = Упражненэ
+    .exercises = Упражненэхэр
+    .given-answer = Жэуап
+    .note = Гулъытэ
+    .objectives = Мурадхэр
+    .paragraphs = Абзацхэр
+    .part = Ӏыхьэ
+    .problem = Задачэ
+    .problems = Задачэхэр
+    .proof = Щыхьэтыгъэ
+    .question = УпщӀэ
+    .section = Пычыгъуэ
+    .solution = ЗэхэгъэкӀыныгъэ
+    .task = Лэжьыгъэ
+    .theorem = Теоремэ
+# The numeral follows the word it counts, as everywhere else in this catalog,
+# and a numbered heading is closed with a period rather than a colon — the
+# convention Kabardian publishing takes from Russian typography.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Чэнджэщ
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблицэ { $enumeration }
+        [numbered-title] Таблицэ { $enumeration }{ ". " }
+        [unnumbered-title] Таблицэ{ ". " }
+       *[unnumbered] Таблицэ
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурэт { $enumeration }
+        [numbered-caption] Сурэт { $enumeration }{ ". " }
+        [unnumbered-caption] Сурэт{ ". " }
+       *[unnumbered] Сурэт
+    }
+
+## Paginator controls
+
+paginator-previous = Ипэрей
+paginator-next = КӀэлъыкӀуэ
+paginator-page = НапэкӀуэцӀ
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## `piecewise-condition-if` is the one key in this catalog that cannot land
+## correctly, and it is recorded rather than worked around. Kabardian's
+## conditional is a **suffix**, «-мэ», on the verb that closes the clause it
+## conditions; there is no free word standing in front of a condition the way
+## English's "if" does. The renderer places this message *before* the
+## mathematics it introduces, so «хъумэ» — "if it is" — sits where Kabardian
+## would never put it. That is the shape `locales/sah`, `locales/tyv`,
+## `locales/udm`, `locales/kv` and `locales/chm` already record for their own
+## clause-final conditionals; splitting the key into a prefix and a suffix
+## would fix it, and no existing catalog needs that.
+
+piecewise-condition-or = е
+piecewise-condition-if = хъумэ
+piecewise-condition-otherwise = нэгъуэщӀ щытыкӀэхэм
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Kabardino-Balkaria and
+## Karachay-Cherkessia is taught in Russian — Kabardian is a subject and the
+## medium of the primary grades, not of the periodic table — so the element
+## names a Kabardian-speaking pupil actually meets are the Russian ones, and
+## the English fallback stands nearer that curriculum than 118 unreviewed
+## coinages would. This is the school-system case, and it is a fact about one
+## education ministry rather than about the language.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Химие дамыгъэ мытэмэм
+chemistry-invalid-ionic-compound = Ион зэгухьэныгъэ мытэмэм

--- a/packages/i18n/locales/kbd/diagnostics.ftl
+++ b/packages/i18n/locales/kbd/diagnostics.ftl
@@ -1,0 +1,702 @@
+# Kabardian (East Circassian) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic literary standard of Kabardino-Balkaria and
+# Karachay-Cherkessia. The palochka Ӏ is a letter of the alphabet, not a Latin
+# capital I and not a digit 1.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Kabardian has no gender and no noun classes, so nothing here forks on
+# agreement; `content.ftl` sets out why. Counted messages put the numeral after
+# the noun, which is Kabardian's order.
+#
+# **The rule this file follows most often: a case ending is never welded onto a
+# placeable.** Kabardian's oblique is «-м» after a vowel and «-ым» after a
+# consonant, and its shape is decided by the last letter of the word in front
+# of it — a word the catalog never sees. So where English would inflect a
+# value, this file names what the value *is* and puts the ending on that word
+# instead: «`<{ $component }>` компонентым», «{ $type } лӀэужьыгъуэ». Where
+# even that would be clumsy the free postposition «папщӀэ» (for) carries the
+# relation, since it governs nothing it has to see. The one place an ending
+# does sit next to a value is after a literal `>` or a quote this catalog wrote
+# itself — «`<{ $component }>`-м» — where the letter in front of the suffix is
+# punctuation the catalog controls and is the same whatever the value is.
+#
+# The technical vocabulary is the one written Kabardian actually uses:
+# Russian-derived where the school subject is taught in Russian («компонент»,
+# «атрибут», «индекс», «функцэ», «интервал», «матрицэ»), naturalized with a
+# final -э where the Russian ends in -а, and Kabardian where the word is not
+# specialist («щыуагъэ» error, «гъэсакъыныгъэ» warning, «убзыхуа» specified,
+# «къэлъытэркъым» is ignored). A speaker should check the naturalized loans
+# first: whether the textbooks print «функцэ» or «функция» is a fact about
+# Kabardian publishing that this seed could not verify.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кӀэух точкитӀ убзыхуамэ { $attributes } къэлъытэркъым
+       *[other] кӀэух точкитӀ убзыхуамэ { $attributes } къэлъытэркъым
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] кӀэух точкэрэ курыт точкэрэ убзыхуамэ { $attributes } къэлъытэркъым
+       *[other] кӀэух точкэрэ курыт точкэрэ убзыхуамэ { $attributes } къэлъытэркъым
+    }
+
+line-segment-midpoint-offset-without-midpoint = курыт точкэ щымыӀэм деж midpointOffset зыми хуэлажьэркъым
+
+## `<line>`
+
+line-points-undetermined-dimensions = Мардэр убзыхуа мыхъуа точкэхэм пхыкӀ линэ занщӀэ.
+
+line-points-too-few-dimensions = Линэ занщӀэр нэхъ мащӀэ дыдэу мардитӀ зиӀэ точкэхэм пхыкӀын хуейщ.
+
+line-points-depend-on-variables = Линэ занщӀэр зэхъуэкӀыгъуэхэм елъыта точкэхэм пхыкӀщ: { $variables }.
+
+line-equation-invalid-format = { $variable1 }, { $variable2 } зэхъуэкӀыгъуэхэмкӀэ тха линэ занщӀэм и уравненэм и формат тэмэмкъым.
+
+## `<ray>`
+
+ray-overprescribed-through = Нэбзийр through, endpoint икӀи direction яхьэлӀауэ убзыхуащ. Убзыхуа through къэлъытэркъым.
+
+ray-dimension-mismatch = нэбзийм и numDimensions зэтехуэркъым.
+
+## `<vector>`
+
+vector-overprescribed-head = Векторыр head, tail икӀи displacement яхьэлӀауэ убзыхуащ. Убзыхуа head къэлъытэркъым.
+
+vector-dimension-mismatch = векторым и numDimensions зэтехуэркъым.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` компонентым хуэшэн хъунукъым, абы nearestPoint зыфӀаща щытыкӀэ зэхъуэкӀыгъуэ иӀэкъыми.
+
+constrain-to-without-nearest-point = `<{ $component }>` компонентым хуэгъэувын хъунукъым, абы nearestPoint зыфӀаща щытыкӀэ зэхъуэкӀыгъуэ иӀэкъыми.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` компонентым и кӀуэцӀым хуэгъэувын хъунукъым, абы nearestPoint зыфӀаща щытыкӀэ зэхъуэкӀыгъуэ иӀэкъыми.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline мыхъу choiceInput-м labelPosition къыщалъытэркъым
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput папщӀэ убзыхуа индексхэр къэлъытэркъым: индексхэм я бжыгъэмрэ choice кӀуэцӀ элементхэм я бжыгъэмрэ зэтехуэркъым.
+
+pretzel-indices-count-mismatch = problem папщӀэ убзыхуа индексхэр къэлъытэркъым: индексхэм я бжыгъэмрэ problem кӀуэцӀ элементхэм я бжыгъэмрэ зэтехуэркъым.
+
+shuffle-indices-count-mismatch = shuffle папщӀэ убзыхуа индексхэр къэлъытэркъым: индексхэм я бжыгъэмрэ компонентхэм я бжыгъэмрэ зэтехуэркъым.
+
+indices-ignored-out-of-range = { $component } папщӀэ убзыхуа индексхэр къэлъытэркъым: зыкъом гъунапкъэм икӀащ.
+
+pretzel-indices-repeated = pretzel папщӀэ убзыхуа индексхэр къэлъытэркъым: зыкъом къытрагъэзэжащ.
+
+pretzel-circuit-first-index = circuit хабзэм тету лажьэ pretzel папщӀэ убзыхуа индексхэр къэлъытэркъым: япэ индексыр 1 хъун хуейщ.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` строкэ кӀуэцӀ элементхэм ядэлэжьэн папщӀэ `type` атрибут убзыхуа хъун хуейщ.
+
+invalid-type-defaulting-to-math = { $component } компонентым и type { $type } тэмэмкъым. math, text, number е boolean хъун хуейщ. math къащтэ.
+
+string-not-valid-component-to-arrange = "{ $value }" строкэр { $component } папщӀэ компонент тэмэмкъым. Къэлъытэркъым.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } лӀэужьыгъуэр тэмэмкъым, number къащтэ.
+
+invalid-variable-value = ЗэхъуэкӀыгъуэм и мыхьэнэ тэмэмкъым: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Вариантым и индекс { $index } бжыгъэ хъун хуейщ
+
+variant-index-must-be-integer = Вариантым и индекс { $index } бжыгъэ псо хъун хуейщ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют мардэхэм хуэгъэпсакъым. Бгъуагъхэр зэпэлъытауэ ягъэувщ.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют мардэхэм хуэгъэпсакъым. Гъунапкъэхэр зэпэлъытауэ ягъэувщ.
+
+side-by-side-no-block-child = `<{ $component }>` тэмэмкъым: блок кӀуэцӀ элементу зы нэхъ мыхъуми иӀэн хуейщ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Графикэ `<label>`-м тет `for` атрибутыр къэлъытэркъым.
+
+label-for-must-resolve-to-one = `<label>`-м тет `for` атрибутым зы компонент закъуэ къигъэлъагъуэ хъун хуейщ.
+
+label-for-unresolved = `<label>`-м тет `for` атрибутым компонент къригъэлъэгъуэн хъуакъым.
+
+label-for-answer-with-authored-inputs = `<label>`-м тет `for` атрибутым и гугъу ищӀыр авторым езым итха хэлъхьапӀэхэр зиӀэ `<answer>`-щ; хэлъхьапӀэм занщӀэу тегъэпсыхь.
+
+label-for-answer-without-input = `<label>`-м тет `for` атрибутым и гугъу ищӀыр хэлъхьапӀэ зимыӀэ `<answer>`-щ.
+
+label-for-must-reference-input-or-answer = `<label>`-м тет `for` атрибутым хэлъхьапӀэ е жэуап и гугъу ищӀын хуейщ.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ӏэрыхуагъэм папщӀэ `<{ $component }>` компонентым гурыӀуэгъуэ кӀэщӀ иӀэн хуейщ, армырамэ гъэщӀэрэщӀэн хуэдэу убзыхуа хъун хуейщ.
+
+accessibility-video-short-description = Ӏэрыхуагъэм папщӀэ `<video>`-м гурыӀуэгъуэ кӀэщӀ иӀэн хуейщ.
+
+accessibility-input-short-description-or-label = Ӏэрыхуагъэм папщӀэ `<{ $component }>` компонентым гурыӀуэгъуэ кӀэщӀ е фӀэщыгъэцӀэ иӀэн хуейщ.
+
+accessibility-answer-input-short-description-or-label = Ӏэрыхуагъэм папщӀэ хэлъхьапӀэ къэзыгъэщӀ `<answer>`-м гурыӀуэгъуэ кӀэщӀ е фӀэщыгъэцӀэ иӀэн хуейщ.
+
+accessibility-short-description-contains-math = ГурыӀуэгъуэ кӀэщӀхэм `<{ $component }>` хуэдэ математикэ компонентхэр хэмытын хуейщ. Математикэр псалъэкӀэ къэӀуэтэж.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Пычыгъуэм и щхьэм и текстым папщӀэ { $colorName } и контрастыр икъукъым (фӀыцӀафэ хабзэм) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; нэхъ мащӀэ дыдэу { $threshold }:1 хуейщ).
+       *[other] Пычыгъуэм и щхьэм и текстым папщӀэ { $colorName } и контрастыр икъукъым ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; нэхъ мащӀэ дыдэу { $threshold }:1 хуейщ).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Точкэ { $count } пхыкӀ `<circle>`, а точкэхэм бжыгъэ мыхьэнэ ямыӀэу, иджыри зэфӀагъэкӀакъым.
+
+circle-too-many-through-points = Точкэ 3-м нэхъыбэм пхыкӀ хъурей къэлъытэн хъунукъым.
+
+circle-overprescribed-radius-center-points = Радиусри центри пхыкӀ точкэхэри убзыхуауэ хъурей къэлъытэн хъунукъым.
+
+circle-center-with-multiple-points = Центр убзыхуауэ, точкэ 1-м нэхъыбэм пхыкӀ хъурей къэлъытэн хъунукъым.
+
+circle-radius-too-small = Хъурей къэлъытэн хъунукъым: точкитӀым я зэхуакур { $distance } щыхъукӀэ, убзыхуа радиус { $radius } цӀыкӀу дыдэщ.
+
+circle-radius-with-many-points = Радиус убзыхуауэ, точкитӀым нэхъыбэм пхыкӀ хъурей къэгъэщӀын хъунукъым.
+
+circle-invalid-center-or-through-points = Хъурейм и центр е пхыкӀ точкэхэр тэмэмкъым.
+
+circle-radius-center-with-multiple-points = Центр убзыхуауэ, точкэ 1-м нэхъыбэм пхыкӀ хъурейм и радиус къэлъытэн хъунукъым.
+
+circle-change-radius-non-numerical = Бжыгъэ мыхьэнэ зимыӀэ точкэхэм пхыкӀ хъурейм и радиус зэхъуэкӀын хъунукъым
+
+circle-radius-with-points-non-numerical = Бжыгъэ мыхьэнэ щымыӀэм деж, радиус убзыхуауэ зы точкэм нэхъыбэм пхыкӀ хъурей къэгъэщӀын хъунукъым.
+
+circle-change-center-non-numerical = Бжыгъэ мыхьэнэ зимыӀэ точкэхэм пхыкӀ хъурейм и центр зэхъуэкӀыныр иджыри зэфӀагъэкӀакъым.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцэм и областым и мардэхэр икъукъым. Областым интервал { $intervals } иӀэщ, ауэ функцэм { $inputs ->
+            [one] хэлъхьэныгъэ { $inputs }
+           *[other] хэлъхьэныгъэ { $inputs }
+        } иӀэщ.
+       *[other] Функцэм и областым и мардэхэр икъукъым. Областым интервал { $intervals } иӀэщ, ауэ функцэм { $inputs ->
+            [one] хэлъхьэныгъэ { $inputs }
+           *[other] хэлъхьэныгъэ { $inputs }
+        } иӀэщ.
+    }
+
+function-domain-invalid-format = Функцэм и областым и формат тэмэмкъым.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцэм и максимум бжыгъэ мыхъур къэлъытэркъым.
+        [minimum] Функцэм и минимум бжыгъэ мыхъур къэлъытэркъым.
+        [extremum] Функцэм и экстремум бжыгъэ мыхъур къэлъытэркъым.
+        [point] Функцэм и точкэ бжыгъэ мыхъур къэлъытэркъым.
+        [slope] Функцэм и наклон бжыгъэ мыхъур къэлъытэркъым.
+       *[other] Функцэм и { $type } бжыгъэ мыхъур къэлъытэркъым.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцэм и максимум нэщӀыр къэлъытэркъым.
+        [minimum] Функцэм и минимум нэщӀыр къэлъытэркъым.
+        [extremum] Функцэм и экстремум нэщӀыр къэлъытэркъым.
+        [point] Функцэм и точкэ нэщӀыр къэлъытэркъым.
+       *[other] Функцэм и { $type } нэщӀыр къэлъытэркъым.
+    }
+
+function-points-too-close = Функцэм и точкитӀ зэпэгъунэгъу дыдэщ. Функцэ убзыхун хъунукъым.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцэм и итерацэхэр хъунур хэлъхьэныгъэхэм я бжыгъэмрэ къыдэкӀыгъуэхэм я бжыгъэмрэ зэхуэдэу щытмэщ. Мы функцэм хэлъхьэныгъэ { $inputs } икӀи { $outputs ->
+            [one] къыдэкӀыгъуэ { $outputs }
+           *[other] къыдэкӀыгъуэ { $outputs }
+        } иӀэщ.
+       *[other] Функцэм и итерацэхэр хъунур хэлъхьэныгъэхэм я бжыгъэмрэ къыдэкӀыгъуэхэм я бжыгъэмрэ зэхуэдэу щытмэщ. Мы функцэм хэлъхьэныгъэ { $inputs } икӀи { $outputs ->
+            [one] къыдэкӀыгъуэ { $outputs }
+           *[other] къыдэкӀыгъуэ { $outputs }
+        } иӀэщ.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = ЗэкӀэлъыкӀуэныгъэм и кӀыхьагъ тэмэмкъым. Нулым нэхъ мащӀэ мыхъу бжыгъэ псо хъун хуейщ.
+
+sequence-invalid-step = ЗэкӀэлъыкӀуэныгъэм и лъэбакъуэ тэмэмкъым. { $type } лӀэужьыгъуэ зиӀэ зэкӀэлъыкӀуэныгъэм папщӀэ бжыгъэ хъун хуейщ.
+
+sequence-invalid-endpoint-number = Бжыгъэ зэкӀэлъыкӀуэныгъэм и "{ $attribute }" тэмэмкъым. Бжыгъэ хъун хуейщ.
+
+sequence-invalid-endpoint-letters = Хьэрф зэкӀэлъыкӀуэныгъэм и "{ $attribute }" тэмэмкъым. Хьэрф зэгухьэныгъэ хъун хуейщ.
+
+sequence-invalid-endpoint = ЗэкӀэлъыкӀуэныгъэм и "{ $attribute }" тэмэмкъым.
+
+select-from-sequence-coprime-not-numbers = бжыгъэхэр къыхэмыхыу coprime къэлъытэркъым
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations убзыхуауэ coprime къэлъытэркъым
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` папщӀэ target тэмэмкъым: target къэгъуэтакъым.
+
+target-state-variable-not-found = `<{ $source }>` папщӀэ target тэмэмкъым: `<{ $component }>` компонентым "{ $property }" зыфӀаща щытыкӀэ зэхъуэкӀыгъуэ къыщагъуэтакъым.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`-м и зэхъуэкӀыгъуэхэр щхьэхуит зэхъуэкӀыгъуэм щхьэщыкӀын хуейщ.
+
+ode-system-duplicate-variable-names = Зэхуэдэ цӀэ зиӀэ зэхъуэкӀыгъуэхэр яӀэу ОДУ-м и функцэхэр убзыхун хъунукъым.
+
+ode-system-rhs-function-error = ОДУ-м и функцэ убзыхун хъунукъым. mathjs функцэ къэгъэщӀыныгъэм щыуагъэ хэлъщ.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Линэ занщӀэ { $count } я зэхуаку дэлъ къуапэ убзыхун хъунукъым
+
+angle-invalid-through-point = `<angle>`-м и through-м хэт точкэ тэмэмкъым
+
+parabola-vertex-too-many-points = Вершинэ иӀэу, точкэ 1-м нэхъыбэм пхыкӀ параболэр иджыри зэфӀагъэкӀакъым.
+
+parabola-too-many-points = Точкэ 3-м нэхъыбэм пхыкӀ параболэр иджыри зэфӀагъэкӀакъым.
+
+intersection-too-many-items = ТӀум нэхъыбэ Ӏыхьэхэм я зэблэкӀыпӀэр иджыри зэфӀагъэкӀакъым
+
+## Other math components
+
+ionic-compound-not-two-ions = Ион зэгухьэныгъэр ионитӀ фӀэкӀ зимыӀэм иджыри зэфӀагъэкӀакъым.
+
+ionic-compound-needs-cation-and-anion = Ион зэгухьэныгъэр зы катионрэ зы анионрэ фӀэкӀ хъуркъым.
+
+solve-equations-cannot-evaluate = Уравненэр къэлъытэн зэрымыхъуам къыхэкӀыу зэхэгъэкӀын хъунукъым: { $equation }
+
+math-operators-operand-number-required = Математикэ операнд къыхэпхын папщӀэ operandNumber убзыхун хуейщ.
+
+eigen-decomposition-failed = Матрицэм и собственнэ мыхьэнэхэр къэлъытэн хъуакъым
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметрыр шаблоным хэткъым, аращи сыт щыгъуи нэщӀым техуэнущ.
+       *[other] `<matchesPattern>`: { $parameters } параметрхэр шаблоным хэткъым, аращи сыт щыгъуи нэщӀым техуэнущ.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" зэхэгъэкӀын хъунукъым. none, medium, dense е зэхуакукӀэ зэпэӀэщӀа позитив бжыгъитӀ хъун хуейщ, псалъэм папщӀэ grid="1 0.5". Сеткэ ящӀыркъым.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` компонентым { $expected ->
+        [one] зы къыдэкӀыгъуэ — точкэ къэс наклон y', псалъэм папщӀэ `y - x` —
+       *[other] къыдэкӀыгъуитӀ — точкэ къэс вектор, псалъэм папщӀэ `(y, -x)` —
+    } зиӀэ функцэ хуейщ, ауэ къыратам { $found ->
+        [one] къыдэкӀыгъуэ { $found }
+       *[other] къыдэкӀыгъуэ { $found }
+    } иӀэщ. { $alternative ->
+        [none] Зыри ящӀыркъым.
+       *[other] А функцэм папщӀэ компонентыр `<{ $alternative }>` аращ. Зыри ящӀыркъым.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибутыр къэлъытэркъым, функцэр компонентым и кӀуэцӀми итщи; кӀуэцӀым итырщ къагъэсэбэпыр. Функцэр зы щӀыкӀэкӀэ фӀэкӀ умыт.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибутым и гугъу ищӀыр компонентым и кӀуэцӀым занщӀэу итха къэгъэлъэгъуэныгъэм и зэхъуэкӀыгъуэхэрщ. { $reason ->
+        [function-child] Мыбдеж функцэр `<function>` кӀуэцӀ элементу ятащ, абы езым и зэхъуэкӀыгъуэхэр къегъэлъагъуэ, аращи `variables` къэлъытэркъым.
+       *[no-expression] Мыбдеж апхуэдэ къэгъэлъэгъуэныгъэ щыӀэкъым, аращи `variables` къэлъытэркъым.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure къэгъэлъэгъуакӀуэм xLabelPosition="left" щыдэӀыгъкъым; ижьымкӀэ щыт хабзэр къагъэсэбэп.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure къэгъэлъэгъуакӀуэм yLabelPosition="bottom" щыдэӀыгъкъым; щхьэщыгум щыт хабзэр къагъэсэбэп.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure зэрахъуэкӀыныгъэм папщӀэ осьхэм я гъунапкъэхэр тэмэмкъым; хабзэ bbox (-10,-10,10,10) къагъэсэбэп.
+
+prefigure-invalid-width = `<graph>`: prefigure зэрахъуэкӀыныгъэм папщӀэ бгъуагъыр тэмэмкъым; хабзэ бгъуагъ 425 къагъэсэбэп.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure зэрахъуэкӀыныгъэм папщӀэ aspectRatio тэмэмкъым; хабзэ зэхэлъыкӀэ 1 къагъэсэбэп.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткэм и зэхуакухэр осьхэм я гъунапкъэхэм тещӀыхьауэ цӀыкӀу дыдэщ; prefigure къэгъэлъэгъуакӀуэм сеткэр щыхагъэкӀ.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure къэгъэлъэгъуакӀуэр къэмыгъэсэбэпмэ, аннотацэхэр къагъэлъэгъуэнукъым.
+
+multiple-annotations-children = `<graph>`-м `<annotations>` кӀуэцӀ элемент зыбжанэ къыщагъуэтащ; иужьрейм фӀэкӀ къэлъытэркъым.
+
+## Referring to other components
+
+copy-unrecognized-component-type = КъамыцӀыху компонент лӀэужьыгъуэ хэгъэхъуэн е тещӀыкӀын хъунукъым: { $type }.
+
+copy-prop-not-found = { $component } лӀэужьыгъуэ зиӀэ компонентым { $property } prop къыщагъуэтакъым
+
+collect-no-source = collect папщӀэ къежьапӀэ къэгъуэтакъым.
+
+collect-invalid-component-type = `<{ $component }>` лӀэужьыгъуэ зиӀэ компонентхэр зэхуэхьэсын хъунукъым, а лӀэужьыгъуэр тэмэмкъыми.
+
+reference-index-unavailable = `{ $reference }` индексым и гугъу пщӀын хъунукъым
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентым { $action } щыпщӀэн хъунукъым
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннэхэм я теплъэ тэмэмкъым. Сатырхэм я кӀыхьагъхэр зэхуэдэкъым. Къыщагъуэтар componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннэхэм зэхуэдэ столбец цӀэхэр яхэтщ. Къыщагъуэтар componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннэхэм столбец цӀэ ящыщ зы щыщӀэщ. Къыщагъуэтар componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Мы жэуапым и award-р answer тегым езым игъэхьа жэуапым тещӀыхьащ, ар мыхъумыщӀэу лэжьэнущ.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` зиӀэ кӀуэцӀым щӀэт `<answer>`-м `maxNumAttempts` тегъэувэным мыхьэнэ иӀэкъым, гъэунэхуныгъэхэм я бжыгъэр кӀуэцӀым иубзыхуми. `maxNumAttempts` кӀуэцӀым тегъэувэ.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` зиӀэ нэгъуэщӀ кӀуэцӀым щӀэт, `sectionWideCheckWork` зиӀэ кӀуэцӀым `maxNumAttempts` тегъэувэным мыхьэнэ иӀэкъым, гъэунэхуныгъэхэм я бжыгъэр щӀыбагъ кӀуэцӀым иубзыхуми. `maxNumAttempts` щӀыбагъ кӀуэцӀым тегъэувэ.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality убзыхуа мыхъумэ { $attributes } атрибутым мыхьэнэ иӀэнукъым.
+       *[other] symbolicEquality убзыхуа мыхъумэ { $attributes } атрибутхэм мыхьэнэ яӀэнукъым.
+    }
+
+answer-invalid-type = Жэуапым и лӀэужьыгъуэ тэмэмкъым: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентым цӀэ иӀэкъыми, модулым и атрибуту къэбгъэсэбэп хъунукъым
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентыр модулым и атрибуту къэбгъэсэбэп хъунукъым, `<module>` лӀэужьыгъуэм "{ $name }" атрибут иӀэжщи.
+
+conditional-content-condition-ignored = case е else кӀуэцӀ элементхэр зиӀэ `<conditionalContent>` компонентым `condition` атрибутыр къыщалъытэркъым.
+
+slider-markers-type-mismatch = Маркерхэм я лӀэужьыгъуэр слайдерым и лӀэужьыгъуэм зэтехуэркъым.
+
+pretzel-problem-needs-statement-and-answer = pretzel тэмэмкъым: `<problem>` къэс зы `<statement>`-рэ зы `<answer>`-рэ хэтын хуейщ.
+
+pretzel-circuit-first-problem-distractor = pretzel тэмэмкъым: mode="circuit" щыгъуэ япэ `<problem>`-р дистрактор хъун хуейкъым.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутым и мыхьэнэ { $values } тэмэмкъым; къэлъытэркъым.
+       *[other] `{ $attribute }` атрибутым и мыхьэнэхэр { $values } тэмэмкъым; къэлъытэркъым.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутым и мыхьэнэ `{ $value }` тэмэмкъым. Атрибутыр `$`-кӀэ къыщӀэздзэ пыщӀэхэмкӀэ зэхэлъын хуейщ.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } папщӀэ функцэ цӀэ тэмэм мыхъухэр къэлъытакъым: { $names }. ЦӀэ къэс и къэгъэлъэгъуапӀэ Ӏыхьэм нэхъ мащӀэ дыдэу дамыгъитӀ (хьэрф е дефис) хэтын хуейщ; абы яужь `|<mathspeak alternative>` кӀэух къыкӀэлъыкӀуэ хъунущ.
+
+## Building components from the source
+
+component-type-invalid = Компонент лӀэужьыгъуэ тэмэмкъым: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутым къытебгъэзэж хъунукъым.
+
+attribute-invalid-for-component = `<{ $componentType }>` лӀэужьыгъуэ зиӀэ компонентым папщӀэ "{ $attribute }" атрибутыр тэмэмкъым.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Стиль убзыхуныгъэ { $styleNumber }: { $context ->
+        [text-on-background] текстым и плъыфэр фоным и плъыфэм пэщӀэту
+        [high-contrast] контраст лъагэ зиӀэ плъыфэр холстым пэщӀэту
+        [line] линэм и плъыфэр холстым пэщӀэту
+        [marker] маркерым и плъыфэр холстым пэщӀэту
+       *[text-on-canvas] текстым и плъыфэр холстым пэщӀэту
+    } контрастыр икъукъым{ $mode ->
+        [dark] { " (фӀыцӀафэ хабзэм)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; нэхъ мащӀэ дыдэу { $threshold }:1 хуейщ).
+
+style-definition-dark-mode-text-background-contrast =
+    Стиль убзыхуныгъэ { $styleNumber }: убзыхуа плъыфэхэм нэхуфэ хабзэм папщӀэ контраст икъу яӀэ пэтми, а мыхьэнэхэм къатехъукӀа фӀыцӀафэ хабзэм и плъыфэхэм текстымрэ фонымрэ я зэхуаку контраст икъу дэлъкъым ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; нэхъ мащӀэ дыдэу { $threshold }:1 хуейщ). { $suggestion ->
+        [available] ФӀыцӀафэ хабзэм контраст икъу щыгъуэтын папщӀэ, е нэхуфэ хабзэм и контрастыр гъэбагъуэ (псалъэм папщӀэ, { $lightAttribute }="{ $lightColor }" гъэув), е фӀыцӀафэ хабзэм и плъыфэр зэхъуэкӀ (псалъэм папщӀэ, { $darkAttribute }="{ $darkColor }" гъэув).
+       *[none] ФӀыцӀафэ хабзэм контраст икъу щыгъуэтын папщӀэ, нэхуфэ хабзэм и контрастыр гъэбагъуэ, армырамэ къатехъукӀа плъыфэхэр textColorDarkMode икӀи/е backgroundColorDarkMode къэбгъэсэбэпкӀэ зэхъуэкӀ.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Стиль убзыхуныгъэ { $styleNumber }: убзыхуа текст плъыфэм нэхуфэ хабзэм папщӀэ контраст икъу иӀэ пэтми, а мыхьэнэм къытехъукӀа фӀыцӀафэ хабзэм и текст плъыфэм холстым пэщӀэту контраст икъу иӀэкъым ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; нэхъ мащӀэ дыдэу { $threshold }:1 хуейщ). { $suggestion ->
+        [available] ФӀыцӀафэ хабзэм контраст икъу щыгъуэтын папщӀэ, е нэхуфэ хабзэм и контрастыр гъэбагъуэ (псалъэм папщӀэ, textColor="{ $lightColor }" гъэув), е фӀыцӀафэ хабзэм и плъыфэр зэхъуэкӀ (псалъэм папщӀэ, textColorDarkMode="{ $darkColor }" гъэув).
+       *[none] ФӀыцӀафэ хабзэм контраст икъу щыгъуэтын папщӀэ, нэхуфэ хабзэм и контрастыр гъэбагъуэ, армырамэ къытехъукӀа плъыфэр textColorDarkMode къэбгъэсэбэпкӀэ зэхъуэкӀ.
+    }
+
+section-multiple-style-palettes = Пычыгъуэм зы <stylePalette> фӀэкӀ къыхихын хъунукъым; иужьрейр къагъэсэбэп.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, numToSelect нулым нэхъ мащӀэ мыхъу бжыгъэ псо хъуркъыми.
+
+variant-num-to-select-not-constant-number = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, numToSelect зэмыхъуэж бжыгъэ хъуркъыми.
+
+variant-with-replacement-not-constant-boolean = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, withReplacement зэмыхъуэж булев хъуркъыми.
+
+variant-select-weight-disables-unique = selectWeight е selectForVariants зиӀэ вариант щыӀэмэ, select-м и вариант щхьэхуэхэр къагъэсэбэпыркъым
+
+variant-coprime-undetermined = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, coprime сыт щыгъуи пцӀыуэ щытыныр убзыхун зэрымыхъум къыхэкӀыу.
+
+variant-attribute-not-constant = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, { $attribute } зэмыхъуэжу щыткъыми.
+
+variant-attribute-not-number = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, { $attribute } бжыгъэ хъуркъыми.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } лӀэужьыгъуэ зиӀэ { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, { $attribute } { $expected ->
+        [letters-combination] хьэрф зэгухьэныгъэ
+        [math-expression] математикэ къэгъэлъэгъуэныгъэ тэмэм
+        [integer] бжыгъэ псо
+       *[number] бжыгъэ
+    } хъуркъыми.
+
+variant-length-not-integer = { $component } и вариант щхьэхуэхэр убзыхун хъунукъым, length бжыгъэ псо хъуркъыми.
+
+variant-sort-not-implemented = sort зиӀэ { $component } и вариант щхьэхуэхэр иджыри зэфӀагъэкӀакъым
+
+variant-exclude-combinations-not-implemented = excludeCombinations зиӀэ { $component } и вариант щхьэхуэхэр иджыри зэфӀагъэкӀакъым
+
+variant-math-exclude-not-implemented = exclude зиӀэ math лӀэужьыгъуэ { $component } и вариант щхьэхуэхэр иджыри зэфӀагъэкӀакъым
+
+variant-non-constant-exclude-not-implemented = зэхъуэкӀыж exclude зиӀэ { $component } и вариант щхьэхуэхэр иджыри зэфӀагъэкӀакъым
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure къэгъэлъэгъуакӀуэм щыдэӀыгъкъым; къытехъукӀар хагъэкӀащ.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометриер мыухауэ е бжыгъэ гъунапкъэншэу; къытехъукӀар хагъэкӀащ.
+
+prefigure-curve-label-omitted = { $subject }: зэрахъуэкӀа линэ гъэшахэм фӀэщыгъэцӀэ ятрагъэувэн хъуркъым; фӀэщыгъэцӀэр хагъэкӀащ.
+
+prefigure-curve-unsupported-definition-type = { $subject }: линэ гъэшам и функцэ убзыхуныгъэ лӀэужьыгъуэ '{ $definitionType }' щыдэӀыгъкъым; къытехъукӀар хагъэкӀащ.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-м тет flipFunctions атрибутыр щыдэӀыгъкъым; къытехъукӀар хагъэкӀащ.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-м формулэ лӀэужьыгъуэ зиӀэ функцэ кӀуэцӀ элементхэр фӀэкӀ щыдэӀыгъкъым; къытехъукӀар хагъэкӀащ.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] линэ лъэпкъым и фӀэщыгъэцӀэм
+       *[point] точкэм и фӀэщыгъэцӀэм
+    } папщӀэ labelPosition '{ $labelPosition }' щыдэӀыгъкъым; PreFigure и хабзэ зэгъэуцуэкӀэр къагъэсэбэп.
+
+prefigure-fill-style-unsupported = { $subject }: изыгъэ лӀэужьыгъуэ '{ $fillStyle }' PreFigure-м щыдэӀыгъкъым; зэпымыу изыгъэ къагъэсэбэп.
+
+prefigure-line-style-unknown = { $subject }: линэ лӀэужьыгъуэ къамыцӀыху '{ $lineStyle }' PreFigure-м и къыдэкӀыгъуэм хагъэкӀащ.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер лӀэужьыгъуэ '{ $markerStyle }' PreFigure и 'diamond' лӀэужьыгъуэм хуагъэкӀуащ.
+
+prefigure-marker-style-unsupported = { $subject }: маркер лӀэужьыгъуэ '{ $markerStyle }' PreFigure-м щыдэӀыгъкъым; хабзэ лӀэужьыгъуэр къагъэсэбэп.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` тэмэмкъым; зыхуэгъэзар къэгъуэтын хъуакъым. Аннотацэр хагъэкӀащ.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref`-м зыхуэгъэза зыбжанэ къигъэлъэгъуащ; япэрейр къагъэсэбэп.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` тэмэмкъым; зыхуэгъэзар графикым и щӀыбагъ къонэ. Аннотацэр хагъэкӀащ.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` тэмэмкъым; зыхуэгъэзар prefigure зэрахъуэкӀыныгъэм щыдэӀыгъ графикэ объект хъуркъым. Аннотацэр хагъэкӀащ.
+
+annotation-text-missing = `<annotation>`: `text` щыӀэкъым е нэщӀщ; текст нэщӀ къыдагъэкӀ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Хъурей елъытыныгъэ къэгъуэтащ.
+       *[other] `<{ $componentType }>` компонентым епха хъурей елъытыныгъэ къэгъуэтащ.
+    }
+
+reference-no-referent = ПыщӀэм и объект къэгъуэтакъым: `{ $reference }`
+
+reference-multiple-referents = ПыщӀэм и объект куэд къэгъуэтащ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` и { $attribute } атрибутым и формат тэмэмкъым.
+
+children-invalid = `<{ $componentType }>` папщӀэ кӀуэцӀ элементхэр тэмэмкъым: тэмэм мыхъу кӀуэцӀ элементхэр къэгъуэтащ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутым и мыхьэнэ `{ $value }` тэмэмкъым, `{ $default }` мыхьэнэр къагъэсэбэп
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML верси { $version } къэгъуэтакъым.
+       *[other] DoenetML верси { $version } къэгъуэтакъым. Верси { $fallback } къагъэсэбэп
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML тэмэмкъым: { $content }
+
+parse-tag-missing-close-tag = DoenetML тэмэмкъым: `{ $tag }` тегым зэхуэзыщӀыж тег иӀэкъым. Езыр зэхуэзыщӀыж тег е `</{ $tagName }>` тег хуейщ.
+
+parse-tag-error = DoenetML тэмэмкъым: `<{ $tagName }>` тегым щыуагъэ хэлъщ
+
+parse-attribute-missing-value = DoenetML тэмэмкъым: `{ $attribute }` атрибутыр тэмэмкъым, мыхьэнэ иӀэкъым хуэдэщ.
+
+parse-attribute-invalid = DoenetML тэмэмкъым: `{ $attribute }` атрибутыр тэмэмкъым
+
+parse-attribute-value-invalid = DoenetML тэмэмкъым: `{ $value }` атрибут мыхьэнэр тэмэмкъым
+
+parse-attribute-value-quote-mismatch = DoenetML тэмэмкъым: `{ $value }` атрибут мыхьэнэр тэмэмкъым. Кавычкэхэр зэтехуэркъым. `{ $quote }` щыщӀэ хуэдэщ
+
+parse-open-tag-name-missing = DoenetML тэмэмкъым: цӀэ зимыӀэ тег къэгъуэтащ, псалъэм папщӀэ `<`
+
+parse-tag-not-closed = DoenetML тэмэмкъым: `{ $tag }` тегыр зэхуащӀыжакъым (`>` щыщӀэ хуэдэщ).
+
+parse-self-closing-tag-name-missing = DoenetML тэмэмкъым: цӀэ зимыӀэ тег къэгъуэтащ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML тэмэмкъым: `{ $tag }` тегыр зэхуащӀыжакъым (`/>` щыщӀэ хуэдэщ).
+
+parse-tag-invalid-attributes = DoenetML тэмэмкъым: `{ $tag }` тегыр тэмэмкъым. Атрибут мытэмэмхэр иӀэнкӀэ хъунущ.
+
+parse-close-tag-name-missing = DoenetML тэмэмкъым: цӀэ зимыӀэ зэхуэщӀыж тег къэгъуэтащ, псалъэм папщӀэ `</`
+
+parse-attribute-value-unquoted = Атрибут мыхьэнэхэр кавычкэхэм яку дэтын хуейщ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML тэмэмкъым: `{ $tag }` зэхуэщӀыж тег къэгъуэтащ, ауэ абы хуэкӀуэ Ӏуих тег щыӀэкъым
+
+parse-close-tag-mismatched = DoenetML тэмэмкъым: зэхуэщӀыж тегыр зэтехуэркъым. `</{ $expected }>` хуейт. Къэгъуэтар `{ $found }`
+
+parser-node-unconvertible = { $node } узелыр Dast узелу зэхъуэкӀын хъуакъым.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' атрибут цӀэр тэмэмкъым. { $reason ->
+        [characters] ЦӀэхэм хьэрфхэр, бжыгъэхэр, щӀэдз линэхэр е дефисхэр фӀэкӀ хэт хъунукъым.
+       *[start] ЦӀэхэр хьэрфкӀэ къыщӀэдзэн хуейщ.
+    }
+
+component-name-invalid-start = Компонент цӀэ "{ $name }" тэмэмкъым. ЦӀэхэр хьэрфкӀэ къыщӀэдзэн хуейщ.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched лӀэужьыгъуэ зиӀэ жэуапым video атрибут иӀэн хуейщ
+
+answer-video-watched-video-not-reference = videoWatched лӀэужьыгъуэ зиӀэ жэуапым и video атрибутыр пыщӀэ хъун хуейщ
+
+answer-name-not-single-text = Жэуапым и name атрибутым зы текст кӀуэцӀ элемент закъуэ иӀэн хуейщ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсие тӀэгъэ куэд зэрыхъум къыхэкӀыу щӀыб DoenetML къэхьын хъуакъым. Хъурей пыщӀэныгъэ щыӀэ хъункӀэ?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" DoenetML къыхэхын хъуакъым
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" къыхэха DoenetML тэмэмкъым: "{ $componentType }" компонент лӀэужьыгъуэм зэтехуэркъым
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибутыр къагъэсэбэпыжыркъым; и пӀэкӀэ `{ $to }` къэгъэсэбэп.
+       *[other] [deprecation] `<{ $component }>`-м тет `{ $from }` атрибутыр къагъэсэбэпыжыркъым; и пӀэкӀэ `{ $to }` къэгъэсэбэп.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибутыр къагъэсэбэпыжыркъым икӀи къэлъытэркъым, `{ $to }` убзыхуащи.
+       *[other] [deprecation] `<{ $component }>`-м тет `{ $from }` атрибутыр къагъэсэбэпыжыркъым икӀи къэлъытэркъым, `{ $to }` убзыхуащи.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-м тет `{ $attribute }` атрибутыр къагъэсэбэпыжыркъым икӀи къэлъытэркъым.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-м тет `{ $attribute }` атрибутыр къагъэсэбэпыжыркъым; и пӀэкӀэ `<{ $child }>` кӀуэцӀ элемент къэгъэсэбэп.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-м тет `{ $attribute }` атрибутым и мыхьэнэ `{ $value }` къагъэсэбэпыжыркъым; и пӀэкӀэ `{ $to }` къэгъэсэбэп.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` инджылызыбзэ фӀэкӀ куэдыгъэм хуэгъэкӀуэфыркъым, аращи { $locale } бзэкӀэ тха документым и текстыр зэрыщытауэ къонэ. Куэдыгъэ формэр езыр итхэ, армырамэ `pluralForm` атрибуткӀэ гъэув.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элементыр Doenet элементу къацӀыхуркъым.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементыр документым и лъабжьэм щыхуит хъуркъым.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементыр `<{ $parent }>` и кӀуэцӀым щыхуит хъуркъым.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементым `{ $attribute }` зыфӀаща атрибут иӀэкъым.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементым и `{ $attribute }` атрибутыр список хъун хуейщ, абы хэт Ӏыхьэ къэс мыхэм ящыщ зы хъууэ: { $allowed }
+       *[other] `<{ $tag }>` элементым и `{ $attribute }` атрибутыр мыхэм ящыщ зы хъун хуейщ: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select папщӀэ вариант цӀэр тэмэмкъым. Вариант цӀэ { $variantName } зыхэт вариантхэм я бжыгъэр { $numOptions }, къыхэхын хуейр { $numToSelect }.
+
+select-variant-name-without-options = select папщӀэ вариантхэр убзыхуащ, ауэ хъуну вариант цӀэ { $variantName } папщӀэ вариант убзыхуакъым.
+
+select-variant-name-not-possible = select папщӀэ убзыхуа вариант цӀэ { $variantName } хъуну вариант цӀэкъым.
+
+select-too-few-options = Компонент { $numOptions } фӀэкӀ щымыӀэм деж компонент { $numToSelect } къыхэхын хъунукъым.
+
+select-from-sequence-too-few-values = КӀыхьагъыр { $length } хъу зэкӀэлъыкӀуэныгъэм мыхьэнэ { $numToSelect } къыхэхын хъунукъым.
+
+select-from-sequence-indices-count-mismatch = select папщӀэ убзыхуа индексхэм я бжыгъэр къыхэхын хуейм и бжыгъэм зэтехуэн хуейщ
+
+select-from-sequence-indices-not-integers = select папщӀэ убзыхуа индекс псори бжыгъэ псо хъун хуейщ
+
+select-from-sequence-index-excluded = selectfromsequence-м и убзыхуа индексыр хагъэкӀат
+
+select-from-sequence-indices-excluded-combination = selectfromsequence-м и убзыхуа индексхэр хагъэкӀа зэгухьэныгъэт
+
+select-from-sequence-coprime-not-positive-integers = Позитив бжыгъэ псохэр къыхамыхыу coprime зэгухьэныгъэхэр къыхэхын хъунукъым.
+
+select-from-sequence-coprime-common-factor = Coprime бжыгъэхэр къыхэхын хъунукъым. Хъуну мыхьэнэ псоми зэхуэдэ множитель яӀэщ. ("from" е "to" я убзыхуа мыхьэнэхэр "step"-м coprime хуэхъун хуейщ.)
+
+select-from-sequence-coprime-single-number = 1 мыхъу зы бжыгъэ закъуэм coprime зэгухьэныгъэхэр къыхэхын хъунукъым.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-м зэгухьэныгъэхэм я 70%-м нэхъыбэ хагъэкӀащ
+
+select-from-sequence-coprime-none-found = Coprime бжыгъэхэр къыхэхын хъуакъым. Хъуну мыхьэнэ псоми зэхуэдэ множитель яӀэщ.
+
+select-from-sequence-too-few-unique-values = КӀыхьагъыр { $numPossibleValues } хъу зэкӀэлъыкӀуэныгъэм мыхьэнэ щхьэхуэ { $numToSelect } къыхэхын хъунукъым
+
+select-prime-numbers-too-few-values = КӀыхьагъыр { $numValues } хъу прост бжыгъэ спискым мыхьэнэ { $numToSelect } къыхэхын хъунукъым
+
+select-prime-numbers-values-count-mismatch = select папщӀэ убзыхуа мыхьэнэхэм я бжыгъэр къыхэхын хуейм и бжыгъэм зэтехуэн хуейщ
+
+select-prime-numbers-values-not-prime = select prime number папщӀэ убзыхуа мыхьэнэ псори прост бжыгъэ спискым хэтын хуейщ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers-м и убзыхуа мыхьэнэхэр хагъэкӀа зэгухьэныгъэт
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-м зэгухьэныгъэхэм я 70%-м нэхъыбэ хагъэкӀащ
+
+select-random-combination-fluke = Хъуфыну мыхъуну насыпыншагъэкӀэ, зэрымыубзыхуа мыхьэнэхэм я зэгухьэныгъэ къыхэхын хъуакъым
+
+select-random-value-fluke = Хъуфыну мыхъуну насыпыншагъэкӀэ, зэрымыубзыхуа мыхьэнэ къыхэхын хъуакъым

--- a/packages/i18n/locales/kbd/editor.ftl
+++ b/packages/i18n/locales/kbd/editor.ftl
@@ -1,0 +1,232 @@
+# Kabardian (East Circassian) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic literary standard of Kabardino-Balkaria and
+# Karachay-Cherkessia. The palochka Ӏ is a letter, not a Latin I and not a
+# digit 1.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Kabardian counts in the same two categories English does, so every selection
+# below keeps both branches — a noun takes no plural ending after a numeral, so
+# the two read alike. A numeral follows the word it counts, so a count is
+# written after its noun. Nothing here agrees with a gender or a class:
+# Kabardian has neither, which `content.ftl` sets out in full.
+#
+# No case ending is welded onto a placeable anywhere in this file. Kabardian's
+# oblique is «-м» after a vowel and «-ым» after a consonant, so a value whose
+# last letter the catalog cannot see cannot be inflected; the identifiers this
+# file receives — `$ref`, `$target`, `$element`, `$owner` — are therefore left
+# bare and the sentence is built around them with free words.
+#
+# The weakest words here, and the first a speaker should replace: «Ӏэрыхуагъэ»
+# for accessibility (formed from «Ӏэрыхуэ», handy, and not an established
+# term), and «Ямыгъэувмэ:» / «Иджыпсту лажьэр:» for `help-default` and
+# `help-active-default`, which paraphrase the idea rather than name it.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Егъэзэжын
+       *[update] ГъэщӀэрэщӀэн
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] КъэгъэлъэгъуапӀэр { $word }
+       *[other] КъэгъэлъэгъуапӀэр { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Къыхэхын…
+editor-variant-next = Вариант къыкӀэлъыкӀуэр къыхэх
+editor-variant-previous = Вариант ипэрейр къыхэх
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA Ӏэрыхуагъэм и къутэныгъэ къэгъуэтащ. Ӏэрыхуагъэм и отчётыр { $action ->
+            [close] зэхуэщӀын
+           *[open] Ӏухын
+        } папщӀэ къытеӀуэ.
+        [advisories] Ӏэрыхуагъэм и отчётыр { $action ->
+            [close] зэхуэщӀын
+           *[open] Ӏухын
+        } папщӀэ къытеӀуэ. WCAG AA къутэныгъэ къэгъуэтакъым, ауэ Ӏэрыхуагъэм теухуа нэгъуэщӀ чэнджэщхэр щыӀэщ.
+       *[clean] Ӏэрыхуагъэм и отчётыр { $action ->
+            [close] зэхуэщӀын
+           *[open] Ӏухын
+        } папщӀэ къытеӀуэ. Ӏэрыхуагъэм теухуа гугъуехь къэгъуэтакъым.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA Ӏэрыхуагъэм и къутэныгъэ къэгъуэтащ. { $count ->
+            [one] WCAG AA къутэныгъэ { $count }
+           *[other] WCAG AA къутэныгъэ { $count }
+        } къэгъуэтащ. Ӏэрыхуагъэм и отчётыр { $action ->
+            [close] зэхуэщӀын
+           *[open] Ӏухын
+        } папщӀэ къытеӀуэ.
+        [advisories] WCAG AA къутэныгъэ къэгъуэтакъым. { $count ->
+            [one] Ӏэрыхуагъэм теухуа нэгъуэщӀ чэнджэщ { $count }
+           *[other] Ӏэрыхуагъэм теухуа нэгъуэщӀ чэнджэщ { $count }
+        } къэгъуэтащ. Ӏэрыхуагъэм и отчётыр { $action ->
+            [close] зэхуэщӀын
+           *[open] Ӏухын
+        } папщӀэ къытеӀуэ.
+       *[clean] WCAG AA къутэныгъэ къэгъуэтакъым. Ӏэрыхуагъэм и отчётыр { $action ->
+            [close] зэхуэщӀын
+           *[open] Ӏухын
+        } папщӀэ къытеӀуэ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML верси { $version }
+
+editor-tab-help = Контекстым елъытауэ дэӀэпыкъуэгъу
+editor-tab-help-short = Контекст
+editor-tab-errors = Щыуагъэхэр
+editor-tab-warnings = Гъэсакъыныгъэхэр
+editor-tab-info = Хъыбар
+editor-tab-accessibility = Ӏэрыхуагъэ
+editor-tab-responses = Ягъэхьа жэуапхэр
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторым и Ӏэмалхэр
+editor-format-as-doenetml = DoenetML хуэдэу гъэпсын
+editor-format-as-xml = XML хуэдэу гъэпсын
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Сатыр #{ $line }
+
+editor-no-errors = Щыуагъэ щыӀэкъым
+editor-no-warnings = Гъэсакъыныгъэ щыӀэкъым
+editor-no-info = Хъыбар щыӀэкъым
+
+editor-show-info-annotations = Хъыбархэр редакторым къыщыгъэлъэгъуэн
+editor-show-accessibility-annotations = Ӏэрыхуагъэм и хъыбархэр редакторым къыщыгъэлъэгъуэн
+
+editor-accessibility-learn-more = Doenet Ӏэрыхуагъэм зэрыбгъэдыхьэр зэгъащӀэ
+
+editor-accessibility-violations-heading = Ӏэрыхуагъэм и къутэныгъэхэр ({ $standard })
+
+editor-accessibility-other-heading = Ӏэрыхуагъэм теухуа нэгъуэщӀ гугъуехьхэр
+editor-none-found = Зыри къэгъуэтакъым
+
+
+## Submitted responses
+
+editor-no-responses = Иджыри жэуап ягъэхьакъым
+editor-response-answer-id = Жэуапым и Id
+editor-response-response = Жэуап
+editor-response-credit = Балл
+editor-response-submitted = Ягъэхьащ
+
+
+## The context-help panel
+
+help-placeholder = Документацэ къэпщтэн папщӀэ курсорыр тегым и цӀэм, атрибутым е { $ref } тегъэувэ.
+
+help-unsupported-ref-chain = { $example } хуэдэу Ӏыхьэ зыбжанэу зэхэт пыщӀэхэм я дэӀэпыкъуэгъу иджыри щыӀэкъым.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ПыщӀэм и объект къэгъуэтакъым: { $ref }.
+        [multiple] ПыщӀэм и объект куэд къэгъуэтащ: { $ref }.
+       *[indeterminate] { $ref } зыхуэгъэза объектыр убзыхун хъуакъым.
+    }
+
+help-learn-about-references = ПыщӀэхэм я хъыбар зэгъащӀэ →
+help-reference-page = Справочнэ напэкӀуэцӀ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } и кӀуэцӀым
+       *[top] ЛъэгапӀэ нэхъыщхьэм
+    }{ $allowed ->
+        [none] { " — мыбдеж зыри хэхуэркъым." }
+        [text] { " — мыбдеж текст птхы хъунущ." }
+        [text-and-components] { " — мыбдеж текст птхы хъунущ, е мыхэр зэгъэлъагъу:" }
+       *[components] { " — мыхэр зэгъэлъагъу:" }
+    }
+
+help-suggestions-footer = Компонент { $total } псори плъагъун папщӀэ { $shortcut } къытеӀуэ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — ар { $target } зыхуэгъэза пыщӀэщ.
+       *[other] { $ref } — ар { $target } зыхуэгъэза пыщӀэщ (сатыр { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Къыхэзылъхьар { $owner }, и мыхьэнэр { $role }.
+       *[other] Къыхэзылъхьар { $owner }, сатыр { $line }, и мыхьэнэр { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — ар { $element } и свойствэ { $property } зыхуэгъэза пыщӀэщ.
+       *[other] { $ref } — ар { $element } и свойствэ { $property } зыхуэгъэза пыщӀэщ (сатыр { $line }).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = пычыгъуэ
+help-kind-array-entry = массивым и элемент
+
+help-default = Ямыгъэувмэ:
+help-active-default = Иджыпсту лажьэр:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Мыхьэнэ хуитхэр (Ӏыхьэ къэс зырыз):
+       *[other] Мыхьэнэ хуитхэр:
+    }
+
+help-suggested-values = Мыхьэнэ чэнджэщахэр:
+
+help-inserts = Хегъэхьэ:
+
+help-coordinates =
+    { $count ->
+        [one] Координатэ:
+       *[other] Координатэхэр:
+    }
+
+help-type = ЛӀэужьыгъуэ:
+
+help-resolved-style = Стиль убзыхуа (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Функцэхэм я цӀэ убзыхуахэр:
+help-reset-list = Мы хэлъхьапӀэм и списк егъэзэжыныгъэ:
+help-added-on-input = Мы хэлъхьапӀэм хагъэхьар:
+help-removed-on-input = Мы хэлъхьапӀэм хахар:
+
+help-reset-overrides = { $reset } — { $additional } икӀи { $removed } тепщэ хуохъу.

--- a/packages/i18n/locales/krc/chrome.ftl
+++ b/packages/i18n/locales/krc/chrome.ftl
@@ -1,0 +1,128 @@
+# Karachay-Balkar viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic alphabet Karachay-Cherkessia and Kabardino-Balkaria
+# use in school and in print, and what CLDR fills a bare `krc` in as
+# (`krc-Cyrl-RU`). The digraphs къ, гъ, нг and дж are single letters of that
+# alphabet; a catalog that spells «къара» as «кара» has quietly written
+# something else.
+#
+# Karachay and Balkar are two literary norms of one language over a shared
+# standard. This catalog writes the **Karachay** norm, which is why дж- stands
+# where a Balkar reader expects ж- («джууап», not «жууап»). Nothing else in
+# the file turns on the choice, and swapping the initial is the whole of what
+# a Balkar reading would change here.
+#
+# Karachay-Balkar counts in two plural categories, `one` and `other`, the same
+# two English has, so every `{ $count -> … }` below keeps the shape it had. A
+# noun after a numeral stays singular — «2 сынау», never a plural — so the two
+# branches differ in nothing but the number they print.
+#
+# Nothing in this file agrees with a gender or a noun class: the language is
+# Turkic and has neither. See `content.ftl`, where that is stated once for the
+# whole catalog.
+
+
+## Answer submission
+
+answer-checking = Тергеледи…
+answer-submitting = Джибериледи…
+answer-checking-status = Джууап тергеледи
+answer-submitting-status = Джууап джибериледи
+answer-correct = Тюз
+answer-incorrect = Терс
+answer-response-saved = Джууап сакъланды
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% тюз
+answer-percent-short = { $percent } %
+max-credit-available = Алыргъа боллукъ эм уллу балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] сынау къалмады
+        [one] { $count } сынау къалды
+       *[other] { $count } сынау къалды
+    }
+validation-correct = (Тюз)
+validation-incorrect = (Терс)
+validation-partially-correct = (Кесеклей тюз)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } ючюн { $count } джууапны кёргюзюу
+       *[other] { $answerId } ючюн { $count } джууапны кёргюзюу
+    }
+
+## Disclosure panels
+
+feedback-heading = Кери байланыу
+collapsible-click-to-open = (ачар ючюн басыгъыз)
+collapsible-click-to-close = (джабар ючюн басыгъыз)
+collapsible-initializing = Хазырланады…
+footnote-show = Тюп джазыуну кёргюзюу
+footnote-hide = Тюп джазыуну джашырыу
+description-more-information = къошакъ билдириу
+
+## Controls
+
+slider-previous = Алгъыннгы
+slider-next = Келлик
+keyboard-open = Клавиатураны ачыу
+keyboard-close = Клавиатураны джабыу
+choice-input-remove-choice = { $choice } сайлауну кетериу
+matrix-remove-row = Тизгинни кетериу
+matrix-add-row = Тизгин къошуу
+matrix-remove-column = Багъананы кетериу
+matrix-add-column = Багъана къошуу
+subset-add-remove-points = Нокъта къошуу/кетериу
+subset-toggle-points-intervals = Нокъталаны эм аралыкъланы алмаштырыу
+subset-move-points = Нокъталаны кёчюрюу
+subset-clear = Тазалау
+orbital-add-row = Тизгин къошуу
+orbital-remove-row = Тизгинни кетериу
+orbital-add-box = Къуту къошуу
+orbital-remove-box = Къутуну кетериу
+orbital-add-up-arrow = Ёрге окъ къошуу
+orbital-add-down-arrow = Тёбенге окъ къошуу
+orbital-remove-arrow = Окъну кетериу
+orbital-row-label = { $row } тизгинни белгиси
+pretzel-answer = Джууап
+summary-statistics-caption = { $column } багъананы къысха статистикасы
+
+## Math input
+
+math-input-preview-region = математика ангылатманы алгъадан кёрюу
+math-input-preview = Алгъадан кёрюу
+math-input-invalid-expression = Тюз болмагъан ангылатма:
+
+## Document status
+
+viewer-initializing = Хазырланады…
+
+## Errors
+
+error-heading = Халат
+error-found-at =
+    { $span ->
+        [line] Табылгъан тизгин: { $startLine }.
+       *[lines] Табылгъан тизгинле: { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Бу документде халатла бардыла!
+diagnostic-heading-error = Халат
+diagnostic-heading-warning = Эсгертиу
+diagnostic-heading-information = Билдириу
+diagnostic-heading-hint = Ишара
+accessibility-heading-level-1 = WCAG AA джетимлилик бузукълукъ
+accessibility-heading-level-2 = Джетимлилик эсгертиу
+something-went-wrong = Бир зат тюз болмады.
+renderer-load-failed = кёргюзтюучюню джюклерге болмады. Бетни джангыртыгъыз.
+core-start-failed = Бу документни ишлетирге болмады. Бетни джангыртыгъыз.
+core-start-failed-busy = Бу документни ишлетирге болмады. Бир къауум документ бир заманда башланнганды; акъырын ишлеген приборда бу кёбюрек заман алады. Башха документле бошагъандан сора бетни джангыртыу болушургъа боллукъду.
+core-start-failed-retry = Бу документни ишлетирге болмады.
+core-start-failed-busy-retry = Бу документни ишлетирге болмады. Бир къауум документ бир заманда башланнганды; акъырын ишлеген приборда бу кёбюрек заман алады.
+core-start-retry = Джангыдан сынау
+saved-state-unavailable = Сакъланнган ишигизни джюклерге болмады.

--- a/packages/i18n/locales/krc/content.ftl
+++ b/packages/i18n/locales/krc/content.ftl
@@ -1,0 +1,286 @@
+# Karachay-Balkar content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic alphabet Karachay-Cherkessia and Kabardino-Balkaria
+# teach and publish in, which is what CLDR fills a bare `krc` in as
+# (`krc-Cyrl-RU`). къ, гъ, нг and дж are letters of that alphabet rather than
+# pairs of Russian ones.
+#
+# Karachay and Balkar are two literary norms of a single language sharing one
+# standard orthography, and a catalog has to pick one. **This one writes the
+# Karachay norm**: дж- where Balkar has ж- («джашил», «джууап», «джокъ»), and
+# a handful of everyday words differ besides. A Balkar reader will find those
+# spellings unfamiliar without finding them unintelligible; correcting the file
+# toward either norm is a consistent, mechanical change.
+#
+# **Karachay-Balkar is Turkic: it has no grammatical gender and no noun class,
+# so `noun-gender` answers with one token for every noun and not one message in
+# this catalog forks.** That is worth saying out loud, because this catalog is
+# seeded beside the Northeast Caucasian and Nakh languages of the same region —
+# `locales/ce` and its neighbours — whose class systems make the fork the
+# expected shape. Nothing about sharing a map implies sharing agreement, and the
+# Turkic answer here is the same flat "no" `locales/ba`, `locales/tt` and
+# `locales/tr` give.
+#
+# An attributive adjective **precedes** its noun and never changes form —
+# «къалын къызыл сызыкъ», thick red line — as in every Turkic language in the
+# roster. So `$gender` and `$role` both go unused, and the composition messages
+# below keep the English word order rather than reversing it.
+#
+# What a clause position wants is marked on the **noun**, by a suffix or a
+# free postposition: «чек бла» for the border, «фонда» for the background.
+# Both of those words are ones this catalog writes out, so no affix is ever
+# welded onto a placeable.
+#
+# **Least certain thing in this file: the geometry nouns.** «майдан» for a
+# mathematical field, «тийре» for a region, and «ангылатма» for an expression
+# are coinages this seed chose from ordinary Karachay-Balkar words on the model
+# of the Tatar and Bashkir terminologies; school geometry in the two republics
+# is taught in Russian, so there is no settled published set to check them
+# against. The colour «ал» for pink is the second-weakest word here: the
+# language names light red and crimson more readily than it names pink, and the
+# style pipeline splits colour where Karachay-Balkar does not.
+
+
+## Style vocabulary
+##
+## Prenominal and invariable. Nothing here forks on `$gender` or `$role`,
+## because nothing here changes shape for either.
+
+color =
+    .black = къара
+    .white = акъ
+    .gray = боз
+    .red = къызыл
+    .orange = къызгъылдым сары
+    .yellow = сары
+    .green = джашил
+    .cyan = ачыкъ кёк
+    .blue = кёк
+    .purple = мор
+    .pink = ал
+    .brown = кюрен
+line-width =
+    .thick = къалын
+    .thin = инчге
+line-style =
+    .dashed = юзюклю
+    .dotted = нокъталы
+# Noun phrases, not adjectives: they stand in front of «оюулу» in the messages
+# that place them, and modify nothing on their own.
+fill-style =
+    .horizontal = горизонталь сызыкъла
+    .vertical = вертикаль сызыкъла
+    .diagonal = диагональ сызыкъла
+    .backdiagonal = тескери диагональ сызыкъла
+    .dots = нокъта
+    .diamonds = ромб
+noun =
+    .line = тюз сызыкъ
+    .line-segment = кесек
+    .ray = нур
+    .vector = вектор
+    .curve = къынгыр сызыкъ
+    .function = функция
+    .slope-field = джантайыуну майданы
+    .vector-field = векторну майданы
+    .parabola = парабола
+    .polyline = сынгъан сызыкъ
+    .polygon = кёпмюйюш
+    .triangle = ючмюйюш
+    .rectangle = тюз мюйюшлюк
+    .circle = тёгерек
+    .region = тийре
+    .point = нокъта
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# The side count is a prenominal modifier here, as every modifier is, so the
+# whole noun phrase is one head and there is no tail for the composition
+# messages to place after the adjectives.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } джанлы тюз кёпмюйюш
+    }
+# Karachay-Balkar has no grammatical gender and no noun class, so every noun
+# answers the same token and no message below selects on it.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = боялгъан
+# «оюулу» — "patterned" — is an adjective built on «оюу», ornament, and takes
+# the pattern noun in front of it, so the whole pattern phrase precedes the
+# colour exactly as any other modifier would.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } оюулу { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } оюулу { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } оюулу { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «чек бла» — "with a border" — carries the sense with a free postposition
+# standing after a noun this catalog writes, so nothing is welded to a
+# placeable and no article is wanted. The two `-article` branches read the same
+# as their plain siblings, because the article is what English needs and
+# Karachay-Balkar does not.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } чек бла
+        [and] эм { $border } чек бла
+        [and-article] эм { $border } чек бла
+       *[with] { $border } чек бла
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = боялмагъан
+# «фонда» is the locative of «фон» and says "on the background" by itself, so
+# nothing stands between the two colours and the background comes first.
+style-text =
+    { $parts ->
+        [background] { $background } фонда { $color }
+       *[plain] { $color }
+    }
+style-background-none = джокъ
+
+
+## Boolean words
+
+boolean-true = тюз
+boolean-false = терс
+
+
+## Answer buttons
+
+answer-submit-label = Тергеу
+answer-submit-label-no-correctness = Джууапны джибериу
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Иш
+    .aside = Къошакъ
+    .cascade = Каскад
+    .definition = Белгилеу
+    .example = Юлгю
+    .exercise = Кёнюгюу
+    .exercises = Кёнюгюуле
+    .given-answer = Джууап
+    .note = Эсгертиу
+    .objectives = Муратла
+    .paragraphs = Абзацла
+    .part = Кесек
+    .problem = Масала
+    .problems = Масалала
+    .proof = Исбатлау
+    .question = Соруу
+    .section = Бёлюм
+    .solution = Чечиу
+    .task = Джумуш
+    .theorem = Теорема
+# A heading separates its number from the title with a period rather than a
+# colon, which is the punctuation Russian-language schooling in the two
+# republics has settled on and what a reader of Karachay-Balkar prose expects.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Ишара
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурат { $enumeration }
+        [numbered-caption] Сурат { $enumeration }{ ". " }
+        [unnumbered-caption] Сурат{ ". " }
+       *[unnumbered] Сурат
+    }
+
+
+## Paginator controls
+
+paginator-previous = Алгъыннгы
+paginator-next = Келлик
+paginator-page = Бет
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = неда
+# The renderer places this word *before* the mathematics it introduces, and
+# Karachay-Balkar can be written that way — but only with the borrowed
+# conjunction. The language's own conditional is the verbal suffix -са/-се,
+# which closes its clause and could never land here; «эгер» is a Persian
+# borrowing that opens one, is what a mathematical condition is introduced with
+# in written Karachay-Balkar, and needs nothing after it. So this key is
+# correct as placed, unlike in `locales/sah`, `locales/tyv`, `locales/udm`,
+# `locales/kv` and `locales/chm`, and for the same reason `locales/ba`'s
+# «әгәр» is.
+piecewise-condition-if = эгер
+piecewise-condition-otherwise = алай болмаса
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Karachay-Cherkessia
+## and Kabardino-Balkaria is taught in Russian, out of Russian-language
+## textbooks; the element names a Karachay- or Balkar-speaking pupil actually
+## meets are the Russian ones, and a table invented in Karachay-Balkar spelling
+## would match neither the curriculum nor the language. The English fallback is
+## the nearer of the two wrong answers, and it is visibly a fallback.
+##
+## `locales/tt` is the counter-example that decides it rather than a
+## contradiction of it: Tatar supplies the whole table, because Tatar-medium
+## chemistry teaching produced one. What settles this is which language a
+## republic teaches the subject in, not which family the language belongs to.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Тюз болмагъан химия белги
+chemistry-invalid-ionic-compound = Тюз болмагъан ион къошулуу

--- a/packages/i18n/locales/krc/diagnostics.ftl
+++ b/packages/i18n/locales/krc/diagnostics.ftl
@@ -1,0 +1,687 @@
+# Karachay-Balkar diagnostics. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of Karachay-Cherkessia and
+# Kabardino-Balkaria, in the Karachay literary norm (дж- rather than Balkar
+# ж-); see `content.ftl`'s header for what that choice covers.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back out of the author's
+# own source.
+#
+# The technical register is largely Russian, which is what written
+# Karachay-Balkar itself reaches for: «компонент», «атрибут», «функция»,
+# «индекс», «формат». What is Karachay-Balkar is the grammar around them and
+# the everyday words — «табылмады», «эсге алынмайды», «болургъа керекди».
+#
+# Karachay-Balkar counts in the same two categories English does, so every
+# selection below keeps both branches — but a noun after a numeral stays
+# singular, so the two usually differ only in the number they print.
+#
+# Nothing here agrees with a gender or a noun class: the language has neither.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] эки уч нокъта берилгенде { $attributes } эсге алынмайды
+       *[other] эки уч нокъта берилгенде { $attributes } эсге алынмайды
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] уч нокъта бла орта нокъта экиси да берилгенде { $attributes } эсге алынмайды
+       *[other] уч нокъта бла орта нокъта экиси да берилгенде { $attributes } эсге алынмайды
+    }
+
+line-segment-midpoint-offset-without-midpoint = орта нокъта болмаса, midpointOffset бир затха да себеб этмейди
+
+## `<line>`
+
+line-points-undetermined-dimensions = Ёлчеми белгисиз нокъталадан ётген тюз сызыкъ.
+
+line-points-too-few-dimensions = Тюз сызыкъ эм аз да эки ёлчемли нокъталадан ётерге керекди.
+
+line-points-depend-on-variables = Тюз сызыкъ тюрлениучюлеге кёре болгъан нокъталадан ётеди: { $variables }.
+
+line-equation-invalid-format = { $variable1 } бла { $variable2 } тюрлениучюледеги тюз сызыкъны тенглигини форматы тюз тюйюлдю.
+
+## `<ray>`
+
+ray-overprescribed-through = Нур through, endpoint эм direction бла берилгенди. Берилген through эсге алынмайды.
+
+ray-dimension-mismatch = нурда numDimensions келишмейди.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail эм displacement бла берилгенди. Берилген head эсге алынмайды.
+
+vector-dimension-mismatch = векторда numDimensions келишмейди.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементге тартыргъа болмайды, нек десенг аны nearestPoint хал тюрлениучюсю джокъду.
+
+constrain-to-without-nearest-point = `<{ $component }>` элемент бла чекленирге болмайды, нек десенг аны nearestPoint хал тюрлениучюсю джокъду.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементни ичи бла чекленирге болмайды, нек десенг аны nearestPoint хал тюрлениучюсю джокъду.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = тизгин ичинде болмагъан choiceInput ючюн labelPosition эсге алынмайды
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput ючюн берилген индексле эсге алынмайдыла, нек десенг аланы саны choice балаланы санына келишмейди.
+
+pretzel-indices-count-mismatch = problem ючюн берилген индексле эсге алынмайдыла, нек десенг аланы саны problem балаланы санына келишмейди.
+
+shuffle-indices-count-mismatch = shuffle ючюн берилген индексле эсге алынмайдыла, нек десенг аланы саны компонентлени санына келишмейди.
+
+indices-ignored-out-of-range = { $component } ючюн берилген индексле эсге алынмайдыла, нек десенг бир къаууму чекден чыгъады.
+
+pretzel-indices-repeated = pretzel ючюн берилген индексле эсге алынмайдыла, нек десенг бир къаууму къайтарылады.
+
+pretzel-circuit-first-index = circuit халда pretzel ючюн берилген индексле эсге алынмайдыла, нек десенг биринчи индекс 1 болургъа керекди.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст балала бла ишлер ючюн `type` атрибут берилирге керекди.
+
+invalid-type-defaulting-to-math = { $component } компонент ючюн { $type } тюр тюз тюйюлдю. Ол math, text, number неда boolean болургъа керекди. math къолланылады.
+
+string-not-valid-component-to-arrange = «{ $value }» тизгин { $component } ючюн джарарыкъ компонент тюйюлдю. Эсге алынмайды.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } тюр тюз тюйюлдю, тюр number этилди.
+
+invalid-variable-value = Тюрлениучюню тюз болмагъан къыйматы: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариант индекс сан болургъа керекди
+
+variant-index-must-be-integer = { $index } вариант индекс бютеу сан болургъа керекди
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют ёлчемле ючюн этилмегенди. Кенгликле салыштырмалы этиледиле.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют ёлчемле ючюн этилмегенди. Джанларындагъы аралыкъла салыштырмалы этиледиле.
+
+side-by-side-no-block-child = Тюз болмагъан `<{ $component }>`: аны эм аз да бир блок баласы болургъа керекди.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементдеги `for` атрибут эсге алынмайды.
+
+label-for-must-resolve-to-one = `<label>` элементдеги `for` атрибут тюп-тюз бир компонентге кёргюзюрге керекди.
+
+label-for-unresolved = `<label>` элементдеги `for` атрибутну компонент бла байларгъа болмады.
+
+label-for-answer-with-authored-inputs = `<label>` элементдеги `for` атрибут автор кеси джазгъан кириу къырлары болгъан `<answer>` элементге кёргюзеди; къыргъа тюзюнлей кёргюзюгюз.
+
+label-for-answer-without-input = `<label>` элементдеги `for` атрибут белгилерик кириу къыры болмагъан `<answer>` элементге кёргюзеди.
+
+label-for-must-reference-input-or-answer = `<label>` элементдеги `for` атрибут кириу къыргъа неда джууапха кёргюзюрге керекди.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Джетимлилик ючюн `<{ $component }>` я къысха ангылатыугъа ие болургъа, я оюу халда белгиленирге керекди.
+
+accessibility-video-short-description = Джетимлилик ючюн `<video>` къысха ангылатыугъа ие болургъа керекди.
+
+accessibility-input-short-description-or-label = Джетимлилик ючюн `<{ $component }>` къысха ангылатыугъа неда белгиге ие болургъа керекди.
+
+accessibility-answer-input-short-description-or-label = Джетимлилик ючюн кириу къыр къурагъан `<answer>` къысха ангылатыугъа неда белгиге ие болургъа керекди.
+
+accessibility-short-description-contains-math = Къысха ангылатыулада `<{ $component }>` кибик математика компонентле болургъа керек тюйюлдюле. Математиканы сёзле бла джазыгъыз.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } бёлюмню башламыны текстине джетерик контраст бермейди (къарангы тема) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм аз да { $threshold }:1 керекди).
+       *[other] { $colorName } бёлюмню башламыны текстине джетерик контраст бермейди ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм аз да { $threshold }:1 керекди).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Нокъталаны сан къыйматлары болмагъан халда { $count } нокътадан ётген `<circle>` этилмегенди.
+
+circle-too-many-through-points = 3 нокътадан кёбюреги бла ётген тёгерекни санаргъа болмайды.
+
+circle-overprescribed-radius-center-points = Радиусу, ара нокътасы эм ётген нокъталары бирден берилген тёгерекни санаргъа болмайды.
+
+circle-center-with-multiple-points = Ара нокъталы тёгерекни 1 нокътадан кёбюреги бла ётдюрюп санаргъа болмайды.
+
+circle-radius-too-small = Тёгерекни санаргъа болмайды: эки нокътаны арасы { $distance } болгъанда, берилген { $radius } радиус бек гитчеди.
+
+circle-radius-with-many-points = Радиусу берилген тёгерекни эки нокътадан кёбюреги бла ётдюрюрге болмайды.
+
+circle-invalid-center-or-through-points = Тёгерекни ара нокътасы неда ётген нокъталары тюз тюйюлдюле.
+
+circle-radius-center-with-multiple-points = Ара нокъталы тёгерекни радиусун 1 нокътадан кёбюреги бла ётдюрюп санаргъа болмайды.
+
+circle-change-radius-non-numerical = Сан къыйматлары болмагъан нокъталадан ётген тёгерекни радиусун тюрлендирирге болмайды
+
+circle-radius-with-points-non-numerical = Сан къыйматла болмагъанда, радиусу берилген тёгерекни бир нокътадан кёбюреги бла ётдюрюрге болмайды.
+
+circle-change-center-non-numerical = Сан къыйматлары болмагъан нокъталадан ётген тёгерекни ара нокътасын тюрлендириу этилмегенди.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцияны белгилениу тийресини ёлчеми джетишмейди. Тийреде { $intervals } аралыкъ барды, функцияда уа { $inputs ->
+            [one] { $inputs } кириу
+           *[other] { $inputs } кириу
+        }.
+       *[other] Функцияны белгилениу тийресини ёлчеми джетишмейди. Тийреде { $intervals } аралыкъ барды, функцияда уа { $inputs ->
+            [one] { $inputs } кириу
+           *[other] { $inputs } кириу
+        }.
+    }
+
+function-domain-invalid-format = Функцияны белгилениу тийресини форматы тюз тюйюлдю.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцияны сан болмагъан эм уллу къыйматы эсге алынмайды.
+        [minimum] Функцияны сан болмагъан эм гитче къыйматы эсге алынмайды.
+        [extremum] Функцияны сан болмагъан экстремуму эсге алынмайды.
+        [point] Функцияны сан болмагъан нокътасы эсге алынмайды.
+        [slope] Функцияны сан болмагъан джантайыуу эсге алынмайды.
+       *[other] Функцияны сан болмагъан { $type } къыйматы эсге алынмайды.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцияны бош эм уллу къыйматы эсге алынмайды.
+        [minimum] Функцияны бош эм гитче къыйматы эсге алынмайды.
+        [extremum] Функцияны бош экстремуму эсге алынмайды.
+        [point] Функцияны бош нокътасы эсге алынмайды.
+       *[other] Функцияны бош { $type } къыйматы эсге алынмайды.
+    }
+
+function-points-too-close = Функцияда орунлары бир бирине бек джууукъ эки нокъта барды. Функцияны белгилерге болмайды.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцияны итерациялары кириулени саны чыгъыуланы санына тенг болгъанда къуру бола эдиле. Бу функцияда { $inputs } кириу бла { $outputs ->
+            [one] { $outputs } чыгъыу барды
+           *[other] { $outputs } чыгъыу барды
+        }.
+       *[other] Функцияны итерациялары кириулени саны чыгъыуланы санына тенг болгъанда къуру бола эдиле. Бу функцияда { $inputs } кириу бла { $outputs ->
+            [one] { $outputs } чыгъыу барды
+           *[other] { $outputs } чыгъыу барды
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Тизмени узунлугъу тюз тюйюлдю. Ол терс болмагъан бютеу сан болургъа керекди.
+
+sequence-invalid-step = Тизмени атламы тюз тюйюлдю. { $type } тюрлю тизме ючюн ол сан болургъа керекди.
+
+sequence-invalid-endpoint-number = Сан тизмени «{ $attribute }» къыйматы тюз тюйюлдю. Ол сан болургъа керекди.
+
+sequence-invalid-endpoint-letters = Харф тизмени «{ $attribute }» къыйматы тюз тюйюлдю. Ол харфланы къошулууу болургъа керекди.
+
+sequence-invalid-endpoint = Тизмени «{ $attribute }» къыйматы тюз тюйюлдю.
+
+select-from-sequence-coprime-not-numbers = санла сайланмагъаны себебли coprime эсге алынмайды
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations берилгени себебли coprime эсге алынмайды
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` ючюн нишан тюз тюйюлдю: нишан табылмайды.
+
+target-state-variable-not-found = `<{ $source }>` ючюн нишан тюз тюйюлдю: `<{ $component }>` элементде «{ $property }» атлы хал тюрлениучю табылмайды.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` элементни тюрлениучюлери кесиалдына тюрлениучюден башха болургъа керекдиле.
+
+ode-system-duplicate-variable-names = Кёре тюрлениучюлени атлары къайтарылгъан ODE онг джанындагъы функцияланы белгилерге болмайды.
+
+ode-system-rhs-function-error = ODE онг джанындагъы функцияны белгилерге болмайды. mathjs функцияны къурауда халат.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } сызыкъны арасында мюйюшню белгилерге болмайды
+
+angle-invalid-through-point = `<angle>` элементни through къыйматында нокъта тюз тюйюлдю
+
+parabola-vertex-too-many-points = Тёбеси берилген параболаны 1 нокътадан кёбюреги бла ётдюрюу этилмегенди.
+
+parabola-too-many-points = 3 нокътадан кёбюреги бла ётген парабола этилмегенди.
+
+intersection-too-many-items = Экиден кёб затны кесишиую этилмегенди
+
+## Other math components
+
+ionic-compound-not-two-ions = Эки иондан башха ион къошулуу этилмегенди.
+
+ionic-compound-needs-cation-and-anion = Ион къошулуу къуру бир катион бла бир анион ючюн этилгенди.
+
+solve-equations-cannot-evaluate = Тенгликни санаргъа болмагъаны себебли аны чечерге болмайды: { $equation }
+
+math-operators-operand-number-required = Математика операндны чыгъаргъанда operandNumber берилирге керекди.
+
+eigen-decomposition-failed = Матрицаны кесиалдына къыйматларын санаргъа болмады
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр оюуда тюбемейди, аны себебли ол хар заманда бош орунну табады.
+       *[other] `<matchesPattern>`: { $parameters } параметрле оюуда тюбемейдиле, аны себебли ала хар заманда бош орунну табадыла.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ангылашынмайды. Ол none, medium, dense неда бош орун бла айырылгъан эки терс болмагъан сан болургъа керекди, сёз ючюн grid="1 0.5". Тор сызылмайды.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` ючюн { $expected ->
+        [one] бир чыгъыуу — хар нокътада y' джантайыуу — болгъан функция керекди, сёз ючюн `y - x`
+       *[other] эки чыгъыуу — хар нокътада вектор — болгъан функция керекди, сёз ючюн `(y, -x)`
+    }, алай берилген функцияда { $found ->
+        [one] { $found } чыгъыу барды
+       *[other] { $found } чыгъыу барды
+    }. { $alternative ->
+        [none] Бир зат да сызылмайды.
+       *[other] Ол функция ючюн `<{ $alternative }>` компонент джарайды. Бир зат да сызылмайды.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибут эсге алынмайды, нек десенг функция компонентни ичинде да берилгенди; ичиндеги къолланылады. Функцияны экисинден къуру биринде бериги.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибут компонентни ичинде тюзюнлей джазылгъан ангылатманы тюрлениучюлерин атайды. { $reason ->
+        [function-child] Мында функция `<function>` бала халда берилгенди, ол а кеси тюрлениучюлерин атайды, аны себебли `variables` эсге алынмайды.
+       *[no-expression] Мында алай джазылгъан ангылатма джокъду, аны себебли `variables` эсге алынмайды.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure кёргюзтюучюде xLabelPosition="left" джюрютюлмейди; онг джанындача этиледи.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure кёргюзтюучюде yLabelPosition="bottom" джюрютюлмейди; ёр джанындача этиледи.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure кёчюрюу ючюн осьланы чеклери тюз тюйюлдюле; сынгар bbox (-10,-10,10,10) къолланылады.
+
+prefigure-invalid-width = `<graph>`: prefigure кёчюрюу ючюн кенглик тюз тюйюлдю; сынгар кенглик 425 къолланылады.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure кёчюрюу ючюн aspectRatio тюз тюйюлдю; сынгар джанлыкъ 1 къолланылады.
+
+prefigure-grid-spacing-too-fine = `<graph>`: осьланы чеклерине кёре торну аралыкълары бек джукъадыла; prefigure кёргюзтюучюде тор сызылмайды.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure кёргюзтюучю къолланылмаса, эсгертиуле сызылмайдыла.
+
+multiple-annotations-children = `<graph>` ичинде бир къауум `<annotations>` бала табылгъанды; ахыргъысындан къалгъанла эсге алынмайдыла.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Танылмагъан компонент тюрню узайтыргъа неда кёчюрюрге болмайды: { $type }.
+
+copy-prop-not-found = { $component } тюрлю компонентде { $property } проп табылмады
+
+collect-no-source = collect ючюн къайнакъ табылмады.
+
+collect-invalid-component-type = `<{ $component }>` тюрлю компонентлени джыяргъа болмайды, нек десенг ол тюз болмагъан компонент тюрдю.
+
+reference-index-unavailable = `{ $reference }` индексге ссылка этерге болмайды
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентде { $action } чакъырыргъа болмайды
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Берилиулени формасы тюз тюйюлдю. Тизгинлени узунлукълары бирча тюйюлдюле. Табылгъан джери componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Берилиуледе багъаналаны атлары къайтарыладыла. Табылгъан джери componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Берилиуледе багъананы аты джокъду. Табылгъан джери componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Бу джууапны бир багъалауу answer тегни кеси джиберген джууабына таянады, ол а сакъланмагъан ишлеге келтирликди.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` болгъан контейнерни ичиндеги `<answer>` элементде `maxNumAttempts` салыуну хайыры джокъду, нек десенг сынауланы саны контейнерден белгиленеди. `maxNumAttempts` контейнерде салыгъыз.
+
+nested-section-wide-check-work-max-num-attempts = Башха `sectionWideCheckWork` контейнерни ичинде тургъан `sectionWideCheckWork` контейнерде `maxNumAttempts` салыуну хайыры джокъду, нек десенг сынауланы саны тышындагъы контейнерден белгиленеди. `maxNumAttempts` тышындагъы контейнерде салыгъыз.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality салынмаса, { $attributes } атрибутну хайыры болмазлыкъды.
+       *[other] symbolicEquality салынмаса, { $attributes } атрибутланы хайыры болмазлыкъды.
+    }
+
+answer-invalid-type = Джууапны тюрю тюз тюйюлдю: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентни аты болмагъаны себебли аны module атрибут ючюн къолланыргъа болмайды
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентни module ючюн атрибут халда къолланыргъа болмайды, нек десенг `<module>` компонент тюрде «{ $name }» атрибут алгъадан белгиленнгенди.
+
+conditional-content-condition-ignored = case неда else балалары болгъан `<conditionalContent>` компонентде `condition` атрибут эсге алынмайды.
+
+slider-markers-type-mismatch = Маркерлени тюрю слайдерни тюрюне келишмейди.
+
+pretzel-problem-needs-statement-and-answer = Тюз болмагъан pretzel: хар `<problem>` ичинде бир `<statement>` бла бир `<answer>` болургъа керекди.
+
+pretzel-circuit-first-problem-distractor = Тюз болмагъан pretzel: mode="circuit" болгъанда биринчи `<problem>` дистрактор болургъа болмайды.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут ючюн { $values } къыймат тюз тюйюлдю; эсге алынмайды.
+       *[other] `{ $attribute }` атрибут ючюн { $values } къыйматла тюз тюйюлдюле; эсге алынмайдыла.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут ючюн `{ $value }` къыймат тюз тюйюлдю. Атрибут `$` бла башланнган ссылкаладан къуралыргъа керекди.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ичинде тюз болмагъан функция атла эсге алынмадыла: { $names }. Хар атны кёргюзюлген кесеги эм аз да 2 белгиден (харфла неда тире) къуралыргъа керекди; ызындан `|<mathspeak alternative>` къошулургъа болады.
+
+## Building components from the source
+
+component-type-invalid = Тюз болмагъан компонент тюр: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутну къайтарыргъа болмайды.
+
+attribute-invalid-for-component = `<{ $componentType }>` тюрлю компонент ючюн «{ $attribute }» атрибут тюз тюйюлдю.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль белгилеуде { $context ->
+        [text-on-background] текстни тюрсюню бла фонну тюрсюню
+        [high-contrast] бийик контрастлы тюрсюн бла сурат майдан
+        [line] сызыкъны тюрсюню бла сурат майдан
+        [marker] маркерни тюрсюню бла сурат майдан
+       *[text-on-canvas] текстни тюрсюню бла сурат майдан
+    } арасында контраст джетишмейди{ $mode ->
+        [dark] { " (къарангы тема)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм аз да { $threshold }:1 керекди).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль белгилеуде джарыкъ тема ючюн джетерик контраст берген тюрсюнле берилген эселе да, ол къыйматладан чыгъарылгъан къарангы тема тюрсюнледе текстни тюрсюню бла фонну тюрсюнюню арасында контраст джетишмейди ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм аз да { $threshold }:1 керекди). { $suggestion ->
+        [available] Къарангы темада контраст джетерик болур ючюн, я джарыкъ теманы контрастын кёбейтигиз (сёз ючюн { $lightAttribute }="{ $lightColor }" салыгъыз), я къарангы теманы тюрсюнюн кесигиз белгилегиз (сёз ючюн { $darkAttribute }="{ $darkColor }" салыгъыз).
+       *[none] Къарангы темада контраст джетерик болур ючюн, джарыкъ теманы контрастын кёбейтигиз неда чыгъарылгъан тюрсюнлени textColorDarkMode эмда/неда backgroundColorDarkMode бла алмаштырыгъыз.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль белгилеуде джарыкъ тема ючюн джетерик контраст берген текст тюрсюн берилген эсе да, ол къыйматдан чыгъарылгъан къарангы тема текст тюрсюню сурат майдан бла джетерик контраст бермейди ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм аз да { $threshold }:1 керекди). { $suggestion ->
+        [available] Къарангы темада контраст джетерик болур ючюн, я джарыкъ теманы контрастын кёбейтигиз (сёз ючюн textColor="{ $lightColor }" салыгъыз), я къарангы теманы тюрсюнюн кесигиз белгилегиз (сёз ючюн textColorDarkMode="{ $darkColor }" салыгъыз).
+       *[none] Къарангы темада контраст джетерик болур ючюн, джарыкъ теманы контрастын кёбейтигиз неда чыгъарылгъан тюрсюнню textColorDarkMode бла алмаштырыгъыз.
+    }
+
+section-multiple-style-palettes = Бир бёлюм къуру бир <stylePalette> сайларгъа болады; ахыргъысы къолланылады.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг numToSelect терс болмагъан бютеу сан тюйюлдю.
+
+variant-num-to-select-not-constant-number = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг numToSelect тохташхан сан тюйюлдю.
+
+variant-with-replacement-not-constant-boolean = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг withReplacement тохташхан boolean тюйюлдю.
+
+variant-select-weight-disables-unique = selectWeight неда selectForVariants берилген вариант болса, select ючюн энчи вариантла джабыладыла
+
+variant-coprime-undetermined = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг coprime хар заманда терс болгъанын белгилерге болмайды.
+
+variant-attribute-not-constant = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг { $attribute } тохташхан тюйюлдю.
+
+variant-attribute-not-number = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг { $attribute } сан тюйюлдю.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тюрлю { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг { $attribute } { $expected ->
+        [letters-combination] харфланы къошулуулары
+        [math-expression] тюз математика ангылатма
+        [integer] бютеу сан
+       *[number] сан
+    } тюйюлдю.
+
+variant-length-not-integer = { $component } компонентни энчи вариантларын белгилерге болмайды, нек десенг length бютеу сан тюйюлдю.
+
+variant-sort-not-implemented = sort болгъан { $component } компонентни энчи вариантлары этилмегендиле
+
+variant-exclude-combinations-not-implemented = excludeCombinations болгъан { $component } компонентни энчи вариантлары этилмегендиле
+
+variant-math-exclude-not-implemented = exclude болгъан math тюрлю { $component } компонентни энчи вариантлары этилмегендиле
+
+variant-non-constant-exclude-not-implemented = тохташмагъан exclude болгъан { $component } компонентни энчи вариантлары этилмегендиле
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure кёргюзтюучюде джюрютюлмейди; туудукъ элемент кетерилди.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометриясы толу тюйюлдю неда чекленмегенди; туудукъ элемент кетерилди.
+
+prefigure-curve-label-omitted = { $subject }: кёчюрюлген къынгыр сызыкъ элементледе белгиле джюрютюлмейдиле; белги кетерилди.
+
+prefigure-curve-unsupported-definition-type = { $subject }: къынгыр сызыкъ функцияны белгилеу тюрю «{ $definitionType }» джюрютюлмейди; туудукъ элемент кетерилди.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементде flipFunctions атрибут джюрютюлмейди; туудукъ элемент кетерилди.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves элементде къуру формула тюрлю бала функцияла джюрютюледиле; туудукъ элемент кетерилди.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] сызыкъ къауумну белгиси
+       *[point] нокътаны белгиси
+    } ючюн labelPosition «{ $labelPosition }» джюрютюлмейди; PreFigure кесини сынгар тюзетиую къолланылады.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure «{ $fillStyle }» боялыу тюрню джюрютмейди; толу боялыу къолланылады.
+
+prefigure-line-style-unknown = { $subject }: танылмагъан «{ $lineStyle }» сызыкъ тюр PreFigure чыгъарыудан кетерилди.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: «{ $markerStyle }» маркер тюр PreFigure «diamond» тюрюне кёчюрюлдю.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure «{ $markerStyle }» маркер тюрню джюрютмейди; сынгар тюр къолланылады.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` тюз тюйюлдю; нишан табылмайды. Эсгертиу кетерилди.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` бир къауум нишан тапды; биринчиси къолланылады.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` тюз тюйюлдю; нишан кесин тутхан graph элементни тышындады. Эсгертиу кетерилди.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` тюз тюйюлдю; нишан prefigure кёчюрюуде джюрютюлген график зат тюйюлдю. Эсгертиу кетерилди.
+
+annotation-text-missing = `<annotation>`: `text` джокъду неда бошду; бош текст чыгъарылады.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Тёгерек байламлыкъ табылды.
+       *[other] `<{ $componentType }>` компонент къошулгъан тёгерек байламлыкъ табылды.
+    }
+
+reference-no-referent = Ссылка ючюн зат табылмады: `{ $reference }`
+
+reference-multiple-referents = Ссылка ючюн бир къауум зат табылды: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементни { $attribute } атрибутуну форматы тюз тюйюлдю.
+
+children-invalid = `<{ $componentType }>` ючюн балала тюз тюйюлдюле: тюз болмагъан балала табылдыла: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут ючюн `{ $value }` къыймат тюз тюйюлдю, `{ $default }` къыймат къолланылады
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версия табылмады.
+       *[other] DoenetML { $version } версия табылмады. { $fallback } версиягъа кёчюледи
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Тюз болмагъан DoenetML: { $content }
+
+parse-tag-missing-close-tag = Тюз болмагъан DoenetML: `{ $tag }` тегни джабыучу теги джокъду. Кесин джабхан тег неда `</{ $tagName }>` тег керек эди.
+
+parse-tag-error = Тюз болмагъан DoenetML: `<{ $tagName }>` тегде халат
+
+parse-attribute-missing-value = Тюз болмагъан DoenetML: `{ $attribute }` атрибут тюз тюйюлдю, къыйматы джокъгъа ушайды.
+
+parse-attribute-invalid = Тюз болмагъан DoenetML: `{ $attribute }` атрибут тюз тюйюлдю
+
+parse-attribute-value-invalid = Тюз болмагъан DoenetML: `{ $value }` атрибут къыймат тюз тюйюлдю
+
+parse-attribute-value-quote-mismatch = Тюз болмагъан DoenetML: `{ $value }` атрибут къыймат тюз тюйюлдю. Тырнакъла келишмейдиле. Бир `{ $quote }` джетишмегенге ушайды
+
+parse-open-tag-name-missing = Тюз болмагъан DoenetML: аты болмагъан тег табылды, сёз ючюн `<`
+
+parse-tag-not-closed = Тюз болмагъан DoenetML: `{ $tag }` тег джабылмагъанды (бир `>` джетишмегенге ушайды).
+
+parse-self-closing-tag-name-missing = Тюз болмагъан DoenetML: аты болмагъан тег табылды `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Тюз болмагъан DoenetML: `{ $tag }` тег джабылмагъанды (`/>` джетишмегенге ушайды).
+
+parse-tag-invalid-attributes = Тюз болмагъан DoenetML: `{ $tag }` тег тюз тюйюлдю. Атрибутлары терс болургъа боладыла.
+
+parse-close-tag-name-missing = Тюз болмагъан DoenetML: аты болмагъан джабыучу тег табылды, сёз ючюн `</`
+
+parse-attribute-value-unquoted = Атрибутланы къыйматлары тырнакъланы ичине алыныргъа керекдиле: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Тюз болмагъан DoenetML: `{ $tag }` джабыучу тег табылды, алай ачыучу теги джокъду
+
+parse-close-tag-mismatched = Тюз болмагъан DoenetML: джабыучу тег келишмейди. `</{ $expected }>` керек эди. `{ $found }` табылды
+
+parser-node-unconvertible = { $node } тюйюмню Dast тюйюмге кёчюрюрге болмады.
+
+## Names
+
+name-attribute-invalid =
+    Тюз болмагъан атрибут name='{ $name }'. { $reason ->
+        [characters] Атлада къуру харфла, санла, тюб тирела неда тирела болургъа боладыла.
+       *[start] Атла харф бла башланыргъа керекдиле.
+    }
+
+component-name-invalid-start = «{ $name }» компонент ат тюз тюйюлдю. Атла харф бла башланыргъа керекдиле.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тюрлю джууапны video атрибуту болургъа керекди
+
+answer-video-watched-video-not-reference = videoWatched тюрлю джууапны video атрибуту ссылка болургъа керекди
+
+answer-name-not-single-text = Джууапны name атрибутуну бир текст баласы болургъа керекди
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Тышындагъы DoenetML алыныргъа болмады, рекурсияны къатлары бек кёбдюле. Тёгерек ссылка бармыды?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" джерден DoenetML алыныргъа болмады
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" джерден алыннган DoenetML тюз тюйюлдю: ол «{ $componentType }» компонент тюрге келишмеди
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эскиргенди; аны орнуна `{ $to }` къолланыгъыз.
+       *[other] [deprecation] `<{ $component }>` элементде `{ $from }` атрибут эскиргенди; аны орнуна `{ $to }` къолланыгъыз.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эскиргенди эм эсге алынмайды, нек десенг `{ $to }` да берилгенди.
+       *[other] [deprecation] `<{ $component }>` элементде `{ $from }` атрибут эскиргенди эм эсге алынмайды, нек десенг `{ $to }` да берилгенди.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементде `{ $attribute }` атрибут эскиргенди эм эсге алынмайды.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементде `{ $attribute }` атрибут эскиргенди; аны орнуна `<{ $child }>` бала къолланыгъыз.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементде `{ $attribute }` атрибутну `{ $value }` къыйматы эскиргенди; аны орнуна `{ $to }` къолланыгъыз.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` къуру ингилиз сёзлени кёблюк санына кёчюрюрге болады, аны себебли { $locale } тилде джазылгъан документде аны тексти тюрленмей къалады. Кёблюк формасын кесигиз джазыгъыз неда `pluralForm` атрибут бла белгилегиз.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент танылгъан Doenet элемент тюйюлдю.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементге документни тамырында эркинлик джокъду.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементге `<{ $parent }>` ичинде эркинлик джокъду.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементни `{ $attribute }` атлы атрибуту джокъду.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементни `{ $attribute }` атрибуту тизме болургъа керекди, аны хар кесеги уа буладан бири: { $allowed }
+       *[other] `<{ $tag }>` элементни `{ $attribute }` атрибуту буладан бири болургъа керекди: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select ючюн вариантны аты тюз тюйюлдю. { $variantName } вариант ат { $numOptions } вариантда тюбейди, сайланырыкъны саны уа { $numToSelect }.
+
+select-variant-name-without-options = select ючюн бир къауум вариант берилгенди, алай { $variantName } боллукъ вариант ат ючюн вариантла берилмегендиле.
+
+select-variant-name-not-possible = select ючюн берилген { $variantName } вариант ат боллукъ вариант ат тюйюлдю.
+
+select-too-few-options = { $numOptions } компонентден { $numToSelect } компонент сайларгъа болмайды.
+
+select-from-sequence-too-few-values = Узунлугъу { $length } болгъан тизмеден { $numToSelect } къыймат сайларгъа болмайды.
+
+select-from-sequence-indices-count-mismatch = select ючюн берилген индекслени саны сайланырыкъны санына келиширге керекди
+
+select-from-sequence-indices-not-integers = select ючюн берилген индекслени барысы да бютеу санла болургъа керекдиле
+
+select-from-sequence-index-excluded = selectfromsequence ючюн берилген индекс тышында къалдырылгъанды
+
+select-from-sequence-indices-excluded-combination = selectfromsequence ючюн берилген индексле тышында къалдырылгъан къошулуу эдиле
+
+select-from-sequence-coprime-not-positive-integers = терс болмагъан бютеу санла сайланмагъаны себебли ортакъ бёлюучюсю болмагъан къошулууланы сайларгъа болмайды.
+
+select-from-sequence-coprime-common-factor = Ортакъ бёлюучюсю болмагъан санланы сайларгъа болмайды. Боллукъ къыйматланы барысыны да ортакъ бёлюучюсю барды. (Берилген "from" неда "to" къыйматланы "step" бла ортакъ бёлюучюлери болмазгъа керекди.)
+
+select-from-sequence-coprime-single-number = 1 болмагъан джангыз сандан ортакъ бёлюучюсю болмагъан къошулууланы сайларгъа болмайды.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ичинде къошулууланы 70%-ден кёбюрегин тышында къалдыргъанды
+
+select-from-sequence-coprime-none-found = Ортакъ бёлюучюсю болмагъан санла сайланмадыла. Боллукъ къыйматланы барысыны да ортакъ бёлюучюсю барды.
+
+select-from-sequence-too-few-unique-values = Узунлугъу { $numPossibleValues } болгъан тизмеден { $numToSelect } энчи къыймат сайларгъа болмайды
+
+select-prime-numbers-too-few-values = Узунлугъу { $numValues } болгъан баш санланы тизмесинден { $numToSelect } къыймат сайларгъа болмайды
+
+select-prime-numbers-values-count-mismatch = select ючюн берилген къыйматланы саны сайланырыкъны санына келиширге керекди
+
+select-prime-numbers-values-not-prime = select ючюн берилген баш санланы барысы да баш санланы тизмесинде болургъа керекдиле
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers ючюн берилген къыйматла тышында къалдырылгъан къошулуу эдиле
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ичинде къошулууланы 70%-ден кёбюрегин тышында къалдыргъанды
+
+select-random-combination-fluke = Бек аз тюбеген иш болуб, эркин къыйматланы къошулууу сайланмады
+
+select-random-value-fluke = Бек аз тюбеген иш болуб, эркин къыймат сайланмады

--- a/packages/i18n/locales/krc/editor.ftl
+++ b/packages/i18n/locales/krc/editor.ftl
@@ -1,0 +1,221 @@
+# Karachay-Balkar editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of Karachay-Cherkessia and
+# Kabardino-Balkaria, in the Karachay literary norm (дж- rather than Balkar
+# ж-); `content.ftl`'s header says what that choice does and does not cover.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Karachay-Balkar counts in the same two categories English does, so every
+# selection below keeps both branches — though a noun after a numeral stays
+# singular, so the two read alike apart from the number.
+#
+# Nothing here agrees with a gender or a noun class: the language has neither.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Артха къайтарыу
+       *[update] Джангыртыу
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Кёргюзтюучюню { $word }
+       *[other] Кёргюзтюучюню { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Сюзюу…
+editor-variant-next = Келлик вариантны сайлау
+editor-variant-previous = Алгъыннгы вариантны сайлау
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA джетимлилик бузукълукъ табылды. Джетимлилик хапарны { $action ->
+            [close] джабар
+           *[open] ачар
+        } ючюн басыгъыз.
+        [advisories] Джетимлилик хапарны { $action ->
+            [close] джабар
+           *[open] ачар
+        } ючюн басыгъыз. WCAG AA бузукълукъла табылмадыла, алай къошакъ джетимлилик теджеуле бардыла.
+       *[clean] Джетимлилик хапарны { $action ->
+            [close] джабар
+           *[open] ачар
+        } ючюн басыгъыз. Джетимлилик бла байламлы проблема табылмады.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA джетимлилик бузукълукъ табылды. { $count ->
+            [one] { $count } WCAG AA бузукълукъ
+           *[other] { $count } WCAG AA бузукълукъ
+        } табылды. Джетимлилик хапарны { $action ->
+            [close] джабар
+           *[open] ачар
+        } ючюн басыгъыз.
+        [advisories] WCAG AA бузукълукъла табылмадыла. { $count ->
+            [one] { $count } къошакъ джетимлилик теджеу
+           *[other] { $count } къошакъ джетимлилик теджеу
+        } табылды. Джетимлилик хапарны { $action ->
+            [close] джабар
+           *[open] ачар
+        } ючюн басыгъыз.
+       *[clean] WCAG AA бузукълукъла табылмадыла. Джетимлилик хапарны { $action ->
+            [close] джабар
+           *[open] ачар
+        } ючюн басыгъыз.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML { $version } версия
+
+editor-tab-help = Орунуна кёре болушлукъ
+editor-tab-help-short = Орун
+editor-tab-errors = Халатла
+editor-tab-warnings = Эсгертиуле
+editor-tab-info = Билдириу
+editor-tab-accessibility = Джетимлилик
+editor-tab-responses = Джиберилген джууапла
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторну амаллары
+editor-format-as-doenetml = DoenetML халда джарашдырыу
+editor-format-as-xml = XML халда джарашдырыу
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Тизгин #{ $line }
+
+editor-no-errors = Халатла джокъдула
+editor-no-warnings = Эсгертиуле джокъдула
+editor-no-info = Билдириу джокъду
+
+editor-show-info-annotations = Билдириулени редакторда кёргюзюу
+editor-show-accessibility-annotations = Джетимлилик эсгертиулени редакторда кёргюзюу
+
+editor-accessibility-learn-more = Doenet джетимлиликге къалай къарагъанын билигиз
+
+editor-accessibility-violations-heading = Джетимлилик бузукълукъла ({ $standard })
+
+editor-accessibility-other-heading = Джетимлилик бла байламлы башха ишле
+editor-none-found = Бир зат да табылмады
+
+
+## Submitted responses
+
+editor-no-responses = Алкъын джиберилген джууап джокъду
+editor-response-answer-id = Джууапны ID-си
+editor-response-response = Джууап
+editor-response-credit = Балл
+editor-response-submitted = Джиберилди
+
+
+## The context-help panel
+
+help-placeholder = Документация ючюн курсорну тегни атына, атрибутха неда { $ref } юсюне салыгъыз.
+
+help-unsupported-ref-chain = { $example } кибик кёб кесекли ссылкала ючюн болушлукъ алкъын джокъду.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ссылка ючюн зат табылмады: { $ref }.
+        [multiple] Ссылка ючюн бир къауум зат табылды: { $ref }.
+       *[indeterminate] { $ref } ючюн зат белгиленмеди.
+    }
+
+help-learn-about-references = Ссылкаланы юсюнден билигиз →
+help-reference-page = Справочник бет →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ичинде
+       *[top] Эм башында
+    }{ $allowed ->
+        [none] { " — мында бир зат да салынмайды." }
+        [text] { " — мында текст джазыгъыз." }
+        [text-and-components] { " — мында текст джазыгъыз неда быланы сынагъыз:" }
+       *[components] { " — сынаргъа боллукъла:" }
+    }
+
+help-suggestions-footer = Битеу { $total } компонентни кёрюр ючюн { $shortcut } басыгъыз.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } затха ссылка.
+       *[other] { $ref } — { $target } затха ссылка ({ $line } тизгин).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } киргизгенди, { $role } халда.
+       *[other] { $owner } { $line } тизгинде киргизгенди, { $role } халда.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементни { $property } къасиетине ссылка.
+       *[other] { $ref } — { $element } элементни { $property } къасиетине ссылка ({ $line } тизгин).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = юзюк
+help-kind-array-entry = массивни кесеги
+
+help-default = Сынгар къыймат:
+help-active-default = Ишлеген сынгар къыймат:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Эркин этилген къыйматла (хар кесекге бирер):
+       *[other] Эркин этилген къыйматла:
+    }
+
+help-suggested-values = Теджелген къыйматла:
+
+help-inserts = Салынады:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатала:
+    }
+
+help-type = Тюр:
+
+help-resolved-style = Белгиленнген стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Белгиленнген функция атла:
+help-reset-list = Бу кириуде тизмени артха къайтарыу:
+help-added-on-input = Бу кириуде къошулгъан:
+help-removed-on-input = Бу кириуде кетерилген:
+
+help-reset-overrides = { $reset } { $additional } бла { $removed } къыйматланы алмаштырады.

--- a/packages/i18n/locales/ku/chrome.ftl
+++ b/packages/i18n/locales/ku/chrome.ftl
@@ -1,0 +1,131 @@
+# Kurdish viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Northern Kurdish (Kurmanji) in the Hawar Latin alphabet — the orthography of
+# Kurmanji publishing in Turkey, Syria and the diaspora, and what CLDR fills a
+# bare `ku` in as (`ku` maximizes to `ku-Latn-TR`, endonym «kurdî
+# (kurmancî)»). This catalog is **left to right**. A reader arriving under
+# `ku-Arab` reaches it and gets Latin, the same script asymmetry `locales/pa`,
+# `locales/sr` and `locales/ha` have; the answer is a second catalog beside
+# this one rather than a rename of it. Central Kurdish (Sorani) is
+# `locales/ckb`, a separate right-to-left catalog.
+#
+# Kurmanji counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gives it, `[0]` branch
+# included. A noun after a numeral stays in the singular, so the two branches
+# differ only in the verb agreeing with them.
+#
+# Kurmanji has grammatical gender, but nothing in this file agrees with a noun
+# the catalog supplies — the gender fork lives in `content.ftl`, where the
+# noun being described is known, and that file's header explains why it lands
+# on the ezafe particle rather than on the adjectives.
+
+
+## Answer submission
+
+answer-checking = Tê kontrolkirin…
+answer-submitting = Tê şandin…
+answer-checking-status = Bersiv tê kontrolkirin
+answer-submitting-status = Bersiv tê şandin
+answer-correct = Rast
+answer-incorrect = Şaş
+answer-response-saved = Bersiv hate tomarkirin
+answer-percent-credit = { $percent }% xal
+answer-percent-correct = { $percent }% rast
+answer-percent-short = { $percent } %
+max-credit-available = Xala herî zêde ya berdest: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] tu ceribandin nemane
+        [one] { $count } ceribandin maye
+       *[other] { $count } ceribandin mane
+    }
+validation-correct = (Rast)
+validation-incorrect = (Şaş)
+validation-partially-correct = (Bi qismî rast)
+answer-show-responses =
+    { $count ->
+        [one] { $count } bersiva ji bo { $answerId } nîşan bide
+       *[other] { $count } bersivên ji bo { $answerId } nîşan bide
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Bertek
+collapsible-click-to-open = (ji bo vekirinê bitikîne)
+collapsible-click-to-close = (ji bo girtinê bitikîne)
+collapsible-initializing = Tê amadekirin…
+footnote-show = Jêrenotê nîşan bide
+footnote-hide = Jêrenotê veşêre
+description-more-information = agahiyên bêtir
+
+
+## Controls
+
+slider-previous = Paş
+slider-next = Pêş
+keyboard-open = Klavyeyê Veke
+keyboard-close = Klavyeyê Bigire
+choice-input-remove-choice = { $choice } jê bibe
+matrix-remove-row = Rêzê jê bibe
+matrix-add-row = Rêzê zêde bike
+matrix-remove-column = Stûnê jê bibe
+matrix-add-column = Stûnê zêde bike
+subset-add-remove-points = Xalan zêde bike/jê bibe
+subset-toggle-points-intervals = Di navbera xal û navberan de biguhêre
+subset-move-points = Xalan Bilivîne
+subset-clear = Paqij Bike
+orbital-add-row = Rêzê Zêde Bike
+orbital-remove-row = Rêzê Jê Bibe
+orbital-add-box = Qutîkê Zêde Bike
+orbital-remove-box = Qutîkê Jê Bibe
+orbital-add-up-arrow = Tîra Jorê Zêde Bike
+orbital-add-down-arrow = Tîra Jêrê Zêde Bike
+orbital-remove-arrow = Tîrê Jê Bibe
+orbital-row-label = Etîketa rêza { $row }
+pretzel-answer = Bersiv
+summary-statistics-caption = Statîstîkên kurt ên { $column }
+
+
+## Math input
+
+math-input-preview-region = pêşdîtina îfadeya matematîkî
+math-input-preview = Pêşdîtin
+math-input-invalid-expression = Îfadeya nederbasdar:
+
+
+## Document status
+
+viewer-initializing = Tê amadekirin…
+
+
+## Errors
+
+error-heading = Çewtî
+error-found-at =
+    { $span ->
+        [line] Li rêza { $startLine } hate dîtin.
+       *[lines] Li rêzên { $startLine }–{ $endLine } hate dîtin.
+    }
+document-contains-errors = Di vê belgeyê de çewtî hene!
+diagnostic-heading-error = Çewtî
+diagnostic-heading-warning = Hişyarî
+diagnostic-heading-information = Agahî
+diagnostic-heading-hint = Şîret
+accessibility-heading-level-1 = Binpêkirina Gihîştinê ya WCAG AA
+accessibility-heading-level-2 = Hişyariya gihîştinê
+something-went-wrong = Tiştek çewt çû.
+renderer-load-failed = nîşanderek nehate barkirin. Ji kerema xwe rûpelê nû bike.
+core-start-failed = Ev belge nehate destpêkirin. Ji kerema xwe rûpelê nû bike.
+core-start-failed-busy = Ev belge nehate destpêkirin. Çend belge bi hev re dest pê dikirin, û ev li ser amûreke hêdî dikare dirêjtir bidome. Piştî ku belgeyên din biqedin, nûkirina rûpelê dikare bibe alîkar.
+core-start-failed-retry = Ev belge nehate destpêkirin.
+core-start-failed-busy-retry = Ev belge nehate destpêkirin. Çend belge bi hev re dest pê dikirin, û ev li ser amûreke hêdî dikare dirêjtir bidome.
+core-start-retry = Dîsa biceribîne
+saved-state-unavailable = Xebata te ya tomarkirî nehate barkirin.

--- a/packages/i18n/locales/ku/content.ftl
+++ b/packages/i18n/locales/ku/content.ftl
@@ -1,0 +1,412 @@
+# Kurdish content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# This is **Northern Kurdish (Kurmanji) in the Hawar Latin alphabet**, which is
+# the orthography Kurmanji publishing uses in Turkey, in Syria and across the
+# diaspora, and it is what CLDR fills a bare `ku` in as: `ku` maximizes to
+# `ku-Latn-TR`, and `Intl.DisplayNames` renders the endonym «kurdî
+# (kurmancî)». So this catalog is **left to right**, and the letters here are
+# the twenty-two consonants and nine vowels of Hawar — `ê`, `î`, `û`, `ç`, `ş`
+# are letters of the alphabet and not decorated Latin ones.
+#
+# **A reader arriving under `ku-Arab` reaches this catalog and gets Latin.**
+# That is the same script asymmetry `locales/pa`, `locales/sr` and `locales/ha`
+# already have, and the answer to it is a second catalog beside this one rather
+# than a rename of this one. **Central Kurdish (Sorani) is `locales/ckb`**, a
+# separate right-to-left catalog seeded alongside this one; `negotiate.ts`
+# keeps the two apart, and nothing here serves a Sorani reader.
+#
+# Kurmanji counts in two plural categories, `one` and `other`. Nothing in this
+# file selects on a count.
+#
+# **Kurmanji has grammatical gender, and this is the one catalog in its batch
+# that forks on it — but not where a reader of `locales/fr` would expect.**
+# A Kurmanji attributive adjective does not itself inflect: «sor», «stûr»,
+# «reş» are the same word after a masculine noun and after a feminine one. What
+# carries the agreement is the **ezafe**, the linking vowel between the noun and
+# what describes it — `-ê` after a masculine singular, `-a` after a feminine
+# singular, `-ên` in the plural — and a chain of adjectives repeats it on each
+# one after the first: «xaniyê mezin ê spî».
+#
+# So the colour, width and dash tables below fork nowhere, and the composition
+# messages fork everywhere. That is the opposite shape from French, and it is
+# the reason `ku` is in this batch.
+#
+# **The ezafe cannot be welded to a placeable, and that decided the design of
+# this file.** The bound ezafe attaches to the *noun*; in `style-with-noun` and
+# `style-filled-with-noun` the noun arrives as `{ $noun }`, a value this
+# catalog never sees, and its vowel depends both on that noun's gender and on
+# whether it ends in a vowel (an epenthetic `y` appears: «xanî» → «xaniyê»).
+# Worse, `attachNoun` in `styleDescriptions.ts` passes `style-with-noun` no
+# `$gender` at all — it passes `parts`, `description`, `noun`, `nounTail` and
+# `role` — so even the gender fork is unavailable in the one message that most
+# needs it.
+#
+# The way out is the README's fifth one, *prefer the free allomorph over the
+# bound one*: Kurmanji's ezafe also exists as the free-standing particle
+# «yê» / «ya» / «yên», which is what stands between a noun and a following
+# adjective in the northern (Behdinî) pattern and what links every adjective
+# after the first in the standard one. So **every describing phrase this
+# catalog builds leads with that free particle, and the particle is written
+# inside the message that knows the gender** — `style-stroke`, `style-filled`,
+# `style-filled-with-noun` — rather than beside the noun that does not.
+# `style-with-noun` then simply places `{ $noun }` in front of a phrase that
+# already agrees, and needs no fork of its own. This is the same move
+# `locales/quc` makes with «rech» and `locales/ceb` with «nga», and it is
+# where this seed is deliberately stiff: standard written Kurmanji would bind
+# the first ezafe to the noun («xêza stûr a sor»), and this catalog writes it
+# free («xêz ya stûr ya sor»). A speaker should read that as a known compromise
+# rather than as a mistake, and the fix is a change to `styleDescriptions.ts` —
+# passing the noun *key* rather than only the rendered word — not a change to
+# the strings.
+#
+# Two smaller consequences of the same constraint, recorded so they are not
+# "fixed" into something worse:
+#
+#   * The particle is written **«yê» / «ya» / «yên» with the `y` throughout**,
+#     never the bare «ê» / «a» / «ên». Which of the two a printed text uses is
+#     decided by the sound of the word in front, and beside a placeable there
+#     is no word to look at. One shape everywhere is findable; a scatter is not.
+#   * `style-unfilled` is rendered with no arguments (`describeFill` hands it
+#     none), so it cannot select on `$gender` and is written flat, as every
+#     agreeing catalog in the roster does. «nedagirtî» does not inflect anyway,
+#     so nothing is lost here — unlike in `locales/ce`, where the flat form is
+#     a real compromise.
+#
+# `$role` goes unused. Kurmanji marks an oblique case, but it marks it on the
+# noun and on the ezafe, never on the adjective, and every position these
+# phrases land in is one this catalog writes the noun for itself.
+#
+# **`noun-gender`'s table is the least certain thing in this file.** The gender
+# of the everyday nouns — «xêz», «xal», «bazine», «herêm» — this seed is
+# confident of; the gender of the loanwords and coinages it is not, and
+# Kurmanji assigns gender to a loanword unpredictably. «parabol»,
+# «fonksiyon», «vektor», «almas», «xaç» and «nîşana komê» are the entries a
+# speaker should check first. Anything not listed falls to `m`.
+
+
+## Style vocabulary
+##
+## Not one word here forks. A Kurmanji attributive adjective is invariable; the
+## agreement is in the ezafe, which lives in the composition messages below.
+
+# «şîn» historically covered both blue and green, and «kesk» is the modern
+# green; cyan has no settled Kurmanji word, so «firûzeyî» — turquoise — is
+# written for it. That is a colour boundary the style pipeline splits where the
+# language does not, and a speaker may well prefer «şîna vekirî».
+color =
+    .black = reş
+    .white = spî
+    .gray = gewr
+    .red = sor
+    .orange = pirteqalî
+    .yellow = zer
+    .green = kesk
+    .cyan = firûzeyî
+    .blue = şîn
+    .purple = mor
+    .pink = pembe
+    .brown = qehweyî
+line-width =
+    .thick = stûr
+    .thin = zirav
+line-style =
+    .dashed = qutbirr
+    .dotted = xalxalî
+# Noun phrases, and the only place in this catalog where a word's position is
+# fixed enough to inflect it in advance: all four uses of a fill pattern stand
+# behind «bi», so these are written as they are wanted there. «xêzên …» carries
+# its own plural ezafe and is already right after a preposition; «xal» and
+# «almas» have no ezafe to carry it, so they are written in the oblique plural.
+# That is the `locales/kab` move — make the position uniform, then one written
+# form is right in all of them.
+fill-style =
+    .horizontal = xêzên asoyî
+    .vertical = xêzên stûnî
+    .diagonal = xêzên çeprast
+    .backdiagonal = xêzên çeprast ên berevajî
+    .dots = xalan
+    .diamonds = almasan
+noun =
+    .line = xêz
+    .line-segment = parçeyê xêzê
+    .ray = tîrêj
+    .vector = vektor
+    .curve = xêza xwar
+    .function = fonksiyon
+    .slope-field = qada hêlan
+    .vector-field = qada vektoran
+    .parabola = parabol
+    .polyline = xêza şikestî
+    .polygon = pirgoşe
+    .triangle = sêgoşe
+    .rectangle = rastgoşe
+    .circle = bazine
+    .region = herêm
+    .point = xal
+    .square = çargoşe
+    .diamond = almas
+    .cross = xaç
+    .plus = nîşana komê
+# Kurmanji builds the word from the side count in front of the noun — «5-goşeyê
+# birêk», a regular 5-gon — so the whole of it is one head and there is no
+# tail. The suffix welded to `{ $numSides }` has one shape whatever number
+# lands there, which is what makes the weld safe.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides }-goşeyê birêk
+    }
+# The gender of the noun being described, which decides the ezafe particle the
+# composition messages write. Only the entries this seed is reasonably
+# confident of are listed; everything else falls to `m`. See the note at the
+# top of this file — this table is the first thing a speaker should check.
+noun-gender =
+    { $noun ->
+        [line] f
+        [curve] f
+        [polyline] f
+        [circle] f
+        [region] f
+        [point] f
+        [cross] f
+        [parabola] f
+        [function] f
+        [slope-field] f
+        [vector-field] f
+        [plus] f
+        [border] f
+        [fill] f
+        [text] f
+        [background] f
+       *[other] m
+    }
+
+## Style composition
+
+# The free ezafe particle leads the phrase and repeats before each further
+# adjective, so that the whole description already agrees with the noun by the
+# time `style-with-noun` puts a noun in front of it. Standing on its own — as
+# `borderStyleDescription` reports it — the same string reads as a nominalized
+# phrase, «yê stûr yê sor», "the thick red one", which is the right citation
+# form for a state variable.
+style-stroke =
+    { $parts ->
+        [width-style-color]
+            { $gender ->
+                [f] ya { $width } ya { $lineStyle } ya { $color }
+               *[m] yê { $width } yê { $lineStyle } yê { $color }
+            }
+        [width-color]
+            { $gender ->
+                [f] ya { $width } ya { $color }
+               *[m] yê { $width } yê { $color }
+            }
+        [style-color]
+            { $gender ->
+                [f] ya { $lineStyle } ya { $color }
+               *[m] yê { $lineStyle } yê { $color }
+            }
+        [width-style]
+            { $gender ->
+                [f] ya { $width } ya { $lineStyle }
+               *[m] yê { $width } yê { $lineStyle }
+            }
+        [width]
+            { $gender ->
+                [f] ya { $width }
+               *[m] yê { $width }
+            }
+        [style]
+            { $gender ->
+                [f] ya { $lineStyle }
+               *[m] yê { $lineStyle }
+            }
+       *[color]
+            { $gender ->
+                [f] ya { $color }
+               *[m] yê { $color }
+            }
+    }
+# The one composition message that is handed no `$gender`, and the reason the
+# particle is written upstream instead of here: the noun leads and the phrase
+# behind it has already agreed with it.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+# «dagirtî» is a past participle and does not inflect for gender in Kurmanji,
+# so this word is flat where `locales/fr` and `locales/ce` fork it. The
+# agreement it would carry elsewhere is in the particle beside it.
+style-filled-word = dagirtî
+style-filled =
+    { $parts ->
+        [pattern]
+            { $gender ->
+                [f] ya { $filled } ya { $color } bi { $pattern }
+               *[m] yê { $filled } yê { $color } bi { $pattern }
+            }
+       *[plain]
+            { $gender ->
+                [f] ya { $filled } ya { $color }
+               *[m] yê { $filled } yê { $color }
+            }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern]
+            { $gender ->
+                [f] { $noun } ya { $filled } ya { $color } bi { $pattern }
+               *[m] { $noun } yê { $filled } yê { $color } bi { $pattern }
+            }
+        [plain-tail]
+            { $gender ->
+                [f] { $noun } { $nounTail } ya { $filled } ya { $color }
+               *[m] { $noun } { $nounTail } yê { $filled } yê { $color }
+            }
+        [pattern-tail]
+            { $gender ->
+                [f] { $noun } { $nounTail } ya { $filled } ya { $color } bi { $pattern }
+               *[m] { $noun } { $nounTail } yê { $filled } yê { $color } bi { $pattern }
+            }
+       *[plain]
+            { $gender ->
+                [f] { $noun } ya { $filled } ya { $color }
+               *[m] { $noun } yê { $filled } yê { $color }
+            }
+    }
+# «kevî» — the edge of a shape — is a noun this catalog writes itself, so the
+# preposition «bi» governs a word whose form is known and nothing is welded to
+# a placeable. `{ $border }` arrives already led by its own particle, since
+# `noun-gender` answers `f` for `border`. Kurmanji needs no article, so only
+# the connective distinguishes the four branches.
+style-border-clause =
+    { $parts ->
+        [with-article] bi kevî { $border }
+        [and] û bi kevî { $border }
+        [and-article] û bi kevî { $border }
+       *[with] bi kevî { $border }
+    }
+# Here the head of the phrase is «dagirtin», a word this catalog supplies, so
+# the *bound* ezafe can be written after all — «dagirtina sor» — and no fork is
+# wanted: `describeFill` only ever asks for `fill`'s gender, so a `$gender`
+# branch here would be a variant nothing else can select.
+style-fill =
+    { $parts ->
+        [pattern] dagirtina { $color } bi { $pattern }
+       *[plain] dagirtina { $color }
+    }
+# Rendered with no arguments at all, so it cannot select on `$gender`. The word
+# does not inflect, so the flat form is also the correct one.
+style-unfilled = nedagirtî
+# «paşxane» is this catalog's own word, so the bound ezafe is written on it.
+# The text colour is predicative here and stays a bare adjective.
+style-text =
+    { $parts ->
+        [background] { $color } li ser paşxaneya { $background }
+       *[plain] { $color }
+    }
+style-background-none = tune
+
+## Boolean words
+
+boolean-true = rast
+boolean-false = şaş
+
+## Answer buttons
+
+answer-submit-label = Kontrol Bike
+answer-submit-label-no-correctness = Bersivê Bişîne
+
+## Sectional blocks
+##
+## Kurmanji does not mark the plural in the direct case, so a heading that
+## names one exercise and a heading that names several are the same word.
+## `.exercise` and `.exercises`, and `.problem` and `.problems`, therefore read
+## alike; that is the language rather than a copy-paste.
+
+section-name =
+    .activity = Çalakî
+    .aside = Nîşeya Alîkî
+    .cascade = Kaskad
+    .definition = Pênase
+    .example = Mînak
+    .exercise = Temrîn
+    .exercises = Temrîn
+    .given-answer = Bersiv
+    .note = Nîşe
+    .objectives = Armanc
+    .paragraphs = Paragraf
+    .part = Parçe
+    .problem = Mesele
+    .problems = Mesele
+    .proof = Îsbat
+    .question = Pirs
+    .section = Beş
+    .solution = Çareserî
+    .task = Erk
+    .theorem = Teorem
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Alîkarî
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+figure-name =
+    { $parts ->
+        [numbered] Şekil { $enumeration }
+        [numbered-caption] Şekil { $enumeration }{ ": " }
+        [unnumbered-caption] Şekil{ ": " }
+       *[unnumbered] Şekil
+    }
+
+## Paginator controls
+
+paginator-previous = Berê
+paginator-next = Pêş
+paginator-page = Rûpel
+paginator-page-status = { $pageLabel } { $currentPage } ji { $numPages }
+
+## Piecewise functions
+##
+## Kurmanji's «eger» opens its clause, exactly where the renderer puts this
+## key and ahead of the mathematics it introduces, so nothing has to be
+## recorded here as unplaceable — unlike the catalogs whose conditional closes
+## its clause.
+
+piecewise-condition-or = an
+piecewise-condition-if = eger
+piecewise-condition-otherwise = wekî din
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Kurmanji-medium secondary schooling barely
+## exists: a pupil in Turkey is taught chemistry in Turkish and a pupil in
+## Syria in Arabic, so there is no Kurmanji element list a student would
+## recognize from their own textbook, and an invented one would be further from
+## the curriculum than the English fallback is. `locales/ckb` beside this one
+## is a different case and says so in its own header — Central Kurdish *is* the
+## medium of secondary science teaching in the Kurdistan Region of Iraq.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Sembola kîmyewî ya nederbasdar
+chemistry-invalid-ionic-compound = Pêkhateya îyonî ya nederbasdar

--- a/packages/i18n/locales/ku/diagnostics.ftl
+++ b/packages/i18n/locales/ku/diagnostics.ftl
@@ -1,0 +1,752 @@
+# Kurdish diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Northern Kurdish (Kurmanji) in the Hawar Latin alphabet — the orthography
+# Kurmanji publishing uses in Turkey, Syria and the diaspora, and what CLDR
+# fills a bare `ku` in as (`ku` maximizes to `ku-Latn-TR`). This catalog is
+# **left to right**; a reader arriving under `ku-Arab` reaches it and gets
+# Latin, and the answer to that is a second catalog beside this one rather than
+# a rename of it. Central Kurdish (Sorani) is `locales/ckb`, a separate
+# right-to-left catalog.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Kurmanji counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` keeps the shape English gives it. The direct-case plural is
+# unmarked, so several of those pairs differ only in the verb agreeing with the
+# count, and a few read alike.
+#
+# Kurmanji's gender agreement does not reach this file: nothing here describes
+# a noun the catalog itself supplies, so no message forks. The fork lives in
+# `content.ftl`, on the ezafe particle, and that file's header says why.
+#
+# The technical vocabulary is the one Kurdish computing prose uses:
+# «pêkhate» component, «taybetmendî» attribute, «hêman» element, «guhêrbar»
+# variable, «referans» reference, «nirx» value.
+
+## `<lineSegment>`
+
+# $attributes is a list of attribute names; $attributesCount is its length.
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] gava du xalên dawî bên diyarkirin { $attributes } tê paşguhkirin
+       *[other] gava du xalên dawî bên diyarkirin { $attributes } tên paşguhkirin
+    }
+
+# $attributes is a list of attribute names; $attributesCount is its length.
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] gava hem xaleke dawî hem jî xala navîn bên diyarkirin { $attributes } tê paşguhkirin
+       *[other] gava hem xaleke dawî hem jî xala navîn bên diyarkirin { $attributes } tên paşguhkirin
+    }
+
+line-segment-midpoint-offset-without-midpoint = bêyî xaleke navîn midpointOffset bandorê nake
+
+## `<line>`
+
+line-points-undetermined-dimensions = Xêz di nav xalên bi dîmensiyonên nediyar re derbas dibe.
+
+line-points-too-few-dimensions = Divê xêz di nav xalên bi kêmî du dîmensiyonan re derbas bibe.
+
+# $variables is a bare enumeration of variable names, not an "and" list.
+line-points-depend-on-variables = Xêz di nav xalên ku bi van guhêrbaran ve girêdayî ne re derbas dibe: { $variables }.
+
+line-equation-invalid-format = Formata hevkêşeya xêzê ya bi guhêrbarên { $variable1 } û { $variable2 } nederbasdar e.
+
+## `<ray>`
+
+ray-overprescribed-through = Tîrêj bi through, endpoint û direction ve hatiye diyarkirin.  Through ya diyarkirî tê paşguhkirin.
+
+ray-dimension-mismatch = Di tîrêjê de numDimensions li hev nake.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor bi head, tail û displacement ve hatiye diyarkirin.  Head ya diyarkirî tê paşguhkirin.
+
+vector-dimension-mismatch = Di vektorê de numDimensions li hev nake.
+
+## Attracting and constraining
+
+# $component is the DoenetML tag of the child that was named, e.g. "polygon".
+attract-to-without-nearest-point = Nikare ber bi `<{ $component }>` ve bikişîne, ji ber ku guhêrbara rewşê ya nearestPoint tune.
+
+constrain-to-without-nearest-point = Nikare bi `<{ $component }>` ve sînordar bike, ji ber ku guhêrbara rewşê ya nearestPoint tune.
+
+constrain-to-interior-without-nearest-point = Nikare bi hundirê `<{ $component }>` ve sînordar bike, ji ber ku guhêrbara rewşê ya nearestPoint tune.
+
+## `<choiceInput>`
+
+# Translators: `labelPosition` is an attribute name and stays in English.
+choice-input-label-position-ignored = ji bo choiceInput ya ne-inline labelPosition tê paşguhkirin
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ji bo choiceInput îndeksên diyarkirî tên paşguhkirin, ji ber ku hejmara îndeksan bi hejmara zarokên choice re li hev nake.
+
+pretzel-indices-count-mismatch = Ji bo problem îndeksên diyarkirî tên paşguhkirin, ji ber ku hejmara îndeksan bi hejmara zarokên problem re li hev nake.
+
+shuffle-indices-count-mismatch = Ji bo shuffle îndeksên diyarkirî tên paşguhkirin, ji ber ku hejmara îndeksan bi hejmara pêkhateyan re li hev nake.
+
+# $component is `choiceInput`, `pretzel` or `shuffle` — a DoenetML component
+# name, so it stays in English.
+indices-ignored-out-of-range = Ji bo { $component } îndeksên diyarkirî tên paşguhkirin, ji ber ku hin îndeks derveyî navberê ne.
+
+pretzel-indices-repeated = Ji bo pretzel îndeksên diyarkirî tên paşguhkirin, ji ber ku hin îndeks dubare ne.
+
+pretzel-circuit-first-index = Ji bo pretzel ya di moda circuit de îndeksên diyarkirî tên paşguhkirin, ji ber ku divê îndeksa yekem 1 be.
+
+## `<shuffle>` and `<sort>`
+
+# $component is `shuffle` or `sort`.
+string-children-need-type = Ji bo ku `<{ $component }>` bi zarokên rêzikê re bixebite, divê taybetmendiya `type` bê diyarkirin.
+
+# $type is what the author wrote; math, text, number and boolean are attribute
+# values and stay in English.
+invalid-type-defaulting-to-math = Ji bo pêkhateya { $component } cureyê { $type } nederbasdar e. Divê yek ji van be: math, text, number an boolean. Math tê bikaranîn.
+
+# $value is the string child that could not be used.
+string-not-valid-component-to-arrange = Rêzika "{ $value }" ji bo { $component } ne pêkhateyeke derbasdar e. Tê paşguhkirin.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Cureyê { $type } nederbasdar e, cure wekî number tê danîn.
+
+invalid-variable-value = Nirxa guhêrbarê nederbasdar e: `{ $value }`
+
+## Variants
+
+# $index is what the author wrote, reproduced verbatim rather than as a number.
+variant-index-must-be-number = Divê îndeksa varyantê { $index } hejmarek be
+
+variant-index-must-be-integer = Divê îndeksa varyantê { $index } hejmareke tam be
+
+## `<sideBySide>`
+
+# $component is `sideBySide` or `sbsGroup`.
+side-by-side-absolute-widths = `<{ $component }>` ji bo pîvanên mutleq nehatiye pêkanîn. Firehî wekî nisbî tên danîn.
+
+side-by-side-absolute-margins = `<{ $component }>` ji bo pîvanên mutleq nehatiye pêkanîn. Kêlek wekî nisbî tên danîn.
+
+side-by-side-no-block-child = `<{ $component }>` nederbasdar e: divê bi kêmî zarokeke blokê hebe.
+
+## `<label>`
+
+# Translators: `for` is an attribute name and stays in English.
+label-for-ignored-on-graphical = Taybetmendiya `for` ya li ser `<label>` ya grafîkî tê paşguhkirin.
+
+label-for-must-resolve-to-one = Divê taybetmendiya `for` ya li ser `<label>` tenê bibe yek pêkhate.
+
+label-for-unresolved = Taybetmendiya `for` ya li ser `<label>` nehate girêdan bi tu pêkhateyekê.
+
+label-for-answer-with-authored-inputs = Taybetmendiya `for` ya li ser `<label>` referansê dide `<answer>`-ekê ku têketinên wê bi eşkereyî hatine nivîsîn; rasterast referansê bide têketinê.
+
+label-for-answer-without-input = Taybetmendiya `for` ya li ser `<label>` referansê dide `<answer>`-ekê ku têketineke wê ya bi navnîşan tune.
+
+label-for-must-reference-input-or-answer = Divê taybetmendiya `for` ya li ser `<label>` referansê bide têketinekê an bersivekê.
+
+## Accessibility
+
+# $component is a DoenetML tag, e.g. "graph" or "image".
+accessibility-short-description-or-decorative = Ji bo gihîştinê, divê `<{ $component }>` an danasîneke kurt hebe an jî wekî xemilandin bê diyarkirin.
+
+accessibility-video-short-description = Ji bo gihîştinê, divê `<video>` danasîneke kurt hebe.
+
+accessibility-input-short-description-or-label = Ji bo gihîştinê, divê `<{ $component }>` danasîneke kurt an etîketek hebe.
+
+accessibility-answer-input-short-description-or-label = Ji bo gihîştinê, divê `<answer>`-a ku têketinekê çêdike danasîneke kurt an etîketek hebe.
+
+accessibility-short-description-contains-math = Divê danasînên kurt pêkhateyên matematîkî yên wekî `<{ $component }>` nehewînin. Matematîkê bi peyvan binivîse.
+
+# $colorName is an attribute name and stays in English.
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ji bo nivîsa sernavê beşê kontrasteke têrê nake (moda tarî) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; bi kêmî { $threshold }:1 divê).
+       *[other] { $colorName } ji bo nivîsa sernavê beşê kontrasteke têrê nake ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; bi kêmî { $threshold }:1 divê).
+    }
+
+## `<circle>`
+
+# $count is the number of through points.
+circle-through-points-non-numerical = `<circle>`-a di nav { $count } xalan re, gava xal nirxên hejmarî nînin, nehatiye pêkanîn.
+
+circle-too-many-through-points = Nikare bazineyeke di nav zêdetirî 3 xalan re hesab bike.
+
+circle-overprescribed-radius-center-points = Nikare bazineyeke bi tîrêj, navend û xalên diyarkirî hesab bike.
+
+circle-center-with-multiple-points = Nikare bazineyeke bi navenda diyarkirî di nav zêdetirî 1 xalê re hesab bike.
+
+# $distance and $radius arrive as strings, not numbers.
+circle-radius-too-small = Nikare bazineyê hesab bike: ji ber ku dûrahiya di navbera her du xalan de { $distance } e, tîrêja diyarkirî { $radius } pir biçûk e.
+
+circle-radius-with-many-points = Nikare bazineyeke bi tîrêja diyarkirî di nav zêdetirî du xalan re çêbike.
+
+circle-invalid-center-or-through-points = Navend an xalên derbasbûnê yên bazineyê nederbasdar in.
+
+circle-radius-center-with-multiple-points = Nikare tîrêja bazineya bi navenda diyarkirî di nav zêdetirî 1 xalê re hesab bike.
+
+circle-change-radius-non-numerical = Nikare tîrêja bazineya bi xalên nehejmarî biguherîne
+
+circle-radius-with-points-non-numerical = Gava nirxên hejmarî tune bin, nikare bazineyeke bi tîrêja diyarkirî di nav zêdetirî yek xalê re çêbike.
+
+circle-change-center-non-numerical = Guherandina navenda bazineya di nav xalên bi nirxên nehejmarî re nehatiye pêkanîn.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Ji bo fonksiyonê dîmensiyonên domênê têrê nakin. Domên { $intervals } navber heye lê fonksiyonê { $inputs ->
+            [one] { $inputs } têketin
+           *[other] { $inputs } têketin
+        } heye.
+       *[other] Ji bo fonksiyonê dîmensiyonên domênê têrê nakin. Domên { $intervals } navber hene lê fonksiyonê { $inputs ->
+            [one] { $inputs } têketin
+           *[other] { $inputs } têketin
+        } heye.
+    }
+
+function-domain-invalid-format = Formata domêna fonksiyonê nederbasdar e.
+
+# $type selects the wording rather than being substituted into it.
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Maksîmuma nehejmarî ya fonksiyonê tê paşguhkirin.
+        [minimum] Mînîmuma nehejmarî ya fonksiyonê tê paşguhkirin.
+        [extremum] Ekstremuma nehejmarî ya fonksiyonê tê paşguhkirin.
+        [point] Xala nehejmarî ya fonksiyonê tê paşguhkirin.
+        [slope] Hêla nehejmarî ya fonksiyonê tê paşguhkirin.
+       *[other] { $type }-a nehejmarî ya fonksiyonê tê paşguhkirin.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Maksîmuma vala ya fonksiyonê tê paşguhkirin.
+        [minimum] Mînîmuma vala ya fonksiyonê tê paşguhkirin.
+        [extremum] Ekstremuma vala ya fonksiyonê tê paşguhkirin.
+        [point] Xala vala ya fonksiyonê tê paşguhkirin.
+       *[other] { $type }-a vala ya fonksiyonê tê paşguhkirin.
+    }
+
+function-points-too-close = Fonksiyon du xalên ku cihên wan pir nêzîkî hev in dihewîne. Fonksiyon nayê pênasekirin.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Dubarekirinên fonksiyonê tenê gava hejmara têketinan bi hejmara derketinan re wekhev be pêkan in. Vê fonksiyonê { $inputs } têketin û { $outputs ->
+            [one] { $outputs } derketin
+           *[other] { $outputs } derketin
+        } hene.
+       *[other] Dubarekirinên fonksiyonê tenê gava hejmara têketinan bi hejmara derketinan re wekhev be pêkan in. Vê fonksiyonê { $inputs } têketin û { $outputs ->
+            [one] { $outputs } derketin
+           *[other] { $outputs } derketin
+        } hene.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Dirêjahiya rêzeyê nederbasdar e.  Divê hejmareke tam a ne-neyînî be.
+
+# $type is a sequence type: number, letters, or math.
+sequence-invalid-step = Gava rêzeyê nederbasdar e.  Ji bo rêzeya bi cureyê { $type } divê hejmarek be.
+
+# $attribute is `from` or `to` — an attribute name, so it stays in English.
+sequence-invalid-endpoint-number = "{ $attribute }" ya rêzeya hejmaran nederbasdar e.  Divê hejmarek be.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ya rêzeya tîpan nederbasdar e.  Divê hevgirtineke tîpan be.
+
+sequence-invalid-endpoint = "{ $attribute }" ya rêzeyê nederbasdar e.
+
+select-from-sequence-coprime-not-numbers = ji ber ku hejmar nayên hilbijartin coprime tê paşguhkirin
+
+select-from-sequence-coprime-with-exclude-combinations = ji ber ku excludeCombinations hatiye diyarkirin coprime tê paşguhkirin
+
+## Resolving a `target`
+
+target-not-found = Ji bo `<{ $source }>` armanc nederbasdar e: armanc nayê dîtin.
+
+# $property is the state variable that was looked for.
+target-state-variable-not-found = Ji bo `<{ $source }>` armanc nederbasdar e: li ser `<{ $component }>`-ekê guhêrbareke rewşê bi navê "{ $property }" nayê dîtin.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Divê guhêrbarên `<odeSystem>` ji guhêrbara serbixwe cuda bin.
+
+ode-system-duplicate-variable-names = Bi navên guhêrbarên girêdayî yên dubare fonksiyonên ODE RHS nayên pênasekirin.
+
+ode-system-rhs-function-error = Fonksiyona ODE RHS nayê pênasekirin.  Di çêkirina fonksiyona mathjs de çewtî.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+# $count is how many line children were found.
+angle-too-many-lines = Nikare goşeyeke di navbera { $count } xêzan de pênase bike
+
+angle-invalid-through-point = Di through ya `<angle>` de xala nederbasdar
+
+parabola-vertex-too-many-points = Parabola bi kelekê di nav zêdetirî 1 xalê re nehatiye pêkanîn.
+
+parabola-too-many-points = Parabola di nav zêdetirî 3 xalan re nehatiye pêkanîn.
+
+intersection-too-many-items = Ji bo zêdetirî du hêmanan hevbirrîn nehatiye pêkanîn
+
+## Other math components
+
+ionic-compound-not-two-ions = Ji bilî du îyonan, pêkhateya îyonî ji bo tiştekî din nehatiye pêkanîn.
+
+ionic-compound-needs-cation-and-anion = Pêkhateya îyonî tenê ji bo yek katyon û yek anyonê hatiye pêkanîn.
+
+# $equation is the equation as the author wrote it.
+solve-equations-cannot-evaluate = Hevkêşe nayê çareserkirin ji ber ku nehate hesibandin: { $equation }
+
+# Translators: `operandNumber` is an attribute name and stays in English.
+math-operators-operand-number-required = Gava operandeke matematîkî tê derxistin, divê operandNumber bê diyarkirin.
+
+eigen-decomposition-failed = Nirxên taybet ên matrîsê nehatin hesibandin
+
+## `<matchesPattern>`
+
+# Translators: `parameters` is an attribute name and stays in English.
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parametreya { $parameters } di nexşeyê de dernakeve, loma wê her tim bi valahiyekê re li hev bike.
+       *[other] `<matchesPattern>`: parametreyên { $parameters } di nexşeyê de dernakevin, loma wê her tim bi valahiyekê re li hev bikin.
+    }
+
+## `<graph>`
+
+# Translators: grid is an attribute name and none, medium and dense are its
+# values; all four stay in English, as does the example.
+graph-grid-invalid = `<graph>`: grid="{ $grid }" nayê şirovekirin. Divê none, medium, dense an du hejmarên erênî yên bi valahiyekê ji hev cuda be, wekî grid="1 0.5". Tu tor nayê xêzkirin.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` fonksiyoneke bi { $expected ->
+        [one] yek derketinê, hêla y' ya li her xalê, wekî `y - x`
+       *[other] du derketinan, vektora li her xalê, wekî `(y, -x)`
+    } dixwaze, lê fonksiyona ku jê re hatiye dayîn { $found ->
+        [one] { $found } derketin
+       *[other] { $found } derketin
+    } heye. { $alternative ->
+        [none] Tiştek nayê xêzkirin.
+       *[other] Ji bo wê fonksiyonê pêkhate `<{ $alternative }>` e. Tiştek nayê xêzkirin.
+    }
+
+# Translators: retired. `function` is an attribute name and stays in English.
+field-function-attribute-ignored-with-child = Taybetmendiya `function` tê paşguhkirin ji ber ku fonksiyon di nav pêkhateyê de jî hatiye dayîn; ya hundir tê bikaranîn. Fonksiyonê tenê bi yek ji van du awayan bide.
+
+# Translators: `variables` and `function` are a DoenetML attribute and tag and
+# stay in English, as does $component, the field's own tag.
+field-variables-ignored =
+    `<{ $component }>`: taybetmendiya `variables` navê guhêrbarên îfadeyeke rasterast di nav pêkhateyê de nivîsandî dide. { $reason ->
+        [function-child] Fonksiyon li vir wekî zarokeke `<function>` hatiye dayîn û ew guhêrbarên xwe bi xwe bi nav dike, loma `variables` tê paşguhkirin.
+       *[no-expression] Li vir îfadeyeke wisa nehatiye dayîn, loma `variables` tê paşguhkirin.
+    }
+
+## PreFigure renderer
+
+# Translators: xLabelPosition, yLabelPosition and their values are attribute
+# names and stay in English, as does the renderer's name.
+prefigure-x-label-position-unsupported = `<graph>`: di nîşanderê prefigure de xLabelPosition="left" nayê piştgirîkirin; tevgera cihê rastê tê bikaranîn.
+
+prefigure-y-label-position-unsupported = `<graph>`: di nîşanderê prefigure de yLabelPosition="bottom" nayê piştgirîkirin; tevgera cihê jorîn tê bikaranîn.
+
+prefigure-invalid-axis-bounds = `<graph>`: ji bo veguhastina prefigure sînorên tewereyê nederbasdar in; bbox ya standard (-10,-10,10,10) tê bikaranîn.
+
+prefigure-invalid-width = `<graph>`: ji bo veguhastina prefigure firehî nederbasdar e; firehiya diagramê ya standard 425 tê bikaranîn.
+
+prefigure-invalid-aspect-ratio = `<graph>`: ji bo veguhastina prefigure aspectRatio nederbasdar e; rêjeya standard 1 tê bikaranîn.
+
+# Translators: the renderer's name, prefigure, stays in English.
+prefigure-grid-spacing-too-fine = `<graph>`: navbera torê ji bo sînorên tewereyê pir teng e; di nîşanderê prefigure de tor tê hiştin.
+
+prefigure-annotations-not-rendered = `<graph>`: gava nîşanderê PreFigure neyê bikaranîn şirove nayên xêzkirin.
+
+multiple-annotations-children = Di `<graph>` de çend zarokên `<annotations>` hatin dîtin; ji bilî ya dawî hemû tên paşguhkirin.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Cureyeke pêkhateyê ya nenas nayê dirêjkirin an kopîkirin: { $type }.
+
+copy-prop-not-found = Li ser pêkhateyeke bi cureyê { $component } prop ya { $property } nehate dîtin
+
+collect-no-source = Ji bo collect tu çavkanî nehate dîtin.
+
+collect-invalid-component-type = Pêkhateyên bi cureyê `<{ $component }>` nayên berhevkirin, ji ber ku ev cureyeke pêkhateyê ya nederbasdar e.
+
+# $reference is the reference exactly as the author wrote it, `$` and all.
+reference-index-unavailable = Îndeksa `{ $reference }` referans nayê dayîn
+
+## `<callAction>`
+
+# $action is the `actionName` the author asked for.
+component-action-unavailable = { $action } li ser pêkhateya `{ $reference }` nayê bangkirin
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Şiklê daneyan nederbasdar e.  Dirêjahiya rêzan li hev nake. Di componentIdx de hate dîtin :{ $componentIdx }
+
+data-frame-duplicate-column-names = Di daneyan de navên stûnan dubare ne.  Di componentIdx de hate dîtin :{ $componentIdx }
+
+data-frame-missing-column-name = Di daneyan de navê stûnekê kêm e.  Di componentIdx de hate dîtin :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Xelateke vê bersivê li ser bersiva şandî ya `<answer>`-a xwe hatiye avakirin, û ev ê bibe sedema tevgereke nediyar.
+
+# Translators: maxNumAttempts and sectionWideCheckWork are attribute names.
+answer-max-num-attempts-in-section-wide-check-work = Danîna `maxNumAttempts` li ser `<answer>`-eke di nav hilgireke bi `sectionWideCheckWork` de bandorê nake, ji ber ku hejmara ceribandinan ji aliyê hilgirê ve tê kontrolkirin. Li şûna wê `maxNumAttempts` li ser hilgirê deyne.
+
+nested-section-wide-check-work-max-num-attempts = Danîna `maxNumAttempts` li ser hilgireke bi `sectionWideCheckWork` ya di nav hilgireke din a bi `sectionWideCheckWork` de bandorê nake, ji ber ku hejmara ceribandinan ji aliyê hilgirê derve ve tê kontrolkirin. Li şûna wê `maxNumAttempts` li ser hilgirê derve deyne.
+
+# $attributes is a list of attribute names; $attributesCount is its length.
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Bêyî ku symbolicEquality bê danîn, taybetmendiya { $attributes } bandorê nake.
+       *[other] Bêyî ku symbolicEquality bê danîn, taybetmendiyên { $attributes } bandorê nakin.
+    }
+
+answer-invalid-type = Ji bo bersivê cure nederbasdar e: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ji ber ku pêkhateya `<{ $component }>` navekî wê tune, ew ji bo taybetmendiyeke modulê nayê bikaranîn
+
+module-attribute-name-already-defined = Pêkhateya `<{ $component } name="{ $name }">` wekî taybetmendiyeke modulê nayê bikaranîn, ji ber ku cureyê pêkhateyê ya `<module>` jixwe taybetmendiyeke bi navê "{ $name }" heye.
+
+conditional-content-condition-ignored = Li ser pêkhateyeke `<conditionalContent>` ya bi zarokên case an else, taybetmendiya `condition` tê paşguhkirin.
+
+slider-markers-type-mismatch = Cureyê nîşankeran bi cureyê slider re li hev nake.
+
+pretzel-problem-needs-statement-and-answer = Pretzel nederbasdar e: divê her `<problem>` yek `<statement>` û yek `<answer>` bihewîne.
+
+pretzel-circuit-first-problem-distractor = Pretzel nederbasdar e: di mode="circuit" de `<problem>`-a yekem nikare bibe distractor.
+
+## Attribute values
+
+# $values is a list of the values that were rejected, each already in
+# backticks; $valuesCount is how many there were.
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Ji bo taybetmendiya `{ $attribute }` nirxa { $values } nederbasdar e; tê paşguhkirin.
+       *[other] Ji bo taybetmendiya `{ $attribute }` nirxên { $values } nederbasdar in; tên paşguhkirin.
+    }
+
+attribute-must-be-references = Ji bo taybetmendiya `{ $attribute }` nirxa `{ $value }` nederbasdar e. Divê taybetmendî ji referansên ku bi `$` dest pê dikin pêk were.
+
+# $names is a list of the rejected names, each already in single quotes.
+math-input-invalid-function-names = <mathInput>: di { $attribute } de navên fonksiyonan ên nederbasdar hatin paşguhkirin: { $names }. Divê para nîşandanê ya her navî bi kêmî 2 tîp be (tîp an xêzik); pişt re dikare paşgireke bijarte ya `|<mathspeak alternative>` bê.
+
+## Building components from the source
+
+component-type-invalid = Cureyê pêkhateyê nederbasdar e: `<{ $componentType }>`
+
+attribute-repeated = Taybetmendiya { $attribute } nayê dubarekirin.
+
+attribute-invalid-for-component = Ji bo pêkhateyeke bi cureyê `<{ $componentType }>` taybetmendiya "{ $attribute }" nederbasdar e.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Pênaseya şêwazê { $styleNumber } ji bo { $context ->
+        [text-on-background] rengê nivîsê li hember rengê paşxanê
+        [high-contrast] rengê kontrasta bilind li hember kanvasê
+        [line] rengê xêzê li hember kanvasê
+        [marker] rengê nîşankerê li hember kanvasê
+       *[text-on-canvas] rengê nivîsê li hember kanvasê
+    } kontrasteke têrê nake{ $mode ->
+        [dark] { " (moda tarî)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; bi kêmî { $threshold }:1 divê).
+
+# $suggestion says whether a concrete replacement colour could be computed.
+style-definition-dark-mode-text-background-contrast =
+    Her çend pênaseya şêwazê { $styleNumber } ji bo moda ronî rengên bi kontrasta têr diyar kiribe jî, rengên moda tarî yên ji van nirxan hatine derxistin ji bo rengê nivîsê li hember rengê paşxanê kontrasteke têrê nakin ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; bi kêmî { $threshold }:1 divê). { $suggestion ->
+        [available] Ji bo kontrasteke têr di moda tarî de, an kontrasta moda ronî zêde bike (mînak, { $lightAttribute }="{ $lightColor }" deyne) an jî rengê moda tarî binivîse (mînak, { $darkAttribute }="{ $darkColor }" deyne).
+       *[none] Ji bo kontrasteke têr di moda tarî de, kontrasta moda ronî zêde bike an jî rengên derxistî bi textColorDarkMode û/an backgroundColorDarkMode ve biguherîne.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Her çend pênaseya şêwazê { $styleNumber } ji bo moda ronî rengê nivîsê bi kontrasta têr diyar kiribe jî, rengê nivîsê yê moda tarî yê ji vê nirxê hatiye derxistin li hember kanvasê kontrasteke têrê nake ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; bi kêmî { $threshold }:1 divê). { $suggestion ->
+        [available] Ji bo kontrasteke têr di moda tarî de, an kontrasta moda ronî zêde bike (mînak, textColor="{ $lightColor }" deyne) an jî rengê moda tarî binivîse (mînak, textColorDarkMode="{ $darkColor }" deyne).
+       *[none] Ji bo kontrasteke têr di moda tarî de, kontrasta moda ronî zêde bike an jî rengê derxistî bi textColorDarkMode ve biguherîne.
+    }
+
+section-multiple-style-palettes = Beşek tenê dikare yek <stylePalette> hilbijêre; ya dawî tê bikaranîn.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = varyantên yekta yên { $component } nayên diyarkirin ji ber ku numToSelect ne hejmareke tam a ne-neyînî ye.
+
+variant-num-to-select-not-constant-number = varyantên yekta yên { $component } nayên diyarkirin ji ber ku numToSelect ne hejmareke sabit e.
+
+variant-with-replacement-not-constant-boolean = varyantên yekta yên { $component } nayên diyarkirin ji ber ku withReplacement ne boolean-eke sabit e.
+
+variant-select-weight-disables-unique = Gava vebijarkek bi selectWeight an selectForVariants hebe, varyantên yekta yên select tên girtin
+
+variant-coprime-undetermined = varyantên yekta yên { $component } nayên diyarkirin ji ber ku nayê diyarkirin ka coprime her tim şaş e.
+
+# $attribute is an attribute name and stays as written.
+variant-attribute-not-constant = varyantên yekta yên { $component } nayên diyarkirin ji ber ku { $attribute } ne sabit e.
+
+variant-attribute-not-number = varyantên yekta yên { $component } nayên diyarkirin ji ber ku { $attribute } ne hejmar e.
+
+variant-attribute-wrong-type-for-sequence =
+    varyantên yekta yên { $component }-a bi cureyê { $type } nayên diyarkirin ji ber ku { $attribute } ne { $expected ->
+        [letters-combination] hevgirtineke tîpan
+        [math-expression] îfadeyeke matematîkî ya derbasdar
+        [integer] hejmareke tam
+       *[number] hejmarek
+    } e.
+
+variant-length-not-integer = varyantên yekta yên { $component } nayên diyarkirin ji ber ku length ne hejmareke tam e.
+
+variant-sort-not-implemented = varyantên yekta yên { $component }-eke bi sort nehatine pêkanîn
+
+variant-exclude-combinations-not-implemented = varyantên yekta yên { $component }-eke bi excludeCombinations nehatine pêkanîn
+
+variant-math-exclude-not-implemented = varyantên yekta yên { $component }-eke bi cureyê math a bi exclude nehatine pêkanîn
+
+variant-non-constant-exclude-not-implemented = varyantên yekta yên { $component }-eke bi exclude ya nesabit nehatine pêkanîn
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: di nîşanderê prefigure yê grafîkê de nayê piştgirîkirin; dûndik tê derbaskirin.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometriyeke ne-fînît an netemam; dûndik tê derbaskirin.
+
+prefigure-curve-label-omitted = { $subject }: li ser hêmanên xêza xwar ên veguhastî etîket nayên piştgirîkirin; etîket tê hiştin.
+
+prefigure-curve-unsupported-definition-type = { $subject }: cureyê pênaseya fonksiyona xêza xwar '{ $definitionType }' nayê piştgirîkirin; dûndik tê derbaskirin.
+
+prefigure-region-flip-functions-unsupported = { $subject }: li ser regionBetweenCurves taybetmendiya flipFunctions nayê piştgirîkirin; dûndik tê derbaskirin.
+
+prefigure-region-non-formula-child = { $subject }: li ser regionBetweenCurves tenê fonksiyonên zarok ên bi cureyê formulayê tên piştgirîkirin; dûndik tê derbaskirin.
+
+# $labelKind says which family of object carried the label.
+prefigure-label-position-unsupported =
+    { $subject }: ji bo { $labelKind ->
+        [line-family] etîketa malbata xêzê
+       *[point] etîketa xalê
+    } labelPosition '{ $labelPosition }' nayê piştgirîkirin; hîzakirina standard a PreFigure tê bikaranîn.
+
+prefigure-fill-style-unsupported = { $subject }: şêwaza dagirtinê '{ $fillStyle }' ji aliyê PreFigure ve nayê piştgirîkirin; dagirtineke tijî tê bikaranîn.
+
+prefigure-line-style-unknown = { $subject }: şêwaza xêzê ya nenas '{ $lineStyle }' ji derketina PreFigure hate hiştin.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: şêwaza nîşankerê '{ $markerStyle }' bo şêwaza PreFigure ya 'diamond' hate veguhastin.
+
+prefigure-marker-style-unsupported = { $subject }: şêwaza nîşankerê '{ $markerStyle }' ji aliyê PreFigure ve nayê piştgirîkirin; şêwaza standard tê bikaranîn.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` nederbasdar e; armanc nayê girêdan. Şirove tê hiştin.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` bû çend armanc; armanca yekem tê bikaranîn.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` nederbasdar e; armanc derveyî grafîka hilgir e. Şirove tê hiştin.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` nederbasdar e; di veguhastina prefigure de armanc ne tişteke grafîkî ya piştgirîkirî ye. Şirove tê hiştin.
+
+annotation-text-missing = `<annotation>`: `text` kêm e an vala ye; nivîseke vala tê dayîn.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Girêdayîbûneke çemberî hate dîtin.
+       *[other] Girêdayîbûneke çemberî ya bi pêkhateya `<{ $componentType }>` ve hate dîtin.
+    }
+
+# $reference is the reference as the author wrote it, already carrying its `$`.
+reference-no-referent = Ji bo referansê tu armanc nehate dîtin: `{ $reference }`
+
+reference-multiple-referents = Ji bo referansê çend armanc hatin dîtin: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ji bo taybetmendiya { $attribute } ya `<{ $componentType }>` format nederbasdar e.
+
+# $children is the list of child types that did not match, already joined.
+children-invalid = Ji bo `<{ $componentType }>` zarok nederbasdar in: zarokên nederbasdar hatin dîtin: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ji bo taybetmendiya `{ $attribute }` nirxa `{ $value }` nederbasdar e, nirxa `{ $default }` tê bikaranîn
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Guhertoya DoenetML { $version } nehate dîtin.
+       *[other] Guhertoya DoenetML { $version } nehate dîtin. Vedigere guhertoya { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML nederbasdar: { $content }
+
+parse-tag-missing-close-tag = DoenetML nederbasdar: Etîketa `{ $tag }` etîketeke girtinê tune. Etîketeke xwe-girtî an etîketeke `</{ $tagName }>` dihate hêvîkirin.
+
+parse-tag-error = DoenetML nederbasdar: Di etîketa `<{ $tagName }>` de çewtî
+
+parse-attribute-missing-value = DoenetML nederbasdar: Wisa xuya dike ku nirxa taybetmendiya nederbasdar `{ $attribute }` kêm e.
+
+parse-attribute-invalid = DoenetML nederbasdar: Taybetmendiya nederbasdar `{ $attribute }`
+
+parse-attribute-value-invalid = DoenetML nederbasdar: Nirxa taybetmendiyê ya nederbasdar `{ $value }`
+
+# $quote is the quote character that would balance the pair: `"` or `'`.
+parse-attribute-value-quote-mismatch = DoenetML nederbasdar: Nirxa taybetmendiyê ya nederbasdar `{ $value }`. Nîşanên gotinê li hev nakin. Wisa xuya dike ku `{ $quote }` kêm e
+
+parse-open-tag-name-missing = DoenetML nederbasdar: Etîketeke bênav hate dîtin, mînak `<`
+
+parse-tag-not-closed = DoenetML nederbasdar: Etîketa `{ $tag }` nehate girtin (wisa xuya dike ku `>` kêm e).
+
+parse-self-closing-tag-name-missing = DoenetML nederbasdar: Etîketeke bênav hate dîtin `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML nederbasdar: Etîketa `{ $tag }` nehate girtin (wisa xuya dike ku `/>` kêm e).
+
+parse-tag-invalid-attributes = DoenetML nederbasdar: Etîketa `{ $tag }` ne derbasdar e. Dibe ku taybetmendiyên wê çewt bin.
+
+parse-close-tag-name-missing = DoenetML nederbasdar: Etîketeke girtinê ya bênav hate dîtin, mînak `</`
+
+# $attribute is the attribute name and $value the unquoted token that followed it.
+parse-attribute-value-unquoted = Divê nirxên taybetmendiyan di nav nîşanên gotinê de bin: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML nederbasdar: Etîketa girtinê `{ $tag }` hate dîtin, lê etîketeke vekirinê ya wê tune
+
+parse-close-tag-mismatched = DoenetML nederbasdar: Etîketa girtinê li hev nake. `</{ $expected }>` dihate hêvîkirin. `{ $found }` hate dîtin
+
+# $node is the node's own name and stays as it is.
+parser-node-unconvertible = Node ya { $node } nehate veguhastin bo node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Navê taybetmendiyê nederbasdar e name='{ $name }'. { $reason ->
+        [characters] Nav tenê dikarin tîp, hejmar, binxêzik an xêzikan bihewînin.
+       *[start] Divê nav bi tîpekê dest pê bikin.
+    }
+
+component-name-invalid-start = Navê pêkhateyê nederbasdar e "{ $name }". Divê nav bi tîpekê dest pê bikin.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Divê bersiva bi cureyê videoWatched taybetmendiyeke video hebe
+
+answer-video-watched-video-not-reference = Divê taybetmendiya video ya bersiva bi cureyê videoWatched referansek be
+
+answer-name-not-single-text = Divê taybetmendiya nav a bersivê zarokeke text a yekane hebe
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ji ber gelek astên dubarebûnê DoenetML ya derveyî nehate anîn. Gelo referanseke çemberî heye?
+
+external-doenetml-unavailable = Ji { $attribute }="{ $uri }" DoenetML nehate anîn
+
+external-doenetml-type-mismatch = DoenetML ya ji { $attribute }="{ $uri }" hatiye anîn nederbasdar e: bi cureyê pêkhateyê "{ $componentType }" re li hev nake
+
+## Deprecated syntax
+
+# The `[deprecation]` opening is a literal marker shared by all four messages,
+# not a word: leave it as it is.
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Taybetmendiya `{ $from }` kevnare ye; li şûna wê `{ $to }` bi kar bîne.
+       *[other] [deprecation] Taybetmendiya `{ $from }` ya li ser `<{ $component }>` kevnare ye; li şûna wê `{ $to }` bi kar bîne.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Taybetmendiya `{ $from }` kevnare ye û tê paşguhkirin ji ber ku `{ $to }` jî hatiye diyarkirin.
+       *[other] [deprecation] Taybetmendiya `{ $from }` ya li ser `<{ $component }>` kevnare ye û tê paşguhkirin ji ber ku `{ $to }` jî hatiye diyarkirin.
+    }
+
+deprecated-attribute-ignored = [deprecation] Taybetmendiya `{ $attribute }` ya li ser `<{ $component }>` kevnare ye û tê paşguhkirin.
+
+deprecated-attribute-to-child = [deprecation] Taybetmendiya `{ $attribute }` ya li ser `<{ $component }>` kevnare ye; li şûna wê zarokeke `<{ $child }>` bi kar bîne.
+
+deprecated-attribute-value-renamed = [deprecation] Nirxa `{ $value }` ya taybetmendiya `{ $attribute }` ya li ser `<{ $component }>` kevnare ye; li şûna wê `{ $to }` bi kar bîne.
+
+
+## Language coverage
+
+# $locale is the document's language tag, as declared.
+pluralize-english-only = `<pluralize>` tenê dikare Îngilîzî pirjimar bike, loma di belgeyeke bi { $locale } hatiye nivîsîn de nivîsa wê wekî xwe dimîne. Forma pirjimar rasterast binivîse, an bi taybetmendiya `pluralForm` diyar bike.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Hêmana `<{ $tag }>` ne hêmaneke Doenetê ya naskirî ye.
+
+schema-element-not-allowed-at-root = Hêmana `<{ $tag }>` li rehê belgeyê nayê destûrkirin.
+
+schema-element-not-allowed-inside = Hêmana `<{ $tag }>` di nav `<{ $parent }>` de nayê destûrkirin.
+
+schema-attribute-unrecognized = Hêmana `<{ $tag }>` taybetmendiyeke bi navê `{ $attribute }` tune.
+
+# $allowed is the attribute's permitted values, each already in double quotes.
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Divê taybetmendiya `{ $attribute }` ya hêmana `<{ $tag }>` lîsteyek be ku her hêmana wê yek ji vana be: { $allowed }
+       *[other] Divê taybetmendiya `{ $attribute }` ya hêmana `<{ $tag }>` yek ji vana be: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+##
+## Translators: component and attribute names — `selectFromSequence`,
+## `selectPrimeNumbers`, `from`, `to`, `step` — are DoenetML identifiers, not
+## words, and are left in English exactly as written.
+
+select-variant-name-option-count-mismatch = Ji bo select navê varyantê nederbasdar e.  Navê varyantê { $variantName } di { $numOptions } vebijarkan de derdikeve lê hejmara hilbijartinê { $numToSelect } e.
+
+select-variant-name-without-options = Ji bo select hin varyant hatine diyarkirin lê ji bo navê varyantê yê pêkan tu vebijark nehatine diyarkirin: { $variantName }.
+
+select-variant-name-not-possible = Navê varyantê { $variantName } yê ji bo select hatiye diyarkirin ne navekî varyantê yê pêkan e.
+
+select-too-few-options = Ji tenê { $numOptions } pêkhateyan { $numToSelect } pêkhate nayên hilbijartin.
+
+select-from-sequence-too-few-values = Ji rêzeyeke bi dirêjahiya { $length } { $numToSelect } nirx nayên hilbijartin.
+
+select-from-sequence-indices-count-mismatch = Divê hejmara îndeksên ji bo select hatine diyarkirin bi hejmara hilbijartinê re li hev bike
+
+select-from-sequence-indices-not-integers = Divê hemû îndeksên ji bo select hatine diyarkirin hejmarên tam bin
+
+select-from-sequence-index-excluded = Îndeksa diyarkirî ya selectfromsequence hatibû derxistin
+
+select-from-sequence-indices-excluded-combination = Îndeksên diyarkirî yên selectfromsequence hevgirtineke derxistî bûn
+
+select-from-sequence-coprime-not-positive-integers = Hevgirtinên coprime nayên hilbijartin ji ber ku hejmarên tam ên erênî nayên hilbijartin.
+
+# Translators: from, to and step are attribute names.
+select-from-sequence-coprime-common-factor = Hejmarên coprime nayên hilbijartin. Hemû nirxên pêkan faktoreke hevbeş parve dikin. (Divê nirxên diyarkirî yên "from" an "to" bi "step" re coprime bin.)
+
+select-from-sequence-coprime-single-number = Ji hejmareke yekane ya ne 1 hevgirtinên coprime nayên hilbijartin.
+
+select-from-sequence-excluded-too-many-combinations = Di selectFromSequence de ji sedî 70î zêdetir hevgirtin hatin derxistin
+
+select-from-sequence-coprime-none-found = Hejmarên coprime nehatin hilbijartin. Hemû nirxên pêkan faktoreke hevbeş parve dikin.
+
+select-from-sequence-too-few-unique-values = Ji rêzeyeke bi dirêjahiya { $numPossibleValues } { $numToSelect } nirxên yekta nayên hilbijartin
+
+select-prime-numbers-too-few-values = Ji lîsteyeke hejmarên pêşîn a bi dirêjahiya { $numValues } { $numToSelect } nirx nayên hilbijartin
+
+select-prime-numbers-values-count-mismatch = Divê hejmara nirxên ji bo select hatine diyarkirin bi hejmara hilbijartinê re li hev bike
+
+select-prime-numbers-values-not-prime = Divê hemû nirxên ji bo hilbijartina hejmara pêşîn hatine diyarkirin di lîsteya hejmarên pêşîn de bin
+
+select-prime-numbers-values-excluded-combination = Nirxên diyarkirî yên selectPrimeNumbers hevgirtineke derxistî bûn
+
+select-prime-numbers-excluded-too-many-combinations = Di selectPrimeNumbers de ji sedî 70î zêdetir hevgirtin hatin derxistin
+
+select-random-combination-fluke = Bi rasthatineke pir kêm îhtîmal, hevgirtineke nirxên tesadufî nehate hilbijartin
+
+select-random-value-fluke = Bi rasthatineke pir kêm îhtîmal, nirxeke tesadufî nehate hilbijartin

--- a/packages/i18n/locales/ku/editor.ftl
+++ b/packages/i18n/locales/ku/editor.ftl
@@ -1,0 +1,228 @@
+# Kurdish editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Northern Kurdish (Kurmanji) in the Hawar Latin alphabet, the orthography of
+# Kurmanji publishing in Turkey, Syria and the diaspora and what CLDR fills a
+# bare `ku` in as (`ku-Latn-TR`). Left to right. A `ku-Arab` reader reaches
+# this catalog and gets Latin; Central Kurdish (Sorani) is `locales/ckb`, a
+# separate right-to-left catalog beside it.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Kurmanji counts in two categories, `one` and `other`, so every selection
+# below keeps both branches; a noun after a numeral stays singular, so the two
+# differ only in the verb. Nothing here agrees with a noun class or gender —
+# the ezafe fork lives in `content.ftl`, where the noun is known.
+#
+# The LSP ships bundled with its DoenetML version, so this catalog is
+# version-correct rather than always-latest.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Vegerîne
+       *[update] Nû bike
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word }: Nîşander
+       *[other] { $word }: Nîşander { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varyant
+editor-variant-filter = Parzûn…
+editor-variant-next = Varyanta pêş hilbijêre
+editor-variant-previous = Varyanta berê hilbijêre
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Binpêkirineke gihîştinê ya WCAG AA hate dîtin. Ji bo { $action ->
+            [close] girtina
+           *[open] vekirina
+        } rapora gihîştinê bitikîne.
+        [advisories] Ji bo { $action ->
+            [close] girtina
+           *[open] vekirina
+        } rapora gihîştinê bitikîne. Tu binpêkirineke WCAG AA nehate dîtin, lê pêşniyarên gihîştinê yên din hene.
+       *[clean] Ji bo { $action ->
+            [close] girtina
+           *[open] vekirina
+        } rapora gihîştinê bitikîne. Tu pirsgirêkeke gihîştinê nehate dîtin.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Binpêkirineke gihîştinê ya WCAG AA hate dîtin. { $count ->
+            [one] { $count } binpêkirina WCAG AA
+           *[other] { $count } binpêkirinên WCAG AA
+        } hate dîtin. Ji bo { $action ->
+            [close] girtina
+           *[open] vekirina
+        } rapora gihîştinê bitikîne.
+        [advisories] Tu binpêkirineke WCAG AA nehate dîtin. { $count ->
+            [one] { $count } pêşniyara gihîştinê ya zêde
+           *[other] { $count } pêşniyarên gihîştinê yên zêde
+        } hate dîtin. Ji bo { $action ->
+            [close] girtina
+           *[open] vekirina
+        } rapora gihîştinê bitikîne.
+       *[clean] Tu binpêkirineke WCAG AA nehate dîtin. Ji bo { $action ->
+            [close] girtina
+           *[open] vekirina
+        } rapora gihîştinê bitikîne.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Guhertoya DoenetML { $version }
+
+editor-tab-help = Alîkariya li gorî cihê kursorê
+editor-tab-help-short = Kontekst
+editor-tab-errors = Çewtî
+editor-tab-warnings = Hişyarî
+editor-tab-info = Agahî
+editor-tab-accessibility = Gihîştin
+editor-tab-responses = Bersivên şandin
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Vebijarkên edîtorê
+editor-format-as-doenetml = Wekî DoenetML format bike
+editor-format-as-xml = Wekî XML format bike
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Rêz #{ $line }
+
+editor-no-errors = Çewtî Tune
+editor-no-warnings = Hişyarî Tune
+editor-no-info = Agahiyên Teşhîsê Tune
+
+editor-show-info-annotations = Agahiyên teşhîsê di edîtorê de nîşan bide
+editor-show-accessibility-annotations = Teşhîsên gihîştinê di edîtorê de nîşan bide
+
+editor-accessibility-learn-more = Fêr bibe ka Doenet çawa nêzîkî gihîştinê dibe
+
+editor-accessibility-violations-heading = Binpêkirinên gihîştinê ({ $standard })
+
+editor-accessibility-other-heading = Pirsgirêkên din ên gihîştinê
+editor-none-found = Tiştek nehate dîtin
+
+
+## Submitted responses
+
+editor-no-responses = Hê tu bersiv nehatiye şandin
+editor-response-answer-id = Nasnavê Bersivê
+editor-response-response = Bersiv
+editor-response-credit = Xal
+editor-response-submitted = Hate şandin
+
+
+## The context-help panel
+
+help-placeholder = Ji bo belgekirinê kursorê deyne ser navekî etîketê, taybetmendiyekê an { $ref }.
+
+help-unsupported-ref-chain = Alîkarî ji bo referansên pirparçe yên wekî { $example } hê nayê piştgirîkirin.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ji bo referansê tu armanc nehate dîtin: { $ref }.
+        [multiple] Ji bo referansê çend armanc hatin dîtin: { $ref }.
+       *[indeterminate] Armanca { $ref } nehate diyarkirin.
+    }
+
+help-learn-about-references = Derbarê referansan de fêr bibe →
+help-reference-page = Rûpela referansê →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Di nav { $element } de
+       *[top] Li asta jorîn
+    }{ $allowed ->
+        [none] { " — tiştek li vir nayê." }
+        [text] { " — li vir nivîsê binivîse." }
+        [text-and-components] { " — li vir nivîsê binivîse, an van biceribîne:" }
+       *[components] { " — tiştên ku bên ceribandin:" }
+    }
+
+help-suggestions-footer = Ji bo dîtina hemû { $total } pêkhateyan { $shortcut } bitikîne.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } referanseke ji bo { $target } e.
+       *[other] { $ref } referanseke ji bo { $target } e (rêz { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ji aliyê { $owner } ve wekî { $role } hate danîn.
+       *[other] Ji aliyê { $owner } ve li rêza { $line } wekî { $role } hate danîn.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } referanseke ji bo taybetmendiya { $property } ya { $element } e.
+       *[other] { $ref } referanseke ji bo taybetmendiya { $property } ya { $element } e (rêz { $line }).
+    }
+
+help-kind-attribute = taybetmendî
+help-kind-snippet = perçenivîs
+help-kind-array-entry = hêmana rêzeyê
+
+help-default = Standard:
+help-active-default = Standarda çalak:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nirxên destûrdar (ji bo her hêmanekê yek):
+       *[other] Nirxên destûrdar:
+    }
+
+help-suggested-values = Nirxên pêşniyarkirî:
+
+help-inserts = Lê zêde dike:
+
+# Kurmanji does not mark the plural in the direct case, so the two branches
+# read alike. They are kept because the plural categories are what
+# `Intl.PluralRules` reports, not because the words differ.
+help-coordinates =
+    { $count ->
+        [one] Koordînat:
+       *[other] Koordînat:
+    }
+
+help-type = Cure:
+
+help-resolved-style = Şêwaza çareserkirî (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Navên fonksiyonên çareserkirî:
+help-reset-list = Lîsteya jinûvedanînê ya li ser vê têketinê:
+help-added-on-input = Li vê têketinê hate zêdekirin:
+help-removed-on-input = Ji vê têketinê hate rakirin:
+
+help-reset-overrides = { $reset } li ser { $additional } û { $removed } digire.

--- a/packages/i18n/locales/kum/chrome.ftl
+++ b/packages/i18n/locales/kum/chrome.ftl
@@ -1,0 +1,130 @@
+# Kumyk viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Kumyk (къумукъ тил) is a Kipchak Turkic language of the Dagestan lowlands.
+# Written in Cyrillic, the orthography the republic's schools, its newspapers
+# and its book publishing have used since 1938 and the one CLDR fills a bare
+# `kum` in as (`kum` maximizes to `kum-Cyrl-RU`). The digraphs гъ, гь, къ, нг
+# and the vowels оь, уь are single letters of that alphabet: «къара» spelled
+# «кара» is Russian, not Kumyk, and «гёк» spelled «гок» is nothing at all.
+#
+# Kumyk counts in two plural categories, `one` and `other`, the same two
+# English has, so every `{ $count -> … }` below keeps the shape it had. A noun
+# after a numeral stays singular — «2 сынав», never «2 сынавлар» — so the two
+# branches usually differ in nothing but the number they print.
+#
+# Kumyk has no grammatical gender and no noun class, so nothing in this file
+# agrees with anything. That is worth stating in a catalog sitting in a batch
+# of Caucasian class systems: Kumyk's neighbours inside the same republic —
+# Avar, Dargwa, Lak and Tabasaran — all mark a noun class on the words that
+# agree with a noun, and Kumyk, in the middle of them, marks none.
+#
+# «онгайлыкъ» for *accessibility* is the weakest word in this file. It means
+# convenience or ease of use, and no settled Kumyk term for accessibility in
+# the WCAG sense exists to reach for; a speaker should feel free to replace
+# every occurrence of it here and in `editor.ftl` at once.
+
+
+## Answer submission
+
+answer-checking = Тергеле…
+answer-submitting = Йибериле…
+answer-checking-status = Жавап тергеле
+answer-submitting-status = Жавап йибериле
+answer-correct = Тюз
+answer-incorrect = Тюз тюгюл
+answer-response-saved = Жавап сакъланды
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% тюз
+answer-percent-short = { $percent } %
+max-credit-available = Алма болагъан инг кёп балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] сынав къалмагъан
+        [one] { $count } сынав къалгъан
+       *[other] { $count } сынав къалгъан
+    }
+validation-correct = (Тюз)
+validation-incorrect = (Тюз тюгюл)
+validation-partially-correct = (Кесеги тюз)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } учун { $count } жавапны гёрсетив
+       *[other] { $answerId } учун { $count } жавапны гёрсетив
+    }
+
+## Disclosure panels
+
+feedback-heading = Кери байлавлукъ
+collapsible-click-to-open = (ачмакъ учун басыгъыз)
+collapsible-click-to-close = (япмакъ учун басыгъыз)
+collapsible-initializing = Гьазирлене…
+footnote-show = Тюп эсгеривню гёрсетив
+footnote-hide = Тюп эсгеривню яшырыв
+description-more-information = къошум малумат
+
+## Controls
+
+slider-previous = Алдагъы
+slider-next = Сонрагъы
+keyboard-open = Клавиатураны ачыв
+keyboard-close = Клавиатураны ябыв
+choice-input-remove-choice = { $choice } танглавну гетерив
+matrix-remove-row = Сатырны гетерив
+matrix-add-row = Сатыр къошув
+matrix-remove-column = Багъананы гетерив
+matrix-add-column = Багъана къошув
+subset-add-remove-points = Нокъат къошув/гетерив
+subset-toggle-points-intervals = Нокъатланы ва аралыкъланы алышдырыв
+subset-move-points = Нокъатланы гёчюрюв
+subset-clear = Тазалав
+orbital-add-row = Сатыр къошув
+orbital-remove-row = Сатырны гетерив
+orbital-add-box = Къуту къошув
+orbital-remove-box = Къутуну гетерив
+orbital-add-up-arrow = Юкъаргъа окъ къошув
+orbital-add-down-arrow = Тёбенге окъ къошув
+orbital-remove-arrow = Окъну гетерив
+orbital-row-label = { $row } сатырны белгиси
+pretzel-answer = Жавап
+summary-statistics-caption = { $column } багъананы жыйынтыкъ статистикасы
+
+## Math input
+
+math-input-preview-region = математика ифаданы алдын гёрюв
+math-input-preview = Алдын гёрюв
+math-input-invalid-expression = Тюз болмагъан ифада:
+
+## Document status
+
+viewer-initializing = Гьазирлене…
+
+## Errors
+
+error-heading = Янгылыш
+error-found-at =
+    { $span ->
+        [line] Табылгъан сатыр: { $startLine }.
+       *[lines] Табылгъан сатырлар: { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Бу документде янгылышлар бар!
+diagnostic-heading-error = Янгылыш
+diagnostic-heading-warning = Эсгертив
+diagnostic-heading-information = Малумат
+diagnostic-heading-hint = Ишара
+accessibility-heading-level-1 = WCAG AA онгайлыкъ бузув
+accessibility-heading-level-2 = Онгайлыкъ гьакъда эсгертив
+something-went-wrong = Бир зат тюз болмады.
+renderer-load-failed = суратлавчуну юклеп болмады. Бетни янгыртыгъыз.
+core-start-failed = Бу документни башлап болмады. Бетни янгыртыгъыз.
+core-start-failed-busy = Бу документни башлап болмады. Бир нече документ бир вакътиде башлангъан эди, оьзю яй ишлейген жагьазда бу кёп заман алма бола. Оьзге документлер битгенде бетни янгыртыв кёмек этме бола.
+core-start-failed-retry = Бу документни башлап болмады.
+core-start-failed-busy-retry = Бу документни башлап болмады. Бир нече документ бир вакътиде башлангъан эди, оьзю яй ишлейген жагьазда бу кёп заман алма бола.
+core-start-retry = Дагъы бир керен сынагъыз
+saved-state-unavailable = Сакъланып тургъан ишигизни юклеп болмады.

--- a/packages/i18n/locales/kum/content.ftl
+++ b/packages/i18n/locales/kum/content.ftl
@@ -1,0 +1,265 @@
+# Kumyk content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Kumyk (къумукъ тил), a Kipchak Turkic language of the Dagestan lowlands,
+# written in the Cyrillic orthography its schools, its press and its publishing
+# have used since 1938 — the script CLDR assumes for a bare `kum`, which
+# maximizes to `kum-Cyrl-RU`. гъ, гь, къ, нг, оь and уь are single letters of
+# that alphabet and are not decorations on the Russian ones.
+#
+# Kumyk has no grammatical gender and no noun class. `noun-gender` therefore
+# returns one token for every noun, nothing below forks on `$gender`, and
+# nothing forks on `$role` either, because an attributive adjective does not
+# inflect. That is worth saying plainly rather than leaving to be inferred:
+# this catalog sits in a batch of Northeast Caucasian class systems, and the
+# languages Kumyk is surrounded by inside its own republic — Avar, Dargwa, Lak,
+# Tabasaran — every one of them agrees a word with a noun's class. Kumyk, a
+# Turkic language in the middle of them, does not, and centuries of contact
+# have not given it one.
+#
+# Attributive modifiers precede the noun, so the composition messages below
+# keep the order English gives them: «боялгъан гёк тёгерек» is *filled blue
+# circle*, in that order, and never the reverse.
+#
+# The border and background clauses are marked by a suffix on a noun this
+# catalog writes out — «четли» on the edge, the locative «фонда» on the
+# background — so nothing is welded onto a placeable.
+#
+# Two colour notes a speaker should check first. Kumyk «гёк» is the old Turkic
+# sky-word: it is blue here, but it still reaches over green in fixed phrases
+# («гёк от», green grass), and the split this file writes — «гёк» blue against
+# «яшыл» green — is the modern one. And there is no single settled word for
+# either *cyan* or *pink*, so both are written as transparent compounds,
+# «ачыкъ гёк» and «ачыкъ къызыл» (light blue, light red). Those are choices,
+# not translations.
+
+
+## Style vocabulary
+
+color =
+    .black = къара
+    .white = акъ
+    .gray = боз
+    .red = къызыл
+    .orange = къызгъылт сари
+    .yellow = сари
+    .green = яшыл
+    .cyan = ачыкъ гёк
+    .blue = гёк
+    .purple = мор
+    .pink = ачыкъ къызыл
+    .brown = къонгур
+line-width =
+    .thick = къалын
+    .thin = инче
+line-style =
+    .dashed = уьзюклю
+    .dotted = нокъатлы
+# Noun phrases: they stand in front of «нагъышлы» and modify nothing.
+fill-style =
+    .horizontal = горизонталь сызыкълар
+    .vertical = вертикаль сызыкълар
+    .diagonal = диагональ сызыкълар
+    .backdiagonal = терс диагональ сызыкълар
+    .dots = нокъатлар
+    .diamonds = ромблар
+noun =
+    .line = тюз сызыкъ
+    .line-segment = кесек
+    .ray = нур
+    .vector = вектор
+    .curve = эгри сызыкъ
+    .function = функция
+    .slope-field = къыялыкъ майданы
+    .vector-field = вектор майданы
+    .parabola = парабола
+    .polyline = сынгъан сызыкъ
+    .polygon = кёпмююш
+    .triangle = уьчмююш
+    .rectangle = тюзмююшлюк
+    .circle = тёгерек
+    .region = майдан
+    .point = нокъат
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# Kumyk counts the sides in front of the noun — «5 янлы тюз кёпмююш» — so the
+# whole of the phrase is one head and there is no tail for the adjectives to
+# sit inside.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } янлы тюз кёпмююш
+    }
+# Kumyk has no grammatical gender and no noun class, so every noun answers the
+# same and the answer goes unused — as in English, Turkish and `locales/ba`,
+# and unlike every Northeast Caucasian language spoken beside it.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = боялгъан
+# «нагъышлы» — "patterned" — is a word of its own standing after the pattern
+# name, not a suffix on it, so the placeable keeps whatever shape it arrives in.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } нагъышлы { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } нагъышлы { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } нагъышлы { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «четли» — "having an edge" — carries the whole of "with a border" in its own
+# suffix, so Kumyk wants neither a preposition nor an article and the four
+# branches differ only by the conjunction «ва», which English needs and Kumyk
+# needs only where a clause has already been said.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } четли
+        [and] ва { $border } четли
+        [and-article] ва { $border } четли
+       *[with] { $border } четли
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = боялмагъан
+# «фонда» is the locative of «фон» and says "on the background" by itself, so
+# nothing stands between the two colours.
+style-text =
+    { $parts ->
+        [background] { $background } фонда { $color }
+       *[plain] { $color }
+    }
+style-background-none = ёкъ
+
+## Boolean words
+
+boolean-true = тюз
+boolean-false = ялгъан
+
+## Answer buttons
+
+answer-submit-label = Ишни тергев
+answer-submit-label-no-correctness = Жавапны йиберив
+
+## Sectional blocks
+
+section-name =
+    .activity = Иш-гьаракат
+    .aside = Ян сёз
+    .cascade = Каскад
+    .definition = Белгилев
+    .example = Мисал
+    .exercise = Чалышыв
+    .exercises = Чалышывлар
+    .given-answer = Жавап
+    .note = Эсгерив
+    .objectives = Мурадлар
+    .paragraphs = Абзацлар
+    .part = Пай
+    .problem = Масала
+    .problems = Масалалар
+    .proof = Исбат
+    .question = Сорав
+    .section = Бёлюк
+    .solution = Чечив
+    .task = Тапшурув
+    .theorem = Теорема
+# Kumyk publishing in Dagestan punctuates a heading the way the Russian-language
+# press beside it does, so a title follows its number after a full stop rather
+# than a colon.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Ишара
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурат { $enumeration }
+        [numbered-caption] Сурат { $enumeration }{ ". " }
+        [unnumbered-caption] Сурат{ ". " }
+       *[unnumbered] Сурат
+    }
+
+## Paginator controls
+
+paginator-previous = Алдагъы
+paginator-next = Сонрагъы
+paginator-page = Бет
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+
+piecewise-condition-or = яда
+# Kumyk's conditional lands correctly, and it is worth recording *why*, because
+# five catalogs in the previous batch had to record the opposite. A full Kumyk
+# conditional is a frame with two ends — clause-initial «эгер» and clause-final
+# «буса» — and the renderer places this message before the mathematics it
+# introduces, which is exactly where «эгер» belongs. So this key writes «эгер»
+# alone: grammatical on its own, clause-initial, and it needs no second half to
+# be understood. Sakha's «буоллаҕына», Tuvan's «болза», Udmurt's «ке», Komi's
+# «кӧ» and Mari's «гын» are the clause-final ones that cannot be written here;
+# Kumyk is on the other side of that line. «эгер» is a Persian word, and its
+# presence is one small mark of Kumyk's long career as the trade language of
+# the northeastern Caucasus, alongside «масала», «исбат», «жавап» and «малумат»
+# elsewhere in these files.
+piecewise-condition-if = эгер
+piecewise-condition-otherwise = болмаса
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Dagestan is taught in
+## Russian: a Kumyk-speaking pupil meets the elements under their Russian names
+## in a Russian-language textbook, and there is no Kumyk-medium chemistry
+## teaching that would have produced a settled list of 118 to seed from.
+## Respelling the Russian names in Kumyk orthography would produce neither
+## language, and the English fallback at least sits beside the symbols the
+## pupil already reads. `locales/tt` is the counter-example that decides it —
+## Tatar supplies the whole table, because Tatar-medium teaching produced one —
+## and nothing about the two languages predicts the difference.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Тюз болмагъан химия белгиси
+chemistry-invalid-ionic-compound = Тюз болмагъан ион къошулув

--- a/packages/i18n/locales/kum/diagnostics.ftl
+++ b/packages/i18n/locales/kum/diagnostics.ftl
@@ -1,0 +1,688 @@
+# Kumyk diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Kumyk in the Cyrillic orthography of Dagestan's schools and press — the
+# script CLDR assumes for a bare `kum`, which maximizes to `kum-Cyrl-RU`.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The computing and mathematics vocabulary here is mostly Russian, which is
+# what written Kumyk itself reaches for: «компонент», «атрибут», «функция»,
+# «индекс», «формат», «радиус». What is Kumyk is the grammar around them and
+# the everyday words — «табылмады», «гьисапгъа алынмай», «болма герек». Three
+# terms are the seed's own derivations rather than attested ones and should be
+# checked first: «оьзгерювчю» for *variable*, «тизбе» for *sequence*, and
+# «силтев» for *reference*.
+#
+# Kumyk counts in the same two categories English does, `one` and `other`, so
+# every selection below keeps both branches — but a noun after a numeral stays
+# singular, so the two usually differ only in the number they print. Nothing
+# here agrees with a gender or a noun class; Kumyk has neither.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] эки уч нокъат да гёрсетилгенде { $attributes } гьисапгъа алынмай
+       *[other] эки уч нокъат да гёрсетилгенде { $attributes } гьисапгъа алынмай
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] уч нокъат да, орта нокъат да гёрсетилгенде { $attributes } гьисапгъа алынмай
+       *[other] уч нокъат да, орта нокъат да гёрсетилгенде { $attributes } гьисапгъа алынмай
+    }
+
+line-segment-midpoint-offset-without-midpoint = орта нокъат ёкъ буса midpointOffset бир зат да этмей
+
+## `<line>`
+
+line-points-undetermined-dimensions = Оьлчевю белгисиз нокъатлар аркъылы оьтеген тюз сызыкъ.
+
+line-points-too-few-dimensions = Тюз сызыкъ инг аз эки оьлчевлю нокъатлар аркъылы оьтме герек.
+
+line-points-depend-on-variables = Тюз сызыкъ оьзгерювчюлеге байлавлу нокъатлар аркъылы оьте: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ва { $variable2 } оьзгерювчюлердеги тюз сызыкъны тенглевюню форматы тюз тюгюл.
+
+## `<ray>`
+
+ray-overprescribed-through = Нур through, endpoint ва direction аркъылы белгиленген. Гёрсетилген through гьисапгъа алынмай.
+
+ray-dimension-mismatch = нурда numDimensions къыйышмай.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ва displacement аркъылы белгиленген. Гёрсетилген head гьисапгъа алынмай.
+
+vector-dimension-mismatch = векторда numDimensions къыйышмай.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` компонентде nearestPoint гьал оьзгерювчюсю ёкъ, шону учун огъар тартма болмай.
+
+constrain-to-without-nearest-point = `<{ $component }>` компонентде nearestPoint гьал оьзгерювчюсю ёкъ, шону учун огъар байлама болмай.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` компонентде nearestPoint гьал оьзгерювчюсю ёкъ, шону учун ону ичине байлама болмай.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline болмагъан choiceInput учун labelPosition гьисапгъа алынмай
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput учун гёрсетилген индекслер гьисапгъа алынмай: индекслени саны бала танглавланы санына къыйышмай.
+
+pretzel-indices-count-mismatch = масала учун гёрсетилген индекслер гьисапгъа алынмай: индекслени саны бала масалаланы санына къыйышмай.
+
+shuffle-indices-count-mismatch = shuffle учун гёрсетилген индекслер гьисапгъа алынмай: индекслени саны компонентлени санына къыйышмай.
+
+indices-ignored-out-of-range = { $component } учун гёрсетилген индекслер гьисапгъа алынмай: бир нече индекс чекден чыгъа.
+
+pretzel-indices-repeated = pretzel учун гёрсетилген индекслер гьисапгъа алынмай: бир нече индекс такрарлана.
+
+pretzel-circuit-first-index = circuit кюйде pretzel учун гёрсетилген индекслер гьисапгъа алынмай: биринчи индекс 1 болма герек.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` сатыр балалар булан ишлесин учун `type` атрибут гёрсетилме герек.
+
+invalid-type-defaulting-to-math = { $component } компонент учун { $type } тюр тюз тюгюл. Ол math, text, number яда boolean болма герек. math алына.
+
+string-not-valid-component-to-arrange = "{ $value }" деген сатыр { $component } учун ярайгъан компонент тюгюл. Гьисапгъа алынмай.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } тюр тюз тюгюл, тюр number этилди.
+
+invalid-variable-value = Оьзгерювчюню къыйматы тюз тюгюл: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } деген вариант индекс сан болма герек
+
+variant-index-must-be-integer = { $index } деген вариант индекс бютюн сан болма герек
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют оьлчевлер учун этилмеген. Генгликлер салыштырывлу этиле.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют оьлчевлер учун этилмеген. Ятлавлар салыштырывлу этиле.
+
+side-by-side-no-block-child = `<{ $component }>` тюз тюгюл: онда инг аз бир блок бала болма герек.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементде `for` атрибут гьисапгъа алынмай.
+
+label-for-must-resolve-to-one = `<label>` элементни `for` атрибуту тек бир компонентге тюшме герек.
+
+label-for-unresolved = `<label>` элементни `for` атрибутун бир компонентге де байлап болмады.
+
+label-for-answer-with-authored-inputs = `<label>` элементни `for` атрибуту автор оьзю язгъан гиришлери булангъы `<answer>` компонентге силтей; тувра гиришге силтегиз.
+
+label-for-answer-without-input = `<label>` элементни `for` атрибуту белги салма гириши болмагъан `<answer>` компонентге силтей.
+
+label-for-must-reference-input-or-answer = `<label>` элементни `for` атрибуту гиришге яда жавапгъа силтеме герек.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Онгайлыкъ учун `<{ $component }>` я къысгъа англатыву булан болма герек, я безев гьисапда гёрсетилме герек.
+
+accessibility-video-short-description = Онгайлыкъ учун `<video>` къысгъа англатыву булан болма герек.
+
+accessibility-input-short-description-or-label = Онгайлыкъ учун `<{ $component }>` къысгъа англатыву яда белгиси булан болма герек.
+
+accessibility-answer-input-short-description-or-label = Онгайлыкъ учун гириш яратагъан `<answer>` къысгъа англатыву яда белгиси булан болма герек.
+
+accessibility-short-description-contains-math = Къысгъа англатывларда `<{ $component }>` йимик математика компонентлер болмаса яхшы. Математиканы сёзлер булан языгъыз.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] бёлюкню башлыгъыны тексти учун { $colorName } контрасты етишмей (къарангы кюй) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; инг аз { $threshold }:1 герек).
+       *[other] бёлюкню башлыгъыны тексти учун { $colorName } контрасты етишмей ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; инг аз { $threshold }:1 герек).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Нокъатланы сан къыйматлары ёкъ буса, { $count } нокъат аркъылы оьтеген `<circle>` гьали этилмеген.
+
+circle-too-many-through-points = 3 нокъатдан кёп нокъат аркъылы оьтеген тёгеректи гьисаплап болмай.
+
+circle-overprescribed-radius-center-points = Радиусу да, центры да, оьтеген нокъатлары да гёрсетилген тёгеректи гьисаплап болмай.
+
+circle-center-with-multiple-points = Центры гёрсетилген тёгерек 1 нокъатдан кёп нокъат аркъылы оьтме болмай.
+
+circle-radius-too-small = Тёгеректи гьисаплап болмай: эки нокъатны арасы { $distance } буса, гёрсетилген { $radius } радиус бек гиччи.
+
+circle-radius-with-many-points = Радиусу гёрсетилген тёгерек эки нокъатдан кёп нокъат аркъылы оьтме болмай.
+
+circle-invalid-center-or-through-points = Тёгеректи центры яда оьтеген нокъатлары тюз тюгюл.
+
+circle-radius-center-with-multiple-points = Центры гёрсетилген ва 1 нокъатдан кёп нокъат аркъылы оьтеген тёгеректи радиусун гьисаплап болмай.
+
+circle-change-radius-non-numerical = Сан къыйматлары болмагъан нокъатлар аркъылы оьтеген тёгеректи радиусун алышдырып болмай
+
+circle-radius-with-points-non-numerical = Сан къыйматлары ёкъ буса, радиусу гёрсетилген тёгеректи бир нокъатдан кёп нокъат аркъылы оьтгерип болмай.
+
+circle-change-center-non-numerical = Сан къыйматлары болмагъан нокъатлар аркъылы оьтеген тёгеректи центрын алышдырыв гьали этилмеген.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцияны берилиш майданыны оьлчевлери етишмей. Майданда { $intervals } аралыкъ бар, тек функцияны { $inputs ->
+            [one] { $inputs } гириши
+           *[other] { $inputs } гириши
+        } бар.
+       *[other] Функцияны берилиш майданыны оьлчевлери етишмей. Майданда { $intervals } аралыкъ бар, тек функцияны { $inputs ->
+            [one] { $inputs } гириши
+           *[other] { $inputs } гириши
+        } бар.
+    }
+
+function-domain-invalid-format = Функцияны берилиш майданыны форматы тюз тюгюл.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцияны сан болмагъан инг уьст къыйматы гьисапгъа алынмай.
+        [minimum] Функцияны сан болмагъан инг тёбен къыйматы гьисапгъа алынмай.
+        [extremum] Функцияны сан болмагъан экстремумы гьисапгъа алынмай.
+        [point] Функцияны сан болмагъан нокъаты гьисапгъа алынмай.
+        [slope] Функцияны сан болмагъан къыялыгъы гьисапгъа алынмай.
+       *[other] Функцияны сан болмагъан { $type } деген къыйматы гьисапгъа алынмай.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцияны бош инг уьст къыйматы гьисапгъа алынмай.
+        [minimum] Функцияны бош инг тёбен къыйматы гьисапгъа алынмай.
+        [extremum] Функцияны бош экстремумы гьисапгъа алынмай.
+        [point] Функцияны бош нокъаты гьисапгъа алынмай.
+       *[other] Функцияны бош { $type } деген къыйматы гьисапгъа алынмай.
+    }
+
+function-points-too-close = Функцияда ерлери бир-бирине бек ювукъ эки нокъат бар. Функцияны белгилеп болмай.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцияны итерациялары тек гиришлерини саны чыгъышларыны санына тенг буса болалар. Бу функцияны { $inputs } гириши ва { $outputs ->
+            [one] { $outputs } чыгъышы
+           *[other] { $outputs } чыгъышы
+        } бар.
+       *[other] Функцияны итерациялары тек гиришлерини саны чыгъышларыны санына тенг буса болалар. Бу функцияны { $inputs } гириши ва { $outputs ->
+            [one] { $outputs } чыгъышы
+           *[other] { $outputs } чыгъышы
+        } бар.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Тизбени узунлугъу тюз тюгюл. Ол терс болмагъан бютюн сан болма герек.
+
+sequence-invalid-step = Тизбени абаты тюз тюгюл. { $type } тюрлю тизбе учун ол сан болма герек.
+
+sequence-invalid-endpoint-number = Сан тизбени "{ $attribute }" къыйматы тюз тюгюл. Ол сан болма герек.
+
+sequence-invalid-endpoint-letters = Гьарп тизбени "{ $attribute }" къыйматы тюз тюгюл. Ол гьарплардан къурулма герек.
+
+sequence-invalid-endpoint = Тизбени "{ $attribute }" къыйматы тюз тюгюл.
+
+select-from-sequence-coprime-not-numbers = санлар танглана болмагъан учун coprime гьисапгъа алынмай
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations гёрсетилген учун coprime гьисапгъа алынмай
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` учун target тюз тюгюл: мурат табылмады.
+
+target-state-variable-not-found = `<{ $source }>` учун target тюз тюгюл: `<{ $component }>` компонентде "{ $property }" деген гьал оьзгерювчю табылмады.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` компонентни оьзгерювчюлери эркин оьзгерювчюден башгъа болма герек.
+
+ode-system-duplicate-variable-names = Такрарланагъан гьасил оьзгерювчю атлары булан ODE RHS функцияланы белгилеп болмай.
+
+ode-system-rhs-function-error = ODE RHS функцияны белгилеп болмай. mathjs функцияны яратывда янгылыш.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } сызыкъны арасындагъы мююшню белгилеп болмай
+
+angle-invalid-through-point = `<angle>` компонентни through къыйматындагъы нокъат тюз тюгюл
+
+parabola-vertex-too-many-points = Тёбеси гёрсетилген ва 1 нокъатдан кёп нокъат аркъылы оьтеген парабола гьали этилмеген.
+
+parabola-too-many-points = 3 нокъатдан кёп нокъат аркъылы оьтеген парабола гьали этилмеген.
+
+intersection-too-many-items = Экиден кёп затны кесилиш ери гьали этилмеген
+
+## Other math components
+
+ionic-compound-not-two-ions = Эки иондан башгъа зат учун ион къошулув гьали этилмеген.
+
+ionic-compound-needs-cation-and-anion = Ион къошулув тек бир катион ва бир анион учун этилген.
+
+solve-equations-cannot-evaluate = Тенглевню гьисаплап болмагъан учун ону чечип болмай: { $equation }
+
+math-operators-operand-number-required = Математика операндны алгъанда operandNumber гёрсетилме герек.
+
+eigen-decomposition-failed = Матрицаны оьз санларын гьисаплап болмады
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } деген параметр уьлгюде ёкъ, шону учун ол гьар заман бош ерге къыйышажакъ.
+       *[other] `<matchesPattern>`: { $parameters } деген параметрлер уьлгюде ёкъ, шону учун олар гьар заман бош ерге къыйышажакъ.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" англашылмай. Ол none, medium, dense яда бош ер булан айырылгъан эки оьр сан болма герек, мисал учун grid="1 0.5". Тор сызылмай.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` учун { $expected ->
+        [one] бир чыгъышы — гьар нокъатда y' къыялыгъы, мисал учун `y - x`
+       *[other] эки чыгъышы — гьар нокъатда вектор, мисал учун `(y, -x)`
+    } болагъан функция герек, тек огъар берилген функцияны { $found ->
+        [one] { $found } чыгъышы
+       *[other] { $found } чыгъышы
+    } бар. { $alternative ->
+        [none] Бир зат да сызылмай.
+       *[other] Шо функция учун компонент — `<{ $alternative }>`. Бир зат да сызылмай.
+    }
+
+field-function-attribute-ignored-with-child = Функция компонентни ичинде де берилген учун `function` атрибут гьисапгъа алынмай; ичиндеги алына. Функцияны тек бир кюйде беригиз.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибут компонентни ичинде тувра язылгъан ифаданы оьзгерювчюлерин атай. { $reason ->
+        [function-child] Мунда функция `<function>` бала гьисапда берилген, ол оьзюню оьзгерювчюлерин оьзю атай, шону учун `variables` гьисапгъа алынмай.
+       *[no-expression] Мунда шолай ифада берилмеген, шону учун `variables` гьисапгъа алынмай.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure суратлавчуда xLabelPosition="left" ишлемей; right кюйде этиле.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure суратлавчуда yLabelPosition="bottom" ишлемей; top кюйде этиле.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure гёчюрюв учун охланы чеклери тюз тюгюл; келишив бойунча bbox (-10,-10,10,10) алына.
+
+prefigure-invalid-width = `<graph>`: prefigure гёчюрюв учун генглик тюз тюгюл; келишив бойунча 425 генглик алына.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure гёчюрюв учун aspectRatio тюз тюгюл; келишив бойунча 1 къатнав алына.
+
+prefigure-grid-spacing-too-fine = `<graph>`: торну аралыгъы охланы чеклери учун бек гиччи; prefigure суратлавчуда тор сызылмай.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure суратлавчу ишлетилмесе, аннотациялар сызылмай.
+
+multiple-annotations-children = `<graph>` ичинде бир нече `<annotations>` бала табылды; ахырынчысындан къайрысы гьисапгъа алынмай.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Танылмагъан компонент тюрню узатып да, гёчюрюп де болмай: { $type }.
+
+copy-prop-not-found = { $component } тюрлю компонентде { $property } деген prop табылмады
+
+collect-no-source = collect учун чашма табылмады.
+
+collect-invalid-component-type = `<{ $component }>` тюр тюз болмагъан учун шолай компонентлени жыйып болмай.
+
+reference-index-unavailable = `{ $reference }` деген индексге силтеп болмай
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентде { $action } чакъырып болмай
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Малуматны кюрчюсю тюз тюгюл. Сатырланы узунлугъу бир болмай. componentIdx :{ $componentIdx } ичинде табылды
+
+data-frame-duplicate-column-names = Малуматда такрарланагъан багъана атлар бар. componentIdx :{ $componentIdx } ичинде табылды
+
+data-frame-missing-column-name = Малуматда бир багъананы аты ёкъ. componentIdx :{ $componentIdx } ичинде табылды
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Бу жавапны award-ы шо жавапны оьзюню йиберилген жавабына таянып ишлей, бу гёзленмеген натижалагъа гелтирежек.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` булангъы контейнерни ичиндеги `<answer>` компонентде `maxNumAttempts` салыв бир зат да этмей, неге тюгюл сынавланы санын контейнер белгилей. `maxNumAttempts` контейнерде салыгъыз.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` булангъы башгъа контейнерни ичиндеги `sectionWideCheckWork` булангъы контейнерде `maxNumAttempts` салыв бир зат да этмей, неге тюгюл сынавланы санын тышдагъы контейнер белгилей. `maxNumAttempts` тышдагъы контейнерде салыгъыз.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality салынмаса, { $attributes } атрибут бир зат да этмежек.
+       *[other] symbolicEquality салынмаса, { $attributes } атрибутлар бир зат да этмежек.
+    }
+
+answer-invalid-type = Жавапны тюрю тюз тюгюл: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентни аты болмагъан учун ону модулну атрибуту гьисапда ишлетип болмай
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентни модулну атрибуту гьисапда ишлетип болмай, неге тюгюл `<module>` компонент тюрде "{ $name }" деген атрибут алдын да белгиленген.
+
+conditional-content-condition-ignored = case яда else балалары булангъы `<conditionalContent>` компонентде `condition` атрибут гьисапгъа алынмай.
+
+slider-markers-type-mismatch = Маркерлени тюрю слайдерни тюрюне къыйышмай.
+
+pretzel-problem-needs-statement-and-answer = pretzel тюз тюгюл: гьар `<problem>` бир `<statement>` ва бир `<answer>` булан болма герек.
+
+pretzel-circuit-first-problem-distractor = pretzel тюз тюгюл: mode="circuit" кюйде биринчи `<problem>` distractor болма болмай.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут учун { $values } къыймат тюз тюгюл; гьисапгъа алынмай.
+       *[other] `{ $attribute }` атрибут учун { $values } къыйматлар тюз тюгюл; гьисапгъа алынмай.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут учун `{ $value }` къыймат тюз тюгюл. Атрибут `$` булан башланагъан силтевлерден къурулма герек.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ичиндеги тюз болмагъан функция атлар гьисапгъа алынмады: { $names }. Гьар атны гёрюнеген бёлюгю инг аз 2 белгиден (гьарплардан яда дефислерден) къурулма герек; ондан сонг `|<mathspeak alternative>` къошум гелме бола.
+
+## Building components from the source
+
+component-type-invalid = Компонентни тюрю тюз тюгюл: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутну такрарлап болмай.
+
+attribute-invalid-for-component = `<{ $componentType }>` тюрлю компонент учун "{ $attribute }" атрибут тюз тюгюл.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } номерли стиль белгилевде { $context ->
+        [text-on-background] текстни тюсюню фонну тюсюне
+        [high-contrast] уьст контрастлы тюсню канвасгъа
+        [line] сызыкъны тюсюню канвасгъа
+        [marker] маркерни тюсюню канвасгъа
+       *[text-on-canvas] текстни тюсюню канвасгъа
+    } гёре контрасты етишмей{ $mode ->
+        [dark] { " (къарангы кюй)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; инг аз { $threshold }:1 герек).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } номерли стиль белгилевде гёрсетилген тюслер ярыкъ кюй учун таман контраст бере буса да, шо къыйматлардан алынагъан къарангы кюйню тюслеринде текстни тюсюню фонну тюсюне гёре контрасты етишмей ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; инг аз { $threshold }:1 герек). { $suggestion ->
+        [available] Къарангы кюйде таман контраст болсун учун я ярыкъ кюйню контрастын артдырыгъыз (мисал учун { $lightAttribute }="{ $lightColor }" салыгъыз), я къарангы кюйню тюсюн оьзюгюз белгилегиз (мисал учун { $darkAttribute }="{ $darkColor }" салыгъыз).
+       *[none] Къарангы кюйде таман контраст болсун учун ярыкъ кюйню контрастын артдырыгъыз яда алынагъан тюслени textColorDarkMode ва/яда backgroundColorDarkMode булан алышдырыгъыз.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } номерли стиль белгилевде гёрсетилген текстни тюсю ярыкъ кюй учун таман контраст бере буса да, шо къыйматдан алынагъан къарангы кюйдеги текстни тюсюню канвасгъа гёре контрасты етишмей ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; инг аз { $threshold }:1 герек). { $suggestion ->
+        [available] Къарангы кюйде таман контраст болсун учун я ярыкъ кюйню контрастын артдырыгъыз (мисал учун textColor="{ $lightColor }" салыгъыз), я къарангы кюйню тюсюн оьзюгюз белгилегиз (мисал учун textColorDarkMode="{ $darkColor }" салыгъыз).
+       *[none] Къарангы кюйде таман контраст болсун учун ярыкъ кюйню контрастын артдырыгъыз яда алынагъан тюсню textColorDarkMode булан алышдырыгъыз.
+    }
+
+section-multiple-style-palettes = Бир бёлюк тек бир <stylePalette> танглама бола; ахырынчысы алына.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect терс болмагъан бютюн сан тюгюл, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-num-to-select-not-constant-number = numToSelect турукълу сан тюгюл, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-with-replacement-not-constant-boolean = withReplacement турукълу boolean тюгюл, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-select-weight-disables-unique = selectWeight яда selectForVariants гёрсетилген вариант бар буса, select учун башгъа-башгъа вариантлар ишлемей
+
+variant-coprime-undetermined = coprime гьар заман ялгъан экенни белгилеп болмай, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-attribute-not-constant = { $attribute } турукълу тюгюл, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-attribute-not-number = { $attribute } сан тюгюл, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } { $expected ->
+        [letters-combination] гьарплардан къурулгъан къошулув
+        [math-expression] тюз математика ифада
+        [integer] бютюн сан
+       *[number] сан
+    } тюгюл, шону учун { $type } тюрлю { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-length-not-integer = length бютюн сан тюгюл, шону учун { $component } компонентни башгъа-башгъа вариантларын белгилеп болмай.
+
+variant-sort-not-implemented = sort булангъы { $component } компонентни башгъа-башгъа вариантлары гьали этилмеген
+
+variant-exclude-combinations-not-implemented = excludeCombinations булангъы { $component } компонентни башгъа-башгъа вариантлары гьали этилмеген
+
+variant-math-exclude-not-implemented = exclude булангъы math тюрлю { $component } компонентни башгъа-башгъа вариантлары гьали этилмеген
+
+variant-non-constant-exclude-not-implemented = турукълу болмагъан exclude булангъы { $component } компонентни башгъа-башгъа вариантлары гьали этилмеген
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure суратлавчуда ишлемей; бала гьисапгъа алынмай.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометриясы битмеген яда чексиз; бала гьисапгъа алынмай.
+
+prefigure-curve-label-omitted = { $subject }: гёчюрюлген эгри сызыкъларда белгилер ишлемей; белги гьисапгъа алынмай.
+
+prefigure-curve-unsupported-definition-type = { $subject }: эгри сызыкъны '{ $definitionType }' деген белгилев тюрю ишлемей; бала гьисапгъа алынмай.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves компонентде flipFunctions атрибут ишлемей; бала гьисапгъа алынмай.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves компонентде тек формула тюрлю бала функциялар ишлей; бала гьисапгъа алынмай.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] сызыкъ группаны белгиси
+       *[point] нокъатны белгиси
+    } учун '{ $labelPosition }' деген labelPosition ишлемей; PreFigure келишив бойунча тизив ишлетиле.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' деген боявну кюю PreFigure-де ишлемей; толу боявгъа къайтарыла.
+
+prefigure-line-style-unknown = { $subject }: '{ $lineStyle }' деген сызыкъны кюю танылмай, PreFigure чыгъышдан алына.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' деген маркерни кюю PreFigure-ни 'diamond' кююне гёчюрюлген.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' деген маркерни кюю PreFigure-де ишлемей; келишив бойунча кюй ишлетиле.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` тюз тюгюл; мурат табылмай. Аннотация гьисапгъа алынмай.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` бир нече муратгъа тюшдю; биринчиси алына.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` тюз тюгюл; мурат оьзюню графигини тышында. Аннотация гьисапгъа алынмай.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` тюз тюгюл; мурат prefigure гёчюрювде ишлейген график объект тюгюл. Аннотация гьисапгъа алынмай.
+
+annotation-text-missing = `<annotation>`: `text` ёкъ яда бош; бош текст чыгъарыла.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Тёгерек байлавлукъ табылды.
+       *[other] `<{ $componentType }>` компонент булангъы тёгерек байлавлукъ табылды.
+    }
+
+reference-no-referent = Силтев учун объект табылмады: `{ $reference }`
+
+reference-multiple-referents = Силтев учун бир нече объект табылды: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` компонентни { $attribute } атрибутуну форматы тюз тюгюл.
+
+children-invalid = `<{ $componentType }>` компонент учун балалар тюз тюгюл: тюз болмагъан балалар табылды: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут учун `{ $value }` къыймат тюз тюгюл, `{ $default }` къыймат ишлетиле
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML-ни { $version } версиясы табылмады.
+       *[other] DoenetML-ни { $version } версиясы табылмады. { $fallback } версиясы ишлетиле
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML тюз тюгюл: { $content }
+
+parse-tag-missing-close-tag = DoenetML тюз тюгюл: `{ $tag }` тегни ябагъан теги ёкъ. Оьзю ябылагъан тег яда `</{ $tagName }>` тег герек эди.
+
+parse-tag-error = DoenetML тюз тюгюл: `<{ $tagName }>` тегде янгылыш
+
+parse-attribute-missing-value = DoenetML тюз тюгюл: `{ $attribute }` деген тюз болмагъан атрибутну къыйматы ёкъ гёремен.
+
+parse-attribute-invalid = DoenetML тюз тюгюл: `{ $attribute }` атрибут тюз тюгюл
+
+parse-attribute-value-invalid = DoenetML тюз тюгюл: `{ $value }` деген атрибутну къыйматы тюз тюгюл
+
+parse-attribute-value-quote-mismatch = DoenetML тюз тюгюл: `{ $value }` деген атрибутну къыйматы тюз тюгюл. Тырнакълар къыйышмай. `{ $quote }` етишмей гёремен
+
+parse-open-tag-name-missing = DoenetML тюз тюгюл: аты болмагъан тег табылды, мисал учун `<`
+
+parse-tag-not-closed = DoenetML тюз тюгюл: `{ $tag }` тег ябылмагъан (`>` етишмей гёремен).
+
+parse-self-closing-tag-name-missing = DoenetML тюз тюгюл: аты болмагъан тег табылды `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML тюз тюгюл: `{ $tag }` тег ябылмагъан (`/>` етишмей гёремен).
+
+parse-tag-invalid-attributes = DoenetML тюз тюгюл: `{ $tag }` тег тюз тюгюл. Ону атрибутлары тюз болмаса ярай.
+
+parse-close-tag-name-missing = DoenetML тюз тюгюл: аты болмагъан ябагъан тег табылды, мисал учун `</`
+
+parse-attribute-value-unquoted = Атрибутну къыйматлары тырнакъланы ичинде болма герек: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML тюз тюгюл: `{ $tag }` ябагъан тег табылды, тек огъар къыйышагъан ачагъан тег ёкъ
+
+parse-close-tag-mismatched = DoenetML тюз тюгюл: ябагъан тег къыйышмай. `</{ $expected }>` герек эди. `{ $found }` табылды
+
+parser-node-unconvertible = { $node } деген тюгюмню Dast тюгюмге гёчюрюп болмады.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' атрибут тюз тюгюл. { $reason ->
+        [characters] Атларда тек гьарплар, санлар, тюп сызыкълар яда дефислер болма бола.
+       *[start] Атлар гьарп булан башланма герек.
+    }
+
+component-name-invalid-start = "{ $name }" деген компонентни аты тюз тюгюл. Атлар гьарп булан башланма герек.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тюрлю жавапны video атрибуту болма герек
+
+answer-video-watched-video-not-reference = videoWatched тюрлю жавапны video атрибуту силтев болма герек
+
+answer-name-not-single-text = Жавапны name атрибутуну тек бир текст баласы болма герек
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсияны даражалары бек кёп болгъан учун тышдагъы DoenetML-ни алып болмай. Тёгерек силтев бармы экен?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" деген ерден DoenetML алып болмай
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" деген ерден алынгъан DoenetML тюз тюгюл: ол "{ $componentType }" компонент тюрге къыйышмады
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эсгиленген; ону орнунда `{ $to }` ишлетигиз.
+       *[other] [deprecation] `<{ $component }>` компонентдеги `{ $from }` атрибут эсгиленген; ону орнунда `{ $to }` ишлетигиз.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эсгиленген ва `{ $to }` да гёрсетилген учун гьисапгъа алынмай.
+       *[other] [deprecation] `<{ $component }>` компонентдеги `{ $from }` атрибут эсгиленген ва `{ $to }` да гёрсетилген учун гьисапгъа алынмай.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` компонентдеги `{ $attribute }` атрибут эсгиленген ва гьисапгъа алынмай.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` компонентдеги `{ $attribute }` атрибут эсгиленген; ону орнунда `<{ $child }>` бала ишлетигиз.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` компонентдеги `{ $attribute }` атрибутну `{ $value }` къыйматы эсгиленген; ону орнунда `{ $to }` ишлетигиз.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` тек ингилис сёзлени кёплюк санына салма бола, шону учун { $locale } тилде язылгъан документде ону тексти алышынмай къала. Кёплюк санын оьзюгюз языгъыз яда `pluralForm` атрибут булан гёрсетигиз.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент Doenet-ни танылагъан элементи тюгюл.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементге документни тамурунда ихтияр ёкъ.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементге `<{ $parent }>` ичинде ихтияр ёкъ.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементни `{ $attribute }` деген атрибуту ёкъ.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементни `{ $attribute }` атрибуту сиягь болма герек, ону гьар элементи буланы бириси: { $allowed }
+       *[other] `<{ $tag }>` элементни `{ $attribute }` атрибуту буланы бириси болма герек: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select учун вариантны аты тюз тюгюл. { $variantName } деген вариантны аты { $numOptions } танглавда бар, тек танглана турагъан сан { $numToSelect }.
+
+select-variant-name-without-options = select учун бир нече вариант гёрсетилген, тек { $variantName } деген болма болагъан вариантны аты учун бир танглав да гёрсетилмеген.
+
+select-variant-name-not-possible = select учун гёрсетилген { $variantName } деген вариантны аты болма болагъан вариантны аты тюгюл.
+
+select-too-few-options = Тек { $numOptions } компонентден { $numToSelect } компонент танглап болмай.
+
+select-from-sequence-too-few-values = Узунлугъу { $length } тизбеден { $numToSelect } къыймат танглап болмай.
+
+select-from-sequence-indices-count-mismatch = select учун гёрсетилген индекслени саны танглана турагъан сангъа къыйышма герек
+
+select-from-sequence-indices-not-integers = select учун гёрсетилген бары да индекслер бютюн санлар болма герек
+
+select-from-sequence-index-excluded = selectfromsequence учун гёрсетилген индекс чыгъарылгъан эди
+
+select-from-sequence-indices-excluded-combination = selectfromsequence учун гёрсетилген индекслер чыгъарылгъан къошулув эди
+
+select-from-sequence-coprime-not-positive-integers = Оьр бютюн санлар тангланмагъан учун оьз ара ярым санланы къошулувун танглап болмай.
+
+select-from-sequence-coprime-common-factor = Оьз ара ярым санланы танглап болмай. Бары да болма болагъан къыйматланы уртакъ бёлюучюсю бар. (Гёрсетилген "from" яда "to" къыйматлар "step" булан оьз ара ярым болма герек.)
+
+select-from-sequence-coprime-single-number = 1 болмагъан бир санны оьзюнден оьз ара ярым къошулув танглап болмай.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ичинде къошулувланы 70%-ден кёбю чыгъарылгъан
+
+select-from-sequence-coprime-none-found = Оьз ара ярым санланы танглап болмады. Бары да болма болагъан къыйматланы уртакъ бёлюучюсю бар.
+
+select-from-sequence-too-few-unique-values = Узунлугъу { $numPossibleValues } тизбеден { $numToSelect } башгъа-башгъа къыймат танглап болмай
+
+select-prime-numbers-too-few-values = Узунлугъу { $numValues } ярым санланы сиягьындан { $numToSelect } къыймат танглап болмай
+
+select-prime-numbers-values-count-mismatch = select учун гёрсетилген къыйматланы саны танглана турагъан сангъа къыйышма герек
+
+select-prime-numbers-values-not-prime = select prime number учун гёрсетилген бары да къыйматлар ярым санланы сиягьында болма герек
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers учун гёрсетилген къыйматлар чыгъарылгъан къошулув эди
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ичинде къошулувланы 70%-ден кёбю чыгъарылгъан
+
+select-random-combination-fluke = Бек болма болмайгъан тюшюм булан тосденгги къыйматланы къошулувун танглап болмады
+
+select-random-value-fluke = Бек болма болмайгъан тюшюм булан тосденгги къыйматны танглап болмады

--- a/packages/i18n/locales/kum/editor.ftl
+++ b/packages/i18n/locales/kum/editor.ftl
@@ -1,0 +1,226 @@
+# Kumyk editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Kumyk in the Cyrillic orthography of Dagestan's schools and press, which is
+# what CLDR assumes for a bare `kum` (`kum-Cyrl-RU`).
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Kumyk counts in the same two categories English does, `one` and `other`, so
+# every selection below keeps both branches — but a noun after a numeral stays
+# singular, so the two read alike apart from the number. Nothing here agrees
+# with a gender or a noun class; Kumyk has neither.
+#
+# Two words in this file are the seed's own choices rather than established
+# terms, and a speaker should expect to replace them wholesale. «онгайлыкъ»
+# for *accessibility* means convenience or ease of use. «силтев» for
+# *reference* is built from «силтемек», to point at; the alternative in the
+# Kumyk press is the Russian «ссылка», and choosing between them is a decision
+# about register that this seed is not entitled to make.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Къайтарыв
+       *[update] Янгыртыв
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Гёрсетивню { $word }
+       *[other] Гёрсетивню { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Сюзюв…
+editor-variant-next = Сонрагъы вариантны танглав
+editor-variant-previous = Алдагъы вариантны танглав
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA онгайлыкъ бузув табылды. Онгайлыкъ отчётну { $action ->
+            [close] ябыв
+           *[open] ачыв
+        } учун басыгъыз.
+        [advisories] Онгайлыкъ отчётну { $action ->
+            [close] ябыв
+           *[open] ачыв
+        } учун басыгъыз. WCAG AA бузувлар табылмады, тек къошум онгайлыкъ таклифлер бар.
+       *[clean] Онгайлыкъ отчётну { $action ->
+            [close] ябыв
+           *[open] ачыв
+        } учун басыгъыз. Онгайлыкъ масалалар табылмады.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA онгайлыкъ бузув табылды. { $count ->
+            [one] { $count } WCAG AA бузув
+           *[other] { $count } WCAG AA бузув
+        } табылды. Онгайлыкъ отчётну { $action ->
+            [close] ябыв
+           *[open] ачыв
+        } учун басыгъыз.
+        [advisories] WCAG AA бузувлар табылмады. { $count ->
+            [one] { $count } къошум онгайлыкъ таклиф
+           *[other] { $count } къошум онгайлыкъ таклиф
+        } табылды. Онгайлыкъ отчётну { $action ->
+            [close] ябыв
+           *[open] ачыв
+        } учун басыгъыз.
+       *[clean] WCAG AA бузувлар табылмады. Онгайлыкъ отчётну { $action ->
+            [close] ябыв
+           *[open] ачыв
+        } учун басыгъыз.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версиясы { $version }
+
+editor-tab-help = Контекст кёмеги
+editor-tab-help-short = Контекст
+editor-tab-errors = Янгылышлар
+editor-tab-warnings = Эсгертивлер
+editor-tab-info = Малумат
+editor-tab-accessibility = Онгайлыкъ
+editor-tab-responses = Йиберилген жаваплар
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторну параметрлери
+editor-format-as-doenetml = DoenetML кюйде форматлав
+editor-format-as-xml = XML кюйде форматлав
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Сатыр №{ $line }
+
+editor-no-errors = Янгылышлар ёкъ
+editor-no-warnings = Эсгертивлер ёкъ
+editor-no-info = Малумат хабарлар ёкъ
+
+editor-show-info-annotations = Малумат хабарланы редакторда гёрсетив
+editor-show-accessibility-annotations = Онгайлыкъ хабарланы редакторда гёрсетив
+
+editor-accessibility-learn-more = Doenet онгайлыкъгъа нечик къарайгъанын билигиз
+
+editor-accessibility-violations-heading = Онгайлыкъ бузувлар ({ $standard })
+
+editor-accessibility-other-heading = Оьзге онгайлыкъ масалалар
+editor-none-found = Бир зат да табылмады
+
+
+## Submitted responses
+
+editor-no-responses = Гьалиге йиберилген жавап ёкъ
+editor-response-answer-id = Жавапны Id-си
+editor-response-response = Жавап
+editor-response-credit = Балл
+editor-response-submitted = Йиберилди
+
+
+## The context-help panel
+
+help-placeholder = Документацияны гёрмек учун курсорну тегни атына, атрибутгъа яда { $ref } уьстюне салыгъыз.
+
+help-unsupported-ref-chain = { $example } йимик кёп бёлюклю силтевлер учун кёмек гьалиге ёкъ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Силтев учун объект табылмады: { $ref }.
+        [multiple] Силтев учун бир нече объект табылды: { $ref }.
+       *[indeterminate] { $ref } учун объектни белгилеп болмады.
+    }
+
+help-learn-about-references = Силтевлер гьакъда билигиз →
+help-reference-page = Малумат бети →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ичинде
+       *[top] Инг уьст даражада
+    }{ $allowed ->
+        [none] { " — мунда бир зат да гирмей." }
+        [text] { " — мунда текст языгъыз." }
+        [text-and-components] { " — мунда текст языгъыз, яда буланы сынагъыз:" }
+       *[components] { " — буланы сынагъыз:" }
+    }
+
+help-suggestions-footer = Бары { $total } компонентни гёрмек учун { $shortcut } басыгъыз.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объектге силтев.
+       *[other] { $ref } — { $target } объектге силтев ({ $line } сатыр).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ону { $owner } { $role } гьисапда гийирген.
+       *[other] Ону { $owner } { $line } сатырда { $role } гьисапда гийирген.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементни { $property } къасиетине силтев.
+       *[other] { $ref } — { $element } элементни { $property } къасиетине силтев ({ $line } сатыр).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = уьзюк
+help-kind-array-entry = массивни элементи
+
+help-default = Келишив бойунча къыймат:
+help-active-default = Ишлейген келишив бойунча къыймат:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ихтияр берилген къыйматлар (гьар элементге бирев):
+       *[other] Ихтияр берилген къыйматлар:
+    }
+
+help-suggested-values = Таклиф этилген къыйматлар:
+
+help-inserts = Къоша:
+
+help-coordinates =
+    { $count ->
+        [one] Координат:
+       *[other] Координатлар:
+    }
+
+help-type = Тюр:
+
+help-resolved-style = Белгиленген стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Белгиленген функцияланы атлары:
+help-reset-list = Бу гиришде къайтарыв сиягьы:
+help-added-on-input = Бу гиришде къошулгъанлар:
+help-removed-on-input = Бу гиришден гетерилгенлер:
+
+help-reset-overrides = { $reset } { $additional } ва { $removed } атрибутлардан уьстюн геле.

--- a/packages/i18n/locales/lbe/chrome.ftl
+++ b/packages/i18n/locales/lbe/chrome.ftl
@@ -1,0 +1,134 @@
+# Lak viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Lak (лакку маз) is a Northeast Caucasian language of central Dagestan,
+# written in Cyrillic since 1938. That orthography is what Dagestan's schools,
+# the Lak-language press and CLDR all use, and `lbe` maximizes to
+# `lbe-Cyrl-RU`, so it is what this catalog is written in.
+#
+# The palochka Ӏ is a letter of the alphabet. It is not a Latin capital I and
+# not a digit 1: a catalog that spells «тӀайласса» with either has quietly
+# become unreadable, and the substitution is invisible in most editors.
+#
+# Lak counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gives it. A noun after a
+# numeral stays in the singular in Lak, so the two branches differ in nothing
+# but the number they print — that is correct rather than an oversight.
+#
+# Lak has a four-class agreement system, but nothing in this file agrees with
+# a noun class: see `content.ftl`, whose header explains where the class
+# markers land and why this seed does not fork on them.
+#
+# Least certain here: the words for abstractions the language has no settled
+# term for. «ХьхьичӀава кӀицӀ» for a warning and «бигьану ишла баву» for
+# accessibility are transparent coinages this seed chose over the bare Russian
+# loans a Lak newspaper would print; a speaker should replace them with
+# whatever Lak-language computing writing actually uses. The keyboard, matrix
+# and orbital controls lean on Russian technical nouns («строка»,
+# «столбец», «клетка», «стрелка»), which is what written Lak does for
+# mathematics and computing.
+
+
+## Answer submission
+
+answer-checking = Ххал дуллай…
+answer-submitting = Гьан дуллай…
+answer-checking-status = Жаваб ххал дуллай
+answer-submitting-status = Жаваб гьан дуллай
+answer-correct = ТӀайласса
+answer-incorrect = КъатӀайласса
+answer-response-saved = Жаваб ябувну
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% тӀайла
+answer-percent-short = { $percent } %
+max-credit-available = Ласун бюхъайсса яла хъунмур балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] хӀарачатру ливчӀун бакъар
+        [one] { $count } хӀарачат ливчӀун бур
+       *[other] { $count } хӀарачат ливчӀун бур
+    }
+validation-correct = (ТӀайласса)
+validation-incorrect = (КъатӀайласса)
+validation-partially-correct = (БутӀалий тӀайласса)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } тӀисса суалданул { $count } жаваб ккаккан бан
+       *[other] { $answerId } тӀисса суалданул { $count } жаваб ккаккан бан
+    }
+
+## Disclosure panels
+
+feedback-heading = Пикри
+collapsible-click-to-open = (тӀитӀин щелк бува)
+collapsible-click-to-close = (лакьин щелк бува)
+collapsible-initializing = ХӀадур дуллай…
+footnote-show = Лувсса кӀицӀ ккаккан бан
+footnote-hide = Лувсса кӀицӀ лакьин
+description-more-information = ялагу хавар
+
+## Controls
+
+slider-previous = ХьхьичӀмур
+slider-next = Махъмур
+keyboard-open = Клавиатура тӀитӀин
+keyboard-close = Клавиатура лакьин
+choice-input-remove-choice = { $choice } дуккан дан
+matrix-remove-row = Строка дуккан дан
+matrix-add-row = Строка бишин
+matrix-remove-column = Столбец дуккан дан
+matrix-add-column = Столбец бишин
+subset-add-remove-points = Нукьтарду бишин/дуккан дан
+subset-toggle-points-intervals = Нукьтарду ва интервалру даххана дан
+subset-move-points = Нукьтарду занан дан
+subset-clear = МарцӀ бан
+orbital-add-row = Строка бишин
+orbital-remove-row = Строка дуккан дан
+orbital-add-box = Клетка бишин
+orbital-remove-box = Клетка дуккан дан
+orbital-add-up-arrow = Лахъуннайсса стрелка бишин
+orbital-add-down-arrow = Лагьуннайсса стрелка бишин
+orbital-remove-arrow = Стрелка дуккан дан
+orbital-row-label = { $row } строкалул цӀа
+pretzel-answer = Жаваб
+summary-statistics-caption = { $column } тӀисса столбецрал жамигьсса статистика
+
+## Math input
+
+math-input-preview-region = математикалул выражение хьхьичӀава ккаккаву
+math-input-preview = ХьхьичӀава ккаккаву
+math-input-invalid-expression = КъатӀайласса выражение:
+
+## Document status
+
+viewer-initializing = ХӀадур дуллай…
+
+## Errors
+
+error-heading = ГъалатӀ
+error-found-at =
+    { $span ->
+        [line] Лявкъуна { $startLine } строкалий.
+       *[lines] Лявкъуна { $startLine }–{ $endLine } строкардай.
+    }
+document-contains-errors = Ва документрай гъалатӀру бур!
+diagnostic-heading-error = ГъалатӀ
+diagnostic-heading-warning = ХьхьичӀава кӀицӀ
+diagnostic-heading-information = Хавар
+diagnostic-heading-hint = Ишара
+accessibility-heading-level-1 = WCAG AA бигьану ишла баврил тӀалавшин лиян баву
+accessibility-heading-level-2 = Бигьану ишла баврил кӀицӀ
+something-went-wrong = ГъалатӀ хьунни.
+renderer-load-failed = сурат буллалисса модуль ласун къавхьунни. ЧӀапӀи цӀуну лахъан бува.
+core-start-failed = Ва документ байбишин къавхьунни. ЧӀапӀи цӀуну лахъан бува.
+core-start-failed-busy = Ва документ байбишин къавхьунни. Ца чӀумал чӀярусса документру байбишлай бивкӀссар, гужсса къадусса компьютердай му яла хӀаллай лякъин бюхъайссар. Цаймигу документру къуртал хьувкун, чӀапӀи цӀуну лахъан бувну кумаг хьун бюхъайссар.
+core-start-failed-retry = Ва документ байбишин къавхьунни.
+core-start-failed-busy-retry = Ва документ байбишин къавхьунни. Ца чӀумал чӀярусса документру байбишлай бивкӀссар, гужсса къадусса компьютердай му яла хӀаллай лякъин бюхъайссар.
+core-start-retry = ЦӀуну ххал бува
+saved-state-unavailable = Вил ябувну бивкӀсса даву ласун къавхьунни.

--- a/packages/i18n/locales/lbe/content.ftl
+++ b/packages/i18n/locales/lbe/content.ftl
@@ -1,0 +1,293 @@
+# Lak content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Lak (лакку маз) is Northeast Caucasian, spoken in central Dagestan, and is
+# written in Cyrillic with the palochka. That has been the standard since 1938
+# and is what the republic's schools, the Lak-language press and CLDR all use;
+# `lbe` maximizes to `lbe-Cyrl-RU`. The palochka Ӏ is a letter of the alphabet
+# — not a Latin capital I and not a digit 1 — and «тӀайласса», «кӀицӀ» and
+# «кӀяласса» are unreadable if it is replaced by either.
+#
+# Lak resolves two plural categories, `one` and `other`, and nothing in this
+# file counts, so no message here selects on a count.
+#
+# **Lak agrees, and this catalog does not fork. That gap is deliberate and is
+# the first thing a speaker should read.** Lak has four noun classes —
+# I masculine human, II feminine human, III and IV non-human — and an agreeing
+# word carries the class as a marker at its *front*: singular в- (I), б- (II
+# and III), д- (IV); plural б- (I and II), д- (III and IV). Only two of the
+# four could ever be reached from here, since nothing the core names is human.
+#
+# What actually carries a marker in this file is a very short list. Lak's
+# attributive adjectives are the -сса forms — «лухӀисса», «ятӀулсса»,
+# «хъунмасса» — and they are invariable, so the whole style vocabulary below
+# agrees with nothing, exactly as Chechen's does in `locales/ce`. The one word
+# that would agree is the participle «дувцӀусса», "filled", whose initial д- is
+# a class-IV marker and would be б- for a class-III shape. That is the single
+# message a fork belongs in.
+#
+# It is not written, because `noun-gender` cannot honestly feed it. This seed
+# could establish Lak's class markers and the shape of the participle; it could
+# not establish the class of a single one of the geometric nouns it needed —
+# and a half-remembered class table is worse than an admitted gap, which is the
+# judgement `locales/ce` made about the entries it left out and `locales/ewo`
+# made about Ewondo. So `noun-gender` answers `d` for everything and
+# `style-filled-word` is written flat in its class-IV form. **If that form is
+# wrong for a shape, it is wrong everywhere rather than in scattered places**,
+# which is the failure mode that is findable. Filling the table in costs one
+# `{ $noun -> … }` table here and one `{ $gender -> [b] бувцӀусса *[d]
+# дувцӀусса }` select in `style-filled-word`; nothing else in the file changes.
+#
+# The second-least certain thing here is the colour vocabulary, and for a
+# reason worth recording. Lak's attested core is small — «кӀяла» white, «лухӀи»
+# black, «ятӀул» red, «хъахъи» yellow, «щюлли» — and «щюлли» covers green and
+# blue together, where the style pipeline needs them as two separate words.
+# So this catalog writes transparent compounds that split them, «урттул
+# щюллисса» (grass-green) and «ссавнил щюллисса» (sky-green), the way
+# `locales/sah` splits Sakha's «күөх» and `locales/os` splits Ossetian's
+# «цъæх». That is a choice, not a translation, and the remaining families —
+# grey, orange, cyan, purple, pink, brown — are built out of the core the same
+# way. «Бинавшасса» for purple is the one loan among them.
+#
+# Third: Lak's own words for thick and thin were not attestable here, so the
+# stroke widths are written with the size adjectives «хъунмасса» and
+# «чӀивисса». The mathematical nouns are the Russian ones — «линия»,
+# «отрезок», «луч», «вектор», «функция», «круг», «квадрат» — which is what
+# written Lak uses for them, and the case endings on those loans («строкалул»,
+# «векторданул», «фондалий») are the other thing to check.
+
+
+## Style vocabulary
+##
+## Lak's attributive adjectives end in -сса and stand *before* the noun, so
+## the composition messages below keep English's order. None of these words
+## takes a class marker, so none of them forks.
+
+color =
+    .black = лухӀисса
+    .white = кӀяласса
+    .gray = лухӀи-кӀяласса
+    .red = ятӀулсса
+    .orange = ятӀул-хъахъисса
+    .yellow = хъахъисса
+    .green = урттул щюллисса
+    .cyan = кӀяла ссавнил щюллисса
+    .blue = ссавнил щюллисса
+    .purple = бинавшасса
+    .pink = ятӀул-кӀяласса
+    .brown = ятӀул-лухӀисса
+line-width =
+    .thick = хъунмасса
+    .thin = чӀивисса
+line-style =
+    .dashed = кьуркьусса
+    .dotted = нукьтардал
+# Noun phrases, all of them plural: the composing messages put «дусса»
+# ("having") after them rather than a case suffix, so nothing is welded to a
+# value and the class marker on «дусса» is the д- that classes III and IV
+# share in the plural.
+fill-style =
+    .horizontal = горизонталлул линиярду
+    .vertical = вертикаллул линиярду
+    .diagonal = диагоналлул линиярду
+    .backdiagonal = махъунмай диагоналлул линиярду
+    .dots = нукьтарду
+    .diamonds = ромбру
+noun =
+    .line = линия
+    .line-segment = отрезок
+    .ray = луч
+    .vector = вектор
+    .curve = кривая
+    .function = функция
+    .slope-field = наклоннал майдан
+    .vector-field = векторданул майдан
+    .parabola = парабола
+    .polyline = мурцӀурдал линия
+    .polygon = чӀявумурцӀу
+    .triangle = шамамурцӀу
+    .rectangle = тӀайласса мукьвамурцӀу
+    .circle = круг
+    .region = кӀану
+    .point = нукьта
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# Lak builds the side count into a prenominal phrase, so the whole noun is one
+# head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } мурцӀу дусса барабарсса чӀявумурцӀу
+    }
+# One token for every noun, and the reason is in this file's header: Lak's
+# four-class system is real, and the class of these particular nouns is what
+# this seed could not check. `d` is class IV, the default the participle below
+# is written in.
+noun-gender = d
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# The one word in this file that carries a class marker — the д- of class IV —
+# and the one message a `{ $gender -> … }` select belongs in the day
+# `noun-gender` above can answer for a class-III shape with «бувцӀусса».
+style-filled-word = дувцӀусса
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } дусса { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } дусса { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } дусса { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «дазущал» — "with a border" — is the comitative of a noun this catalog
+# writes, so no affix lands on a value. Lak has no articles, so the two
+# `-article` branches read exactly as the two without one.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } дазущал
+        [and] ва { $border } дазущал
+        [and-article] ва { $border } дазущал
+       *[with] { $border } дазущал
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+# The negation is written with the prefix къа-, which has one shape. This
+# message describes a fill standing on its own — `describeFill` hands it no
+# arguments at all — so no noun and therefore no `$gender` reaches it, and the
+# class-IV form is written flat. A fork here could only ever render its
+# default branch.
+style-unfilled = къадувцӀусса
+# «фондалий» — "on the background" — is a case form of a word this catalog
+# writes, and the colour follows it, so the two words keep Lak's own order.
+style-text =
+    { $parts ->
+        [background] { $background } фондалий { $color }
+       *[plain] { $color }
+    }
+style-background-none = дакъар
+
+## Boolean words
+
+boolean-true = тӀайла
+boolean-false = къатӀайла
+
+## Answer buttons
+
+answer-submit-label = Даву ххал дан
+answer-submit-label-no-correctness = Жаваб гьан бан
+
+## Sectional blocks
+
+section-name =
+    .activity = Даву
+    .aside = Чулухасса кӀицӀ
+    .cascade = Каскад
+    .definition = Баян баву
+    .example = Мисал
+    .exercise = Упражнение
+    .exercises = Упражнениярду
+    .given-answer = Жаваб
+    .note = КӀицӀ
+    .objectives = Мурадру
+    .paragraphs = Абзацру
+    .part = БутӀа
+    .problem = Масъала
+    .problems = Масъалартту
+    .proof = Исбат баву
+    .question = Суал
+    .section = Раздел
+    .solution = Щаллу баву
+    .task = Тапшуру
+    .theorem = Теорема
+# Lak follows the Russian typographic convention its textbooks are set in, so
+# a heading separates its title with a period rather than with a colon.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Ишара
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурат { $enumeration }
+        [numbered-caption] Сурат { $enumeration }{ ". " }
+        [unnumbered-caption] Сурат{ ". " }
+       *[unnumbered] Сурат
+    }
+
+## Paginator controls
+
+paginator-previous = ХьхьичӀмур
+paginator-next = Махъмур
+paginator-page = ЧӀапӀи
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## **`piecewise-condition-if` cannot land correctly in Lak, and no wording here
+## fixes it.** Lak marks a condition on the *verb that closes the clause* — the
+## conditional converb, «духьурча» "if it is" — so the word belongs after the
+## mathematics rather than in front of it, and the renderer places this message
+## before. That is the limit `locales/sah`, `locales/tyv`, `locales/udm`,
+## `locales/kv` and `locales/chm` record for the same reason; splitting the key
+## into a prefix and a suffix would fix it and nothing in the composition
+## messages exposes the distinction today. The Lak form is written out anyway,
+## so a reader sees a Lak word in the wrong position rather than an English one.
+
+piecewise-condition-or = я
+piecewise-condition-if = духьурча
+piecewise-condition-otherwise = цамур ишираву
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Dagestan is taught in
+## Russian — Lak is a subject in the lower grades and not the medium the
+## periodic table arrives in — so the element names a Lak-speaking pupil meets
+## are the Russian ones, and the English fallback sits nearer their curriculum
+## than an invented Lak list would.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = КъатӀайласса химиялул ишара
+chemistry-invalid-ionic-compound = КъатӀайласса ионнал цачӀуншиву

--- a/packages/i18n/locales/lbe/diagnostics.ftl
+++ b/packages/i18n/locales/lbe/diagnostics.ftl
@@ -1,0 +1,693 @@
+# Lak diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Lak (лакку маз), Northeast Caucasian, written in Cyrillic with the palochka
+# — the orthography of Dagestan's schools and of the Lak-language press, and
+# what `lbe-Cyrl-RU` names. Ӏ is a letter, not a Latin I and not a digit 1.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language rather than prose and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Lak's four-class agreement does not reach this file: nothing here describes a
+# noun this catalog itself supplies, so no message forks on a class. Lak's
+# class system, and the reason `content.ftl` does not fork on it either, are
+# written out in that file's header.
+#
+# Lak resolves two plural categories, `one` and `other`, and a noun after a
+# numeral stays singular, so a counted message's two branches differ only in
+# the number they print.
+#
+# The technical nouns are the Russian ones, which is what written Lak uses for
+# mathematics and computing: «компонент», «атрибут», «функция», «индекс»,
+# «строка», «последовательность». The case endings this catalog puts on them
+# are the part of this file a speaker should check first.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кӀива яржалул нукьта кӀицӀ бувну бухьурча, { $attributes } хӀисав къадуллай бур
+       *[other] кӀива яржалул нукьта кӀицӀ бувну бухьурча, { $attributes } хӀисав къадуллай бур
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] яржалул нукьта ва дянивсса нукьта кӀицӀ бувну бухьурча, { $attributes } хӀисав къадуллай бур
+       *[other] яржалул нукьта ва дянивсса нукьта кӀицӀ бувну бухьурча, { $attributes } хӀисав къадуллай бур
+    }
+
+line-segment-midpoint-offset-without-midpoint = дянивсса нукьта дакъасса midpointOffset хӀисаврайн ласлай бакъар
+
+## `<line>`
+
+line-points-undetermined-dimensions = Измерениярду кӀул къадурсса нукьтардайх бавчусса линия.
+
+line-points-too-few-dimensions = Линия яла чӀивимур кӀива измерения дусса нукьтардайх бачин аьркинссар.
+
+line-points-depend-on-variables = Линия переменнардайн лавхьхьусса нукьтардайх бачлай бур: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ва { $variable2 } переменнардаву линиялул уравнениялул формат къатӀайлассар.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint ва direction тӀисса шамагу кӀицӀ бувну бур.  КӀицӀ бувсса through хӀисав къадуллай бур.
+
+ray-dimension-mismatch = Лучраву numDimensions дархӀуну дакъар.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ва displacement тӀисса шамагу кӀицӀ бувну бур.  КӀицӀ бувсса head хӀисав къадуллай бур.
+
+vector-dimension-mismatch = Векторданува numDimensions дархӀуну дакъар.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` тӀисса кӀанттухун кӀункӀу бан къабюхъай, мунихь nearestPoint тӀисса шартӀирал переменная дакъа духьувкун.
+
+constrain-to-without-nearest-point = `<{ $component }>` тӀисса кӀанттуцӀун дахьханнин дишин къабюхъай, мунихь nearestPoint тӀисса шартӀирал переменная дакъа духьувкун.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` тӀисса кӀанттул бухсса кӀанттуцӀун дахьханнин дишин къабюхъай, мунихь nearestPoint тӀисса шартӀирал переменная дакъа духьувкун.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = инлайн бакъасса choiceInput-рай labelPosition хӀисав къадуллай бур
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-рай кӀицӀ бувсса индексру хӀисав къадуллай бур, индексирттал хӀисав лувсса choice элементирттал хӀисаврацӀун къадархӀуну духьувкун.
+
+pretzel-indices-count-mismatch = problem-лий кӀицӀ бувсса индексру хӀисав къадуллай бур, индексирттал хӀисав лувсса problem элементирттал хӀисаврацӀун къадархӀуну духьувкун.
+
+shuffle-indices-count-mismatch = shuffle-рай кӀицӀ бувсса индексру хӀисав къадуллай бур, индексирттал хӀисав компонентирттал хӀисаврацӀун къадархӀуну духьувкун.
+
+indices-ignored-out-of-range = { $component } тӀисса кӀанттай кӀицӀ бувсса индексру хӀисав къадуллай бур, цаппара индексру дазулия бувккуну духьувкун.
+
+pretzel-indices-repeated = pretzel-рай кӀицӀ бувсса индексру хӀисав къадуллай бур, цаппара индексру кӀилцӀа кӀицӀ бувну бухьувкун.
+
+pretzel-circuit-first-index = circuit режимрайсса pretzel-рай кӀицӀ бувсса индексру хӀисав къадуллай бур, цалчинмур индекс 1 бикӀан аьркинну духьувкун.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` лувсса строкардащал зузаваншиврул, type тӀисса атрибут кӀицӀ бан аьркинссар.
+
+invalid-type-defaulting-to-math = { $component } компонентрал { $type } тӀисса тип къатӀайлассар. math, text, number я boolean тӀисса цамур бикӀан аьркинссар. math ласлай бур.
+
+string-not-valid-component-to-arrange = "{ $value }" тӀисса строка { $component } баншиврул лархьхьусса компонент бакъассар. ХӀисав къадуллай бур.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } тӀисса тип къатӀайлассар, тип number хӀисаврай бишлай бур.
+
+invalid-variable-value = Переменнарал кьимат къатӀайлассар: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } тӀисса вариантрал индекс хӀисав бикӀан аьркинссар
+
+variant-index-must-be-integer = { $index } тӀисса вариантрал индекс щалла хӀисав бикӀан аьркинссар
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютсса ккаккиярттахлу щаллу дурну дакъар. Гьаннурду относительныйну бишлай бур.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютсса ккаккиярттахлу щаллу дурну дакъар. Яржарду относительныйну бишлай бур.
+
+side-by-side-no-block-child = `<{ $component }>` къатӀайлассар: мунихь яла чӀивимур ца блок элемент бикӀан аьркинссар.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Графикалул `<label>`-рай `for` тӀисса атрибут хӀисав къадуллай бур.
+
+label-for-must-resolve-to-one = `<label>`-рай `for` тӀисса атрибут щалва ца компонентрайн бачин аьркинссар.
+
+label-for-unresolved = `<label>`-рай `for` тӀисса атрибут компонентрайн бачин къавхьунни.
+
+label-for-answer-with-authored-inputs = `<label>`-рай `for` тӀисса атрибут авторнал цала чивчусса инпутру дусса `<answer>`-райн бачлай бур; инпутрайн цийнува ссылка бува.
+
+label-for-answer-without-input = `<label>`-рай `for` тӀисса атрибут цӀа дишинсса инпут дакъасса `<answer>`-райн бачлай бур.
+
+label-for-must-reference-input-or-answer = `<label>`-рай `for` тӀисса атрибут инпутрайн я жавабрайн (answer) бачин аьркинссар.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Бигьану ишла баншиврул, `<{ $component }>`-хь я кутӀасса баян бикӀан аьркинссар, я ва чӀюлушинна дур тӀий кӀицӀ бан аьркинссар.
+
+accessibility-video-short-description = Бигьану ишла баншиврул, `<video>`-хь кутӀасса баян бикӀан аьркинссар.
+
+accessibility-input-short-description-or-label = Бигьану ишла баншиврул, `<{ $component }>`-хь кутӀасса баян я цӀа бикӀан аьркинссар.
+
+accessibility-answer-input-short-description-or-label = Бигьану ишла баншиврул, инпут буллалисса `<answer>`-хь кутӀасса баян я цӀа бикӀан аьркинссар.
+
+accessibility-short-description-contains-math = КутӀасса баянну дянив `<{ $component }>` кунмасса математикалул компонентру бикӀан къааьркинссар. Математика мукъурттий чичара.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } разделданул бакӀлавсуйсса текстрахлу дурксса контраст дакъар (лухӀимур режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яла чӀивимур { $threshold }:1 аьркинссар).
+       *[other] { $colorName } разделданул бакӀлавсуйсса текстрахлу дурксса контраст дакъар ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яла чӀивимур { $threshold }:1 аьркинссар).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Нукьтардахь хӀисаврал кьиматру дакъа духьурча, { $count } нукьтардайх бавчусса `<circle>` щаллу дурну дакъар.
+
+circle-too-many-through-points = 3 нукьталияр чӀявусса нукьтардайх бавчусса круг хӀисав бан къабюхъай.
+
+circle-overprescribed-radius-center-points = Радиус, центр ва нукьтарду цачӀу кӀицӀ бувсса круг хӀисав бан къабюхъай.
+
+circle-center-with-multiple-points = КӀицӀ бувсса центр дусса круг ца нукьталияр чӀявусса нукьтардайх бачин къабюхъай.
+
+circle-radius-too-small = Круг хӀисав бан къабюхъай: кӀива нукьталул дянивсса манзил { $distance } бухьувкун, кӀицӀ бувсса радиус { $radius } лап чӀивиссар.
+
+circle-radius-with-many-points = КӀицӀ бувсса радиус дусса круг кӀива нукьталияр чӀявусса нукьтардайх бачин къабюхъай.
+
+circle-invalid-center-or-through-points = Круграл центр я нукьтарду къатӀайлассар.
+
+circle-radius-center-with-multiple-points = КӀицӀ бувсса центр дусса круграл радиус ца нукьталияр чӀявусса нукьтардайх хӀисав бан къабюхъай.
+
+circle-change-radius-non-numerical = ХӀисаврал кьиматру дакъасса нукьтардайх бавчусса круграл радиус даххана бан къабюхъай
+
+circle-radius-with-points-non-numerical = ХӀисаврал кьиматру дакъа духьурча, кӀицӀ бувсса радиус дусса круг ца нукьталияр чӀявусса нукьтардайх бачин къабюхъай.
+
+circle-change-center-non-numerical = ХӀисаврал кьиматру дакъасса нукьтардайх бавчусса круграл центр даххана баву щаллу дурну дакъар.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциялул областрал измерениярду дурксса дакъар. Областрахь { $intervals } интервал бур, амма функциялухь { $inputs ->
+            [one] { $inputs } инпут
+           *[other] { $inputs } инпут
+        } бур.
+       *[other] Функциялул областрал измерениярду дурксса дакъар. Областрахь { $intervals } интервал бур, амма функциялухь { $inputs ->
+            [one] { $inputs } инпут
+           *[other] { $inputs } инпут
+        } бур.
+    }
+
+function-domain-invalid-format = Функциялул областрал формат къатӀайлассар.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциялул хӀисаврал кьимат дакъасса максимум хӀисав къадуллай бур.
+        [minimum] Функциялул хӀисаврал кьимат дакъасса минимум хӀисав къадуллай бур.
+        [extremum] Функциялул хӀисаврал кьимат дакъасса экстремум хӀисав къадуллай бур.
+        [point] Функциялул хӀисаврал кьимат дакъасса нукьта хӀисав къадуллай бур.
+        [slope] Функциялул хӀисаврал кьимат дакъасса наклон хӀисав къадуллай бур.
+       *[other] Функциялул хӀисаврал кьимат дакъасса { $type } хӀисав къадуллай бур.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциялул бачӀисса максимум хӀисав къадуллай бур.
+        [minimum] Функциялул бачӀисса минимум хӀисав къадуллай бур.
+        [extremum] Функциялул бачӀисса экстремум хӀисав къадуллай бур.
+        [point] Функциялул бачӀисса нукьта хӀисав къадуллай бур.
+       *[other] Функциялул бачӀисса { $type } хӀисав къадуллай бур.
+    }
+
+function-points-too-close = Функциялуву цанналагу гъан-маччасса кӀива нукьта бур. Функция кӀул бан къабюхъай.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функциялул итерациярду функциялул инпутирттал хӀисав аутпутирттал хӀисавравун дархӀуну духьурчакьай хьун бюхъайссар. Ва функциялухь { $inputs } инпут ва { $outputs ->
+            [one] { $outputs } аутпут
+           *[other] { $outputs } аутпут
+        } бур.
+       *[other] Функциялул итерациярду функциялул инпутирттал хӀисав аутпутирттал хӀисавравун дархӀуну духьурчакьай хьун бюхъайссар. Ва функциялухь { $inputs } инпут ва { $outputs ->
+            [one] { $outputs } аутпут
+           *[other] { $outputs } аутпут
+        } бур.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Последовательностьрал лахъишиву къатӀайлассар.  Минус бакъасса щалла хӀисав бикӀан аьркинссар.
+
+sequence-invalid-step = Последовательностьрал шаттира къатӀайлассар.  { $type } тӀисса типрал последовательностьрахлу хӀисав бикӀан аьркинссар.
+
+sequence-invalid-endpoint-number = ХӀисаврал последовательностьрал "{ $attribute }" къатӀайлассар.  ХӀисав бикӀан аьркинссар.
+
+sequence-invalid-endpoint-letters = ХӀарпирттал последовательностьрал "{ $attribute }" къатӀайлассар.  ХӀарпирттал цачӀуншиву бикӀан аьркинссар.
+
+sequence-invalid-endpoint = Последовательностьрал "{ $attribute }" къатӀайлассар.
+
+select-from-sequence-coprime-not-numbers = хӀисаврду язи къадугьлай духьувкун, coprime хӀисав къадуллай бур
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations кӀицӀ бувну духьувкун, coprime хӀисав къадуллай бур
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>`-рал target къатӀайлассар: кӀанттул лякъин къавхьунни.
+
+target-state-variable-not-found = `<{ $source }>`-рал target къатӀайлассар: `<{ $component }>`-рай "{ $property }" тӀисса шартӀирал переменная лякъин къавхьунни.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`-рал переменнарду цала цурда дусса переменнаярая личӀисса бикӀан аьркинссар.
+
+ode-system-duplicate-variable-names = КӀилцӀа кӀицӀ бувсса переменнардал цӀардащал ОДУ-рал ялувсса функциярду кӀул бан къабюхъай.
+
+ode-system-rhs-function-error = ОДУ-рал ялувсса функция кӀул бан къабюхъай.  Mathjs функция буллалийни гъалатӀ хьунни.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } линиялул дянивсса кьутӀи кӀул бан къабюхъай
+
+angle-invalid-through-point = `<angle>`-рал through-рай нукьта къатӀайлассар
+
+parabola-vertex-too-many-points = Вершина дусса парабола ца нукьталияр чӀявусса нукьтардайх бачаву щаллу дурну дакъар.
+
+parabola-too-many-points = 3 нукьталияр чӀявусса нукьтардайх бавчусса парабола щаллу дурну дакъар.
+
+intersection-too-many-items = КӀива затраяр чӀявусса затирттал дянивсса кьутӀаву щаллу дурну дакъар
+
+## Other math components
+
+ionic-compound-not-two-ions = КӀива ионнаяр личӀисса затирттахлу ионнал цачӀуншиву щаллу дурну дакъар.
+
+ionic-compound-needs-cation-and-anion = Ионнал цачӀуншиву щалва ца катионналлий ва ца анионналлий щаллу дурну дур.
+
+solve-equations-cannot-evaluate = Уравнение кӀул бан къавхьуну духьувкун, ми щаллу бан къабюхъай: { $equation }
+
+math-operators-operand-number-required = Математикалул операнд ласлайни operandNumber кӀицӀ бан аьркинссар.
+
+eigen-decomposition-failed = Матрицалул цала кьиматру хӀисав бан къавхьунни
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } тӀисса параметр паттернраву дакъар, мунихлуну ва гьарзаманагу бачӀисса кӀанттуцӀун бавхӀуну бикӀанссар.
+       *[other] `<matchesPattern>`: { $parameters } тӀисса параметрду паттернраву дакъар, мунихлуну ми гьарзаманагу бачӀисса кӀанттуцӀун бавхӀуну бикӀанссар.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" кӀул бан къабюхъай. Ва none, medium, dense я кӀива минус бакъасса хӀисав кӀива-кӀивалухун бивхьуну бикӀан аьркинссар, масала grid="1 0.5". Тор битлай бакъар.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>`-хьхьун { $expected ->
+        [one] ца аутпут, гьарца нукьталий наклон y', масала `y - x`, дусса функция
+       *[other] кӀива аутпут, гьарца нукьталий вектор, масала `(y, -x)`, дусса функция
+    } аьркинссар, амма мунахьхьун дуллусса функциялухь { $found ->
+        [one] { $found } аутпут
+       *[other] { $found } аутпут
+    } бур. { $alternative ->
+        [none] ЦучӀав битлай бакъар.
+       *[other] Му функциялухлу `<{ $alternative }>` бикӀан аьркинссар. ЦучӀав битлай бакъар.
+    }
+
+field-function-attribute-ignored-with-child = `function` тӀисса атрибут хӀисав къадуллай бур, функция компонентрал дянивгу дуллуну духьувкун; дянивмур ишла дуллай бур. Функция кӀивагу кьяйдалий дакъа, щалва ца кьяйдалий дула.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` тӀисса атрибутрал компонентрал дянив цийнува чивчусса выражениялул переменнардал цӀарду кӀицӀ буллай бур. { $reason ->
+        [function-child] Шиккусса функция `<function>` лувсса элементну дуллуну дур, мунил цалва переменнардал цӀарду кӀицӀ буллай дур, мунихлуну `variables` хӀисав къадуллай бур.
+       *[no-expression] Шикку мукунсса выражение дакъар, мунихлуну `variables` хӀисав къадуллай бур.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure рендерданий xLabelPosition="left" щаллу дурну дакъар; right кьяйда ишла дуллай бур.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure рендерданий yLabelPosition="bottom" щаллу дурну дакъар; top кьяйда ишла дуллай бур.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure-райнсса дахханашиннаву осирттал дазурду къатӀайлассар; дефолтсса bbox (-10,-10,10,10) ишла дуллай бур.
+
+prefigure-invalid-width = `<graph>`: prefigure-райнсса дахханашиннаву гьанну къатӀайлассар; дефолтсса диаграммалул гьанну 425 ишла дуллай бур.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure-райнсса дахханашиннаву aspectRatio къатӀайлассар; дефолтсса 1 ишла дуллай бур.
+
+prefigure-grid-spacing-too-fine = `<graph>`: осирттал дазурдахлу торданул дянивсса манзил лап чӀивиссар; prefigure рендерданий тор битлай бакъар.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure рендер ишла къадуллалийни аннотациярду ккаккан къадуллантӀиссар.
+
+multiple-annotations-children = `<graph>`-раву чӀярусса `<annotations>` элементру лявкъунни; яла махъмур бакъа гьарцагу хӀисав къадуллай бур.
+
+## Referring to other components
+
+copy-unrecognized-component-type = КӀул къавхьусса компонентрал тип ласун я даххана дан къабюхъай: { $type }.
+
+copy-prop-not-found = { $component } тӀисса типрал компонентрай { $property } тӀисса проп лякъин къавхьунни
+
+collect-no-source = Collect баншиврул кӀану лявкъуну дакъар.
+
+collect-invalid-component-type = `<{ $component }>` тӀисса типрал компонентру дуртӀун къабюхъай, ва тип къатӀайлану духьувкун.
+
+reference-index-unavailable = `{ $reference }` тӀисса индексрайн ссылка бан къабюхъай
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` тӀисса компонентрай { $action } щаллу бан къабюхъай
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннайл куц къатӀайлассар.  Строкардал лахъишивурду цанналацӀун цанна къадархӀуссар. Лявкъунни componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннайл столбецирттал цӀарду кӀилцӀа кӀицӀ бувну бур.  Лявкъунни componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннайх столбецрал цӀа бакъар.  Лявкъунни componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ва жавабрал award му жавабрал цалва гьан дурсса жавабрайн лавхьхьуну бур, мунихлуну хӀасил дурчӀин къабюхъайсса бикӀантӀиссар.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` дусса контейнердануву бусса `<answer>`-рай `maxNumAttempts` бишаву хӀисаврайн ласлай бакъар, хӀарачатирттал хӀисав контейнерданул ялув бухьувкун. `maxNumAttempts` контейнерданий бишира.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` дусса цамур контейнердануву бусса, `sectionWideCheckWork` дусса контейнерданий `maxNumAttempts` бишаву хӀисаврайн ласлай бакъар, хӀарачатирттал хӀисав кьатӀувсса контейнерданул ялув бухьувкун. `maxNumAttempts` кьатӀувсса контейнерданий бишира.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality бивхьуну бакъа духьурча, { $attributes } тӀисса атрибут хӀисаврайн къаласлантӀиссар.
+       *[other] symbolicEquality бивхьуну бакъа духьурча, { $attributes } тӀисса атрибутру хӀисаврайн къаласлантӀиссар.
+    }
+
+answer-invalid-type = Жавабрал тип къатӀайлассар: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` тӀисса компонентрахь цӀа дакъа духьувкун, ми модульданул атрибутну ишла бан къабюхъай
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` тӀисса компонент модульданул атрибутну ишла бан къабюхъай, `<module>` тӀисса компонентрал типрахь "{ $name }" тӀисса атрибут хьхьичӀавагу бухьувкун.
+
+conditional-content-condition-ignored = case я else лувсса элементру дусса `<conditionalContent>` компонентрай `condition` тӀисса атрибут хӀисав къадуллай бур.
+
+slider-markers-type-mismatch = Маркердал тип слайдердал типрацӀун къадархӀуссар.
+
+pretzel-problem-needs-statement-and-answer = Pretzel къатӀайлассар: гьарца `<problem>`-раву ца `<statement>` ва ца `<answer>` бикӀан аьркинссар.
+
+pretzel-circuit-first-problem-distractor = Pretzel къатӀайлассар: mode="circuit" бухьурча, цалчинмур `<problem>` дистрактор бикӀан къабюхъай.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` тӀисса атрибутрал { $values } тӀисса кьимат къатӀайлассар; хӀисав къадуллай бур.
+       *[other] `{ $attribute }` тӀисса атрибутрал { $values } тӀисса кьиматру къатӀайлассар; хӀисав къадуллай бур.
+    }
+
+attribute-must-be-references = `{ $attribute }` тӀисса атрибутрал `{ $value }` тӀисса кьимат къатӀайлассар. Атрибут `$`-лия байбишлашисса ссылкардая сакин хьуну бикӀан аьркинссар.
+
+math-input-invalid-function-names = <mathInput>: { $attribute }-раву къатӀайласса функциялул цӀарду хӀисав къадурунни: { $names }. Гьарца цӀалул ккаккан байсса бутӀраву яла чӀивимур 2 символ (хӀарпру я дефисру) бикӀан аьркинссар; мунихун `|<mathspeak alternative>` бишин бучӀиссар.
+
+## Building components from the source
+
+component-type-invalid = Компонентрал тип къатӀайлассар: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } тӀисса атрибут кӀилцӀа кӀицӀ бан къабюхъай.
+
+attribute-invalid-for-component = `<{ $componentType }>` тӀисса типрал компонентрахлу "{ $attribute }" тӀисса атрибут къатӀайлассар.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } тӀисса стилданухь { $context ->
+        [text-on-background] текстрал ранг фондалул рангирацӀун
+        [high-contrast] лахъсса контрастрал ранг холстрацӀун
+        [line] линиялул ранг холстрацӀун
+        [marker] маркердал ранг холстрацӀун
+       *[text-on-canvas] текстрал ранг холстрацӀун
+    } дурксса контраст дакъар{ $mode ->
+        [dark] { " (лухӀимур режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яла чӀивимур { $threshold }:1 аьркинссар).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } тӀисса стилданухь кӀяламур режимрахлу дурксса контраст дусса рангру кӀицӀ бувну духьурчагу, ми кьиматирттая ласун дурсса лухӀимур режимрал рангирдахь текстрал ва фондалул дянив дурксса контраст дакъар ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яла чӀивимур { $threshold }:1 аьркинссар). { $suggestion ->
+        [available] ЛухӀимур режимрай контраст дуркссану бикӀаншиврул, я кӀяламур режимрал контраст гьаз бува (масала, { $lightAttribute }="{ $lightColor }" бишира), я лухӀимур режимрал ранг цамунищал даххана бува (масала, { $darkAttribute }="{ $darkColor }" бишира).
+       *[none] ЛухӀимур режимрай контраст дуркссану бикӀаншиврул, кӀяламур режимрал контраст гьаз бува, я ласун дурсса рангру textColorDarkMode ва/я backgroundColorDarkMode-щал даххана бува.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } тӀисса стилданухь кӀяламур режимрахлу дурксса контраст дусса текстрал ранг кӀицӀ бувну духьурчагу, му кьиматрая ласун дурсса лухӀимур режимрал текстрал рангирахь холстрацӀун дурксса контраст дакъар ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яла чӀивимур { $threshold }:1 аьркинссар). { $suggestion ->
+        [available] ЛухӀимур режимрай контраст дуркссану бикӀаншиврул, я кӀяламур режимрал контраст гьаз бува (масала, textColor="{ $lightColor }" бишира), я лухӀимур режимрал ранг цамунищал даххана бува (масала, textColorDarkMode="{ $darkColor }" бишира).
+       *[none] ЛухӀимур режимрай контраст дуркссану бикӀаншиврул, кӀяламур режимрал контраст гьаз бува, я ласун дурсса ранг textColorDarkMode-щал даххана бува.
+    }
+
+section-multiple-style-palettes = Разделданул щалва ца <stylePalette> язи бугьин бюхъайссар; яла махъмур ишла дуллай бур.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, numToSelect минус бакъасса щалла хӀисав бакъа духьувкун.
+
+variant-num-to-select-not-constant-number = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, numToSelect даххана къашайсса хӀисав бакъа духьувкун.
+
+variant-with-replacement-not-constant-boolean = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, withReplacement даххана къашайсса булеан кьимат бакъа духьувкун.
+
+variant-select-weight-disables-unique = selectWeight я selectForVariants кӀицӀ бувсса вариант бухьурча, select-рал хасъсса вариантру лещан дантӀиссар
+
+variant-coprime-undetermined = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, coprime гьарзаманагу къатӀайлассарив кӀул бан къахьувкун.
+
+variant-attribute-not-constant = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, { $attribute } даххана къашайсса кьимат бакъа духьувкун.
+
+variant-attribute-not-number = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, { $attribute } хӀисав бакъа духьувкун.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тӀисса типрал { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, { $attribute } { $expected ->
+        [letters-combination] хӀарпирттал цачӀуншиву
+        [math-expression] тӀайласса математикалул выражение
+        [integer] щалла хӀисав
+       *[number] хӀисав
+    } бакъа духьувкун.
+
+variant-length-not-integer = { $component } тӀисса кӀанттул хасъсса вариантру кӀул бан къабюхъай, length щалла хӀисав бакъа духьувкун.
+
+variant-sort-not-implemented = sort дусса { $component } тӀисса кӀанттул хасъсса вариантру щаллу дурну дакъар
+
+variant-exclude-combinations-not-implemented = excludeCombinations дусса { $component } тӀисса кӀанттул хасъсса вариантру щаллу дурну дакъар
+
+variant-math-exclude-not-implemented = exclude дусса math типрал { $component } тӀисса кӀанттул хасъсса вариантру щаллу дурну дакъар
+
+variant-non-constant-exclude-not-implemented = даххана шайсса exclude дусса { $component } тӀисса кӀанттул хасъсса вариантру щаллу дурну дакъар
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: график prefigure рендерданий щаллу дурну дакъар; лувсса элемент кьабивтунни.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометрия дазу дакъасса я щаллу бакъасса дур; лувсса элемент кьабивтунни.
+
+prefigure-curve-label-omitted = { $subject }: дахханну дурсса кривая элементирттай цӀарду щаллу дурну дакъар; цӀа кьабивтунни.
+
+prefigure-curve-unsupported-definition-type = { $subject }: кривая кӀул баврил '{ $definitionType }' тӀисса тип щаллу дурну дакъар; лувсса элемент кьабивтунни.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-рай flipFunctions тӀисса атрибут щаллу дурну дакъар; лувсса элемент кьабивтунни.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-рай формулалул типрал лувсса функциярду бакъа щаллу дурну дакъар; лувсса элемент кьабивтунни.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] линиялул тайпалул цӀалухлу
+       *[point] нукьталул цӀалухлу
+    } '{ $labelPosition }' тӀисса labelPosition щаллу дурну дакъар; PreFigure-рал дефолтсса кьяйда ишла дурунни.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure-рай '{ $fillStyle }' тӀисса дуцӀаврил стиль щаллу дурну дакъар; дурцӀусса рангирайн бувккунни.
+
+prefigure-line-style-unknown = { $subject }: '{ $lineStyle }' тӀисса линиялул стиль кӀул бан къавхьуну, PreFigure-рал хӀасилрая кьабивтунни.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' тӀисса маркердал стиль PreFigure-рал 'diamond' стилданийн бувккунни.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure-рай '{ $markerStyle }' тӀисса маркердал стиль щаллу дурну дакъар; дефолтсса стиль ишла дурунни.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` къатӀайлассар; кӀану лякъин къабюхълай бур. Аннотация кьабивтунни.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` чӀярусса кӀанттурдайн бавчунни; цалчинмур кӀану ишла дуллай бур.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` къатӀайлассар; кӀану графикрал кьатӀув бур. Аннотация кьабивтунни.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` къатӀайлассар; кӀану prefigure дахханашиннаву щаллу дурсса графикалул зат бакъар. Аннотация кьабивтунни.
+
+annotation-text-missing = `<annotation>`: `text` дакъар я бачӀиссар; бачӀисса текст дуллай бур.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Гуртирал аьлакъа лявкъунни.
+       *[other] `<{ $componentType }>` тӀисса компонент дусса гуртирал аьлакъа лявкъунни.
+    }
+
+reference-no-referent = `{ $reference }` тӀисса ссылкалун кӀану лявкъуну дакъар
+
+reference-multiple-referents = `{ $reference }` тӀисса ссылкалун чӀярусса кӀанттурду лявкъунни
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` тӀисса кӀанттул { $attribute } тӀисса атрибутрал формат къатӀайлассар.
+
+children-invalid = `<{ $componentType }>` тӀисса кӀанттул лувсса элементру къатӀайлассар: къатӀайласса элементру лявкъунни: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` тӀисса атрибутрал `{ $value }` тӀисса кьимат къатӀайлассар, `{ $default }` тӀисса кьимат ишла дуллай бур
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML-рал { $version } версия лявкъуну дакъар.
+       *[other] DoenetML-рал { $version } версия лявкъуну дакъар. { $fallback } версиялийн бувккунни
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML къатӀайлассар: { $content }
+
+parse-tag-missing-close-tag = DoenetML къатӀайлассар: `{ $tag }` тӀисса тегърахь лакьлакьисса тег дакъар. Цийнува лакьлакьисса тег я `</{ $tagName }>` тӀисса тег бикӀан аьркинссар.
+
+parse-tag-error = DoenetML къатӀайлассар: `<{ $tagName }>` тӀисса тегъраву гъалатӀ бур
+
+parse-attribute-missing-value = DoenetML къатӀайлассар: `{ $attribute }` тӀисса къатӀайласса атрибутрахь кьимат дакъасса кунма бур.
+
+parse-attribute-invalid = DoenetML къатӀайлассар: `{ $attribute }` тӀисса атрибут къатӀайлассар
+
+parse-attribute-value-invalid = DoenetML къатӀайлассар: `{ $value }` тӀисса атрибутрал кьимат къатӀайлассар
+
+parse-attribute-value-quote-mismatch = DoenetML къатӀайлассар: `{ $value }` тӀисса атрибутрал кьимат къатӀайлассар. Кавычкарду цанналацӀун цанна къадархӀуссар. Вихь `{ $quote }` дакъасса кунма бур
+
+parse-open-tag-name-missing = DoenetML къатӀайлассар: цӀа дакъасса тег лявкъунни, масала `<`
+
+parse-tag-not-closed = DoenetML къатӀайлассар: `{ $tag }` тӀисса тег лавкьуну дакъар (`>` дакъасса кунма бур).
+
+parse-self-closing-tag-name-missing = DoenetML къатӀайлассар: цӀа дакъасса тег лявкъунни `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML къатӀайлассар: `{ $tag }` тӀисса тег лавкьуну дакъар (`/>` дакъасса кунма бур).
+
+parse-tag-invalid-attributes = DoenetML къатӀайлассар: `{ $tag }` тӀисса тег къатӀайлассар. Мунил атрибутру къатӀайлассарив ххал бува.
+
+parse-close-tag-name-missing = DoenetML къатӀайлассар: цӀа дакъасса лакьлакьисса тег лявкъунни, масала `</`
+
+parse-attribute-value-unquoted = Атрибутирттал кьиматру кавычкардаву бикӀан аьркинссар: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML къатӀайлассар: `{ $tag }` тӀисса лакьлакьисса тег лявкъунни, амма муницӀун бавхӀусса тӀитӀлатӀисса тег дакъар
+
+parse-close-tag-mismatched = DoenetML къатӀайлассар: лакьлакьисса тег дархӀуну дакъар. `</{ $expected }>` бикӀан аьркинссия. `{ $found }` лявкъунни
+
+parser-node-unconvertible = { $node } тӀисса узел Dast узелданийн дахханна бан къавхьунни.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' тӀисса атрибут къатӀайлассар. { $reason ->
+        [characters] ЦӀардаву хӀарпру, хӀисаврду, лувсса чӀапӀирду я дефисру бакъа бикӀан къабюхъай.
+       *[start] ЦӀарду хӀарпирая байбишин аьркинссар.
+    }
+
+component-name-invalid-start = "{ $name }" тӀисса компонентрал цӀа къатӀайлассар. ЦӀарду хӀарпирая байбишин аьркинссар.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched типрал жавабрахь video тӀисса атрибут бикӀан аьркинссар
+
+answer-video-watched-video-not-reference = videoWatched типрал жавабрал video тӀисса атрибут ссылка бикӀан аьркинссар
+
+answer-name-not-single-text = Жавабрал name тӀисса атрибутрахь щалва ца лувсса текст бикӀан аьркинссар
+
+## Referencing another document
+
+external-doenetml-recursion-limit = КьатӀувсса DoenetML ласун къавхьунни, лап чӀявусса даражалул рекурсия духьувкун. Гуртирал ссылка дакъарив?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" тӀисса кӀанттая DoenetML ласун къавхьунни
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" тӀисса кӀанттая ласурсса DoenetML къатӀайлассар: ми "{ $componentType }" тӀисса компонентрал типрацӀун къадархӀуссар
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` тӀисса атрибут ишла къадуллалиссар; мунил кӀанттай `{ $to }` бишира.
+       *[other] [deprecation] `<{ $component }>`-рай `{ $from }` тӀисса атрибут ишла къадуллалиссар; мунил кӀанттай `{ $to }` бишира.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` тӀисса атрибут ишла къадуллалиссар ва хӀисав къадуллай бур, `{ $to }` цигу кӀицӀ бувну духьувкун.
+       *[other] [deprecation] `<{ $component }>`-рай `{ $from }` тӀисса атрибут ишла къадуллалиссар ва хӀисав къадуллай бур, `{ $to }` цигу кӀицӀ бувну духьувкун.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-рай `{ $attribute }` тӀисса атрибут ишла къадуллалиссар ва хӀисав къадуллай бур.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-рай `{ $attribute }` тӀисса атрибут ишла къадуллалиссар; мунил кӀанттай `<{ $child }>` тӀисса лувсса элемент бишира.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-рай `{ $attribute }` тӀисса атрибутрал `{ $value }` тӀисса кьимат ишла къадуллалиссар; мунил кӀанттай `{ $to }` бишира.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>`-хьхьун ингилис мазрайсса мукъурттил чӀявушиврул форма бакъа бан къабюхъай, мунихлуну { $locale } мазрай чивчусса документраву мунил текст даххана къадурну бур. ЧӀявушиврул форма цийнува чичара, я `pluralForm` тӀисса атрибутрай бишира.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` тӀисса элемент Doenet-рал кӀулсса элемент бакъассар.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` тӀисса элемент документрал ххяххиялий бикӀан бучӀи бакъассар.
+
+schema-element-not-allowed-inside = `<{ $tag }>` тӀисса элемент `<{ $parent }>`-рал дянив бикӀан бучӀи бакъассар.
+
+schema-attribute-unrecognized = `<{ $tag }>` тӀисса элементрахь `{ $attribute }` тӀисса атрибут дакъар.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` тӀисса элементрал `{ $attribute }` тӀисса атрибут список бикӀан аьркинссар, мунил гьарца бутӀа шивува кӀицӀ бувмуния ца бикӀан аьркинссар: { $allowed }
+       *[other] `<{ $tag }>` тӀисса элементрал `{ $attribute }` тӀисса атрибут шивува кӀицӀ бувмуния ца бикӀан аьркинссар: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select-рал вариантрал цӀа къатӀайлассар.  { $variantName } тӀисса вариантрал цӀа { $numOptions } вариантраву дур, амма язи бугьин аьркинмур хӀисав { $numToSelect } бур.
+
+select-variant-name-without-options = Select-рахлу цаппара вариантру кӀицӀ бувну бур, амма { $variantName } тӀисса вариантрал цӀалухлу цукунчӀавсса вариант кӀицӀ бувну бакъар.
+
+select-variant-name-not-possible = Select-рахлу кӀицӀ бувсса { $variantName } тӀисса вариантрал цӀа бикӀан бюхъайсса цӀа бакъассар.
+
+select-too-few-options = Щалва { $numOptions } компонентрая { $numToSelect } компонент язи бугьин къабюхъай.
+
+select-from-sequence-too-few-values = Лахъишиву { $length } дусса последовательностьрая { $numToSelect } кьимат язи бугьин къабюхъай.
+
+select-from-sequence-indices-count-mismatch = Select-рахлу кӀицӀ бувсса индексирттал хӀисав язи бугьин аьркинсса хӀисаврацӀун дархӀуну бикӀан аьркинссар
+
+select-from-sequence-indices-not-integers = Select-рахлу кӀицӀ бувсса гьарца индексру щалла хӀисаврду бикӀан аьркинссар
+
+select-from-sequence-index-excluded = Selectfromsequence-рал кӀицӀ бувсса индекс кьабивтсса индекс бивкӀссар
+
+select-from-sequence-indices-excluded-combination = Selectfromsequence-рал кӀицӀ бувсса индексру кьабивтсса цачӀуншиву бивкӀссар
+
+select-from-sequence-coprime-not-positive-integers = Плюсрал щалла хӀисаврду язи къадугьлай духьувкун, coprime цачӀуншивурду язи бугьин къабюхъай.
+
+select-from-sequence-coprime-common-factor = Coprime хӀисаврду язи бугьин къабюхъай. БикӀан бюхъайсса гьарца кьиматирттахь ца уртакьсса множитель бур. ("from" я "to" тӀисса кӀицӀ бувсса кьиматру "step"-рацӀун coprime бикӀан аьркинссар.)
+
+select-from-sequence-coprime-single-number = 1 бакъасса ца хӀисаврая coprime цачӀуншивурду язи бугьин къабюхъай.
+
+select-from-sequence-excluded-too-many-combinations = SelectFromSequence-рай цачӀуншивурттал 70%-я ххишала кьабивтунни
+
+select-from-sequence-coprime-none-found = Coprime хӀисаврду язи бугьин къавхьунни. БикӀан бюхъайсса гьарца кьиматирттахь ца уртакьсса множитель бур.
+
+select-from-sequence-too-few-unique-values = Лахъишиву { $numPossibleValues } дусса последовательностьрая { $numToSelect } хасъсса кьимат язи бугьин къабюхъай
+
+select-prime-numbers-too-few-values = Лахъишиву { $numValues } дусса ца ялун къабячайсса хӀисаврдал спискалия { $numToSelect } кьимат язи бугьин къабюхъай
+
+select-prime-numbers-values-count-mismatch = Select-рахлу кӀицӀ бувсса кьиматирттал хӀисав язи бугьин аьркинсса хӀисаврацӀун дархӀуну бикӀан аьркинссар
+
+select-prime-numbers-values-not-prime = Select prime number-рахлу кӀицӀ бувсса гьарца кьиматру ца ялун къабячайсса хӀисаврдал спискалуву бикӀан аьркинссар
+
+select-prime-numbers-values-excluded-combination = SelectPrimeNumbers-рал кӀицӀ бувсса кьиматру кьабивтсса цачӀуншиву бивкӀссар
+
+select-prime-numbers-excluded-too-many-combinations = SelectPrimeNumbers-рай цачӀуншивурттал 70%-я ххишала кьабивтунни
+
+select-random-combination-fluke = Лап чансса тӀайлабацӀулул сававрай, гьаксса кьиматирттал цачӀуншиву язи бугьин къавхьунни
+
+select-random-value-fluke = Лап чансса тӀайлабацӀулул сававрай, гьаксса кьимат язи бугьин къавхьунни

--- a/packages/i18n/locales/lbe/editor.ftl
+++ b/packages/i18n/locales/lbe/editor.ftl
@@ -1,0 +1,192 @@
+# Lak editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Lak in Cyrillic with the palochka, the orthography of Dagestan's schools and
+# of the Lak-language press. Ӏ is a letter, not a Latin I and not a digit 1.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers rather than prose and stay exactly as written.
+#
+# Lak resolves the same two plural categories English does, so every count
+# below keeps both branches. A noun after a numeral stays singular in Lak, so
+# the two branches read alike; that is correct rather than an unfinished
+# translation.
+#
+# Nothing here agrees with a noun class. Lak's four-class system is real, and
+# where it would reach this package is `content.ftl` — whose header explains
+# why that file does not fork on it either.
+#
+# The panel vocabulary is the weakest part of this file. Lak-language writing
+# about software is very small, so «хьхьичӀава кӀицӀ» for a warning, «бигьану
+# ишла баву» for accessibility and «хӀадур баву» for formatting are coinages
+# this seed chose to be transparent rather than terms it found in use. A
+# speaker should check those first.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Зана бан
+       *[update] ЦӀудуккан дан
+    }
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Ккаккаву { $word }
+       *[other] Ккаккаву { $word } { $shortcut }
+    }
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Личлачаву…
+editor-variant-next = Махъмур вариант язи бугьин
+editor-variant-previous = ХьхьичӀмур вариант язи бугьин
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA бигьану ишла баврил тӀалавшин лиян дурну дур. Бигьану ишла баврил отчёт { $action ->
+            [close] лакьин
+           *[open] тӀитӀин
+        } щелк бува.
+        [advisories] Бигьану ишла баврил отчёт { $action ->
+            [close] лакьин
+           *[open] тӀитӀин
+        } щелк бува. WCAG AA лиян даву лявкъуну дакъар, амма бигьану ишла баврил цаймигу маслихӀатру бур.
+       *[clean] Бигьану ишла баврил отчёт { $action ->
+            [close] лакьин
+           *[open] тӀитӀин
+        } щелк бува. Бигьану ишла баврил цукунчӀавсса захӀматшиву лявкъуну дакъар.
+    }
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA бигьану ишла баврил тӀалавшин лиян дурну дур. { $count ->
+            [one] WCAG AA { $count } лиян даву
+           *[other] WCAG AA { $count } лиян даву
+        } лявкъунни. Бигьану ишла баврил отчёт { $action ->
+            [close] лакьин
+           *[open] тӀитӀин
+        } щелк бува.
+        [advisories] WCAG AA лиян даву лявкъуну дакъар. Бигьану ишла баврил { $count ->
+            [one] цаймигу { $count } маслихӀат
+           *[other] цаймигу { $count } маслихӀат
+        } лявкъунни. Бигьану ишла баврил отчёт { $action ->
+            [close] лакьин
+           *[open] тӀитӀин
+        } щелк бува.
+       *[clean] WCAG AA лиян даву лявкъуну дакъар. Бигьану ишла баврил отчёт { $action ->
+            [close] лакьин
+           *[open] тӀитӀин
+        } щелк бува.
+    }
+editor-accessibility-badge = WCAG
+
+## The footer
+
+editor-version-title = DoenetML версия { $version }
+editor-tab-help = КӀанттуцӀун бавхӀусса кумаг
+editor-tab-help-short = Кумаг
+editor-tab-errors = ГъалатӀру
+editor-tab-warnings = ХьхьичӀава кӀицӀру
+editor-tab-info = Хаварду
+editor-tab-accessibility = Бигьану ишла баву
+editor-tab-responses = Гьан дурсса жавабру
+editor-tab-with-count = { $label }: { $count }
+editor-options = Редакторданул параметрду
+editor-format-as-doenetml = DoenetML куццуй хӀадур бан
+editor-format-as-xml = XML куццуй хӀадур бан
+
+## The diagnostics panel
+
+editor-diagnostic-line = Строка #{ $line }
+editor-no-errors = ГъалатӀру дакъар
+editor-no-warnings = ХьхьичӀава кӀицӀру дакъар
+editor-no-info = Хаварду дакъар
+editor-show-info-annotations = Редакторданий хаварду ккаккан бан
+editor-show-accessibility-annotations = Редакторданий бигьану ишла баврил кӀицӀру ккаккан бан
+editor-accessibility-learn-more = Doenet бигьану ишла баврихун цукун бучӀайссарив лахьхьу
+editor-accessibility-violations-heading = Бигьану ишла баврил лиян даврду ({ $standard })
+editor-accessibility-other-heading = Бигьану ишла баврил цаймигу захӀматшивурду
+editor-none-found = Лявкъуну дакъар
+
+## Submitted responses
+
+editor-no-responses = Гьан дурсса жавабру хӀаллихшиннайн дакъар
+editor-response-answer-id = Жавабрал ид
+editor-response-response = Жаваб
+editor-response-credit = Балл
+editor-response-submitted = Гьан дурну
+
+## The context-help panel
+
+help-placeholder = Документация ккаккан бан курсор тегърал цӀанийн, атрибутрайн я { $ref } тӀисса кӀанттайн бишира.
+help-unsupported-ref-chain = { $example } кунмасса чӀярусса бутӀайх бавчусса ссылкардан кумаг хӀаллихшиннайн дакъар.
+help-unresolved-ref =
+    { $reason ->
+        [notFound] { $ref } тӀисса ссылкалун ци кӀицӀ бувссарив лявкъуну дакъар.
+        [multiple] { $ref } тӀисса ссылкалун чӀярусса кӀанттурду лявкъунни.
+       *[indeterminate] { $ref } тӀисса ссылкалун ци кӀицӀ бувссарив кӀул бан къавхьунни.
+    }
+help-learn-about-references = Ссылкардая лахьхьу →
+help-reference-page = Справкалул чӀапӀи →
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } дуссаксса
+       *[top] Яла лахъмур даражалий
+    }{ $allowed ->
+        [none] { " — ва кӀанттай цучӀав къабагьай." }
+        [text] { " — ва кӀанттай текст чичара." }
+        [text-and-components] { " — ва кӀанттай текст чичара, я ххал бува:" }
+       *[components] { " — ххал бансса затру:" }
+    }
+help-suggestions-footer = Гьарца { $total } компонент ккаккан бан { $shortcut } бишира.
+help-name-summary = { $name } — { $summary }
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } тӀисса кӀанттайн бавчусса ссылка.
+       *[other] { $ref } — { $target } тӀисса кӀанттайн бавчусса ссылка ({ $line } строка).
+    }
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } тӀисса кӀанттай { $role } хӀисаврай бивхьуссар.
+       *[other] { $owner } тӀисса кӀанттай { $line } строкалий { $role } хӀисаврай бивхьуссар.
+    }
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } тӀисса кӀанттул { $property } свойстволийн бавчусса ссылка.
+       *[other] { $ref } — { $element } тӀисса кӀанттул { $property } свойстволийн бавчусса ссылка ({ $line } строка).
+    }
+help-kind-attribute = атрибут
+help-kind-snippet = сниппет
+help-kind-array-entry = массивраву бивхьумур
+help-default = Дефолт:
+help-active-default = Даврий дусса дефолт:
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+help-allowed-values =
+    { $perItem ->
+        [true] Ихтияр дусса кьиматру (гьарца бутӀлун ца):
+       *[other] Ихтияр дусса кьиматру:
+    }
+help-suggested-values = МаслихӀат бувсса кьиматру:
+help-inserts = Бишлашиссар:
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатру:
+    }
+help-type = Тип:
+help-resolved-style = КӀул бувсса стиль (styleNumber { $styleNumber }):
+help-resolved-function-names = КӀул бувсса функциярттал цӀарду:
+help-reset-list = Ва инпутрай список зана баву:
+help-added-on-input = Ва инпутрай бивхьумур:
+help-removed-on-input = Ва инпутрай дуккан дурмур:
+help-reset-overrides = { $reset } { $additional } ва { $removed } ххишалану бишлашиссар.

--- a/packages/i18n/locales/lez/chrome.ftl
+++ b/packages/i18n/locales/lez/chrome.ftl
@@ -1,0 +1,145 @@
+# Lezgian viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography Dagestan's schools, its newspapers and
+# its book publishing have used since 1938, which is also what CLDR fills a
+# bare `lez` in as (`lez` maximizes to `lez-Cyrl-RU`). Lezgian is also spoken
+# across the border in the Qusar, Qəbələ and Ismayıllı districts of Azerbaijan,
+# where the same language is written in the Latin alphabet; this catalog is the
+# Cyrillic standard, and a Latin-script Lezgian catalog would be a second
+# catalog rather than an edit to this one. CLDR's English name for the language
+# is **Lezghian**; it is more usually called Lezgian or Lezgi in English, and
+# «лезги чӀал» in the language itself.
+#
+# The palochka Ӏ is a letter of the alphabet. It is not a Latin capital I and
+# not the digit 1; «гъалатӀ» spelled with either has quietly stopped being a
+# Lezgian word.
+#
+# Lezgian counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gives it. A noun after a
+# numeral stays in the singular — «3 алахъун», not a plural — so the two
+# branches differ in nothing but the number they print. The explicit `[0]`
+# branch English writes is kept, because Lezgian says «алахъунар амач» there
+# rather than counting to zero.
+#
+# **Lezgian has no noun classes and no grammatical gender**, unlike every one
+# of its Northeast Caucasian neighbours seeded beside it. See `content.ftl`,
+# where that fact is set out and where `noun-gender` returns a single token.
+# Nothing in this file agrees with anything.
+#
+# Where an English preposition would land on a placeable, the Lezgian case
+# suffix is put on a word this catalog writes instead — see
+# `answer-show-responses` and `summary-statistics-caption` below, both of which
+# name what the value is («… тӀвар алай суал», «… тӀвар алай столбец») rather
+# than welding -диз or -дин onto it.
+
+
+## Answer submission
+
+answer-checking = Ахтармишзава…
+answer-submitting = Ракъурзава…
+answer-checking-status = Жаваб ахтармишзава
+answer-submitting-status = Жаваб ракъурзава
+answer-correct = Дуьз
+answer-incorrect = Дуьз туш
+answer-response-saved = Жаваб хвена
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% дуьз
+answer-percent-short = { $percent } %
+max-credit-available = Къачуз жедай виридалайни гзаф балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] алахъунар амач
+        [one] { $count } алахъун ама
+       *[other] { $count } алахъун ама
+    }
+validation-correct = (Дуьз)
+validation-incorrect = (Дуьз туш)
+validation-partially-correct = (Са пай дуьз)
+# «-диз» is a dative and cannot sit on a placeable, so the message names what
+# the value is and puts the case on «суал», a word written here.
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } тӀвар алай суалдиз гайи { $count } жаваб къалура
+       *[other] { $answerId } тӀвар алай суалдиз гайи { $count } жаваб къалура
+    }
+
+## Disclosure panels
+
+feedback-heading = Къейдер
+collapsible-click-to-open = (ахъаюн патал тӀуша)
+collapsible-click-to-close = (агалун патал тӀуша)
+collapsible-initializing = Гьазурзава…
+footnote-show = КӀаник авай къейд къалура
+footnote-hide = КӀаник авай къейд чуьнуьха
+description-more-information = артух малумат
+
+## Controls
+
+slider-previous = Вилик
+slider-next = Гуьгъуьнин
+keyboard-open = Клавиатура ахъая
+keyboard-close = Клавиатура агала
+choice-input-remove-choice = { $choice } алуда
+matrix-remove-row = ЦӀар алуда
+matrix-add-row = ЦӀар алава ая
+matrix-remove-column = Столбец алуда
+matrix-add-column = Столбец алава ая
+subset-add-remove-points = Нукьтаяр алава ая/алуда
+subset-toggle-points-intervals = Нукьтаяр ва интервалар дегишара
+subset-move-points = Нукьтаяр юзура
+subset-clear = Михьа
+orbital-add-row = ЦӀар алава ая
+orbital-remove-row = ЦӀар алуда
+orbital-add-box = Клетка алава ая
+orbital-remove-box = Клетка алуда
+orbital-add-up-arrow = Виниз стрелка алава ая
+orbital-add-down-arrow = Агъуз стрелка алава ая
+orbital-remove-arrow = Стрелка алуда
+# «лагьай» is a free word and forms the ordinal after a numeral, so nothing is
+# welded to the placeable here.
+orbital-row-label = { $row } лагьай цӀарцӀин тӀвар
+pretzel-answer = Жаваб
+# The genitive «-дин» would have to sit on `{ $column }`, so the column is
+# named instead and the case falls on «столбец».
+summary-statistics-caption = { $column } тӀвар алай столбецдин уьмуми статистика
+
+## Math input
+
+math-input-preview-region = математикадин ибарадин вилик квай килигун
+math-input-preview = Вилик квай килигун
+math-input-invalid-expression = Дуьз тушир ибара:
+
+## Document status
+
+viewer-initializing = Гьазурзава…
+
+## Errors
+
+error-heading = ГъалатӀ
+error-found-at =
+    { $span ->
+        [line] { $startLine } лагьай цӀарал жагъана.
+       *[lines] { $startLine }–{ $endLine } лагьай цӀарарал жагъана.
+    }
+document-contains-errors = И документда гъалатӀар ава!
+diagnostic-heading-error = ГъалатӀ
+diagnostic-heading-warning = Хабардарвал
+diagnostic-heading-information = Малумат
+diagnostic-heading-hint = Ишара
+accessibility-heading-level-1 = WCAG AA агакьунвилин къайда чӀурун
+accessibility-heading-level-2 = Агакьунвилин хабардарвал
+something-went-wrong = Са затӀ дуьз хьанач.
+renderer-load-failed = къалурдайди эхцигиз хьанач. Чин цӀийи хъия.
+core-start-failed = И документ кардик кутаз хьанач. Чин цӀийи хъия.
+core-start-failed-busy = И документ кардик кутаз хьанач. Са вахтунда гзаф документ кардик акатзавай, им зайиф аппаратда мадни яваш физвай кар я. Муькуь документар куьтягь хьайила чин цӀийи хъувуни куьмек гуз жеда.
+core-start-failed-retry = И документ кардик кутаз хьанач.
+core-start-failed-busy-retry = И документ кардик кутаз хьанач. Са вахтунда гзаф документ кардик акатзавай, им зайиф аппаратда мадни яваш физвай кар я.
+core-start-retry = Мад сеферда алахъа
+saved-state-unavailable = Ви хвенвай кӀвалах хкиз хьанач.

--- a/packages/i18n/locales/lez/content.ftl
+++ b/packages/i18n/locales/lez/content.ftl
@@ -1,0 +1,277 @@
+# Lezgian content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of 1938, which Dagestan's schools, its
+# Lezgian-language press and its book publishing use, and which is what CLDR
+# fills a bare `lez` in as (`lez` → `lez-Cyrl-RU`). The palochka Ӏ is a letter:
+# not a Latin capital I, not the digit 1. Lezgian written in Azerbaijan uses
+# the Latin alphabet for the same language; that would be a second catalog, not
+# an edit to this one.
+#
+# **LEZGIAN IS THE NORTHEAST CAUCASIAN LANGUAGE THAT LOST ITS NOUN CLASSES, AND
+# THAT IS THE FACT WORTH READING HERE.** Avar, Dargwa, Lak and Tabasaran —
+# seeded in the same batch, and all of them relatives — agree a word with the
+# class of the noun it describes; Lezgian does not, and neither does the rest
+# of its own Lezgic sub-branch. There is no grammatical gender, no class
+# prefix, no class agreement of any kind: the whole system was lost before the
+# modern language. So `noun-gender` below returns one token for every noun and
+# **nothing in this catalog forks on `$gender` or on `$role`** — the shape
+# `locales/ba` and `locales/ktu` have, reached from inside a family where a
+# reader would expect the opposite. A fork appearing in this file later is an
+# error, not an improvement.
+#
+# **Attributive adjectives precede the noun in Lezgian and do not inflect**, so
+# the composition messages below keep the order English gives them: width, dash
+# pattern, colour, then the noun. An attributive adjective takes no case ending
+# either — case falls on the last word of the noun phrase — which is the other
+# half of why `$role` goes unused.
+#
+# Lezgian has a very large case system (an ergative, a genitive, a dative and
+# some fourteen locative cases). None of those suffixes may be welded to a
+# placeable, so every message that would want one puts the ending on a word
+# this catalog writes instead: `style-border-clause` says «{ $border } къерех
+# авай» — "having a … edge" — rather than putting a comitative on the border
+# description, and `style-text` puts the locative on «фон». Both are recorded
+# beside their messages below.
+#
+# **What this seed is least sure of is the vocabulary, not the grammar.**
+# Lezgian mathematics is taught and written in Russian, so a settled Lezgian
+# word for several of the shapes below does not exist to be looked up; where
+# that is so, the Russian term is written («отрезок», «луч», «кривая»,
+# «ломаная», «парабола»), which is what a Lezgian pupil actually meets, and
+# where a Lezgian formation is well established it is used («пудпипӀ»,
+# «гзафпипӀ», «нукьта», «чин»). The colour list is the second weak spot: the
+# grey, orange, pink and brown terms below lean on Azerbaijani loans that are
+# ordinary in speech but are not fixed in the dictionaries this seed could
+# check. A speaker should read the `color`, `noun` and `fill-style` tables
+# first.
+
+
+## Style vocabulary
+##
+## No word here inflects for the noun it describes, and all of them stand in
+## front of it.
+
+color =
+    .black = чӀулав
+    .white = лацу
+    .gray = боз
+    .red = яру
+    .orange = нарнжи
+    .yellow = хъипи
+    .green = къацу
+    .cyan = экуь вили
+    .blue = вили
+    .purple = мор
+    .pink = чагьрайи
+    .brown = къумрал
+line-width =
+    .thick = яцӀу
+    .thin = назук
+line-style =
+    .dashed = атӀай
+    .dotted = нукьтаяр алай
+# Noun phrases: the composition messages put «алай» — "on it" — after them, so
+# they stand on their own and modify nothing.
+fill-style =
+    .horizontal = горизонтал цӀарар
+    .vertical = вертикал цӀарар
+    .diagonal = диагонал цӀарар
+    .backdiagonal = эксина диагонал цӀарар
+    .dots = нукьтаяр
+    .diamonds = ромбаяр
+noun =
+    .line = дуьз цӀар
+    .line-segment = отрезок
+    .ray = луч
+    .vector = вектор
+    .curve = кривая
+    .function = функция
+    .slope-field = наклондин поле
+    .vector-field = векторрин поле
+    .parabola = парабола
+    .polyline = ломаная
+    .polygon = гзафпипӀ
+    .triangle = пудпипӀ
+    .rectangle = дуьзпипӀ
+    .circle = гьалкъа
+    .region = чка
+    .point = нукьта
+    .square = квадрат
+    .diamond = ромб
+    .cross = хаш
+    .plus = плюс
+# Lezgian says "a regular polygon having N sides" and keeps the whole of it in
+# front of the noun, so there is one head and no tail. «пад» stays singular
+# after the numeral, and «авай» is a free participle — nothing is welded to
+# `{ $numSides }`.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } пад авай дуьз гзафпипӀ
+    }
+# Lezgian has no noun classes and no grammatical gender, so every noun answers
+# the same and no message below selects on the answer. See the note at the top
+# of this file: the loss of the class system is what separates Lezgian from its
+# Avar, Dargwa, Lak and Tabasaran neighbours.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = ацӀурнавай
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } алай { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } алай { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } алай { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «къерех авай» — "having an edge" — carries the whole of English's "with a …
+# border" in a participle that follows the catalog's own noun, so no case
+# ending goes anywhere near `{ $border }` and no article is wanted. The four
+# branches differ only by the connective «ва», which Lezgian needs and English
+# spells as "and".
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } къерех авай
+        [and] ва { $border } къерех авай
+        [and-article] ва { $border } къерех авай
+       *[with] { $border } къерех авай
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } алай { $color } ранг
+       *[plain] { $color } ранг
+    }
+style-unfilled = ацӀурнавачир
+# «фондал» is the locative of «фон» and says "on the background" by itself, so
+# the two colours stand one after the other with no preposition between them
+# and nothing attached to either placeable.
+style-text =
+    { $parts ->
+        [background] { $background } фондал { $color }
+       *[plain] { $color }
+    }
+style-background-none = авач
+
+## Boolean words
+
+boolean-true = дуьз
+boolean-false = дуьз туш
+
+## Answer buttons
+
+answer-submit-label = Ахтармишун
+answer-submit-label-no-correctness = Жаваб ракъурун
+
+## Sectional blocks
+
+section-name =
+    .activity = Кар
+    .aside = Къвалан къейд
+    .cascade = Каскад
+    .definition = Тайинарун
+    .example = Мисал
+    .exercise = Упражнение
+    .exercises = Упражненияр
+    .given-answer = Жаваб
+    .note = Къейд
+    .objectives = Метлебар
+    .paragraphs = Абзацар
+    .part = Пай
+    .problem = Месэла
+    .problems = Месэлаяр
+    .proof = Субут
+    .question = Суал
+    .section = Кьил
+    .solution = Гьялун
+    .task = Тапшуругъ
+    .theorem = Теорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Меслят
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Шикил { $enumeration }
+        [numbered-caption] Шикил { $enumeration }{ ". " }
+        [unnumbered-caption] Шикил{ ". " }
+       *[unnumbered] Шикил
+    }
+
+## Paginator controls
+
+paginator-previous = Вилик квайди
+paginator-next = Гуьгъуьнинди
+paginator-page = Чин
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## Lezgian's own conditional is a suffix, -тӀа, on the verb that closes the
+## protasis — which this key could not reach, since the renderer places it in
+## front of the mathematics rather than behind it. What is written here is
+## «эгер», the borrowed clause-initial particle that ordinarily accompanies
+## that suffix and is perfectly usual in written Lezgian, so this key lands
+## where the renderer puts it and needs none of the caveat `locales/sah`,
+## `locales/tyv`, `locales/udm`, `locales/kv` and `locales/chm` record.
+
+piecewise-condition-or = ва я
+piecewise-condition-if = эгер
+piecewise-condition-otherwise = тахьайтӀа
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry is not taught in Lezgian
+## anywhere it is spoken, and the two halves of the language are schooled in
+## two different languages: in Dagestan the subject is taught in Russian, and
+## in the Lezgian-speaking districts of northern Azerbaijan it is taught in
+## Azerbaijani. So there is no one curriculum for a fallback to match, the
+## situation `locales/lom` and `locales/mnk` already record for a border of
+## their own, and inventing 118 Lezgian element names would serve neither side
+## of this one. The English fallback stands nearer the textbook than a coinage
+## would.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Дуьз тушир химиядин лишан
+chemistry-invalid-ionic-compound = Дуьз тушир иондин кутӀунвал

--- a/packages/i18n/locales/lez/diagnostics.ftl
+++ b/packages/i18n/locales/lez/diagnostics.ftl
@@ -1,0 +1,700 @@
+# Lezgian diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Cyrillic, the 1938 orthography Dagestan's schools, press and publishing use,
+# and what CLDR fills a bare `lez` in as. The palochka Ӏ is a letter, not a
+# Latin I and not a digit 1.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Lezgian has no noun classes and no grammatical gender, so nothing here forks
+# on `$gender`; the reason that is worth saying out loud in a Northeast
+# Caucasian catalog is written out in `content.ftl`. The plural categories are
+# `one` and `other`, and a noun after a numeral stays singular, so the two
+# branches of every count read alike apart from the number.
+#
+# Lezgian's case endings cannot be welded to a placeable, and this file needs
+# one constantly: almost every message names a component, an attribute or a
+# value that arrives as an argument and would want a genitive, a dative or one
+# of the locatives on it. The way out throughout is the first one the README
+# lists — **name what the value is** — so the ending falls on a noun this
+# catalog writes: «`<{ $component }>` компонентдихъ …», «{ $column } тӀвар алай
+# столбец», «{ $attribute } атрибутда», «{ $attribute }="{ $uri }" адресдай».
+# A reviewer who deletes one of those nouns has to put the case somewhere else,
+# not onto the placeable.
+#
+# The technical vocabulary is Russian, because that is what a Lezgian speaker
+# who studied mathematics or computing studied it in: «компонент», «атрибут»,
+# «функция», «индекс», «переменная», «последовательность», «матрица». Words
+# that are ordinary prose are Lezgian. «велед» for a child component and
+# «агакьунвал» for accessibility are this seed's own coinages, and are the two
+# terms a speaker is most likely to want to replace.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кьве кьилин нукьта къалурнавайла { $attributes } гьисаба кьазвач
+       *[other] кьве кьилин нукьта къалурнавайла { $attributes } гьисаба кьазвач
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] кьилин нукьта ва юкьван нукьта кьведни къалурнавайла { $attributes } гьисаба кьазвач
+       *[other] кьилин нукьта ва юкьван нукьта кьведни къалурнавайла { $attributes } гьисаба кьазвач
+    }
+
+line-segment-midpoint-offset-without-midpoint = юкьван нукьта авачиз midpointOffset кардик акатзавач
+
+## `<line>`
+
+line-points-undetermined-dimensions = Тайин тушир измерениер авай нукьтайрай физвай дуьз цӀар.
+
+line-points-too-few-dimensions = Дуьз цӀар кьве ва я мадни гзаф измерение авай нукьтайрай фин лазим я.
+
+line-points-depend-on-variables = Дуьз цӀар переменнайрилай аслу тир нукьтайрай физва: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ва { $variable2 } переменнаяр авай дуьз цӀарцӀин уравненидин формат дуьз туш.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint ва direction атрибутри тайинарнава. Къалурнавай through гьисаба кьазвач.
+
+ray-dimension-mismatch = Лучда numDimensions кьазвач.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ва displacement атрибутри тайинарнава. Къалурнавай head гьисаба кьазвач.
+
+vector-dimension-mismatch = Векторда numDimensions кьазвач.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` компонентдихъ nearestPoint статусдин переменная авачирвиляй, адаз ялиз жезвач.
+
+constrain-to-without-nearest-point = `<{ $component }>` компонентдихъ nearestPoint статусдин переменная авачирвиляй, адал сергьятар эцигиз жезвач.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` компонентдихъ nearestPoint статусдин переменная авачирвиляй, адан къенепатал сергьятар эцигиз жезвач.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline тушир choiceInput патал labelPosition гьисаба кьазвач
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput патал къалурнавай indices гьисаба кьазвач: индексрин кьадар choice веледрин кьадардихъ галаз кьазвач.
+
+pretzel-indices-count-mismatch = problem патал къалурнавай indices гьисаба кьазвач: индексрин кьадар problem веледрин кьадардихъ галаз кьазвач.
+
+shuffle-indices-count-mismatch = shuffle патал къалурнавай indices гьисаба кьазвач: индексрин кьадар компонентрин кьадардихъ галаз кьазвач.
+
+indices-ignored-out-of-range = { $component } патал къалурнавай indices гьисаба кьазвач: бязи индексар сергьятдилай элячӀнава.
+
+pretzel-indices-repeated = pretzel патал къалурнавай indices гьисаба кьазвач: бязи индексар тикрар хьанва.
+
+pretzel-circuit-first-index = circuit режимда авай pretzel патал къалурнавай indices гьисаба кьазвач: сифте индекс 1 хьун лазим я.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` строкадин веледрихъ галаз кӀвалахун патал `type` атрибут къалурун лазим я.
+
+invalid-type-defaulting-to-math = { $component } компонент патал { $type } тип дуьз туш. Ам math, text, number ва я boolean тайпайрикай сад хьун лазим я. math ишлемишзава.
+
+string-not-valid-component-to-arrange = "{ $value }" строка { $component } патал дуьз компонент туш. Гьисаба кьазвач.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } тип дуьз туш, тип number яз эцигзава.
+
+invalid-variable-value = Переменнадин дуьз тушир къимет: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантдин индекс число хьун лазим я
+
+variant-index-must-be-integer = { $index } вариантдин индекс тамам число хьун лазим я
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют алцумунар патал кьилиз акъуднавач. Гьяркьуьвилер нисбат яз эцигзава.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют алцумунар патал кьилиз акъуднавач. Къерехар нисбат яз эцигзава.
+
+side-by-side-no-block-child = Дуьз тушир `<{ $component }>`: адахъ са блокдин велед ятӀани хьун лазим я.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Графикадин `<label>`-дал алай `for` атрибут гьисаба кьазвач.
+
+label-for-must-resolve-to-one = `<label>`-дал алай `for` атрибут анжах са компонентдиз тайин хьун лазим я.
+
+label-for-unresolved = `<label>`-дал алай `for` атрибут са компонентдизни тайинариз хьанач.
+
+label-for-answer-with-authored-inputs = `<label>`-дал алай `for` атрибутди кхьенвай вводар авай `<answer>` компонентдиз къалурзава; вводдиз дуьм-дуьз къалура.
+
+label-for-answer-without-input = `<label>`-дал алай `for` атрибутди тӀвар гудай ввод авачир `<answer>` компонентдиз къалурзава.
+
+label-for-must-reference-input-or-answer = `<label>`-дал алай `for` атрибутди вводдиз ва я `<answer>` компонентдиз къалурун лазим я.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Агакьунвал патал `<{ $component }>` компонентдихъ куьруь баян хьун, ва я ам безекдин яз къалурун лазим я.
+
+accessibility-video-short-description = Агакьунвал патал `<video>` компонентдихъ куьруь баян хьун лазим я.
+
+accessibility-input-short-description-or-label = Агакьунвал патал `<{ $component }>` компонентдихъ куьруь баян ва я тӀвар хьун лазим я.
+
+accessibility-answer-input-short-description-or-label = Агакьунвал патал ввод туькӀуьрзавай `<answer>` компонентдихъ куьруь баян ва я тӀвар хьун лазим я.
+
+accessibility-short-description-contains-math = Куьруь баянра `<{ $component }>` хьтин математикадин компонентар хьун лазим туш. Математика гафаралди кхьихь.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } рангунин контраст кьилин тӀварцӀин текст патал бес туш (мичӀи режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; гьич хьайитӀани { $threshold }:1 лазим я).
+       *[other] { $colorName } рангунин контраст кьилин тӀварцӀин текст патал бес туш ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; гьич хьайитӀани { $threshold }:1 лазим я).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Нукьтайрихъ числодин къиметар авачирла, { $count } нукьтадай физвай `<circle>` гьеле кьилиз акъуднавач.
+
+circle-too-many-through-points = Пуд нукьтадилай гзаф нукьтадай физвай гьалкъа гьисабиз жезвач.
+
+circle-overprescribed-radius-center-points = Радиус, юкь ва фидай нукьтаяр къалурнавай гьалкъа гьисабиз жезвач.
+
+circle-center-with-multiple-points = Къалурнавай юкь аваз са нукьтадилай гзаф нукьтадай физвай гьалкъа гьисабиз жезвач.
+
+circle-radius-too-small = Гьалкъа гьисабиз жезвач: кьве нукьтадин арада авай мензил { $distance } тирвиляй, къалурнавай { $radius } радиус лап гъвечӀи я.
+
+circle-radius-with-many-points = Радиус къалурнаваз кьве нукьтадилай гзаф нукьтадай физвай гьалкъа туькӀуьриз жезвач.
+
+circle-invalid-center-or-through-points = Гьалкъадин юкь ва я адай физвай нукьтаяр дуьз туш.
+
+circle-radius-center-with-multiple-points = Къалурнавай юкь аваз са нукьтадилай гзаф нукьтадай физвай гьалкъадин радиус гьисабиз жезвач.
+
+circle-change-radius-non-numerical = Числодин къиметар авачир нукьтадай физвай гьалкъадин радиус дегишиз жезвач
+
+circle-radius-with-points-non-numerical = Числодин къиметар авачирла, радиус къалурнаваз са нукьтадилай гзаф нукьтадай физвай гьалкъа туькӀуьриз жезвач.
+
+circle-change-center-non-numerical = Числодин къиметар авачир нукьтадай физвай гьалкъадин юкь дегишун гьеле кьилиз акъуднавач.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциядин областдин измерениер бес туш. Областда { $intervals } интервал ава, амма функциядихъ { $inputs ->
+            [one] { $inputs } ввод
+           *[other] { $inputs } ввод
+        } ава.
+       *[other] Функциядин областдин измерениер бес туш. Областда { $intervals } интервал ава, амма функциядихъ { $inputs ->
+            [one] { $inputs } ввод
+           *[other] { $inputs } ввод
+        } ава.
+    }
+
+function-domain-invalid-format = Функциядин областдин формат дуьз туш.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциядин числодин тушир максимум гьисаба кьазвач.
+        [minimum] Функциядин числодин тушир минимум гьисаба кьазвач.
+        [extremum] Функциядин числодин тушир экстремум гьисаба кьазвач.
+        [point] Функциядин числодин тушир нукьта гьисаба кьазвач.
+        [slope] Функциядин числодин тушир наклон гьисаба кьазвач.
+       *[other] Функциядин числодин тушир { $type } гьисаба кьазвач.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциядин ичӀи максимум гьисаба кьазвач.
+        [minimum] Функциядин ичӀи минимум гьисаба кьазвач.
+        [extremum] Функциядин ичӀи экстремум гьисаба кьазвач.
+        [point] Функциядин ичӀи нукьта гьисаба кьазвач.
+       *[other] Функциядин ичӀи { $type } гьисаба кьазвач.
+    }
+
+function-points-too-close = Функцияда чкаяр сад-садаз лап мукьва тир кьве нукьта ава. Функция тайинариз жезвач.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функциядин итерацияр анжах функциядин вводрин кьадар выходрин кьадардихъ галаз сад тирла жеда. И функциядихъ { $inputs } ввод ва { $outputs ->
+            [one] { $outputs } выход
+           *[other] { $outputs } выход
+        } ава.
+       *[other] Функциядин итерацияр анжах функциядин вводрин кьадар выходрин кьадардихъ галаз сад тирла жеда. И функциядихъ { $inputs } ввод ва { $outputs ->
+            [one] { $outputs } выход
+           *[other] { $outputs } выход
+        } ава.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Последовательностдин яргъивал дуьз туш. Ам манфи тушир тамам число хьун лазим я.
+
+sequence-invalid-step = Последовательностдин кам дуьз туш. { $type } тип авай последовательность патал ам число хьун лазим я.
+
+sequence-invalid-endpoint-number = number типдин последовательностдин "{ $attribute }" дуьз туш. Ам число хьун лазим я.
+
+sequence-invalid-endpoint-letters = letters типдин последовательностдин "{ $attribute }" дуьз туш. Ам гьарфарин кутӀунвал хьун лазим я.
+
+sequence-invalid-endpoint = Последовательностдин "{ $attribute }" дуьз туш.
+
+select-from-sequence-coprime-not-numbers = числояр хкязвачирвиляй coprime гьисаба кьазвач
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations къалурнавайвиляй coprime гьисаба кьазвач
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` патал дуьз тушир target: target жагъанач.
+
+target-state-variable-not-found = `<{ $source }>` патал дуьз тушир target: `<{ $component }>` компонентдал "{ $property }" тӀвар алай статусдин переменная жагъанач.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` компонентдин переменнаяр аслу тушир переменнадивай тафаватлу хьун лазим я.
+
+ode-system-duplicate-variable-names = Тикрар жезвай аслу переменнайрин тӀварар аваз ОДУ-дин эрчӀи патан функцияр тайинариз жезвач.
+
+ode-system-rhs-function-error = ОДУ-дин эрчӀи патан функция тайинариз жезвач. mathjs функция туькӀуьрдайла гъалатӀ хьана.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } дуьз цӀарцӀин арада авай пипӀ тайинариз жезвач
+
+angle-invalid-through-point = `<angle>` компонентдин through-да дуьз тушир нукьта ава
+
+parabola-vertex-too-many-points = КӀукӀ аваз са нукьтадилай гзаф нукьтадай физвай парабола гьеле кьилиз акъуднавач.
+
+parabola-too-many-points = Пуд нукьтадилай гзаф нукьтадай физвай парабола гьеле кьилиз акъуднавач.
+
+intersection-too-many-items = Кьве затӀунилай гзаф затӀарин пересечение гьеле кьилиз акъуднавач
+
+## Other math components
+
+ionic-compound-not-two-ions = Кьве иондилай маса затӀарин иондин кутӀунвал гьеле кьилиз акъуднавач.
+
+ionic-compound-needs-cation-and-anion = Иондин кутӀунвал анжах са катион ва са анион патал кьилиз акъуднава.
+
+solve-equations-cannot-evaluate = Уравнение гьялиз жезвач, ам къиметламишиз хьаначирвиляй: { $equation }
+
+math-operators-operand-number-required = Математикадин операнд къачудайла operandNumber къалурун лазим я.
+
+eigen-decomposition-failed = Матрицадин собственный къиметар гьисабиз хьанач
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр шаблонда авач, гьавиляй ада гьамиша ичӀи чка кьада.
+       *[other] `<matchesPattern>`: { $parameters } параметрар шаблонда авач, гьавиляй абуру гьамиша ичӀи чка кьада.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" гъавурда акьаз жезвач. Ам none, medium, dense ва я пробелди чара авунвай кьве позитив число хьун лазим я, месела grid="1 0.5". Сетка эцигзавач.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` компонентдиз { $expected ->
+        [one] са выход авай — гьар са нукьтада авай y' наклон, месела `y - x` —
+       *[other] кьве выход авай — гьар са нукьтада авай вектор, месела `(y, -x)` —
+    } функция лазим я, амма ганвай функциядихъ { $found ->
+        [one] { $found } выход
+       *[other] { $found } выход
+    } ава. { $alternative ->
+        [none] ЗатӀни къалурзавач.
+       *[other] А функция патал `<{ $alternative }>` компонент кутугнава. ЗатӀни къалурзавач.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибут гьисаба кьазвач, вучиз лагьайтӀа функция компонентдин къенени ганва; къенепатан функция ишлемишзава. Функция кьве рекьяй анжах садалди це.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибутди компонентдин къене дуьм-дуьз кхьенвай ибарадин переменнайриз тӀвар гузва. { $reason ->
+        [function-child] Ина функция `<function>` велед яз ганва, ада вичин переменнайриз вичи тӀвар гузва, гьавиляй `variables` гьисаба кьазвач.
+       *[no-expression] Ина ихьтин ибара ганвач, гьавиляй `variables` гьисаба кьазвач.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure къалурдайда xLabelPosition="left" хуьзвач; эрчӀи патан къайда ишлемишзава.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure къалурдайда yLabelPosition="bottom" хуьзвач; винел патан къайда ишлемишзава.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure-диз элкъуьрун патал осьрин сергьятар дуьз туш; асул bbox (-10,-10,10,10) ишлемишзава.
+
+prefigure-invalid-width = `<graph>`: prefigure-диз элкъуьрун патал гьяркьуьвал дуьз туш; асул диаграммадин гьяркьуьвал 425 ишлемишзава.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure-диз элкъуьрун патал aspectRatio дуьз туш; асул нисбат 1 ишлемишзава.
+
+prefigure-grid-spacing-too-fine = `<graph>`: осьрин сергьятар патал сеткадин арадин мензил лап гъвечӀи я; prefigure къалурдайда сетка эцигзавач.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure къалурдайди ишлемишзавачирла, аннотацияр къалурзавач.
+
+multiple-annotations-children = `<graph>`-да гзаф `<annotations>` велед жагъана; эхиримжидилай гъейри вири гьисаба кьазвач.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Чир тежезвай компонентдин тип артухариз ва я куьчуьриз жезвач: { $type }.
+
+copy-prop-not-found = { $component } типдин компонентдал { $property } проп жагъанач
+
+collect-no-source = collect патал source жагъанач.
+
+collect-invalid-component-type = `<{ $component }>` типдин компонентар кӀватӀиз жезвач, им дуьз тушир компонентдин тип я.
+
+reference-index-unavailable = `{ $reference }` индексдиз къалуриз жезвач
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентдиз { $action } эвериз жезвач
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Малуматрин форма дуьз туш. ЦӀарарин яргъивилер сад хьиз туш. Жагъай чка — componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Малуматра столбецрин тӀварар тикрар жезва. Жагъай чка — componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Малуматрихъ столбецдин тӀвар галач. Жагъай чка — componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = И жавабдин award вич жавабдин тегди ракъурай жавабдилай аслу я, им фикирдиз текъвей нетижайрал гъида.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` авай контейнердин къене авай `<answer>`-дал `maxNumAttempts` эцигуни са затӀни ийизвач, алахъунрин кьадар контейнерди идара ийизвайвиляй. `maxNumAttempts` контейнердал эциг.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` авай маса контейнердин къене авай, `sectionWideCheckWork` авай контейнердал `maxNumAttempts` эцигуни са затӀни ийизвач, алахъунрин кьадар къецепатан контейнерди идара ийизвайвиляй. `maxNumAttempts` къецепатан контейнердал эциг.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality эцигнавачиз { $attributes } атрибутди са затӀни ийидач.
+       *[other] symbolicEquality эцигнавачиз { $attributes } атрибутри са затӀни ийидач.
+    }
+
+answer-invalid-type = Жаваб патал дуьз тушир тип: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентдихъ тӀвар галачирвиляй, ам модулдин атрибут яз ишлемишиз жезвач
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонент модулдин атрибут яз ишлемишиз жезвач, вучиз лагьайтӀа `<module>` типдин компонентдихъ "{ $name }" атрибут хьанвайди я.
+
+conditional-content-condition-ignored = case ва я else веледар авай `<conditionalContent>` компонентдал `condition` атрибут гьисаба кьазвач.
+
+slider-markers-type-mismatch = Маркеррин тип слайдердин типдихъ галаз кьазвач.
+
+pretzel-problem-needs-statement-and-answer = Дуьз тушир pretzel: гьар са `<problem>`-да са `<statement>` ва са `<answer>` хьун лазим я.
+
+pretzel-circuit-first-problem-distractor = Дуьз тушир pretzel: mode="circuit" тирла, сифте `<problem>` дистрактор хьун жедач.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут патал { $values } къимет дуьз туш; гьисаба кьазвач.
+       *[other] `{ $attribute }` атрибут патал { $values } къиметар дуьз туш; гьисаба кьазвач.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут патал `{ $value }` къимет дуьз туш. Атрибут `$`-дилай эгечӀзавай къалурунрикай ибарат хьун лазим я.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } атрибутда авай дуьз тушир функциядин тӀварар гьисаба кьазвач: { $names }. Гьар са тӀварцӀин къалурдай пай гьич хьайитӀани 2 лишандикай (гьарфар ва я дефисар) ибарат хьун лазим я; адан гуьгъуьниз ихтиярдин `|<mathspeak alternative>` пай атуз жеда.
+
+## Building components from the source
+
+component-type-invalid = Дуьз тушир компонентдин тип: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут тикрариз жезвач.
+
+attribute-invalid-for-component = `<{ $componentType }>` типдин компонент патал "{ $attribute }" атрибут дуьз туш.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилдин тайинарунин контраст { $context ->
+        [text-on-background] текстдин ранг фондин рангунихъ галаз
+        [high-contrast] кьакьан контрастдин ранг холстунихъ галаз
+        [line] цӀарцӀин ранг холстунихъ галаз
+        [marker] маркердин ранг холстунихъ галаз
+       *[text-on-canvas] текстдин ранг холстунихъ галаз
+    } гекъигайла бес туш{ $mode ->
+        [dark] { " (мичӀи режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; гьич хьайитӀани { $threshold }:1 лазим я).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилдин тайинаруни экуь режим патал бес тир контраст гузвай рангар къалурнаватӀани, а къиметрикай къачунвай мичӀи режимдин текстдин рангуни фондин рангунихъ галаз бес тир контраст гузвач ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; гьич хьайитӀани { $threshold }:1 лазим я). { $suggestion ->
+        [available] МичӀи режимда бес тир контраст хьун патал я экуь режимдин контраст артух ая (месела, { $lightAttribute }="{ $lightColor }" эциг), я тахьайтӀа мичӀи режимдин ранг эвез ая (месела, { $darkAttribute }="{ $darkColor }" эциг).
+       *[none] МичӀи режимда бес тир контраст хьун патал экуь режимдин контраст артух ая, я тахьайтӀа къачунвай рангар textColorDarkMode ва/ва я backgroundColorDarkMode атрибутралди эвез ая.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилдин тайинаруни экуь режим патал бес тир контраст гузвай текстдин ранг къалурнаватӀани, а къиметдикай къачунвай мичӀи режимдин текстдин рангуни холстунихъ галаз бес тир контраст гузвач ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; гьич хьайитӀани { $threshold }:1 лазим я). { $suggestion ->
+        [available] МичӀи режимда бес тир контраст хьун патал я экуь режимдин контраст артух ая (месела, textColor="{ $lightColor }" эциг), я тахьайтӀа мичӀи режимдин ранг эвез ая (месела, textColorDarkMode="{ $darkColor }" эциг).
+       *[none] МичӀи режимда бес тир контраст хьун патал экуь режимдин контраст артух ая, я тахьайтӀа къачунвай ранг textColorDarkMode атрибутдалди эвез ая.
+    }
+
+section-multiple-style-palettes = Кьилиз анжах са <stylePalette> хкяз жеда; эхиримжиди ишлемишзава.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } компонентдин уникал вариантар тайинариз жезвач: numToSelect манфи тушир тамам число туш.
+
+variant-num-to-select-not-constant-number = { $component } компонентдин уникал вариантар тайинариз жезвач: numToSelect даим число туш.
+
+variant-with-replacement-not-constant-boolean = { $component } компонентдин уникал вариантар тайинариз жезвач: withReplacement даим boolean туш.
+
+variant-select-weight-disables-unique = selectWeight ва я selectForVariants къалурнавай хкягъун авайла, select патал уникал вариантар кардай акъудзава
+
+variant-coprime-undetermined = { $component } компонентдин уникал вариантар тайинариз жезвач: coprime гьамиша false ятӀа тайинариз жезвач.
+
+variant-attribute-not-constant = { $component } компонентдин уникал вариантар тайинариз жезвач: { $attribute } даим туш.
+
+variant-attribute-not-number = { $component } компонентдин уникал вариантар тайинариз жезвач: { $attribute } число туш.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } типдин { $component } компонентдин уникал вариантар тайинариз жезвач: { $attribute } { $expected ->
+        [letters-combination] гьарфарин кутӀунвал
+        [math-expression] дуьз математикадин ибара
+        [integer] тамам число
+       *[number] число
+    } туш.
+
+variant-length-not-integer = { $component } компонентдин уникал вариантар тайинариз жезвач: length тамам число туш.
+
+variant-sort-not-implemented = sort авай { $component } компонентдин уникал вариантар гьеле кьилиз акъуднавач
+
+variant-exclude-combinations-not-implemented = excludeCombinations авай { $component } компонентдин уникал вариантар гьеле кьилиз акъуднавач
+
+variant-math-exclude-not-implemented = exclude авай math типдин { $component } компонентдин уникал вариантар гьеле кьилиз акъуднавач
+
+variant-non-constant-exclude-not-implemented = даим тушир exclude авай { $component } компонентдин уникал вариантар гьеле кьилиз акъуднавач
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure къалурдайда хуьзвач; эвлед гьисаба кьазвач.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометрия эхир авачирди ва я тамам туш; эвлед гьисаба кьазвач.
+
+prefigure-curve-label-omitted = { $subject }: элкъуьрнавай кривойрин элементрал тӀварар хуьзвач; тӀвар эцигзавач.
+
+prefigure-curve-unsupported-definition-type = { $subject }: кривой тайинарунин '{ $definitionType }' тип хуьзвач; эвлед гьисаба кьазвач.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-дал алай flipFunctions атрибут хуьзвач; эвлед гьисаба кьазвач.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-дал анжах formula типдин функциядин веледар хуьзва; эвлед гьисаба кьазвач.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] цӀарцӀин хизандин тӀвар
+       *[point] нукьтадин тӀвар
+    } патал '{ $labelPosition }' labelPosition хуьзвач; PreFigure-дин асул дуьзарун ишлемишзава.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' ацӀурунин стиль PreFigure-ди хуьзвач; кӀеви ацӀурунал элкъвезва.
+
+prefigure-line-style-unknown = { $subject }: '{ $lineStyle }' чир тежезвай цӀарцӀин стиль PreFigure-дин нетижадай акъудзава.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' маркердин стиль PreFigure-дин 'diamond' стилдал элкъуьрнава.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' маркердин стиль PreFigure-ди хуьзвач; асул стиль ишлемишзава.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: дуьз тушир `ref`; нишан тайинариз жезвач. Аннотация эцигзавач.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref`-ди гзаф нишандиз къалурзава; сифте нишан ишлемишзава.
+
+annotation-ref-outside-graph = `<annotation>`: дуьз тушир `ref`; нишан вич авай graph-дилай къецел ама. Аннотация эцигзавач.
+
+annotation-ref-unsupported-target = `<annotation>`: дуьз тушир `ref`; нишан prefigure-диз элкъуьрдайла хуьзвай графикадин объект туш. Аннотация эцигзавач.
+
+annotation-text-missing = `<annotation>`: `text` авач ва я ичӀи я; ичӀи текст акъудзава.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Элкъвей аслувал жагъана.
+       *[other] `<{ $componentType }>` компонент квай элкъвей аслувал жагъана.
+    }
+
+reference-no-referent = Къалурун патал объект жагъанач: `{ $reference }`
+
+reference-multiple-referents = Къалурун патал гзаф объект жагъана: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` компонентдин { $attribute } атрибутдин формат дуьз туш.
+
+children-invalid = `<{ $componentType }>` патал веледар дуьз туш: дуьз тушир веледар жагъана: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут патал `{ $value }` къимет дуьз туш, `{ $default }` къимет ишлемишзава
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } верси жагъанач.
+       *[other] DoenetML { $version } верси жагъанач. { $fallback } версидал элкъвезва
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Дуьз тушир DoenetML: { $content }
+
+parse-tag-missing-close-tag = Дуьз тушир DoenetML: `{ $tag }` тегдихъ агалдай тег галач. Вич-вичи агалзавай тег ва я `</{ $tagName }>` тег хьун лазим я.
+
+parse-tag-error = Дуьз тушир DoenetML: `<{ $tagName }>` тегда гъалатӀ ава
+
+parse-attribute-missing-value = Дуьз тушир DoenetML: `{ $attribute }` атрибут дуьз туш, адахъ къимет галачиз аквазва.
+
+parse-attribute-invalid = Дуьз тушир DoenetML: `{ $attribute }` атрибут дуьз туш
+
+parse-attribute-value-invalid = Дуьз тушир DoenetML: `{ $value }` атрибутдин къимет дуьз туш
+
+parse-attribute-value-quote-mismatch = Дуьз тушир DoenetML: `{ $value }` атрибутдин къимет дуьз туш. Кавычкаяр сад-садаз кьазвач. Ваз `{ $quote }` кими яз аквазва
+
+parse-open-tag-name-missing = Дуьз тушир DoenetML: тӀвар галачир тег жагъана, месела `<`
+
+parse-tag-not-closed = Дуьз тушир DoenetML: `{ $tag }` тег агалнавач (`>` кими яз аквазва).
+
+parse-self-closing-tag-name-missing = Дуьз тушир DoenetML: тӀвар галачир тег жагъана `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Дуьз тушир DoenetML: `{ $tag }` тег агалнавач (`/>` кими яз аквазва).
+
+parse-tag-invalid-attributes = Дуьз тушир DoenetML: `{ $tag }` тег дуьз туш. Адан атрибутар дуьз тахьун мумкин я.
+
+parse-close-tag-name-missing = Дуьз тушир DoenetML: тӀвар галачир агалдай тег жагъана, месела `</`
+
+parse-attribute-value-unquoted = Атрибутдин къиметар кавычкайра тун лазим я: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Дуьз тушир DoenetML: `{ $tag }` агалдай тег жагъана, амма адаз кутугай ахъайдай тег авач
+
+parse-close-tag-mismatched = Дуьз тушир DoenetML: агалдай тег кьазвач. `</{ $expected }>` хьун лазим тир. `{ $found }` жагъана
+
+parser-node-unconvertible = { $node } узел Dast узелдиз элкъуьриз хьанач.
+
+## Names
+
+name-attribute-invalid =
+    Дуьз тушир атрибут name='{ $name }'. { $reason ->
+        [characters] ТӀварара анжах гьарфар, числояр, подчёркиваниер ва я дефисар хьун жеда.
+       *[start] ТӀварар гьарфуналди эгечӀун лазим я.
+    }
+
+component-name-invalid-start = "{ $name }" компонентдин тӀвар дуьз туш. ТӀварар гьарфуналди эгечӀун лазим я.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тип авай жавабдихъ video атрибут хьун лазим я
+
+answer-video-watched-video-not-reference = videoWatched тип авай жавабдин video атрибут къалурун хьун лазим я
+
+answer-name-not-single-text = Жавабдин name атрибутдихъ анжах са текстдин велед хьун лазим я
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Къецепатан DoenetML къачуз жезвач: рекурсиядин дережаяр гзаф я. Элкъвей къалурун авани?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресдай DoenetML къачуз жезвач
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресдай къачунвай DoenetML дуьз туш: ам "{ $componentType }" компонентдин типдихъ галаз кьазвач
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут ишлемишунай акъуднава; адан чкадал `{ $to }` ишлемиша.
+       *[other] [deprecation] `<{ $component }>`-дал алай `{ $from }` атрибут ишлемишунай акъуднава; адан чкадал `{ $to }` ишлемиша.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут ишлемишунай акъуднава ва гьисаба кьазвач, вучиз лагьайтӀа `{ $to }` атрибутни къалурнава.
+       *[other] [deprecation] `<{ $component }>`-дал алай `{ $from }` атрибут ишлемишунай акъуднава ва гьисаба кьазвач, вучиз лагьайтӀа `{ $to }` атрибутни къалурнава.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-дал алай `{ $attribute }` атрибут ишлемишунай акъуднава ва гьисаба кьазвач.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-дал алай `{ $attribute }` атрибут ишлемишунай акъуднава; адан чкадал `<{ $child }>` велед ишлемиша.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-дал алай `{ $attribute }` атрибутдин `{ $value }` къимет ишлемишунай акъуднава; адан чкадал `{ $to }` ишлемиша.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` анжах ингилис чӀалан гафар гзафвилин кьадардиз элкъуьриз алакьдайвиляй, { $locale } чӀалал кхьенвай документда адан текст дегиш тавуна амукьзава. Гзафвилин форма вуна дуьм-дуьз кхьихь, ва я ам `pluralForm` атрибутдалди къалура.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент Doenet-дин чир жезвай элемент туш.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементдиз документдин дувулда ихтияр авач.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементдиз `<{ $parent }>` компонентдин къене ихтияр авач.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементдихъ `{ $attribute }` тӀвар алай атрибут авач.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементдин `{ $attribute }` атрибут списокдикай ибарат хьун лазим я, ва адан гьар са элемент ибурукай сад: { $allowed }
+       *[other] `<{ $tag }>` элементдин `{ $attribute }` атрибут ибурукай сад хьун лазим я: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select патал дуьз тушир вариантдин тӀвар. { $variantName } вариантдин тӀвар { $numOptions } хкягъунра ава, амма хкядай кьадар { $numToSelect } я.
+
+select-variant-name-without-options = select патал бязи вариантар къалурнава, амма мумкин тир вариантдин тӀвар патал хкягъунар къалурнавач: { $variantName }.
+
+select-variant-name-not-possible = select патал къалурнавай { $variantName } вариантдин тӀвар мумкин тир вариантдин тӀвар туш.
+
+select-too-few-options = Анжах { $numOptions } хкягъундикай { $numToSelect } компонент хкяз жезвач.
+
+select-from-sequence-too-few-values = { $length } яргъивал авай последовательностдикай { $numToSelect } къимет хкяз жезвач.
+
+select-from-sequence-indices-count-mismatch = select патал къалурнавай индексрин кьадар хкядай кьадардихъ галаз кьун лазим я
+
+select-from-sequence-indices-not-integers = select патал къалурнавай вири индексар тамам числояр хьун лазим я
+
+select-from-sequence-index-excluded = selectfromsequence патал къалурнавай индекс акъуднавайдакай тир
+
+select-from-sequence-indices-excluded-combination = selectfromsequence патал къалурнавай индексар акъуднавай кутӀунвал тир
+
+select-from-sequence-coprime-not-positive-integers = Позитив тамам числояр хкязвачирвиляй, coprime кутӀунвалар хкяз жезвач.
+
+select-from-sequence-coprime-common-factor = Coprime числояр хкяз жезвач. Мумкин тир вири къиметрихъ санлай са делил ава. ("from" ва я "to" атрибутрин къалурнавай къиметар "step" атрибутдихъ галаз coprime хьун лазим я.)
+
+select-from-sequence-coprime-single-number = 1 тушир са числодикай coprime кутӀунвалар хкяз жезвач.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-да кутӀунвилерин 70%-дилай гзафбур акъуднава
+
+select-from-sequence-coprime-none-found = Coprime числояр хкяз хьанач. Мумкин тир вири къиметрихъ санлай са делил ава.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } яргъивал авай последовательностдикай { $numToSelect } уникал къимет хкяз жезвач
+
+select-prime-numbers-too-few-values = { $numValues } яргъивал авай простой числойрин списокдикай { $numToSelect } къимет хкяз жезвач
+
+select-prime-numbers-values-count-mismatch = select патал къалурнавай къиметрин кьадар хкядай кьадардихъ галаз кьун лазим я
+
+select-prime-numbers-values-not-prime = select prime number патал къалурнавай вири къиметар простой числойрин списокда хьун лазим я
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers патал къалурнавай къиметар акъуднавай кутӀунвал тир
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-да кутӀунвилерин 70%-дилай гзафбур акъуднава
+
+select-random-combination-fluke = Лап мумкин тушир дуьшуьшдалди, кьисметдин къиметрин кутӀунвал хкяз хьанач
+
+select-random-value-fluke = Лап мумкин тушир дуьшуьшдалди, кьисметдин къимет хкяз хьанач

--- a/packages/i18n/locales/lez/editor.ftl
+++ b/packages/i18n/locales/lez/editor.ftl
@@ -1,0 +1,230 @@
+# Lezgian editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Cyrillic, the 1938 orthography Dagestan's schools and publishing use; the
+# palochka Ӏ is a letter, not a Latin I and not a digit 1.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Lezgian counts in the same two categories English does, `one` and `other`, so
+# every selection below keeps both branches — a noun after a numeral stays
+# singular, so the two read alike apart from the number.
+#
+# Nothing here agrees with anything: Lezgian has no noun classes and no
+# grammatical gender, which is set out in `content.ftl`.
+#
+# The editor vocabulary is the least settled part of this file. Lezgian has no
+# established computing register, so the Russian technical nouns written in
+# Lezgian sentences below — «редактор», «курсор», «формат», «координата»,
+# «свойство», «ввод», «список», «массив» — are what a Lezgian speaker would
+# actually reach for, and «агакьунвал» for "accessibility" is a coinage this
+# seed made rather than a term it found.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Эвелдиз хкая
+       *[update] ЦӀийи ая
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Килигдайди { $word }
+       *[other] Килигдайди { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Филтр…
+editor-variant-next = Гуьгъуьнин вариант хкягъа
+editor-variant-previous = Вилик квай вариант хкягъа
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA агакьунвилин къайда чӀурун жагъана. Агакьунвилин отчёт { $action ->
+            [close] агалун
+           *[open] ахъаюн
+        } патал тӀуша.
+        [advisories] Агакьунвилин отчёт { $action ->
+            [close] агалун
+           *[open] ахъаюн
+        } патал тӀуша. WCAG AA къайда чӀурунар жагъанач, амма агакьунвилин артух меслятар ава.
+       *[clean] Агакьунвилин отчёт { $action ->
+            [close] агалун
+           *[open] ахъаюн
+        } патал тӀуша. Агакьунвилин четинвилер жагъанач.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA агакьунвилин къайда чӀурун жагъана. { $count ->
+            [one] { $count } WCAG AA къайда чӀурун
+           *[other] { $count } WCAG AA къайда чӀурун
+        } жагъана. Агакьунвилин отчёт { $action ->
+            [close] агалун
+           *[open] ахъаюн
+        } патал тӀуша.
+        [advisories] WCAG AA къайда чӀурунар жагъанач. { $count ->
+            [one] { $count } агакьунвилин артух меслят
+           *[other] { $count } агакьунвилин артух меслят
+        } жагъана. Агакьунвилин отчёт { $action ->
+            [close] агалун
+           *[open] ахъаюн
+        } патал тӀуша.
+       *[clean] WCAG AA къайда чӀурунар жагъанач. Агакьунвилин отчёт { $action ->
+            [close] агалун
+           *[open] ахъаюн
+        } патал тӀуша.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML верси { $version }
+
+editor-tab-help = Контекстдин куьмек
+editor-tab-help-short = Контекст
+editor-tab-errors = ГъалатӀар
+editor-tab-warnings = Хабардарвилер
+editor-tab-info = Малумат
+editor-tab-accessibility = Агакьунвал
+editor-tab-responses = Ракъурнавай жавабар
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редактордин къайдаяр
+editor-format-as-doenetml = DoenetML хьиз формат ая
+editor-format-as-xml = XML хьиз формат ая
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line } лагьай цӀар
+
+editor-no-errors = ГъалатӀар авач
+editor-no-warnings = Хабардарвилер авач
+editor-no-info = Малуматдин къейдер авач
+
+editor-show-info-annotations = Малуматдин къейдер редактордал къалура
+editor-show-accessibility-annotations = Агакьунвилин къейдер редактордал къалура
+
+editor-accessibility-learn-more = Doenet агакьунвилихъ гьикӀ эгечӀзаватӀа чир хьухь
+
+editor-accessibility-violations-heading = Агакьунвилин къайда чӀурунар ({ $standard })
+
+editor-accessibility-other-heading = Агакьунвилин маса четинвилер
+editor-none-found = ЗатӀни жагъанач
+
+
+## Submitted responses
+
+editor-no-responses = Гьеле ракъурнавай жаваб авач
+editor-response-answer-id = Жавабдин Id
+editor-response-response = Жаваб
+editor-response-credit = Балл
+editor-response-submitted = Ракъурнава
+
+
+## The context-help panel
+
+# The dative would have to sit on `{ $ref }`, so «лишан» — "sign" — is written
+# after it and carries the case instead.
+help-placeholder = Документация патал курсор тегдин тӀварцӀел, атрибутдал ва я { $ref } лишандал эциг.
+
+help-unsupported-ref-chain = { $example } хьтин гзаф паюникай ибарат къалурунрин куьмек гьеле авач.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Къалурунин объект жагъанач: { $ref }.
+        [multiple] Къалурунин гзаф объект жагъана: { $ref }.
+       *[indeterminate] { $ref } патал объект тайинариз хьанач.
+    }
+
+help-learn-about-references = Къалурунрикай чир хьухь →
+help-reference-page = Малуматдин чин →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } къене
+       *[top] Винел дережада
+    }{ $allowed ->
+        [none] { " — инал затӀни физвач." }
+        [text] { " — инал текст кхьихь." }
+        [text-and-components] { " — инал текст кхьихь, ва я ибур синагъ ая:" }
+       *[components] { " — ибур синагъ ая:" }
+    }
+
+help-suggestions-footer = Вири { $total } компонент акун патал { $shortcut } тӀуша.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — им { $target } объектдиз къалурун я.
+       *[other] { $ref } — им { $target } объектдиз къалурун я ({ $line } лагьай цӀар).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } { $role } хьиз тунва.
+       *[other] { $owner } { $line } лагьай цӀарал { $role } хьиз тунва.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — им { $element } элементдин { $property } свойстводиз къалурун я.
+       *[other] { $ref } — им { $element } элементдин { $property } свойстводиз къалурун я ({ $line } лагьай цӀар).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = кӀус
+help-kind-array-entry = массивдин элемент
+
+help-default = Асул къимет:
+help-active-default = Гилан асул къимет:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ихтияр авай къиметар (гьар са затӀуниз сад):
+       *[other] Ихтияр авай къиметар:
+    }
+
+help-suggested-values = Меслят гузвай къиметар:
+
+help-inserts = Эцигзава:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатаяр:
+    }
+
+help-type = Тип:
+
+help-resolved-style = Тайинарнавай стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Тайинарнавай функцийрин тӀварар:
+help-reset-list = И вводда эвелдиз хкидай список:
+help-added-on-input = И вводда алава авунвайди:
+help-removed-on-input = И вводда алуднавайди:
+
+help-reset-overrides = { $reset } { $additional } ва { $removed } эвездайди я.

--- a/packages/i18n/locales/nog/chrome.ftl
+++ b/packages/i18n/locales/nog/chrome.ftl
@@ -1,0 +1,131 @@
+# Nogai viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic, which is the only orthography Nogai has been printed in
+# since 1938 and what CLDR fills a bare `nog` in as (`nog` maximizes to
+# `nog-Cyrl-RU`). The digraphs аь, оь, уь and нъ are letters of the Nogai
+# alphabet, not Russian sequences: «коьрсетуьв» is spelled with two of them and
+# nothing in it may be simplified to «керсетув».
+#
+# Nogai counts in two plural categories, `one` and `other`, the same two
+# English has, so every `{ $count -> … }` below keeps the shape it had. A noun
+# after a numeral stays singular — «2 аьрекет», never a plural — so the two
+# branches differ in nothing but the number they print, and the explicit `[0]`
+# branch English writes is kept where English writes one.
+#
+# Nogai has no grammatical gender and no noun classes, so nothing in this file
+# or in `content.ftl` forks on `$gender`.
+#
+# What this file is least sure of is its UI vocabulary. Nogai's published
+# technical writing is small, and the words for interface objects a browser
+# shows — a keyboard tray, a preview popover, a footnote marker, an orbital
+# box — have no attested Nogai usage this seed could copy. They are built here
+# from general Kipchak vocabulary («куты» for a box, «эскертпе» for a footnote,
+# «алдын коьруьв» for a preview) and are the first thing a speaker should
+# rewrite. The mathematical and computing terms are Russian, which is what
+# written Nogai itself uses for them.
+
+
+## Answer submission
+
+answer-checking = Тексериледи…
+answer-submitting = Йибериледи…
+answer-checking-status = Явап тексериледи
+answer-submitting-status = Явап йибериледи
+answer-correct = Дурыс
+answer-incorrect = Дурыс тувыл
+answer-response-saved = Явап сакланды
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% дурыс
+answer-percent-short = { $percent } %
+max-credit-available = Алынатаган эм оьр балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] аьрекет калмады
+        [one] { $count } аьрекет калды
+       *[other] { $count } аьрекет калды
+    }
+validation-correct = (Дурыс)
+validation-incorrect = (Дурыс тувыл)
+validation-partially-correct = (Яртылай дурыс)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } уьшин { $count } явапты коьрсетуьв
+       *[other] { $answerId } уьшин { $count } явапты коьрсетуьв
+    }
+
+## Disclosure panels
+
+feedback-heading = Кери байланыс
+collapsible-click-to-open = (ашув уьшин басынъыз)
+collapsible-click-to-close = (ябув уьшин басынъыз)
+collapsible-initializing = Аьзирленеди…
+footnote-show = Эскертпени коьрсетуьв
+footnote-hide = Эскертпени ясырув
+description-more-information = косымша малюмат
+
+## Controls
+
+slider-previous = Алдынгы
+slider-next = Келеси
+keyboard-open = Клавиатураны ашув
+keyboard-close = Клавиатураны ябув
+choice-input-remove-choice = { $choice } сайлавын алып таслав
+matrix-remove-row = Катарды алып таслав
+matrix-add-row = Катар косув
+matrix-remove-column = Багананы алып таслав
+matrix-add-column = Багана косув
+subset-add-remove-points = Нокталар косув/алып таслав
+subset-toggle-points-intervals = Нокталар мен аралыкларды авыстырув
+subset-move-points = Нокталарды коьшируьв
+subset-clear = Тазалав
+orbital-add-row = Катар косув
+orbital-remove-row = Катарды алып таслав
+orbital-add-box = Куты косув
+orbital-remove-box = Кутыны алып таслав
+orbital-add-up-arrow = Йогары ок косув
+orbital-add-down-arrow = Тоьмен ок косув
+orbital-remove-arrow = Окты алып таслав
+orbital-row-label = { $row } катардынъ белгиси
+pretzel-answer = Явап
+summary-statistics-caption = { $column } баганасы бойынша йыйынтык статистика
+
+## Math input
+
+math-input-preview-region = математикалык аьнълатпаны алдын коьруьв
+math-input-preview = Алдын коьруьв
+math-input-invalid-expression = Дурыс тувыл аьнълатпа:
+
+## Document status
+
+viewer-initializing = Аьзирленеди…
+
+## Errors
+
+error-heading = Кате
+error-found-at =
+    { $span ->
+        [line] { $startLine } катарда табылды.
+       *[lines] { $startLine }–{ $endLine } катарларда табылды.
+    }
+document-contains-errors = Бу документте кателер бар!
+diagnostic-heading-error = Кате
+diagnostic-heading-warning = Эскертуьв
+diagnostic-heading-information = Малюмат
+diagnostic-heading-hint = Коьрсетпе
+accessibility-heading-level-1 = WCAG AA колайлык бузылувы
+accessibility-heading-level-2 = Колайлык хабары
+something-went-wrong = Бир зат дурыс болмады.
+renderer-load-failed = коьрсетуьвши юкленмеди. Бетти янъыртынъыз.
+core-start-failed = Бу документти баслап болмады. Бетти янъыртынъыз.
+core-start-failed-busy = Бу документти баслап болмады. Бир заманда бир кесек документ басланган эди, ол оьзи аста аьсбапта коьбирек заман алады. Баска документлер тамамланганнан сонъ бетти янъыртув коьмек этуьви мумкин.
+core-start-failed-retry = Бу документти баслап болмады.
+core-start-failed-busy-retry = Бу документти баслап болмады. Бир заманда бир кесек документ басланган эди, ол оьзи аста аьсбапта коьбирек заман алады.
+core-start-retry = Кайтадан баслав
+saved-state-unavailable = Сакланган ислевинъизди юклеп болмады.

--- a/packages/i18n/locales/nog/content.ftl
+++ b/packages/i18n/locales/nog/content.ftl
@@ -1,0 +1,262 @@
+# Nogai content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic, the only orthography Nogai has been printed in since
+# 1938 and what CLDR fills a bare `nog` in as. аь, оь, уь and нъ are letters of
+# the alphabet rather than Russian letter sequences.
+#
+# Nogai is spoken across three federal subjects — Dagestan, Karachay-Cherkessia
+# and Stavropol Krai — in three dialect groups: Kara-Nogai in Dagestan, Aqnogay
+# on the Kuban in Karachay-Cherkessia, and the central variety in the Nogai
+# steppe of Stavropol. This catalog writes the **literary norm built on the
+# Kara-Nogai and central varieties**, which is the standard the Dagestani and
+# Cherkessk school books and the newspaper «Ногай давысы» use. An Aqnogay
+# reader will find some of these words are not the ones they say; that is a
+# dialect difference and not an error in the file.
+#
+# Nogai is Turkic, so it has **no grammatical gender and no noun classes**, and
+# an attributive adjective never agrees with anything. `noun-gender` therefore
+# returns one token for every noun and **no message in this file forks on
+# `$gender` or on `$role`** — the same flat answer `locales/ba`, `locales/tt`
+# and `locales/tr` give.
+#
+# Attributive adjectives **precede** the noun, in the same order English writes
+# them, so the composition messages below keep the English word order:
+# «калын кызыл сызык» is width, colour, noun.
+#
+# What this file is least sure of is its vocabulary rather than its grammar.
+# Nogai's written output is small and its published technical vocabulary is
+# smaller: the colour words, the everyday nouns and the sectioning words below
+# are Nogai, but several of the mathematical nouns — «авышлык майданы» for a
+# slope field, «дурыс коьпмуьйиш» for a regular polygon, «анъламлама» for a
+# definition — are built here out of general Kipchak vocabulary on the pattern
+# Kazakh and Karakalpak use, because no attested Nogai term was available to
+# copy. Those are the entries to check first.
+
+
+## Style vocabulary
+
+# «коьк» is blue and «ясыл» green, so the two do not overlap the way a Turkic
+# «коьк» sometimes does; cyan is the separate «коьгилдир». «куьлгин» for purple
+# is the least attested word in this table.
+color =
+    .black = кара
+    .white = ак
+    .gray = боз
+    .red = кызыл
+    .orange = кызгылт сары
+    .yellow = сары
+    .green = ясыл
+    .cyan = коьгилдир
+    .blue = коьк
+    .purple = куьлгин
+    .pink = кызгылт
+    .brown = коьнъир
+line-width =
+    .thick = калын
+    .thin = йинъишке
+line-style =
+    .dashed = уьзик
+    .dotted = ноктали
+# Noun phrases. They stand in front of «оювлы» in the composition messages
+# below and modify nothing themselves.
+fill-style =
+    .horizontal = горизонталь сызыклар
+    .vertical = вертикаль сызыклар
+    .diagonal = диагональ сызыклар
+    .backdiagonal = кери диагональ сызыклар
+    .dots = нокталар
+    .diamonds = ромблар
+noun =
+    .line = туьз сызык
+    .line-segment = кесинди
+    .ray = нур
+    .vector = вектор
+    .curve = кыйсык сызык
+    .function = функция
+    .slope-field = авышлык майданы
+    .vector-field = вектор майданы
+    .parabola = парабола
+    .polyline = сынык сызык
+    .polygon = коьпмуьйиш
+    .triangle = уьшмуьйиш
+    .rectangle = туьзмуьйишлик
+    .circle = тоьгерек
+    .region = аймак
+    .point = нокта
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# Nogai builds the side count into a modifier in front of the noun, so the
+# whole of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } муьйишли дурыс коьпмуьйиш
+    }
+# Nogai has no grammatical gender and no noun classes, so every noun answers
+# the same and the answer goes unused.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = толтырылган
+# «оювлы» — "having the pattern of" — carries the "with" by itself, and the
+# whole phrase goes in front of what it describes, as every modifier does here.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } оювлы { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } оювлы { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } оювлы { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# The renderer appends this after the shape it belongs to, where a prenominal
+# modifier cannot go. So it is written as a predicate instead — «шети { $border }»,
+# "its border is thick red" — which is what Nogai puts after a noun. Neither
+# the article nor the preposition English needs has anything to answer to here,
+# so the two pairs of branches differ only in the «эм» that joins a second one.
+style-border-clause =
+    { $parts ->
+        [with-article] шети { $border }
+        [and] эм шети { $border }
+        [and-article] эм шети { $border }
+       *[with] шети { $border }
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = толтырылмаган
+# «фонында» is the locative of «фон» and says "on the background" by itself, so
+# nothing stands between the two colours. The suffix sits on a word this
+# catalog writes, never on a placeable.
+style-text =
+    { $parts ->
+        [background] { $background } фонында { $color }
+       *[plain] { $color }
+    }
+style-background-none = йок
+
+## Boolean words
+
+boolean-true = дурыс
+boolean-false = ялган
+
+## Answer buttons
+
+answer-submit-label = Тексеруьв
+answer-submit-label-no-correctness = Явапты йиберуьв
+
+## Sectional blocks
+
+section-name =
+    .activity = Аьрекет
+    .aside = Ян соьз
+    .cascade = Каскад
+    .definition = Анъламлама
+    .example = Уьлги
+    .exercise = Коьнигуьв
+    .exercises = Коьнигуьвлер
+    .given-answer = Явап
+    .note = Эскертпе
+    .objectives = Максатлар
+    .paragraphs = Абзацлар
+    .part = Боьлик
+    .problem = Масала
+    .problems = Масалалар
+    .proof = Далиллев
+    .question = Сорав
+    .section = Боьлим
+    .solution = Шешуьв
+    .task = Тапсырма
+    .theorem = Теорема
+# Nogai punctuates a heading the way the Cyrillic school tradition does, with a
+# period rather than the colon English uses.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Коьрсетпе
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Сурет { $enumeration }
+        [numbered-caption] Сурет { $enumeration }{ ". " }
+        [unnumbered-caption] Сурет{ ". " }
+       *[unnumbered] Сурет
+    }
+
+## Paginator controls
+
+paginator-previous = Алдынгы
+paginator-next = Келеси
+paginator-page = Бет
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+
+piecewise-condition-or = яде
+# Nogai's "if" opens its clause and lands correctly here. The conditional
+# itself is a suffix on the verb (-са/-се), but the word that introduces the
+# condition — «эгер» — stands at the **front** of it, so the renderer placing
+# this before the mathematics is where Nogai wants it. This catalog therefore
+# has none of the limit `locales/sah`, `locales/tyv`, `locales/udm`,
+# `locales/kv` and `locales/chm` record beside this key, whose «буоллаҕына»,
+# «болза», «ке», «кӧ» and «гын» all close the clause instead.
+piecewise-condition-if = эгер
+piecewise-condition-otherwise = болмаса
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Dagestan,
+## Karachay-Cherkessia and Stavropol Krai is taught in Russian, and the element
+## names a Nogai-speaking pupil meets are the Russian ones out of a
+## Russian-language textbook, so the English fallback sits nearer their
+## curriculum than an invented Nogai list would. Nogai has no published
+## chemical nomenclature to seed from, and respelling the Russian list in Nogai
+## letters would produce neither language — the argument `locales/min` already
+## makes against copying Indonesian's table.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Дурыс тувыл химиялык белги
+chemistry-invalid-ionic-compound = Дурыс тувыл ион косылысы

--- a/packages/i18n/locales/nog/diagnostics.ftl
+++ b/packages/i18n/locales/nog/diagnostics.ftl
@@ -1,0 +1,687 @@
+# Nogai diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source, and so does the literal `[deprecation]` marker.
+#
+# Nogai counts in the same two categories English does, `one` and `other`, so
+# every selection below keeps both branches — but a noun after a numeral stays
+# singular, so the two usually differ only in the number they print. Nothing
+# here agrees with a gender or a noun class; Nogai has neither.
+#
+# The technical vocabulary here is largely Russian, which is what written Nogai
+# uses for it: «компонент», «атрибут», «функция», «индекс», «версия»,
+# «параметр». What is Nogai is the grammar around them and the everyday words
+# — «табылмады», «эсапка алынмайды», «болувы керек», «дурыс тувыл».
+#
+# The words this file is least sure of are the mathematical and computing terms
+# that are *not* Russian loans, because Nogai has published almost nothing in
+# which they would appear. «тизбек» for a sequence, «оьз-ара туьп санлар» for
+# coprime numbers, «силтеме» for a reference, «нысан» for a target or referent,
+# «урпак» for a descendant node and «оьзгеше вариантлар» for unique variants
+# are all built on the general Kipchak pattern rather than copied from attested
+# Nogai usage. A speaker should read them as proposals.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } эки уш нокта белгиленгенде эсапка алынмайды
+       *[other] { $attributes } эки уш нокта белгиленгенде эсапка алынмайды
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } уш нокта эм орта нокта экеви де белгиленгенде эсапка алынмайды
+       *[other] { $attributes } уш нокта эм орта нокта экеви де белгиленгенде эсапка алынмайды
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset орта нокта болмаса эсер этпейди
+
+## `<line>`
+
+line-points-undetermined-dimensions = Оьлшемлери белгисиз нокталар аша оьтетаган туьз сызык.
+
+line-points-too-few-dimensions = Туьз сызык эм азы эки оьлшемли нокталар аша оьтуьви керек.
+
+line-points-depend-on-variables = Туьз сызык оьзгеруьвшилерге байланыслы нокталар аша оьтеди: { $variables }.
+
+line-equation-invalid-format = { $variable1 } эм { $variable2 } оьзгеруьвшилериндеги туьз сызык тенълемесининъ форматы дурыс тувыл.
+
+## `<ray>`
+
+ray-overprescribed-through = Нур through, endpoint эм direction мен белгиленген. Белгиленген through эсапка алынмайды.
+
+ray-dimension-mismatch = Нурда numDimensions келиспейди.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail эм displacement пен белгиленген. Белгиленген head эсапка алынмайды.
+
+vector-dimension-mismatch = Векторда numDimensions келиспейди.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` уьстине тартылып болмайды, себеби онда nearestPoint хал оьзгеруьвшиси йок.
+
+constrain-to-without-nearest-point = `<{ $component }>` пен шеклендирилип болмайды, себеби онда nearestPoint хал оьзгеруьвшиси йок.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` ишине шеклендирилип болмайды, себеби онда nearestPoint хал оьзгеруьвшиси йок.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition инлайн болмаган choiceInput уьшин эсапка алынмайды
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput уьшин белгиленген индекслер эсапка алынмайды, себеби индекслер саны choice балаларынынъ санына келиспейди.
+
+pretzel-indices-count-mismatch = problem уьшин белгиленген индекслер эсапка алынмайды, себеби индекслер саны problem балаларынынъ санына келиспейди.
+
+shuffle-indices-count-mismatch = shuffle уьшин белгиленген индекслер эсапка алынмайды, себеби индекслер саны компонентлер санына келиспейди.
+
+indices-ignored-out-of-range = { $component } уьшин белгиленген индекслер эсапка алынмайды, себеби базы индекслер шектен тыс.
+
+pretzel-indices-repeated = pretzel уьшин белгиленген индекслер эсапка алынмайды, себеби базы индекслер кайталанады.
+
+pretzel-circuit-first-index = circuit режиминде pretzel уьшин белгиленген индекслер эсапка алынмайды, себеби биринши индекс 1 болувы керек.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` сатыр балалары мен ислев уьшин `type` атрибуты белгиленуьви керек.
+
+invalid-type-defaulting-to-math = { $component } компоненти уьшин { $type } туьри дурыс тувыл. Ол math, text, number яде boolean болувы керек. math алынады.
+
+string-not-valid-component-to-arrange = «{ $value }» сатыры { $component } уьшин ярайтаган компонент тувыл. Эсапка алынмайды.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } туьри дурыс тувыл, туьр number этип салынады.
+
+invalid-variable-value = Оьзгеруьвшидинъ маьнеси дурыс тувыл: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариант индекси сан болувы керек
+
+variant-index-must-be-integer = { $index } вариант индекси бутин сан болувы керек
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют оьлшемлер уьшин ясалмаган. Кенъликлер салыстырмалы этип салынады.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют оьлшемлер уьшин ясалмаган. Шетлер салыстырмалы этип салынады.
+
+side-by-side-no-block-child = `<{ $component }>` дурыс тувыл: онда эм азы бир блок бала болувы керек.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` уьстиндеги `for` атрибуты эсапка алынмайды.
+
+label-for-must-resolve-to-one = `<label>` уьстиндеги `for` атрибуты тек бир компонентти коьрсетуьви керек.
+
+label-for-unresolved = `<label>` уьстиндеги `for` атрибуты компонентке келтирилип болмады.
+
+label-for-answer-with-authored-inputs = `<label>` уьстиндеги `for` атрибуты автор язган киргистуьвлери бар `<answer>` уьстине силтейди; киргистуьвдинъ оьзине силтенъиз.
+
+label-for-answer-without-input = `<label>` уьстиндеги `for` атрибуты белгилейтаган киргистуьви йок `<answer>` уьстине силтейди.
+
+label-for-must-reference-input-or-answer = `<label>` уьстиндеги `for` атрибуты киргистуьв яде явап уьстине силтеви керек.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Колайлык уьшин `<{ $component }>` кыска суьвретлемеси болувы яде безев этип белгиленуьви керек.
+
+accessibility-video-short-description = Колайлык уьшин `<video>` кыска суьвретлемеси болувы керек.
+
+accessibility-input-short-description-or-label = Колайлык уьшин `<{ $component }>` кыска суьвретлемеси яде белгиси болувы керек.
+
+accessibility-answer-input-short-description-or-label = Колайлык уьшин киргистуьв ясайтаган `<answer>` кыска суьвретлемеси яде белгиси болувы керек.
+
+accessibility-short-description-contains-math = Кыска суьвретлемелерде `<{ $component }>` киби математика компонентлери болмавы керек. Математиканы соьз бен язынъыз.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } боьлим баслыгынынъ тексти уьшин етерли контраст бермейди (карангы режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм азы { $threshold }:1 керек).
+       *[other] { $colorName } боьлим баслыгынынъ тексти уьшин етерли контраст бермейди ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм азы { $threshold }:1 керек).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Нокталардынъ сан маьнелери болмаган аьлде { $count } нокта аша оьтетаган `<circle>` ясалмаган.
+
+circle-too-many-through-points = 3 ноктадан коьп нокта аша оьтетаган тоьгеректи есаплап болмайды.
+
+circle-overprescribed-radius-center-points = Белгиленген радиус, орталык эм нокталар мен тоьгеректи есаплап болмайды.
+
+circle-center-with-multiple-points = Белгиленген орталык пан 1 ноктадан коьп нокта аша оьтетаган тоьгеректи есаплап болмайды.
+
+circle-radius-too-small = Тоьгеректи есаплап болмайды: эки нокта арасындагы аралык { $distance } болганда, белгиленген { $radius } радиусы бек кишкей.
+
+circle-radius-with-many-points = Белгиленген радиус пан эки ноктадан коьп нокта аша оьтетаган тоьгерек ясап болмайды.
+
+circle-invalid-center-or-through-points = Тоьгеректинъ орталыгы яде нокталары дурыс тувыл.
+
+circle-radius-center-with-multiple-points = Белгиленген орталык пан 1 ноктадан коьп нокта аша оьтетаган тоьгеректинъ радиусын есаплап болмайды.
+
+circle-change-radius-non-numerical = Сан маьнелери болмаган нокталы тоьгеректинъ радиусын авыстырып болмайды
+
+circle-radius-with-points-non-numerical = Сан маьнелери болмаганда белгиленген радиус пан бир ноктадан коьп нокта аша оьтетаган тоьгерек ясап болмайды.
+
+circle-change-center-non-numerical = Сан маьнелери болмаган нокталар аша оьтетаган тоьгеректинъ орталыгын авыстырув ясалмаган.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциядынъ анъламлав аймагынынъ оьлшеми етерли тувыл. Аймакта { $intervals } аралык бар, ама функцияда { $inputs ->
+            [one] { $inputs } киргистуьв
+           *[other] { $inputs } киргистуьв
+        } бар.
+       *[other] Функциядынъ анъламлав аймагынынъ оьлшеми етерли тувыл. Аймакта { $intervals } аралык бар, ама функцияда { $inputs ->
+            [one] { $inputs } киргистуьв
+           *[other] { $inputs } киргистуьв
+        } бар.
+    }
+
+function-domain-invalid-format = Функциядынъ анъламлав аймагынынъ форматы дурыс тувыл.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциядынъ сан болмаган максимумы эсапка алынмайды.
+        [minimum] Функциядынъ сан болмаган минимумы эсапка алынмайды.
+        [extremum] Функциядынъ сан болмаган экстремумы эсапка алынмайды.
+        [point] Функциядынъ сан болмаган ноктасы эсапка алынмайды.
+        [slope] Функциядынъ сан болмаган авышлыгы эсапка алынмайды.
+       *[other] Функциядынъ сан болмаган { $type } маьнеси эсапка алынмайды.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциядынъ бос максимумы эсапка алынмайды.
+        [minimum] Функциядынъ бос минимумы эсапка алынмайды.
+        [extremum] Функциядынъ бос экстремумы эсапка алынмайды.
+        [point] Функциядынъ бос ноктасы эсапка алынмайды.
+       *[other] Функциядынъ бос { $type } маьнеси эсапка алынмайды.
+    }
+
+function-points-too-close = Функцияда бир-бирине бек ювык эки нокта бар. Функцияны анъламлап болмайды.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функция итерациялары киргистуьвлер саны шыгыслар санына тенъ болганда ганъа мумкин. Бу функцияда { $inputs } киргистуьв эм { $outputs ->
+            [one] { $outputs } шыгыс
+           *[other] { $outputs } шыгыс
+        } бар.
+       *[other] Функция итерациялары киргистуьвлер саны шыгыслар санына тенъ болганда ганъа мумкин. Бу функцияда { $inputs } киргистуьв эм { $outputs ->
+            [one] { $outputs } шыгыс
+           *[other] { $outputs } шыгыс
+        } бар.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Тизбектинъ узынлыгы дурыс тувыл. Ол кери болмаган бутин сан болувы керек.
+
+sequence-invalid-step = Тизбектинъ адымы дурыс тувыл. { $type } туьрли тизбек уьшин ол сан болувы керек.
+
+sequence-invalid-endpoint-number = Сан тизбегининъ «{ $attribute }» маьнеси дурыс тувыл. Ол сан болувы керек.
+
+sequence-invalid-endpoint-letters = Аьриплер тизбегининъ «{ $attribute }» маьнеси дурыс тувыл. Ол аьриплер косылувы болувы керек.
+
+sequence-invalid-endpoint = Тизбектинъ «{ $attribute }» маьнеси дурыс тувыл.
+
+select-from-sequence-coprime-not-numbers = санлар сайланмаганга coprime эсапка алынмайды
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations белгиленгенге coprime эсапка алынмайды
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` уьшин target дурыс тувыл: нысан табылмады.
+
+target-state-variable-not-found = `<{ $source }>` уьшин target дурыс тувыл: `<{ $component }>` уьстинде «{ $property }» атлы хал оьзгеруьвшиси табылмады.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` оьзгеруьвшилери гаьрезсиз оьзгеруьвшиден баска болувы керек.
+
+ode-system-duplicate-variable-names = Кайталанатаган гаьрезли оьзгеруьвши атлары мен ODE RHS функцияларын анъламлап болмайды.
+
+ode-system-rhs-function-error = ODE RHS функциясын анъламлап болмайды. mathjs функциясын ясаганда кате шыкты.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } туьз сызык арасындагы муьйишти анъламлап болмайды
+
+angle-invalid-through-point = `<angle>` through ишиндеги нокта дурыс тувыл
+
+parabola-vertex-too-many-points = Тоьбеси белгиленген эм 1 ноктадан коьп нокта аша оьтетаган парабола ясалмаган.
+
+parabola-too-many-points = 3 ноктадан коьп нокта аша оьтетаган парабола ясалмаган.
+
+intersection-too-many-items = Эки затдан коьп зат уьшин кесилуьв ясалмаган
+
+## Other math components
+
+ionic-compound-not-two-ions = Эки ионнан баска зат уьшин ион косылысы ясалмаган.
+
+ionic-compound-needs-cation-and-anion = Ион косылысы тек бир катион эм бир анион уьшин ясалган.
+
+solve-equations-cannot-evaluate = Тенълемени есаплап болмаганга ону шешип болмайды: { $equation }
+
+math-operators-operand-number-required = Математикалык операндты алганда operandNumber белгиленуьви керек.
+
+eigen-decomposition-failed = Матрицадынъ оьз маьнелерин есаплап болмады
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметри уьлгиде йок, сонынъ уьшин ол аьр заман бос маьнеге келиседи.
+       *[other] `<matchesPattern>`: { $parameters } параметрлери уьлгиде йок, сонынъ уьшин олар аьр заман бос маьнеге келиседи.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" анъламга алынмайды. Ол none, medium, dense яде бослык пан боьлинген эки он сан болувы керек, мысалы grid="1 0.5". Тор сызылмайды.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` уьшин { $expected ->
+        [one] бир шыгысы бар, аьр ноктада y' авышлыгын беретаган функция керек, мысалы `y - x`
+       *[other] эки шыгысы бар, аьр ноктада векторды беретаган функция керек, мысалы `(y, -x)`
+    }, ама берилген функцияда { $found ->
+        [one] { $found } шыгыс
+       *[other] { $found } шыгыс
+    } бар. { $alternative ->
+        [none] Бир зат та сызылмайды.
+       *[other] Ол функция уьшин `<{ $alternative }>` компоненти керек. Бир зат та сызылмайды.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибуты эсапка алынмайды, себеби функция компонент ишинде де берилген; ишиндегиси колланылады. Функцияны тек бир йол мен беринъиз.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибуты компонент ишинде тувра язылган аьнълатпадынъ оьзгеруьвшилерин атайды. { $reason ->
+        [function-child] Мунда функция `<function>` баласы болып берилген, ол оьз оьзгеруьвшилерин оьзи атайды, сонынъ уьшин `variables` эсапка алынмайды.
+       *[no-expression] Мунда сондай аьнълатпа берилмеген, сонынъ уьшин `variables` эсапка алынмайды.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" prefigure коьрсетуьвшисинде колланылмайды; онъ якка салув колланылады.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" prefigure коьрсетуьвшисинде колланылмайды; йогары якка салув колланылады.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure авыстырувы уьшин ок шеклери дурыс тувыл; аьдепки bbox (-10,-10,10,10) колланылады.
+
+prefigure-invalid-width = `<graph>`: prefigure авыстырувы уьшин кенълик дурыс тувыл; аьдепки диаграмма кенълиги 425 колланылады.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure авыстырувы уьшин aspectRatio дурыс тувыл; аьдепки катнас 1 колланылады.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ок шеклери уьшин тор аралыгы бек кишкей; prefigure коьрсетуьвшисинде тор сызылмайды.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure коьрсетуьвшиси колланылмаганда аннотациялар сызылмайды.
+
+multiple-annotations-children = `<graph>` ишинде бир кесек `<annotations>` баласы табылды; эм сонъгысыннан баскалары эсапка алынмайды.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Танылмаган компонент туьрин кенъейтип яде коьширип болмайды: { $type }.
+
+copy-prop-not-found = { $component } туьриндеги компонентте { $property } проп табылмады
+
+collect-no-source = collect уьшин дерек табылмады.
+
+collect-invalid-component-type = `<{ $component }>` туьриндеги компонентлерди йыйып болмайды, себеби ол дурыс компонент туьри тувыл.
+
+reference-index-unavailable = `{ $reference }` индексине силтеп болмайды
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентинде { $action } шакырып болмайды
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Деректинъ формасы дурыс тувыл. Катарлардынъ узынлыклары бирдей тувыл. Табылган ер: componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Деректе кайталанатаган багана атлары бар. Табылган ер: componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Деректинъ багана аты йок. Табылган ер: componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Бу яваптынъ бир баллавы answer тегининъ оьзи йиберген явабына таянады, ол куьтилмеген аьрекетке аькеледи.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` бар контейнер ишиндеги `<answer>` уьстине `maxNumAttempts` салув эсер этпейди, себеби аьрекетлер саны контейнер мен басшыланады. `maxNumAttempts` контейнердинъ оьзине салынъыз.
+
+nested-section-wide-check-work-max-num-attempts = Баска `sectionWideCheckWork` бар контейнер ишиндеги `sectionWideCheckWork` бар контейнерге `maxNumAttempts` салув эсер этпейди, себеби аьрекетлер саны сыртта турган контейнер мен басшыланады. `maxNumAttempts` сыртта турган контейнерге салынъыз.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } атрибуты symbolicEquality салынмаса эсер этпейди.
+       *[other] { $attributes } атрибутлары symbolicEquality салынмаса эсер этпейди.
+    }
+
+answer-invalid-type = Явап уьшин туьр дурыс тувыл: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентининъ аты болмаганга ол модуль атрибуты уьшин колланылып болмайды
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компоненти модуль атрибуты болып колланылып болмайды, себеби `<module>` компонент туьринде «{ $name }» атлы атрибут алдын анъламланган.
+
+conditional-content-condition-ignored = case яде else балалары бар `<conditionalContent>` компонентинде `condition` атрибуты эсапка алынмайды.
+
+slider-markers-type-mismatch = Маркерлер туьри слайдер туьрине келиспейди.
+
+pretzel-problem-needs-statement-and-answer = pretzel дурыс тувыл: аьр `<problem>` ишинде бир `<statement>` эм бир `<answer>` болувы керек.
+
+pretzel-circuit-first-problem-distractor = pretzel дурыс тувыл: mode="circuit" болганда биринши `<problem>` дистрактор болып болмайды.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибуты уьшин { $values } маьнеси дурыс тувыл; эсапка алынмайды.
+       *[other] `{ $attribute }` атрибуты уьшин { $values } маьнелери дурыс тувыл; эсапка алынмайды.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибуты уьшин `{ $value }` маьнеси дурыс тувыл. Атрибут `$` пен басланатаган силтемелерден куралувы керек.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ишиндеги дурыс тувыл функция атлары эсапка алынмады: { $names }. Аьр аттынъ коьрсетилетаган боьлиги эм азы 2 белгиден (аьрип яде дефис) турувы керек; сонъында `|<mathspeak alternative>` косымшасы болувы мумкин.
+
+## Building components from the source
+
+component-type-invalid = Компонент туьри дурыс тувыл: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутын кайталап болмайды.
+
+attribute-invalid-for-component = `<{ $componentType }>` туьриндеги компонент уьшин «{ $attribute }» атрибуты дурыс тувыл.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль анъламламасында { $context ->
+        [text-on-background] фон туьси алдында текст туьси
+        [high-contrast] полотно алдында оьр контрастлы туьс
+        [line] полотно алдында сызык туьси
+        [marker] полотно алдында маркер туьси
+       *[text-on-canvas] полотно алдында текст туьси
+    } уьшин етерли контраст йок{ $mode ->
+        [dark] { " (карангы режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм азы { $threshold }:1 керек).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль анъламламасында ярык режим уьшин етерли контраст беретаган туьслер белгиленген болса да, бу маьнелерден шыгарылган карангы режим туьслери фон туьси алдында текст туьси уьшин етерли контраст бермейди ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм азы { $threshold }:1 керек). { $suggestion ->
+        [available] Карангы режимде етерли контраст болсын деп, яде ярык режимдеги контрастты арттырынъыз (мысалы, { $lightAttribute }="{ $lightColor }" салынъыз), яде карангы режим туьсин авыстырынъыз (мысалы, { $darkAttribute }="{ $darkColor }" салынъыз).
+       *[none] Карангы режимде етерли контраст болсын деп, ярык режимдеги контрастты арттырынъыз яде шыгарылган туьслерди textColorDarkMode эм/яде backgroundColorDarkMode пен авыстырынъыз.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль анъламламасында ярык режим уьшин етерли контраст беретаган текст туьси белгиленген болса да, бу маьнеден шыгарылган карангы режим текст туьси полотно алдында етерли контраст бермейди ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эм азы { $threshold }:1 керек). { $suggestion ->
+        [available] Карангы режимде етерли контраст болсын деп, яде ярык режимдеги контрастты арттырынъыз (мысалы, textColor="{ $lightColor }" салынъыз), яде карангы режим туьсин авыстырынъыз (мысалы, textColorDarkMode="{ $darkColor }" салынъыз).
+       *[none] Карангы режимде етерли контраст болсын деп, ярык режимдеги контрастты арттырынъыз яде шыгарылган туьсти textColorDarkMode пен авыстырынъыз.
+    }
+
+section-multiple-style-palettes = Боьлим тек бир <stylePalette> сайлап болады; эм сонъгысы колланылады.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби numToSelect кери болмаган бутин сан тувыл.
+
+variant-num-to-select-not-constant-number = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби numToSelect турувлы сан тувыл.
+
+variant-with-replacement-not-constant-boolean = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби withReplacement турувлы boolean тувыл.
+
+variant-select-weight-disables-unique = selectWeight яде selectForVariants белгиленген вариант болса, select уьшин оьзгеше вариантлар оьширилген
+
+variant-coprime-undetermined = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби coprime аьр заман ялган болатаганын белгилеп болмайды.
+
+variant-attribute-not-constant = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби { $attribute } турувлы тувыл.
+
+variant-attribute-not-number = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби { $attribute } сан тувыл.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } туьриндеги { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби { $attribute } { $expected ->
+        [letters-combination] аьриплер косылувы
+        [math-expression] ярайтаган математикалык аьнълатпа
+        [integer] бутин сан
+       *[number] сан
+    } тувыл.
+
+variant-length-not-integer = { $component } компонентининъ оьзгеше вариантларын белгилеп болмайды, себеби length бутин сан тувыл.
+
+variant-sort-not-implemented = sort пен { $component } компонентининъ оьзгеше вариантлары ясалмаган
+
+variant-exclude-combinations-not-implemented = excludeCombinations пен { $component } компонентининъ оьзгеше вариантлары ясалмаган
+
+variant-math-exclude-not-implemented = exclude пен math туьриндеги { $component } компонентининъ оьзгеше вариантлары ясалмаган
+
+variant-non-constant-exclude-not-implemented = турувлы тувыл exclude пен { $component } компонентининъ оьзгеше вариантлары ясалмаган
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure коьрсетуьвшисинде колланылмайды; урпак атлап оьтилди.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометриясы шексиз яде толы тувыл; урпак атлап оьтилди.
+
+prefigure-curve-label-omitted = { $subject }: авыстырылган кыйсык элементлеринде белгилер колланылмайды; белги калдырылды.
+
+prefigure-curve-unsupported-definition-type = { $subject }: кыйсык функциясынынъ анъламлав туьри «{ $definitionType }» колланылмайды; урпак атлап оьтилди.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves уьстиндеги flipFunctions атрибуты колланылмайды; урпак атлап оьтилди.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves уьшин тек formula туьриндеги бала функциялар колланылады; урпак атлап оьтилди.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] сызык аьелиндеги белги
+       *[point] нокта белгиси
+    } уьшин labelPosition «{ $labelPosition }» колланылмайды; аьдепки PreFigure тегислеви колланылады.
+
+prefigure-fill-style-unsupported = { $subject }: толтырув стили «{ $fillStyle }» PreFigure уьшин колланылмайды; тегис толтырув алынады.
+
+prefigure-line-style-unknown = { $subject }: белгисиз сызык стили «{ $lineStyle }» PreFigure шыгысыннан калдырылды.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стили «{ $markerStyle }» PreFigure «diamond» стилине келтирилди.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стили «{ $markerStyle }» PreFigure уьшин колланылмайды; аьдепки стиль колланылады.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` дурыс тувыл; нысанды табып болмайды. Аннотация калдырылды.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` бир кесек нысанды коьрсетти; биринши нысан колланылады.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` дурыс тувыл; нысан оьзи турган графиктинъ сыртында. Аннотация калдырылды.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` дурыс тувыл; нысан prefigure авыстырувында колланылатаган график объект тувыл. Аннотация калдырылды.
+
+annotation-text-missing = `<annotation>`: `text` йок яде бос; бос текст шыгарылады.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Тоьгерек гаьрезлилик табылды.
+       *[other] `<{ $componentType }>` компоненти катнасатаган тоьгерек гаьрезлилик табылды.
+    }
+
+reference-no-referent = Силтеме уьшин нысан табылмады: `{ $reference }`
+
+reference-multiple-referents = Силтеме уьшин бир кесек нысан табылды: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` компонентининъ { $attribute } атрибутынынъ форматы дурыс тувыл.
+
+children-invalid = `<{ $componentType }>` уьшин балалар дурыс тувыл: дурыс тувыл балалар табылды: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибуты уьшин `{ $value }` маьнеси дурыс тувыл, `{ $default }` маьнеси колланылады
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версиясы табылмады.
+       *[other] DoenetML { $version } версиясы табылмады. { $fallback } версиясы колланылады
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML дурыс тувыл: { $content }
+
+parse-tag-missing-close-tag = DoenetML дурыс тувыл: `{ $tag }` тегининъ ябув теги йок. Оьзи ябылатаган тег яде `</{ $tagName }>` теги керек эди.
+
+parse-tag-error = DoenetML дурыс тувыл: `<{ $tagName }>` тегинде кате
+
+parse-attribute-missing-value = DoenetML дурыс тувыл: `{ $attribute }` атрибутынынъ маьнеси йок болып коьринеди.
+
+parse-attribute-invalid = DoenetML дурыс тувыл: `{ $attribute }` атрибуты дурыс тувыл
+
+parse-attribute-value-invalid = DoenetML дурыс тувыл: `{ $value }` атрибут маьнеси дурыс тувыл
+
+parse-attribute-value-quote-mismatch = DoenetML дурыс тувыл: `{ $value }` атрибут маьнеси дурыс тувыл. Тырнаклар келиспейди. `{ $quote }` йок болып коьринеди
+
+parse-open-tag-name-missing = DoenetML дурыс тувыл: аты йок тег табылды, мысалы `<`
+
+parse-tag-not-closed = DoenetML дурыс тувыл: `{ $tag }` теги ябылмаган (`>` йок болып коьринеди).
+
+parse-self-closing-tag-name-missing = DoenetML дурыс тувыл: аты йок тег табылды `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML дурыс тувыл: `{ $tag }` теги ябылмаган (`/>` йок болып коьринеди).
+
+parse-tag-invalid-attributes = DoenetML дурыс тувыл: `{ $tag }` теги дурыс тувыл. Онынъ атрибутлары дурыс тувыл болувы мумкин.
+
+parse-close-tag-name-missing = DoenetML дурыс тувыл: аты йок ябув теги табылды, мысалы `</`
+
+parse-attribute-value-unquoted = Атрибут маьнелери тырнак ишинде болувы керек: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML дурыс тувыл: `{ $tag }` ябув теги табылды, ама онъа келисетаган ашув теги йок
+
+parse-close-tag-mismatched = DoenetML дурыс тувыл: ябув теги келиспейди. `</{ $expected }>` керек эди. `{ $found }` табылды
+
+parser-node-unconvertible = { $node } туьйинин Dast туьйинине авыстырып болмады.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' атрибут аты дурыс тувыл. { $reason ->
+        [characters] Атларда тек аьриплер, санлар, астыннан сызыклар яде дефислер болады.
+       *[start] Атлар аьрип пен басланувы керек.
+    }
+
+component-name-invalid-start = «{ $name }» компонент аты дурыс тувыл. Атлар аьрип пен басланувы керек.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched туьриндеги яваптынъ video атрибуты болувы керек
+
+answer-video-watched-video-not-reference = videoWatched туьриндеги яваптынъ video атрибуты силтеме болувы керек
+
+answer-name-not-single-text = Яваптынъ name атрибутында бир ганъа текст баласы болувы керек
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсия дережеси бек коьп болганга сырткы DoenetML алынып болмады. Тоьгерек силтеме бар ма экен?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" ерден DoenetML алынып болмады
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" ерден алынган DoenetML дурыс тувыл: ол «{ $componentType }» компонент туьрине келиспеди
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибуты эскирген; онынъ орнына `{ $to }` колланынъыз.
+       *[other] [deprecation] `<{ $component }>` уьстиндеги `{ $from }` атрибуты эскирген; онынъ орнына `{ $to }` колланынъыз.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибуты эскирген эм эсапка алынмайды, себеби `{ $to }` да белгиленген.
+       *[other] [deprecation] `<{ $component }>` уьстиндеги `{ $from }` атрибуты эскирген эм эсапка алынмайды, себеби `{ $to }` да белгиленген.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` уьстиндеги `{ $attribute }` атрибуты эскирген эм эсапка алынмайды.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` уьстиндеги `{ $attribute }` атрибуты эскирген; онынъ орнына `<{ $child }>` баласын колланынъыз.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` уьстиндеги `{ $attribute }` атрибутынынъ `{ $value }` маьнеси эскирген; онынъ орнына `{ $to }` колланынъыз.
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` тек инглиз тилинде коьплик сан ясап болады, сонынъ уьшин { $locale } тилинде язылган документте онынъ тексти авыспай калады. Коьплик формасын оьзинъиз язынъыз яде ону `pluralForm` атрибуты мен беринъиз.
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элементи танылатаган Doenet элементи тувыл.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементи документтинъ тамырында турып болмайды.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементи `<{ $parent }>` ишинде турып болмайды.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементининъ `{ $attribute }` атлы атрибуты йок.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементининъ `{ $attribute }` атрибуты аьр элементи мыналардынъ бирев болатаган тизим болувы керек: { $allowed }
+       *[other] `<{ $tag }>` элементининъ `{ $attribute }` атрибуты мыналардынъ бирев болувы керек: { $allowed }
+    }
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select уьшин вариант аты дурыс тувыл. { $variantName } вариант аты { $numOptions } вариантта расады, ама сайланатаган сан { $numToSelect }.
+
+select-variant-name-without-options = select уьшин базы вариантлар белгиленген, ама { $variantName } деген болатаган вариант аты уьшин бир зат та белгиленмеген.
+
+select-variant-name-not-possible = select уьшин белгиленген { $variantName } вариант аты болатаган вариант аты тувыл.
+
+select-too-few-options = { $numOptions } компоненттен { $numToSelect } компонент сайлап болмайды.
+
+select-from-sequence-too-few-values = Узынлыгы { $length } болган тизбектен { $numToSelect } маьне сайлап болмайды.
+
+select-from-sequence-indices-count-mismatch = select уьшин белгиленген индекслер саны сайланатаган санга келисуьви керек
+
+select-from-sequence-indices-not-integers = select уьшин белгиленген барлык индекслер бутин сан болувы керек
+
+select-from-sequence-index-excluded = selectfromsequence уьшин шыгарылып тасланган индекс белгиленген
+
+select-from-sequence-indices-excluded-combination = selectfromsequence уьшин шыгарылып тасланган косылув индекслери белгиленген
+
+select-from-sequence-coprime-not-positive-integers = Он бутин санлар сайланмаганга оьз-ара туьп косылувлар сайлап болмайды.
+
+select-from-sequence-coprime-common-factor = Оьз-ара туьп санлар сайлап болмайды. Барлык болатаган маьнелердинъ ортак боьлуьвшиси бар. («from» яде «to» маьнелери «step» пен оьз-ара туьп болувы керек.)
+
+select-from-sequence-coprime-single-number = 1 болмаган бир саннан оьз-ара туьп косылувлар сайлап болмайды.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ишинде косылувлардынъ 70%-ыннан коьби шыгарылып тасланган
+
+select-from-sequence-coprime-none-found = Оьз-ара туьп санлар сайланып болмады. Барлык болатаган маьнелердинъ ортак боьлуьвшиси бар.
+
+select-from-sequence-too-few-unique-values = Узынлыгы { $numPossibleValues } болган тизбектен { $numToSelect } оьзгеше маьне сайлап болмайды
+
+select-prime-numbers-too-few-values = Узынлыгы { $numValues } болган туьп санлар тизиминнен { $numToSelect } маьне сайлап болмайды
+
+select-prime-numbers-values-count-mismatch = select уьшин белгиленген маьнелер саны сайланатаган санга келисуьви керек
+
+select-prime-numbers-values-not-prime = select prime number уьшин белгиленген барлык маьнелер туьп санлар тизиминде болувы керек
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers уьшин белгиленген маьнелер шыгарылып тасланган косылув эди
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ишинде косылувлардынъ 70%-ыннан коьби шыгарылып тасланган
+
+select-random-combination-fluke = Бек сийрек расайтаган аьл себебинен тосын маьнелер косылувы сайланып болмады
+
+select-random-value-fluke = Бек сийрек расайтаган аьл себебинен тосын маьне сайланып болмады

--- a/packages/i18n/locales/nog/editor.ftl
+++ b/packages/i18n/locales/nog/editor.ftl
@@ -1,0 +1,212 @@
+# Nogai editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Nogai counts in the same two categories English does, `one` and `other`, so
+# every selection below keeps both branches — but a noun after a numeral stays
+# singular, so the two read alike apart from the number.
+#
+# Nogai has no gender and no noun classes, so nothing here agrees with a noun.
+#
+# This is the file with the most invented vocabulary in the catalog, and it is
+# invented in the open: Nogai has no published writing about editors, language
+# servers or accessibility reports. «силтеме» for a reference, «карагыш» for
+# the viewer pane, «суьзуьв» for a filter, «аьдепки» for a default value and
+# «колайлык» for accessibility are built on the Kazakh and Karakalpak pattern
+# because no attested Nogai term exists; a speaker should treat every one of
+# them as a proposal. The Russian loans that written Nogai does use —
+# «редактор», «атрибут», «компонент», «координата», «стиль» — are kept.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Кайтарув
+       *[update] Янъыртув
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Карагышты { $word }
+       *[other] Карагышты { $word } { $shortcut }
+    }
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Суьзуьв…
+editor-variant-next = Келеси вариантты сайлав
+editor-variant-previous = Алдынгы вариантты сайлав
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA колайлык бузылувы табылды. Колайлык отчетын { $action ->
+            [close] ябув
+           *[open] ашув
+        } уьшин басынъыз.
+        [advisories] Колайлык отчетын { $action ->
+            [close] ябув
+           *[open] ашув
+        } уьшин басынъыз. WCAG AA бузылувлары табылмады, амма косымша колайлык кенъеслери бар.
+       *[clean] Колайлык отчетын { $action ->
+            [close] ябув
+           *[open] ашув
+        } уьшин басынъыз. Колайлык маьселелери табылмады.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA колайлык бузылувы табылды. { $count ->
+            [one] { $count } WCAG AA бузылувы
+           *[other] { $count } WCAG AA бузылувы
+        } табылды. Колайлык отчетын { $action ->
+            [close] ябув
+           *[open] ашув
+        } уьшин басынъыз.
+        [advisories] WCAG AA бузылувлары табылмады. { $count ->
+            [one] { $count } косымша колайлык кенъеси
+           *[other] { $count } косымша колайлык кенъеси
+        } табылды. Колайлык отчетын { $action ->
+            [close] ябув
+           *[open] ашув
+        } уьшин басынъыз.
+       *[clean] WCAG AA бузылувлары табылмады. Колайлык отчетын { $action ->
+            [close] ябув
+           *[open] ашув
+        } уьшин басынъыз.
+    }
+
+editor-accessibility-badge = WCAG
+
+## The footer
+
+editor-version-title = DoenetML версиясы { $version }
+editor-tab-help = Контекстке коьре коьмек
+editor-tab-help-short = Контекст
+editor-tab-errors = Кателер
+editor-tab-warnings = Эскертуьвлер
+editor-tab-info = Малюмат
+editor-tab-accessibility = Колайлык
+editor-tab-responses = Йиберилген яваплар
+editor-tab-with-count = { $label }: { $count }
+editor-options = Редактор параметрлери
+editor-format-as-doenetml = DoenetML болып форматлав
+editor-format-as-xml = XML болып форматлав
+
+## The diagnostics panel
+
+editor-diagnostic-line = Катар №{ $line }
+editor-no-errors = Кателер йок
+editor-no-warnings = Эскертуьвлер йок
+editor-no-info = Малюмат диагностикалары йок
+editor-show-info-annotations = Редакторда малюмат диагностикаларын коьрсетуьв
+editor-show-accessibility-annotations = Редакторда колайлык диагностикаларын коьрсетуьв
+editor-accessibility-learn-more = Doenet колайлыкка калай карайтаганын билинъиз
+editor-accessibility-violations-heading = Колайлык бузылувлары ({ $standard })
+editor-accessibility-other-heading = Баска колайлык маьселелери
+editor-none-found = Табылмады
+
+## Submitted responses
+
+editor-no-responses = Аьли йиберилген явап йок
+editor-response-answer-id = Явап Id
+editor-response-response = Явап
+editor-response-credit = Балл
+editor-response-submitted = Йиберилди
+
+## The context-help panel
+
+help-placeholder = Документация уьшин курсорды тег атына, атрибутка яде { $ref } уьстине коьширинъиз.
+
+help-unsupported-ref-chain = { $example } киби коьп боьликли силтемелер уьшин коьмек аьли берилмейди.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] { $ref } силтемеси коьрсеткен нысан табылмады.
+        [multiple] { $ref } силтемеси бир кесек нысанды коьрсетеди.
+       *[indeterminate] { $ref } уьшин нысанды белгилеп болмады.
+    }
+
+help-learn-about-references = Силтемелер акында билуьв →
+help-reference-page = Аныклама бети →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ишинде
+       *[top] Эм оьр дережеде
+    }{ $allowed ->
+        [none] { " — мунда бир зат та кирмейди." }
+        [text] { " — мунда текст язынъыз." }
+        [text-and-components] { " — мунда текст язынъыз яде мыналарды сынанъыз:" }
+       *[components] { " — мыналарды сынанъыз:" }
+    }
+
+help-suggestions-footer = Барлык { $total } компонентти коьруьв уьшин { $shortcut } басынъыз.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } уьстине силтеме.
+       *[other] { $ref } — { $target } уьстине силтеме ({ $line } катар).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } тарапыннан { $role } болып киргизилген.
+       *[other] { $owner } тарапыннан { $line } катарда { $role } болып киргизилген.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементининъ { $property } касиетине силтеме.
+       *[other] { $ref } — { $element } элементининъ { $property } касиетине силтеме ({ $line } катар).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = уьзинди
+help-kind-array-entry = массив элементи
+
+help-default = Аьдепки:
+help-active-default = Актив аьдепки:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ярайтаган маьнелер (аьр элемент уьшин бирев):
+       *[other] Ярайтаган маьнелер:
+    }
+
+help-suggested-values = Кенъес этилетаган маьнелер:
+
+help-inserts = Киргистеди:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координаталар:
+    }
+
+help-type = Туьри:
+
+help-resolved-style = Аныкланган стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Аныкланган функция атлары:
+help-reset-list = Бу киргистуьвде тизимди кайтарув:
+help-added-on-input = Бу киргистуьвде косылган:
+help-removed-on-input = Бу киргистуьвде алып тасланган:
+
+help-reset-overrides = { $reset } { $additional } эм { $removed } маьнелерин авыстырады.

--- a/packages/i18n/locales/tab/chrome.ftl
+++ b/packages/i18n/locales/tab/chrome.ftl
@@ -1,0 +1,131 @@
+# Tabasaran viewer chrome. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of the Tabasaran literary language, the
+# standard Dagestan's Tabasaran-medium schooling and the Tabasaran press use.
+# The palochka Ӏ is a letter: not a Latin capital I, not a digit 1.
+#
+# `Intl.PluralRules("tab")` reports `one` and `other`, so every
+# `{ $count -> … }` below keeps the two branches English gives it. A Tabasaran
+# noun after a numeral stays in the singular, so the two branches differ in
+# nothing but the number they print — that is correct and not a copy-paste
+# slip.
+#
+# Nothing in this file agrees with a noun class. Tabasaran does have a human /
+# non-human distinction, but it is carried by numerals, by the verb and by a
+# few pronouns, none of which these messages reach; `content.ftl`'s header sets
+# out why that means no message in this catalog forks.
+#
+# Where a value is followed by a word that would take a case ending, the ending
+# is put on a noun this file writes — «бадали» after `{ $answerId }`,
+# «сутундин» after `{ $column }` — rather than welded onto the placeable.
+#
+# Least certain here: «хъуркьувал» for accessibility is a coinage off
+# «хъуркьуб» (to reach) rather than a term this seed could attest, and the
+# words around the buttons («клик апӀин», «элаве апӀуб», «адагъуб») are the
+# everyday verbs a speaker will most want to look at first.
+
+
+## Answer submission
+
+answer-checking = Ахтармиш апӀура…
+answer-submitting = Ивура…
+answer-checking-status = Жаваб ахтармиш апӀура
+answer-submitting-status = Жаваб ивура
+answer-correct = Дюз
+answer-incorrect = Дюз дар
+answer-response-saved = Жаваб уьбхна
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% дюз
+answer-percent-short = { $percent } %
+max-credit-available = Максималлу балл: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] гьяракатар гъузнадар
+        [one] { $count } гьяракат гъузна
+       *[other] { $count } гьяракат гъузна
+    }
+validation-correct = (Дюз)
+validation-incorrect = (Дюз дар)
+validation-partially-correct = (Са пай дюз)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } бадали { $count } жаваб улупуб
+       *[other] { $answerId } бадали { $count } жаваб улупуб
+    }
+
+## Disclosure panels
+
+feedback-heading = Фикир
+collapsible-click-to-open = (ачмиш апӀуз клик апӀин)
+collapsible-click-to-close = (багъламиш апӀуз клик апӀин)
+collapsible-initializing = Гьязур шула…
+footnote-show = Сноска улупуб
+footnote-hide = Сноска гизлемиш апӀуб
+description-more-information = артухъ мялумат
+
+## Controls
+
+slider-previous = Улихьна
+slider-next = Кьяляхъна
+keyboard-open = Клавиатура ачмиш апӀуб
+keyboard-close = Клавиатура багъламиш апӀуб
+choice-input-remove-choice = { $choice } адагъуб
+matrix-remove-row = Жерге адагъуб
+matrix-add-row = Жерге элаве апӀуб
+matrix-remove-column = Сутун адагъуб
+matrix-add-column = Сутун элаве апӀуб
+subset-add-remove-points = НукьтӀйир элаве апӀуб/адагъуб
+subset-toggle-points-intervals = НукьтӀйир ва интервалар дегиш апӀуб
+subset-move-points = НукьтӀйир гъахуб
+subset-clear = Марцц апӀуб
+orbital-add-row = Жерге элаве апӀуб
+orbital-remove-row = Жерге адагъуб
+orbital-add-box = Клетка элаве апӀуб
+orbital-remove-box = Клетка адагъуб
+orbital-add-up-arrow = Зиина стрелка элаве апӀуб
+orbital-add-down-arrow = КӀанди стрелка элаве апӀуб
+orbital-remove-arrow = Стрелка адагъуб
+orbital-row-label = { $row } жергейин лишан
+pretzel-answer = Жаваб
+summary-statistics-caption = { $column } сутундин умуми статистика
+
+## Math input
+
+math-input-preview-region = математический ифада улихьди лигуб
+math-input-preview = Улихьди лигуб
+math-input-invalid-expression = Дюз дару ифада:
+
+## Document status
+
+viewer-initializing = Гьязур шула…
+
+## Errors
+
+error-heading = ГъалатӀ
+error-found-at =
+    { $span ->
+        [line] Жерге: { $startLine }.
+       *[lines] Жергйир: { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Му документиъ гъалатӀар а!
+diagnostic-heading-error = ГъалатӀ
+diagnostic-heading-warning = Хабардар
+diagnostic-heading-information = Мялумат
+diagnostic-heading-hint = Меслят
+accessibility-heading-level-1 = WCAG AA хъуркьувалин нарушение
+accessibility-heading-level-2 = Хъуркьувалин хабардар
+something-went-wrong = Са зат дюз гъабхьундар.
+renderer-load-failed = рендерер гъюз гъабхьундар. Ччин цӀийи апӀин.
+core-start-failed = Му документ ккебгъуз гъабхьундар. Ччин цӀийи апӀин.
+core-start-failed-busy = Му документ ккебгъуз гъабхьундар. Са вахтна гизаф документар ккебгъурайи, зяиф аьлетдиин думу гизаф вахт гъадабгъуру. Жара документар ккудубкӀган ччин цӀийи апӀуб кюмек апӀиди.
+core-start-failed-retry = Му документ ккебгъуз гъабхьундар.
+core-start-failed-busy-retry = Му документ ккебгъуз гъабхьундар. Са вахтна гизаф документар ккебгъурайи, зяиф аьлетдиин думу гизаф вахт гъадабгъуру.
+core-start-retry = Мадсана гьяракат апӀуб
+saved-state-unavailable = Уву уьбхнайи ляхин гъадагъуз гъабхьундар.

--- a/packages/i18n/locales/tab/content.ftl
+++ b/packages/i18n/locales/tab/content.ftl
@@ -1,0 +1,297 @@
+# Tabasaran content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of the Tabasaran literary language — the
+# standard built on the Nitrik speech of the southern dialect group, which is
+# what Dagestan's Tabasaran-medium primary schooling, the republic's Tabasaran
+# publishing and the Tabasaran press are set in. CLDR carries no language data
+# for `tab` at all, but its own likely-subtags fill the bare tag in as
+# `tab-Cyrl-RU`, so the script this catalog is written in is the script a
+# reader arriving under `tab` is expected in.
+#
+# The palochka Ӏ is a letter of the alphabet. It is not a Latin capital I and
+# not a digit 1, and «апӀуб», «нукьтӀа» and «чӀал» stop being words the moment
+# one of those is substituted for it. That check is worth running over any
+# correction made to this file in an editor that autocorrects.
+#
+# **Tabasaran has a human / non-human class distinction, and this catalog forks
+# on nothing — which is a claim about where the agreement lands rather than
+# about whether the language has it.** Lezgian, its nearest neighbour, lost
+# classes entirely; Avar has three and Lak four; Tabasaran keeps two in the
+# singular. What carries that class, though, is the numeral (сар against саб),
+# the verb, and a handful of pronouns — none of which the style pipeline ever
+# reaches. The words this file's style vocabulary is made of are attributive
+# adjectives, and a Tabasaran attributive adjective stands in front of its noun
+# and does not change shape for it. So `noun-gender` answers one token, and a
+# `$gender` fork written here would render the same string in every branch,
+# which is the noise the roster's other agreeing catalogs are careful not to
+# write.
+#
+# `style-unfilled` would be unreachable even if something did agree:
+# `describeFill` renders it with no arguments at all, so no noun and therefore
+# no `$gender` ever arrives. The flat form below is the only form it could
+# have had.
+#
+# **Adjective placement: before the noun**, as in English, and a string of them
+# keeps the order width, dash, colour, noun. So the composition messages below
+# read in the same sequence English's do — that is Tabasaran's own order and
+# not English's showing through.
+#
+# **Tabasaran is cited for a very large case inventory, and no case ending in
+# this file is welded onto a placeable.** Wherever a value is followed by
+# something that would take one, the ending is put on a noun this catalog
+# writes out instead: «нахшди» (with a pattern) after `{ $pattern }` in
+# `style-filled` and `style-filled-with-noun`, «гъирагъди» (with an edge) after
+# `{ $border }` in `style-border-clause`, and «фондиин» (on the background)
+# after `{ $background }` in `style-text`. That is the README's *name what the
+# value is*, and it is why those three messages are phrased differently from
+# English rather than translated in place.
+#
+# **The colour table and the geometric nouns are the least certain things in
+# this file, and a speaker should read them before anything else.** The basic
+# colours are written with the inherited Lezgic terms this seed judged most
+# likely — «чӀару», «лизи», «уьру», «хъипи», «вили» — and the derived ones are
+# built as compounds of them («уьру-хъипи» for orange, «вили-уьру» for purple,
+# «уьру-лизи» for pink) rather than borrowed, on the pattern `locales/ce`
+# already uses. «яшил» for green and «къагьвайи» for brown are the two that
+# came in from outside the family, and either may simply be the wrong word.
+# Secondary mathematics in Dagestan is taught in Russian, so the technical
+# nouns below are the Russian terms a Tabasaran-speaking pupil actually meets —
+# «вектор», «функция», «парабола», «квадрат», «ромб» — while the shapes named
+# long before the syllabus was («нукьтӀа», «цӀар», «пай», «майдан») keep their
+# own words. Where this seed had to build a word rather than recall one, it
+# built it out of «пипӀ» (corner): «шубпипӀ», «дюзпипӀ», «гизафпипӀ». Those
+# three are coinages and are named here so that they read as coinages.
+
+
+## Style vocabulary
+##
+## A Tabasaran attributive adjective stands before its noun and does not
+## inflect for the noun's class, so nothing here forks. See the header.
+
+color =
+    .black = чӀару
+    .white = лизи
+    .gray = боз
+    .red = уьру
+    .orange = уьру-хъипи
+    .yellow = хъипи
+    .green = яшил
+    .cyan = аку вили
+    .blue = вили
+    .purple = вили-уьру
+    .pink = уьру-лизи
+    .brown = къагьвайи
+line-width =
+    .thick = яцӀу
+    .thin = шуькю
+line-style =
+    .dashed = штрихрин
+    .dotted = нукьтӀйирин
+# Noun phrases in the plural: they name what the interior is drawn out of and
+# modify nothing, so no class marker is wanted on any of them.
+fill-style =
+    .horizontal = горизонталин цӀарар
+    .vertical = вертикалин цӀарар
+    .diagonal = диагоналин цӀарар
+    .backdiagonal = акси диагоналин цӀарар
+    .dots = нукьтӀйир
+    .diamonds = ромбар
+noun =
+    .line = дюз цӀар
+    .line-segment = цӀарин пай
+    .ray = нур
+    .vector = вектор
+    .curve = эгри цӀар
+    .function = функция
+    .slope-field = наклонарин поле
+    .vector-field = векторарин поле
+    .parabola = парабола
+    .polyline = гъубгъу цӀар
+    .polygon = гизафпипӀ
+    .triangle = шубпипӀ
+    .rectangle = дюзпипӀ
+    .circle = даире
+    .region = майдан
+    .point = нукьтӀа
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+# Tabasaran puts the side count in front of the noun, like every other
+# modifier, so the whole of the phrase is one head and there is no tail.
+# «тереф» is the side and «айи» the participle "having", which is a word this
+# catalog writes rather than an ending on `{ $numSides }`.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } тереф айи дюз гизафпипӀ
+    }
+# One token for everything. Tabasaran's two classes are carried by numerals,
+# by the verb and by some pronouns, and by none of the adjectives this file is
+# made of — see the header.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# Invariable: a Tabasaran participle used attributively takes no class marker,
+# so there is nothing for `$gender` to choose between.
+style-filled-word = ацӀу
+# «нахшди» — "with a pattern" — is the instrumental of a noun this catalog
+# writes, so the case ending sits on a word the file owns rather than on
+# `{ $pattern }`.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } нахшди { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } нахшди { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } нахшди { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «гъирагъди» — "with an edge" — carries the case for the same reason, and
+# Tabasaran wants no article, so the two article branches read like the two
+# without one.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } гъирагъди
+        [and] ва { $border } гъирагъди
+        [and-article] ва { $border } гъирагъди
+       *[with] { $border } гъирагъди
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+# Rendered with no arguments by `describeFill`, so no noun and no `$gender`
+# reach it and a fork here could only ever render its own default. «дару» is
+# the negative participle and stands after the word it negates.
+style-unfilled = ацӀу дару
+# «фондиин» — "on the background" — is the case-bearing word again, and it
+# follows the colour rather than preceding it.
+style-text =
+    { $parts ->
+        [background] { $background } фондиин { $color }
+       *[plain] { $color }
+    }
+style-background-none = адар
+
+## Boolean words
+
+boolean-true = дюз
+boolean-false = дюз дар
+
+## Answer buttons
+
+answer-submit-label = Ахтармиш апӀуб
+answer-submit-label-no-correctness = Жаваб ивуб
+
+## Sectional blocks
+
+section-name =
+    .activity = Машгъулат
+    .aside = Гъирагъдин къайд
+    .cascade = Каскад
+    .definition = Тайинуб
+    .example = Мисал
+    .exercise = Упражнени
+    .exercises = Упражненйир
+    .given-answer = Жаваб
+    .note = Къайд
+    .objectives = Мурадар
+    .paragraphs = Абзацар
+    .part = Пай
+    .problem = Масъала
+    .problems = Масъалаяр
+    .proof = Исбат
+    .question = Суал
+    .section = Кьил
+    .solution = Гьял
+    .task = Тапшуругъ
+    .theorem = Теорема
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Меслят
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+figure-name =
+    { $parts ->
+        [numbered] Шикил { $enumeration }
+        [numbered-caption] Шикил { $enumeration }{ ". " }
+        [unnumbered-caption] Шикил{ ". " }
+       *[unnumbered] Шикил
+    }
+
+## Paginator controls
+
+paginator-previous = Улихьна
+paginator-next = Кьяляхъна
+paginator-page = Ччин
+# «of» is not written: a Tabasaran genitive would have to sit on
+# `{ $numPages }`, and that is an ending on a value this catalog never sees.
+# The slash says the same thing and belongs to no language.
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+## Piecewise functions
+##
+## Tabasaran's own conditional is a suffix on the verb and so closes the clause
+## it conditions, which is the limit `locales/sah`, `locales/tyv`,
+## `locales/udm`, `locales/kv` and `locales/chm` record. This key escapes it:
+## «эгер» is the borrowed conjunction, it is clause-initial, and it is what
+## written Tabasaran actually puts in front of a stated condition — so the word
+## lands where the renderer places it, in front of the mathematics, and nothing
+## here has to be worked around.
+
+piecewise-condition-or = я
+piecewise-condition-if = эгер
+piecewise-condition-otherwise = жара гьаларди
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Dagestan is taught in
+## Russian — Tabasaran-medium schooling covers the primary grades — so the
+## element names a Tabasaran-speaking pupil meets are the Russian ones, and an
+## invented Tabasaran list would be further from their textbook than the
+## English fallback is.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Дюз дару химический лишан
+chemistry-invalid-ionic-compound = Дюз дару ион бирлешме

--- a/packages/i18n/locales/tab/diagnostics.ftl
+++ b/packages/i18n/locales/tab/diagnostics.ftl
@@ -1,0 +1,705 @@
+# Tabasaran diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of the Tabasaran literary language. The
+# palochka Ӏ is a letter, not a Latin I and not a digit 1 — «апӀуб»,
+# «нукьтӀа» and «гъалатӀ» run through almost every line below and each of them
+# depends on it.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language rather than prose and stay in
+# English exactly as written, as does anything quoted back from the author's
+# own source.
+#
+# Tabasaran counts in `one` and `other` and keeps a noun after a numeral in the
+# singular, so the two branches of every count read alike. Nothing here forks
+# on a noun class: Tabasaran's two classes ride on numerals, on the verb and on
+# some pronouns, and `content.ftl`'s header explains why that keeps them out of
+# these files.
+#
+# **No case ending is welded onto a placeable anywhere in this file, and that
+# is what several of these sentences are shaped around.** Tabasaran has a very
+# large case inventory and the ending's shape depends on the stem it lands on,
+# so wherever English put a value next to a word that wanted a case, the ending
+# went onto a noun this catalog writes instead: «компонентдиз»,
+# «компонентдиинди» and «компонентдин» after `<{ $component }>`,
+# «лишандиин» after a reference, «терефнаан» after a URI. That is the README's
+# *name what the value is*, and it is why `attract-to-without-nearest-point`,
+# `constrain-to-without-nearest-point`, `external-doenetml-unavailable` and the
+# three `data-frame-*` messages are rephrased rather than translated in place —
+# the last three end on the placeable outright, because a Tabasaran locative
+# after `componentIdx :{ $componentIdx }` had nowhere safe to sit.
+#
+# The technical nouns are the Russian ones written Tabasaran technical prose
+# uses — «компонент», «атрибут», «функция», «индекс», «переменная»,
+# «последовательность» — since secondary mathematics in Dagestan is taught in
+# Russian. The everyday verbs around them («гьисаба ккабхьуру дар» for *is
+# ignored*, «апӀуз шулдар» for *cannot*, «гьеле мумкин дар» for *not
+# implemented*, «герек ву» for *must*) are this seed's own consistent
+# renderings and are the first thing a speaker should read.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кьюб ахирин нукьтӀа улупнайиш { $attributes } гьисаба ккабхьуру дар
+       *[other] кьюб ахирин нукьтӀа улупнайиш { $attributes } гьисаба ккабхьуру дар
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] ахирин нукьтӀа ва юкьван нукьтӀа улупнайиш { $attributes } гьисаба ккабхьуру дар
+       *[other] ахирин нукьтӀа ва юкьван нукьтӀа улупнайиш { $attributes } гьисаба ккабхьуру дар
+    }
+
+line-segment-midpoint-offset-without-midpoint = юкьван нукьтӀа адарди midpointOffset тӀаьсир апӀуру дар
+
+## `<line>`
+
+line-points-undetermined-dimensions = Тайин дару измеренйир айи нукьтӀйириан гъябгъру дюз цӀар.
+
+line-points-too-few-dimensions = Дюз цӀар кьюбдихьан кем дару измеренйир айи нукьтӀйириан гъябгъуб герек ву.
+
+line-points-depend-on-variables = Дюз цӀар переменнйириин аслу вуйи нукьтӀйириан гъябгъюра: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ва { $variable2 } переменнйириъ дюз цӀарин уравненийин формат дюз дар.
+
+## `<ray>`
+
+ray-overprescribed-through = Нур through, endpoint ва direction лишнариинди тайин апӀна.  Улупу through гьисаба ккабхьуру дар.
+
+ray-dimension-mismatch = Нуриъ numDimensions уйгъун дар.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ва displacement лишнариинди тайин апӀна.  Улупу head гьисаба ккабхьуру дар.
+
+vector-dimension-mismatch = Векториъ numDimensions уйгъун дар.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` компонентдиз жалб апӀуз шулдар: думуъ nearestPoint гьалин дегишлу адар.
+
+constrain-to-without-nearest-point = `<{ $component }>` компонентдиинди сергьятламиш апӀуз шулдар: думуъ nearestPoint гьалин дегишлу адар.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` компонентдин ичӀ пайиинди сергьятламиш апӀуз шулдар: думуъ nearestPoint гьалин дегишлу адар.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = инлайн дару choiceInput бадали labelPosition гьисаба ккабхьуру дар
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput бадали улупу индексар гьисаба ккабхьуру дар: индексарин кьадар choice элементарин кьадариз уйгъун дар.
+
+pretzel-indices-count-mismatch = problem бадали улупу индексар гьисаба ккабхьуру дар: индексарин кьадар problem элементарин кьадариз уйгъун дар.
+
+shuffle-indices-count-mismatch = shuffle бадали улупу индексар гьисаба ккабхьуру дар: индексарин кьадар компонентарин кьадариз уйгъун дар.
+
+indices-ignored-out-of-range = { $component } бадали улупу индексар гьисаба ккабхьуру дар: бязи индексар сергьятдиан адагъу ву.
+
+pretzel-indices-repeated = pretzel бадали улупу индексар гьисаба ккабхьуру дар: бязи индексар тикрар шула.
+
+pretzel-circuit-first-index = mode="circuit" вуйи pretzel бадали улупу индексар гьисаба ккабхьуру дар: сифтени индекс 1 вуйи герек ву.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` строкйин элементарихъди лихуз `type` атрибут улупуб герек ву.
+
+invalid-type-defaulting-to-math = { $component } компонент бадали { $type } жюре дюз дар. Думу math, text, number ва я boolean хьуб герек ву. math гъадабгъна.
+
+string-not-valid-component-to-arrange = "{ $value }" строка { $component } бадали дюз компонент дар. Гьисаба ккабхьуру дар.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } жюре дюз дар, жюре number кьяйдайиинди тайин апӀна.
+
+invalid-variable-value = Переменнайин дюз дару кьимат: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантдин индекс число вуйи герек ву
+
+variant-index-must-be-integer = { $index } вариантдин индекс бутӀун число вуйи герек ву
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют измеренйирихъди гьеле мумкин дар. Гьяркьувалар нисбий кьяйдайиинди тайин апӀна.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют измеренйирихъди гьеле мумкин дар. Гъирагъар нисбий кьяйдайиинди тайин апӀна.
+
+side-by-side-no-block-child = Дюз дару `<{ $component }>`: думуъ эн кем саб блок элемент хьуб герек ву.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` компонентдиин `for` атрибут гьисаба ккабхьуру дар.
+
+label-for-must-resolve-to-one = `<label>` компонентдиин `for` атрибут таман саб компонентдиз хъуркьуб герек ву.
+
+label-for-unresolved = `<label>` компонентдиин `for` атрибут компонентдиз хъуркьуз гъабхьундар.
+
+label-for-answer-with-authored-inputs = `<label>` компонентдиин `for` атрибутди автори улупу ивруяр айи `<answer>` компонентдиз ссылка апӀура; гьадму ивруйиз ссылка апӀин.
+
+label-for-answer-without-input = `<label>` компонентдиин `for` атрибутди лишан апӀуз ивру адру `<answer>` компонентдиз ссылка апӀура.
+
+label-for-must-reference-input-or-answer = `<label>` компонентдиин `for` атрибутди ивруйиз ва я жавабиз ссылка апӀуб герек ву.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Хъуркьувал бадали `<{ $component }>` компонентдиъ кюрт баян хьуб, ва я думу декоративни вуш улупуб герек ву.
+
+accessibility-video-short-description = Хъуркьувал бадали `<video>` компонентдиъ кюрт баян хьуб герек ву.
+
+accessibility-input-short-description-or-label = Хъуркьувал бадали `<{ $component }>` компонентдиъ кюрт баян ва я лишан хьуб герек ву.
+
+accessibility-answer-input-short-description-or-label = Хъуркьувал бадали ивру дапӀну айи `<answer>` компонентдиъ кюрт баян ва я лишан хьуб герек ву.
+
+accessibility-short-description-contains-math = Кюрт баяниъ `<{ $component }>` жюре математический компонентар хьуб дюз дар. Математика гафариинди ликӀин.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } кьилин текстдиз таман дару контраст тувра (мичӀи режим) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн кем { $threshold }:1 герек ву).
+       *[other] { $colorName } кьилин текстдиз таман дару контраст тувра ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн кем { $threshold }:1 герек ву).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = НукьтӀйириъ числайин кьиматар адарки, { $count } нукьтӀайиан гъябгъру `<circle>` гьеле мумкин дар.
+
+circle-too-many-through-points = 3 нукьтӀадихьан гизаф нукьтӀайиан гъябгъру даире гьисаб апӀуз шулдар.
+
+circle-overprescribed-radius-center-points = Улупу радиус, юкь ва нукьтӀйирихъди даире гьисаб апӀуз шулдар.
+
+circle-center-with-multiple-points = Улупу юкьихъди саб нукьтӀадихьан гизаф нукьтӀайиан гъябгъру даире гьисаб апӀуз шулдар.
+
+circle-radius-too-small = Даире гьисаб апӀуз шулдар: кьюб нукьтӀайин арайин месафе { $distance } вуйиган, улупу { $radius } радиус гизаф бицӀи ву.
+
+circle-radius-with-many-points = Улупу радиусихъди кьюб нукьтӀадихьан гизаф нукьтӀайиан гъябгъру даире дапӀуз шулдар.
+
+circle-invalid-center-or-through-points = Даирейин юкь ва я нукьтӀйир дюз дар.
+
+circle-radius-center-with-multiple-points = Улупу юкьихъди саб нукьтӀадихьан гизаф нукьтӀайиан гъябгъру даирейин радиус гьисаб апӀуз шулдар.
+
+circle-change-radius-non-numerical = Числайин дару нукьтӀйириан гъябгъру даирейин радиус дегиш апӀуз шулдар
+
+circle-radius-with-points-non-numerical = Числайин кьиматар адарки, улупу радиусихъди саб нукьтӀадихьан гизаф нукьтӀайиан гъябгъру даире дапӀуз шулдар.
+
+circle-change-center-non-numerical = Числайин дару нукьтӀйириан гъябгъру даирейин юкь дегиш апӀуб гьеле мумкин дар.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцийин областназ таман дару измеренйир. Областдиъ { $intervals } интервал а, амма функцийихъ { $inputs ->
+            [one] { $inputs } ивру
+           *[other] { $inputs } ивру
+        } а.
+       *[other] Функцийин областназ таман дару измеренйир. Областдиъ { $intervals } интервал а, амма функцийихъ { $inputs ->
+            [one] { $inputs } ивру
+           *[other] { $inputs } ивру
+        } а.
+    }
+
+function-domain-invalid-format = Функцийин областдин формат дюз дар.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцийин числайин дару максимум гьисаба ккабхьуру дар.
+        [minimum] Функцийин числайин дару минимум гьисаба ккабхьуру дар.
+        [extremum] Функцийин числайин дару экстремум гьисаба ккабхьуру дар.
+        [point] Функцийин числайин дару нукьтӀа гьисаба ккабхьуру дар.
+        [slope] Функцийин числайин дару наклон гьисаба ккабхьуру дар.
+       *[other] Функцийин числайин дару { $type } гьисаба ккабхьуру дар.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцийин ичӀи максимум гьисаба ккабхьуру дар.
+        [minimum] Функцийин ичӀи минимум гьисаба ккабхьуру дар.
+        [extremum] Функцийин ичӀи экстремум гьисаба ккабхьуру дар.
+        [point] Функцийин ичӀи нукьтӀа гьисаба ккабхьуру дар.
+       *[other] Функцийин ичӀи { $type } гьисаба ккабхьуру дар.
+    }
+
+function-points-too-close = Функцияйиъ саб-сариз гизаф мукьа айи кьюб нукьтӀа а. Функция тайин апӀуз шулдар.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцийин итерацйир анжах ивруйирин кьадар удучӀвуйирин кьадариз барабар вуш мумкин ву. Му функцийихъ { $inputs } ивру ва { $outputs ->
+            [one] { $outputs } удучӀву
+           *[other] { $outputs } удучӀву
+        } а.
+       *[other] Функцийин итерацйир анжах ивруйирин кьадар удучӀвуйирин кьадариз барабар вуш мумкин ву. Му функцийихъ { $inputs } ивру ва { $outputs ->
+            [one] { $outputs } удучӀву
+           *[other] { $outputs } удучӀву
+        } а.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Последовательностин кьадар дюз дар.  Думу минус дару бутӀун число вуйи герек ву.
+
+sequence-invalid-step = Последовательностин аддим дюз дар.  { $type } жюрейин последовательность бадали думу число вуйи герек ву.
+
+sequence-invalid-endpoint-number = Числайин последовательностин "{ $attribute }" дюз дар.  Думу число вуйи герек ву.
+
+sequence-invalid-endpoint-letters = Гьярфарин последовательностин "{ $attribute }" дюз дар.  Думу гьярфарин бирикме вуйи герек ву.
+
+sequence-invalid-endpoint = Последовательностин "{ $attribute }" дюз дар.
+
+select-from-sequence-coprime-not-numbers = числаяр сечмиш апӀурадарки coprime гьисаба ккабхьуру дар
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations улупнайиз coprime гьисаба ккабхьуру дар
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` бадали дюз дару target: target агуз шулдар.
+
+target-state-variable-not-found = `<{ $source }>` бадали дюз дару target: `<{ $component }>` компонентдиъ "{ $property }" ччвур айи гьалин дегишлу агуз шулдар.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` компонентдин переменнйир аслу дару переменнайиз тафаватлу хьуб герек ву.
+
+ode-system-duplicate-variable-names = Тикрар шулайи аслу переменнйирин ччвурарихъди ОДУ функцйир тайин апӀуз шулдар.
+
+ode-system-rhs-function-error = ОДУ функция тайин апӀуз шулдар.  mathjs функция дапӀруган гъалатӀ.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } дюз цӀарин арайин пипӀ тайин апӀуз шулдар
+
+angle-invalid-through-point = `<angle>` компонентдин through-иъ дюз дару нукьтӀа
+
+parabola-vertex-too-many-points = Кьилихъди саб нукьтӀадихьан гизаф нукьтӀайиан гъябгъру парабола гьеле мумкин дар.
+
+parabola-too-many-points = 3 нукьтӀадихьан гизаф нукьтӀайиан гъябгъру парабола гьеле мумкин дар.
+
+intersection-too-many-items = Кьюбдихьан гизаф затнан кесишме гьеле мумкин дар
+
+## Other math components
+
+ionic-compound-not-two-ions = Кьюб иондихьан жара затӀариз ион бирлешме гьеле мумкин дар.
+
+ionic-compound-needs-cation-and-anion = Ион бирлешме анжах саб катион ва саб анион бадали мумкин ву.
+
+solve-equations-cannot-evaluate = Уравнение гьял апӀуз шулдар: уравнение гьисаб апӀуз гъабхьундар: { $equation }
+
+math-operators-operand-number-required = Математический операнд адагърайиз operandNumber улупуб герек ву.
+
+eigen-decomposition-failed = Матрицайин собственный кьиматар гьисаб апӀуз гъабхьундар
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр шаблондиъ адар, гьаддиз думу гьаммишан ичӀи затӀихъди уйгъун жеди.
+       *[other] `<matchesPattern>`: { $parameters } параметрар шаблондиъ адар, гьаддиз дурар гьаммишан ичӀи затӀихъди уйгъун жеди.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" гъавриъ ахъуз шулдар. Думу none, medium, dense ва я бушлугъди айирди улупу кьюб минус дару число хьуб герек ву, месела grid="1 0.5". Сетка улупру дар.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` компонентдиз { $expected ->
+        [one] саб удучӀву — гьар са нукьтӀайиъ y' наклон, месела `y - x`
+       *[other] кьюб удучӀву — гьар са нукьтӀайиъ вектор, месела `(y, -x)`
+    } айи функция герек ву, амма тувнайи функцийихъ { $found ->
+        [one] { $found } удучӀву
+       *[other] { $found } удучӀву
+    } а. { $alternative ->
+        [none] ЗатӀ улупру дар.
+       *[other] Гьадму функция бадали `<{ $alternative }>` компонент ву. ЗатӀ улупру дар.
+    }
+
+field-function-attribute-ignored-with-child = `function` атрибут гьисаба ккабхьуру дар, гьаз гъи функция компонентдин ичӀ пайиъ гьаци тувна; ичӀ пайиъ айиб ишлетмиш апӀура. Функция анжах саб кьяйдайиинди тувин.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` атрибутди компонентдин ичӀ пайиъ ликӀнайи ифадайин переменнйир улупура. { $reason ->
+        [function-child] Му функция `<function>` элементди тувна, ва думу чан переменнйир чиб улупура, гьаддиз `variables` гьисаба ккабхьуру дар.
+       *[no-expression] Мушв гьаци ифада тувну адар, гьаддиз `variables` гьисаба ккабхьуру дар.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure рендердиъ xLabelPosition="left" гъабул апӀуру дар; right кьяйда ишлетмиш апӀура.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure рендердиъ yLabelPosition="bottom" гъабул апӀуру дар; top кьяйда ишлетмиш апӀура.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure бадали осьарин сергьятар дюз дар; стандарт bbox (-10,-10,10,10) ишлетмиш апӀура.
+
+prefigure-invalid-width = `<graph>`: prefigure бадали гьяркьувал дюз дар; стандарт диаграммайин гьяркьувал 425 ишлетмиш апӀура.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure бадали aspectRatio дюз дар; стандарт нисбат 1 ишлетмиш апӀура.
+
+prefigure-grid-spacing-too-fine = `<graph>`: осьарин сергьятариз сеткайин арайир гизаф бицӀи ву; prefigure рендердиъ сетка адабгъна.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure рендер ишлетмиш апӀурадарки, аннотацйир улупру дар.
+
+multiple-annotations-children = `<graph>` компонентдиъ гизаф `<annotations>` элементар а; ахиримжибдилан гъайри вари гьисаба ккабхьуру дар.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Аьгъю дару компонентдин жюре давам апӀуз ва я копия апӀуз шулдар: { $type }.
+
+copy-prop-not-found = { $component } жюрейин компонентдиъ { $property } свойство агуз гъабхьундар
+
+collect-no-source = collect бадали источник агуз гъабхьундар.
+
+collect-invalid-component-type = `<{ $component }>` жюрейин компонентар жем апӀуз шулдар: думу дюз дару компонентдин жюре ву.
+
+reference-index-unavailable = `{ $reference }` индексдиз ссылка апӀуз шулдар
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентдиз { $action } эвер тувуз шулдар
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Данныйирин форма дюз дар.  Жергйир саб кьадар дар. Мушв: componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Данныйириъ сутнарин ччвурар тикрар шула.  Мушв: componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Данныйириъ сутундин ччвур адар.  Мушв: componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Му жавабин award думу `<answer>` тегдин чан ивнайи жавабиин аслу ву, гьадму гюзлемиш дару нетижйириз гъухуди.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` айи контейнердин ичӀ пайиъ айи `<answer>` компонентдиин `maxNumAttempts` тайин апӀуб тӀаьсирсуз ву, гьаз гъи гьяракатарин кьадар контейнерди тайин апӀура. `maxNumAttempts` контейнердиин тайин апӀин.
+
+nested-section-wide-check-work-max-num-attempts = Жара `sectionWideCheckWork` айи контейнердин ичӀ пайиъ айи `sectionWideCheckWork` айи контейнердиин `maxNumAttempts` тайин апӀуб тӀаьсирсуз ву, гьаз гъи гьяракатарин кьадар гъирагъдин контейнерди тайин апӀура. `maxNumAttempts` гъирагъдин контейнердиин тайин апӀин.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality тайин апӀундарди { $attributes } атрибут тӀаьсирсуз жеди.
+       *[other] symbolicEquality тайин апӀундарди { $attributes } атрибутар тӀаьсирсуз жеди.
+    }
+
+answer-invalid-type = Жавабин жюре дюз дар: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентдиъ ччвур адарки, думу модулин атрибут кьяйдайиинди ишлетмиш апӀуз шулдар
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонент модулин атрибут кьяйдайиинди ишлетмиш апӀуз шулдар, гьаз гъи `<module>` компонентдин жюрейиъ "{ $name }" атрибут гьаци тайин дапӀна.
+
+conditional-content-condition-ignored = case ва я else элементар айи `<conditionalContent>` компонентдиин `condition` атрибут гьисаба ккабхьуру дар.
+
+slider-markers-type-mismatch = Маркерарин жюре слайдерин жюрейиз уйгъун дар.
+
+pretzel-problem-needs-statement-and-answer = Дюз дару pretzel: гьар са `<problem>` компонентдиъ саб `<statement>` ва саб `<answer>` хьуб герек ву.
+
+pretzel-circuit-first-problem-distractor = Дюз дару pretzel: mode="circuit" вуйиган сифтени `<problem>` дистрактор хьуз шулдар.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутдин дюз дару кьимат { $values }; гьисаба ккабхьуру дар.
+       *[other] `{ $attribute }` атрибутдин дюз дару кьиматар { $values }; гьисаба ккабхьуру дар.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутдин `{ $value }` кьимат дюз дар. Атрибут `$` лишандиан ккебгъру ссылкйирикан ибарат хьуб герек ву.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } атрибутдиъ дюз дару функцйирин ччвурар гьисаба ккабхьундар: { $names }. Гьар са ччвурин улупру пай эн кем 2 гьярф (гьярфар ва я дефисар) хьуб герек ву; ччвурихъ хъуркьуз `|<mathspeak alternative>` элаве апӀуз шулу.
+
+## Building components from the source
+
+component-type-invalid = Дюз дару компонентдин жюре: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут тикрар апӀуз шулдар.
+
+attribute-invalid-for-component = `<{ $componentType }>` жюрейин компонент бадали "{ $attribute }" атрибут дюз дар.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилин тайинатдиъ { $context ->
+        [text-on-background] текстдин рангниз фондин рангнахъди
+        [high-contrast] заан контрастин рангниз холстнахъди
+        [line] цӀарин рангниз холстнахъди
+        [marker] маркерин рангниз холстнахъди
+       *[text-on-canvas] текстдин рангниз холстнахъди
+    } таман дару контраст а{ $mode ->
+        [dark] { " (мичӀи режим)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн кем { $threshold }:1 герек ву).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилин тайинатдиъ улупу ранграр ачухъ режимназ таман контраст тувра, амма гьаму кьиматариан адагъу мичӀи режимдин ранграриъ текстдин рангниз фондин рангнахъди таман дару контраст а ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн кем { $threshold }:1 герек ву). { $suggestion ->
+        [available] МичӀи режимдиъ таман контраст хьуб бадали ва я ачухъ режимдин контраст артмиш апӀин (месела, { $lightAttribute }="{ $lightColor }" тайин апӀин), ва я мичӀи режимдин ранг эвез апӀин (месела, { $darkAttribute }="{ $darkColor }" тайин апӀин).
+       *[none] МичӀи режимдиъ таман контраст хьуб бадали ачухъ режимдин контраст артмиш апӀин, ва я адагъу ранграр textColorDarkMode ва/ва я backgroundColorDarkMode лишнариинди эвез апӀин.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилин тайинатдиъ улупу текстдин рангди ачухъ режимназ таман контраст тувра, амма гьаму кьиматиан адагъу мичӀи режимдин текстдин рангниз холстнахъди таман дару контраст а ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн кем { $threshold }:1 герек ву). { $suggestion ->
+        [available] МичӀи режимдиъ таман контраст хьуб бадали ва я ачухъ режимдин контраст артмиш апӀин (месела, textColor="{ $lightColor }" тайин апӀин), ва я мичӀи режимдин ранг эвез апӀин (месела, textColorDarkMode="{ $darkColor }" тайин апӀин).
+       *[none] МичӀи режимдиъ таман контраст хьуб бадали ачухъ режимдин контраст артмиш апӀин, ва я адагъу ранг textColorDarkMode лишандиинди эвез апӀин.
+    }
+
+section-multiple-style-palettes = Кьилиз анжах саб <stylePalette> сечмиш апӀуз шулу; ахиримжиб ишлетмиш апӀура.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: numToSelect минус дару бутӀун число дар.
+
+variant-num-to-select-not-constant-number = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: numToSelect дегиш дару число дар.
+
+variant-with-replacement-not-constant-boolean = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: withReplacement дегиш дару boolean дар.
+
+variant-select-weight-disables-unique = selectWeight ва я selectForVariants улупу сечим айиш, select бадали тек-тек вариантар тайин апӀуз шулдар
+
+variant-coprime-undetermined = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: coprime гьаммишан ялгъан вуш тайин апӀуз шулдар.
+
+variant-attribute-not-constant = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: { $attribute } дегиш дару кьимат дар.
+
+variant-attribute-not-number = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: { $attribute } число дар.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } жюрейин { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: { $attribute } { $expected ->
+        [letters-combination] гьярфарин бирикме
+        [math-expression] дюз математический ифада
+        [integer] бутӀун число
+       *[number] число
+    } дар.
+
+variant-length-not-integer = { $component } компонентдин тек-тек вариантар тайин апӀуз шулдар: length бутӀун число дар.
+
+variant-sort-not-implemented = sort айи { $component } компонентдин тек-тек вариантар гьеле мумкин дар
+
+variant-exclude-combinations-not-implemented = excludeCombinations айи { $component } компонентдин тек-тек вариантар гьеле мумкин дар
+
+variant-math-exclude-not-implemented = exclude айи math жюрейин { $component } компонентдин тек-тек вариантар гьеле мумкин дар
+
+variant-non-constant-exclude-not-implemented = дегиш жеру exclude айи { $component } компонентдин тек-тек вариантар гьеле мумкин дар
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure рендердиъ гъабул апӀуру дар; элемент адабгъна.
+
+prefigure-descendant-invalid-geometry = { $subject }: геометрия таман дар ва я числаяр сергьятсуз ву; элемент адабгъна.
+
+prefigure-curve-label-omitted = { $subject }: эгри цӀарин элементариин лишнар гъабул апӀуру дар; лишан адабгъна.
+
+prefigure-curve-unsupported-definition-type = { $subject }: эгри цӀарин функцийин тайинатдин '{ $definitionType }' жюре гъабул апӀуру дар; элемент адабгъна.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves компонентдиин flipFunctions атрибут гъабул апӀуру дар; элемент адабгъна.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves компонентдиъ анжах формулайин жюрейин функцйир гъабул апӀура; элемент адабгъна.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] цӀарин жюрейин лишандиз
+       *[point] нукьтӀайин лишандиз
+    } '{ $labelPosition }' labelPosition гъабул апӀуру дар; PreFigure стандарт кьяйда ишлетмиш апӀна.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' ацӀруйин стиль PreFigure гъабул апӀуру дар; саб рангнан ацӀруб ишлетмиш апӀура.
+
+prefigure-line-style-unknown = { $subject }: аьгъю дару '{ $lineStyle }' цӀарин стиль PreFigure удучӀвуйиан адабгъна.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' маркерин стиль PreFigure 'diamond' стилиз элкъюрна.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' маркерин стиль PreFigure гъабул апӀуру дар; стандарт стиль ишлетмиш апӀна.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` дюз дар; объект тайин апӀуз шулдар. Аннотация адабгъна.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` гизаф объектариз хъуркьна; сифтени объект ишлетмиш апӀура.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` дюз дар; объект graph компонентдин гъирагъдиан удучӀвура. Аннотация адабгъна.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` дюз дар; объект prefigure элкъуйиъ гъабул апӀру график объект дар. Аннотация адабгъна.
+
+annotation-text-missing = `<annotation>`: `text` адар ва я ичӀи ву; ичӀи текст удучӀвура.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Даире аслувал а.
+       *[other] `<{ $componentType }>` компонент иштирак апӀурайи даире аслувал а.
+    }
+
+reference-no-referent = Ссылкйин объект адар: `{ $reference }`
+
+reference-multiple-referents = Ссылкйиз гизаф объектар а: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` компонентдин { $attribute } атрибутдин формат дюз дар.
+
+children-invalid = `<{ $componentType }>` компонентдин элементар дюз дар: дюз дару элементар а: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутдин `{ $value }` кьимат дюз дар, `{ $default }` кьимат ишлетмиш апӀура
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версия агуз гъабхьундар.
+       *[other] DoenetML { $version } версия агуз гъабхьундар. { $fallback } версия ишлетмиш апӀура
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Дюз дару DoenetML: { $content }
+
+parse-tag-missing-close-tag = Дюз дару DoenetML: `{ $tag }` тегдихъ багъламиш апӀру тег адар. Чаз-чаб багъламиш шулу тег ва я `</{ $tagName }>` тег хьуб герек ву.
+
+parse-tag-error = Дюз дару DoenetML: `<{ $tagName }>` тегдиъ гъалатӀ
+
+parse-attribute-missing-value = Дюз дару DoenetML: `{ $attribute }` дюз дару атрибутдин кьимат адарси гъилигура.
+
+parse-attribute-invalid = Дюз дару DoenetML: `{ $attribute }` атрибут дюз дар
+
+parse-attribute-value-invalid = Дюз дару DoenetML: `{ $value }` атрибутдин кьимат дюз дар
+
+parse-attribute-value-quote-mismatch = Дюз дару DoenetML: `{ $value }` атрибутдин кьимат дюз дар. Кавычкйир саб-сариз уйгъун дар. `{ $quote }` адарси гъилигура
+
+parse-open-tag-name-missing = Дюз дару DoenetML: ччвур адру тег а, месела `<`
+
+parse-tag-not-closed = Дюз дару DoenetML: `{ $tag }` тег багъламиш дапӀундар (`>` адарси гъилигура).
+
+parse-self-closing-tag-name-missing = Дюз дару DoenetML: ччвур адру тег а `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Дюз дару DoenetML: `{ $tag }` тег багъламиш дапӀундар (`/>` адарси гъилигура).
+
+parse-tag-invalid-attributes = Дюз дару DoenetML: `{ $tag }` тег дюз дар. Думуъ дюз дару атрибутар хьуз шулу.
+
+parse-close-tag-name-missing = Дюз дару DoenetML: ччвур адру багъламиш апӀру тег а, месела `</`
+
+parse-attribute-value-unquoted = Атрибутарин кьиматар кавычкйириъ хьуб герек ву: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Дюз дару DoenetML: `{ $tag }` багъламиш апӀру тег а, амма ачмиш апӀру тег адар
+
+parse-close-tag-mismatched = Дюз дару DoenetML: багъламиш апӀру тег уйгъун дар. `</{ $expected }>` герек вуй. `{ $found }` а
+
+parser-node-unconvertible = { $node } узел Dast узелиз элкъюруз гъабхьундар.
+
+## Names
+
+name-attribute-invalid =
+    Дюз дару name='{ $name }' атрибут. { $reason ->
+        [characters] Ччвурариъ анжах гьярфар, числаяр, кӀан цӀарар ва я дефисар хьуз шулу.
+       *[start] Ччвурар гьярфнаан ккебгъуб герек ву.
+    }
+
+component-name-invalid-start = Дюз дару "{ $name }" компонентдин ччвур. Ччвурар гьярфнаан ккебгъуб герек ву.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched жюрейин жавабихъ video атрибут хьуб герек ву
+
+answer-video-watched-video-not-reference = videoWatched жюрейин жавабин video атрибут ссылка хьуб герек ву
+
+answer-name-not-single-text = Жавабин name атрибутдиъ саб текст элемент хьуб герек ву
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Гизаф рекурсийин дережйир гъахьи бадали кьяляхъна DoenetML гъадагъуз гъабхьундар. Даире ссылка адарин?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" терефнаан DoenetML гъадагъуз гъабхьундар
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" терефнаан гъадагъу DoenetML дюз дар: думу "{ $componentType }" компонентдин жюрейиз уйгъун дар
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут кюгьне ву; думун эвезиъ `{ $to }` ишлетмиш апӀин.
+       *[other] [deprecation] `<{ $component }>` компонентдиин `{ $from }` атрибут кюгьне ву; думун эвезиъ `{ $to }` ишлетмиш апӀин.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут кюгьне ву ва гьисаба ккабхьуру дар, гьаз гъи `{ $to }` гьаци улупна.
+       *[other] [deprecation] `<{ $component }>` компонентдиин `{ $from }` атрибут кюгьне ву ва гьисаба ккабхьуру дар, гьаз гъи `{ $to }` гьаци улупна.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` компонентдиин `{ $attribute }` атрибут кюгьне ву ва гьисаба ккабхьуру дар.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` компонентдиин `{ $attribute }` атрибут кюгьне ву; думун эвезиъ `<{ $child }>` элемент ишлетмиш апӀин.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` компонентдиин `{ $attribute }` атрибутдин `{ $value }` кьимат кюгьне ву; думун эвезиъ `{ $to }` ишлетмиш апӀин.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` анжах инглис чӀалнан гафар гизафвалин кьяйдайиз элкъюруз шулу, гьаддиз { $locale } чӀалниъ ликӀнайи документиъ текст автори ликӀу кьяйдайиинди гъузура. Гизафвалин форма чиб ликӀин, ва я `pluralForm` атрибутдиинди тайин апӀин.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент Doenet аьгъю вуйи элемент дар.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элемент документдин дувулиъ хьуз ихтияр адар.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элемент `<{ $parent }>` компонентдин ичӀ пайиъ хьуз ихтияр адар.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементдиъ `{ $attribute }` ччвур айи атрибут адар.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементдин `{ $attribute }` атрибут список хьуб герек ву, ва думун гьар са элемент гьаму кьиматарикан саб хьуб герек ву: { $allowed }
+       *[other] `<{ $tag }>` элементдин `{ $attribute }` атрибут гьаму кьиматарикан саб хьуб герек ву: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select бадали вариантдин ччвур дюз дар.  { $variantName } вариантдин ччвур { $numOptions } сечимиъ а, амма сечмиш апӀру кьадар { $numToSelect } ву.
+
+select-variant-name-without-options = select бадали бязи вариантар улупна, амма мумкин вуйи { $variantName } вариантдин ччвур бадали сечимар улупундар.
+
+select-variant-name-not-possible = select бадали улупу { $variantName } вариантдин ччвур мумкин вуйи вариантдин ччвур дар.
+
+select-too-few-options = Анжах { $numOptions } сечимиан { $numToSelect } компонент сечмиш апӀуз шулдар.
+
+select-from-sequence-too-few-values = { $length } кьадар айи последовательностиан { $numToSelect } кьимат сечмиш апӀуз шулдар.
+
+select-from-sequence-indices-count-mismatch = select бадали улупу индексарин кьадар сечмиш апӀру кьадариз уйгъун хьуб герек ву
+
+select-from-sequence-indices-not-integers = select бадали улупу вари индексар бутӀун числаяр хьуб герек ву
+
+select-from-sequence-index-excluded = selectfromsequence бадали адабгъу индекс улупна
+
+select-from-sequence-indices-excluded-combination = selectfromsequence бадали адабгъу бирикме вуйи индексар улупна
+
+select-from-sequence-coprime-not-positive-integers = Позитив бутӀун числаяр сечмиш апӀурадарки, coprime бирикмйир сечмиш апӀуз шулдар.
+
+select-from-sequence-coprime-common-factor = Coprime числаяр сечмиш апӀуз шулдар. Мумкин вуйи вари кьиматариъ умуми делитель а. (Улупу "from" ва я "to" кьиматар "step" кьиматдихъди coprime хьуб герек ву.)
+
+select-from-sequence-coprime-single-number = 1 дару саб числайиан coprime бирикмйир сечмиш апӀуз шулдар.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence компонентдиъ бирикмйирин 70%-дихьан гизафси адабгъна
+
+select-from-sequence-coprime-none-found = Coprime числаяр сечмиш апӀуз гъабхьундар. Мумкин вуйи вари кьиматариъ умуми делитель а.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } кьадар айи последовательностиан { $numToSelect } тек-тек кьимат сечмиш апӀуз шулдар
+
+select-prime-numbers-too-few-values = { $numValues } кьадар айи простой числйирин спискйиан { $numToSelect } кьимат сечмиш апӀуз шулдар
+
+select-prime-numbers-values-count-mismatch = select бадали улупу кьиматарин кьадар сечмиш апӀру кьадариз уйгъун хьуб герек ву
+
+select-prime-numbers-values-not-prime = select prime number бадали улупу вари кьиматар простой числйирин спискйиъ хьуб герек ву
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers бадали адабгъу бирикме вуйи кьиматар улупна
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers компонентдиъ бирикмйирин 70%-дихьан гизафси адабгъна
+
+select-random-combination-fluke = Гизаф аьжайиб гьалди, тесадуф кьиматарин бирикме сечмиш апӀуз гъабхьундар
+
+select-random-value-fluke = Гизаф аьжайиб гьалди, тесадуф кьимат сечмиш апӀуз гъабхьундар

--- a/packages/i18n/locales/tab/editor.ftl
+++ b/packages/i18n/locales/tab/editor.ftl
@@ -1,0 +1,234 @@
+# Tabasaran editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Cyrillic orthography of the Tabasaran literary language. The
+# palochka Ӏ is a letter, not a Latin I and not a digit 1.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers rather than prose and stay exactly as written.
+#
+# Tabasaran counts in `one` and `other`, so both branches of every count stay —
+# and a noun after a numeral stays singular, so the two read alike. Nothing
+# here forks on a noun class: Tabasaran's two classes are carried by numerals,
+# by the verb and by some pronouns, and `content.ftl`'s header sets out why
+# that keeps them out of these catalogs entirely.
+#
+# No case ending is welded onto a placeable. Where one was wanted the ending
+# went onto a noun this file writes — «лишандиин» after `{ $ref }` in
+# `help-placeholder`, «элементдиъ» after `{ $element }`, «терефнаан» after
+# `{ $owner }` — which is why those three read differently from English rather
+# than being translated in place.
+#
+# Least certain: the interface vocabulary is where an unreviewed seed is
+# weakest, and «хъуркьувал» for accessibility, «лигру пенжер» for the viewer
+# and «ивру» for an input field are this seed's own renderings rather than
+# terms it could attest. Everything computing-specific that Tabasaran writing
+# takes from Russian is left in Russian — «редактор», «вариант», «фильтр»,
+# «ссылка», «отчёт», «координата» — which is what Tabasaran technical prose
+# does.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Хътакуб
+       *[update] ЦӀийи апӀуб
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Лигру пенжер { $word }
+       *[other] Лигру пенжер { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Фильтр…
+editor-variant-next = Кьяляхъна вариант сечмиш апӀуб
+editor-variant-previous = Улихьна вариант сечмиш апӀуб
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA хъуркьувалин нарушение а. Хъуркьувалин отчёт { $action ->
+            [close] багъламиш
+           *[open] ачмиш
+        } апӀуз клик апӀин.
+        [advisories] Хъуркьувалин отчёт { $action ->
+            [close] багъламиш
+           *[open] ачмиш
+        } апӀуз клик апӀин. WCAG AA нарушенияр адар, амма жара меслятар а.
+       *[clean] Хъуркьувалин отчёт { $action ->
+            [close] багъламиш
+           *[open] ачмиш
+        } апӀуз клик апӀин. Хъуркьувалин масъалаяр адар.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA хъуркьувалин нарушение а. { $count ->
+            [one] { $count } WCAG AA нарушение
+           *[other] { $count } WCAG AA нарушение
+        } а. Хъуркьувалин отчёт { $action ->
+            [close] багъламиш
+           *[open] ачмиш
+        } апӀуз клик апӀин.
+        [advisories] WCAG AA нарушенияр адар. { $count ->
+            [one] { $count } элаве меслят
+           *[other] { $count } элаве меслят
+        } а. Хъуркьувалин отчёт { $action ->
+            [close] багъламиш
+           *[open] ачмиш
+        } апӀуз клик апӀин.
+       *[clean] WCAG AA нарушенияр адар. Хъуркьувалин отчёт { $action ->
+            [close] багъламиш
+           *[open] ачмиш
+        } апӀуз клик апӀин.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версия { $version }
+
+editor-tab-help = Контекстдин кюмек
+editor-tab-help-short = Контекст
+editor-tab-errors = ГъалатӀар
+editor-tab-warnings = Хабардарар
+editor-tab-info = Мялумат
+editor-tab-accessibility = Хъуркьувал
+editor-tab-responses = Ивнайи жавабар
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторин параметрар
+editor-format-as-doenetml = DoenetML кьяйдайиинди форматламиш апӀуб
+editor-format-as-xml = XML кьяйдайиинди форматламиш апӀуб
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Жерге #{ $line }
+
+editor-no-errors = ГъалатӀар адар
+editor-no-warnings = Хабардарар адар
+editor-no-info = Мялуматин хабарар адар
+
+editor-show-info-annotations = Мялуматин хабарар редакториъ улупуб
+editor-show-accessibility-annotations = Хъуркьувалин хабарар редакториъ улупуб
+
+editor-accessibility-learn-more = Doenet хъуркьувализ фици лигура
+
+editor-accessibility-violations-heading = Хъуркьувалин нарушенияр ({ $standard })
+
+editor-accessibility-other-heading = Жара хъуркьувалин масъалаяр
+editor-none-found = ЗатӀ адар
+
+
+## Submitted responses
+
+editor-no-responses = Гьеле ивнайи жавабар адар
+editor-response-answer-id = Жавабин Id
+editor-response-response = Жаваб
+editor-response-credit = Балл
+editor-response-submitted = Ивна
+
+
+## The context-help panel
+
+help-placeholder = Документация бадали курсор тегдин ччвуриин, атрибутиин ва я { $ref } лишандиин ивин.
+
+help-unsupported-ref-chain = { $example } жюре гизаф пайлу ссылкйириз кюмек гьеле адар.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ссылкйин объект адар: { $ref }.
+        [multiple] Ссылкйиз гизаф объектар а: { $ref }.
+       *[indeterminate] { $ref } ссылкйин объект тайин апӀуз гъабхьундар.
+    }
+
+help-learn-about-references = Ссылкйирикан аьгъю апӀин →
+help-reference-page = Справкайин ччин →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } элементдиъ
+       *[top] Заан дережайиъ
+    }{ $allowed ->
+        [none] { " — мушв затӀ жеди дар." }
+        [text] { " — мушв текст ликӀуз шулу." }
+        [text-and-components] { " — мушв текст ликӀуз шулу, ва я мурар синамиш апӀин:" }
+       *[components] { " — мурар синамиш апӀин:" }
+    }
+
+help-suggestions-footer = Вари { $total } компонент лигуз { $shortcut } тӀуб иливин.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объектдиз ссылка ву.
+       *[other] { $ref } — { $target } объектдиз ссылка ву ({ $line } жерге).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } терефнаан { $role } кьяйдайиинди гъибтна.
+       *[other] { $owner } терефнаан { $line } жергейиъ { $role } кьяйдайиинди гъибтна.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементдин { $property } свойствойиз ссылка ву.
+       *[other] { $ref } — { $element } элементдин { $property } свойствойиз ссылка ву ({ $line } жерге).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = фрагмент
+help-kind-array-entry = массивдин элемент
+
+help-default = Стандарт кьимат:
+help-active-default = Гьамусдин стандарт кьимат:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ихтияр вуйи кьиматар (гьар са элементдиз саб):
+       *[other] Ихтияр вуйи кьиматар:
+    }
+
+help-suggested-values = Меслят вуйи кьиматар:
+
+help-inserts = Ивура:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатйир:
+    }
+
+help-type = Жюре:
+
+help-resolved-style = Тайин гъабхьи стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Тайин гъабхьи функцйирин ччвурар:
+help-reset-list = Му ивруйин хътакру список:
+help-added-on-input = Му ивруйиъ элаве гъапӀу:
+help-removed-on-input = Му ивруйиан адагъу:
+
+help-reset-overrides = { $reset } { $additional } ва { $removed } эвез апӀуру.

--- a/packages/i18n/locales/tly/chrome.ftl
+++ b/packages/i18n/locales/tly/chrome.ftl
@@ -1,0 +1,147 @@
+# Talysh viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the **Latin** orthography Talysh publishing in Azerbaijan uses —
+# the Azerbaijani alphabet, with ə, ı, ö, ü, ğ, ş and ç — because that is what
+# the language's own periodicals print and what CLDR answers with:
+# `Intl.Locale("tly").maximize()` is `tly-Latn-AZ`, so a reader who types the
+# bare tag is, by CLDR's own data, most likely a Latin reader in Azerbaijan.
+# Talysh is also written in Cyrillic, and in Iran in the Perso-Arabic script.
+# A reader arriving under `tly-Cyrl` or `tly-Arab` reaches this catalog and
+# gets Latin; the answer to that is a second catalog beside this one rather
+# than a rename of it, which is the asymmetry `locales/pa`, `locales/sr`,
+# `locales/jv` and `locales/ku` already carry.
+#
+# Talysh counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape English gives it. A noun after a
+# numeral stays singular, so the two branches usually read alike.
+#
+# Talysh is Iranian and, like Persian and Ossetic, has no grammatical gender
+# and no noun class. Nothing in this catalog agrees with anything:
+# `content.ftl`'s `noun-gender` returns one token for every noun and no
+# message forks on it. This catalog sits in a batch full of Caucasian class
+# systems, so it is worth saying plainly — a reader expecting a fork here
+# should stop looking for one.
+#
+# **This is likely the least certain catalog in its batch.** Talysh is
+# endangered, its written output is small, and its Latin orthography is not
+# settled even within Azerbaijan — the vowels ə/e and ı/i especially. Interface
+# and technical vocabulary barely exists in it, so the words below lean on
+# Azerbaijani and on Persian the way written Talysh itself does. A speaker
+# should check the coined technical nouns before anything else: «xəto» (error),
+# «hoşdor» (warning), «dastrəsi» (accessibility), «pozey» (violation),
+# «nışondəkə» (renderer) and «səhv» for "invalid" are chosen here, not found
+# in use.
+
+
+## Answer submission
+
+answer-checking = Yoxlə kardedə…
+answer-submitting = Vığandedə…
+answer-checking-status = Cəvob yoxlə kardedə
+answer-submitting-status = Cəvob vığandedə
+answer-correct = Rost
+answer-incorrect = Rost ni
+answer-response-saved = Cəvob nığo doə be
+answer-percent-credit = { $percent }% bal
+answer-percent-correct = { $percent }% rost
+answer-percent-short = { $percent } %
+max-credit-available = Ən vey bal: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] cəhd nımandə
+        [one] { $count } cəhd mandə
+       *[other] { $count } cəhd mandə
+    }
+validation-correct = (Rost)
+validation-incorrect = (Rost ni)
+validation-partially-correct = (Qismən rost)
+# The answer's own name follows the count rather than taking a postposition of
+# its own: a Talysh «-ro» welded to a placeable would be an affix on a word
+# this catalog never sees.
+answer-show-responses =
+    { $count ->
+        [one] { $count } cəvob nışon doy: { $answerId }
+       *[other] { $count } cəvob nışon doy: { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Əks-cəvob
+collapsible-click-to-open = (oj kardeyro kılik bıkə)
+collapsible-click-to-close = (bandeyro kılik bıkə)
+collapsible-initializing = Hozı bedə…
+footnote-show = Zerənivişt nışon doy
+footnote-hide = Zerənivişt nıhon kardey
+description-more-information = vey məlumat
+
+
+## Controls
+
+slider-previous = Navınə
+slider-next = Peşinə
+keyboard-open = Klaviaturə oj kardey
+keyboard-close = Klaviaturə bandey
+choice-input-remove-choice = { $choice } bekardey
+matrix-remove-row = Sıra bekardey
+matrix-add-row = Sıra əlovə kardey
+matrix-remove-column = Sutun bekardey
+matrix-add-column = Sutun əlovə kardey
+subset-add-remove-points = Nuğtəon əlovə kardey/bekardey
+subset-toggle-points-intervals = Nuğtəon iyən intervalon əvəz kardey
+subset-move-points = Nuğtəon bardey
+subset-clear = Pok kardey
+orbital-add-row = Sıra əlovə kardey
+orbital-remove-row = Sıra bekardey
+orbital-add-box = Xonə əlovə kardey
+orbital-remove-box = Xonə bekardey
+orbital-add-up-arrow = Bə pe tir əlovə kardey
+orbital-add-down-arrow = Bə ji tir əlovə kardey
+orbital-remove-arrow = Tir bekardey
+orbital-row-label = Sıra { $row } nışonə
+pretzel-answer = Cəvob
+summary-statistics-caption = { $column } sutuni icmalə statistikə
+
+
+## Math input
+
+math-input-preview-region = riyoziyə ifodə navınə nışon
+math-input-preview = Navınə nışon
+math-input-invalid-expression = Səhvə ifodə:
+
+
+## Document status
+
+viewer-initializing = Hozı bedə…
+
+
+## Errors
+
+error-heading = Xəto
+error-found-at =
+    { $span ->
+        [line] { $startLine } sətirədə peydo be.
+       *[lines] { $startLine }–{ $endLine } sətironədə peydo be.
+    }
+document-contains-errors = Ə sənəddə xətoon heste!
+diagnostic-heading-error = Xəto
+diagnostic-heading-warning = Hoşdor
+diagnostic-heading-information = Məlumat
+diagnostic-heading-hint = İşorə
+accessibility-heading-level-1 = WCAG AA dastrəsi pozey
+accessibility-heading-level-2 = Dastrəsi barədə hoşdor
+something-went-wrong = Çiyi səhv beşe.
+renderer-load-failed = nışondəkə bar nıbe. Səhifə təzədən oj bıkə.
+core-start-failed = Ə sənəd bino be nışe. Səhifə təzədən oj bıkə.
+core-start-failed-busy = Ə sənəd bino be nışe. Çand sənəd i vaxtədə bino bedəbin, ım ki kandə cihozədə vey vaxt bardedə. Co sənədon ğırteysə peştə səhifə təzədən oj kardey kümək bəkarde.
+core-start-failed-retry = Ə sənəd bino be nışe.
+core-start-failed-busy-retry = Ə sənəd bino be nışe. Çand sənəd i vaxtədə bino bedəbin, ım ki kandə cihozədə vey vaxt bardedə.
+core-start-retry = Təzədən sınəğ bıkə
+saved-state-unavailable = Şımə nığo doə kor bar nıbe.

--- a/packages/i18n/locales/tly/content.ftl
+++ b/packages/i18n/locales/tly/content.ftl
@@ -1,0 +1,276 @@
+# Talysh content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the **Latin** orthography Talysh publishing in Azerbaijan uses —
+# the Azerbaijani alphabet, with ə, ı, ö, ü, ğ, ş and ç. That is what the
+# language's own periodicals print and what CLDR answers with:
+# `Intl.Locale("tly").maximize()` is `tly-Latn-AZ`. Talysh is also written in
+# Cyrillic, and in Iran in the Perso-Arabic script, and a reader arriving under
+# `tly-Cyrl` or `tly-Arab` reaches this catalog and gets Latin. A second
+# catalog beside this one is the answer to that, not a rename of this one —
+# the same asymmetry `locales/pa`, `locales/sr`, `locales/jv` and `locales/ku`
+# already carry.
+#
+# **Talysh has no grammatical gender and no noun class**, as Persian and
+# Ossetic have none. `noun-gender` below answers `neuter` for every noun, the
+# answer goes unused, and not one message in this file forks on `$gender` or on
+# `$role`. This catalog was seeded in a batch full of Northeast Caucasian and
+# Nakh class systems, where a fork is the normal shape, so it is worth saying
+# outright: there is nothing to fork here, and a table of classes added later
+# would be describing a language other than this one.
+#
+# **The colour table is the first thing to read, and part of it is a choice
+# rather than a translation.** Talysh's inherited colour vocabulary does not
+# split where the style pipeline needs it split: «kavu» covers blue and
+# blue-grey and reaches into green, and the green/blue/cyan contrast the
+# pipeline draws is not one the language draws in one word each. So this
+# catalog writes the compounds that split it — «vaşi rang», grass-colour, for
+# green, «osmoni rang», sky-colour, for blue, and «ravşanə osmoni rang» for
+# cyan. That is the move `locales/sah` and `locales/os` already made for the
+# same reason, and it is a decision a speaker may reverse; if they do, they
+# should reverse it in this table rather than in the composition messages.
+#
+# Attributive adjectives **precede** their noun in Talysh, as they do in
+# English, so the style descriptions keep English's order and the composition
+# messages below are unrearranged. The adjectives carry the attributive «-ə»
+# where they take one; the colours that end in «-i» or in a vowel do not.
+#
+# The affix rule is met once, in `style-border-clause` and `style-filled`:
+# "with a red border" is written «{ $border } kənordor», border-having, and
+# "with diamonds" «{ $pattern } nəxşdorə», pattern-having, so the suffix lands
+# on a noun this catalog supplies rather than on a placeable whose shape it
+# cannot see.
+#
+# **Least certain here:** the geometry nouns. «çandkunc», «sekunc»,
+# «rostəkunc», «şıkəstə xət» and «meyli meydon» are built on Talysh stems the
+# way Azerbaijani builds its own, but Talysh has no school geometry of its own
+# to check them against, and a speaker who has read mathematics in the language
+# should overwrite them without hesitating.
+
+
+## Style vocabulary
+
+color =
+    .black = siyo
+    .white = sipi
+    .gray = xokəsti
+    .red = sıə
+    .orange = narinci
+    .yellow = zard
+    .green = vaşi rang
+    .cyan = ravşanə osmoni rang
+    .blue = osmoni rang
+    .purple = bənəvşəyi
+    .pink = çəhrayi
+    .brown = ğəhvəyi
+line-width =
+    .thick = kuluftə
+    .thin = nozıkə
+line-style =
+    .dashed = tirəyinə
+    .dotted = nuğtəyinə
+# Noun phrases: they stand in front of «nəxşdorə» and modify nothing.
+fill-style =
+    .horizontal = üfüqiyə xəton
+    .vertical = şaquliyə xəton
+    .diagonal = diaqonalə xəton
+    .backdiagonal = əkəs diaqonalə xəton
+    .dots = nuğtəon
+    .diamonds = rombon
+noun =
+    .line = xət
+    .line-segment = xəti poə
+    .ray = şüə
+    .vector = vektor
+    .curve = kəcə xət
+    .function = funksiya
+    .slope-field = meyli meydon
+    .vector-field = vektori meydon
+    .parabola = parabola
+    .polyline = şıkəstə xət
+    .polygon = çandkunc
+    .triangle = sekunc
+    .rectangle = rostəkunc
+    .circle = doyrə
+    .region = sahə
+    .point = nuğtə
+    .square = kvadrat
+    .diamond = romb
+    .cross = xaç
+    .plus = plyus
+# «-kunc» is welded to the side count, which is safe for `locales/tlh`'s
+# reason rather than by luck: the stem has one shape whatever number precedes
+# it. The whole of the word is the head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] müntəzəmə { $numSides }-kunc
+    }
+# Talysh has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = purə
+# «nəxşdorə» — "pattern-having" — is written after the pattern words this
+# catalog supplies, so the suffix sits on a noun of its own rather than on a
+# placeable, and no preposition is wanted.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } nəxşdorə { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } nəxşdorə { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } nəxşdorə { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «kənordor» — "border-having" — is the same construction, and Talysh wants
+# neither an article nor a preposition in front of it, so the four branches
+# differ only in the conjunction.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } kənordor
+        [and] iyən { $border } kənordor
+        [and-article] iyən { $border } kənordor
+       *[with] { $border } kənordor
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = pur nıbə
+# «-ədə» is a locative on the catalog's own word «fon», and it stands in front
+# of the text colour, which is where a Talysh clause of place goes.
+style-text =
+    { $parts ->
+        [background] { $background } fonədə { $color }
+       *[plain] { $color }
+    }
+style-background-none = ni
+
+
+## Boolean words
+
+boolean-true = rost
+boolean-false = rost ni
+
+
+## Answer buttons
+
+answer-submit-label = Kor yoxlə kardey
+answer-submit-label-no-correctness = Cəvob vığandey
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Fəoliyət
+    .aside = Kənoə ğeyd
+    .cascade = Kaskad
+    .definition = Tərif
+    .example = Nımunə
+    .exercise = Təmrin
+    .exercises = Təmrinon
+    .given-answer = Cəvob
+    .note = Ğeyd
+    .objectives = Məğsədon
+    .paragraphs = Abzason
+    .part = Poə
+    .problem = Məsələ
+    .problems = Məsələon
+    .proof = İsbot
+    .question = Soal
+    .section = Bəxş
+    .solution = Həll
+    .task = Tapşırığ
+    .theorem = Teorem
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = İşorə
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Cədvəl { $enumeration }
+        [numbered-title] Cədvəl { $enumeration }{ ". " }
+        [unnumbered-title] Cədvəl{ ". " }
+       *[unnumbered] Cədvəl
+    }
+figure-name =
+    { $parts ->
+        [numbered] Şəkil { $enumeration }
+        [numbered-caption] Şəkil { $enumeration }{ ". " }
+        [unnumbered-caption] Şəkil{ ". " }
+       *[unnumbered] Şəkil
+    }
+
+
+## Paginator controls
+
+paginator-previous = Navınə
+paginator-next = Peşinə
+paginator-page = Səhifə
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## Talysh's conditional «əqər» opens its clause, as Persian's «agar» does, so
+## `piecewise-condition-if` lands where the renderer puts it — in front of the
+## mathematics it introduces. This catalog therefore records no limit here,
+## unlike `locales/sah`, `locales/tyv`, `locales/udm`, `locales/kv` and
+## `locales/chm`, whose conditionals close their clause.
+
+piecewise-condition-or = ya
+piecewise-condition-if = əqər
+piecewise-condition-otherwise = əks holədə
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. This is the school-system case, and for
+## Talysh it is a two-country one: there is no single school system to point
+## at. Secondary chemistry is taught in Azerbaijani in Azerbaijan and in
+## Persian in Iran, and Talysh is a language of the home and the newspaper on
+## both sides of that border rather than of the chemistry lesson on either. So
+## the element names a Talysh-speaking pupil has actually met are Azerbaijani
+## or Persian ones, and an invented Talysh table would be further from every
+## classroom than the English fallback is.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Səhvə kimyəvi işorə
+chemistry-invalid-ionic-compound = Səhvə ionə tərkib

--- a/packages/i18n/locales/tly/diagnostics.ftl
+++ b/packages/i18n/locales/tly/diagnostics.ftl
@@ -1,0 +1,693 @@
+# Talysh diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the **Latin** orthography Talysh publishing in Azerbaijan uses —
+# the Azerbaijani alphabet, with ə, ı, ö, ü, ğ, ş and ç — which is what CLDR
+# fills the bare tag in as: `tly` maximizes to `tly-Latn-AZ`. Talysh is also
+# written in Cyrillic, and in Iran in the Perso-Arabic script; a reader
+# arriving under `tly-Cyrl` or `tly-Arab` reaches this catalog and gets Latin,
+# and the answer to that is a second catalog beside this one rather than a
+# rename of it.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Talysh counts in two plural categories, `one` and `other`, and a noun after
+# a numeral stays singular, so the two branches of every selection below read
+# alike. Nothing here agrees with a gender or a noun class: Talysh has neither,
+# which is the whole of the agreement story for this locale.
+#
+# The technical vocabulary leans on Azerbaijani, as written Talysh in
+# Azerbaijan does: «komponent», «atribut», «indeks», «funksiya», «dəyişən».
+# The words this seed had to choose rather than find — «xəto» for error,
+# «səhv» for invalid, «nəzərə səə nibe» for "is ignored", «nışondəkə» for
+# renderer, «dastrəsi» for accessibility — are the first thing a speaker
+# should go over.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] dı qılə kəno nuğtə təyin bəbu, { $attributes } nəzərə səə nibe
+       *[other] dı qılə kəno nuğtə təyin bəbu, { $attributes } nəzərə səə nibe
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] kəno nuğtə iyən miyonə nuğtə har dı təyin bəbu, { $attributes } nəzərə səə nibe
+       *[other] kəno nuğtə iyən miyonə nuğtə har dı təyin bəbu, { $attributes } nəzərə səə nibe
+    }
+
+line-segment-midpoint-offset-without-midpoint = miyonə nuğtə nıbu, midpointOffset heç təsir kardedəni
+
+## `<line>`
+
+line-points-undetermined-dimensions = Ölçüon təyin nıbə nuğtəonədə dəvardə xət.
+
+line-points-too-few-dimensions = Xət bəpe ən kam dı ölçüynə nuğtəonədə dəvardo.
+
+line-points-depend-on-variables = Xət dəyişənonro bastə bə nuğtəonədə dəvardedə: { $variables }.
+
+line-equation-invalid-format = { $variable1 } iyən { $variable2 } dəyişənonədə xəti tənliki format səhve.
+
+## `<ray>`
+
+ray-overprescribed-through = Şüə through, endpoint iyən direction sədo təyin bə. Təyin bə through nəzərə səə nibe.
+
+ray-dimension-mismatch = şüədə numDimensions uyğun nibe.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor head, tail iyən displacement sədo təyin bə. Təyin bə head nəzərə səə nibe.
+
+vector-dimension-mismatch = vektordə numDimensions uyğun nibe.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` tərəf cəlb kardey nibe, çünki əy nearestPoint holətə dəyişən ni.
+
+constrain-to-without-nearest-point = `<{ $component }>` sədo məhdud kardey nibe, çünki əy nearestPoint holətə dəyişən ni.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` dılədə məhdud kardey nibe, çünki əy nearestPoint holətə dəyişən ni.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline nıbə choiceInput-ro labelPosition nəzərə səə nibe
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-ro təyin bə indekson nəzərə səə nibe, çünki indekson şumor choice dılə elementon şumori uyğun nibe.
+
+pretzel-indices-count-mismatch = problem-ro təyin bə indekson nəzərə səə nibe, çünki indekson şumor problem dılə elementon şumori uyğun nibe.
+
+shuffle-indices-count-mismatch = shuffle-ro təyin bə indekson nəzərə səə nibe, çünki indekson şumor komponenton şumori uyğun nibe.
+
+indices-ignored-out-of-range = { $component } komponentiro təyin bə indekson nəzərə səə nibe, çünki bəzi indekson həddiku beşedən.
+
+pretzel-indices-repeated = pretzel-ro təyin bə indekson nəzərə səə nibe, çünki bəzi indekson təkror bedən.
+
+pretzel-circuit-first-index = circuit rejimədə pretzel-ro təyin bə indekson nəzərə səə nibe, çünki avvəlnə indeks bəpe 1 bıbu.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` mətnə dılə elementon sədo kor bıkəro, `type` atribut bəpe təyin bıbu.
+
+invalid-type-defaulting-to-math = { $component } komponentiro { $type } tip səhve. Bəpe math, text, number ya boolean bıbu. math peqətə bedə.
+
+string-not-valid-component-to-arrange = "{ $value }" mətn { $component } kardeyro düzə komponent ni. Nəzərə səə nibe.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } tip səhve, tip number noə bedə.
+
+invalid-variable-value = Dəyişəni ğıymət səhve: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } variant indeks bəpe ədəd bıbu
+
+variant-index-must-be-integer = { $index } variant indeks bəpe tam ədəd bıbu
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` mütləğə ölçüon sədo kor kardedəni. Enon nisbi noə bedən.
+
+side-by-side-absolute-margins = `<{ $component }>` mütləğə ölçüon sədo kor kardedəni. Kənoon nisbi noə bedən.
+
+side-by-side-no-block-child = Səhvə `<{ $component }>`: əy bəpe ən kam i qılə blokə dılə element bıbu.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Qrafikə `<label>` sədo `for` atribut nəzərə səə nibe.
+
+label-for-must-resolve-to-one = `<label>` sədo `for` atribut bəpe düz i qılə komponent nışon bıdo.
+
+label-for-unresolved = `<label>` sədo `for` atributi i qılə komponenti sədo təyin kardey nışe.
+
+label-for-answer-with-authored-inputs = `<label>` sədo `for` atribut ə `<answer>` nışon dedə ki, dənoydəon əyo müəllif ıştən nıvıştə; dənoydə bevositə nışon bıdə.
+
+label-for-answer-without-input = `<label>` sədo `for` atribut ə `<answer>` nışon dedə ki, əy nışonə noyro dənoydə ni.
+
+label-for-must-reference-input-or-answer = `<label>` sədo `for` atribut bəpe dənoydə ya cəvob nışon bıdo.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Dastrəsiro `<{ $component }>` bəpe ya kırtə təsvir bıbu, ya bəzəkinə kimi təyin bıbu.
+
+accessibility-video-short-description = Dastrəsiro `<video>` bəpe kırtə təsvir bıbu.
+
+accessibility-input-short-description-or-label = Dastrəsiro `<{ $component }>` bəpe kırtə təsvir ya nışonə bıbu.
+
+accessibility-answer-input-short-description-or-label = Dastrəsiro dənoydə soxdə `<answer>` bəpe kırtə təsvir ya nışonə bıbu.
+
+accessibility-short-description-contains-math = Kırtə təsviron dılədə `<{ $component }>` kimi riyoziyə komponenton nıbəpe bıbun. Riyoziyot sıxanon sədo bınıvışt.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } bəxşi sərlöhə mətniro bəs nıbə kontrast dodə (tarikə rejim) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ən kam { $threshold }:1 lozime).
+       *[other] { $colorName } bəxşi sərlöhə mətniro bəs nıbə kontrast dodə ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ən kam { $threshold }:1 lozime).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Nuğtəon ədədə ğıymət nıbəyədə { $count } nuğtə sədo dəvardə `<circle>` hələ həyotə dənoə nıbe.
+
+circle-too-many-through-points = 3-ku vey nuğtəonədə dəvardə doyrə hisob kardey nibe.
+
+circle-overprescribed-radius-center-points = Təyin bə radius, mərkəz iyən dəvardə nuğtəon sədo doyrə hisob kardey nibe.
+
+circle-center-with-multiple-points = Təyin bə mərkəz iyən 1-ku vey nuğtə sədo doyrə hisob kardey nibe.
+
+circle-radius-too-small = Doyrə hisob kardey nibe: dı qılə nuğtə arədə məsafə { $distance } bəbu, təyin bə { $radius } radius vey kıçhe.
+
+circle-radius-with-many-points = Təyin bə radius sədo dı qıləku vey nuğtəonədə doyrə soxtey nibe.
+
+circle-invalid-center-or-through-points = Doyrə mərkəz ya dəvardə nuğtəon səhvin.
+
+circle-radius-center-with-multiple-points = Təyin bə mərkəz iyən 1-ku vey nuğtə sədo doyrə radius hisob kardey nibe.
+
+circle-change-radius-non-numerical = Ədədə ğıymət nıbə nuğtəonədə dəvardə doyrə radius əvəz kardey nibe
+
+circle-radius-with-points-non-numerical = Ədədə ğıymət nıbəyədə təyin bə radius sədo i qıləku vey nuğtəonədə doyrə soxtey nibe.
+
+circle-change-center-non-numerical = Ədədə ğıymət nıbə nuğtəonədə dəvardə doyrə mərkəzi əvəz kardey hələ həyotə dənoə nıbe.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Funksiya təyin sahəro ölçüon bəs kardedənin. Sahədə { $intervals } interval heste, funksiyədə isə { $inputs ->
+            [one] { $inputs } dəşiş
+           *[other] { $inputs } dəşiş
+        } heste.
+       *[other] Funksiya təyin sahəro ölçüon bəs kardedənin. Sahədə { $intervals } interval heste, funksiyədə isə { $inputs ->
+            [one] { $inputs } dəşiş
+           *[other] { $inputs } dəşiş
+        } heste.
+    }
+
+function-domain-invalid-format = Funksiya təyin sahəro format səhve.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Funksiya ədədə nıbə maksimum nəzərə səə nibe.
+        [minimum] Funksiya ədədə nıbə minimum nəzərə səə nibe.
+        [extremum] Funksiya ədədə nıbə ekstremum nəzərə səə nibe.
+        [point] Funksiya ədədə nıbə nuğtə nəzərə səə nibe.
+        [slope] Funksiya ədədə nıbə meyl nəzərə səə nibe.
+       *[other] Funksiya ədədə nıbə { $type } nəzərə səə nibe.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Funksiya xolə maksimum nəzərə səə nibe.
+        [minimum] Funksiya xolə minimum nəzərə səə nibe.
+        [extremum] Funksiya xolə ekstremum nəzərə səə nibe.
+        [point] Funksiya xolə nuğtə nəzərə səə nibe.
+       *[other] Funksiya xolə { $type } nəzərə səə nibe.
+    }
+
+function-points-too-close = Funksiyədə dı qılə nuğtə bo-bə vey nezin. Funksiya təyin kardey nibe.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Funksiya təkroron ancaq dəşişon şumor beşişon şumori bərobər bəbu mümkine. Ə funksiyədə { $inputs } dəşiş iyən { $outputs ->
+            [one] { $outputs } beşiş
+           *[other] { $outputs } beşiş
+        } heste.
+       *[other] Funksiya təkroron ancaq dəşişon şumor beşişon şumori bərobər bəbu mümkine. Ə funksiyədə { $inputs } dəşiş iyən { $outputs ->
+            [one] { $outputs } beşiş
+           *[other] { $outputs } beşiş
+        } heste.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Ardıcıllığ dırozi səhve. Bəpe mənfi nıbə tam ədəd bıbu.
+
+sequence-invalid-step = Ardıcıllığ addım səhve. { $type } tipə ardıcıllığro bəpe ədəd bıbu.
+
+sequence-invalid-endpoint-number = Ədədə ardıcıllığ "{ $attribute }" səhve. Bəpe ədəd bıbu.
+
+sequence-invalid-endpoint-letters = Hərfinə ardıcıllığ "{ $attribute }" səhve. Bəpe hərfon birləşmə bıbu.
+
+sequence-invalid-endpoint = Ardıcıllığ "{ $attribute }" səhve.
+
+select-from-sequence-coprime-not-numbers = ədədon peqətə nibe, ımiro coprime nəzərə səə nibe
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations təyin bə, ımiro coprime nəzərə səə nibe
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` sədo səhvə target: hədəf peydo nıbe.
+
+target-state-variable-not-found = `<{ $source }>` sədo səhvə target: `<{ $component }>` sədo "{ $property }" nomədə holətə dəyişən peydo nıbe.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` dəyişənon bəpe müstəğilə dəyişəniku co bıbun.
+
+ode-system-duplicate-variable-names = Təkrorinə asılə dəyişən nomon sədo ODE RHS funksiyaon təyin kardey nibe.
+
+ode-system-rhs-function-error = ODE RHS funksiya təyin kardey nibe. mathjs funksiya soxdeydə xəto.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } xət arədə kunc təyin kardey nibe
+
+angle-invalid-through-point = `<angle>` through dılədə nuğtə səhve
+
+parabola-vertex-too-many-points = Təpə iyən 1-ku vey nuğtəonədə dəvardə parabola hələ həyotə dənoə nıbe.
+
+parabola-too-many-points = 3-ku vey nuğtəonədə dəvardə parabola hələ həyotə dənoə nıbe.
+
+intersection-too-many-items = Dı qıləku vey obyektiro kəsişmə hələ həyotə dənoə nıbe
+
+## Other math components
+
+ionic-compound-not-two-ions = Dı qılə ioniku co çiyiro ionə tərkib hələ həyotə dənoə nıbe.
+
+ionic-compound-needs-cation-and-anion = Ionə tərkib ancaq i qılə kation iyən i qılə anioniro həyotə dənoə bə.
+
+solve-equations-cannot-evaluate = Tənlik həll kardey nibe, çünki tənliki hisob kardey nışe: { $equation }
+
+math-operators-operand-number-required = Riyoziyə operandi bekardeydə operandNumber bəpe təyin bıbu.
+
+eigen-decomposition-failed = Matrisi məxsusə ğıyməton hisob kardey nışe
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } parametr şablonədə ni, ımiro həmişə xolə yer sədo uyğun bəome.
+       *[other] `<matchesPattern>`: { $parameters } parametron şablonədə nin, ımiro həmişə xolə yer sədo uyğun bəomen.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ənə kardey nibe. Bəpe none, medium, dense, ya boşluğ sədo co bə dı qılə müsbətə ədəd bıbu, məsələn grid="1 0.5". Şəbəkə kəşə nibe.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` komponentiro { $expected ->
+        [one] i beşişinə funksiya lozime, har nuğtədə y' meyl, məsələn `y - x`
+       *[other] dı beşişinə funksiya lozime, har nuğtədə vektor, məsələn `(y, -x)`
+    }, əmmo doə bə funksiyədə { $found ->
+        [one] { $found } beşiş
+       *[other] { $found } beşiş
+    } heste. { $alternative ->
+        [none] Heçi kəşə nibe.
+       *[other] Ə funksiyaro `<{ $alternative }>` komponente. Heçi kəşə nibe.
+    }
+
+field-function-attribute-ignored-with-child = `function` atribut nəzərə səə nibe, çünki funksiya komponenti dılədə ham doə bə; dılədəyni işlədə bedə. Funksiya ancaq i cür bıdə.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` atribut komponenti dılədə bevositə nıvıştə bə ifodə dəyişənon nom bardedə. { $reason ->
+        [function-child] Ədə funksiya `<function>` dılə element kimi doə bə, əy ıştə dəyişənon ıştən nom bardedə, ımiro `variables` nəzərə səə nibe.
+       *[no-expression] Ədə belə ifodə doə nıbe, ımiro `variables` nəzərə səə nibe.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure nışondəkədə xLabelPosition="left" dəstək bedəni; rost tərəfi davranış işlədə bedə.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure nışondəkədə yLabelPosition="bottom" dəstək bedəni; səpe tərəfi davranış işlədə bedə.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure çevirmiro oxi sərhədon səhvin; əsosə bbox (-10,-10,10,10) işlədə bedə.
+
+prefigure-invalid-width = `<graph>`: prefigure çevirmiro en səhve; əsosə diaqram eni 425 işlədə bedə.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure çevirmiro aspectRatio səhve; əsosə nisbət 1 işlədə bedə.
+
+prefigure-grid-spacing-too-fine = `<graph>`: oxi həddonro şəbəkə arə vey nozıke; prefigure nışondəkədə şəbəkə kəşə nibe.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure nışondəkə işlədə nıbəbu, ğeydon kəşə nibin.
+
+multiple-annotations-children = `<graph>` dılədə çand `<annotations>` dılə element peydo be; axırınəku ğəyri həmməy nəzərə səə nibe.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ənə nıbə komponent tip dıroz kardey ya nusxə peqətey nibe: { $type }.
+
+copy-prop-not-found = { $component } tipə komponentədə { $property } xüsusiyət peydo nıbe
+
+collect-no-source = collect-ro mənbə peydo nıbe.
+
+collect-invalid-component-type = `<{ $component }>` tipə komponenton co kardey nibe, çünki ım səhvə komponent tipe.
+
+reference-index-unavailable = `{ $reference }` indeksi nışon doy nibe
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` komponentədə { $action } sədo kor kardey nibe
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Məlumaton şəkil səhve. Sıraon dırozi bo-bə uyğun ni. componentIdx :{ $componentIdx } dılədə peydo be
+
+data-frame-duplicate-column-names = Məlumatonədə təkrorinə sutun nomon heste. componentIdx :{ $componentIdx } dılədə peydo be
+
+data-frame-missing-column-name = Məlumatonədə i qılə sutuni nom ni. componentIdx :{ $componentIdx } dılədə peydo be
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ə cəvobiro i qılə mükafat ıştə `<answer>` teqi vığandə cəvobi səpe qıniyə, ım qözləniş nıbə davranışi bədoy.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` bə ğabi dılədə `<answer>` sədo `maxNumAttempts` noy heç təsir kardedəni, çünki cəhdon şumori ğab idarə kardedə. `maxNumAttempts` ğabi səpe bınə.
+
+nested-section-wide-check-work-max-num-attempts = Co `sectionWideCheckWork` bə ğabi dılədə bə `sectionWideCheckWork` bə ğabi səpe `maxNumAttempts` noy heç təsir kardedəni, çünki cəhdon şumori bəyrunə ğab idarə kardedə. `maxNumAttempts` bəyrunə ğabi səpe bınə.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality noə nıbu, { $attributes } atribut heç təsir bənıkarde.
+       *[other] symbolicEquality noə nıbu, { $attributes } atributon heç təsir bənıkarden.
+    }
+
+answer-invalid-type = Cəvobiro səhvə tip: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` komponenti nom nıbəyo, əy moduli atributiro işlədey nibe
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` komponenti moduli atributiro işlədey nibe, çünki `<module>` komponent tipədə jə "{ $name }" atribut təyin bə.
+
+conditional-content-condition-ignored = case ya else dılə elementon bə `<conditionalContent>` komponentədə `condition` atribut nəzərə səə nibe.
+
+slider-markers-type-mismatch = Nışonəon tip slayderi tipi uyğun nibe.
+
+pretzel-problem-needs-statement-and-answer = Səhvə pretzel: har `<problem>` dılədə bəpe i qılə `<statement>` iyən i qılə `<answer>` bıbu.
+
+pretzel-circuit-first-problem-distractor = Səhvə pretzel: mode="circuit" bəbu, avvəlnə `<problem>` çaşdəbardə bənıbe.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` atributiro { $values } ğıymət səhve; nəzərə səə nibe.
+       *[other] `{ $attribute }` atributiro { $values } ğıyməton səhvin; nəzərə səə nibin.
+    }
+
+attribute-must-be-references = `{ $attribute }` atributiro `{ $value }` ğıymət səhve. Atribut bəpe `$` sədo bino bə istinodonku ibarət bıbu.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } dılədə səhvə funksiya nomon nəzərə səə nibin: { $names }. Har nomi nışon doə poə bəpe ən kam 2 işorə bıbu (hərf ya tire); peştəyo ixtiyorə `|<mathspeak alternative>` şəkilçi bome bəzıne.
+
+## Building components from the source
+
+component-type-invalid = Səhvə komponent tip: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } atributi təkror kardey nibe.
+
+attribute-invalid-for-component = `<{ $componentType }>` tipə komponentiro "{ $attribute }" atribut səhve.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } stil təyinotədə { $context ->
+        [text-on-background] mətni rang fonə rangi sədo
+        [high-contrast] vey kontrastinə rang lövhə sədo
+        [line] xəti rang lövhə sədo
+        [marker] nışonə rang lövhə sədo
+       *[text-on-canvas] mətni rang lövhə sədo
+    } bəs nıbə kontrast dodə{ $mode ->
+        [dark] { " (tarikə rejim)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ən kam { $threshold }:1 lozime).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } stil təyinot ruşnə rejimiro bəs bə kontrastinə rangon təyin kardəş bıbu ham, ə ğıymətonku bekardə tarikə rejimi rangon mətni rangi fonə rangi sədo bəs nıbə kontrast dodən ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ən kam { $threshold }:1 lozime). { $suggestion ->
+        [available] Tarikə rejimədə kontrast bəs bıburo, ya ruşnə rejimi kontrast vey bıkə (məsələn, { $lightAttribute }="{ $lightColor }" bınə), ya tarikə rejimi rang əvəz bıkə (məsələn, { $darkAttribute }="{ $darkColor }" bınə).
+       *[none] Tarikə rejimədə kontrast bəs bıburo, ruşnə rejimi kontrast vey bıkə ya bekardə bə rangon textColorDarkMode iyən/ya backgroundColorDarkMode sədo əvəz bıkə.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } stil təyinot ruşnə rejimiro bəs bə kontrast bə mətni rang təyin kardəş bıbu ham, ə ğıymətiku bekardə tarikə rejimi mətni rang lövhə sədo bəs nıbə kontrast dodə ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ən kam { $threshold }:1 lozime). { $suggestion ->
+        [available] Tarikə rejimədə kontrast bəs bıburo, ya ruşnə rejimi kontrast vey bıkə (məsələn, textColor="{ $lightColor }" bınə), ya tarikə rejimi rang əvəz bıkə (məsələn, textColorDarkMode="{ $darkColor }" bınə).
+       *[none] Tarikə rejimədə kontrast bəs bıburo, ruşnə rejimi kontrast vey bıkə ya bekardə bə rang textColorDarkMode sədo əvəz bıkə.
+    }
+
+section-multiple-style-palettes = I qılə bəxş ancaq i qılə <stylePalette> peqətey bəzıne; axırınə işlədə bedə.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } komponenti təkinə varianton təyin kardey nibe, çünki numToSelect mənfi nıbə tam ədəd ni.
+
+variant-num-to-select-not-constant-number = { $component } komponenti təkinə varianton təyin kardey nibe, çünki numToSelect sabitə ədəd ni.
+
+variant-with-replacement-not-constant-boolean = { $component } komponenti təkinə varianton təyin kardey nibe, çünki withReplacement sabitə boolean ni.
+
+variant-select-weight-disables-unique = selectWeight ya selectForVariants təyin bə seçim bıbu, select-ro təkinə varianton söndə bedən
+
+variant-coprime-undetermined = { $component } komponenti təkinə varianton təyin kardey nibe, çünki coprime həmişə false bey təyin kardey nibe.
+
+variant-attribute-not-constant = { $component } komponenti təkinə varianton təyin kardey nibe, çünki { $attribute } sabit ni.
+
+variant-attribute-not-number = { $component } komponenti təkinə varianton təyin kardey nibe, çünki { $attribute } ədəd ni.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } tipə { $component } komponenti təkinə varianton təyin kardey nibe, çünki { $attribute } { $expected ->
+        [letters-combination] hərfon birləşmə
+        [math-expression] düzə riyoziyə ifodə
+        [integer] tam ədəd
+       *[number] ədəd
+    } ni.
+
+variant-length-not-integer = { $component } komponenti təkinə varianton təyin kardey nibe, çünki length tam ədəd ni.
+
+variant-sort-not-implemented = sort bə { $component } komponenti təkinə varianton hələ həyotə dənoə nıbin
+
+variant-exclude-combinations-not-implemented = excludeCombinations bə { $component } komponenti təkinə varianton hələ həyotə dənoə nıbin
+
+variant-math-exclude-not-implemented = exclude bə math tipə { $component } komponenti təkinə varianton hələ həyotə dənoə nıbin
+
+variant-non-constant-exclude-not-implemented = sabit nıbə exclude bə { $component } komponenti təkinə varianton hələ həyotə dənoə nıbin
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: qrafiki prefigure nışondəkədə dəstək bedəni; dılə element dəvardə bedə.
+
+prefigure-descendant-invalid-geometry = { $subject }: sonsuzə ya nıtomə həndəsə; dılə element dəvardə bedə.
+
+prefigure-curve-label-omitted = { $subject }: çevirə bə əyriyə elementonədə nışonəon dəstək bedənin; nışonə dəvardə bedə.
+
+prefigure-curve-unsupported-definition-type = { $subject }: dəstək nıbə əyri funksiya təyinot tip '{ $definitionType }'; dılə element dəvardə bedə.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves sədo dəstək nıbə flipFunctions atribut; dılə element dəvardə bedə.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves sədo ancaq formula tipə dılə funksiyaon dəstək bedən; dılə element dəvardə bedə.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] xət ailə nışonəro
+       *[point] nuğtə nışonəro
+    } dəstək nıbə labelPosition '{ $labelPosition }'; əsosə PreFigure düzəniş işlədə bedə.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' purkardə stil PreFigure tərəfo dəstək bedəni; bərkə pur bə oqardedə.
+
+prefigure-line-style-unknown = { $subject }: ənə nıbə xəti stil '{ $lineStyle }' PreFigure bekardəku dəvardə bedə.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' nışonə stil PreFigure 'diamond' stili sədo uyğun kardə be.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' nışonə stil PreFigure tərəfo dəstək bedəni; əsosə stil işlədə bedə.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: səhvə `ref`; hədəf təyin kardey nibe. Ğeyd dəvardə bedə.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` çand hədəf nışon dodə; avvəlnə hədəf işlədə bedə.
+
+annotation-ref-outside-graph = `<annotation>`: səhvə `ref`; hədəf ğabi qrafiki bekardəyo. Ğeyd dəvardə bedə.
+
+annotation-ref-unsupported-target = `<annotation>`: səhvə `ref`; hədəf prefigure çevirmədə dəstək bə qrafikə obyekt ni. Ğeyd dəvardə bedə.
+
+annotation-text-missing = `<annotation>`: `text` ni ya xolie; xolə mətn bekardə bedə.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Doyrəvi asılılığ peydo be.
+       *[other] `<{ $componentType }>` komponenti sədo doyrəvi asılılığ peydo be.
+    }
+
+reference-no-referent = İstinodro obyekt peydo nıbe: `{ $reference }`
+
+reference-multiple-referents = İstinodro çand obyekt peydo be: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` komponenti { $attribute } atributi format səhve.
+
+children-invalid = `<{ $componentType }>` komponentiro dılə elementon səhvin: səhvə dılə elementon peydo be: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` atributiro `{ $value }` ğıymət səhve, `{ $default }` ğıymət işlədə bedə
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } versiya peydo nıbe.
+       *[other] DoenetML { $version } versiya peydo nıbe. { $fallback } versiya işlədə bedə
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Səhvə DoenetML: { $content }
+
+parse-tag-missing-close-tag = Səhvə DoenetML: `{ $tag }` teqi bandə teq ni. Ya ıştən-bandə teq, ya `</{ $tagName }>` teq qözləniş bedəbe.
+
+parse-tag-error = Səhvə DoenetML: `<{ $tagName }>` teqədə xəto
+
+parse-attribute-missing-value = Səhvə DoenetML: `{ $attribute }` səhvə atributi ğıymət nıbe bənze.
+
+parse-attribute-invalid = Səhvə DoenetML: `{ $attribute }` atribut səhve
+
+parse-attribute-value-invalid = Səhvə DoenetML: `{ $value }` atributi ğıymət səhve
+
+parse-attribute-value-quote-mismatch = Səhvə DoenetML: `{ $value }` atributi ğıymət səhve. Dırnəğon bo-bə uyğun nin. Şımə `{ $quote }` yoddo bənzedə
+
+parse-open-tag-name-missing = Səhvə DoenetML: Nom nıbə teq peydo be, məsələn `<`
+
+parse-tag-not-closed = Səhvə DoenetML: `{ $tag }` teq bandə nıbe (`>` ni bənze).
+
+parse-self-closing-tag-name-missing = Səhvə DoenetML: Nom nıbə teq peydo be `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Səhvə DoenetML: `{ $tag }` teq bandə nıbe (`/>` ni bənze).
+
+parse-tag-invalid-attributes = Səhvə DoenetML: `{ $tag }` teq düz ni. Bəlkə atributon səhvin.
+
+parse-close-tag-name-missing = Səhvə DoenetML: Nom nıbə bandə teq peydo be, məsələn `</`
+
+parse-attribute-value-unquoted = Atributon ğıyməton bəpe dırnəğ dılədə bıbun: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Səhvə DoenetML: `{ $tag }` bandə teq peydo be, əmmo uyğunə oj bə teq ni
+
+parse-close-tag-mismatched = Səhvə DoenetML: Bandə teq uyğun nibe. `</{ $expected }>` qözləniş bedəbe. `{ $found }` peydo be
+
+parser-node-unconvertible = { $node } düyüni Dast düyüni sədo çevirmiş kardey nışe.
+
+## Names
+
+name-attribute-invalid =
+    Səhvə atribut name='{ $name }'. { $reason ->
+        [characters] Nomonədə ancaq hərfon, ədədon, jiə xət ya tire bome bəzınen.
+       *[start] Nomon bəpe hərfiku bino bıbun.
+    }
+
+component-name-invalid-start = Səhvə komponent nom "{ $name }". Nomon bəpe hərfiku bino bıbun.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched tipə cəvobədə bəpe video atribut bıbu
+
+answer-video-watched-video-not-reference = videoWatched tipə cəvobi video atribut bəpe istinod bıbu
+
+answer-name-not-single-text = Cəvobi name atributədə bəpe tanhə i qılə mətnə dılə element bıbu
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Bəyrunə DoenetML peqətey nibe, çünki rekursiya səviyyəon vey vein. Doyrəvi istinod heste?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" sədo DoenetML peqətey nibe
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" sədo peqətə bə DoenetML səhve: əy "{ $componentType }" komponent tipi uyğun nibe
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` atribut kohnə bə; ıvəzi `{ $to }` işlət.
+       *[other] [deprecation] `<{ $component }>` sədo `{ $from }` atribut kohnə bə; ıvəzi `{ $to }` işlət.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` atribut kohnə bə iyən nəzərə səə nibe, çünki `{ $to }` ham təyin bə.
+       *[other] [deprecation] `<{ $component }>` sədo `{ $from }` atribut kohnə bə iyən nəzərə səə nibe, çünki `{ $to }` ham təyin bə.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` sədo `{ $attribute }` atribut kohnə bə iyən nəzərə səə nibe.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` sədo `{ $attribute }` atribut kohnə bə; ıvəzi `<{ $child }>` dılə element işlət.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` sədo `{ $attribute }` atributi `{ $value }` ğıymət kohnə bə; ıvəzi `{ $to }` işlət.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ancaq inqiliso sıxanon cəm kardey bəzıne, ımiro { $locale } zıvonədə nıvıştə bə sənəddə əy mətn dəyiş nibe. Cəmə şəkil bevositə bınıvışt, ya `pluralForm` atribut sədo təyin bıkə.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` element ənə bə Doenet element ni.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` elementi sənədi rişədə noyro icozə ni.
+
+schema-element-not-allowed-inside = `<{ $tag }>` elementi `<{ $parent }>` dılədə noyro icozə ni.
+
+schema-attribute-unrecognized = `<{ $tag }>` elementədə `{ $attribute }` nomədə atribut ni.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` elementi `{ $attribute }` atribut bəpe siyahi bıbu ki, har elementış ımonku i qılə bıbu: { $allowed }
+       *[other] `<{ $tag }>` elementi `{ $attribute }` atribut bəpe ımonku i qılə bıbu: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select-ro variant nom səhve. { $variantName } variant nom { $numOptions } seçimədə peydo bedə, əmmo peqətey lozim bə şumor { $numToSelect }e.
+
+select-variant-name-without-options = select-ro bəzi varianton təyin bin, əmmo mümkün bə variant nomiro seçimon təyin nıbin: { $variantName }.
+
+select-variant-name-not-possible = select-ro təyin bə { $variantName } variant nom mümkün bə variant nom ni.
+
+select-too-few-options = Tanhə { $numOptions } seçimiku { $numToSelect } komponent peqətey nibe.
+
+select-from-sequence-too-few-values = { $length } dırozinə ardıcıllığiku { $numToSelect } ğıymət peqətey nibe.
+
+select-from-sequence-indices-count-mismatch = select-ro təyin bə indekson şumor peqətey lozim bə şumori uyğun bəpe bıbu
+
+select-from-sequence-indices-not-integers = select-ro təyin bə həmmə indekson bəpe tam ədədon bıbun
+
+select-from-sequence-index-excluded = selectfromsequence sədo bekardə bə indeks təyin bə
+
+select-from-sequence-indices-excluded-combination = selectfromsequence sədo bekardə bə birləşmə indekson təyin bin
+
+select-from-sequence-coprime-not-positive-integers = Müsbətə tam ədədon peqətə nibe, ımiro coprime birləşməon peqətey nibe.
+
+select-from-sequence-coprime-common-factor = Coprime ədədon peqətey nibe. Həmmə mümkün bə ğıyməton ümumiyə bölən dodən. (Təyin bə "from" ya "to" ğıyməton bəpe "step" sədo coprime bıbun.)
+
+select-from-sequence-coprime-single-number = 1 nıbə tanhə ədədiku coprime birləşməon peqətey nibe.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence dılədə birləşməon 70%-ku vey bekardə be
+
+select-from-sequence-coprime-none-found = Coprime ədədon peqətey nışe. Həmmə mümkün bə ğıyməton ümumiyə bölən dodən.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } dırozinə ardıcıllığiku { $numToSelect } təkinə ğıymət peqətey nibe
+
+select-prime-numbers-too-few-values = { $numValues } dırozinə sadə ədədon siyahiku { $numToSelect } ğıymət peqətey nibe
+
+select-prime-numbers-values-count-mismatch = select-ro təyin bə ğıyməton şumor peqətey lozim bə şumori uyğun bəpe bıbu
+
+select-prime-numbers-values-not-prime = select prime number-ro təyin bə həmmə ğıyməton bəpe sadə ədədon siyahidə bıbun
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers sədo təyin bə ğıyməton bekardə bə birləşmə bin
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers dılədə birləşməon 70%-ku vey bekardə be
+
+select-random-combination-fluke = Vey kam mümkün bə təsodüfiku, təsodüfiyə ğıyməton birləşmə peqətey nışe
+
+select-random-value-fluke = Vey kam mümkün bə təsodüfiku, təsodüfiyə ğıymət peqətey nışe

--- a/packages/i18n/locales/tly/editor.ftl
+++ b/packages/i18n/locales/tly/editor.ftl
@@ -1,0 +1,230 @@
+# Talysh editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the **Latin** orthography Talysh publishing in Azerbaijan uses —
+# the Azerbaijani alphabet, with ə, ı, ö, ü, ğ, ş and ç — which is what CLDR
+# fills the bare tag in as (`tly` maximizes to `tly-Latn-AZ`). A reader
+# arriving under `tly-Cyrl` or `tly-Arab` reaches this catalog and gets Latin;
+# a second catalog beside this one is the answer to that, not a rename of it.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Talysh counts in the same two categories English does, `one` and `other`, so
+# every selection below keeps both branches — though a noun after a numeral
+# stays singular, so the two read alike.
+#
+# Talysh has no grammatical gender and no noun class, so nothing here agrees
+# with anything. That is the whole of the agreement story for this locale; see
+# `content.ftl`'s header.
+#
+# The editor vocabulary is the least settled part of this seed. Talysh has no
+# software register of its own, so «nışondəkə» (renderer), «dastrəsi»
+# (accessibility) and «hoşdor» (warning) are coined here on Azerbaijani and
+# Persian models rather than taken from use.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Oqarde
+       *[update] Təzə kardey
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Nışondə { $word }
+       *[other] Nışondə { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = Süzgəc…
+editor-variant-next = Peşinə variant peqətey
+editor-variant-previous = Navınə variant peqətey
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA dastrəsi pozey peydo be. Dastrəsi hesobot { $action ->
+            [close] bandeyro
+           *[open] oj kardeyro
+        } kılik bıkə.
+        [advisories] Dastrəsi hesobot { $action ->
+            [close] bandeyro
+           *[open] oj kardeyro
+        } kılik bıkə. WCAG AA pozey peydo nıbe, əmmo co dastrəsi məsləhəton heste.
+       *[clean] Dastrəsi hesobot { $action ->
+            [close] bandeyro
+           *[open] oj kardeyro
+        } kılik bıkə. Dastrəsi məsələ peydo nıbe.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA dastrəsi pozey peydo be. { $count ->
+            [one] { $count } WCAG AA pozey
+           *[other] { $count } WCAG AA pozey
+        } peydo be. Dastrəsi hesobot { $action ->
+            [close] bandeyro
+           *[open] oj kardeyro
+        } kılik bıkə.
+        [advisories] WCAG AA pozey peydo nıbe. { $count ->
+            [one] { $count } co dastrəsi məsləhət
+           *[other] { $count } co dastrəsi məsləhət
+        } peydo be. Dastrəsi hesobot { $action ->
+            [close] bandeyro
+           *[open] oj kardeyro
+        } kılik bıkə.
+       *[clean] WCAG AA pozey peydo nıbe. Dastrəsi hesobot { $action ->
+            [close] bandeyro
+           *[open] oj kardeyro
+        } kılik bıkə.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versiya { $version }
+
+editor-tab-help = Konteksti kümək
+editor-tab-help-short = Kontekst
+editor-tab-errors = Xətoon
+editor-tab-warnings = Hoşdoron
+editor-tab-info = Məlumat
+editor-tab-accessibility = Dastrəsi
+editor-tab-responses = Vığandə cəvobon
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Redaktori nizomon
+editor-format-as-doenetml = DoenetML kimi formatlə kardey
+editor-format-as-xml = XML kimi formatlə kardey
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Sətir #{ $line }
+
+editor-no-errors = Xəto ni
+editor-no-warnings = Hoşdor ni
+editor-no-info = Məlumatə xəbər ni
+
+editor-show-info-annotations = Məlumatə xəbəron redaktordə nışon doy
+editor-show-accessibility-annotations = Dastrəsi xəbəron redaktordə nışon doy
+
+editor-accessibility-learn-more = Doenet dastrəsiyədə çı cür kor kardedə, bızın
+
+editor-accessibility-violations-heading = Dastrəsi pozeyon ({ $standard })
+
+editor-accessibility-other-heading = Co dastrəsi məsələon
+editor-none-found = Heçi peydo nıbe
+
+
+## Submitted responses
+
+editor-no-responses = Hələ vığandə cəvob ni
+editor-response-answer-id = Cəvobi Id
+editor-response-response = Cəvob
+editor-response-credit = Bal
+editor-response-submitted = Vığandə be
+
+
+## The context-help panel
+
+help-placeholder = Sənədnoməro kursor bəqət teqi nom, atribut ya { $ref } sədo.
+
+help-unsupported-ref-chain = { $example } kimi çandpoəyinə istinodonro kümək hələ ni.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] İstinodro obyekt peydo nıbe: { $ref }.
+        [multiple] İstinodro çand obyekt peydo be: { $ref }.
+       *[indeterminate] { $ref } obyekt təyin be nışe.
+    }
+
+help-learn-about-references = İstinodon barədə bızın →
+help-reference-page = Məlumatə səhifə →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } dılədə
+       *[top] Ən co səviyyədə
+    }{ $allowed ->
+        [none] { " — ıyo heçi nibe." }
+        [text] { " — ıyo mətn nıvışte bəbe." }
+        [text-and-components] { " — ıyo mətn nıvışte bəbe, ya ımon sınəğ bıkə:" }
+       *[components] { " — ımon sınəğ bıkə:" }
+    }
+
+help-suggestions-footer = Həmmə { $total } komponent vindeyro { $shortcut } bıjən.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } obyektiro istinod.
+       *[other] { $ref } — { $target } obyektiro istinod (sətir { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ıji { $role } kimi dənoə.
+       *[other] { $owner } ıji sətir { $line }-də { $role } kimi dənoə.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } elementi { $property } xüsusiyəti istinod.
+       *[other] { $ref } — { $element } elementi { $property } xüsusiyəti istinod (sətir { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = ğəlib
+help-kind-array-entry = massivi element
+
+help-default = Əsosə ğıymət:
+help-active-default = Fəolə əsosə ğıymət:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] İcozəynə ğıyməton (har elementiro i):
+       *[other] İcozəynə ğıyməton:
+    }
+
+help-suggested-values = Məsləhət bə ğıyməton:
+
+help-inserts = Dənoydə:
+
+help-coordinates =
+    { $count ->
+        [one] Koordinat:
+       *[other] Koordinaton:
+    }
+
+help-type = Tip:
+
+help-resolved-style = Təyin bə stil (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Təyin bə funksiya nomon:
+help-reset-list = Ə dənoydədə oqardeyro siyahi:
+help-added-on-input = Ə dənoydədə əlovə bə:
+help-removed-on-input = Ə dənoydədə bekardə bə:
+
+help-reset-overrides = { $reset } { $additional } iyən { $removed } sədo qıləni.

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -637,8 +637,9 @@ function renderUnionMembers(values: string[]): string {
  * seed catalogs they accompany; they are the best available answer, not a
  * speaker's. `endonym` is therefore optional: an entry whose endonym turns out
  * to be wrong should have the field deleted rather than guessed at again, and
- * the label falls back to the English name alone — the shape every locale whose
- * two names coincide already has. `englishName` is required because an English
+ * the endonym then falls back to the tag, so the label reads "Baoulé (bci)" —
+ * an admitted gap rather than a guess, and legible either way. `englishName` is
+ * required because an English
  * name is what identifies a language to someone choosing one and costs nothing
  * to be sure of.
  *
@@ -679,7 +680,8 @@ export const LOCALE_NAME_FALLBACKS: Record<
     // `locales/lbe`'s own header names the language «лакку маз» and three of its
     // four files repeat it, while no `locales/tab` header commits to a
     // self-name in any script. So Lak gets an endonym and Tabasaran does not,
-    // and its label is the English name alone rather than a guess.
+    // and Tabasaran's label reads "Tabasaran (tab)" — `locales/bci`'s shape,
+    // an admitted gap rather than a guess.
     lbe: { englishName: "Lak", endonym: "лакку маз" },
     tab: { englishName: "Tabasaran" },
 };

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -639,9 +639,8 @@ function renderUnionMembers(values: string[]): string {
  * to be wrong should have the field deleted rather than guessed at again, and
  * the endonym then falls back to the tag, so the label reads "Baoulé (bci)" —
  * an admitted gap rather than a guess, and legible either way. `englishName` is
- * required because an English
- * name is what identifies a language to someone choosing one and costs nothing
- * to be sure of.
+ * required because an English name is what identifies a language to someone
+ * choosing one and costs nothing to be sure of.
  *
  * Keep this table as small as it can be. Two tests hold it to that: one fails
  * if any locale's label is still just its code, so a future batch cannot

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -673,6 +673,15 @@ export const LOCALE_NAME_FALLBACKS: Record<
     bci: { englishName: "Baoulé" },
     lom: { englishName: "Loma" },
     urh: { englishName: "Urhobo" },
+    // The two locales of the Caucasus and Kurdish batch CLDR has no data for.
+    // Both are Dagestanian languages written in Cyrillic, and they part company
+    // over the endonym for the reason `locales/bci` and `locales/lom` did:
+    // `locales/lbe`'s own header names the language «лакку маз» and three of its
+    // four files repeat it, while no `locales/tab` header commits to a
+    // self-name in any script. So Lak gets an endonym and Tabasaran does not,
+    // and its label is the English name alone rather than a guess.
+    lbe: { englishName: "Lak", endonym: "лакку маз" },
+    tab: { englishName: "Tabasaran" },
 };
 
 /**

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -7,7 +7,9 @@
 /** A locale this repository ships a catalog for. */
 export type SupportedLocale =
     | "en"
+    | "ab"
     | "ace"
+    | "ady"
     | "af"
     | "ak"
     | "am"
@@ -15,6 +17,7 @@ export type SupportedLocale =
     | "arn"
     | "as"
     | "ast"
+    | "av"
     | "ay"
     | "az"
     | "ba"
@@ -39,12 +42,14 @@ export type SupportedLocale =
     | "ceb"
     | "ch"
     | "chm"
+    | "ckb"
     | "co"
     | "cs"
     | "cv"
     | "cy"
     | "da"
     | "dag"
+    | "dar"
     | "de"
     | "dje"
     | "doi"
@@ -87,12 +92,14 @@ export type SupportedLocale =
     | "id"
     | "ig"
     | "ilo"
+    | "inh"
     | "is"
     | "it"
     | "ja"
     | "jv"
     | "ka"
     | "kab"
+    | "kbd"
     | "kbp"
     | "kg"
     | "ki"
@@ -104,12 +111,17 @@ export type SupportedLocale =
     | "kok"
     | "kpe"
     | "kr"
+    | "krc"
     | "kri"
     | "ks"
     | "ktu"
+    | "ku"
+    | "kum"
     | "kv"
     | "ky"
     | "lb"
+    | "lbe"
+    | "lez"
     | "lg"
     | "ln"
     | "lo"
@@ -140,6 +152,7 @@ export type SupportedLocale =
     | "nds"
     | "ne"
     | "nl"
+    | "nog"
     | "nso"
     | "ny"
     | "nyn"
@@ -185,6 +198,7 @@ export type SupportedLocale =
     | "sv"
     | "sw"
     | "ta"
+    | "tab"
     | "te"
     | "tem"
     | "tet"
@@ -194,6 +208,7 @@ export type SupportedLocale =
     | "tiv"
     | "tk"
     | "tlh"
+    | "tly"
     | "tn"
     | "to"
     | "tpi"
@@ -260,10 +275,22 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "English",
     },
     {
+        locale: "ab",
+        englishName: "Abkhazian",
+        endonym: "Abkhazian",
+        label: "Abkhazian",
+    },
+    {
         locale: "ace",
         englishName: "Acehnese",
         endonym: "Acehnese",
         label: "Acehnese",
+    },
+    {
+        locale: "ady",
+        englishName: "Adyghe",
+        endonym: "Adyghe",
+        label: "Adyghe",
     },
     {
         locale: "af",
@@ -302,6 +329,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "asturianu",
         label: "Asturian (asturianu)",
     },
+    { locale: "av", englishName: "Avaric", endonym: "Avaric", label: "Avaric" },
     { locale: "ay", englishName: "Aymara", endonym: "Aymara", label: "Aymara" },
     {
         locale: "az",
@@ -417,6 +445,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     },
     { locale: "chm", englishName: "Mari", endonym: "Mari", label: "Mari" },
     {
+        locale: "ckb",
+        englishName: "Central Kurdish",
+        endonym: "کوردیی ناوەندی",
+        label: "Central Kurdish (کوردیی ناوەندی)",
+    },
+    {
         locale: "co",
         englishName: "Corsican",
         endonym: "Corsican",
@@ -451,6 +485,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Dagbani",
         endonym: "Dagbanli",
         label: "Dagbani (Dagbanli)",
+    },
+    {
+        locale: "dar",
+        englishName: "Dargwa",
+        endonym: "Dargwa",
+        label: "Dargwa",
     },
     {
         locale: "de",
@@ -660,6 +700,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     { locale: "ig", englishName: "Igbo", endonym: "Igbo", label: "Igbo" },
     { locale: "ilo", englishName: "Iloko", endonym: "Iloko", label: "Iloko" },
     {
+        locale: "inh",
+        englishName: "Ingush",
+        endonym: "Ingush",
+        label: "Ingush",
+    },
+    {
         locale: "is",
         englishName: "Icelandic",
         endonym: "íslenska",
@@ -694,6 +740,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Kabyle",
         endonym: "Taqbaylit",
         label: "Kabyle (Taqbaylit)",
+    },
+    {
+        locale: "kbd",
+        englishName: "Kabardian",
+        endonym: "Kabardian",
+        label: "Kabardian",
     },
     {
         locale: "kbp",
@@ -751,6 +803,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Kpelle",
     },
     { locale: "kr", englishName: "Kanuri", endonym: "Kanuri", label: "Kanuri" },
+    {
+        locale: "krc",
+        englishName: "Karachay-Balkar",
+        endonym: "Karachay-Balkar",
+        label: "Karachay-Balkar",
+    },
     { locale: "kri", englishName: "Krio", endonym: "Krio", label: "Krio" },
     {
         locale: "ks",
@@ -764,6 +822,13 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Kikongo ya leta",
         label: "Kituba (Kikongo ya leta)",
     },
+    {
+        locale: "ku",
+        englishName: "Kurdish",
+        endonym: "kurdî (kurmancî)",
+        label: "Kurdish (kurdî (kurmancî))",
+    },
+    { locale: "kum", englishName: "Kumyk", endonym: "Kumyk", label: "Kumyk" },
     { locale: "kv", englishName: "Komi", endonym: "Komi", label: "Komi" },
     {
         locale: "ky",
@@ -776,6 +841,13 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Luxembourgish",
         endonym: "Lëtzebuergesch",
         label: "Luxembourgish (Lëtzebuergesch)",
+    },
+    { locale: "lbe", englishName: "lbe", endonym: "lbe", label: "lbe" },
+    {
+        locale: "lez",
+        englishName: "Lezghian",
+        endonym: "Lezghian",
+        label: "Lezghian",
     },
     {
         locale: "lg",
@@ -927,6 +999,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Nederlands",
         label: "Dutch (Nederlands)",
     },
+    { locale: "nog", englishName: "Nogai", endonym: "Nogai", label: "Nogai" },
     {
         locale: "nso",
         englishName: "Northern Sotho",
@@ -1172,6 +1245,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "தமிழ்",
         label: "Tamil (தமிழ்)",
     },
+    { locale: "tab", englishName: "tab", endonym: "tab", label: "tab" },
     {
         locale: "te",
         englishName: "Telugu",
@@ -1205,6 +1279,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Klingon",
         endonym: "Klingon",
         label: "Klingon",
+    },
+    {
+        locale: "tly",
+        englishName: "Talysh",
+        endonym: "Talysh",
+        label: "Talysh",
     },
     {
         locale: "tn",

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -842,7 +842,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Lëtzebuergesch",
         label: "Luxembourgish (Lëtzebuergesch)",
     },
-    { locale: "lbe", englishName: "lbe", endonym: "lbe", label: "lbe" },
+    {
+        locale: "lbe",
+        englishName: "Lak",
+        endonym: "лакку маз",
+        label: "Lak (лакку маз)",
+    },
     {
         locale: "lez",
         englishName: "Lezghian",
@@ -1245,7 +1250,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "தமிழ்",
         label: "Tamil (தமிழ்)",
     },
-    { locale: "tab", englishName: "tab", endonym: "tab", label: "tab" },
+    {
+        locale: "tab",
+        englishName: "Tabasaran",
+        endonym: "tab",
+        label: "Tabasaran (tab)",
+    },
     {
         locale: "te",
         englishName: "Telugu",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -68,9 +68,9 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * The rule is published membership rather than a judgement about how close two
  * varieties are, which is what makes it checkable and what distinguishes it from
  * the `nn` and `fat` cases in {@link LANGUAGE_ALIASES}: neither of those is a
- * member of `nb` or `ak`, and both are deliberately left to miss. Thirteen of
- * the sixteen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`,
- * `kg`, `bua`, `kv`, `chm` — are ISO 639-3 macrolanguages and list their
+ * member of `nb` or `ak`, and both are deliberately left to miss. Fourteen of
+ * the seventeen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`,
+ * `kg`, `bua`, `kv`, `chm`, `ku` — are ISO 639-3 macrolanguages and list their
  * macrolanguage members; `nah` is an ISO 639-3 **collection** code rather than a
  * macrolanguage, so it lists the individual Nahuan languages ISO 639-5 groups
  * under it; and `mnk` and `dje` are neither, being *members* — of `man` and
@@ -78,7 +78,8 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * Those two are the shape {@link LANGUAGE_ALIASES}'s `man` entry explains, and
  * it is why the members listed under `mnk` exclude `bam` and `dyu`: those two
  * have catalogs of their own, and folding them here would serve a Bambara
- * reader Mandinka.
+ * reader Mandinka. `ku` excludes `ckb` for that same reason, and is the first
+ * key here to exclude a member while still *being* the macrolanguage.
  *
  * The two member cases part company over their macrolanguage, and the reason
  * is CLDR rather than a preference: `man` is aliased onto `mnk` because
@@ -287,6 +288,31 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // a written standard with an orthography of its own rather than a spelling
     // of this one.
     chm: ["mhr", "mrj"],
+    // Kurdish. `locales/ku` is Northern Kurdish (Kurmanji) in the Hawar Latin
+    // alphabet, which is what ICU folds `kmr` onto and what a bare `ku`
+    // maximizes to (`ku-Latn-TR`). ISO 639-3 gives the macrolanguage three
+    // members — `ckb`, `kmr`, `sdh` — and this list holds two of them.
+    //
+    // `ckb` (Central Kurdish, Sorani) is deliberately absent: it has a catalog
+    // of its own, added in the same batch, and folding it here would serve a
+    // Sorani reader Kurmanji in a script they do not read. That is `locales/mnk`
+    // excluding `bam` and `dyu`, arriving for the first time on a key that is
+    // the macrolanguage rather than one of its members.
+    //
+    // `sdh` (Southern Kurdish) maximizes to `sdh-Arab-IR`, so a reader CLDR
+    // expects in the Perso-Arabic script is served the Latin catalog. That is
+    // this batch's script debt and the same one `locales/kr` owes `kby` in
+    // Ajami, `locales/dje` owes `tda` in Tifinagh and `locales/bua` owes `bxu`
+    // in Mongolian script; the answer to it is a second catalog rather than a
+    // change here, and routing `sdh` to `locales/ckb` on script alone would be
+    // exactly the judgement this map exists to avoid.
+    //
+    // `lki` (Laki) is left to miss. It is often described as Southern Kurdish
+    // and is written in the same script, but ISO 639-3's macrolanguage mapping
+    // gives it a code outside `kur`, so folding it would be a judgement about
+    // how close two varieties are rather than a published fact — `kbl` under
+    // `kr` and `alq` under `oj` land the same way.
+    ku: ["kmr", "sdh"],
 };
 
 /** Flattened once at module load rather than searched per request. */

--- a/packages/i18n/test/direction.test.ts
+++ b/packages/i18n/test/direction.test.ts
@@ -5,18 +5,25 @@ import { PSEUDO_LOCALE, PSEUDO_RTL_LOCALE } from "../src/pseudo";
 import { SUPPORTED_LOCALES } from "../src/generated/supportedLocales";
 
 /**
- * Arabic, Persian, Hebrew, Urdu, Pashto, Sindhi, Uyghur, Yiddish, Kashmiri and
- * Dhivehi — the seven #1614 existed to make renderable, the one the European
- * regional and minority batch added, the two the South Asian batch added, and
- * the whole of it as of today.
+ * Arabic, Persian, Hebrew, Urdu, Pashto, Sindhi, Uyghur, Yiddish, Kashmiri,
+ * Dhivehi and Central Kurdish — the seven #1614 existed to make renderable, the
+ * one the European regional and minority batch added, the two the South Asian
+ * batch added, the one the Caucasus and Kurdish batch added, and the whole of
+ * it as of today.
  *
  * Written out rather than derived, so that the two tests below can hold it
  * from opposite sides: one says these tags are right-to-left whether or not a
  * catalog exists, the other says the roster contains exactly these and no
- * other right-to-left locale. None of the last three needed anything from
- * `direction.ts` — `yi`, `ks` and `dv` were all listed there already, and
- * Thaana was already in `RTL_SCRIPTS` — so this line is the only place seeding
- * them had to be recorded.
+ * other right-to-left locale. None of the last four needed anything from
+ * `direction.ts` — `yi`, `ks`, `dv` and `ckb` were all listed there already,
+ * and Thaana was already in `RTL_SCRIPTS` — so this line is the only place
+ * seeding them had to be recorded.
+ *
+ * `ku` is deliberately not here and is the pair worth reading beside `ckb`:
+ * two catalogs of one macrolanguage, one Latin and left-to-right, the other
+ * Perso-Arabic and right-to-left. Direction is a fact about a script rather
+ * than about a language, which is why `direction.ts` keys on the script and
+ * why `ku` needed no entry there either.
  */
 const RTL_LANGUAGES = [
     "ar",
@@ -29,6 +36,7 @@ const RTL_LANGUAGES = [
     "yi",
     "ks",
     "dv",
+    "ckb",
 ];
 
 describe("directionOf", () => {

--- a/packages/i18n/test/load.test.ts
+++ b/packages/i18n/test/load.test.ts
@@ -26,6 +26,22 @@ const LAZY_LOCALES = SUPPORTED_LOCALES.map((info) => info.locale)
     .sort();
 
 /**
+ * The one code-split catalog the two tests below actually load.
+ *
+ * Named rather than taken off the front of {@link LAZY_LOCALES}, because that
+ * front moves: it is whichever tag sorts first, so seeding a language earlier
+ * in the alphabet silently changes which catalog these tests read — `ace` was
+ * the subject until `ab` arrived, with nothing in either diff to say so. A
+ * named one keeps the subject where a reader can see it, and turns a catalog
+ * that has stopped shipping all four namespaces into a failure that names the
+ * catalog rather than one that names the registry.
+ *
+ * Spanish because it is the reference translation elsewhere in this package
+ * and is complete. The assertion below is what keeps the name honest.
+ */
+const LAZY_LOCALE = "es";
+
+/**
  * A loader map standing in for the shipped one, returning marker text rather
  * than a real catalog, so the negotiation and caching rules can be tested
  * without depending on which translations happen to exist or what they say.
@@ -59,14 +75,14 @@ describe("the lazy loader registry", () => {
         // Both lists being empty would satisfy the equality above and leave
         // the two tests below with no locale to reach for. Every translation
         // is code-split today; one is enough for any of this to mean
-        // something.
-        expect(LAZY_LOCALES.length).toBeGreaterThan(0);
+        // something — and it has to be the one they name.
+        expect(LAZY_LOCALES).toContain(LAZY_LOCALE);
     });
 
     describe("a code-split locale", () => {
         it("loads a catalog per namespace, each with something in it", async () => {
             const catalogs =
-                await LAZY_LOCALE_LOADERS[LAZY_LOCALES[0]](CATALOG_NAMESPACES);
+                await LAZY_LOCALE_LOADERS[LAZY_LOCALE](CATALOG_NAMESPACES);
             expect(Object.keys(catalogs).sort()).toEqual(
                 [...CATALOG_NAMESPACES].sort(),
             );
@@ -77,7 +93,7 @@ describe("the lazy loader registry", () => {
 
         it("loads only the namespaces the asking context renders", async () => {
             const catalogs =
-                await LAZY_LOCALE_LOADERS[LAZY_LOCALES[0]](WORKER_NAMESPACES);
+                await LAZY_LOCALE_LOADERS[LAZY_LOCALE](WORKER_NAMESPACES);
             expect(Object.keys(catalogs)).toEqual(["content"]);
         });
     });

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -1202,7 +1202,7 @@ describe("negotiateLocales", () => {
             ["ku-SY", "ku"],
             ["ckb-IQ", "ckb"],
             ["ckb-IR", "ckb"],
-            // Script asymmetries. The eleven Caucasian catalogs are Cyrillic,
+            // Script asymmetries. The twelve Caucasian catalogs are Cyrillic,
             // `ku` and `tly` are Latin and `ckb` is Perso-Arabic, so a reader
             // arriving under the other script of their own language reaches the
             // catalog and gets the one it is written in — the answer

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -1103,21 +1103,156 @@ describe("negotiateLocales", () => {
         });
 
         /**
-         * The near misses, and this batch's are unusually sharp because two of
-         * them are the *other half* of a pair whose first half now has a
-         * catalog. `mdf` is Moksha, Erzya's sister: ISO 639-3 gives the two
-         * separate codes and no macrolanguage over them, so `locales/myv` can
-         * do nothing for a Moksha reader and must not pretend to. `krc`, `kum`
-         * and `nog` are Turkic neighbours of `ba` in the Caucasus and the
-         * Volga; `ady`, `kbd` and `av` are Caucasian neighbours of `ce` in
-         * three different families; `sel` is Uralic beside `udm` and `kv`
-         * without belonging to either.
+         * The near misses. `mdf` is Moksha, Erzya's sister: ISO 639-3 gives the
+         * two separate codes and no macrolanguage over them, so `locales/myv`
+         * can do nothing for a Moksha reader and must not pretend to. `sel` is
+         * Uralic beside `udm` and `kv` without belonging to either.
+         *
+         * Both fall to English, which is the membership rule working rather
+         * than a gap in it — Moksha is not Erzya, however close a map makes
+         * them look.
+         *
+         * This list was six codes longer when the Russian Federation batch
+         * wrote it: `krc`, `kum`, `nog`, `ady`, `kbd` and `av` were named here
+         * as neighbours of `ba` and `ce` that fall back rather than being
+         * guessed at. All six have catalogs of their own as of the Caucasus and
+         * Kurdish batch, so they moved to that batch's rows below. What they
+         * were pinning still holds and is worth keeping straight: they reach a
+         * catalog now because one was *written* for them, not because anything
+         * in `negotiate.ts` learned to fold a neighbour onto a neighbour.
+         */
+        it.each(["mdf", "sel"])(
+            "leaves %s on English rather than folding it onto a neighbour",
+            (requested) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual(["en"]);
+            },
+        );
+    });
+
+    /**
+     * The Caucasus and Kurdish batch. Fifteen catalogs, and the negotiation
+     * question it raises that no earlier batch did is what happens when a
+     * macrolanguage and one of its own members both have a catalog.
+     *
+     * `ku` is Northern Kurdish (Kurmanji) in Latin and `ckb` is Central Kurdish
+     * (Sorani) in the Perso-Arabic script. ISO 639-3 makes `ckb` a member of
+     * the `ku` macrolanguage, so the naive entry would fold it — and would
+     * serve a Sorani reader a script they do not read while their own catalog
+     * sat on disk. `MACROLANGUAGE_MEMBERS` therefore lists `ku`'s other two
+     * members and excludes `ckb`, which is `locales/mnk` excluding `bam` and
+     * `dyu` arriving on a key that is the macrolanguage rather than a member of
+     * one.
+     *
+     * The other thirteen are individual languages that filter unaided, so the
+     * batch adds no `LANGUAGE_ALIASES` entry at all.
+     */
+    describe("the Caucasus and Kurdish batch", () => {
+        it.each([
+            // The macrolanguage. `kmr` is the member ICU folds on its own;
+            // `sdh` reaches the catalog only because the map names it.
+            ["ku", "ku"],
+            ["kmr", "ku"],
+            ["sdh", "ku"],
+            // …and the member that is deliberately not folded, because it
+            // answers for itself.
+            ["ckb", "ckb"],
+            // The ISO 639-3 codes ICU canonicalizes to a 639-1 code on its own.
+            ["abk", "ab"],
+            ["ava", "av"],
+            ["kur", "ku"],
+            // The eleven with no 639-1 code, which arrive under the same tag
+            // the directory is named for.
+            ["ady", "ady"],
+            ["kbd", "kbd"],
+            ["dar", "dar"],
+            ["lbe", "lbe"],
+            ["tab", "tab"],
+            ["inh", "inh"],
+            ["lez", "lez"],
+            ["krc", "krc"],
+            ["kum", "kum"],
+            ["nog", "nog"],
+            ["tly", "tly"],
+            // Region tags, which filter without help. `ab` maximizes to
+            // Georgia and `tly` to Azerbaijan rather than to Russia or Iran,
+            // which is CLDR's data rather than an error and costs negotiation
+            // nothing either way.
+            ["ab-GE", "ab"],
+            ["ab-RU", "ab"],
+            ["ady-RU", "ady"],
+            ["kbd-RU", "kbd"],
+            ["av-RU", "av"],
+            ["lez-RU", "lez"],
+            ["lez-AZ", "lez"],
+            ["dar-RU", "dar"],
+            ["lbe-RU", "lbe"],
+            ["tab-RU", "tab"],
+            ["inh-RU", "inh"],
+            ["krc-RU", "krc"],
+            ["kum-RU", "kum"],
+            ["nog-RU", "nog"],
+            ["tly-AZ", "tly"],
+            ["tly-IR", "tly"],
+            ["ku-TR", "ku"],
+            ["ku-SY", "ku"],
+            ["ckb-IQ", "ckb"],
+            ["ckb-IR", "ckb"],
+            // Script asymmetries. The eleven Caucasian catalogs are Cyrillic,
+            // `ku` and `tly` are Latin and `ckb` is Perso-Arabic, so a reader
+            // arriving under the other script of their own language reaches the
+            // catalog and gets the one it is written in — the answer
+            // `locales/pa`, `locales/sr` and `locales/ha` already give, and the
+            // answer to it is a second catalog rather than a rename of this
+            // one.
+            ["ku-Arab", "ku"],
+            ["tly-Cyrl", "tly"],
+            ["tly-Arab", "tly"],
+            ["ab-Latn", "ab"],
+            ["ckb-Latn", "ckb"],
+        ])("reaches %s's catalog as %s", (requested, expected) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual([expected, "en"]);
+        });
+
+        /**
+         * `sdh` is this batch's script debt, and — like `locales/bua`'s to
+         * `bxu` — it is recorded rather than fixed. Southern Kurdish maximizes
+         * to `sdh-Arab-IR`, so CLDR's own data says such a reader most likely
+         * arrives in the Perso-Arabic script, and what published membership
+         * hands them is Kurmanji in Latin.
+         *
+         * Routing it to `locales/ckb` instead would read better on the page and
+         * would be exactly the judgement `MACROLANGUAGE_MEMBERS` exists to
+         * avoid: Southern Kurdish is not Sorani, and "shares a script with"
+         * is not a membership fact. The answer is a `sdh` catalog.
+         */
+        it("serves Southern Kurdish the Latin catalog although CLDR expects it in Perso-Arabic", () => {
+            expect(new Intl.Locale("sdh").maximize().script).toBe("Arab");
+            expect(negotiateLocales([normalizeLocaleTag("sdh")], available)) //
+                .toEqual(["ku", "en"]);
+        });
+
+        /**
+         * The near misses. `lki` (Laki) is the sharpest: it is written in the
+         * same script as `ckb`, is often described as a variety of Southern
+         * Kurdish, and ISO 639-3's macrolanguage mapping still gives it a code
+         * outside `kur` — so it falls back, exactly as `alq` does beside `oj`.
+         * `zza` (Zaza) is the same shape one family over. `agx` (Aghul) is
+         * Lezgic beside `lez` and `tab`, `ddo` (Tsez) is Avar's neighbour in
+         * Dagestan, and `xmf` (Mingrelian) and `sva` (Svan) are Kartvelian
+         * beside `ab` without belonging to any macrolanguage with a catalog.
          *
          * Every one falls to English, which is the membership rule working
-         * rather than a gap in it — Moksha is not Erzya, however close a map
-         * makes them look, and Kabardian is not Chechen at all.
+         * rather than a gap in it — the moment "is spoken next to" decides the
+         * map, nothing in it is checkable any more.
          */
-        it.each(["mdf", "krc", "kum", "nog", "ady", "kbd", "av", "sel"])(
+        it.each(["lki", "zza", "agx", "ddo", "xmf", "sva"])(
             "leaves %s on English rather than folding it onto a neighbour",
             (requested) => {
                 expect(

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -3343,20 +3343,30 @@ describe("AutoCompleter", () => {
 
         it("Documents each suggested locale with its name", async () => {
             // The descriptions are derived at codegen time from
-            // `Intl.DisplayNames`, so a new locale carries help text without
-            // anyone writing any. An empty one would render as a blank
-            // autocomplete row.
+            // `Intl.DisplayNames` — or, for the handful of tags CLDR has no
+            // data for, from `LOCALE_NAME_FALLBACKS` — so a new locale carries
+            // help text without anyone writing any. Every row is checked
+            // against the roster's own label rather than one row being spot-
+            // checked for non-emptiness, because the failure this guards
+            // against is a *stale* schema rather than a blank one: a locale
+            // whose name arrived after the last `build:schema` run documents
+            // itself with its bare tag, which is truthy and reads as a defect
+            // in the roster rather than in the generated file.
             const source = `<document lang="`;
             const ac = new AutoCompleter(source, doenetSchema.elements);
             const items = await ac.getCompletionItems(source.length);
-            const spanish = items.find((i) => i.label === "es");
-            expect(spanish?.documentation).toBeTruthy();
-            const documentation = spanish?.documentation;
-            const text =
-                typeof documentation === "string"
+            const documentationOf = (locale: string) => {
+                const documentation = items.find(
+                    (i) => i.label === locale,
+                )?.documentation;
+                return typeof documentation === "string"
                     ? documentation
                     : (documentation?.value ?? "");
-            expect(text).toContain("Spanish");
+            };
+            expect(documentationOf("es")).toContain("Spanish");
+            for (const { locale, label } of SUPPORTED_LOCALES) {
+                expect(documentationOf(locale)).toBe(label);
+            }
         });
 
         it("Still offers to quote a bare tag that isn't on the list", async () => {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65844,7 +65844,7 @@
                         },
                         {
                             "value": "lbe",
-                            "description": "lbe"
+                            "description": "Lak (лакку маз)"
                         },
                         {
                             "value": "lez",
@@ -66156,7 +66156,7 @@
                         },
                         {
                             "value": "tab",
-                            "description": "tab"
+                            "description": "Tabasaran (tab)"
                         },
                         {
                             "value": "te",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65391,8 +65391,16 @@
                             "description": "English"
                         },
                         {
+                            "value": "ab",
+                            "description": "Abkhazian"
+                        },
+                        {
                             "value": "ace",
                             "description": "Acehnese"
+                        },
+                        {
+                            "value": "ady",
+                            "description": "Adyghe"
                         },
                         {
                             "value": "af",
@@ -65421,6 +65429,10 @@
                         {
                             "value": "ast",
                             "description": "Asturian (asturianu)"
+                        },
+                        {
+                            "value": "av",
+                            "description": "Avaric"
                         },
                         {
                             "value": "ay",
@@ -65519,6 +65531,10 @@
                             "description": "Mari"
                         },
                         {
+                            "value": "ckb",
+                            "description": "Central Kurdish (کوردیی ناوەندی)"
+                        },
+                        {
                             "value": "co",
                             "description": "Corsican"
                         },
@@ -65541,6 +65557,10 @@
                         {
                             "value": "dag",
                             "description": "Dagbani (Dagbanli)"
+                        },
+                        {
+                            "value": "dar",
+                            "description": "Dargwa"
                         },
                         {
                             "value": "de",
@@ -65711,6 +65731,10 @@
                             "description": "Iloko"
                         },
                         {
+                            "value": "inh",
+                            "description": "Ingush"
+                        },
+                        {
                             "value": "is",
                             "description": "Icelandic (íslenska)"
                         },
@@ -65733,6 +65757,10 @@
                         {
                             "value": "kab",
                             "description": "Kabyle (Taqbaylit)"
+                        },
+                        {
+                            "value": "kbd",
+                            "description": "Kabardian"
                         },
                         {
                             "value": "kbp",
@@ -65779,6 +65807,10 @@
                             "description": "Kanuri"
                         },
                         {
+                            "value": "krc",
+                            "description": "Karachay-Balkar"
+                        },
+                        {
                             "value": "kri",
                             "description": "Krio"
                         },
@@ -65791,6 +65823,14 @@
                             "description": "Kituba (Kikongo ya leta)"
                         },
                         {
+                            "value": "ku",
+                            "description": "Kurdish (kurdî (kurmancî))"
+                        },
+                        {
+                            "value": "kum",
+                            "description": "Kumyk"
+                        },
+                        {
                             "value": "kv",
                             "description": "Komi"
                         },
@@ -65801,6 +65841,14 @@
                         {
                             "value": "lb",
                             "description": "Luxembourgish (Lëtzebuergesch)"
+                        },
+                        {
+                            "value": "lbe",
+                            "description": "lbe"
+                        },
+                        {
+                            "value": "lez",
+                            "description": "Lezghian"
                         },
                         {
                             "value": "lg",
@@ -65921,6 +65969,10 @@
                         {
                             "value": "nl",
                             "description": "Dutch (Nederlands)"
+                        },
+                        {
+                            "value": "nog",
+                            "description": "Nogai"
                         },
                         {
                             "value": "nso",
@@ -66103,6 +66155,10 @@
                             "description": "Tamil (தமிழ்)"
                         },
                         {
+                            "value": "tab",
+                            "description": "tab"
+                        },
+                        {
                             "value": "te",
                             "description": "Telugu (తెలుగు)"
                         },
@@ -66137,6 +66193,10 @@
                         {
                             "value": "tlh",
                             "description": "Klingon"
+                        },
+                        {
+                            "value": "tly",
+                            "description": "Talysh"
                         },
                         {
                             "value": "tn",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3406,3 +3406,366 @@ describe("Chechen noun classes", () => {
         ).toBe("дуьзна доцу");
     });
 });
+
+describe("the Caucasus and Kurdish batch", () => {
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
+
+    const words = {
+        lineWidthWord: "thick",
+        lineStyleWord: "dashed",
+        colorWord: "red",
+    };
+
+    /**
+     * Fifteen catalogs, and the first batch whose members **do not agree about
+     * where an adjective goes**. Every previous batch could be pinned as one
+     * shape — the Russian Federation's twelve are prenominal to a catalog, and
+     * that row was asserted as an identity. Here ten put the description in
+     * front of the noun and five put it behind, and the five are not a
+     * subfamily anyone would guess from the map: all three Northwest Caucasian
+     * catalogs (`ab`, `ady`, `kbd`), plus both Kurdish ones, which are Iranian
+     * and sit at the other end of the batch.
+     *
+     * Held from both sides — `startsWith` for one group and `endsWith` for the
+     * other — so that the noun is being *appended to* or *prefixed to* a
+     * description rather than woven into it. What this catches is someone
+     * "correcting" a catalog into English's order because the neighbouring
+     * files are in it.
+     */
+    const prenominal: [string, string, string][] = [
+        ["av", "кӀудияб бекараб багӀараб мухъ", "кӀудияб бекараб багӀараб"],
+        ["lez", "яцӀу атӀай яру дуьз цӀар", "яцӀу атӀай яру"],
+        [
+            "dar",
+            "халаси кӀапӀбикибси хӀунтӀена линия",
+            "халаси кӀапӀбикибси хӀунтӀена",
+        ],
+        [
+            "lbe",
+            "хъунмасса кьуркьусса ятӀулсса линия",
+            "хъунмасса кьуркьусса ятӀулсса",
+        ],
+        ["tab", "яцӀу штрихрин уьру дюз цӀар", "яцӀу штрихрин уьру"],
+        ["inh", "дуькъа кагдаь цӀе нийса сиз", "дуькъа кагдаь цӀе"],
+        ["krc", "къалын юзюклю къызыл тюз сызыкъ", "къалын юзюклю къызыл"],
+        ["kum", "къалын уьзюклю къызыл тюз сызыкъ", "къалын уьзюклю къызыл"],
+        ["nog", "калын уьзик кызыл туьз сызык", "калын уьзик кызыл"],
+        ["tly", "kuluftə tirəyinə sıə xət", "kuluftə tirəyinə sıə"],
+    ];
+
+    const postnominal: [string, string, string][] = [
+        ["ab", "аҵәаӷәа аҭбаа ахәҭа-хәҭа аҟаԥшь", "аҭбаа ахәҭа-хәҭа аҟаԥшь"],
+        [
+            "ady",
+            "линие занкӀэ Ӏужъу зэпыугъэ плъыжьы",
+            "Ӏужъу зэпыугъэ плъыжьы",
+        ],
+        ["kbd", "линэ занщӀэ Ӏув зэпыуда плъыжь", "Ӏув зэпыуда плъыжь"],
+        ["ku", "xêz ya stûr ya qutbirr ya sor", "ya stûr ya qutbirr ya sor"],
+        ["ckb", "هێڵی سوور و پچڕپچڕ و ئەستوور", "سوور و پچڕپچڕ و ئەستوور"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of prenominal) {
+        it(`puts ${locale}'s description in front of the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
+        it(`puts ${locale}'s description behind the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
+            // The same string with the noun withheld, which is what makes this
+            // a claim about placement rather than about two unrelated
+            // renderings.
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    /**
+     * A regular polygon's side count, and the batch's second split. Thirteen
+     * catalogs fold it into the head — `noun-regular-polygon`'s `[tail]` branch
+     * renders empty, as it does in every catalog of the Russian Federation
+     * batch — while `kbd` and `ckb` cannot, and put it in a trailing
+     * complement instead.
+     *
+     * Both had the same reason and reached it in different scripts. Kabardian
+     * incorporates a numeral into the noun («къуапитху»), which is a word this
+     * catalog cannot build around a formatted `{ $numSides }`, so it writes
+     * «къуапэ 5 иӀэу» after the description; Sorani's noun carries its ezafe
+     * and takes the count in a «بە … ەوە» phrase behind it. That is what
+     * `$part` exists for, and these two are the reason it is not dead weight.
+     */
+    it.each([...prenominal, ...postnominal].map(([locale]) => locale))(
+        "renders %s's side count exactly once, with no stray spacing",
+        (locale) => {
+            const description = describeStrokedShape(forLocale(locale), words, {
+                noun: { key: "regular-polygon", numSides: 5 },
+                withNoun: true,
+            });
+            expect(description).toContain("5");
+            expect(description.trimEnd()).toBe(description);
+            expect(description).not.toContain("  ");
+        },
+    );
+
+    /**
+     * Which of the two shapes a catalog chose, asserted where the answer is
+     * visible: in the five catalogs whose adjectives come *last*, a head-only
+     * rendering still ends with the adjectives, while a catalog using the tail
+     * has appended something behind them.
+     *
+     * `ab` and `ady` fold the count into the head and so still end with the
+     * colour; `kbd` and `ckb` do not. That is the whole of the split, held on
+     * the group where the string position actually distinguishes it.
+     */
+    it.each([
+        ["ab", true],
+        ["ady", true],
+        ["ku", true],
+        ["kbd", false],
+        ["ckb", false],
+    ])("puts %s's side count in the head: %s", (locale, inHead) => {
+        const t = forLocale(locale);
+        // Taken from the *same* noun, because `ku`'s ezafe agrees with it:
+        // a polygon is masculine and a line feminine, so comparing across two
+        // nouns would fail on gender rather than on placement.
+        const adjectivesOnly = describeStrokedShape(t, words, {
+            noun: { key: "regular-polygon", numSides: 5 },
+            withNoun: false,
+        });
+        const regular = describeStrokedShape(t, words, {
+            noun: { key: "regular-polygon", numSides: 5 },
+            withNoun: true,
+        });
+        expect(regular.endsWith(adjectivesOnly)).toBe(inHead);
+    });
+});
+
+/**
+ * Ingush noun classes, and the reason this block is not a copy of the Chechen
+ * one above it.
+ *
+ * Ingush and Chechen are the two Vainakh languages and share the в-/й-/б-/д-
+ * class system, so `locales/inh` forks `style-filled-word` exactly as
+ * `locales/ce` does. It also forks **`line-style.dashed`**, which `locales/ce`
+ * leaves flat although «кагйина» is the same kind of participle and the same
+ * `$gender` reaches it — `describeStroke` hands every adjective the noun's
+ * gender, so the branch is live rather than decorative.
+ *
+ * That divergence is a question for a speaker of either language rather than a
+ * bug in either file, and these rows are what would notice if someone flattened
+ * `locales/inh` to match its neighbour without answering it.
+ */
+describe("Ingush noun classes", () => {
+    const inh: Translator = createTranslatorFromLocaleData(
+        { locale: "inh", resources: { inh: readCatalog("inh", "content") } },
+        "inh",
+    );
+
+    const blueFill = { fillColorWord: "blue", fillStyleWord: "" };
+
+    // «го» is `d` and «тӀадам» is `b`. The `withNoun: false` half is the one
+    // that could not pass by accident: with the noun withheld, the prefix is
+    // all that distinguishes the two classes.
+    it.each([
+        ["circle", "сийна дизза го", "сийна дизза"],
+        ["point", "сийна бизза тӀадам", "сийна бизза"],
+    ])("agrees the filled participle with «%s»", (key, withNoun, alone) => {
+        expect(
+            describeClosedShape(inh, blueFill, {
+                filled: true,
+                noun: { key: key as NounKey },
+                withNoun: true,
+            }),
+        ).toBe(withNoun);
+        expect(
+            describeClosedShape(inh, blueFill, {
+                filled: true,
+                noun: { key: key as NounKey },
+                withNoun: false,
+            }),
+        ).toBe(alone);
+    });
+
+    /** The second fork, and the one `locales/ce` does not write. */
+    it.each([
+        ["line", "кагдаь цӀе нийса сиз"],
+        ["point", "кагбаь цӀе тӀадам"],
+    ])("agrees the dashed participle with «%s»", (key, expected) => {
+        expect(
+            describeStrokedShape(
+                inh,
+                { lineStyleWord: "dashed", colorWord: "red" },
+                { noun: { key: key as NounKey }, withNoun: true },
+            ),
+        ).toBe(expected);
+    });
+
+    /**
+     * The same rule that keeps `locales/ce`'s `style-unfilled` flat:
+     * `describeFill` renders it with no arguments, so there is no noun to take
+     * a class from and a `$gender` select could only ever reach its default.
+     */
+    it("says unfilled without agreeing with anything", () => {
+        expect(
+            describeFill(inh, { fillColorWord: "blue" }, { filled: false }),
+        ).toBe("дизза доаца");
+    });
+});
+
+/**
+ * Kurmanji's ezafe, which is the batch's one agreement mechanism that is not a
+ * Caucasian noun class — and the roster's sixth thing `$gender` has been asked
+ * to carry, after a European gender, a Bantu noun class, Ojibwe's animacy,
+ * Fula's suffixed concord and Chechen's class prefix.
+ *
+ * Kurmanji has masculine and feminine nouns, and an attributive adjective
+ * follows its noun linked by an ezafe. The bound ezafe cannot be welded onto
+ * `{ $noun }`, so `locales/ku` writes the free particle — «ya» after a feminine
+ * noun and «yê» after a masculine one — and repeats it before each further
+ * adjective. A line is feminine and a polygon masculine, so one description
+ * changes in three places and the other does not change at all.
+ */
+describe("Kurmanji ezafe agreement", () => {
+    const ku: Translator = createTranslatorFromLocaleData(
+        { locale: "ku", resources: { ku: readCatalog("ku", "content") } },
+        "ku",
+    );
+
+    const words = {
+        lineWidthWord: "thick",
+        lineStyleWord: "dashed",
+        colorWord: "red",
+    };
+
+    it.each([
+        ["line", "xêz ya stûr ya qutbirr ya sor"],
+        ["circle", "bazine ya stûr ya qutbirr ya sor"],
+        ["square", "çargoşe yê stûr yê qutbirr yê sor"],
+        ["polygon", "pirgoşe yê stûr yê qutbirr yê sor"],
+    ])("links «%s» to its adjectives with the right ezafe", (key, expected) => {
+        expect(
+            describeStrokedShape(ku, words, {
+                noun: { key: key as NounKey },
+                withNoun: true,
+            }),
+        ).toBe(expected);
+    });
+
+    /**
+     * «dagirtî» is a past participle and does not inflect, so the agreement in
+     * a filled shape is carried by the particle beside it rather than by the
+     * word itself — and `style-unfilled`, rendered with no arguments, has no
+     * particle and no noun and stays bare.
+     */
+    it("carries a filled shape's agreement in the particle, not the participle", () => {
+        const blueFill = { fillColorWord: "blue", fillStyleWord: "" };
+        expect(
+            describeClosedShape(ku, blueFill, {
+                filled: true,
+                noun: { key: "circle" },
+                withNoun: true,
+            }),
+        ).toBe("bazine ya dagirtî ya şîn");
+        expect(
+            describeFill(ku, { fillColorWord: "blue" }, { filled: false }),
+        ).toBe("nedagirtî");
+    });
+});
+
+/**
+ * The three catalogs that agree in the language and render one form anyway,
+ * which is the batch's most easily "corrected" property and the reason it is
+ * pinned.
+ *
+ * Avar agrees *more* than Chechen — three singular classes plus a plural, and
+ * every attributive adjective takes the marker as a suffix, where Chechen's
+ * colour and width words take none at all. It still forks nothing, because
+ * every noun this core names is a thing rather than a person and so is class
+ * III: `[v]`, `[j]` and `[l]` branches would be variants nothing could select.
+ * Lak reached the same place from four classes, and Dargwa wrote its select out
+ * with only the `[b]` branch reachable.
+ *
+ * That is the reachability rule `locales/ve`, `locales/ts`, `locales/ki` and
+ * `locales/bem` already apply to their unreached Bantu classes, arriving here
+ * from languages that agree more rather than less. A reader who knows the
+ * family will expect these three to vary by noun, and they must not.
+ */
+describe("Dagestanian agreement that no message can reach", () => {
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
+
+    it.each([
+        ["av", "багӀараб"],
+        ["lbe", "ятӀулсса"],
+        ["dar", "хӀунтӀена"],
+    ])(
+        "renders %s's colour word identically for every noun it is given",
+        (locale, expected) => {
+            const t = forLocale(locale);
+            for (const key of ["line", "point", "circle", "region", "text"]) {
+                expect(
+                    describeStrokedShape(
+                        t,
+                        { colorWord: "red" },
+                        { noun: { key: key as NounKey }, withNoun: false },
+                    ),
+                    `${locale}/${key}`,
+                ).toBe(expected);
+            }
+        },
+    );
+
+    /**
+     * Dargwa is the one of the three whose select is actually written, so this
+     * says what the other two say by absence: the `[v]` and `[r]` branches are
+     * unreachable through the public API, and the catalog renders `[b]` for
+     * every noun until a speaker fills the class table in.
+     */
+    it("reaches only Dargwa's b-class branch", () => {
+        const dar = forLocale("dar");
+        const blueFill = { fillColorWord: "blue", fillStyleWord: "" };
+        for (const key of ["circle", "point", "line", "region"]) {
+            expect(
+                describeClosedShape(dar, blueFill, {
+                    filled: true,
+                    noun: { key: key as NounKey },
+                    withNoun: false,
+                }),
+                key,
+            ).toBe("хьанцӀа бицӀибси");
+        }
+    });
+});

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3543,9 +3543,12 @@ describe("the Caucasus and Kurdish batch", () => {
      * rendering still ends with the adjectives, while a catalog using the tail
      * has appended something behind them.
      *
-     * `ab` and `ady` fold the count into the head and so still end with the
-     * colour; `kbd` and `ckb` do not. That is the whole of the split, held on
-     * the group where the string position actually distinguishes it.
+     * `ab`, `ady` and `ku` fold the count into the head and so still end with
+     * the adjectives; `kbd` and `ckb` do not. That is the whole of the split,
+     * held on the group where the string position actually distinguishes it.
+     * The ten prenominal catalogs all fold it in too, but their adjectives
+     * come first, so a trailing complement would be invisible to `endsWith`
+     * and the row above is what covers them.
      */
     it.each([
         ["ab", true],

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -36,38 +36,37 @@ import {
 const en: Translator = createTranslator([], {});
 
 /**
- * Spanish handed over exactly as the worker gets it: only English is bundled,
- * so every other language reaches the core as `LocaleData.resources`, loaded on
- * the main thread and sent through `setLocaleData`.
+ * Any other locale on the roster, loaded the way the worker receives it: only
+ * English is bundled, so every translation reaches the core as
+ * `LocaleData.resources`, read on the main thread and sent through
+ * `setLocaleData`.
+ *
+ * Defined once rather than redeclared per `describe`, which is what a dozen
+ * blocks below used to do with byte-identical copies: the shape a catalog is
+ * loaded in is a property of this file, not of the language a block is about.
+ * `readCatalog` is a function declaration and so is in scope here despite
+ * being written below.
  */
-const es: Translator = createTranslatorFromLocaleData(
-    { locale: "es", resources: { es: readCatalog("es", "content") } },
-    "es",
-);
+const forLocale = (locale: string): Translator =>
+    createTranslatorFromLocaleData(
+        { locale, resources: { [locale]: readCatalog(locale, "content") } },
+        locale,
+    );
+
+/** The reference translation, used throughout the tables below. */
+const es: Translator = forLocale("es");
 
 /** The same, for a right-to-left language that agrees its adjectives. */
-const he: Translator = createTranslatorFromLocaleData(
-    { locale: "he", resources: { he: readCatalog("he", "content") } },
-    "he",
-);
+const he: Translator = forLocale("he");
 
 /** One whose adjectives follow the noun rather than preceding it. */
-const ar: Translator = createTranslatorFromLocaleData(
-    { locale: "ar", resources: { ar: readCatalog("ar", "content") } },
-    "ar",
-);
+const ar: Translator = forLocale("ar");
 
 /** One that agrees them *and* inflects them for the position they land in. */
-const ur: Translator = createTranslatorFromLocaleData(
-    { locale: "ur", resources: { ur: readCatalog("ur", "content") } },
-    "ur",
-);
+const ur: Translator = forLocale("ur");
 
 /** One whose case marking shows up in a single gender and a single position. */
-const ps: Translator = createTranslatorFromLocaleData(
-    { locale: "ps", resources: { ps: readCatalog("ps", "content") } },
-    "ps",
-);
+const ps: Translator = forLocale("ps");
 
 /** One of this repository's catalogs, read the way a host would supply it. */
 function readCatalog(locale: string, namespace: string): string {
@@ -310,13 +309,7 @@ describe("closed shapes", () => {
      * everything else, including 5.
      */
     it("picks the Filipino linker from the side count", () => {
-        const fil: Translator = createTranslatorFromLocaleData(
-            {
-                locale: "fil",
-                resources: { fil: readCatalog("fil", "content") },
-            },
-            "fil",
-        );
+        const fil: Translator = forLocale("fil");
         const sided = (numSides: number) =>
             describeStrokedShape(
                 fil,
@@ -673,10 +666,7 @@ describe("Pashto", () => {
 });
 
 describe("Tajik", () => {
-    const tg: Translator = createTranslatorFromLocaleData(
-        { locale: "tg", resources: { tg: readCatalog("tg", "content") } },
-        "tg",
-    );
+    const tg: Translator = forLocale("tg");
 
     // Tajik is Persian in Cyrillic, so its adjectives follow the noun and the
     // link between them is the izafat. Persian's is an unwritten vowel after a
@@ -734,10 +724,7 @@ describe("Tajik", () => {
 });
 
 describe("Irish", () => {
-    const ga: Translator = createTranslatorFromLocaleData(
-        { locale: "ga", resources: { ga: readCatalog("ga", "content") } },
-        "ga",
-    );
+    const ga: Translator = forLocale("ga");
 
     // The Celtic answer to agreement: a feminine singular noun does not give
     // its adjectives an ending, it softens the front of them. «líne» is
@@ -800,10 +787,7 @@ describe("Irish", () => {
  * below would collapse onto one prefix.
  */
 describe("Swahili noun classes", () => {
-    const sw: Translator = createTranslatorFromLocaleData(
-        { locale: "sw", resources: { sw: readCatalog("sw", "content") } },
-        "sw",
-    );
+    const sw: Translator = forLocale("sw");
 
     const words = {
         lineWidthWord: "thick",
@@ -874,10 +858,7 @@ describe("Swahili noun classes", () => {
 });
 
 describe("Ojibwe animacy", () => {
-    const oj: Translator = createTranslatorFromLocaleData(
-        { locale: "oj", resources: { oj: readCatalog("oj", "content") } },
-        "oj",
-    );
+    const oj: Translator = forLocale("oj");
 
     const words = {
         lineWidthWord: "thick",
@@ -962,12 +943,6 @@ describe("Ojibwe animacy", () => {
 });
 
 describe("the Indigenous Americas batch's word order", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -1085,12 +1060,6 @@ describe("the Indigenous Americas batch's word order", () => {
 });
 
 describe("the Austronesian batch's word order", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -1256,10 +1225,7 @@ describe("the Austronesian batch's word order", () => {
 });
 
 describe("Klingon, which builds its phrase out of a relative clause", () => {
-    const tlh: Translator = createTranslatorFromLocaleData(
-        { locale: "tlh", resources: { tlh: readCatalog("tlh", "content") } },
-        "tlh",
-    );
+    const tlh: Translator = forLocale("tlh");
 
     const words = {
         lineWidthWord: "thick",
@@ -1519,12 +1485,6 @@ describe("a phrase rendered in two positions", () => {
      * and are here to hold the cases where the two positions legitimately read
      * alike.
      */
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const de = forLocale("de");
     const ru = forLocale("ru");
     const pl = forLocale("pl");
@@ -2368,12 +2328,6 @@ describe("the role argument", () => {
  * it behind the adjectives rather than stranding them behind the sides.
  */
 describe("a regular polygon's side count", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const polygon: NounSpec = { key: "regular-polygon", numSides: 5 };
     const words = { colorWord: "red", lineWidthWord: "thick" };
 
@@ -2442,15 +2396,6 @@ describe("a regular polygon's side count", () => {
  * in the same script agree with everything.
  */
 describe("the South Asian batch", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            {
-                locale,
-                resources: { [locale]: readCatalog(locale, "content") },
-            },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -2681,12 +2626,6 @@ describe("the South Asian batch", () => {
  * uniform so that an affix could be written beside a placeable at all.
  */
 describe("the African and Berber batch", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -2851,12 +2790,6 @@ describe("the African and Berber batch", () => {
 });
 
 describe("the West and Central African batch", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -2999,12 +2932,6 @@ describe("the West and Central African batch", () => {
 });
 
 describe("the West and Central African batch, continued", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -3151,12 +3078,6 @@ describe("the West and Central African batch, continued", () => {
 });
 
 describe("the Angolan, Sierra Leonean and Songhay batch", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -3263,12 +3184,6 @@ describe("the Angolan, Sierra Leonean and Songhay batch", () => {
 });
 
 describe("the Russian Federation's Cyrillic batch", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -3361,10 +3276,7 @@ describe("the Russian Federation's Cyrillic batch", () => {
  * concludes that Chechen agrees nothing.
  */
 describe("Chechen noun classes", () => {
-    const ce: Translator = createTranslatorFromLocaleData(
-        { locale: "ce", resources: { ce: readCatalog("ce", "content") } },
-        "ce",
-    );
+    const ce: Translator = forLocale("ce");
 
     const blueFill = { fillColorWord: "blue", fillStyleWord: "" };
 
@@ -3408,12 +3320,6 @@ describe("Chechen noun classes", () => {
 });
 
 describe("the Caucasus and Kurdish batch", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     const words = {
         lineWidthWord: "thick",
         lineStyleWord: "dashed",
@@ -3623,10 +3529,7 @@ describe("the Caucasus and Kurdish batch", () => {
  * `locales/inh` to match its neighbour without answering it.
  */
 describe("Ingush noun classes", () => {
-    const inh: Translator = createTranslatorFromLocaleData(
-        { locale: "inh", resources: { inh: readCatalog("inh", "content") } },
-        "inh",
-    );
+    const inh: Translator = forLocale("inh");
 
     const blueFill = { fillColorWord: "blue", fillStyleWord: "" };
 
@@ -3676,10 +3579,7 @@ describe("Ingush noun classes", () => {
      * noun and a `b` noun alike.
      */
     it("has no counterpart in locales/ce, which leaves the same word flat", () => {
-        const ce: Translator = createTranslatorFromLocaleData(
-            { locale: "ce", resources: { ce: readCatalog("ce", "content") } },
-            "ce",
-        );
+        const ce: Translator = forLocale("ce");
         const dashed = (key: NounKey) =>
             describeStrokedShape(
                 ce,
@@ -3716,10 +3616,7 @@ describe("Ingush noun classes", () => {
  * changes in three places and the other does not change at all.
  */
 describe("Kurmanji ezafe agreement", () => {
-    const ku: Translator = createTranslatorFromLocaleData(
-        { locale: "ku", resources: { ku: readCatalog("ku", "content") } },
-        "ku",
-    );
+    const ku: Translator = forLocale("ku");
 
     const words = {
         lineWidthWord: "thick",
@@ -3781,12 +3678,6 @@ describe("Kurmanji ezafe agreement", () => {
  * family will expect these three to vary by noun, and they must not.
  */
 describe("Dagestanian agreement that no message can reach", () => {
-    const forLocale = (locale: string): Translator =>
-        createTranslatorFromLocaleData(
-            { locale, resources: { [locale]: readCatalog(locale, "content") } },
-            locale,
-        );
-
     it.each([
         ["av", "багӀараб"],
         ["lbe", "ятӀулсса"],

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3435,6 +3435,11 @@ describe("the Caucasus and Kurdish batch", () => {
      * description rather than woven into it. What this catches is someone
      * "correcting" a catalog into English's order because the neighbouring
      * files are in it.
+     *
+     * Each row's two strings pin one rendering exactly; the placement rule is
+     * then checked over {@link placementNouns} against what the catalog
+     * actually renders, so that a file reordered for a single noun fails even
+     * though the row it was pinned on still passes.
      */
     const prenominal: [string, string, string][] = [
         ["av", "кӀудияб бекараб багӀараб мухъ", "кӀудияб бекараб багӀараб"],
@@ -3469,46 +3474,71 @@ describe("the Caucasus and Kurdish batch", () => {
         ["ckb", "هێڵی سوور و پچڕپچڕ و ئەستوور", "سوور و پچڕپچڕ و ئەستوور"],
     ];
 
-    for (const [locale, withNoun, adjectivesOnly] of prenominal) {
-        it(`puts ${locale}'s description in front of the noun`, () => {
-            const t = forLocale(locale);
-            expect(
-                describeStrokedShape(t, words, {
-                    noun: { key: "line" },
-                    withNoun: true,
-                }),
-            ).toBe(withNoun);
-            expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
-            expect(
-                describeStrokedShape(t, words, {
-                    noun: { key: "line" },
-                    withNoun: false,
-                }),
-            ).toBe(adjectivesOnly);
-        });
-    }
+    /**
+     * The nouns the placement rule is checked over — one of each shape the
+     * `noun` table names, rather than the single `line` the rows above spell
+     * out. `ku`'s ezafe makes the spread matter for a second reason: a polygon
+     * is masculine and a line feminine, so these six cover both agreements.
+     */
+    const placementNouns: NounKey[] = [
+        "line",
+        "circle",
+        "square",
+        "polygon",
+        "point",
+        "region",
+    ];
 
-    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
-        it(`puts ${locale}'s description behind the noun`, () => {
-            const t = forLocale(locale);
-            expect(
-                describeStrokedShape(t, words, {
-                    noun: { key: "line" },
-                    withNoun: true,
-                }),
-            ).toBe(withNoun);
-            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
-            // The same string with the noun withheld, which is what makes this
-            // a claim about placement rather than about two unrelated
-            // renderings.
-            expect(
-                describeStrokedShape(t, words, {
-                    noun: { key: "line" },
-                    withNoun: false,
-                }),
-            ).toBe(adjectivesOnly);
-        });
-    }
+    /**
+     * One row's worth of both claims: the exact rendering for `line`, and the
+     * placement rule over every noun in {@link placementNouns}. The second is
+     * asserted between two *rendered* strings — never between the row's own two
+     * literals, which would only ever restate the table to itself.
+     */
+    const itPlaces = (
+        group: [string, string, string][],
+        where: "in front of" | "behind",
+    ) => {
+        for (const [locale, withNoun, adjectivesOnly] of group) {
+            it(`puts ${locale}'s description ${where} the noun`, () => {
+                const t = forLocale(locale);
+                expect(
+                    describeStrokedShape(t, words, {
+                        noun: { key: "line" },
+                        withNoun: true,
+                    }),
+                ).toBe(withNoun);
+                // The same string with the noun withheld, which is what makes
+                // this a claim about placement rather than about two unrelated
+                // renderings.
+                expect(
+                    describeStrokedShape(t, words, {
+                        noun: { key: "line" },
+                        withNoun: false,
+                    }),
+                ).toBe(adjectivesOnly);
+                for (const key of placementNouns) {
+                    const described = describeStrokedShape(t, words, {
+                        noun: { key },
+                        withNoun: true,
+                    });
+                    const alone = describeStrokedShape(t, words, {
+                        noun: { key },
+                        withNoun: false,
+                    });
+                    expect(
+                        where === "in front of"
+                            ? described.startsWith(alone)
+                            : described.endsWith(alone),
+                        `${locale}/${key}: ${described} / ${alone}`,
+                    ).toBe(true);
+                }
+            });
+        }
+    };
+
+    itPlaces(prenominal, "in front of");
+    itPlaces(postnominal, "behind");
 
     /**
      * A regular polygon's side count, and the batch's second split. Thirteen
@@ -3531,7 +3561,11 @@ describe("the Caucasus and Kurdish batch", () => {
                 noun: { key: "regular-polygon", numSides: 5 },
                 withNoun: true,
             });
-            expect(description).toContain("5");
+            // Exactly once, which is what the title claims and what `toContain`
+            // alone would not catch: a catalog that writes the count into the
+            // head and *also* leaves it in the `[tail]` branch renders it
+            // twice, and only splitting on it says so.
+            expect(description.split("5")).toHaveLength(2);
             expect(description.trimEnd()).toBe(description);
             expect(description).not.toContain("  ");
         },
@@ -3631,6 +3665,29 @@ describe("Ingush noun classes", () => {
                 { noun: { key: key as NounKey }, withNoun: true },
             ),
         ).toBe(expected);
+    });
+
+    /**
+     * The other side of that divergence, which the row above cannot see. What
+     * makes `locales/inh`'s second fork worth a paragraph is that its sister
+     * catalog does not write it, and nothing said so until here: flattening
+     * `locales/inh` is caught above, but *forking* `locales/ce` to match would
+     * quietly retire the claim instead. Chechen renders «кагйина» for a `d`
+     * noun and a `b` noun alike.
+     */
+    it("has no counterpart in locales/ce, which leaves the same word flat", () => {
+        const ce: Translator = createTranslatorFromLocaleData(
+            { locale: "ce", resources: { ce: readCatalog("ce", "content") } },
+            "ce",
+        );
+        const dashed = (key: NounKey) =>
+            describeStrokedShape(
+                ce,
+                { lineStyleWord: "dashed", colorWord: "red" },
+                { noun: { key }, withNoun: false },
+            );
+        expect(dashed("line")).toBe(dashed("point"));
+        expect(dashed("line")).toBe("кагйина цӀен");
     });
 
     /**


### PR DESCRIPTION
Seeds fifteen unreviewed machine-generated catalogs for the languages of the
Caucasus and the Kurdish-speaking world, taking the roster from 215 locales to
230: Abkhaz (`ab`), Adyghe (`ady`), Kabardian (`kbd`), Avar (`av`), Lezgian
(`lez`), Dargwa (`dar`), Lak (`lbe`), Tabasaran (`tab`), Ingush (`inh`),
Karachay-Balkar (`krc`), Kumyk (`kum`), Nogai (`nog`), Talysh (`tly`), Kurmanji
Kurdish (`ku`) and Central Kurdish (`ckb`) — five families and three scripts.

It continues the Russian Federation batch in the most literal way available:
**six of these fifteen were named in that batch's own test** as neighbours of
`ba` and `ce` that fall back to English rather than being guessed at. Those
rows have moved rather than been deleted, because what they were pinning still
holds — `krc`, `kum`, `nog`, `ady`, `kbd` and `av` reach a catalog now because
one was written for them, not because `negotiate.ts` learned to fold a
neighbour onto a neighbour.

## What the batch found

**It is the first batch that cannot be pinned as one word order.** Every
earlier one could — the Russian Federation's twelve are prenominal to a
catalog. Here ten put the description in front of the noun and five put it
behind, and the five are all three Northwest Caucasian catalogs plus both
Kurdish ones, which are Iranian and sit at the other end of the batch.

**Agreement splits four ways, and only two of the four are a fork.**

- `inh` forks the Vainakh class system as `ce` does — and forks one message
  more: `line-style.dashed`, which `ce` leaves flat although the same
  `$gender` reaches it. That is a question for a speaker of either language,
  not a defect in either file, and both forks are pinned so nobody flattens one
  to match the other without answering it.
- `ku` agrees through an ezafe rather than a class: «ya» after a feminine noun,
  «yê» after a masculine one, forking three messages.
- `av` **agrees more than Chechen and forks nothing.** Avar has three singular
  classes plus a plural and every attributive adjective carries the marker,
  where Chechen's colour and width words carry none — yet every noun this core
  names is a thing rather than a person, so all of them are class III and the
  other branches are variants nothing can select. That is the reachability rule
  `ve`, `ts`, `ki` and `bem` already apply to unreached Bantu classes, arriving
  for the first time from a language that agrees *more*. `lbe` reaches the same
  place from four classes; `dar` writes the select out with only `[b]`
  reachable.
- `lez` is the Northeast Caucasian language that lost its classes, and
  thirteen catalogs here have five different reasons for the same flat
  `noun-gender` — only `inh` and `ku` answer it per noun.

## The Kurdish pair

One macrolanguage, two catalogs, differing in script, direction and whether the
language agrees at all — Kurmanji is Latin, left-to-right and gendered; Sorani
is Perso-Arabic, right-to-left and genderless. `ckb` is the roster's eleventh
right-to-left catalog and needed nothing from `direction.ts`, which keys on the
script: the plainest demonstration this repository has that direction is a fact
about a script rather than about a language.

`ku` is the **first key in `MACROLANGUAGE_MEMBERS` that is the macrolanguage
and still excludes one of its own members**. ISO 639-3 gives Kurdish three
(`ckb`, `kmr`, `sdh`); the map lists two, leaving `ckb` out because folding it
would serve a Sorani reader Kurmanji in a script they do not read. `sdh` is a
recorded script debt — it maximizes to `sdh-Arab-IR` and is served Latin —
because routing it to `ckb` on shared script would be exactly the judgement
these maps exist to avoid. `lki` is the sharp near miss: same script, often
called Southern Kurdish, and outside `kur` in the published mapping, so it
falls back.

## Also here

- `LOCALE_NAME_FALLBACKS` entries for `lbe` and `tab`, which CLDR has no name
  for in any language. Lak gets an endonym («лакку маз») and Tabasaran does
  not, because no catalog of its commits to a self-name and a wrong endonym is
  worse than none.
- Regenerated locale roster and schema, so `<document lang>` autocompletes all
  fifteen under their own names — Lak and Tabasaran included, whose names come
  from `LOCALE_NAME_FALLBACKS` rather than from CLDR. The autocomplete test now
  compares every suggested locale's documentation against the roster's own
  label rather than spot-checking one row for non-emptiness, which is what
  catches a schema regenerated before a name landed: a bare tag is neither
  missing nor empty. `load.test.ts` pins by name the code-split catalog it
  loads, rather than taking whichever tag sorts first — `ab` moved that front.
- The README's "Writing a right-to-left catalog" section now lists eleven
  catalogs rather than ten, with `ckb` in its comparison table.
- `styleDescriptions.test.ts` builds its translators through one
  module-level `forLocale` helper. The file carried twelve byte-identical
  copies of it, one per `describe`, and this batch would have added two more;
  every single-locale translator now goes through the one definition, which
  is a hundred and nine lines shorter and asserts exactly what it did before.
- README section covering the above, plus the batch's recorded limits: four
  catalogs whose conditional closes its clause and so cannot place
  `piecewise-condition-if`; two that put a polygon's side count in a trailing
  complement because they cannot build a numeral into a placeable; and the two
  Circassian catalogs that cannot write the adjective-noun compound their
  grammar wants, for the same reason.

## Honesty

Every string is machine-generated and unread by a speaker, and each catalog
says so in its own header. Three carry a further caveat: `tly` is the least
certain of the fifteen, `dar` discloses that seven of its twelve colour slots
are still plain Russian, and `nog` names its editor vocabulary as largely
coined. The chemistry tables are left out of all fifteen — fourteen for the
school-system reason, and `ckb` for the Tibetan reason instead, its schools
teaching chemistry in Sorani but publishing no convention this seed could
reproduce rather than invent.

## Testing

`lint:i18n` passes across 230 locales. `@doenet/i18n` (612), `@doenet/utils`
(842) and `@doenet/lsp-tools` (651) all pass, including the new negotiation,
direction and style-description assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




