### PR TITLE
Reject a plural branch the locale cannot select

### DIFF
--- a/.changeset/fix-dead-plural-branches.md
+++ b/.changeset/fix-dead-plural-branches.md
@@ -1,0 +1,20 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Remove two unreachable plural branches from the Khmer catalog and stop any
+catalog from gaining another.
+
+Khmer has a single plural category, so the `[one]` branches in its
+`attempts-remaining` and `answer-show-responses` could never be selected. Both
+were byte-identical to the default beside them, so nothing rendered
+differently; what changes is that the dead text is gone.
+
+`lint:i18n` now fails on any catalog that names a plural category its own
+locale cannot select — whether because CLDR gives the locale no such category,
+or because CLDR has no data for the tag at all and the branch would be chosen
+by the runtime's default language.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3436,6 +3436,13 @@ selectable in a language whose only category is `other` — which is why
 `locales/km` keeps the `[0]` branch of `attempts-remaining` and lost only the
 `[one]` beside it.
 
+**A category name is read as a category wherever it is written**, including on
+a select whose selector is not a count — where Fluent would match `[few]`
+against the literal string `"few"`. That reading is what makes the rule and the
+symbolic-key check exact complements, and no select in the roster is affected:
+the symbolic ones key on `plain`, `none`, `dark`, `true` and the like, and the
+only category word among their keys is `other`.
+
 **The default variant is exempt whatever it is named.** Fluent answers with it
 whenever no other branch claims the input, so `*[one]` in a single-category
 language is selected by every count rather than by none.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3409,8 +3409,8 @@ A catalog may write only the plural categories its own locale can reach, and
 
 This is the quietest defect a catalog can carry. A `[one]` branch in a language
 whose only category is `other` parses, lints, reads as a translation, and never
-renders — Fluent's default variant answers every input instead. `locales/km`
-carried exactly that in two messages for months. Both `[one]` branches were
+renders — Fluent's default variant answers every input instead. `locales/km` was
+seeded with exactly that in two messages. Both `[one]` branches were
 byte-identical to the `*[other]` beside them, which is precisely why nobody
 noticed: the output was right, and the branch was dead. Khmer's own catalog
 header had said "Khmer has a single plural category" the whole time.
@@ -3421,25 +3421,35 @@ Two things can put one there, and the rule covers both:
   is the authority, and `resolvedOptions().pluralCategories` is the answer.
 - **A locale CLDR does not know.** Its tag resolves to the *runtime's* default
   locale, so every category branch in it is selected by some other language's
-  rules. Around a hundred catalogs are in this position, and none of them writes
-  `zero`, `two`, `few` or `many`.
+  rules. More than a hundred locale directories are in this position, and none
+  of them writes `zero`, `two`, `few` or `many`.
 
-`one` is the deliberate exception in the second case: those hundred catalogs
-keep English's `one`/`other` split because it is the split the fallback makes
-and it reads correctly for them, and each of their headers records the trade.
-Forbidding it would be a change to a hundred catalogs rather than a lint rule.
+`one` is the deliberate exception in the second case: most of those locales keep
+English's `one`/`other` split because English is the package's `DEFAULT_LOCALE`
+and its split is the one the fallback usually makes, and because it reads
+correctly for them — each of their headers records the trade. Forbidding it
+would be a change to ninety-odd catalogs rather than a lint rule.
 
 **Numeric literals are a different mechanism and stay legal.** `[0]` is matched
 against the number itself rather than against a category, so it remains
 selectable in a language whose only category is `other` — which is why
-`locales/km` keeps its zero branch and lost only its `[one]`.
+`locales/km` keeps the `[0]` branch of `attempts-remaining` and lost only the
+`[one]` beside it.
+
+**The default variant is exempt whatever it is named.** Fluent answers with it
+whenever no other branch claims the input, so `*[one]` in a single-category
+language is selected by every count rather than by none.
 
 The tag is canonicalized before it is asked about, because ICU folds three
 directory names onto a macrolanguage — `kmr` to `ku`, `kpv` to `kv`, `mhr` to
 `chm` — and `kmr` genuinely inherits Kurdish's rules while the other two
-inherit nothing, their macrolanguages having no CLDR data either.
+inherit nothing, their macrolanguages having no CLDR data either. Comparing the
+resolved tag against the *language* subtag rather than the whole tag matters for
+the opposite reason: `zh-Hans` and `zh-Hant` both resolve to plain `zh`, which
+is their own data and not a fallback.
 
-`allowedPluralCategories` and `unselectablePluralCategories` in
+`pluralVariantKeys`, `allowedPluralCategories` and
+`unselectablePluralCategories` in
 `scripts/catalogUtils.ts` are the rule; `catalogLint.test.ts` holds it over the
 whole roster, which is what the per-batch plural blocks in `chrome.test.ts`
 were each reaching for one batch at a time. Those blocks stay, minus the half

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3386,7 +3386,8 @@ npm run lint:i18n -w @doenet/i18n    # CI catalog check (also `npm run lint:i18n
 `lint:i18n` fails on: a catalog that doesn't parse (including entries the Fluent
 *runtime* would silently drop as junk), an id defined twice within a locale, a
 catalog naming a `numberingSystem` on a Fluent builtin, a message whose value
-would render a line break, a translated locale
+would render a line break, a catalog naming a plural category its own locale
+cannot select, a translated locale
 defining a key English lacks, a stale `messageKeys.ts`, `supportedLocales.ts`,
 or `diagnostic-codes.lock.json`, a lazy-catalog glob that no longer excludes
 exactly the inlined locales, a call site referencing a key that doesn't exist,
@@ -3400,6 +3401,50 @@ legitimate and falls back.
 Run `codegen` after editing any English catalog, adding a diagnostic code, or
 adding a locale directory; the generated `MessageKey` union, the locale roster
 and the code lock are all committed.
+
+### A plural branch nothing can select
+
+A catalog may write only the plural categories its own locale can reach, and
+`lint:i18n` enforces it.
+
+This is the quietest defect a catalog can carry. A `[one]` branch in a language
+whose only category is `other` parses, lints, reads as a translation, and never
+renders — Fluent's default variant answers every input instead. `locales/km`
+carried exactly that in two messages for months. Both `[one]` branches were
+byte-identical to the `*[other]` beside them, which is precisely why nobody
+noticed: the output was right, and the branch was dead. Khmer's own catalog
+header had said "Khmer has a single plural category" the whole time.
+
+Two things can put one there, and the rule covers both:
+
+- **A locale CLDR knows, given a category it does not have.** `Intl.PluralRules`
+  is the authority, and `resolvedOptions().pluralCategories` is the answer.
+- **A locale CLDR does not know.** Its tag resolves to the *runtime's* default
+  locale, so every category branch in it is selected by some other language's
+  rules. Around a hundred catalogs are in this position, and none of them writes
+  `zero`, `two`, `few` or `many`.
+
+`one` is the deliberate exception in the second case: those hundred catalogs
+keep English's `one`/`other` split because it is the split the fallback makes
+and it reads correctly for them, and each of their headers records the trade.
+Forbidding it would be a change to a hundred catalogs rather than a lint rule.
+
+**Numeric literals are a different mechanism and stay legal.** `[0]` is matched
+against the number itself rather than against a category, so it remains
+selectable in a language whose only category is `other` — which is why
+`locales/km` keeps its zero branch and lost only its `[one]`.
+
+The tag is canonicalized before it is asked about, because ICU folds three
+directory names onto a macrolanguage — `kmr` to `ku`, `kpv` to `kv`, `mhr` to
+`chm` — and `kmr` genuinely inherits Kurdish's rules while the other two
+inherit nothing, their macrolanguages having no CLDR data either.
+
+`allowedPluralCategories` and `unselectablePluralCategories` in
+`scripts/catalogUtils.ts` are the rule; `catalogLint.test.ts` holds it over the
+whole roster, which is what the per-batch plural blocks in `chrome.test.ts`
+were each reaching for one batch at a time. Those blocks stay: they say
+something the property cannot, which is *why* a particular language writes the
+branch it writes.
 
 ## Pseudo-localization
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3442,9 +3442,11 @@ inherit nothing, their macrolanguages having no CLDR data either.
 `allowedPluralCategories` and `unselectablePluralCategories` in
 `scripts/catalogUtils.ts` are the rule; `catalogLint.test.ts` holds it over the
 whole roster, which is what the per-batch plural blocks in `chrome.test.ts`
