### PR TITLE
Offer element names when a tag-name terminator follows the cursor

### DIFF
--- a/.changeset/element-autocomplete-tag-name-terminator.md
+++ b/.changeset/element-autocomplete-tag-name-terminator.md
@@ -8,7 +8,7 @@
 
 Editor: keep offering element names when the character after the cursor cannot be part of a tag name.
 
-Typing `<` opened the element menu, and typing the first letter of the tag name emptied it, whenever the character immediately following the cursor was one that ends a tag name — `}`, `{`, `)`, `]`, `$`, `&`, `%`, or `\`. The menu now stays open and filters by what has been typed, as it does when nothing follows the cursor.
+Typing `<` opened the element menu, and typing the first letter of the tag name emptied it, whenever the character immediately following the cursor was one that ends a tag name, such as `}`, `{`, `)`, `]`, `$`, `&`, `%`, or `\`. The menu now stays open and filters by what has been typed, as it does when nothing follows the cursor.
 
 The case that surfaces this is a tag typed inside a brace group of typeset math, such as an input in the bounds of an integral: because the editor closes brackets as you type, `<me>\int_{` is already `<me>\int_{|}` by the time you type `<`, so every tag written there hit this.
 

--- a/.changeset/element-autocomplete-tag-name-terminator.md
+++ b/.changeset/element-autocomplete-tag-name-terminator.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: keep offering element names when the character after the cursor cannot be part of a tag name.
+
+Typing `<` opened the element menu, and typing the first letter of the tag name emptied it, whenever the character immediately following the cursor was one that ends a tag name — `}`, `{`, `)`, `]`, `$`, `&`, `%`, or `\`. The menu now stays open and filters by what has been typed, as it does when nothing follows the cursor.
+
+The case that surfaces this is a tag typed inside a brace group of typeset math, such as an input in the bounds of an integral: because the editor closes brackets as you type, `<me>\int_{` is already `<me>\int_{|}` by the time you type `<`, so every tag written there hit this.
+
+Closes #1767.

--- a/.changeset/element-autocomplete-tag-name-terminator.md
+++ b/.changeset/element-autocomplete-tag-name-terminator.md
@@ -12,4 +12,6 @@ Typing `<` opened the element menu, and typing the first letter of the tag name 
 
 The case that surfaces this is a tag typed inside a brace group of typeset math, such as an input in the bounds of an integral: because the editor closes brackets as you type, `<me>\int_{` is already `<me>\int_{|}` by the time you type `<`, so every tag written there hit this.
 
+The context-help panel follows the same correction: while you type such a tag name it now describes the element being named, rather than listing the elements allowed inside it.
+
 Closes #1767.

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -187,6 +187,17 @@ describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
         const help = await helpAt(source, 9);
         expect(help).toMatchObject({ kind: "element", elementName: "text" });
     });
+
+    it("reports element help while a tag name is typed before a terminator (#1767)", async () => {
+        // A character that cannot continue a tag name — here the `}` the
+        // editor auto-inserted for `\frac{` — used to make the half-typed
+        // `<math` look like a finished element the cursor was *inside*, so the
+        // panel listed that element's allowed children instead of describing
+        // the element being named.
+        const source = `<me>\\frac{<math}</me>`;
+        const help = await helpAt(source, source.indexOf("<math}") + 5);
+        expect(help).toMatchObject({ kind: "element", elementName: "math" });
+    });
 });
 
 describe("computeContextHelp — attribute help", () => {

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -48,8 +48,11 @@ export function elementAtOffsetWithContext(
         (leftLezerNodeParentName === "OpenTag" ||
             leftLezerNodeParentName === "SelfClosingTag");
 
-    // If our exact node is not the same as our containing element, then we're a child of the containing
-    // element and so we're in the body.
+    // The cursor is in a body when it is not on the containing element itself:
+    // on one of that element's children (the exact node at the offset differs
+    // from it), with no node or parent to place it in, or on the empty-named
+    // element the parser produces for a lone `<` at the top level. A tag name
+    // still being typed is left to the `openTagName` handling below.
     const cursorIsInSomeBody =
         !exactNodeAtOffset ||
         exactNodeAtOffset !== node ||

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -31,11 +31,14 @@ export function elementAtOffsetWithContext(
     // The lezer node immediately to the left of the cursor. When it is an
     // open tag's `TagName`, the author is still typing that tag's name (the
     // tag hasn't been terminated with `>` yet). Error recovery can
-    // tentatively parse a half-typed `<nu` that is immediately followed by
-    // another tag (`<nu|<text>` or `<text><nu|</text>`) as a *complete*
-    // `<nu>` element, which otherwise makes the cursor look like it is in
-    // that element's body. Detect this so the body-classifying branches
-    // below defer to the open-tag-name handling instead (#1328).
+    // tentatively parse such a half-typed `<nu` as a *complete* `<nu>`
+    // element, which otherwise makes the cursor look like it is in that
+    // element's body. That happens when the tag is immediately followed by
+    // another tag (`<nu|<text>` or `<text><nu|</text>`, #1328), and also
+    // when it is followed by any character that cannot continue a tag name,
+    // which error recovery then takes as the element's text content
+    // (`<p><nu|}</p>`, #1767). Detect this so the body-classifying branches
+    // below defer to the open-tag-name handling instead.
     const leftLezerCursor = this._lezerCursor();
     leftLezerCursor.moveTo(offset, -1);
     const leftLezerNodeParentName = leftLezerCursor.node.parent?.type?.name as
@@ -46,10 +49,13 @@ export function elementAtOffsetWithContext(
             leftLezerNodeParentName === "SelfClosingTag");
 
     if (
-        (exactNodeAtOffset && exactNodeAtOffset !== node) ||
-        !exactNodeAtOffset ||
-        !parent ||
-        (node?.type === "element" && node.name === "" && parent.type === "root")
+        !atOpenTagNameEnd &&
+        ((exactNodeAtOffset && exactNodeAtOffset !== node) ||
+            !exactNodeAtOffset ||
+            !parent ||
+            (node?.type === "element" &&
+                node.name === "" &&
+                parent.type === "root"))
     ) {
         // If our exact node is not the same as our containing element, then we're a child of the containing
         // element and so we're in the body.

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -48,17 +48,16 @@ export function elementAtOffsetWithContext(
         (leftLezerNodeParentName === "OpenTag" ||
             leftLezerNodeParentName === "SelfClosingTag");
 
-    if (
-        !atOpenTagNameEnd &&
-        ((exactNodeAtOffset && exactNodeAtOffset !== node) ||
-            !exactNodeAtOffset ||
-            !parent ||
-            (node?.type === "element" &&
-                node.name === "" &&
-                parent.type === "root"))
-    ) {
-        // If our exact node is not the same as our containing element, then we're a child of the containing
-        // element and so we're in the body.
+    // If our exact node is not the same as our containing element, then we're a child of the containing
+    // element and so we're in the body.
+    const cursorIsInSomeBody =
+        !exactNodeAtOffset ||
+        exactNodeAtOffset !== node ||
+        !parent ||
+        (node?.type === "element" &&
+            node.name === "" &&
+            parent.type === "root");
+    if (!atOpenTagNameEnd && cursorIsInSomeBody) {
         cursorPosition = "body";
     }
 
@@ -66,11 +65,9 @@ export function elementAtOffsetWithContext(
     // so it is positioned before that element in the containing body rather
     // than inside the element itself (#1327).
     //
-    // Excludes the `atOpenTagNameEnd` case (`<nu|<text>`), where error recovery
-    // tentatively parsed a half-typed `<nu` as a complete element wrapping the
-    // following tag: there the author is still typing the open tag name, so we
-    // defer to the `openTagName` handling below rather than treating the cursor
-    // as the parent's body (#1328).
+    // Excluded when `atOpenTagNameEnd`: the author is still typing the open tag
+    // name, so we defer to the `openTagName` handling below rather than
+    // treating the cursor as the parent's body.
     if (
         node?.type === "element" &&
         node.position?.start?.offset === offset &&
@@ -123,10 +120,10 @@ export function elementAtOffsetWithContext(
             // otherwise overwrite this). Which element's body it is depends on
             // whether the `>` to the left *opens* or *closes* an element.
             //
-            // Excludes the `atOpenTagNameEnd` case (`<text><nu|</text>`), where
+            // Excluded when `atOpenTagNameEnd` (`<text><nu|</text>`), where
             // `leftNode` is an unterminated open tag's `TagName` rather than a
             // `>` — there the author is still typing the tag name, so we fall
-            // through to the `openTagName` handling below (#1328).
+            // through to the `openTagName` handling below.
             cursorPosition = "body";
             const leftElement = this.nodeAtOffset(leftNode.from, {
                 type: "element",

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -30,15 +30,14 @@ export function elementAtOffsetWithContext(
 
     // The lezer node immediately to the left of the cursor. When it is an
     // open tag's `TagName`, the author is still typing that tag's name (the
-    // tag hasn't been terminated with `>` yet). Error recovery can
-    // tentatively parse such a half-typed `<nu` as a *complete* `<nu>`
-    // element, which otherwise makes the cursor look like it is in that
-    // element's body. That happens when the tag is immediately followed by
-    // another tag (`<nu|<text>` or `<text><nu|</text>`, #1328), and also
-    // when it is followed by any character that cannot continue a tag name,
-    // which error recovery then takes as the element's text content
-    // (`<p><nu|}</p>`, #1767). Detect this so the body-classifying branches
-    // below defer to the open-tag-name handling instead.
+    // tag hasn't been terminated with `>` yet). The body-classifying branches
+    // below would otherwise misread such a cursor, because error recovery
+    // gives the half-typed tag an element of its own that wraps whatever
+    // follows: another tag (`<a><nu|<text></text></a>`, #1328), or the
+    // character that ended the name, which becomes text content
+    // (`<p><nu|}</p>`, #1767). A following *close* tag (`<text><nu|</text>`,
+    // #1328) instead leaves the cursor on a close-tag boundary. Detect all of
+    // these so those branches defer to the open-tag-name handling instead.
     const leftLezerCursor = this._lezerCursor();
     leftLezerCursor.moveTo(offset, -1);
     const leftLezerNodeParentName = leftLezerCursor.node.parent?.type?.name as
@@ -52,7 +51,8 @@ export function elementAtOffsetWithContext(
     // on one of that element's children (the exact node at the offset differs
     // from it), with no node or parent to place it in, or on the empty-named
     // element the parser produces for a lone `<` at the top level. A tag name
-    // still being typed is left to the `openTagName` handling below.
+    // still being typed (`<p><nu|}</p>`) is left to the `openTagName` handling
+    // below.
     const cursorIsInSomeBody =
         !exactNodeAtOffset ||
         exactNodeAtOffset !== node ||
@@ -68,9 +68,11 @@ export function elementAtOffsetWithContext(
     // so it is positioned before that element in the containing body rather
     // than inside the element itself (#1327).
     //
-    // Excluded when `atOpenTagNameEnd`: the author is still typing the open tag
-    // name, so we defer to the `openTagName` handling below rather than
-    // treating the cursor as the parent's body.
+    // Excluded when `atOpenTagNameEnd` (`<a><nu|<text></text></a>`, where the
+    // element starting at the cursor is the tag the recovered `<nu>` wrapped):
+    // the author is still typing the open tag name, so we defer to the
+    // `openTagName` handling below rather than treating the cursor as the
+    // parent's body.
     if (
         node?.type === "element" &&
         node.position?.start?.offset === offset &&

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -277,8 +277,14 @@ describe("AutoCompleter", () => {
 
         // `/` ends the tag name too, through a self-closing tag whose `>` has
         // yet to be typed, and was equally empty before.
-        const selfClosing = new AutoCompleter(`<aa><b/</aa>`, schema.elements);
-        const selfClosingItems = await selfClosing.getCompletionItems(6);
+        const selfClosingSource = `<aa><b/</aa>`;
+        const selfClosing = new AutoCompleter(
+            selfClosingSource,
+            schema.elements,
+        );
+        const selfClosingItems = await selfClosing.getCompletionItems(
+            selfClosingSource.indexOf("<b") + 2, // right after `<b`
+        );
         expect(selfClosingItems.map((i) => i.label)).toEqual(["b"]);
     });
 

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -59,6 +59,14 @@ const schema = {
     ],
 };
 
+/**
+ * Characters that cannot continue a tag name, so typing one ends the tag name
+ * being typed. These are the ones the report for #1767 tabulated; the fix isn't
+ * keyed to a list, so any other such character (`!`, `#`, `,`, `;`, `"`, …)
+ * behaves the same way.
+ */
+const TAG_NAME_TERMINATORS = ["}", "{", ")", "]", "$", "&", "%", "\\"];
+
 describe("AutoCompleter", () => {
     it("Can suggest completions", async () => {
         let source: string;
@@ -256,7 +264,7 @@ describe("AutoCompleter", () => {
         // the cursor right after `<b` used to look like `<b>`'s body and offer
         // nothing. It should offer element names filtered by the typed text,
         // exactly as it does with no terminator present.
-        for (const terminator of ["}", "{", ")", "]", "$", "&", "%", "\\"]) {
+        for (const terminator of TAG_NAME_TERMINATORS) {
             const source = `<aa><b${terminator}</aa>`;
             const autoCompleter = new AutoCompleter(source, schema.elements);
             const offset = source.indexOf("<b") + 2; // right after `<b`
@@ -274,16 +282,23 @@ describe("AutoCompleter", () => {
         // same replacement ranges on the snippet items (which replace `<m`,
         // leaving the terminator in place). Checked against the real schema,
         // where snippets and ranking are in play.
-        const plain = new AutoCompleter(`<p><m</p>`, doenetSchema.elements);
-        const expected = await plain.getCompletionItems(5);
-        expect(expected.map((i) => i.label)).toContain("math");
 
-        for (const terminator of ["}", "{", ")", "]", "$", "&", "%", "\\"]) {
+        // `withCursor` marks the cursor with `|`, which is stripped before parsing.
+        async function itemsFor(withCursor: string) {
+            const source = withCursor.replace("|", "");
             const autoCompleter = new AutoCompleter(
-                `<p><m${terminator}</p>`,
+                source,
                 doenetSchema.elements,
             );
-            const items = await autoCompleter.getCompletionItems(5);
+            return await autoCompleter.getCompletionItems(
+                withCursor.indexOf("|"),
+            );
+        }
+
+        const expected = await itemsFor(`<p><m|</p>`);
+        expect(expected.map((i) => i.label)).toContain("math");
+        for (const terminator of TAG_NAME_TERMINATORS) {
+            const items = await itemsFor(`<p><m|${terminator}</p>`);
             expect({ terminator, items }).toEqual({
                 terminator,
                 items: expected,
@@ -292,13 +307,11 @@ describe("AutoCompleter", () => {
 
         // The shape from the issue: a tag typed inside a brace group of an
         // `<me>`, where `closeBrackets` has already supplied the `}`. The
-        // suggestions must come from `<me>`'s allowed children.
-        const inMe = new AutoCompleter(
-            `<me>\\frac{<m}</me>`,
-            doenetSchema.elements,
-        );
-        const inMeItems = await inMe.getCompletionItems(12);
-        expect(inMeItems.map((i) => i.label)).toContain("mathInput");
+        // suggestions come from `<me>`'s allowed children, and again match the
+        // terminator-free source exactly.
+        const inMe = await itemsFor(`<me>\\frac{<m|}</me>`);
+        expect(inMe.map((i) => i.label)).toContain("mathInput");
+        expect(inMe).toEqual(await itemsFor(`<me>\\frac{<m|</me>`));
     });
 
     it("matches element names by substring, not only by prefix (#1328)", async () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -274,6 +274,12 @@ describe("AutoCompleter", () => {
                 labels: ["b"],
             });
         }
+
+        // `/` ends the tag name too, through a self-closing tag whose `>` has
+        // yet to be typed, and was equally empty before.
+        const selfClosing = new AutoCompleter(`<aa><b/</aa>`, schema.elements);
+        const selfClosingItems = await selfClosing.getCompletionItems(6);
+        expect(selfClosingItems.map((i) => i.label)).toEqual(["b"]);
     });
 
     it("offers the same items with and without a tag-name terminator (#1767)", async () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -268,6 +268,39 @@ describe("AutoCompleter", () => {
         }
     });
 
+    it("offers the same items with and without a tag-name terminator (#1767)", async () => {
+        // The terminator sits *after* the cursor, so it must not perturb the
+        // completions at all: the same elements, in the same order, with the
+        // same replacement ranges on the snippet items (which replace `<m`,
+        // leaving the terminator in place). Checked against the real schema,
+        // where snippets and ranking are in play.
+        const plain = new AutoCompleter(`<p><m</p>`, doenetSchema.elements);
+        const expected = await plain.getCompletionItems(5);
+        expect(expected.map((i) => i.label)).toContain("math");
+
+        for (const terminator of ["}", "{", ")", "]", "$", "&", "%", "\\"]) {
+            const autoCompleter = new AutoCompleter(
+                `<p><m${terminator}</p>`,
+                doenetSchema.elements,
+            );
+            const items = await autoCompleter.getCompletionItems(5);
+            expect({ terminator, items }).toEqual({
+                terminator,
+                items: expected,
+            });
+        }
+
+        // The shape from the issue: a tag typed inside a brace group of an
+        // `<me>`, where `closeBrackets` has already supplied the `}`. The
+        // suggestions must come from `<me>`'s allowed children.
+        const inMe = new AutoCompleter(
+            `<me>\\frac{<m}</me>`,
+            doenetSchema.elements,
+        );
+        const inMeItems = await inMe.getCompletionItems(12);
+        expect(inMeItems.map((i) => i.label)).toContain("mathInput");
+    });
+
     it("matches element names by substring, not only by prefix (#1328)", async () => {
         // Typing part of a tag name that appears in the *middle* of other tag
         // names should still surface those tags (e.g. `num` -> `isNumber`), so

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -250,6 +250,24 @@ describe("AutoCompleter", () => {
         expect(items.map((i) => i.label)).not.toContain("/b>");
     });
 
+    it("suggests element names when a tag-name terminator follows the cursor (#1767)", async () => {
+        // `<aa><b}</aa>` — error recovery parses the half-typed `<b` plus the
+        // `}` that ends it as a complete `<b>` element holding `}` as text, so
+        // the cursor right after `<b` used to look like `<b>`'s body and offer
+        // nothing. It should offer element names filtered by the typed text,
+        // exactly as it does with no terminator present.
+        for (const terminator of ["}", "{", ")", "]", "$", "&", "%", "\\"]) {
+            const source = `<aa><b${terminator}</aa>`;
+            const autoCompleter = new AutoCompleter(source, schema.elements);
+            const offset = source.indexOf("<b") + 2; // right after `<b`
+            const items = await autoCompleter.getCompletionItems(offset);
+            expect({ terminator, labels: items.map((i) => i.label) }).toEqual({
+                terminator,
+                labels: ["b"],
+            });
+        }
+    });
+
     it("matches element names by substring, not only by prefix (#1328)", async () => {
         // Typing part of a tag name that appears in the *middle* of other tag
         // names should still surface those tags (e.g. `num` -> `isNumber`), so

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -351,7 +351,10 @@ describe("DoenetSourceObject", () => {
         // *complete* `<m>` element holding it as text. The cursor right after
         // `<m` is still typing the open tag name. `}` is the one that shows up
         // in practice, since the editor closes brackets as you type, so
-        // `<me>\frac{` is already `<me>\frac{|}` when the tag is typed.
+        // `<me>\frac{` is already `<me>\frac{|}` when the tag is typed. The
+        // trailing `>` is the well-formed control: it terminates the tag
+        // properly (no error recovery involved) and already reported
+        // `openTagName`, so the recovered shapes must agree with it.
         for (const terminator of [
             "}",
             "{",

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -345,6 +345,58 @@ describe("DoenetSourceObject", () => {
         }
     });
 
+    it("Reports openTagName when a tag-name terminator follows the cursor (#1767)", () => {
+        // Any character that cannot continue a tag name ends the half-typed
+        // tag, and error recovery then parses `<m` plus that character as a
+        // *complete* `<m>` element holding it as text. The cursor right after
+        // `<m` is still typing the open tag name. `}` is the one that shows up
+        // in practice, since the editor closes brackets as you type, so
+        // `<me>\frac{` is already `<me>\frac{|}` when the tag is typed.
+        for (const terminator of [
+            "}",
+            "{",
+            ")",
+            "]",
+            "$",
+            "&",
+            "%",
+            "\\",
+            ">",
+        ]) {
+            const source = `<p><m${terminator}</p>`;
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(5);
+            expect({ terminator, cursorPosition, name: node?.name }).toEqual({
+                terminator,
+                cursorPosition: "openTagName",
+                name: "m",
+            });
+        }
+
+        // The shape that surfaced this: a tag typed inside a brace group of an
+        // `<me>`, with the auto-closed `}` sitting right after the cursor.
+        {
+            const source = `<me>\\frac{<m}</me>`;
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(source.indexOf("<m}") + 2);
+            expect(cursorPosition).toEqual("openTagName");
+            expect(node).toMatchObject({ type: "element", name: "m" });
+        }
+
+        // Regression guard: once the cursor moves past the terminator it is in
+        // the (recovered) element's body again, not in its tag name.
+        {
+            const source = `<p><m}</p>`;
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(6);
+            expect(cursorPosition).toEqual("body");
+            expect(node).toMatchObject({ type: "element", name: "m" });
+        }
+    });
+
     it("Reports the container (not the element) when the cursor is on a tag boundary (#1327)", () => {
         for (const { source, offset } of [
             { source: `<text/>`, offset: 0 },

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -351,10 +351,11 @@ describe("DoenetSourceObject", () => {
         // *complete* `<m>` element holding it as text. The cursor right after
         // `<m` is still typing the open tag name. `}` is the one that shows up
         // in practice, since the editor closes brackets as you type, so
-        // `<me>\frac{` is already `<me>\frac{|}` when the tag is typed. The
-        // trailing `>` is the well-formed control: it terminates the tag
-        // properly (no error recovery involved) and already reported
-        // `openTagName`, so the recovered shapes must agree with it.
+        // `<me>\frac{` is already `<me>\frac{|}` when the tag is typed. `/`
+        // ends the name the same way, through a self-closing tag whose `>` has
+        // yet to be typed. The trailing `>` is the well-formed control: it
+        // terminates the tag properly (no error recovery involved) and already
+        // reported `openTagName`, so the recovered shapes must agree with it.
         for (const terminator of [
             "}",
             "{",
@@ -364,6 +365,7 @@ describe("DoenetSourceObject", () => {
             "&",
             "%",
             "\\",
+            "/",
             ">",
         ]) {
             const source = `<p><m${terminator}</p>`;

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -367,9 +367,10 @@ describe("DoenetSourceObject", () => {
             ">",
         ]) {
             const source = `<p><m${terminator}</p>`;
+            const offset = source.indexOf("<m") + 2; // right after `<m`
             const { cursorPosition, node } = new DoenetSourceObject(
                 source,
-            ).elementAtOffsetWithContext(5);
+            ).elementAtOffsetWithContext(offset);
             expect({ terminator, cursorPosition, name: node?.name }).toEqual({
                 terminator,
                 cursorPosition: "openTagName",
@@ -392,9 +393,10 @@ describe("DoenetSourceObject", () => {
         // the (recovered) element's body again, not in its tag name.
         {
             const source = `<p><m}</p>`;
+            const offset = source.indexOf("<m}") + 3; // right after the `}`
             const { cursorPosition, node } = new DoenetSourceObject(
                 source,
-            ).elementAtOffsetWithContext(6);
+            ).elementAtOffsetWithContext(offset);
             expect(cursorPosition).toEqual("body");
             expect(node).toMatchObject({ type: "element", name: "m" });
         }


### PR DESCRIPTION
## Summary

Element autocomplete emptied itself as soon as the first letter of a tag name was typed, whenever the character immediately after the cursor was one that cannot appear in a tag name. Typing `<` opened a full menu; typing `m` closed it down to nothing.

| Source (cursor at `|`) | Completions before | after |
| --- | --- | --- |
| `<p><m\|</p>` | 50 | 50 |
| `<p><m\|}</p>` | **0** | 50 |
| `<p><m\|{</p>` | **0** | 50 |
| `<p><m\|)</p>` | **0** | 50 |
| `<p><m\|]</p>` | **0** | 50 |
| `<p><m\|$</p>` | **0** | 50 |
| `<p><m\|&</p>` | **0** | 50 |
| `<p><m\|%</p>` | **0** | 50 |
| `<p><m\|\</p>` | **0** | 50 |

Those nine are the characters the issue tabulated; the fix is not keyed to a list — any character that cannot continue a tag name (`!`, `#`, `,`, `;`, `"`, …) behaves the same way, before and after. So does the `/` of a self-closing tag whose `>` has not been typed yet (`<p><m|/</p>`), which was equally empty before and now matches `<p><m|</p>`.

The shape that surfaces it in practice is a tag typed inside a brace group of typeset math — an input in the bounds of an integral, as `me.mdx` documents since #1765:

```doenet
<me>\int_{<mathInput name="lower" />}^{<mathInput name="upper" />} <mathInput name="integrand" /> \, dx</me>
```

`closeBrackets` is on, so `<me>\int_{` is already `<me>\int_{|}` by the time the author types `<`, and every tag written there hit this. The bug is pre-existing and unrelated to #1765 — it reproduces identically at `fc5cbf33f`.

## Cause

Lezer's error recovery parses `<m}` as a *complete* `<m>` element (`OpenTag[3,5]`, `⚠[5,5]`, `Text[5,6]` — the `}` becomes the element's text content). The DAST element `m` then spans `<m}` rather than `<m`, so at the cursor `nodeAtOffset(offset)` returns that text child while `nodeAtOffset(offset, {type: "element"})` returns `m`. The two differ, and `elementAtOffsetWithContext`'s first branch reads that as "the cursor is a child of the containing element, so it is in the body" — settling `cursorPosition` to `body` before the switch that would have classified the lezer `TagName` as `openTagName` ever runs. `getCompletionItems` never reaches its `openTagName` branch, so no element names are offered.

## Fix

`elementAtOffsetWithContext` already computes `atOpenTagNameEnd` — "the lezer node immediately left of the cursor is an open tag's `TagName`" — introduced in #1328 for the sibling recovery shape `<nu|<text>`, where the half-typed tag is followed by *another tag* rather than by a stray character. That flag guards two later body-classifying branches but not the first one. Adding it there makes all three defer to the same open-tag-name handling, which then points `node` at the tag's owner via `nodeAtOffset(lezerNode.from, {type: "element"})`.

The first branch's disjunction is lifted into a named `cursorIsInSomeBody` so the added guard doesn't bury it three parens deep; `(a && a !== node) || !a` collapses to the equivalent `!a || a !== node` in the process. That part is a readability change only — the classification corpus below is byte-identical across it.

Nothing after the cursor is disturbed. The `openTagName` branch derives its replacement range from `element.position.start.offset` (the tag's `<`) to the cursor, so the snippet items replace `<m` and leave the terminator alone. Against the real schema the resulting item lists — labels, ordering, `sortText`, snippet ranges — are identical to those for the same source with no terminator, which is now asserted directly.

## Effect on the context-help panel

`cursorPosition` also feeds `computeContextHelp`, so the same misclassification made the panel list the elements allowed *inside* `<m>` while the author was still typing `<m`'s name. It now describes the element being named, matching what it already did without a terminator:

| `<me>\frac{<math\|}</me>` | before | after |
| --- | --- | --- |
| panel | `suggestions` — `<math>`'s allowed children | `element` — help for `math` |

## Verification

The classification change was checked by diffing `elementAtOffsetWithContext`, `getCompletionItems` and `computeContextHelp` at every offset of a corpus of sources against `main` (well-formed elements, self-closing tags, bare `<`, unterminated tags, attribute-value recovery, close-tag boundaries). Every changed offset sits at the end of a half-typed open tag name, and there are only two kinds:

- The intended `body` → `openTagName` flips, `node` unchanged in each — including the `<p><m|/</p>` self-closing shape, whose completions and help now match `<p><m|</p>` as well.
- Names whose last typed character is not a word character — `<p><multiple-|}</p>`, `<p><m-|}</p>` — go `body` → `unknown`. Their completions (empty) and their help panel are identical before and after, so nothing user-visible moves there. See below.

## Adjacent, out of scope

A tag name whose last typed character is not a word character — `<p><multiple-|}</p>` — is still not offered completions, and its context-help panel is wrong. That one is a different fault: the `openTagName` guess picks the node to the *right* of the cursor unless `prevChar` is `\w`, so it misfires with or without a terminator. It predates both this fix and #1328, is unchanged by it, and is filed separately as #1780.

Attribute completion inside an unterminated open tag (`<mathInput |`) is also empty, but equally so with and without a terminator — an unrelated pre-existing gap, not this bug.

## On the issue's "second thing to look at"

The issue notes that the broken classification did not fall through to body completion either — `<m>` has 143 possible children and 0 were offered — and suggests that is a second bug. It isn't: completions in an element body are only offered once a `<` has been typed. `<p></p>`, `<p>hi |</p>` and `<math>|</math>` all return 0 for the same reason, while `<p><|</p>` returns 149. The misclassified cursor sat after `<m`, not after a `<`, so 0 was the correct response to the wrong classification. Fixing the classification is the whole fix.

## Tests

- `doenet-source-object.test.ts` — `elementAtOffsetWithContext` reports `openTagName` for each terminator (`}`, `{`, `)`, `]`, `$`, `&`, `%`, `\`, and `/`, plus the well-formed `>` as a control), for the `<me>\frac{<m}</me>` shape from the issue, and still reports `body` once the cursor moves past the terminator.
- `doenet-auto-complete.test.ts` — element-name completions are offered for each terminator, filtered by the typed text; and, against the real Doenet schema, the full item list for `<p><m}</p>` equals the one for `<p><m</p>` for every terminator, with `<me>\frac{<m}</me>` matching its terminator-free counterpart and drawing its suggestions from `<me>`'s allowed children (`mathInput` among them).
- `computeContextHelp.test.ts` — the panel reports element help for `math` while `<me>\frac{<math}</me>` is being typed.

All four fail on `main` and pass here. Full `@doenet/lsp-tools` (655), `@doenet/lsp` and `@doenet/parser` suites pass.

Closes #1767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

