### PR TITLE
fix: exclude .wireit caches from the vite dev-server file watcher

### DIFF
--- a/packages/codemirror/vite.config.ts
+++ b/packages/codemirror/vite.config.ts
@@ -1,11 +1,16 @@
 import { visualizer } from "rollup-plugin-visualizer";
 import { PluginOption, defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true }), visualizer() as PluginOption],
+    plugins: [
+        ignoreWireitCachesPlugin(),
+        dts({ rollupTypes: true }),
+        visualizer() as PluginOption,
+    ],
     build: {
         minify: false,
         sourcemap: true,

--- a/packages/debug-hooks/vite.config.ts
+++ b/packages/debug-hooks/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true })],
+    plugins: [ignoreWireitCachesPlugin(), dts({ rollupTypes: true })],
     build: {
         minify: false,
         sourcemap: true,

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -3,7 +3,10 @@ import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 import { version } from "./package.json";
-import { suppressLogPlugin } from "../../scripts/vite-plugins";
+import {
+    ignoreWireitCachesPlugin,
+    suppressLogPlugin,
+} from "../../scripts/vite-plugins";
 import { serveDoenetmlWorkerPlugin } from "./serve-doenetml-worker-plugin";
 
 /**
@@ -28,6 +31,7 @@ function isExternal(id: string): boolean {
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         dts({ rollupTypes: true }),
         viteStaticCopy({
             targets: [

--- a/packages/doenetml-print/vite.config.ts
+++ b/packages/doenetml-print/vite.config.ts
@@ -7,6 +7,7 @@ import arraybuffer from "vite-plugin-arraybuffer";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PluginOption } from "vite";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 const EXTERNAL_DEPS = ["react", "react-dom"];
 
@@ -60,6 +61,7 @@ export default defineConfig(({ mode }) => {
     return {
         base: "./",
         plugins: [
+            ignoreWireitCachesPlugin(),
             dts({ rollupTypes: true }),
             viteStaticCopyPyodide(),
             vitePluginPrefigure(),
@@ -69,9 +71,6 @@ export default defineConfig(({ mode }) => {
             format: "es",
         },
         server: {
-            // The wireit caches hold hundreds of thousands of files; watching
-            // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-            watch: { ignored: ["**/.wireit/**"] },
             host: "0.0.0.0",
             port: 8012,
         },

--- a/packages/doenetml-print/vite.config.ts
+++ b/packages/doenetml-print/vite.config.ts
@@ -69,6 +69,9 @@ export default defineConfig(({ mode }) => {
             format: "es",
         },
         server: {
+            // The wireit caches hold hundreds of thousands of files; watching
+            // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+            watch: { ignored: ["**/.wireit/**"] },
             host: "0.0.0.0",
             port: 8012,
         },

--- a/packages/doenetml-prototype/vite.config.ts
+++ b/packages/doenetml-prototype/vite.config.ts
@@ -7,7 +7,10 @@ import * as fs from "node:fs/promises";
 import { visualizer } from "rollup-plugin-visualizer";
 import { version } from "./package.json";
 import { createRequire } from "module";
-import { suppressLogPlugin } from "../../scripts/vite-plugins";
+import {
+    ignoreWireitCachesPlugin,
+    suppressLogPlugin,
+} from "../../scripts/vite-plugins";
 const require = createRequire(import.meta.url);
 
 // These are the dependencies that will not be bundled into the library.
@@ -17,6 +20,7 @@ const EXTERNAL_DEPS = ["react", "react-dom"];
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         react(),
         // Pre-create doenetml-worker/ before viteStaticCopy's closeBundle hook runs.
         // Node's fs.cp for a directory calls mkdirAsync(dest) WITHOUT {recursive:true},
@@ -56,9 +60,6 @@ export default defineConfig({
         suppressLogPlugin(),
     ],
     server: {
-        // The wireit caches hold hundreds of thousands of files; watching
-        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-        watch: { ignored: ["**/.wireit/**"] },
         host: "0.0.0.0",
         port: 8012,
     },

--- a/packages/doenetml-prototype/vite.config.ts
+++ b/packages/doenetml-prototype/vite.config.ts
@@ -56,6 +56,9 @@ export default defineConfig({
         suppressLogPlugin(),
     ],
     server: {
+        // The wireit caches hold hundreds of thousands of files; watching
+        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+        watch: { ignored: ["**/.wireit/**"] },
         host: "0.0.0.0",
         port: 8012,
     },

--- a/packages/doenetml-to-pretext/vite.config.ts
+++ b/packages/doenetml-to-pretext/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "vitest/config";
 import dts from "vite-plugin-dts";
 import { version } from "./package.json";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom"];
@@ -13,14 +14,11 @@ export default defineConfig(({ mode }) => {
     const devBuild = mode === "development";
     return {
         base: "./",
-        plugins: [dts({ rollupTypes: true })],
+        plugins: [ignoreWireitCachesPlugin(), dts({ rollupTypes: true })],
         worker: {
             format: "es",
         },
         server: {
-            // The wireit caches hold hundreds of thousands of files; watching
-            // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-            watch: { ignored: ["**/.wireit/**"] },
             host: "0.0.0.0",
             port: 8012,
         },

--- a/packages/doenetml-to-pretext/vite.config.ts
+++ b/packages/doenetml-to-pretext/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig(({ mode }) => {
             format: "es",
         },
         server: {
+            // The wireit caches hold hundreds of thousands of files; watching
+            // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+            watch: { ignored: ["**/.wireit/**"] },
             host: "0.0.0.0",
             port: 8012,
         },

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -55,6 +55,9 @@ export default defineConfig(({ mode }) => {
             DOENETML_VERSION: JSON.stringify(version),
         },
         server: {
+            // The wireit caches hold hundreds of thousands of files; watching
+            // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+            watch: { ignored: ["**/.wireit/**"] },
             host: "0.0.0.0",
             port: 8012,
         },

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -8,6 +8,7 @@ import dts from "vite-plugin-dts";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 import { version } from "./package.json";
 import {
+    ignoreWireitCachesPlugin,
     prefigureDynamicImportIgnorePlugin,
     suppressLogPlugin,
 } from "../../scripts/vite-plugins";
@@ -23,6 +24,7 @@ export default defineConfig(({ mode }) => {
     return {
         base: "./",
         plugins: [
+            ignoreWireitCachesPlugin(),
             react(),
             dts({ rollupTypes: false }),
             viteStaticCopy({
@@ -55,9 +57,6 @@ export default defineConfig(({ mode }) => {
             DOENETML_VERSION: JSON.stringify(version),
         },
         server: {
-            // The wireit caches hold hundreds of thousands of files; watching
-            // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-            watch: { ignored: ["**/.wireit/**"] },
             host: "0.0.0.0",
             port: 8012,
         },

--- a/packages/lsp-tools/vite.config.ts
+++ b/packages/lsp-tools/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts()],
+    plugins: [ignoreWireitCachesPlugin(), dts()],
     resolve: {
         // The package `decode-named-character-reference` imported by `micromark-util-decode-string`
         // which is imported by `mdast-util-to-markdown` defaults to using the browser's DOM to compute

--- a/packages/parser/vite.config.ts
+++ b/packages/parser/vite.config.ts
@@ -6,11 +6,13 @@ import peg from "peggy";
 import * as esbuild from "esbuild";
 import { visualizer } from "rollup-plugin-visualizer";
 import arraybuffer from "vite-plugin-arraybuffer";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         arraybuffer(),
         dts(),
         //{ rollupTypes: true }

--- a/packages/prefigure/vite.config.ts
+++ b/packages/prefigure/vite.config.ts
@@ -17,6 +17,9 @@ const PYODIDE_EXCLUDE = [
 export default defineConfig({
     base: "./",
     server: {
+        // The wireit caches hold hundreds of thousands of files; watching
+        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+        watch: { ignored: ["**/.wireit/**"] },
         host: "0.0.0.0",
     },
     optimizeDeps: { exclude: ["pyodide"] },

--- a/packages/prefigure/vite.config.ts
+++ b/packages/prefigure/vite.config.ts
@@ -5,7 +5,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 import { version } from "./package.json";
-import { suppressLogPlugin } from "../../scripts/vite-plugins";
+import {
+    ignoreWireitCachesPlugin,
+    suppressLogPlugin,
+} from "../../scripts/vite-plugins";
 
 const PYODIDE_EXCLUDE = [
     "!**/*.{md,html}",
@@ -17,13 +20,11 @@ const PYODIDE_EXCLUDE = [
 export default defineConfig({
     base: "./",
     server: {
-        // The wireit caches hold hundreds of thousands of files; watching
-        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-        watch: { ignored: ["**/.wireit/**"] },
         host: "0.0.0.0",
     },
     optimizeDeps: { exclude: ["pyodide"] },
     plugins: [
+        ignoreWireitCachesPlugin(),
         dts({ rollupTypes: true }),
         vitePluginPyodide(),
         viteStaticCopy({

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -8,6 +8,7 @@ import { version } from "./package.json";
 import {
     copyLocaleCatalogsPlugin,
     forceEsbuildMinifyPlugin,
+    ignoreWireitCachesPlugin,
     suppressLogPlugin,
 } from "../../scripts/vite-plugins";
 import { pinChunkUrlsPlugin } from "./scripts/pin-chunk-urls-plugin";
@@ -18,6 +19,7 @@ const require = createRequire(import.meta.url);
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         dts({ rollupTypes: true }),
         viteStaticCopy({
             targets: [

--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "module";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -80,6 +81,7 @@ function standaloneCdnPathsPlugin(): Plugin {
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         react(),
         standaloneCdnPathsPlugin(),
         viteStaticCopy({
@@ -146,9 +148,6 @@ export default defineConfig({
         }),
     ],
     server: {
-        // The wireit caches hold hundreds of thousands of files; watching
-        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-        watch: { ignored: ["**/.wireit/**"] },
         port: 8012,
     },
 });

--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -146,6 +146,9 @@ export default defineConfig({
         }),
     ],
     server: {
+        // The wireit caches hold hundreds of thousands of files; watching
+        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+        watch: { ignored: ["**/.wireit/**"] },
         port: 8012,
     },
 });

--- a/packages/test-viewer/vite.config.ts
+++ b/packages/test-viewer/vite.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
         suppressLogPlugin(),
     ],
     server: {
+        // The wireit caches hold hundreds of thousands of files; watching
+        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
+        watch: { ignored: ["**/.wireit/**"] },
         host: "0.0.0.0",
         port: 8012,
     },

--- a/packages/test-viewer/vite.config.ts
+++ b/packages/test-viewer/vite.config.ts
@@ -3,13 +3,17 @@ import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import path from "node:path";
 import { createRequire } from "module";
-import { suppressLogPlugin } from "../../scripts/vite-plugins";
+import {
+    ignoreWireitCachesPlugin,
+    suppressLogPlugin,
+} from "../../scripts/vite-plugins";
 const require = createRequire(import.meta.url);
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         react(),
         viteStaticCopy({
             targets: [
@@ -25,9 +29,6 @@ export default defineConfig({
         suppressLogPlugin(),
     ],
     server: {
-        // The wireit caches hold hundreds of thousands of files; watching
-        // them exhausts the system inotify limit (ENOSPC on `npm run dev`).
-        watch: { ignored: ["**/.wireit/**"] },
         host: "0.0.0.0",
         port: 8012,
     },

--- a/packages/ui-components/vite.config.ts
+++ b/packages/ui-components/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true })],
+    plugins: [ignoreWireitCachesPlugin(), dts({ rollupTypes: true })],
     build: {
         minify: false,
         sourcemap: true,

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true })],
+    plugins: [ignoreWireitCachesPlugin(), dts({ rollupTypes: true })],
     build: {
         minify: false,
         sourcemap: true,

--- a/packages/v06-to-v07/vite.config.ts
+++ b/packages/v06-to-v07/vite.config.ts
@@ -3,6 +3,7 @@ import dts from "vite-plugin-dts";
 import arraybuffer from "vite-plugin-arraybuffer";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 const EXTERNAL_DEPS = [];
 
@@ -10,6 +11,7 @@ const EXTERNAL_DEPS = [];
 export default defineConfig({
     base: "./",
     plugins: [
+        ignoreWireitCachesPlugin(),
         arraybuffer(),
         dts(),
         viteStaticCopy({

--- a/packages/virtual-keyboard/vite.config.ts
+++ b/packages/virtual-keyboard/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true })],
+    plugins: [ignoreWireitCachesPlugin(), dts({ rollupTypes: true })],
     build: {
         minify: false,
         sourcemap: true,

--- a/packages/vscode-extension/vite.preview-window.config.mts
+++ b/packages/vscode-extension/vite.preview-window.config.mts
@@ -3,12 +3,14 @@ import react from "@vitejs/plugin-react";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import * as path from "node:path";
 import { createRequire } from "module";
+import { ignoreWireitCachesPlugin } from "../../scripts/vite-plugins";
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [
+        ignoreWireitCachesPlugin(),
         react(),
         viteStaticCopy({
             targets: [

--- a/scripts/vite-plugins.ts
+++ b/scripts/vite-plugins.ts
@@ -226,3 +226,34 @@ export function copyLocaleCatalogsPlugin(): PluginOption {
         },
     };
 }
+
+/**
+ * Keep the dev server's file watcher out of the wireit build caches.
+ *
+ * Wireit stores a full copy of a package's `dist` per cache key under
+ * `packages/*\/.wireit/*\/cache/`, so a long-lived checkout accumulates
+ * hundreds of thousands of files there. Vite watches the whole project root
+ * and its default ignore list covers `node_modules` and `.git` but not
+ * `.wireit`, so the watcher descends into the caches and exhausts the system
+ * inotify budget — `npm run dev` then dies at startup with `ENOSPC: System
+ * limit for number of file watchers reached`, pointing at some `.d.ts.map`
+ * deep inside a cache directory. Raising `fs.inotify.max_user_watches` does
+ * not help for long; the cache grows past any limit.
+ *
+ * Nothing under `.wireit` is a source file a dev server should reload on, so
+ * ignoring it outright costs nothing. Vite merges this into its built-in
+ * ignore list rather than replacing it.
+ *
+ * This belongs in every config whose `dev` script starts Vite, which is why it
+ * is a plugin: it applies in serve mode only and needs no `server` block of
+ * its own at the call site.
+ */
+export function ignoreWireitCachesPlugin(): PluginOption {
+    return {
+        name: "doenet-ignore-wireit-caches",
+        apply: "serve",
+        config() {
+            return { server: { watch: { ignored: ["**/.wireit/**"] } } };
+        },
+    };
+}


### PR DESCRIPTION
## Problem

`npm run dev` can crash on startup:

```
Error: ENOSPC: System limit for number of file watchers reached, watch
'.../packages/doenetml/.wireit/6275696c64/cache/<hash>/dist/Viewer/renderers/codeEditor.d.ts.map'
```

## Cause

Not a low system limit — this reproduced with `fs.inotify.max_user_watches` already at 524288. The wireit build caches keep a full copy of `dist` per cache key, and in a long-lived checkout that adds up fast (in mine: ~779,000 files, ~74 GB across `packages/*/.wireit`). Vite watches the whole project root, and its default ignore list covers `node_modules` and `.git` but not `.wireit`, so the watcher descends into the caches and exhausts the watch budget before the dev server is usable. Raising the inotify limit only defers it; the cache keeps growing.

## Fix

A shared `ignoreWireitCachesPlugin()` in `scripts/vite-plugins.ts` contributes `server.watch.ignored: ["**/.wireit/**"]`, used by all eighteen vite configs whose `dev` script starts vite:

`codemirror`, `debug-hooks`, `doenetml`, `doenetml-iframe`, `doenetml-print`, `doenetml-prototype`, `doenetml-to-pretext`, `lsp-tools`, `parser`, `prefigure`, `standalone`, `test-cypress`, `test-viewer`, `ui-components`, `utils`, `v06-to-v07`, `virtual-keyboard`, and `vscode-extension`'s preview-window config.

A plugin rather than a per-config `server.watch` block: it is `apply: "serve"` so it is inert in build mode, and a config that never customized `server` does not grow a block just to hold this. Vite merges the ignore into its built-in list rather than replacing it, and nothing under `.wireit` is a source file a dev server should reload on.

Verified locally: `vite` in `packages/doenetml` comes up in ~400 ms with no ENOSPC.

No changeset: dev-tooling only, no published output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)