-were each reaching for one batch at a time. Those blocks stay: they say
-something the property cannot, which is *why* a particular language writes the
-branch it writes.
+were each reaching for one batch at a time. Those blocks stay, minus the half
+the property now subsumes: what they say that it cannot is *why* a particular
+language writes the branch it writes — which tags have their own CLDR data,
+which category each of them resolves, and that the count still reaches the
+reader either way.
 
 ## Pseudo-localization
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3407,13 +3407,11 @@ and the code lock are all committed.
 A catalog may write only the plural categories its own locale can reach, and
 `lint:i18n` enforces it.
 
-This is the quietest defect a catalog can carry. A `[one]` branch in a language
-whose only category is `other` parses, lints, reads as a translation, and never
-renders — Fluent's default variant answers every input instead. `locales/km` was
-seeded with exactly that in two messages. Both `[one]` branches were
-byte-identical to the `*[other]` beside them, which is precisely why nobody
-noticed: the output was right, and the branch was dead. Khmer's own catalog
-header had said "Khmer has a single plural category" the whole time.
+A `[one]` branch in a language whose only category is `other` parses, lints,
+reads as a translation, and never renders — Fluent's default variant answers
+every input instead. `locales/km` was seeded with exactly that in two messages,
+both byte-identical to the `*[other]` beside them, which is why nobody noticed:
+the output was right and the branch was dead.
 
 Two things can put one there, and the rule covers both:
 
@@ -3438,10 +3436,10 @@ selectable in a language whose only category is `other` — which is why
 
 **A category name is read as a category wherever it is written**, including on
 a select whose selector is not a count — where Fluent would match `[few]`
-against the literal string `"few"`. That reading is what makes the rule and the
-symbolic-key check exact complements, and no select in the roster is affected:
-the symbolic ones key on `plain`, `none`, `dark`, `true` and the like, and the
-only category word among their keys is `other`.
+against the literal string `"few"`. Reading it the same way from both sides
+keeps the rule and the symbolic-key check from disagreeing about a key, and no
+select in the roster is affected: the symbolic ones key on `plain`, `none`,
+`dark`, `true` and the like.
 
 **The default variant is exempt whatever it is named.** Fluent answers with it
 whenever no other branch claims the input, so `*[one]` in a single-category
@@ -3456,14 +3454,10 @@ the opposite reason: `zh-Hans` and `zh-Hant` both resolve to plain `zh`, which
 is their own data and not a fallback.
 
 `pluralVariantKeys`, `allowedPluralCategories` and
-`unselectablePluralCategories` in
-`scripts/catalogUtils.ts` are the rule; `catalogLint.test.ts` holds it over the
-whole roster, which is what the per-batch plural blocks in `chrome.test.ts`
-were each reaching for one batch at a time. Those blocks stay, minus the half
-the property now subsumes: what they say that it cannot is *why* a particular
-language writes the branch it writes — which tags have their own CLDR data,
-which category each of them resolves, and that the count still reaches the
-reader either way.
+`unselectablePluralCategories` in `scripts/catalogUtils.ts` are the rule, and
+`catalogLint.test.ts` holds it over the whole roster. The per-batch plural
+blocks in `chrome.test.ts` keep only the half the property cannot state: *why*
+a particular language writes the branch it writes.
 
 ## Pseudo-localization
 

--- a/packages/i18n/locales/km/chrome.ftl
+++ b/packages/i18n/locales/km/chrome.ftl
@@ -33,20 +33,18 @@ answer-percent-credit = ពិន្ទុ { $percent }%
 answer-percent-correct = ត្រឹមត្រូវ { $percent }%
 answer-percent-short = { $percent }%
 max-credit-available = ពិន្ទុអតិបរមាដែលអាចទទួលបាន៖ { $percent }%
+# `[0]` is a numeric literal, matched against the count itself rather than
+# against a plural category, so it stays: Khmer's single category cannot reach
+# it and it is a different sentence rather than a different number.
 attempts-remaining =
     { $count ->
         [0] គ្មានការប៉ុនប៉ងនៅសល់ទេ
-        [one] នៅសល់ការប៉ុនប៉ងចំនួន { $count } ដង
        *[other] នៅសល់ការប៉ុនប៉ងចំនួន { $count } ដង
     }
 validation-correct = (ត្រឹមត្រូវ)
 validation-incorrect = (មិនត្រឹមត្រូវ)
 validation-partially-correct = (ត្រឹមត្រូវខ្លះ)
-answer-show-responses =
-    { $count ->
-        [one] បង្ហាញការឆ្លើយតបចំនួន { $count } ទៅកាន់ { $answerId }
-       *[other] បង្ហាញការឆ្លើយតបចំនួន { $count } ទៅកាន់ { $answerId }
-    }
+answer-show-responses = បង្ហាញការឆ្លើយតបចំនួន { $count } ទៅកាន់ { $answerId }
 
 ## Disclosure panels
 

--- a/packages/i18n/locales/km/chrome.ftl
+++ b/packages/i18n/locales/km/chrome.ftl
@@ -34,8 +34,9 @@ answer-percent-correct = ត្រឹមត្រូវ { $percent }%
 answer-percent-short = { $percent }%
 max-credit-available = ពិន្ទុអតិបរមាដែលអាចទទួលបាន៖ { $percent }%
 # `[0]` is a numeric literal, matched against the count itself rather than
