### PR TITLE
Replace three false naming superlatives with counts

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -403,6 +403,16 @@ read only there. The rule above therefore still holds: a language is named
 whatever CLDR names it, and an entry stops being consulted the day ICU learns a
 name of its own.
 
+**A batch section states counts, not superlatives.** Three claims of the form
+"the first batch to…" or "the best-named batch the roster has had" have now
+been written into this file and later found false — one about grammatical
+duals, one about `zero` plural categories, and one about display names. Each
+was true of the batch that wrote it and false across the roster, and each
+survived several readings because checking it means measuring every earlier
+batch rather than the one in front of you. A count is checkable in one command
+and stays true; a superlative is a claim about twenty other sections that
+nobody re-measures when the twenty-first lands. Write the count.
+
 The names in the table are **unreviewed and machine-generated**, the same status
 as the seed catalogs — the best available answer, not a speaker's. `endonym` is
 optional for that reason: an entry whose endonym turns out to be wrong should
@@ -2076,8 +2086,11 @@ nothing where it does not, and the seed cannot always tell which.
   has no name for in any language, its own included. The endonym «Fakaʻuvea» is
   copied letter for letter from `locales/wls`'s headers — `locales/sjd` fashion
   rather than `locales/olo` fashion, because those headers do commit to a
-  self-name. ICU knows the other ten, down to `tkl` and `niu`, which makes this
-  the best-named batch the roster has had.
+  self-name. ICU knows the other ten in English, down to `tkl` and `niu`. It
+  knows none of the eleven **in its own language**, so `wls` — the one tag it
+  could not name at all — is the only one of the batch whose roster label reads
+  as a pair: "Wallisian (Fakaʻuvea)" beside ten that read their English name
+  once.
 - Two tags left to miss for `smi`'s reason one family up: `map`, the ISO 639-5
   collection over all Austronesian languages, which maximizes to nothing at all,
   and — recorded rather than fixed — `und-WF`, which CLDR maximizes to
@@ -2319,8 +2332,9 @@ regularizes one of a pair to match the other.
 #### Also here
 
 - **No `LOCALE_NAME_FALLBACKS` entry at all.** CLDR knows every one of the
-  fifteen, in English, and knows **ten** of them in themselves, so this is the
-  first batch since the table existed to need nothing from it.
+  fifteen in English and **ten** of them in themselves. Two earlier batches
+  needed nothing from the table either — the four African languages of #1687
+  and the twelve Cyrillic ones of #1689 — so this is the third, not the first.
 - **No `direction.ts` change.** Fourteen are Latin and `rue` is Cyrillic; all
   fifteen run left to right.
 - **Five** of the fifteen read their **English name once** in

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -886,11 +886,10 @@ export const LOCALE_NAME_FALLBACKS: Record<
     olo: { englishName: "Livvi-Karelian" },
     kca: { englishName: "Khanty", endonym: "хӑнты ясӑӈ" },
     mns: { englishName: "Mansi", endonym: "мāньси лāтыӈ" },
-    // The one locale of the Oceania batch CLDR has no data for, and the batch
-    // is otherwise the best-named this roster has had: ICU knows ten of the
-    // eleven tags, down to `tkl` and `niu`. `wls` it knows in no language
-    // at all, not even its own, so without this entry a Wallisian reader would
-    // be offered "wls" in `<document lang>`'s autocomplete. The endonym is
+    // The one locale of the Oceania batch CLDR has no data for: ICU knows the
+    // other ten tags in English, down to `tkl` and `niu`, and `wls` in no
+    // language at all, not even its own — so without this entry a Wallisian
+    // reader would be offered "wls" in `<document lang>`'s autocomplete. The endonym is
     // copied letter for letter from `locales/wls`'s own headers, `locales/sjd`
     // fashion rather than `locales/olo` fashion, because those headers do
     // commit to a self-name: the ʻokina is U+02BB, the same character the


### PR DESCRIPTION
Two claims in `packages/i18n/README.md` about how well CLDR names a batch's
locales are false. This corrects them, and the surrounding `wls` comment in
`scripts/catalogUtils.ts` that repeats one of them.

Documentation and comments only — no behavior change, and no changeset:
`@doenet/i18n` is never published and must never appear in one.

## The Oceania claim was never true

The Oceania section says ICU knowing ten of its eleven tags "makes this the
best-named batch the roster has had". Measured across the batches:

| batch | ICU English names | endonyms | fallback entries needed |
|---|---|---|---|
| Austronesian (#1663) | **15/15** | 1/15 | 0 |
| Oceania (#1769) | 10/11 | **0/11** | 1 (`wls`) |
| European regional (#1773) | 15/15 | 10/15 | 0 |

The Austronesian batch was already 15/15 a year earlier, while Oceania was
10/11 and needed a hand-written entry; and on endonyms Oceania is 0/11, the
worst of any batch measured. It was reported to me as having gone stale when
#1773 landed. It had not — it was false when it was written.

Replaced with the fact worth recording, which is sharper than the superlative
was: ICU knows none of the eleven in its *own* language, so `wls` — the one tag
it could not name at all — is the only one of the batch whose roster label
reads as a pair, "Wallisian (Fakaʻuvea)", beside ten that read their English
name once.

## So was its replacement, in my own PR

Checking the first sent me to the second. When #1773's review struck
"best-named batch" from the European section it substituted "the first batch
since the table existed to need nothing from it", reporting that verified.
Counting actual additions to `LOCALE_NAME_FALLBACKS` per batch:

```
#1685 +4   #1686 +1   #1687 +0   #1688 +3
#1689 +0   #1763 +2   #1764 +4   #1769 +1   #1773 +0
```

`#1687` (four African languages) and `#1689` (twelve Cyrillic languages) both
needed no entry and both predate #1773 — and ICU knows all 4 and all 12 English
names, so those zeros are real rather than names added elsewhere. The European
batch is the third, not the first. Corrected to say so.

## The convention that would have caught both

Three such claims have now been written into this file and later found false:
one about grammatical duals, one about `zero` plural categories, and this one
about display names. Each was true of the batch that wrote it and false across
the roster, and each survived several readings, because checking one means
measuring every earlier batch rather than the one in front of you.

So the section on `LOCALE_NAME_FALLBACKS` now says plainly: **a batch section
states counts, not superlatives.** A count is checkable in one command and
stays true; a superlative is a claim about twenty other sections that nobody
re-measures when the twenty-first lands.

## Verification

Every number above was measured against the roster and `git log`, not carried
over from a report. `lint:i18n` passes (575 keys / 271 locales), 1163 tests
pass, prettier is clean. `README.md` is deliberately not prettier-formatted in
this repo, so it was edited by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