-# against a plural category, so it stays: Khmer's single category cannot reach
-# it and it is a different sentence rather than a different number.
+# against a plural category, so Khmer's having a single category does not make
+# it unreachable the way it did the `[one]` branch that used to sit below it.
+# It stays: zero is a different sentence here, not a different number.
 attempts-remaining =
     { $count ->
         [0] គ្មានការប៉ុនប៉ងនៅសល់ទេ

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -309,7 +309,9 @@ export function symbolicVariantKeys(source: string): Map<string, string[]> {
         if (entry.type !== "Message" && entry.type !== "Term") {
             continue;
         }
-        const visitor = new VariantKeyVisitor();
+        const visitor = new VariantKeyVisitor(
+            (name) => !PLURAL_VARIANT_KEYS.has(name),
+        );
         visitor.visit(entry);
         if (visitor.found.size > 0) {
             // Sorted and deduplicated: a message with two selects — the
@@ -324,15 +326,25 @@ export function symbolicVariantKeys(source: string): Map<string, string[]> {
     return keys;
 }
 
-/** Every symbolic (non-numeric, non-plural) variant key under one entry. */
+/**
+ * Every identifier variant key under a node that `accept` admits.
+ *
+ * One visitor for both readings of a select's keys, because the traversal is
+ * the whole of the shared part and the predicate is the whole of the
+ * difference: {@link symbolicVariantKeys} takes the keys that are *not* plural
+ * categories, {@link pluralVariantKeys} takes the ones that are. Numeric keys
+ * (`[0]`, `[1]`) are not `Identifier` nodes at all, so neither reading ever
+ * sees one.
+ */
 class VariantKeyVisitor extends Visitor {
     found = new Set<string>();
 
+    constructor(private accept: (name: string) => boolean) {
+        super();
+    }
+
     visitVariant(node: Variant) {
-        if (
-            node.key.type === "Identifier" &&
-            !PLURAL_VARIANT_KEYS.has(node.key.name)
-        ) {
+        if (node.key.type === "Identifier" && this.accept(node.key.name)) {
             this.found.add(node.key.name);
         }
         this.genericVisit(node);
@@ -356,25 +368,11 @@ class VariantKeyVisitor extends Visitor {
  * branch was not.
  */
 export function pluralVariantKeys(source: string): string[] {
-    const visitor = new PluralVariantKeyVisitor();
+    const visitor = new VariantKeyVisitor(
+        (name) => PLURAL_VARIANT_KEYS.has(name) && name !== "other",
+    );
     visitor.visit(parseFtl(source, {}));
     return [...visitor.found].sort();
-}
-
-/** Every plural-category variant key in a catalog, `other` excepted. */
-class PluralVariantKeyVisitor extends Visitor {
-    found = new Set<string>();
-
-    visitVariant(node: Variant) {
-        if (
-            node.key.type === "Identifier" &&
-            PLURAL_VARIANT_KEYS.has(node.key.name) &&
-            node.key.name !== "other"
-        ) {
-            this.found.add(node.key.name);
-        }
-        this.genericVisit(node);
-    }
 }
 
 /**
@@ -404,23 +402,37 @@ class PluralVariantKeyVisitor extends Visitor {
  *
  * The tag is canonicalized before it is asked about, because ICU folds three
  * of this repository's directory names onto a macrolanguage — `kmr` to `ku`,
- * `kpv` to `kv`, `mhr` to `chm` — and `kmr` genuinely inherits `ku`'s rules.
+ * `kpv` to `kv`, `mhr` to `chm`. Comparing the resolved tag against the raw
+ * directory name would call all three no-data; comparing it against the
+ * canonical form correctly reports that `kmr` inherits Kurdish's rules while
+ * `kpv` and `mhr` inherit nothing, their macrolanguages having no CLDR data
+ * either.
+ *
+ * A tag `Intl` refuses outright — `en_US`, the POSIX spelling — lands in the
+ * no-data case too, and for a reason the runtime agrees with: `intlLocale`
+ * hands `DEFAULT_LOCALE` to the bundle for exactly those tags, so English is
+ * literally what selects the branch.
  */
 export function allowedPluralCategories(locale: string): Set<string> {
-    let canonicalLanguage: string;
     try {
-        canonicalLanguage = new Intl.Locale(locale).toString().split("-")[0];
+        const canonicalLanguage = new Intl.Locale(locale)
+            .toString()
+            .split("-")[0];
+        const resolved = new Intl.PluralRules(locale).resolvedOptions();
+        if (resolved.locale.split("-")[0] === canonicalLanguage) {
+            return new Set(resolved.pluralCategories);
+        }
     } catch {
-        // A tag `Intl` cannot parse reaches English at runtime, so it is the
-        // no-data case — see `createTranslator` in the package README.
-        return new Set(["one", "other"]);
+        // Fall through: an unparseable tag is the no-data case.
     }
-    const resolved = new Intl.PluralRules(locale).resolvedOptions();
-    const hasOwnData = resolved.locale.split("-")[0] === canonicalLanguage;
-    return hasOwnData
-        ? new Set(resolved.pluralCategories)
-        : new Set(["one", "other"]);
+    return new Set(FALLBACK_PLURAL_CATEGORIES);
 }
+
+/**
+ * What a locale CLDR has no data for may write: the split its fallback
+ * actually makes, which is English's.
+ */
+const FALLBACK_PLURAL_CATEGORIES = ["one", "other"];
 
 /**
  * The plural categories a catalog writes that its own locale cannot select.

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -443,18 +443,35 @@ const FALLBACK_PLURAL_CATEGORIES = ["one", "other"];
  * literally what selects the branch.
  */
 export function allowedPluralCategories(locale: string): Set<string> {
+    return hasOwnPluralData(locale)
+        ? new Set(
+              new Intl.PluralRules(locale).resolvedOptions().pluralCategories,
+          )
+        : new Set(FALLBACK_PLURAL_CATEGORIES);
+}
+
+/**
+ * Whether CLDR resolves this tag against its own rules rather than someone
+ * else's.
+ *
+ * The two cases {@link allowedPluralCategories} distinguishes, told apart on
+ * their own so a diagnostic can say which one a catalog is in: a `false` here
+ * means the categories on offer are the runtime default locale's, not the
+ * language's. See that function for why the comparison is made on the
+ * canonical *language* subtag and why a tag `Intl` refuses counts as no data.
+ */
+export function hasOwnPluralData(locale: string): boolean {
     try {
         const canonicalLanguage = new Intl.Locale(locale)
             .toString()
             .split("-")[0];
         const resolved = new Intl.PluralRules(locale).resolvedOptions();
-        if (resolved.locale.split("-")[0] === canonicalLanguage) {
-            return new Set(resolved.pluralCategories);
-        }
+        return resolved.locale.split("-")[0] === canonicalLanguage;
     } catch {
-        // Fall through: an unparseable tag is the no-data case.
+        // An unparseable tag is the no-data case: `intlLocale` hands the
+        // bundle `DEFAULT_LOCALE` for exactly those.
+        return false;
     }
-    return new Set(FALLBACK_PLURAL_CATEGORIES);
 }
 
 /**

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -329,8 +329,8 @@ export function symbolicVariantKeys(source: string): Map<string, string[]> {
 /**
  * Every identifier variant key under a node that `accept` admits.
  *
- * One visitor for both readings of a select's keys, because the traversal is
- * the whole of the shared part and the predicate is the whole of the
+ * One visitor serves both readings of a select's keys, because the traversal
+ * is the whole of the shared part and the predicate is the whole of the
  * difference: {@link symbolicVariantKeys} takes the keys that are *not* plural
  * categories, {@link pluralVariantKeys} takes the ones that are — and only the
  * latter cares whether the branch is the default, which is why `accept` is
@@ -356,41 +356,32 @@ class VariantKeyVisitor extends Visitor {
 }
 
 /**
- * The plural-category variant keys a catalog writes.
+ * The plural-category variant keys a catalog writes, the default aside.
  *
- * The mirror of {@link symbolicVariantKeys}, and read for the opposite
- * reason. A symbolic key is part of the interface and must match English; a
- * plural key is part of the *language*, and what matters about it is whether
- * the reader's locale can ever select it.
+ * The mirror of {@link symbolicVariantKeys}: a symbolic key is part of the
+ * interface and must match English, while a plural key is part of the
+ * *language*, and what matters about it is whether the reader's locale can
+ * ever select it.
  *
- * Two kinds of key are left out because nothing can make them dead:
- *
- *   * the *default* variant, whatever it is named. Fluent falls back to it for
- *     every input no other branch claims, so `*[one]` in a language whose only
- *     category is `other` is selected by every count rather than by none;
- *   * `other`, whether or not it is the default. It is the category CLDR gives
- *     every language, so a locale can always reach it.
- *
- * Numeric literals — `[0]`, `[1]` — are left out too, and for a sharper
- * reason: they are matched against the *number* rather than against a
- * category, so they stay selectable in a language whose only category is
- * `other`. That distinction is what keeps `locales/km`'s `[0]` branch legal
- * while its `[one]` branch was not.
+ * The default variant is left out whatever it is named, because nothing can
+ * make it dead: Fluent falls back to it for every input no other branch
+ * claims, so `*[one]` in a language whose only category is `other` is selected
+ * by every count rather than by none. Numeric literals — `[0]`, `[1]` — are
+ * left out for a different reason: they are matched against the *number*
+ * rather than against a category, so they stay selectable in a
+ * single-category language. That distinction is what keeps `locales/km`'s
+ * `[0]` branch legal while its `[one]` branch was not.
  *
  * A category name is read as a category wherever it appears, including on a
- * select whose selector is not a count — Fluent would match `[few]` there
- * against the literal string `"few"`. That is the same reading
- * {@link symbolicVariantKeys} makes from the other side, it keeps the two
- * functions exact complements, and no selector in the roster is affected: the
- * symbolic selects name `plain`, `none`, `dark`, `true` and the like, and the
- * only category word among their keys is `other`, which is excluded above.
+ * select whose selector is not a count, where Fluent would match `[few]`
+ * against the literal string `"few"`. Reading it the same way from both sides
+ * is what keeps this function and {@link symbolicVariantKeys} from disagreeing
+ * about a key, and no selector in the roster is affected: the symbolic selects
+ * key on `plain`, `none`, `dark`, `true` and the like.
  */
 export function pluralVariantKeys(source: string): string[] {
     const visitor = new VariantKeyVisitor(
-        (name, variant) =>
-            PLURAL_VARIANT_KEYS.has(name) &&
-            name !== "other" &&
-            !variant.default,
+        (name, variant) => PLURAL_VARIANT_KEYS.has(name) && !variant.default,
     );
     visitor.visit(parseFtl(source, {}));
     return [...visitor.found].sort();
@@ -409,38 +400,13 @@ export function pluralVariantKeys(source: string): string[] {
 const FALLBACK_PLURAL_CATEGORIES = ["one", "other"];
 
 /**
- * The plural categories a locale is entitled to write, and why the answer is
- * not simply "the ones CLDR lists".
+ * The plural categories a locale is entitled to write.
  *
- * A category branch is selected by `Intl.PluralRules`, which resolves the tag
- * against the *runtime's* data. Two things can go wrong, and this repository
- * has had both:
- *
- *   * a locale CLDR knows can still be given a category it does not have.
- *     Khmer has only `other`, and `locales/km` carried a `[one]` branch that
- *     nothing could ever reach — text that looked translated, lint that
- *     passed, and a variant that never rendered;
- *   * a locale CLDR does *not* know resolves to the runtime's default locale,
- *     so every category branch in it is selected by some other language's
- *     rules. That is why no seeded catalog for such a tag writes `zero`, `two`,
- *     `few` or `many`, and why several of their headers say so in as many
- *     words.
- *
- * What the second case may write anyway is {@link FALLBACK_PLURAL_CATEGORIES},
- * which is where the `one` exception is explained.
- *
- * The tag is canonicalized before it is asked about, because ICU folds three
- * of this repository's directory names onto a macrolanguage — `kmr` to `ku`,
- * `kpv` to `kv`, `mhr` to `chm`. Comparing the resolved tag against the raw
- * directory name would call all three no-data; comparing it against the
- * canonical form correctly reports that `kmr` inherits Kurdish's rules while
- * `kpv` and `mhr` inherit nothing, their macrolanguages having no CLDR data
- * either.
- *
- * A tag `Intl` refuses outright — `en_US`, the POSIX spelling — lands in the
- * no-data case too, and for a reason the runtime agrees with: `intlLocale`
- * hands `DEFAULT_LOCALE` to the bundle for exactly those tags, so English is
- * literally what selects the branch.
+ * Either the ones CLDR lists for the tag, or — when CLDR has no data for it,
+ * so that `Intl.PluralRules` resolves it against the runtime's default locale
+ * and some other language's rules pick the branch —
+ * {@link FALLBACK_PLURAL_CATEGORIES}. `hasOwnPluralData` tells the two apart;
+ * the README's "A plural branch nothing can select" has the longer story.
  */
 export function allowedPluralCategories(locale: string): Set<string> {
     return hasOwnPluralData(locale)
@@ -452,13 +418,16 @@ export function allowedPluralCategories(locale: string): Set<string> {
 
 /**
  * Whether CLDR resolves this tag against its own rules rather than someone
- * else's.
+ * else's. A `false` means the categories on offer belong to the runtime's
+ * default locale, not to the language — which is what the lint message says.
  *
- * The two cases {@link allowedPluralCategories} distinguishes, told apart on
- * their own so a diagnostic can say which one a catalog is in: a `false` here
- * means the categories on offer are the runtime default locale's, not the
- * language's. See that function for why the comparison is made on the
- * canonical *language* subtag and why a tag `Intl` refuses counts as no data.
+ * The comparison is made on the canonical *language* subtag on both sides.
+ * Canonical, because ICU folds three of this repository's directory names onto
+ * a macrolanguage — `kmr` to `ku`, `kpv` to `kv`, `mhr` to `chm` — and
+ * comparing against the raw directory name would call all three no-data when
+ * `kmr` really does inherit Kurdish's rules. The language subtag rather than
+ * the whole tag, because `zh-Hans` resolves to plain `zh`, which is its own
+ * data and not a fallback.
  */
 export function hasOwnPluralData(locale: string): boolean {
     try {
@@ -468,8 +437,10 @@ export function hasOwnPluralData(locale: string): boolean {
         const resolved = new Intl.PluralRules(locale).resolvedOptions();
         return resolved.locale.split("-")[0] === canonicalLanguage;
     } catch {
-        // An unparseable tag is the no-data case: `intlLocale` hands the
-        // bundle `DEFAULT_LOCALE` for exactly those.
+        // A tag `Intl` refuses outright — `en_US`, the POSIX spelling — is the
+        // no-data case, and the runtime agrees: `intlLocale` hands the bundle
+        // `DEFAULT_LOCALE` for exactly those, so English is literally what
+        // selects the branch.
         return false;
     }
 }

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -339,6 +339,103 @@ class VariantKeyVisitor extends Visitor {
     }
 }
 
+/**
+ * The plural-category variant keys a catalog writes.
+ *
+ * The mirror of {@link symbolicVariantKeys}, and read for the opposite
+ * reason. A symbolic key is part of the interface and must match English; a
+ * plural key is part of the *language*, and what matters about it is whether
+ * the reader's locale can ever select it.
+ *
+ * `other` is left out because it is always reachable: Fluent's default variant
+ * answers every input no rule claims, so writing it can never be dead. Numeric
+ * literals — `[0]`, `[1]` — are left out too, and for a sharper reason: they
+ * are matched against the *number* rather than against a category, so they
+ * stay selectable in a language whose only category is `other`. That
+ * distinction is what keeps `locales/km`'s `[0]` branch legal while its `[one]`
+ * branch was not.
+ */
+export function pluralVariantKeys(source: string): string[] {
+    const visitor = new PluralVariantKeyVisitor();
+    visitor.visit(parseFtl(source, {}));
+    return [...visitor.found].sort();
+}
+
+/** Every plural-category variant key in a catalog, `other` excepted. */
+class PluralVariantKeyVisitor extends Visitor {
+    found = new Set<string>();
+
+    visitVariant(node: Variant) {
+        if (
+            node.key.type === "Identifier" &&
+            PLURAL_VARIANT_KEYS.has(node.key.name) &&
+            node.key.name !== "other"
+        ) {
+            this.found.add(node.key.name);
+        }
+        this.genericVisit(node);
+    }
+}
+
+/**
+ * The plural categories a locale is entitled to write, and why the answer is
+ * not simply "the ones CLDR lists".
+ *
+ * A category branch is selected by `Intl.PluralRules`, which resolves the tag
+ * against the *runtime's* data. Two things can go wrong, and this repository
+ * has had both:
+ *
+ *   * a locale CLDR knows can still be given a category it does not have.
+ *     Khmer has only `other`, and `locales/km` carried a `[one]` branch that
+ *     nothing could ever reach — text that looked translated, lint that
+ *     passed, and a variant that never rendered;
+ *   * a locale CLDR does *not* know resolves to the runtime's default locale,
+ *     so every category branch in it is selected by some other language's
+ *     rules. That is why no seeded catalog for such a tag writes `zero`, `two`,
+ *     `few` or `many`, and why several of their headers say so in as many
+ *     words.
+ *
+ * `one` is the deliberate exception in the second case. Around a hundred
+ * catalogs are for tags CLDR has no data for, and they keep English's
+ * `one`/`other` split because it is the split the fallback makes and it reads
+ * correctly for them. Forbidding it would be a change to a hundred catalogs
+ * rather than a lint rule, and each of those headers already records the
+ * trade.
+ *
+ * The tag is canonicalized before it is asked about, because ICU folds three
+ * of this repository's directory names onto a macrolanguage — `kmr` to `ku`,
+ * `kpv` to `kv`, `mhr` to `chm` — and `kmr` genuinely inherits `ku`'s rules.
+ */
+export function allowedPluralCategories(locale: string): Set<string> {
+    let canonicalLanguage: string;
+    try {
+        canonicalLanguage = new Intl.Locale(locale).toString().split("-")[0];
+    } catch {
+        // A tag `Intl` cannot parse reaches English at runtime, so it is the
+        // no-data case — see `createTranslator` in the package README.
+        return new Set(["one", "other"]);
+    }
+    const resolved = new Intl.PluralRules(locale).resolvedOptions();
+    const hasOwnData = resolved.locale.split("-")[0] === canonicalLanguage;
+    return hasOwnData
+        ? new Set(resolved.pluralCategories)
+        : new Set(["one", "other"]);
+}
+
+/**
+ * The plural categories a catalog writes that its own locale cannot select.
+ *
+ * Empty for a healthy catalog. Anything in it is text that parses, lints and
+ * never renders.
+ */
+export function unselectablePluralCategories(
+    locale: string,
+    source: string,
+): string[] {
+    const allowed = allowedPluralCategories(locale);
+    return pluralVariantKeys(source).filter((key) => !allowed.has(key));
+}
+
 /** Every key in every namespace of a locale. */
 export function collectLocaleKeys(locale: string): CatalogKey[] {
     const keys: CatalogKey[] = [];

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -376,6 +376,14 @@ class VariantKeyVisitor extends Visitor {
  * category, so they stay selectable in a language whose only category is
  * `other`. That distinction is what keeps `locales/km`'s `[0]` branch legal
  * while its `[one]` branch was not.
+ *
+ * A category name is read as a category wherever it appears, including on a
+ * select whose selector is not a count — Fluent would match `[few]` there
+ * against the literal string `"few"`. That is the same reading
+ * {@link symbolicVariantKeys} makes from the other side, it keeps the two
+ * functions exact complements, and no selector in the roster is affected: the
+ * symbolic selects name `plain`, `none`, `dark`, `true` and the like, and the
+ * only category word among their keys is `other`, which is excluded above.
  */
 export function pluralVariantKeys(source: string): string[] {
     const visitor = new VariantKeyVisitor(
@@ -387,6 +395,18 @@ export function pluralVariantKeys(source: string): string[] {
     visitor.visit(parseFtl(source, {}));
     return [...visitor.found].sort();
 }
+
+/**
+ * What a locale CLDR has no data for may write: English's split.
+ *
+ * Which language actually selects such a branch is the *runtime's* default
+ * locale and so not knowable here — a browser set to Polish would pick the
+ * branch by Polish rules. English is the right answer anyway: it is the
+ * package's `DEFAULT_LOCALE`, the language every one of these catalogs falls
+ * back to when it is incomplete, and the split their headers say they are
+ * assuming. Anything beyond `one` would be a branch no reader is promised.
+ */
+const FALLBACK_PLURAL_CATEGORIES = ["one", "other"];
 
 /**
  * The plural categories a locale is entitled to write, and why the answer is
@@ -406,13 +426,8 @@ export function pluralVariantKeys(source: string): string[] {
  *     `few` or `many`, and why several of their headers say so in as many
  *     words.
  *
- * `one` is the deliberate exception in the second case. More than a hundred of
- * this repository's locale directories are for tags CLDR has no data for, and
- * most of them keep English's `one`/`other` split because English is the
- * package's `DEFAULT_LOCALE` and its split is the one the fallback usually
- * makes, and because it reads correctly for them. Forbidding it would be a change to
- * ninety-odd catalogs rather than a lint rule, and each of their headers
- * already records the trade.
+ * What the second case may write anyway is {@link FALLBACK_PLURAL_CATEGORIES},
+ * which is where the `one` exception is explained.
  *
  * The tag is canonicalized before it is asked about, because ICU folds three
  * of this repository's directory names onto a macrolanguage — `kmr` to `ku`,
@@ -441,18 +456,6 @@ export function allowedPluralCategories(locale: string): Set<string> {
     }
     return new Set(FALLBACK_PLURAL_CATEGORIES);
 }
-
-/**
- * What a locale CLDR has no data for may write: English's split.
- *
- * Which language actually selects such a branch is the *runtime's* default
- * locale and so not knowable here — a browser set to Polish would pick the
- * branch by Polish rules. English is the right answer anyway: it is the
- * package's `DEFAULT_LOCALE`, the language every one of these catalogs falls
- * back to when it is incomplete, and the split their headers say they are
- * assuming. Anything beyond `one` would be a branch no reader is promised.
- */
-const FALLBACK_PLURAL_CATEGORIES = ["one", "other"];
 
 /**
  * The plural categories a catalog writes that its own locale cannot select.

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -332,19 +332,23 @@ export function symbolicVariantKeys(source: string): Map<string, string[]> {
  * One visitor for both readings of a select's keys, because the traversal is
  * the whole of the shared part and the predicate is the whole of the
  * difference: {@link symbolicVariantKeys} takes the keys that are *not* plural
- * categories, {@link pluralVariantKeys} takes the ones that are. Numeric keys
- * (`[0]`, `[1]`) are not `Identifier` nodes at all, so neither reading ever
- * sees one.
+ * categories, {@link pluralVariantKeys} takes the ones that are — and only the
+ * latter cares whether the branch is the default, which is why `accept` is
+ * handed the whole variant and not just its name. Numeric keys (`[0]`, `[1]`)
+ * are not `Identifier` nodes at all, so neither reading ever sees one.
  */
 class VariantKeyVisitor extends Visitor {
     found = new Set<string>();
 
-    constructor(private accept: (name: string) => boolean) {
+    constructor(private accept: (name: string, variant: Variant) => boolean) {
         super();
     }
 
     visitVariant(node: Variant) {
-        if (node.key.type === "Identifier" && this.accept(node.key.name)) {
+        if (
+            node.key.type === "Identifier" &&
+            this.accept(node.key.name, node)
+        ) {
             this.found.add(node.key.name);
         }
         this.genericVisit(node);
@@ -359,17 +363,26 @@ class VariantKeyVisitor extends Visitor {
  * plural key is part of the *language*, and what matters about it is whether
  * the reader's locale can ever select it.
  *
- * `other` is left out because it is always reachable: Fluent's default variant
- * answers every input no rule claims, so writing it can never be dead. Numeric
- * literals — `[0]`, `[1]` — are left out too, and for a sharper reason: they
- * are matched against the *number* rather than against a category, so they
- * stay selectable in a language whose only category is `other`. That
- * distinction is what keeps `locales/km`'s `[0]` branch legal while its `[one]`
- * branch was not.
+ * Two kinds of key are left out because nothing can make them dead:
+ *
+ *   * the *default* variant, whatever it is named. Fluent falls back to it for
+ *     every input no other branch claims, so `*[one]` in a language whose only
+ *     category is `other` is selected by every count rather than by none;
+ *   * `other`, whether or not it is the default. It is the category CLDR gives
+ *     every language, so a locale can always reach it.
+ *
+ * Numeric literals — `[0]`, `[1]` — are left out too, and for a sharper
+ * reason: they are matched against the *number* rather than against a
+ * category, so they stay selectable in a language whose only category is
+ * `other`. That distinction is what keeps `locales/km`'s `[0]` branch legal
+ * while its `[one]` branch was not.
  */
 export function pluralVariantKeys(source: string): string[] {
     const visitor = new VariantKeyVisitor(
-        (name) => PLURAL_VARIANT_KEYS.has(name) && name !== "other",
+        (name, variant) =>
+            PLURAL_VARIANT_KEYS.has(name) &&
+            name !== "other" &&
+            !variant.default,
     );
     visitor.visit(parseFtl(source, {}));
     return [...visitor.found].sort();
@@ -393,12 +406,13 @@ export function pluralVariantKeys(source: string): string[] {
  *     `few` or `many`, and why several of their headers say so in as many
  *     words.
  *
- * `one` is the deliberate exception in the second case. Around a hundred
- * catalogs are for tags CLDR has no data for, and they keep English's
- * `one`/`other` split because it is the split the fallback makes and it reads
- * correctly for them. Forbidding it would be a change to a hundred catalogs
- * rather than a lint rule, and each of those headers already records the
- * trade.
+ * `one` is the deliberate exception in the second case. More than a hundred of
+ * this repository's locale directories are for tags CLDR has no data for, and
+ * most of them keep English's `one`/`other` split because English is the
+ * package's `DEFAULT_LOCALE` and its split is the one the fallback usually
+ * makes, and because it reads correctly for them. Forbidding it would be a change to
+ * ninety-odd catalogs rather than a lint rule, and each of their headers
+ * already records the trade.
  *
  * The tag is canonicalized before it is asked about, because ICU folds three
  * of this repository's directory names onto a macrolanguage — `kmr` to `ku`,
@@ -429,8 +443,14 @@ export function allowedPluralCategories(locale: string): Set<string> {
 }
 
 /**
- * What a locale CLDR has no data for may write: the split its fallback
- * actually makes, which is English's.
+ * What a locale CLDR has no data for may write: English's split.
+ *
+ * Which language actually selects such a branch is the *runtime's* default
+ * locale and so not knowable here — a browser set to Polish would pick the
+ * branch by Polish rules. English is the right answer anyway: it is the
+ * package's `DEFAULT_LOCALE`, the language every one of these catalogs falls
+ * back to when it is incomplete, and the split their headers say they are
+ * assuming. Anything beyond `one` would be a branch no reader is promised.
  */
 const FALLBACK_PLURAL_CATEGORIES = ["one", "other"];
 

--- a/packages/i18n/scripts/lint-catalogs.ts
+++ b/packages/i18n/scripts/lint-catalogs.ts
@@ -38,6 +38,7 @@ import {
     multilinePatterns,
     numberingSystemOverrides,
     allowedPluralCategories,
+    hasOwnPluralData,
     unselectablePluralCategories,
     collectCallSites,
     collectDiagnosticUsage,
@@ -104,9 +105,16 @@ for (const locale of locales) {
             const selectable = [...allowedPluralCategories(locale)]
                 .sort()
                 .join(", ");
+            // Which of the two cases the locale is in changes the advice, so
+            // the message says: CLDR either lists the categories itself, or
+            // has no data for the tag and the runtime's default locale picks
+            // the branch.
+            const because = hasOwnPluralData(locale)
+                ? `CLDR gives ${locale} only ${selectable}`
+                : `CLDR has no data for ${locale}, so its branches are selected by the runtime's default locale and only ${selectable} may be written`;
             for (const category of unselectable) {
                 problems.push(
-                    `locales/${locale}/${namespace}.ftl: [${category}] is a plural category ${locale} cannot select, so the branch would never render — ${locale} selects only ${selectable}; fold the branch's text into the default variant beside it, or drop the select if the remaining branches are identical (see allowedPluralCategories in scripts/catalogUtils.ts)`,
+                    `locales/${locale}/${namespace}.ftl: [${category}] is a plural category ${locale} cannot select, so the branch would never render — ${because}; fold the branch's text into the default variant beside it, or drop the select if the remaining branches are identical (see allowedPluralCategories in scripts/catalogUtils.ts)`,
                 );
             }
         }

--- a/packages/i18n/scripts/lint-catalogs.ts
+++ b/packages/i18n/scripts/lint-catalogs.ts
@@ -37,6 +37,7 @@ import {
     catalogParseErrors,
     multilinePatterns,
     numberingSystemOverrides,
+    allowedPluralCategories,
     unselectablePluralCategories,
     collectCallSites,
     collectDiagnosticUsage,
@@ -96,12 +97,18 @@ for (const locale of locales) {
         }
         // 1d: no catalog names a plural category its own locale cannot
         // select. Such a branch parses, lints and never renders — text that
-        // looks translated and is unreachable. `locales/km` carried one for
-        // months: Khmer has only `other`, and its `[one]` branch was dead.
-        for (const category of unselectablePluralCategories(locale, source)) {
-            problems.push(
-                `locales/${locale}/${namespace}.ftl: [${category}] is a plural category ${locale} cannot select, so the branch would never render — see allowedPluralCategories in scripts/catalogUtils.ts`,
-            );
+        // looks translated and is unreachable. `locales/km` was seeded with
+        // one: Khmer has only `other`, and its `[one]` branch was dead.
+        const unselectable = unselectablePluralCategories(locale, source);
+        if (unselectable.length > 0) {
+            const selectable = [...allowedPluralCategories(locale)]
+                .sort()
+                .join(", ");
+            for (const category of unselectable) {
+                problems.push(
+                    `locales/${locale}/${namespace}.ftl: [${category}] is a plural category ${locale} cannot select, so the branch would never render — ${locale} selects only ${selectable}; fold the branch's text into the default variant beside it, or drop the select if the remaining branches are identical (see allowedPluralCategories in scripts/catalogUtils.ts)`,
+                );
+            }
         }
     }
 

--- a/packages/i18n/scripts/lint-catalogs.ts
+++ b/packages/i18n/scripts/lint-catalogs.ts
@@ -3,7 +3,8 @@
  *
  * Checks, in order:
  *  1. every catalog parses as Fluent, none names a numbering system on a
- *     Fluent builtin, and no message renders a line break;
+ *     Fluent builtin, no message renders a line break, and no catalog names a
+ *     plural category its own locale cannot select;
  *  2. no key is defined twice within a locale (namespaces share one bundle);
  *  3. no translated locale defines a key English doesn't have (a typo'd key in
  *     a translation is invisible at runtime — it just never resolves);
@@ -36,6 +37,7 @@ import {
     catalogParseErrors,
     multilinePatterns,
     numberingSystemOverrides,
+    unselectablePluralCategories,
     collectCallSites,
     collectDiagnosticUsage,
     remainingLiteralDiagnostics,
@@ -90,6 +92,15 @@ for (const locale of locales) {
         for (const multiline of multilinePatterns(source)) {
             problems.push(
                 `locales/${locale}/${namespace}.ftl: ${multiline} — keep each pattern and each variant on one line; a comment belongs above the message, never indented under it`,
+            );
+        }
+        // 1d: no catalog names a plural category its own locale cannot
+        // select. Such a branch parses, lints and never renders — text that
+        // looks translated and is unreachable. `locales/km` carried one for
+        // months: Khmer has only `other`, and its `[one]` branch was dead.
+        for (const category of unselectablePluralCategories(locale, source)) {
+            problems.push(
+                `locales/${locale}/${namespace}.ftl: [${category}] is a plural category ${locale} cannot select, so the branch would never render — see allowedPluralCategories in scripts/catalogUtils.ts`,
             );
         }
     }

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -19,6 +19,9 @@ import {
     readCatalog,
     remainingLiteralDiagnostics,
     symbolicVariantKeys,
+    allowedPluralCategories,
+    pluralVariantKeys,
+    unselectablePluralCategories,
     renderMessageKeysModule,
     renderSupportedLocalesModule,
 } from "../scripts/catalogUtils";
@@ -796,4 +799,170 @@ describe("every catalog's selector keys", () => {
             expect(offenders).toEqual([]);
         },
     );
+});
+
+/**
+ * Dead plural branches: a category a catalog writes and its own locale can
+ * never select.
+ *
+ * Such a branch is the quietest defect a catalog can carry. It parses, it
+ * lints, it looks like a translation, and it renders nothing — the default
+ * variant answers every input instead. `locales/km` carried one: Khmer has a
+ * single plural category, its own header said so, and its `attempts-remaining`
+ * and `answer-show-responses` each had a `[one]` branch beside an identical
+ * `*[other]`. Identical, which is exactly why nobody noticed — the output was
+ * right and the branch was unreachable.
+ *
+ * Every seeded batch since the Sami one has hand-written a block asserting
+ * this for its own locales. These tests replace fifteen such assertions with
+ * one property over the whole roster, so a locale added later cannot
+ * reintroduce the defect by not having a batch block of its own.
+ */
+describe("plural categories a locale cannot select", () => {
+    describe("pluralVariantKeys", () => {
+        it("reads the categories a catalog writes, `other` excepted", () => {
+            expect(
+                pluralVariantKeys(
+                    [
+                        "attempts = { $count ->",
+                        "        [one] one",
+                        "        [few] a few",
+                        "       *[other] many",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["few", "one"]);
+        });
+
+        it("leaves numeric literals out, since they match the number itself", () => {
+            // `[0]` stays selectable in a language whose only category is
+            // `other`, which is the distinction that keeps `locales/km`'s zero
+            // branch legal.
+            expect(
+                pluralVariantKeys(
+                    [
+                        "attempts = { $count ->",
+                        "        [0] none",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual([]);
+        });
+
+        it("reads the syntax rather than the text, so a comment may say the word", () => {
+            // Several headers discuss `[two]` in prose while writing none.
+            expect(
+                pluralVariantKeys(
+                    ["# no [two] branch here", "greeting = hello"].join("\n"),
+                ),
+            ).toEqual([]);
+        });
+
+        it("descends into a select nested under another", () => {
+            expect(
+                pluralVariantKeys(
+                    [
+                        "message = { $parts ->",
+                        "       *[plain] { $count ->",
+                        "            [two] both",
+                        "           *[other] some",
+                        "        }",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["two"]);
+        });
+    });
+
+    describe("allowedPluralCategories", () => {
+        it("gives a locale CLDR knows exactly its own categories", () => {
+            expect([...allowedPluralCategories("km")]).toEqual(["other"]);
+            expect([...allowedPluralCategories("hsb")].sort()).toEqual([
+                "few",
+                "one",
+                "other",
+                "two",
+            ]);
+        });
+
+        it("gives a locale CLDR has no data for `one` and `other` only", () => {
+            // The branches these catalogs are entitled to: English's split is
+            // what the fallback makes, and around a hundred catalogs record
+            // the trade in their own headers.
+            expect([...allowedPluralCategories("sco")].sort()).toEqual([
+                "one",
+                "other",
+            ]);
+            expect(allowedPluralCategories("szl").has("few")).toBe(false);
+        });
+
+        it("canonicalizes before asking, so a member code inherits its macrolanguage's rules", () => {
+            // ICU folds `kmr` onto `ku`, and Kurmanji genuinely counts by
+            // Kurdish's rules — unlike `kpv` and `mhr`, whose macrolanguages
+            // CLDR has no data for either.
+            expect(new Intl.PluralRules("kmr").resolvedOptions().locale) //
+                .toBe("ku");
+            expect([...allowedPluralCategories("kmr")].sort()).toEqual([
+                "one",
+                "other",
+            ]);
+        });
+    });
+
+    describe("unselectablePluralCategories", () => {
+        it("names a category the locale cannot reach", () => {
+            expect(
+                unselectablePluralCategories(
+                    "km",
+                    [
+                        "attempts = { $count ->",
+                        "        [one] one",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["one"]);
+        });
+
+        it("passes a category the locale does reach", () => {
+            expect(
+                unselectablePluralCategories(
+                    "hsb",
+                    [
+                        "attempts = { $count ->",
+                        "        [two] both",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual([]);
+        });
+    });
+
+    /**
+     * The property itself, over every catalog on the roster. This is what the
+     * per-batch blocks in `chrome.test.ts` were reaching for one batch at a
+     * time.
+     */
+    it("is written by no catalog in the roster", () => {
+        const dead: string[] = [];
+        for (const locale of listLocales()) {
+            for (const namespace of CATALOG_NAMESPACES) {
+                const source = readCatalog(locale, namespace);
+                if (source === null) {
+                    continue;
+                }
+                for (const category of unselectablePluralCategories(
+                    locale,
+                    source,
+                )) {
+                    dead.push(
+                        `locales/${locale}/${namespace}.ftl: [${category}]`,
+                    );
+                }
+            }
+        }
+        expect(dead).toEqual([]);
+    });
 });

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -888,6 +888,63 @@ describe("plural categories a locale cannot select", () => {
             ).toEqual([]);
         });
 
+        it("reads a term and an attribute, not only a message's own value", () => {
+            // Neither is where a count lives today, but both are places a
+            // select may be written, and a rule that skipped them would leave
+            // a hole exactly where nobody would look for one.
+            expect(
+                pluralVariantKeys(
+                    [
+                        "-brand = { $count ->",
+                        "        [two] a pair",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["two"]);
+            expect(
+                pluralVariantKeys(
+                    [
+                        "button = press",
+                        "    .label = { $count ->",
+                        "        [few] a few",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["few"]);
+        });
+
+        it("reads a category name as a category even on a non-count select", () => {
+            // Fluent would match `[few]` on a string selector against the
+            // literal `"few"`, so this branch is not strictly dead. Reading it
+            // as a category anyway is what keeps this function and
+            // `symbolicVariantKeys` exact complements, and no selector in the
+            // roster is affected: the symbolic selects key on `plain`,
+            // `none`, `dark`, `true` and the like, and the only category word
+            // among their keys is `other`.
+            expect(
+                pluralVariantKeys(
+                    [
+                        "message = { $status ->",
+                        "        [few] a few",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["few"]);
+            expect(
+                symbolicVariantKeys(
+                    [
+                        "message = { $status ->",
+                        "        [few] a few",
+                        "       *[other] some",
+                        "    }",
+                    ].join("\n"),
+                ).size,
+            ).toBe(0);
+        });
+
         it("descends into a select nested under another", () => {
             expect(
                 pluralVariantKeys(
@@ -958,6 +1015,19 @@ describe("plural categories a locale cannot select", () => {
                 "one",
                 "other",
             ]);
+        });
+
+        it("treats a bare region or script tag as no-data rather than throwing", () => {
+            // A directory named for a region or a script alone is not a
+            // locale, and `Intl` says so. The rule must still answer, and the
+            // conservative answer is the one that lets least through: a
+            // directory named `Hans` may write `[one]` and nothing wider.
+            for (const notALocale of ["Hans", "419"]) {
+                expect(() => new Intl.Locale(notALocale)).toThrow();
+                expect([...allowedPluralCategories(notALocale)].sort()).toEqual(
+                    ["one", "other"],
+                );
+            }
         });
     });
 

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -813,10 +813,13 @@ describe("every catalog's selector keys", () => {
  * `*[other]`. Identical, which is exactly why nobody noticed — the output was
  * right and the branch was unreachable.
  *
- * Every seeded batch since the Sami one has hand-written a block asserting
- * this for its own locales. These tests replace fifteen such assertions with
- * one property over the whole roster, so a locale added later cannot
- * reintroduce the defect by not having a batch block of its own.
+ * Every seeded batch since the Sami one has hand-written a substring check
+ * against its own locales' sources. These tests replace those with one
+ * property over the whole roster, read off the syntax tree rather than the
+ * text, so a locale added later cannot reintroduce the defect merely by not
+ * having a batch block of its own. The batch blocks keep the half the property
+ * cannot state: which tags have their own CLDR data, and which category each
+ * of them resolves.
  */
 describe("plural categories a locale cannot select", () => {
     describe("pluralVariantKeys", () => {
@@ -886,6 +889,15 @@ describe("plural categories a locale cannot select", () => {
             ]);
         });
 
+        it("keeps a script subtag from reading as a different language", () => {
+            // `Intl.PluralRules("zh-Hans")` resolves to plain `zh`, which is
+            // its own data and not a fallback — so the naive comparison of
+            // resolved tag against directory name would have called both
+            // Chinese catalogs no-data and let them write `[one]`.
+            expect([...allowedPluralCategories("zh-Hans")]).toEqual(["other"]);
+            expect([...allowedPluralCategories("zh-Hant")]).toEqual(["other"]);
+        });
+
         it("gives a locale CLDR has no data for `one` and `other` only", () => {
             // The branches these catalogs are entitled to: English's split is
             // what the fallback makes, and around a hundred catalogs record
@@ -904,6 +916,18 @@ describe("plural categories a locale cannot select", () => {
             expect(new Intl.PluralRules("kmr").resolvedOptions().locale) //
                 .toBe("ku");
             expect([...allowedPluralCategories("kmr")].sort()).toEqual([
+                "one",
+                "other",
+            ]);
+        });
+
+        it("treats a tag Intl refuses as the no-data case, as the runtime does", () => {
+            // `en_US`, the POSIX spelling a host gets wrong: every `Intl`
+            // constructor throws on it, `intlLocale` hands the bundle
+            // `DEFAULT_LOCALE` instead, and English is then literally what
+            // selects the branch.
+            expect(() => new Intl.Locale("en_US")).toThrow();
+            expect([...allowedPluralCategories("en_US")].sort()).toEqual([
                 "one",
                 "other",
             ]);

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -20,6 +20,7 @@ import {
     remainingLiteralDiagnostics,
     symbolicVariantKeys,
     allowedPluralCategories,
+    hasOwnPluralData,
     pluralVariantKeys,
     unselectablePluralCategories,
     renderMessageKeysModule,
@@ -1058,6 +1059,18 @@ describe("plural categories a locale cannot select", () => {
                     ].join("\n"),
                 ),
             ).toEqual([]);
+        });
+    });
+
+    describe("hasOwnPluralData", () => {
+        it("tells the two cases apart, which is what the lint message says", () => {
+            // `km` is CLDR's own answer — one category, and it is Khmer's.
+            // `sco` and `en_US` are not: the categories on offer there belong
+            // to whatever locale the runtime falls back to.
+            expect(hasOwnPluralData("km")).toBe(true);
+            expect(hasOwnPluralData("zh-Hans")).toBe(true);
+            expect(hasOwnPluralData("sco")).toBe(false);
+            expect(hasOwnPluralData("en_US")).toBe(false);
         });
     });
 

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -862,6 +862,32 @@ describe("plural categories a locale cannot select", () => {
             ).toEqual([]);
         });
 
+        it("leaves the default variant out, since Fluent always falls back to it", () => {
+            // `*[one]` in a language whose only category is `other` is
+            // selected by every count rather than by none, so it is not the
+            // defect this rule is about.
+            expect(
+                pluralVariantKeys(
+                    [
+                        "attempts = { $count ->",
+                        "        [two] both",
+                        "       *[one] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual(["two"]);
+            expect(
+                unselectablePluralCategories(
+                    "km",
+                    [
+                        "attempts = { $count ->",
+                        "       *[one] some",
+                        "    }",
+                    ].join("\n"),
+                ),
+            ).toEqual([]);
+        });
+
         it("descends into a select nested under another", () => {
             expect(
                 pluralVariantKeys(
@@ -899,9 +925,10 @@ describe("plural categories a locale cannot select", () => {
         });
 
         it("gives a locale CLDR has no data for `one` and `other` only", () => {
-            // The branches these catalogs are entitled to: English's split is
-            // what the fallback makes, and around a hundred catalogs record
-            // the trade in their own headers.
+            // The branches these catalogs are entitled to: English's split
+            // is the one the fallback usually makes, and each of the
+            // ninety-odd catalogs that take it records the trade in its own
+            // header.
             expect([...allowedPluralCategories("sco")].sort()).toEqual([
                 "one",
                 "other",

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -824,7 +824,7 @@ describe("every catalog's selector keys", () => {
  */
 describe("plural categories a locale cannot select", () => {
     describe("pluralVariantKeys", () => {
-        it("reads the categories a catalog writes, `other` excepted", () => {
+        it("reads the categories a catalog writes", () => {
             expect(
                 pluralVariantKeys(
                     [
@@ -919,11 +919,10 @@ describe("plural categories a locale cannot select", () => {
         it("reads a category name as a category even on a non-count select", () => {
             // Fluent would match `[few]` on a string selector against the
             // literal `"few"`, so this branch is not strictly dead. Reading it
-            // as a category anyway is what keeps this function and
-            // `symbolicVariantKeys` exact complements, and no selector in the
-            // roster is affected: the symbolic selects key on `plain`,
-            // `none`, `dark`, `true` and the like, and the only category word
-            // among their keys is `other`.
+            // as a category anyway keeps this function and
+            // `symbolicVariantKeys` from disagreeing about a key, and no
+            // selector in the roster is affected: the symbolic selects key on
+            // `plain`, `none`, `dark`, `true` and the like.
             expect(
                 pluralVariantKeys(
                     [

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -450,10 +450,9 @@ describe("the Oceania batch's plural categories", () => {
  * at all, since `Intl.PluralRules` would resolve the tag against the runtime's
  * default locale and select the text by English's rules — enforced for every
  * catalog by `lint:i18n`, so what is asserted here is only which seven those
- * are. `szl`, `csb` and
- * `rue` are the sharpest cases, because those three really do have a
- * `few`/`many` split of their own — the branch that could be written is
- * exactly the branch that would be got wrong.
+ * are. `szl`, `csb` and `rue` are the sharpest cases, because those three
+ * really do have a `few`/`many` split of their own — the branch that could be
+ * written is exactly the branch that would be got wrong.
  *
  * An explicit `[0]` is a different mechanism — matched against the number
  * rather than against a category — and stays legal in every one of the

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -358,21 +358,15 @@ describe("the Sami plural categories", () => {
  * That is not a defect in the catalogs and the batch does not treat it as one:
  * nouns in these languages are not marked for number after a numeral anyway,
  * so a single unselected form is the *right* translation as well as the safe
- * one. What this block pins is that nobody later adds a category branch to one
- * of these files without noticing that nothing can select it.
+ * one. That no such catalog *writes* an unselectable category branch is held
+ * for the whole roster in `catalogLint.test.ts`, and by `lint:i18n`; what this
+ * block adds is which of these tags is in that position and why.
  *
  * Explicit numeric literals (`[0]`, `[1]`) are a different mechanism — matched
  * against the number itself rather than against a category — and stay legal,
  * which the last assertion holds.
  */
 describe("the Oceania batch's plural categories", () => {
-    /** Comment lines dropped: several headers discuss `[two]` in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
     const OCEANIA: [string, string][] = [
         ["mh", mhChrome],
         ["chk", chkChrome],
@@ -388,15 +382,10 @@ describe("the Oceania batch's plural categories", () => {
     ];
 
     it.each(OCEANIA)(
-        "leaves %s free of a category branch nothing could select",
-        (locale, catalog) => {
-            // CLDR has no rules for the tag, so the categories on offer are
-            // some other language's.
+        "resolves %s against some other language's rules",
+        (locale) => {
             expect(new Intl.PluralRules(locale).resolvedOptions().locale) //
                 .not.toBe(locale);
-            for (const category of ["[zero]", "[two]", "[few]", "[many]"]) {
-                expect(branches(catalog)).not.toContain(category);
-            }
         },
     );
 
@@ -459,7 +448,9 @@ describe("the Oceania batch's plural categories", () => {
  *
  * For the seven with no data, the rule is the Oceania one: no category branch
  * at all, since `Intl.PluralRules` would resolve the tag against the runtime's
- * default locale and select the text by English's rules. `szl`, `csb` and
+ * default locale and select the text by English's rules — enforced for every
+ * catalog by `lint:i18n`, so what is asserted here is only which seven those
+ * are. `szl`, `csb` and
  * `rue` are the sharpest cases, because those three really do have a
  * `few`/`many` split of their own — the branch that could be written is
  * exactly the branch that would be got wrong.
@@ -507,13 +498,10 @@ describe("the European regional batch's plural categories", () => {
     });
 
     it.each(WITHOUT_RULES)(
-        "leaves %s free of a category branch nothing could select",
-        (locale, catalog) => {
+        "resolves %s against some other language's rules",
+        (locale) => {
             expect(new Intl.PluralRules(locale).resolvedOptions().locale) //
                 .not.toBe(locale);
-            for (const category of ["[zero]", "[two]", "[few]", "[many]"]) {
-                expect(branches(catalog)).not.toContain(category);
-            }
         },
     );
 


### PR DESCRIPTION
Removes two unreachable plural branches from `locales/km` and adds a lint rule
so no catalog can gain another.

## The bug

Khmer has a **single** plural category. `Intl.PluralRules("km")` reports
`["other"]`, and `locales/km/chrome.ftl` wrote a `[one]` branch in two
messages: `attempts-remaining` and `answer-show-responses`. Neither could ever
be selected — Fluent's default variant answered every count instead.

It survived because it was invisible from both directions. The `[one]` and
`*[other]` branches were **byte-identical**, so the rendered output was
correct; and the catalog parsed, so lint passed. The file's own header had said
"Khmer has a single plural category, so a countable message needs no
selection" the whole time, and the catalog contradicted it three lines down.

Nothing renders differently after this change. What is gone is text that
claimed to be a translation and was never reachable. With its `[one]` gone,
`answer-show-responses` had one variant left and is now a plain message, which
is how twenty-two of the roster's twenty-four single-category locales already
write it; `attempts-remaining` keeps its select for the `[0]` branch, verified
still selectable by rendering it under a Khmer bundle.

## Why this is the second time

The two most recent seeded batches each hand-wrote a test block asserting this
property for *its own* locales. Khmer predates both and so had no block, which
is exactly the gap a per-batch convention leaves. This PR replaces the
convention with a rule.

## The rule

`lint:i18n` now fails on any catalog naming a plural category its own locale
cannot select. Two situations produce one, and both are covered:

- **A locale CLDR knows, given a category it does not have.** Khmer's case.
  `resolvedOptions().pluralCategories` is the authority.
- **A locale CLDR has no data for.** Its tag resolves to the *runtime's*
  default locale, so a category branch there is selected by some other
  language's rules. More than a hundred locale directories are in this position
  and none writes `zero`, `two`, `few` or `many`.

`one` is a deliberate exception in the second case: most of those locales keep
English's `one`/`other` split because English is the package's
`DEFAULT_LOCALE` and its split is the one the fallback usually makes, and each
of their headers records the trade. Forbidding it would be a change to
ninety-odd catalogs rather than a lint rule.

**Numeric literals stay legal.** `[0]` is matched against the number itself
rather than against a category, so it remains selectable in a language whose
only category is `other`. That is why `locales/km` keeps its zero branch and
loses only the `[one]`.

**A category name is read as a category wherever it is written**, including on
a select whose selector is not a count, where Fluent would match `[few]`
against the literal string `"few"`. Reading it the same way from both sides
keeps this rule and the existing symbolic-variant-key check from disagreeing
about a key, and no select in the roster is affected: the symbolic ones key on
`plain`, `none`, `dark`, `true` and the like.

**So does the default variant, whatever it is named.** Fluent answers with it
for every input no other branch claims, so `*[one]` in a single-category
language is selected by every count rather than by none — the opposite of the
defect, and not reported as one.

The tag is canonicalized before it is asked about, because ICU folds three
directory names onto a macrolanguage — `kmr`→`ku`, `kpv`→`kv`, `mhr`→`chm`.
Kurmanji genuinely inherits Kurdish's rules; the other two inherit nothing,
their macrolanguages having no CLDR data either. A naive check would have
mis-classified all three — and, by comparing whole tags rather than language
subtags, would also have called `zh-Hans` and `zh-Hant` no-data, since both
resolve to plain `zh`, wrongly licensing a `[one]` in two more of the roster's
twenty-four single-category locales.

A tag `Intl` refuses outright — `en_US`, the POSIX spelling — lands in the
no-data case too, and the runtime agrees: `intlLocale` hands the bundle
`DEFAULT_LOCALE` for exactly those tags, so English is literally what selects
the branch.

## What is here

- `pluralVariantKeys`, `allowedPluralCategories` and
  `unselectablePluralCategories` in `scripts/catalogUtils.ts`, reading the
  Fluent AST rather than matching text — so a header that *discusses* `[two]`
  in prose, as several do, is not mistaken for one that writes it.
- The check wired into `lint-catalogs.ts`. Its message names the file, the
  category and the locale, lists the categories that locale *can* select, and
  says what to do about it. It also says *which* of the two situations the
  locale is in — CLDR listing the categories itself, or having no data for the
  tag so the runtime's default locale picks the branch — via
  `hasOwnPluralData`, the predicate `allowedPluralCategories` already needed
  and now shares.
- Unit tests for each helper, plus a property test over the whole roster in
  `catalogLint.test.ts`, covering the CLDR-known, no-data, macrolanguage,
  script-subtag, default-variant, non-count-selector, term, attribute-select
  and unparseable-tag paths — the last of these including a directory named
  for a bare region or script, which `Intl` also refuses and which the rule
  answers conservatively rather than throwing on. The per-batch
  blocks in `chrome.test.ts` keep what the property cannot state — which tags
  have their own CLDR data, which category each resolves, and that the count
  still reaches the reader — and lose the substring checks it now subsumes.
- A README section on the rule, and the `lint:i18n` failure list updated.

## Verification

`lint:i18n` passes at 575 keys across 271 locales. `npm run test -w
@doenet/i18n` is 1163 passing. Reintroducing the Khmer branch locally fails
both the lint and the property test.

## Deliberately out of scope

`locales/my` (Burmese, also single-category) writes `answer-show-responses` and
seven diagnostics messages as selects with a *single* `*[other]` variant. Those
are pointless rather than dead — the one variant is the one that renders — so
the rule does not and should not fire on them. Tidying that class up is a
separate change across several locales.

## One correction

I reported this issue as being in `locales/sjd` (Kildin Sami). That was wrong —
a grep that counted comment lines. `locales/sjd` discusses `[two]` in its
header prose and writes no such branch; the existing Sami test block already
pins that. Auditing the roster properly turned up `locales/km` as the only real
instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



