### PR TITLE
Seed catalogs for fifteen languages of the Americas

### DIFF
--- a/.changeset/seed-americas-catalogs.md
+++ b/.changeset/seed-americas-catalogs.md
@@ -16,9 +16,8 @@ renders its style descriptions, section headings, boolean words, answer
 buttons, editor chrome and diagnostics in that language instead of falling
 back to English.
 
-Inuktitut is written in Canadian Aboriginal syllabics and is the roster's
-fifth catalog with a dual, so a count in it selects one of three forms rather
-than one of two. It also leaves the geometry nouns to fall back to English
+Inuktitut is written in Canadian Aboriginal syllabics and has a dual, so a
+count in it selects one of three forms rather than one of two. It also leaves the geometry nouns to fall back to English
 rather than writing them in roman letters inside a syllabic sentence, so a
 style description in Inuktitut is part English by design.
 

--- a/.changeset/seed-americas-catalogs.md
+++ b/.changeset/seed-americas-catalogs.md
@@ -1,0 +1,33 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for fifteen more languages of the Americas:
+Kalaallisut (`kl`), Inuktitut (`iu`), Yucatec Maya (`yua`), Qʼeqchiʼ (`kek`),
+Garifuna (`cab`), Mískito (`miq`), Papiamentu (`pap`), Sranan Tongo (`srn`),
+Jamaican Creole (`jam`), Guadeloupean Creole French (`gcf`), Saint Lucian
+Creole French (`acf`), Guianese Creole French (`gcr`), Belize Kriol (`bzj`),
+Aukan (`djk`) and Saramaccan (`srm`). A document declaring one of them now
+renders its style descriptions, section headings, boolean words, answer
+buttons, editor chrome and diagnostics in that language instead of falling
+back to English.
+
+Inuktitut is written in Canadian Aboriginal syllabics and is the roster's
+fifth catalog with a dual, so a count in it selects one of three forms rather
+than one of two. It also leaves the geometry nouns to fall back to English
+rather than writing them in roman letters inside a syllabic sentence, so a
+style description in Inuktitut is part English by design.
+
+An Inuinnaqtun (`ikt`) reader is served English rather than the Inuktitut
+catalog, because Inuinnaqtun is written in roman letters and that catalog is
+written in syllabics. Nine of the fifteen are creoles and none of them is
+reachable through its lexifier: `gcf` does not answer a request for French,
+and French does not answer a request for `gcf`.
+
+All fifteen leave the two chemistry tables to fall back to English, since
+school science across these communities is taught in Dutch, Danish, Spanish,
+French or English.

--- a/.changeset/seed-americas-catalogs.md
+++ b/.changeset/seed-americas-catalogs.md
@@ -17,8 +17,8 @@ buttons, editor chrome and diagnostics in that language instead of falling
 back to English.
 
 Inuktitut is written in Canadian Aboriginal syllabics and has a dual, so a
-count in it selects one of three forms rather than one of two. It also leaves the geometry nouns to fall back to English
-rather than writing them in roman letters inside a syllabic sentence, so a
+count in it selects one of three forms rather than one of two. It also leaves
+the geometry nouns to fall back to English rather than writing them in roman letters inside a syllabic sentence, so a
 style description in Inuktitut is part English by design.
 
 An Inuinnaqtun (`ikt`) reader is served English rather than the Inuktitut

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2943,6 +2943,23 @@ and says nothing, which is the same defect as a `[one]` in a locale that cannot
 select one, met from the other side, so the test asserts the three forms differ
 rather than merely that three branches exist.
 
+The seed shipped five branches of exactly that kind, and all five were in `kl`
+and `iu` — which is where they matter, since those are two of the three
+catalogs here whose branches a runtime can actually select. Each wrote a count
+select whose branches were the same sentence: «interval» and «input» are
+roman-letter loans in `iu` that take no Inuktitut number ending, and `kl`'s
+«input-eqarpoq» does not change with the count because the numeral carries it.
+All five are now single forms, which is the honest shape for a message whose
+wording does not turn on the count, and `catalogLint.test.ts` holds every
+select in the batch to having at least two branches that differ.
+
+The floor is *some* branch differing rather than all of them, and the
+difference matters: `style-border-clause` forks four ways on an article
+English has and six of these languages do not, so `[with-article]` and
+`[with]` land on one string in `kl`, `cab`, `miq`, `srn`, `djk` and `srm`
+while `[and]` stays apart. That is a distinction the target language does not
+draw, not one the translation lost.
+
 #### One character, and the homoglyph question in a new form
 
 `locales/yua` and `locales/kek` state in their headers that the glottal stop

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2889,8 +2889,11 @@ members: `ike` (Eastern Canadian Inuktitut) and `ikt` (Inuinnaqtun). ICU folds
 `ike` on its own, so `iu: ["ike"]` changes no negotiation result — it is the
 `quz` and `ojg` shape, a member written down so the list is the whole of a
 group. **`ikt` is left out, and the reason is the script**: Inuinnaqtun is
-written in roman letters and `locales/iu` is written wholly in syllabics, so
-folding it would hand a reader a catalog in a script they do not read. This map
+written in roman letters, and every Inuktitut word in `locales/iu` is
+syllabic — the roman that appears there is DoenetML's own identifiers and the
+handful of declared English loans the coverage section above describes, never
+Inuktitut prose. So folding `ikt` would hand a reader a catalog whose every
+translated sentence is in a script they do not read. This map
 now excludes members for three different reasons, and they are worth keeping
 apart: `kbl` under `kr` and `alq` under `oj` because published membership does
 not cover them; `bam` and `dyu` under `mnk` because they have catalogs of their

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2826,7 +2826,7 @@ one, and leave the key out where they do not.**
 `locales/iu` is the same judgement applied inside a catalog rather than to
 one — see the coverage note below.
 
-#### Coverage: thirteen at the ceiling, and one that stops short on purpose
+#### Coverage: fourteen at the ceiling, and one that stops short on purpose
 
 Fourteen of the fifteen sit at **445/575**, which is the whole catalog minus
 the two chemistry tables and the same figure the Silk Road batch reached. The
@@ -2936,9 +2936,10 @@ twelve therefore write one unselected form wherever English forks a count.
 
 **`iu` is the reason that matters.** Inuktitut's rules give it `one`, `two` and
 `other`, and `attempts-remaining` writes all three with a different ending in
-each: ᐆᒃᑐᕐᓂᒃᓴᖅ, ᐆᒃᑐᕐᓂᒃᓵᒃ, ᐆᒃᑐᕐᓂᒃᓴᐃᑦ. Four catalogs on the roster had a
-`[two]` before it — `hsb`, `dsb` and two Sami catalogs — and none of them is in
-the Americas. A dual that repeated the plural would be a branch that renders
+each: ᐆᒃᑐᕐᓂᒃᓴᖅ, ᐆᒃᑐᕐᓂᒃᓵᒃ, ᐆᒃᑐᕐᓂᒃᓴᐃᑦ. Sixteen catalogs on the roster already
+write a `[two]` their own rules select — Arabic, Hebrew, Maltese, Slovene, the
+Celtic four, the Sorbian pair, Santali and the five Sami — and `iu` is the
+seventeenth and the first in the Americas. A dual that repeated the plural would be a branch that renders
 and says nothing, which is the same defect as a `[one]` in a locale that cannot
 select one, met from the other side, so the test asserts the three forms differ
 rather than merely that three branches exist.
@@ -2955,10 +2956,13 @@ select in the batch to having at least two branches that differ.
 
 The floor is *some* branch differing rather than all of them, and the
 difference matters: `style-border-clause` forks four ways on an article
-English has and six of these languages do not, so `[with-article]` and
-`[with]` land on one string in `kl`, `cab`, `miq`, `srn`, `djk` and `srm`
-while `[and]` stays apart. That is a distinction the target language does not
-draw, not one the translation lost.
+English has and a linker English spells two ways, and six of these catalogs
+collapse one of those forks. `kl` and `miq` write no article, so
+`[with-article]` lands on `[with]` and `[and-article]` on `[and]`; `cab`,
+`srn`, `djk` and `srm` use one word for both *with* and *and*, so `[with]`
+lands on `[and]` and the two article branches stay together. Either way two
+branches remain, and either way it is a distinction the target language does
+not draw rather than one the translation lost.
 
 #### One character, and the homoglyph question in a new form
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -110,8 +110,8 @@ everywhere, for the reason in
 Inuktitut over the geometry nouns as well, for the reason in
 [Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws).
 The two hundred and twenty-one are: Somali, Hmong Njua, Amharic, Assamese,
-Nepali, Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
-Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
+Nepali, Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino,
+Vietnamese, Zulu, Xhosa, Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
 Southern Sotho, Setswana, Tigrinya, Ganda, Luxembourgish, Western Frisian, Low
 German, Romansh, Occitan, Asturian, Sardinian, Sicilian, Corsican, Northern
@@ -135,10 +135,10 @@ Tuvaluan, Rarotongan, Wallisian, Bislama, Scots, Swiss German, Colognian,
 Limburgish, Friulian, Venetian, Ligurian, Piedmontese, Neapolitan, Upper
 Sorbian, Lower Sorbian, Kashubian, Silesian, Rusyn, Crimean Tatar, Gagauz,
 Karakalpak, Khakas, Southern Altai, Balochi, Hazaragi, Muslim Tat, Zazaki,
-Shughni, Dungan, Wakhi, Kalaallisut,
-Yucatec Maya, Qʼeqchiʼ, Garifuna, Mískito, Papiamentu, Sranan Tongo, Jamaican
-Creole, Guadeloupean Creole French, Saint Lucian Creole French, Guianese
-Creole French, Belize Kriol, Aukan and Saramaccan
+Shughni, Dungan, Wakhi, Kalaallisut, Yucatec Maya, Qʼeqchiʼ, Garifuna,
+Mískito, Papiamentu, Sranan Tongo, Jamaican Creole, Guadeloupean Creole
+French, Saint Lucian Creole French, Guianese Creole French, Belize Kriol,
+Aukan and Saramaccan
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -2830,8 +2830,8 @@ one — see the coverage note below.
 
 Fourteen of the fifteen sit at **445/575**, which is the whole catalog minus
 the two chemistry tables and the same figure the Silk Road batch reached. The
-chemistry reason is the school-system one for all
-fifteen and is stated in each `content.ftl` header: science is taught in Dutch
+chemistry reason is the school-system one for all fifteen and is stated in
+each `content.ftl` header: science is taught in Dutch
 in Curaçao, Bonaire and Suriname, in Danish in Greenland, in Spanish in Yucatán
 and Alta Verapaz, in French in Guadeloupe and French Guiana, and in English in
 Belize, Jamaica and Saint Lucia. In none of the fifteen is the fallback a
@@ -2915,9 +2915,10 @@ rename of this one. The other fourteen maximize to `-Latn`.
 `acf`, `gcr`, `bzj`, `djk` and `srm` — which is the largest number a batch
 here has needed, the next largest being the seven of the West and Central
 African batch, and is a fact about which languages CLDR carries rather than
-about how many speak these. ICU names `kl`, `iu`, `pap`, `srn` and `jam` and stops there; six
-of the nine gaps are creoles, and the three creoles ICU *does* name are the
-three with national or quasi-official standing.
+about how many speak these. ICU names the other six — `kl`, `iu`, `kek`,
+`pap`, `srn` and `jam` — and stops there; six of the nine gaps are creoles,
+and the three creoles ICU *does* name are the three with national or
+quasi-official standing.
 
 Every one of the nine gets an endonym, which is where this block parts company
 with the Silk Road's. Each of these catalogs names its language exactly one way
@@ -2927,7 +2928,7 @@ is needed nowhere here. The spellings are copied letter for letter from the
 catalogs' own headers, so a corrector who respells a catalog must respell its
 roster label with it.
 
-#### Plurals: three catalogs with rules, and the roster's fifth dual
+#### Plurals: three catalogs with rules, and the roster's seventeenth dual
 
 Three of the fifteen have CLDR plural data of their own — `iu`, `kl` and `pap`
 — and the other twelve resolve to the runtime's default locale, so any category
@@ -2939,8 +2940,9 @@ twelve therefore write one unselected form wherever English forks a count.
 each: ᐆᒃᑐᕐᓂᒃᓴᖅ, ᐆᒃᑐᕐᓂᒃᓵᒃ, ᐆᒃᑐᕐᓂᒃᓴᐃᑦ. Sixteen catalogs on the roster already
 write a `[two]` their own rules select — Arabic, Hebrew, Maltese, Slovene, the
 Celtic four, the Sorbian pair, Santali and the five Sami — and `iu` is the
-seventeenth and the first in the Americas. A dual that repeated the plural would be a branch that renders
-and says nothing, which is the same defect as a `[one]` in a locale that cannot
+seventeenth and the first in the Americas. A dual that repeated the plural
+would be a branch that renders and says nothing, which is the same defect as a
+`[one]` in a locale that cannot
 select one, met from the other side, so the test asserts the three forms differ
 rather than merely that three branches exist.
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -12,14 +12,14 @@ This package is **never published**. Its `vite.config.ts` has no
 
 ## The two locales
 
-DoenetML separates the language of the _content_ from the language of the
-_chrome_, because they genuinely differ: a Spanish-speaking student may work a
+DoenetML separates the language of the *content* from the language of the
+*chrome*, because they genuinely differ: a Spanish-speaking student may work a
 French physics problem, and a French activity embedded in an English course
 should still say "thick red line" in French.
 
-| Setting          | Selects                                                  | Namespaces                        |
-| ---------------- | -------------------------------------------------------- | --------------------------------- |
-| `documentLocale` | Prose the core computes into the document                | `content`                         |
+| Setting          | Selects                                                 | Namespaces                |
+| ---------------- | ------------------------------------------------------- | ------------------------- |
+| `documentLocale` | Prose the core computes into the document               | `content`                 |
 | `uiLocale`       | Everything addressed to whoever is looking at the screen | `chrome`, `diagnostics`, `editor` |
 
 `<document lang>` wins over the `documentLocale` prop, which falls back to
@@ -109,8 +109,8 @@ everywhere, for the reason in
 [A language with no word for it](#a-language-with-no-word-for-it), and
 Inuktitut over the geometry nouns as well, for the reason in
 [Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws).
-The two hundred and twenty-one are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
-Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
+The two hundred and twenty-one are: Somali, Hmong Njua, Amharic, Assamese,
+Nepali, Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
 Southern Sotho, Setswana, Tigrinya, Ganda, Luxembourgish, Western Frisian, Low
@@ -151,7 +151,7 @@ Vietnamese school chemistry has moved from the transliterated names to the
 IUPAC forms, so in each case the fallback is already what the curriculum uses.
 The eight from the first sub-Saharan batch are that same case for a different
 reason: secondary science is taught in English, French or Afrikaans across all
-of them, so the fallback _is_ the curriculum. Afrikaans and Swahili are the two
+of them, so the fallback *is* the curriculum. Afrikaans and Swahili are the two
 of that batch that do have a settled list and supply it.
 
 The eight from the Southeast Asian and Pacific batch split three ways, and the
@@ -160,7 +160,7 @@ the language. Cebuano is the Filipino case again and for the same school
 system, and Malagasy the French-medium case; Samoan and Hawaiian have no
 settled list of all 118 to seed from, and neither does Māori, whose
 kura-taught science coins terms without having reached the whole table.
-Khmer, Lao and Sinhala are the one group where the language _does_ have the
+Khmer, Lao and Sinhala are the one group where the language *does* have the
 names — all three are taught chemistry in their own language, out of textbooks
 that print their own transcriptions — and what is missing is a convention this
 seed could reproduce rather than invent. An unreviewed guess written in a
@@ -181,7 +181,7 @@ Shona, Southern Sotho, Setswana, Tigrinya and Ganda — are partial too, and
 unlike the batches above them they split no ways at all: every one of the ten
 is the school-system case. Secondary science is taught in English across
 Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French
-across Senegal, Mali and both Congos, so in all ten the fallback _is_ the
+across Senegal, Mali and both Congos, so in all ten the fallback *is* the
 curriculum. That is a fact about ten education ministries rather than about ten
 languages, which is why it reads as one sentence here and takes a sentence of
 its own in each catalog's header.
@@ -193,7 +193,7 @@ textbooks, Asturian out of Spanish, Sardinian and Sicilian out of Italian,
 Western Frisian out of Dutch, Low German and Luxembourgish out of German —
 Luxembourg's upper grades in French as well — and Romansh-medium schooling
 stops below the grades where the periodic table is taught. Northern Sami is the
-one of the eleven where the schooling _is_ in the language and the table still
+one of the eleven where the schooling *is* in the language and the table still
 does not settle: a Sami pupil meets the Norwegian, Swedish or Finnish names
 depending on which side of a border the school is, and those three differ, so
 choosing any of them would report a fact about a border. Yiddish has the
@@ -218,7 +218,7 @@ Mexico, Guatemala, Chile and Argentina — and Haitian Creole out of French ones
 Every one of those seven reaches real classrooms, and Guarani reaches further
 than any other language in the batch, being co-official in Paraguay; but
 bilingual education in all seven is the primary grades and the language
-classroom, and secondary chemistry is not. So in all seven the fallback _is_ the
+classroom, and secondary chemistry is not. So in all seven the fallback *is* the
 curriculum, which is the same sentence the two sub-Saharan batches earned and
 for the same reason.
 
@@ -241,7 +241,7 @@ case — the Philippines from the intermediate grades, Guam and the Northern
 Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
 catalogs already record. Balinese, Minangkabau, Acehnese and Madurese are the
 Indonesian-medium case, and they differ from `jv` and `su` in an instructive
-way: those two _supply_ the Indonesian names, because their own vocabulary for
+way: those two *supply* the Indonesian names, because their own vocabulary for
 the substances agrees with Indonesian's often enough that the table reads as
 theirs. These four do not, and copying it whole would be neither language —
 Minangkabau says «ameh» where Indonesian says «emas» — so where `jv` and `su`
@@ -263,10 +263,10 @@ every shape the batches above them found, arriving together for the first
 time. Maithili, Bhojpuri, Konkani, Dogri, Manipuri, Kashmiri and Dzongkha are
 the school-system case, in six different school systems: secondary science is
 Hindi-, Nepali-, English-, Marathi- or Urdu-medium depending on the state or
-the country, so in all seven the fallback _is_ the curriculum, and `locales/hi`,
+the country, so in all seven the fallback *is* the curriculum, and `locales/hi`,
 `locales/ne`, `locales/mr` and `locales/ur` are the parallel texts each header
 names. Bodo and Sanskrit are the Samoan case: Bodo-medium schooling in Assam
-_does_ run to the secondary grades, and Sanskrit has words for the metals it
+*does* run to the secondary grades, and Sanskrit has words for the metals it
 knew, but neither has a settled list of all 118 to seed from. Santali is the
 Ojibwe shape — schooling in it stops below the grades where the table is
 taught, and no table waits on the other side — and Dhivehi is `locales/to`'s and
@@ -291,7 +291,7 @@ taught in English or Afrikaans in South Africa, English in Eswatini, Kenya and
 Zambia, Portuguese in Mozambique, French in the Central African Republic and
 across Fula's whole range but Nigeria, and Arabic and French in Morocco and
 Algeria, where Amazigh is taught as a subject rather than used as a medium. So
-in all twelve the fallback _is_ the curriculum. That is a fact about those
+in all twelve the fallback *is* the curriculum. That is a fact about those
 school systems rather than about twelve languages, which is why it reads as one
 paragraph here and takes a sentence of its own in each catalog's header.
 
@@ -307,7 +307,7 @@ answers.
 **All fifteen of the Caucasus and Kurdish batch are partial, and fourteen of
 the fifteen are partial for the school-system reason.** Secondary chemistry
 across the North Caucasus is taught in Russian, so for the twelve Cyrillic
-catalogs the fallback _is_ the curriculum, exactly as it was for the twelve of
+catalogs the fallback *is* the curriculum, exactly as it was for the twelve of
 the Russian Federation batch — one sentence for twelve education ministries
 that are really one.
 `locales/tly` is a two-country version of the same case and the only one that
@@ -318,7 +318,7 @@ existing at all — Turkish in Turkey, Arabic in Syria.
 
 **`locales/ckb` is the fifteenth and the one claim about a language, and it
 stands beside `locales/kmr` the way `locales/bo` stands beside `locales/dz`.**
-Central Kurdish _is_ the medium of secondary science teaching in the Kurdistan
+Central Kurdish *is* the medium of secondary science teaching in the Kurdistan
 Region of Iraq, and its schools print the periodic table in Sorani — so the
 names exist, and this is the Khmer and Tibetan case rather than the
 school-system one: what is missing is a settled convention this seed could
@@ -593,7 +593,7 @@ itself, CLDR has no Corsican-language data to answer with, and the fallback is
 English — so `endonym` equals `englishName`, the label drops its parenthesis,
 and the roster reads "Corsican" once rather than "Corsican (Corsican)". It is
 not the first to do that: `ak`, `ceb`, `fil`, `hnj`, `mg`, `mi`, `ny` and `sm`
-already read that way, and so do the several whose endonym genuinely _is_ the
+already read that way, and so do the several whose endonym genuinely *is* the
 English word — Afrikaans, Hausa, Igbo, Wolof. Nothing here hand-writes around
 either case, which is why the rule that makes `ny` read "Nyanja" is the rule
 that makes this read "Corsican".
@@ -603,7 +603,7 @@ than one individual language**, and doing so uncovered a real fallback bug rathe
 than merely needing a note.
 
 `qu`, `ay`, `gn` and `oj` are ISO 639-3 macrolanguages and `nah` is an ISO 639-3
-_collection_ code: each covers a family of individual languages with codes of
+*collection* code: each covers a family of individual languages with codes of
 their own. **CLDR's likely-subtags folds exactly one member of a macrolanguage to
 it and leaves the rest unresolvable.** So `quz` reached `qu` on ICU data alone
 and `quh` did not; `ojg` reached `oj` and `ojb` did not; `gug` reached `gn` and
@@ -631,7 +631,7 @@ too.
 
 Serving a related variety is a real compromise, and each of these catalogs says
 in its own header which written standard it is: Southern Quechua in the
-trivocalic orthography, Paraguayan Guarani in the _jopara_ register, Central
+trivocalic orthography, Paraguayan Guarani in the *jopara* register, Central
 Nahuatl in the SEP/INALI orthography, Ojibwe in the Fiero double-vowel
 orthography, Mapudungun in the Alfabeto Mapuche Unificado — which is a choice
 among three live orthographies rather than a neutral default, and its header says
@@ -686,7 +686,7 @@ untouched.
 ### Naming a catalog when a sibling member has one too
 
 A catalog is named after the **individual language it is written in**, not after
-the macrolanguage that language belongs to, whenever a _sibling_ member of that
+the macrolanguage that language belongs to, whenever a *sibling* member of that
 macrolanguage also has a catalog here.
 
 The rule exists because a macrolanguage tag makes a promise the file cannot
@@ -702,7 +702,7 @@ file.
 **An alias adds a fallback; it does not replace the tag.** `available` is not
 only this repository's roster — a host passes its own catalogs in as
 `localeResources`, and [the contract those have is that they
-win](#delivery). So `negotiateLocales` asks for the tag as written _and then_
+win](#delivery). So `negotiateLocales` asks for the tag as written *and then*
 its alias, in that order. Rewriting `ku` to `kmr` before matching would step
 over a host that had keyed a catalog on `ku`: its key would never be compared
 against anything, and its reader would get English while the translation sat in
@@ -714,7 +714,7 @@ which all three of these were.
 What an alias cannot do is tell the two tags apart. `normalizeLocaleTag` folds
 `kmr` to `ku` before negotiation runs — ICU's canonicalization again — so
 `<document lang="kmr">` and `<document lang="ku">` arrive as the same request,
-and a host offering catalogs under _both_ keys is answered with the
+and a host offering catalogs under *both* keys is answered with the
 macrolanguage's for either. That predates the aliases rather than following
 from them: `kmr` folded to `ku` before there was a `locales/kmr` to fold it
 onto. Undoing it would mean `normalizeLocaleTag` declining to canonicalize
@@ -734,12 +734,12 @@ new Intl.Locale("mhr").toString(); // "chm"
 `normalizeLocaleTag` runs that canonicalization, so a hand-typed `<document
 lang="kmr">` has already become `ku` before negotiation sees it. A directory
 named `kmr` is therefore unreachable under **both** names unless something maps
-the macrolanguage _forward_ onto the member — which is what the `ku: "kmr"`,
+the macrolanguage *forward* onto the member — which is what the `ku: "kmr"`,
 `kv: "kpv"` and `chm: "mhr"` rows in `LANGUAGE_ALIASES` do. Delete them as
 redundant and three catalogs fall to English with nothing to say why.
 
-That is the mirror of the `koi`/`mrj` case: there an alias had to be _removed_
-for a member's own catalog to win, here one has to be _added_ for a member's own
+That is the mirror of the `koi`/`mrj` case: there an alias had to be *removed*
+for a member's own catalog to win, here one has to be *added* for a member's own
 catalog to be reachable at all. `negotiate.test.ts` asserts both the
 canonicalization and the negotiation result, so neither half can be quietly
 dropped.
@@ -761,14 +761,14 @@ the ISO 639-1 code an author is most likely to type for no gain.
 Twelve languages, and the thing they add to this file is not any one of them
 but the **five Devanagari catalogs that answer the agreement question three
 different ways**. Sanskrit selects on `$gender` and `$role` and inflects for
-gender, number _and_ case; Konkani selects on both with Marathi's three
+gender, number *and* case; Konkani selects on both with Marathi's three
 genders; Dogri selects on `$gender` alone; Maithili and Bhojpuri select on
 neither. Hindi, Marathi and Nepali were already three more answers in the same
 letters. **A script says nothing about the fork**, which is the sharpest
 statement of that this repository has, and `styleDescriptions.test.ts` pins all
 five side by side so it cannot quietly stop being true.
 
-Dogri is the one worth reading closely, because it is _not_ a claim that Dogri
+Dogri is the one worth reading closely, because it is *not* a claim that Dogri
 does not inflect. Its masculine -आ adjectives take an oblique; none of the three
 clause positions reaches it, because the border and background are feminine and
 the text colour is a direct masculine. A `$role` branch would render what the
@@ -788,7 +788,7 @@ Hebrew's eight. **Tibetan and Dzongkha are the opposite extreme**: ICU reports
 exactly one category for each, so no message in either can select on a count and
 every counted message in both is written flat, the way `locales/ja` and
 `locales/th` write theirs. The `[0]` branches that survive are matched by
-_number_ rather than by category — Fluent resolves an explicit number before it
+*number* rather than by category — Fluent resolves an explicit number before it
 consults the plural rules, which is why a wording for none is still reachable.
 
 Three catalogs put their adjectives **after** the noun — Meitei and both
@@ -800,7 +800,7 @@ split is the shape of the complement, not the side the adjectives sit on.
 `bo` and `dz` are two directories rather than one with a script tag, and it is
 the `hr`-against-`sr` case a fifth time: two standard languages, two
 vocabularies, one script. `locales/dz` writes ཧོནམ where `locales/bo` writes
-སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for _opposite_
+སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for *opposite*
 reasons — see the chemistry paragraph above — which is the neatest illustration
 in the roster that the gap is a fact about a school system rather than about a
 script.
@@ -842,7 +842,7 @@ filled in with the real genders anyway, so that a speaker adding the fork has
 the table already and need only write the feminine forms. And `locales/dv` puts
 `piecewise-condition-if` on the wrong side of the mathematics: Dhivehi's
 conditional particle «ނަމަ» is clause-final and the renderer places that key
-_before_ what it introduces, which no wording in the catalog can fix. That is
+*before* what it introduces, which no wording in the catalog can fix. That is
 the `locales/tpi` shape — a distinction the composition messages do not expose
 — and splitting the key into a prefix and a suffix is a change to the worker
 that no existing catalog needs and this one would use.
@@ -861,7 +861,7 @@ any of the ten and get prose in it. (South African Sign Language, official
 since 2023, is the eleventh and has no written form to seed.)
 
 **Six more Bantu catalogs take the noun-class group from ten to sixteen**, and
-the thing they add is how _unevenly_ a class concord lands. `locales/ts` is the
+the thing they add is how *unevenly* a class concord lands. `locales/ts` is the
 case worth reading: Xitsonga has very few true adjectives, and almost
 everything English calls one is a noun joined with a possessive concord — so
 the class fork falls on «-kulu», «-tsongo» and the passive «-tateriwaka» and on
@@ -878,8 +878,8 @@ agrees with its noun's class through a **suffix**: «ɓaleewol» against a `ngol
 noun, «ɓaleere» against a `nde` one. `$gender` is a token set and nothing
 outside a catalog reads its values, so the argument needed no widening to reach
 a suffix any more than it needed widening to reach a noun class — which is the
-cleanest demonstration this file has that the mechanism is about _what a word
-agrees with_ rather than about gender, prefixes, or Bantu.
+cleanest demonstration this file has that the mechanism is about *what a word
+agrees with* rather than about gender, prefixes, or Bantu.
 
 **Luo and Sango select on neither argument, and they sit between catalogs that
 select on three classes each.** Dholuo is Nilotic and Sango Ubangian; neither has
@@ -887,7 +887,7 @@ gender or noun classes, and `locales/ki` and `locales/bem` on either side of
 them fork on `c3`, `c7` and `c9`. A region says as little about agreement
 as a script does. `locales/luo` adds one thing of its own: its relative
 particle «ma-» is written onto the front of the colour, including when the
-colour is a placeable, which makes it the roster's first _prefix_ welded
+colour is a placeable, which makes it the roster's first *prefix* welded
 onto a value the catalog never sees. That is sound for `locales/tlh`'s reason —
 «ma-» has one shape and never assimilates — and its header records the one case
 that would break it.
@@ -1050,13 +1050,13 @@ Ten of the eleven are the school-system case, in two mediums across eleven
 countries rather than one: English in Ghana, Nigeria and Uganda, French in
 Burundi, Burkina Faso, Côte d'Ivoire and both Congos, and English or French
 depending on the country for Kanuri, which spans four. So in all ten the
-fallback _is_ the curriculum, which is a fact about those education ministries
+fallback *is* the curriculum, which is a fact about those education ministries
 rather than about ten languages.
 
 **Mandinka is the eleventh and the one claim of a different kind.** It is
 spoken across three countries with three different mediums of secondary
 instruction — English in the Gambia, French in Senegal, Portuguese in
-Guinea-Bissau — so there is no one curriculum for a fallback to _be_, and
+Guinea-Bissau — so there is no one curriculum for a fallback to *be*, and
 choosing any of the three would report which side of which border a reader's
 school is on. `locales/se` reached exactly that place between Norway, Sweden
 and Finland; this is the Northern Sami case in West Africa, and it is the first
@@ -1065,7 +1065,7 @@ time a batch's chemistry paragraph has split since the South Asian one.
 ### The batch continued: a creole beside its lexifier
 
 Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne — six more from the same
-region, and where the eleven above were arranged around _where_ a language puts
+region, and where the eleven above were arranged around *where* a language puts
 its agreement, these six are arranged around a sharper question: **what can you
 learn from two catalogs that you cannot learn from either one alone?**
 
@@ -1079,12 +1079,12 @@ that «ya» turns out to be Kongo's class-9 row, frozen. The whole of the
 agreement in `locales/kg` is that one syllable, and the describing stem behind
 it never moves:
 
-| class | linker | black      | thick    |
-| ----- | ------ | ---------- | -------- |
-| 5     | dya    | dya ndombe | dya nene |
-| 7     | kya    | kya ndombe | kya nene |
-| 9     | ya     | ya ndombe  | ya nene  |
-| 11    | lwa    | lwa ndombe | lwa nene |
+| class | linker | black         | thick       |
+| ----- | ------ | ------------- | ----------- |
+| 5     | dya    | dya ndombe    | dya nene    |
+| 7     | kya    | kya ndombe    | kya nene    |
+| 9     | ya     | ya ndombe     | ya nene     |
+| 11    | lwa    | lwa ndombe    | lwa nene    |
 
 Putting `color.black` in the two files side by side is the shortest statement of
 what a creole did to its lexifier that this repository can make, and it cost
@@ -1114,7 +1114,7 @@ in Kabiyè, and as a separate word between the two in Tiv. Three positions, one
 argument, no change to anything outside those files.
 
 **`tem` is the one that can be checked without knowing the language.** Temne's
-concord is _alliterative_: the describing word takes the same prefix the noun
+concord is *alliterative*: the describing word takes the same prefix the noun
 itself carries, so a rendered description reads «kʌlayn kʌbana-bana kʌbana» —
 the same syllable three times. In every other noun-class catalog here the
 concord and the noun's own prefix are different morphs, and `noun-gender` has to
@@ -1139,15 +1139,15 @@ the map lists them, and `kng` because ICU already folds it.
 
 **`ktu` is deliberately absent from that list**, and it is the one exclusion
 here that is not simply "it has a catalog of its own" — though it does. Kituba
-is a creole _of_ Kikongo rather than a variety of it, ISO 639-3 gives it a code
+is a creole *of* Kikongo rather than a variety of it, ISO 639-3 gives it a code
 outside `kg`, and folding it would serve a Kituba reader a different language.
 `mkw`, Kituba of the Republic of the Congo, is left to miss for the same reason;
 answering it with `ktu` would be defensible and is not a membership fact, so it
-is not done. `negotiate.test.ts` asserts the exclusion on the _un-normalized_
+is not done. `negotiate.test.ts` asserts the exclusion on the *un-normalized*
 tag, which is the only form the mistake would be visible in.
 
 **`son` is the road not taken, and the test says why.** It is the macrolanguage
-over the Songhay varieties, and it is _not_ aliased the way `man` was, because
+over the Songhay varieties, and it is *not* aliased the way `man` was, because
 the justification `man`'s entry rests on does not exist here:
 `new Intl.Locale("son").maximize()` adds no region, so CLDR has no opinion about
 which variety a bare `son` means. Picking one would be the judgement these maps
@@ -1165,7 +1165,7 @@ again, and it is not an error.
 All six leave `element-name` and `element-anion-name` out. Four are the ordinary
 school-system case — the DRC, Benin and Togo teach secondary science in French,
 Sierra Leone in English — but `pcm` and `kri` are a shape no earlier batch had.
-Their lexifier _is_ English, so the fallback is not merely the curriculum, it is
+Their lexifier *is* English, so the fallback is not merely the curriculum, it is
 very nearly the language: filling those 130 keys in would produce entries
 character-identical to `locales/en` and claim a translation that had not
 happened. Leaving the gap visible is the honest answer, and it is the
@@ -1183,10 +1183,10 @@ class system, spoken next door to one another — and Umbundu prefixes the class
 straight onto the describing stem while Kimbundu leaves the stem alone and moves
 an agreeing connective in front of it:
 
-|       | line (c9)          | circle (c7)            | point (c5)            |
-| ----- | ------------------ | ---------------------- | --------------------- |
-| `umb` | ongoli **yi**nene  | ocilinganya **ci**nene | ondimbu **li**nene    |
-| `kmb` | nlonji **ya** nene | kizenge **kya** nene   | kimbanza **kya** nene |
+| | line (c9) | circle (c7) | point (c5) |
+| --- | --- | --- | --- |
+| `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene |
+| `kmb` | nlonji **ya** nene | kizenge **kya** nene | kimbanza **kya** nene |
 
 And Kimbundu's mechanism is `locales/kg`'s exactly — an agreeing «-a»
 connective a thousand kilometres north, in another country, differing only in
@@ -1198,7 +1198,7 @@ which makes it a fact about Bantu rather than about creolization.
 
 **`men` is the clearest instance of the affix rule in the tree.** Mende's
 definite marker is a suffix that attaches not to the noun but to whichever word
-_ends_ the noun phrase, and a describing word follows its noun here — so a style
+*ends* the noun phrase, and a describing word follows its noun here — so a style
 description ends in a placeable, and «{ $color }i» is exactly what
 [An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
 forbids. The catalog therefore leaves **every describing word indefinite**, so
@@ -1225,14 +1225,14 @@ for the readers.
 
 #### Negotiation: a second member-shaped macrolanguage, and a road still not taken
 
-`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a _member_
+`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a *member*
 catalog carrying its siblings, rather than a macrolanguage carrying its members.
 `ddn`, `hmb`, `khq`, `ses`, `tda` and `twq` reach Zarma, and ICU folds none of
 them on its own, so every one of those six depends on the entry existing.
 
 **`son` is still not aliased**, and that is the half worth reading. #1686
 recorded the reason when no Songhay catalog existed; Zarma's arrival makes the
-alias _possible_ and no more justified. `man` earns its alias because CLDR
+alias *possible* and no more justified. `man` earns its alias because CLDR
 decides for itself which member a bare macrolanguage means —
 `new Intl.Locale("man").maximize()` is `man-Latn-GM`, Mandinka's country.
 `new Intl.Locale("son").maximize()` adds no region at all, so CLDR has no
@@ -1246,7 +1246,7 @@ reader CLDR expects in Tifinagh is served Latin. That is `locales/kr`'s
 asymmetry with `kby` in Ajami and `locales/ff`'s in Adlam, and the answer is a
 second catalog rather than a change here.
 
-Three codes came _off_ negative-control lists this batch — `men`, `umb` and
+Three codes came *off* negative-control lists this batch — `men`, `umb` and
 `kmb` were all asserted to fall to English until they got catalogs of their own.
 That is the only thing that should ever shorten such a list, and `nyn` set the
 precedent two batches ago.
@@ -1283,19 +1283,19 @@ the translation dropped (`attract-to-without-nearest-point` and its two
 that changed which claim it made ("will **always** match a blank" became
 "matches **only** a blank"), a complaint that reversed
 (`function-domain-insufficient-dimensions` read "dimensions are not
-_required_"), and buttons whose word belonged to a different control — the
+*required*"), and buttons whose word belonged to a different control — the
 orbital spin arrows were labelled with `umb`'s, `kmb`'s and `dje`'s word for
-_point_, three lines from a real points control.
+*point*, three lines from a real points control.
 
 **What review deliberately did not fix is the larger finding**, and it is a
 limit of seeding rather than a bug in these four. Each catalog spreads one
-word across several English concepts that the UI shows _at the same time_:
-`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry _variant_,
-_version_, _type_ and _style_ together, and `men`'s «wotela» carries
-_variant_, _version_ and _variable_, so in all four the editor's version
+word across several English concepts that the UI shows *at the same time*:
+`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry *variant*,
+*version*, *type* and *style* together, and `men`'s «wotela» carries
+*variant*, *version* and *variable*, so in all four the editor's version
 footer and its variant picker are labelled identically. Three of the
-four also head the feedback panel with their word for _answer_, and all four
-use one noun for both _viewer_ and _renderer_, so the whole-page failure and
+four also head the feedback panel with their word for *answer*, and all four
+use one noun for both *viewer* and *renderer*, so the whole-page failure and
 the one-component failure read alike. Separating these needs new words chosen
 by someone who speaks the language; picking them here would be the
 substitution the chemistry tables are left out to avoid. They are named here
@@ -1329,7 +1329,7 @@ branches — Central Mande, and two Southwestern Mande sisters) fork on neither
 already made to seven Mande catalogs in a row; `kpe` and `lom` go further
 than `sus` by lacking even a definite or qualifier suffix, so Southwestern
 Mande genuinely marks nothing where Central Mande and Manding each mark one
-thing. `ewo` and `bum` are the pair that shows agreement can be _present_ and
+thing. `ewo` and `bum` are the pair that shows agreement can be *present* and
 still not written down: both are Beti-Pahuin Bantu with a real class-concord
 system, but `bum`'s header commits to two classes (`c1`/`c7`) it found enough
 colour-stem data to write with confidence, while `ewo`'s header explains why
@@ -1407,7 +1407,7 @@ Guinea depending on which is meant (`bci`, `sus`). `lom` is the one worth a
 sentence of its own: Loma is spoken across a border where the two sides teach
 science in different languages entirely — English in Liberia, French in
 Guinea — so, as `locales/mnk` and `locales/se` already established for a
-border of their own, there is no single curriculum for a fallback to _be_, and
+border of their own, there is no single curriculum for a fallback to *be*, and
 leaving both keys out serves each side of the border the same way English
 already partially does for the Liberian half.
 
@@ -1427,7 +1427,7 @@ forks.** Turkic, Mongolic, Uralic and Iranian all answer the agreement question
 with a flat "no": no grammatical gender, no inflected attributive adjective, so
 `noun-gender` returns one token and no message forks on it. `locales/ce` is
 Nakh, and Chechen has a real class system — nouns fall into classes marked by
-в-, й-, б- and д-, and an agreeing word carries the class at the _front_. So
+в-, й-, б- and д-, and an agreeing word carries the class at the *front*. So
 `locales/ce` writes a class table and forks `style-filled-word` on it, which
 `styleDescriptions.test.ts` pins across two classes. One script, twelve
 catalogs, one fork: a script says as little about agreement as a family or a
@@ -1453,7 +1453,7 @@ and waiting, so filling the table in costs a speaker one line per noun.
 
 **Two catalogs record a colour vocabulary that does not split where the style
 pipeline splits, and they are unrelated.** Sakha's «күөх» covers green and
-blue; Ossetian's «цъæх» covers green, blue _and_ grey. The style pipeline needs
+blue; Ossetian's «цъæх» covers green, blue *and* grey. The style pipeline needs
 those as separate words, so both catalogs write the modern compounds that split
 them — «от күөх» and «халлаан күөҕэ» for Sakha, «кæрдæгхуыз» and «æрвхуыз» for
 Ossetian — and both headers say plainly that this is a choice rather than a
@@ -1469,7 +1469,7 @@ plural perfectly well; what it does not do is keep it after a numeral, so a
 category would have nothing to choose between.
 
 **`locales/cv` is the roster's fourth `zero` category, and the interesting
-comparison is with the one it does _not_ match.** `locales/ar`, `locales/cy`
+comparison is with the one it does *not* match.** `locales/ar`, `locales/cy`
 and `locales/lv` are the other three; Arabic's and Welsh's `zero` fire for
 exactly 0, and so does Chuvash's, with `one` for exactly 1. Latvian's is the
 odd one out — it covers every number ending in 0 and the whole of the teens, so
@@ -1481,7 +1481,7 @@ first (`attempts-remaining`).
 
 **Five catalogs record the same limit, and it is word order rather than family
 that decides which.** `piecewise-condition-if` is placed by the renderer
-_before_ the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
+*before* the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
 Udmurt's «ке», Komi's «кӧ» and Mari's «гын» all close the clause they condition,
 so all five files record the `locales/dv` shape beside the key — a distinction
 the composition messages do not expose, which splitting the key into a prefix
@@ -1542,7 +1542,7 @@ and the Uralic north batches, and `negotiate.test.ts` pins each of them in the
 All twelve leave `element-name` and `element-anion-name` out, and — like the
 second sub-Saharan batch and the African and Berber one — they split no ways at
 all. Secondary chemistry across the Russian Federation is taught in Russian, so
-in all twelve the fallback _is_ the curriculum. That is a fact about one
+in all twelve the fallback *is* the curriculum. That is a fact about one
 education system rather than about twelve languages, which is why it reads as
 one sentence here and takes a sentence of its own in each catalog's header.
 
@@ -1608,14 +1608,14 @@ mechanism is not a class at all — see [The Kurdish pair](#the-kurdish-pair).
 
 **`locales/av` agrees more than Chechen does and still forks nothing, which is
 the sharpest thing in the batch.** Avar has three singular classes and a
-plural, the marker is a _suffix_ rather than a prefix, and — unlike Chechen,
+plural, the marker is a *suffix* rather than a prefix, and — unlike Chechen,
 where the colour and width words take no marker at all — **every attributive
 adjective carries it**. On the face of it every style word in the file should
 fork. None does, because every noun this core names is a thing rather than a
 person and so is class III: `[v]`, `[j]` and `[l]` would be variants nothing
 can select. That is the reachability rule `locales/ve`, `locales/ts`,
 `locales/ki` and `locales/bem` already apply to their unreached Bantu classes,
-arriving for the first time from a language that agrees _more_ rather than
+arriving for the first time from a language that agrees *more* rather than
 less. `locales/lbe` reaches the same place from four classes. `locales/dar` is
 the one of the three whose select is actually written out — `[v]` вицӀибси,
 `[r]` рицӀибси, `*[b]` бицӀибси, with only the last reachable — left standing
@@ -1670,7 +1670,7 @@ that direction is a fact about a script rather than about a language.
 
 #### Negotiation
 
-**`kmr` is a key in `MACROLANGUAGE_MEMBERS` that is a _member_ rather than the
+**`kmr` is a key in `MACROLANGUAGE_MEMBERS` that is a *member* rather than the
 macrolanguage, and still excludes one of its own siblings.** ISO 639-3 gives
 Kurdish three members — `ckb`, `kmr`, `sdh` — and this key names one of them
 and lists a second. `ckb` is left out because it has a catalog of its own, and
@@ -1737,7 +1737,7 @@ Each catalog's header says which language it is.
 #### What the batch could not do, and says so
 
 **`piecewise-condition-if` splits, and the wall is syntax rather than family.**
-The renderer places the key _before_ the mathematics it introduces. Abkhaz,
+The renderer places the key *before* the mathematics it introduces. Abkhaz,
 Adyghe, Kabardian and Lak all mark a condition on a clause-final verb form and
 have no free word to put in front, so all four record the `locales/sah` shape
 beside the key rather than inventing a workaround — the same limit five
@@ -1766,7 +1766,7 @@ so the only group in which the split is visible from the outside.
 
 **`locales/ady` and `locales/kbd` both record a limit the affix rule creates
 from the other direction.** A postnominal adjective in Circassian is normally
-written _together_ with its noun as one word, and the noun is a placeable, so
+written *together* with its noun as one word, and the noun is a placeable, so
 both catalogs write it as a separate word one space away from the compound a
 speaker would write. Splitting the key would not help: the affix belongs to
 whichever word lands last, and that word is a placeable too.
@@ -1808,7 +1808,7 @@ nouns rather than the one the rows spell out.
 **None of the fifteen forks on `$gender`, and the test says so rather than the
 headers.** No Uralic language has grammatical gender, so `noun-gender` returns
 one token in every file — the flat answer eleven of the Russian Federation's
-twelve gave. What is new is that it is _asserted_: the same suite checks that a
+twelve gave. What is new is that it is *asserted*: the same suite checks that a
 catalog's adjectives come out identical whatever noun follows them, which is
 exactly what `locales/inh` and `locales/kmr` fail — their descriptions come out
 in two different shapes depending on the noun — and it turns "this language
@@ -1818,7 +1818,7 @@ noun key can reach; that is the separate thing the "Dagestanian agreement that
 no message can reach" rows pin.)
 
 **Four catalogs do use `$role`, and none of them for gender.** Finnic
-adjectives agree in _case_, so `locales/vep`, `locales/olo`, `locales/krl` and
+adjectives agree in *case*, so `locales/vep`, `locales/olo`, `locales/krl` and
 `locales/fit` fork on the syntactic position the way `locales/fi` does — a
 nominative standing alone, an adessive inside a border clause. `locales/vro` is
 the honest failure beside them and says so in its own header: Võro needs the
@@ -1847,7 +1847,7 @@ speaker can pay it off in a dozen lines.
 
 **`sjd` is the family's fifth, and gets only `one` and `other`.** Kildin Sami
 has a dual as surely as the others do; what it does not have is CLDR plural
-data, so `Intl.PluralRules("sjd")` resolves against the _runtime's_ default
+data, so `Intl.PluralRules("sjd")` resolves against the *runtime's* default
 locale and a `[two]` branch in that catalog would be text nothing could select.
 Its header says so, `chrome.test.ts` pins both halves — the four resolving from
 their own data, `sjd` resolving from something else — and the assertion is made
@@ -1868,19 +1868,19 @@ has ever removed one.** `koi` (Komi-Permyak) was folded onto `locales/kpv` and
 batch, both correct at the time: neither had anywhere else to go, and a reader
 served a neighbouring standard beats a reader served English. The moment each
 had a catalog of its own the fold became the thing the map exists to prevent —
-`applyLanguageAlias` rewrites the tag _before_ negotiation, so a `locales/koi`
+`applyLanguageAlias` rewrites the tag *before* negotiation, so a `locales/koi`
 on disk would have been unreachable while every Komi-Permyak reader kept
 getting Zyrian.
 
 So `kv` was left listing `kpv` alone and `chm` listing `mhr` alone. That was
 `kmr` excluding `ckb` and `mnk` excluding `bam` and `dyu`, arriving for the
-first time as a _removal_ rather than as an omission, and `negotiate.test.ts`
+first time as a *removal* rather than as an omission, and `negotiate.test.ts`
 asserts it as a removal: `koi` and `mrj` reach themselves even when the
 neighbouring standard's catalog is also on offer.
 
 Those two one-member lists are gone now, and their disappearance finished the
 argument this batch started. A list folding a macrolanguage's last unwritten
-member onto a catalog written _in_ that member is not a fold at all, so when
+member onto a catalog written *in* that member is not a fold at all, so when
 the catalogs were renamed to `locales/kpv` and `locales/mhr` both rows became
 `LANGUAGE_ALIASES` entries instead. See [Naming a catalog when a sibling
 member has one too](#naming-a-catalog-when-a-sibling-member-has-one-too).
@@ -1933,7 +1933,7 @@ catalog's header says which language it is.
 #### What the batch could not do, and says so
 
 **`piecewise-condition-if` splits four against eleven, and the wall is syntax
-rather than branch.** The renderer places the key _before_ the mathematics it
+rather than branch.** The renderer places the key *before* the mathematics it
 introduces. Komi-Permyak's «кӧ», Hill Mari's «гӹнь», Khanty's «ки» and Mansi's
 «ке» are all clause-final enclitics, so all four record the `locales/dv` shape
 beside the key rather than inventing a workaround — the same limit
@@ -1961,7 +1961,7 @@ attested**, and each lists its coinages by name in its own header — the
 the least certain of the five Sami catalogs, for `locales/xal`'s reasons:
 severely endangered, small written output, Russian technical nouns where
 written Kildin uses them. `locales/sms` records that a large share of its
-lexicon is _derived_ from Northern Sami by regular sound correspondence rather
+lexicon is *derived* from Northern Sami by regular sound correspondence rather
 than found in Skolt, and names the two words it is least sure of. Correcting
 any of it needs no permission.
 
@@ -1990,8 +1990,8 @@ and territories without a single shared administration between them.
 
 `MACROLANGUAGE_MEMBERS` and `LANGUAGE_ALIASES` are **unchanged**, and after two
 batches that each turned on them that is worth saying rather than passing over.
-The Caucasus batch had to keep `ckb` _out_ of a list it had never been in; the
-Uralic north had to take `koi` and `mrj` _out_ of lists they were already in.
+The Caucasus batch had to keep `ckb` *out* of a list it had never been in; the
+Uralic north had to take `koi` and `mrj` *out* of lists they were already in.
 Here not one of the eleven is a macrolanguage, not one is a member of one, and
 not one was being folded onto a wider code — so every tag reached English on its
 own account before this batch and reaches its own catalog after it.
@@ -2008,7 +2008,7 @@ rows are pinned because the folding is ICU's rather than this repository's.
 This is the first batch of which that is true, and it inverts the Uralic north's
 finding. There, four Sami catalogs wrote a `[two]` branch because their own CLDR
 rules select it and a fifth could not; here the fifth case is the whole batch.
-`Intl.PluralRules` resolves all eleven tags against the _runtime's_ default
+`Intl.PluralRules` resolves all eleven tags against the *runtime's* default
 locale, so a category branch in any of these files would be text selected by
 English's rules on English's terms.
 
@@ -2038,14 +2038,14 @@ that range rather than papering over it:
 - **Translated.** `pon`, `mh`, `chk`, `niu`, `tkl`, `tvl`, `rar`, `wls`, `bi`
   write their own vocabulary throughout, leaning on a published dictionary each
   header names.
-- **Framed.** `kos` and `gil` write a catalog's _frame_ in the language —
+- **Framed.** `kos` and `gil` write a catalog's *frame* in the language —
   «Tia ku in…», «Wangin…», «ke sripen» — around English technical nouns, and
   say so.
 
 **A third tier was seeded and then dropped from the batch, which is worth
 recording rather than losing.** Nauruan (`na`), Yapese (`yap`), Palauan (`pau`)
 and Rotuman (`rtm`) began as correct frames with the whole technical lexicon
-declared as English loans, and a later pass recovered their _basic_ vocabulary —
+declared as English loans, and a later pass recovered their *basic* vocabulary —
 colour terms, thick and thin, the geometric nouns — from Josephs, Churchward and
 Jensen. That recovery reached `content.ftl` and stopped there, because the style
 tables are single words and the other three namespaces are sentences: their
@@ -2058,7 +2058,7 @@ variant key is in place in them, so nothing structural stands in the way; what
 they need is words.
 
 No word went in by guess. Where a dictionary gave nothing the English loan
-stands and is _declared_ a loan rather than respelled by an invented loan
+stands and is *declared* a loan rather than respelled by an invented loan
 phonology — `locales/kos` argues that case explicitly, on the grounds that
 `b c d g h j q v x z` are not Kosraean letters, so a loan should stay visibly a
 loan. `styleDescriptions.test.ts` pins the words that are the language beside
@@ -2085,7 +2085,7 @@ reach `[noun-tail]`, which is the widest use `[noun-tail]` has had in one batch.
 The other three fold it into the head: `mh`, `gil` and `tkl`, each because its
 own grammar puts it there. `tkl` is the interesting one, because it is
 Tuvaluan's closest relative here and `tvl` went the other way — a disagreement
-_inside_ a subfamily, which no earlier batch's had, and both files state their
+*inside* a subfamily, which no earlier batch's had, and both files state their
 choice so a reviewer can tell it is deliberate.
 
 A catalog that reaches `[noun-tail]` has to place the tail the same way in
@@ -2137,7 +2137,7 @@ nothing where it does not, and the seed cannot always tell which.
   `locales/ty` takes French ones.
 - Twelve near misses, and the Pacific's are sharper than the north's because its
   language boundaries do not follow its political ones. `kpg` and `nkr` are
-  _Polynesian_ languages spoken inside the Federated States of Micronesia, so
+  *Polynesian* languages spoken inside the Federated States of Micronesia, so
   neither the country's catalogs nor the family's is the right answer. `fud`
   (East Futunan) is this batch's `fkv` and sharper than `fkv` was: it is not
   merely a sister of a catalogued language but is spoken in the **same
@@ -2152,7 +2152,7 @@ nothing where it does not, and the seed cannot always tell which.
 
 Every string is machine-generated and unread by a speaker, and each catalog says
 so in its own header. Beyond the confidence scale above, `locales/chk` names
-«pwóón» — its word for _answer_, the highest-frequency word in the catalog — as
+«pwóón» — its word for *answer*, the highest-frequency word in the catalog — as
 one it could not confirm, and `locales/gil` names its colour line as its least
 certain. Each catalog lists its own coinages, and correcting any of it needs no
 permission.
@@ -2169,7 +2169,7 @@ Piedmontese (`pms`) and Neapolitan (`nap`); **Slavic** — Upper Sorbian
 It is the first batch assembled as **three families of five in one continent**
 rather than around an ocean, a script, a state or a family, and the shape is
 not decoration: nearly everything below divides along it, and the two places
-where it does _not_ are the interesting ones.
+where it does *not* are the interesting ones.
 
 #### One complete catalog, and fourteen school systems
 
@@ -2187,11 +2187,11 @@ Piedmont and Campania; in Standard German in German-speaking Switzerland and
 the Rhineland; in Dutch in Limburg; in Polish in Pomerania and Upper Silesia;
 in German in Lusatia; in English in Scotland; and in Slovak, Polish or
 Ukrainian across Rusyn's range depending on the state. So in all fourteen the
-fallback _is_ the curriculum, and `locales/it`, `locales/de`, `locales/nl`,
+fallback *is* the curriculum, and `locales/it`, `locales/de`, `locales/nl`,
 `locales/pl` and `locales/sk` are the parallel texts each header names.
 
 `locales/sco` is the batch's plainest case of it. For the other thirteen a
-school-system gap means the reader meets the table in a _neighbouring_
+school-system gap means the reader meets the table in a *neighbouring*
 language — a Friulian pupil in Italian, a Sorbian one in German. A Scots
 speaker meets it in **the fallback language itself**, which is not new in the
 roster: `pcm` and `kri` are the same coincidence for two English-lexified
@@ -2200,7 +2200,7 @@ language](#the-chemistry-gap-and-the-case-where-the-fallback-is-the-language)),
 and every catalog whose school system teaches in English — `gil`, `tpi`, `mh`,
 `tkl`, `tvl`, `niu` and `bi` among them — falls back to the language of the
 classroom rather than of a neighbouring state. What is particular to Scots is
-that English is also its _sister_ language, which is the difficulty
+that English is also its *sister* language, which is the difficulty
 `locales/sco`'s header is written around.
 
 #### The plural split, and three categories no catalog here had
@@ -2228,8 +2228,8 @@ fourth has one it deliberately leaves unwritten:
   the note on `dsb` beside `hsb` below.
 - **`ksh` writes a `zero`.** Colognian is the only locale in the batch whose
   own rules select one, and its header spells out the distinction that makes it
-  safe: an explicit `[0]` is matched against the _number_, a `[zero]` against
-  the _category_, and writing both into one selector would be two mechanisms
+  safe: an explicit `[0]` is matched against the *number*, a `[zero]` against
+  the *category*, and writing both into one selector would be two mechanisms
   competing for the same input. So the branch goes where English leaves a real
   count with no `[0]` already standing on it — `help-suggestions-footer` in
   `locales/ksh/editor.ftl` — and `attempts-remaining` keeps English's literal
@@ -2243,7 +2243,7 @@ fourth has one it deliberately leaves unwritten:
 three really do have a `few`/`many` split of their own. The branch that could
 be written is exactly the branch that would be got wrong.
 
-#### The batch that needed nothing from the maps, and the row that had to _stay_
+#### The batch that needed nothing from the maps, and the row that had to *stay*
 
 `MACROLANGUAGE_MEMBERS` and `LANGUAGE_ALIASES` are **unchanged**. Not one of
 the fifteen is a macrolanguage, not one is a member of one, and not one was
@@ -2264,7 +2264,7 @@ Those rows are pinned because the folding is ICU's rather than this
 repository's.
 
 **Alsatian is this batch's near miss that is not one.** `gsw-FR` is Alsatian,
-and ISO puts it _inside_ `gsw` rather than beside it, so an Alsatian reader
+and ISO puts it *inside* `gsw` rather than beside it, so an Alsatian reader
 reaches `locales/gsw` and is served the Zurich-based koine that catalog is
 written in. That is the trade region-stripping already makes for `es-MX`, and
 `locales/gsw`'s header says which variety it is so a reader can tell what they
@@ -2272,10 +2272,10 @@ were served.
 
 Twenty-one tags are left to miss, and this batch's near misses are the densest
 the roster has had, because Europe's regional languages sit in continua rather
-than on islands: `bar`, `swg` and `wae` beside `gsw` — `wae` spoken _inside
-Switzerland_ and still a language with a code of its own; `pfl` and `yec`
+than on islands: `bar`, `swg` and `wae` beside `gsw` — `wae` spoken *inside
+Switzerland* and still a language with a code of its own; `pfl` and `yec`
 beside `ksh`; `stq`, `frr`, `vls` and `zea` beside `li`; `lmo`, `rgn`, `cim`
-and `mhn` among the five Romance catalogs, with `cim` and `mhn` being _Germanic_
+and `mhn` among the five Romance catalogs, with `cim` and `mhn` being *Germanic*
 languages spoken inside Italy, so neither the country's catalogs nor the
 family's is the right answer; `mwl`, `ext`, `an` and `wa`; `sgs` and `ltg`;
 `pdc` and `hrx`.
@@ -2328,7 +2328,7 @@ existing catalog, and every one of the six is argued in a header instead.
   «ikkje», «kva», «frå», «eit», «sida», «berre», «nokon», «fleire».
 - **`dsb` beside `hsb`** is the batch's `tkl`/`tvl`: two standards close enough
   that a seed reading one while writing the other will reproduce its choices,
-  so the two catalogs are _expected_ to look alike and **their agreement is not
+  so the two catalogs are *expected* to look alike and **their agreement is not
   evidence either is right**. `locales/dsb`'s header names its own largest risk
   outright — the Upper-to-Lower correspondences («hdyž»→«gaž»,
   «dokelž»→«dokulaž», «dyrbi»→«musy», «njemóžu»→«njamóžom») are regular enough
@@ -2340,10 +2340,10 @@ existing catalog, and every one of the six is argued in a header instead.
   everyday words where the two part company, because those are what a reviewer
   can check in a second.
 - **`sco` beside `en`** is that shape at its limit. English is Scots's sister
-  language _and_ its roofing language, so a seed with nothing to say falls into
+  language *and* its roofing language, so a seed with nothing to say falls into
   English without anything looking wrong. `locales/pcm`, `locales/kri` and
   `locales/bi` meet the same trap from the other side, as creoles English
-  lexified; what no other catalog has is a _sister_ language that is also the
+  lexified; what no other catalog has is a *sister* language that is also the
   roof. `locales/sco`'s header answers it the way `locales/bi` answers it for
   an English-lexified creole: a word is written
   there because a Scots dictionary has it, not because it differs from English,
@@ -2502,7 +2502,7 @@ language with no macrolanguage over it; `srh` (Sarikoli) and `yah`
 (Judeo-Tat) beside `locales/ttt`, which `locales/ttt`'s header explicitly
 names as a separate written tradition rather than a variety of itself.
 
-**`prs` is the one that needs saying because it is _not_ a near miss.**
+**`prs` is the one that needs saying because it is *not* a near miss.**
 `Intl.getCanonicalLocales("prs")` returns `fa-AF`, so a Dari reader
 region-strips to `locales/fa` today and gets Iranian Persian. That is exactly
 the fact `locales/haz`'s chemistry argument turns on, below.
@@ -2532,7 +2532,7 @@ alike leave a noun unmarked after a numeral.
 not a count.** Ten catalogs — every one of the fifteen except `alt`, `kaa`,
 `kjh`, `ttt` and `sgh` — write exactly one `[one]`, and all ten write it in the
 same message: `field-function-wrong-num-outputs`, which forks on how many
-outputs a component _needs_ ("one output" against "two outputs") rather than on
+outputs a component *needs* ("one output" against "two outputs") rather than on
 a quantity the reader is looking at. `alt`, `kaa` and `kjh` write that same
 fork as the numeric literal `[1]`, which Fluent matches against the number
 before consulting any plural rule and which therefore does not depend on whose
@@ -2561,7 +2561,7 @@ teaches the periodic table in another language. The mediums are listed in
 [Catalog layout](#catalog-layout) above. Two of the twelve add something to
 that argument:
 
-- **`locales/haz`'s gap is a _missing sibling_ rather than a missing list.**
+- **`locales/haz`'s gap is a *missing sibling* rather than a missing list.**
   Hazaragi is a variety of Persian, so
   a Persian table is exactly the kind of loan the three below ship — but the
   table a Hazara pupil meets is the **Dari** one, which differs from
@@ -2584,11 +2584,11 @@ The complete tables the roster already had were each a language's own list —
 Afrikaans's, Bosnian's, Swahili's — or, in
 `locales/jv` and `locales/su`, an adapted one: those two take the Indonesian
 names their schools' textbooks print, but their `element-name` tables are
-_not_ `locales/id`'s, because both keep their own words for the substances
+*not* `locales/id`'s, because both keep their own words for the substances
 known long before the elements were. These three copy a neighbour's table
 **unchanged**, and argue for it: chemistry in Māzandarān, Gilan and Lorestan is **taught, examined and
 printed in Persian**, so the settled, checkable list of 118 names a
-Mazanderani, Gilaki or Luri speaker actually reads and writes _is_ the Persian
+Mazanderani, Gilaki or Luri speaker actually reads and writes *is* the Persian
 one. It is a loan the language genuinely uses rather than a nomenclature this
 seed invented, which is the only kind of table it may ship — and it serves a
 reader better than English, which is neither their school language nor their
@@ -2668,7 +2668,7 @@ welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable).
 invariant shape, so this is `{ $numSides }-kulmio`'s adjacency rather than
 `locales/tg`'s agreement, and all three of `locales/wbl`'s headers that
 mention the postpositions now say which of the two it is. `locales/gag` is the
-one place in the batch where the distinction had to be _acted_ on: a Gagauz
+one place in the batch where the distinction had to be *acted* on: a Gagauz
 ordinal suffix harmonizes with the vowels of the spoken numeral — «beșinci»
 but «dokuzuncu» — which a digit does not show, so the line and row numbers are
 written with a period after the figure, `{ $line }. satır`, exactly as
@@ -2690,11 +2690,11 @@ masculine and feminine, and spends the agreement in the `noun` table, so the
 attributive adjectives after the ezafe are invariable and nothing is left to
 fork. `locales/sgh` is the honest failure: Shughni distinguishes gender in the
 demonstratives, in some nouns and in parts of the verb, and its header says in
-as many words that the seed cannot assign the right gender to _line_, _curve_
-and _region_ and would rather leave the agreement flat than get it wrong in
+as many words that the seed cannot assign the right gender to *line*, *curve*
+and *region* and would rather leave the agreement flat than get it wrong in
 eighty places — with the note that the machinery is already wired for a
 speaker who fills `noun-gender` in. `locales/wbl` is a third shape again: it
-declines to write down "no gender" as a _finding_, because the Pamir languages
+declines to write down "no gender" as a *finding*, because the Pamir languages
 differ here, and says what it is actually confident of, which is that it has
 no reliable table to fork with.
 
@@ -2743,7 +2743,7 @@ or for software. All three tell a reviewer to expect to be **rewriting
 sentences, not correcting typos**. `locales/haz` records the mirror image:
 most of its vocabulary is shared with Dari word for word, and **a Dari word in
 that file is not an oversight** — the two places Hazaragi's own usage shows
-are «قد» for _with_ and «بلدِ» for _for_.
+are «قد» for *with* and «بلدِ» for *for*.
 
 **`locales/sgh` keeps a loan register for two whole namespaces.** Its
 `diagnostics.ftl` header says that Shughni has no written register for
@@ -2751,7 +2751,7 @@ compiler diagnostics at all, that a Shughni speaker who reads an error message
 reads it in Tajik or Russian, and that the file therefore keeps **that loan
 register** rather than inventing a Shughni one: the wording is Tajik almost
 throughout, with the Russian internationalisms Tajik itself uses, and **only
-the conjunctions are Shughni** — «ат» for _and_, «йо» for _or_. It calls
+the conjunctions are Shughni** — «ат» for *and*, «йо» for *or*. It calls
 itself a usable frame and not yet Shughni prose. That is the Oceania batch's
 "framed" tier stated for two whole namespaces rather than for a vocabulary.
 
@@ -2793,7 +2793,7 @@ Jamaican Creole (`jam`), Guadeloupean Creole French (`gcf`), Saint Lucian
 Creole French (`acf`), Guianese Creole French (`gcr`), Belize Kriol (`bzj`),
 Aukan (`djk`) and Saramaccan (`srm`).
 
-Nine of fifteen makes this the first batch a _contact_ language dominates, and
+Nine of fifteen makes this the first batch a *contact* language dominates, and
 that is what most of its properties turn out to be about. A creole is a hard
 case for nearly every list in this package: it belongs to no macrolanguage,
 CLDR mostly does not name it, its technical vocabulary comes from a language it
@@ -2816,7 +2816,7 @@ keeps that register openly, and this batch does the same thing nine times over
 — Danish in `kl`, Dutch in `srn` and `djk`, French in the three
 French-lexifier creoles. It does **not** transfer to Navajo or Mohawk. There
 is no Navajo technical register to record: a speaker doing mathematics does it
-in English and does not Navajo-ize _polygon_. Writing «pálagan» would not be a
+in English and does not Navajo-ize *polygon*. Writing «pálagan» would not be a
 loan register but English respelled, which reads as translation to a tool, as
 noise to a speaker, and which a reviewer has to delete before they can begin.
 That is worse than the English fallback, which at least announces itself. The
@@ -2828,9 +2828,9 @@ one — see the coverage note below.
 
 #### Coverage: thirteen at the ceiling, and one that stops short on purpose
 
-Thirteen of the fifteen sit at **445/575**, which is the whole catalog minus
-the two chemistry tables and the same figure the Silk Road batch reached.
-`pap` is there too. The chemistry reason is the school-system one for all
+Fourteen of the fifteen sit at **445/575**, which is the whole catalog minus
+the two chemistry tables and the same figure the Silk Road batch reached. The
+chemistry reason is the school-system one for all
 fifteen and is stated in each `content.ftl` header: science is taught in Dutch
 in Curaçao, Bonaire and Suriname, in Danish in Greenland, in Spanish in Yucatán
 and Alta Verapaz, in French in Guadeloupe and French Guiana, and in English in
@@ -2839,14 +2839,14 @@ guess about the language; it is the language the periodic table is actually
 taught in.
 
 **`iu` is at 373/575, and the 72-key difference is one decision.** Inuktitut
-has no settled syllabic forms for _matrix_, _interval_, _domain_, _variant_,
-_index_, _row_ or _column_, so the catalog writes those few technical nouns in
+has no settled syllabic forms for *matrix*, *interval*, *domain*, *variant*,
+*index*, *row* or *column*, so the catalog writes those few technical nouns in
 roman letters inside a syllabic sentence — the `sgh` move — but it **omits the
 `noun` table whole**, all twenty geometry names, rather than doing the same
 thing twenty more times. Writing "line segment" in roman letters inside an
 Inuktitut catalog raises the coverage number without giving the reader anything
 the English fallback did not already give them. That is the one place in the
-roster where a catalog's own header argues that a _lower_ number is the better
+roster where a catalog's own header argues that a *lower* number is the better
 answer, and it is why `iu` is named separately in the count of partial catalogs
 above.
 
@@ -2876,7 +2876,7 @@ first.
 `kl` is the seventh postnominal catalog and is not a lexifier case at all.
 Kalaallisut builds the phrase by suffixing, so what comes out is a noun
 followed by agreeing participles — «titarneq silissooq avissaartorsimasoq
-aappaluttoq» — and the description is the _tail_ of the phrase rather than its
+aappaluttoq» — and the description is the *tail* of the phrase rather than its
 head, which is the shape `style-with-noun` needs to be read against.
 
 #### Negotiation: the map's third kind of exclusion
@@ -2894,7 +2894,7 @@ folding it would hand a reader a catalog in a script they do not read. This map
 now excludes members for three different reasons, and they are worth keeping
 apart: `kbl` under `kr` and `alq` under `oj` because published membership does
 not cover them; `bam` and `dyu` under `mnk` because they have catalogs of their
-own; and `ikt` because the catalog cannot serve a member membership _does_
+own; and `ikt` because the catalog cannot serve a member membership *does*
 cover.
 
 **Nine creoles and not one macrolanguage question between them.** That is the
@@ -2912,10 +2912,11 @@ rename of this one. The other fourteen maximize to `-Latn`.
 #### Nine names CLDR does not have, and nine endonyms
 
 `LOCALE_NAME_FALLBACKS` gained **nine** entries — `yua`, `cab`, `miq`, `gcf`,
-`acf`, `gcr`, `bzj`, `djk` and `srm` — which is more than any batch before it
-and is a fact about which languages CLDR carries rather than about how many
-speak these. ICU names `kl`, `iu`, `pap`, `srn` and `jam` and stops there; six
-of the nine gaps are creoles, and the three creoles ICU _does_ name are the
+`acf`, `gcr`, `bzj`, `djk` and `srm` — which is the largest number a batch
+here has needed, the next largest being the seven of the West and Central
+African batch, and is a fact about which languages CLDR carries rather than
+about how many speak these. ICU names `kl`, `iu`, `pap`, `srn` and `jam` and stops there; six
+of the nine gaps are creoles, and the three creoles ICU *does* name are the
 three with national or quasi-official standing.
 
 Every one of the nine gets an endonym, which is where this block parts company
@@ -2974,16 +2975,19 @@ worse than a stated absence.
 lain» — and the same boolean words, «chruu» and «faals». Both are
 English-lexifier creoles written in a phonemic orthography, so short everyday
 words converge; that is the language, not a copy. What would be worth catching
-is a catalog duplicated under two tags, so the test asserts a _rate_ rather
-than a difference: two fifths of the values the two both define differ, and
-across all four namespaces four fifths do.
+is a catalog duplicated under two tags, so the tests assert a *rate* rather
+than a difference: `styleDescriptions.test.ts` holds more than a third of the
+values the two both define in `content.ftl` to differing, beside the phrase
+itself, and `catalogLint.test.ts` holds 342 of their 389 values across all
+four namespaces to it.
 
 The French-lexifier trio is the same question with a sharper answer. `gcf` and
 `gcr` render this phrase identically — the two languages agree on all four
 words — while `acf` differs by one sound, the etymological French /r/ that
 Saint Lucian writes «w»: «tiwè» against «tirè». Underneath, the three are not
-close: `gcr` writes the indefinite «roun» 129 times in its diagnostics where
-`gcf` writes it 4, and only 14 of their 203 shared diagnostics are identical.
+close: `gcr` writes the indefinite «roun» 161 times in its diagnostics where
+`gcf` writes «on» in the same slot and «roun» nowhere at all, and only 14 of
+their 220 shared diagnostics are identical.
 The three headers name the conventions that separate them, so a reviewer can
 tell an intrusion from a coincidence.
 
@@ -2996,7 +3000,7 @@ check first. `locales/miq` records that its conditional marker «kaka» is
 clause-final in Mískito while the renderer places it before the inequality, so
 the message reads out of position: a defect in the composition rather than in
 the words, and one only a speaker could have spotted. `locales/jam` flags
-«pwaint» for _point_, built on Cassidy's «bwai» because English /ɔɪ/ has no
+«pwaint» for *point*, built on Cassidy's «bwai» because English /ɔɪ/ has no
 letter in the five-vowel system, as the single most-repeated uncertain form in
 the catalog. `locales/gcr` records that it writes the equative «sé» throughout
 where Guianese also uses «sa».
@@ -3020,7 +3024,7 @@ an ISO 639-3 code, so it filters like any other individual language, needs no
 entry in `LANGUAGE_ALIASES`, and belongs to no macrolanguage. `Intl` knows the
 English name, so the roster reads **Klingon** — once, not twice, because CLDR
 has no `tlh`-language data to answer the endonym with and the fallback is the
-English name. That is the `co` case, with the twist that Klingon _has_ a
+English name. That is the `co` case, with the twist that Klingon *has* a
 well-known endonym («tlhIngan Hol») and CLDR simply does not carry it.
 
 pIqaD is ISO 15924 `Piqd`, so `tlh-Piqd` is a well-formed tag and reaches the
@@ -3031,7 +3035,7 @@ pIqaD. Quenya (`qya`), Sindarin (`sjn`) and the ISO 639-2 collection code `art`
 all fall to English, which is the membership rule working rather than a gap in
 it — none of them is a member of `tlh`. `negotiate.test.ts` holds all of that.
 
-What _is_ new is the **shape of the gap**. Every other partial catalog leaves
+What *is* new is the **shape of the gap**. Every other partial catalog leaves
 out the chemistry tables because a school system teaches chemistry in another
 language; the language has the words and the seed has no settled list to copy.
 Klingon is the first partial for a lexical reason — its lexicon is closed, since
@@ -3044,7 +3048,7 @@ The line it draws is stated once in `content.ftl` and applied everywhere:
 > description, and is written. A new root is an invention, and is not.
 
 Under it «nagHom» — «nagh» (rock) with the canon diminutive — is a fair way to
-say _dot_, and a word for _parabola_ is not a translation of anything. It is the
+say *dot*, and a word for *parabola* is not a translation of anything. It is the
 argument `locales/oj` already makes about coining 118 element names, generalized
 from one table to a whole catalog.
 
@@ -3055,9 +3059,9 @@ has released a mathematics register over the years, well after TKD, so «mey'»
 (point), «baSta'» (vector) and «chav» (function) all exist and are all used. So
 are «wa'chaw» (table), «wev» and «war» (row and column), «tenwal» (page) and
 «vorgh» (be previous), each of which an earlier draft either coined around or
-left to English. What is genuinely absent is smaller and stranger: _parabola_,
-_polyline_, _curve_ as a noun, and the vocabulary of a document editor —
-_attribute_, _variant_, _matrix_, _snippet_, _accessibility_. **The lesson
+left to English. What is genuinely absent is smaller and stranger: *parabola*,
+*polyline*, *curve* as a noun, and the vocabulary of a document editor —
+*attribute*, *variant*, *matrix*, *snippet*, *accessibility*. **The lesson
 generalizes past Klingon: "this language has no word for X" is a claim about a
 word list, and it needs checking against the word list.**
 
@@ -3069,7 +3073,7 @@ four colour terms are TKD entries. Some are Okrand's own but were released at a
 `qep'a'` or `qepHom'a'` gathering or posted to the old `startrek.klingon`
 newsgroup: «meyrI'», «me'cheD», «baSta'», «chav» in its mathematical sense,
 «vorgh», «wa'chaw», «wev», «war», «tenwal» and «nItlh 'echlet» (keyboard). And
-three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a _single_
+three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a *single*
 relayed answer on the KLI mailing list, one post of 2014.01.27, with no second
 attestation; «ghantoH» (example) and «nompuq» (reference) are the same. All
 three classes are used and none is removed, but the catalogs mark the third
@@ -3080,7 +3084,7 @@ is still his, and what a reader has to go on is one paraphrase. Telling them
 which entries those are is what lets a speaker overrule the right ones.
 
 `.diamond` is the instructive omission, because it is not a lexical gap at all.
-Okrand's note on «chanmon» (the gemstone) says the diamond _shape_ is «meyrI'»,
+Okrand's note on «chanmon» (the gemstone) says the diamond *shape* is «meyrI'»,
 which the catalog already spends on `square`. Writing it would make a square
 marker and a diamond marker report identically — the one distinction a shape
 noun exists to carry — so the key falls back to English instead. That is the
@@ -3139,7 +3143,7 @@ every consumer whether or not anyone reads it, and no single language earns
 that. English is exempt because every fallback chain ends there: it has to be
 present with no network, in every bundling variant.
 
-Note that `content` and `diagnostics` answer to _different_ settings —
+Note that `content` and `diagnostics` answer to *different* settings —
 `documentLocale` and `uiLocale` respectively — which is why `WORKER_NAMESPACES`
 is `content` alone. The worker knows only the content locale, and needs only
 that: it renders `content` itself, but for a diagnostic it emits a code and the
@@ -3176,7 +3180,7 @@ would offer the author English and nothing else.
 
 Neither list is exhaustive from an author's point of view: a deployment can
 hand over catalogs of its own as `localeResources`, which no build-time list
-can know about. So the roster _suggests_ and never _enforces_ — `lang` accepts
+can know about. So the roster *suggests* and never *enforces* — `lang` accepts
 any BCP-47 tag, and an unlisted one draws no diagnostic.
 
 ## Delivery
@@ -3184,7 +3188,7 @@ any BCP-47 tag, and an unlisted one draws no diagnostic.
 A locale that is not inlined still has to reach the browser. `load.ts` does
 that, and the viewer calls it for you: `useLocaleCatalogs` (in
 `@doenet/doenetml`'s `utils/i18n.tsx`) loads the catalogs for whatever tags are
-in play and merges them _under_ the host's `localeResources`, so a deployment
+in play and merges them *under* the host's `localeResources`, so a deployment
 correcting a shipped translation still wins. Adding `locales/pt/` and running
 `npm run codegen` is therefore the whole job — no list of languages to register
 anywhere, and `documentLocale="pt"` and `<document lang="pt">` both work with
@@ -3216,17 +3220,17 @@ catalogs to get one.
 Where the catalogs come from depends on the build, and the difference is real
 rather than cosmetic:
 
-| Build                     | Mechanism                                                                           |
-| ------------------------- | ----------------------------------------------------------------------------------- |
-| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog                               |
-| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle                                   |
-| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`                                        |
+| Build                     | Mechanism                                              |
+| ------------------------- | ------------------------------------------------------ |
+| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog   |
+| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle       |
+| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`           |
 | `@doenet/doenetml-iframe` | Neither: what renders inside its iframe is a standalone bundle, which loads its own |
 
 The glob is what makes adding a language cost a directory. It is also why two
 builds need a different answer. The worker is one file — an IIFE started from
-a blob URL in some variants — so it cannot code-split, and _being reachable is
-enough_, whether or not anything calls it, to fold every catalog in. The
+a blob URL in some variants — so it cannot code-split, and *being reachable is
+enough*, whether or not anything calls it, to fold every catalog in. The
 standalone build is code-split, but serves its catalogs as plain
 runtime-fetched files all the same: as served assets they can be
 version-pinned, and the single-file `doenet-standalone-inline.js` variant
@@ -3294,7 +3298,7 @@ catalogs a context loads. `lint:i18n` enforces that.
 ### A variant key is an interface, not prose
 
 A key is not the only identifier a catalog has to leave alone. Fluent matches a
-variant by comparing the selector's value to the key _letter for letter_, so
+variant by comparing the selector's value to the key *letter for letter*, so
 `$parts`, `$role`, `$reason`, `$context` and the rest are symbols the core
 passes in and a translated key is not a translation — it is a branch nothing can
 reach:
@@ -3315,14 +3319,14 @@ chosen it. `locales/fit` shipped exactly that, having applied Meänkieli's
 `symbolicVariantKeys` in `scripts/catalogUtils.ts` lists the keys a catalog
 selects on, and `catalogLint.test.ts` holds every translation's list against
 English, one test per locale. Plural categories are excluded, because those are
-the keys a language _is_ entitled to differ on: CLDR gives each its own set, so
+the keys a language *is* entitled to differ on: CLDR gives each its own set, so
 a catalog resolving `one` and `other` where English resolves `one`, `two` and
 `other` is right rather than broken — see [The dual, and the one Sami language
 that cannot write it](#the-dual-and-the-one-sami-language-that-cannot-write-it).
 The check is a subset rather than an equality for the mirror-image reason: a
 catalog may legitimately select on more than English does — `locales/kmr` and the
 Dagestanian catalogs nest a `$gender` select inside `$parts`, and the four
-Finnic catalogs fork on `$role` — so what it forbids is a branch going _missing_,
+Finnic catalogs fork on `$role` — so what it forbids is a branch going *missing*,
 which is the only shape the failure takes.
 
 ## Call sites
@@ -3378,7 +3382,7 @@ shared by every viewer on the page, which context cannot cross, so it takes a
 Prose the core computes — style descriptions today — is content, so it follows
 `documentLocale` and is built where the core builds everything else. The
 translator arrives as the value of the `translator` dependency, which is a
-_factory_ keyed by locale rather than a translator: the catalogs are fixed for
+*factory* keyed by locale rather than a translator: the catalogs are fixed for
 a core's lifetime but the locale is not, since a nested `<document lang>` can
 differ from the one around it. A definition takes the `locale` of the document
 it sits in — an ordinary ancestor dependency, alongside `theme` — and asks the
@@ -3413,7 +3417,7 @@ that cannot be translated word for word. English writes adjectives before the
 noun and inserts an article before "border"; Spanish writes them after and
 agrees them with the noun's gender. So each description is assembled by a
 message that receives the pieces as arguments plus a `$parts` argument naming
-_which_ pieces are present, and every adjective is handed `$gender`. An absent
+*which* pieces are present, and every adjective is handed `$gender`. An absent
 piece selects a different branch rather than substituting an empty string —
 that is what lets a translation reorder and re-punctuate each combination on
 its own terms.
@@ -3430,7 +3434,7 @@ its fifth is `c12` — «akadomo», the point, is a diminutive there, as it is i
 Ganda. The reachability rule applies to the class tokens exactly as it does to
 `$role`: a catalog writes a branch for a class only if its own `noun-gender`
 can answer that class. That is why Swahili and Nyanja carry `c6` — the plural
-class, which their word for _text_ or _border_ lands in — and the other
+class, which their word for *text* or *border* lands in — and the other
 seventeen do not, and why Venda, Tsonga, Kikuyu and Bemba stop at `c3`, `c7`
 and `c9`: no noun the core names is class 5 in any of the four, so the ḽi-,
 leri-, i- and ili- forms are named in those catalogs' headers rather than
@@ -3440,7 +3444,7 @@ written as branches nothing can select.
 `locales/ff` writes «ɓaleewol» against a `ngol` noun and «ɓaleere» against a
 `nde` one, so the same argument that reaches the front of a Bantu adjective
 reaches the back of a Fula one. Nothing outside the catalog changed to allow
-that, which is the point: what `$gender` names is _what a word agrees with_,
+that, which is the point: what `$gender` names is *what a word agrees with*,
 not where the agreement is spelled.
 
 **The Gur pair spells it the same way from a different family**, which is what
@@ -3452,12 +3456,12 @@ which nouns a catalog happens to name, not about a family, which is what the
 nineteen Bantu catalogs have been saying all along in a script where it is
 easier to miss.
 
-Both write the _juxtaposed_ construction, where the noun keeps its own class
+Both write the *juxtaposed* construction, where the noun keeps its own class
 suffix and each modifier agrees with it, rather than the compound one, where
 the noun drops to its bare stem and the last modifier carries the suffix alone.
 That is the affix rule below: the last element of a description is often a
 placeable, and a suffix cannot be welded to a word the catalog never sees. It
-is _choose the words that land there_ applied to a whole construction rather
+is *choose the words that land there* applied to a whole construction rather
 than to one word.
 
 **Tiv writes it as a word of its own, which is the third place it can go.**
@@ -3491,7 +3495,7 @@ words are rendered in two places each — a border's adjectives, the background
 colour, and the text colour beside it — once standing alone as a state
 variable reports them and once embedded in a clause, and a language that
 inflects for case wants a different form in each. So every adjective is handed
-`$role` as well, naming the _position_ the phrase is going into rather than
+`$role` as well, naming the *position* the phrase is going into rather than
 the case it takes: which case a position governs is the catalog's business,
 exactly as `$gender`'s token set already is. `locales/en/content.ftl` lists the
 positions, and `be`, `bs`, `cs`, `de`, `el`, `et`, `fi`, `fo`, `hi`, `hr`,
@@ -3523,7 +3527,7 @@ The **Celtic four** — `ga`, `gd`, `cy`, `br` — reach that same answer from t
 other end. They mark an adjective heavily, but by mutating the front of it
 rather than by inflecting the end: a feminine singular noun softens whatever
 follows it, so «dearg» is «dhearg» in Irish, «coch» is «goch» in Welsh, and
-«du» is «zu» in Breton. That trigger is the _noun_, and the noun's gender is
+«du» is «zu» in Breton. That trigger is the *noun*, and the noun's gender is
 already a token these messages carry — so all four select on `$gender` alone
 and none of them writes a `$role` branch. Welsh goes one step past the other
 three: a handful of its adjectives have a feminine form of their own before the
@@ -3543,8 +3547,8 @@ width first. Each of those says so above its own `style-stroke`, for the same
 reason.
 
 Basque is the clean case of the opposite: it has a great many cases and selects
-on neither argument, because a Basque case is a suffix on the _last word of the
-whole noun phrase_. What a position asks for lands on a word `locales/eu`
+on neither argument, because a Basque case is a suffix on the *last word of the
+whole noun phrase*. What a position asks for lands on a word `locales/eu`
 writes — «batekin», «planoarekin» — rather than on the adjective, so the
 description reads the same in all four positions.
 
@@ -3585,7 +3589,7 @@ verb, «'ej» between them, and stands the whole clause in front of the noun:
 an attested pattern, since no canon example chains three relative clauses, and
 the catalog's header says so. That puts Klingon on the prenominal
 side with the Philippine catalogs and Tok Pisin, for a reason none of them
-shares, and it is why the catalog needs no `$role` fork — the _position_ is
+shares, and it is why the catalog needs no `$role` fork — the *position* is
 handled by the message that composes the phrase rather than by the word inside
 it, so its tables can hold bare verbs that double as the citation form a state
 variable reports.
@@ -3623,10 +3627,10 @@ the order of the adjectives, and `styleDescriptions.test.ts` pins both halves.
 Two further Fluent constraints shaped it, and both are easy to rediscover the
 hard way:
 
-- **A word that inflects has to be passed in, not referenced.** A _term_
+- **A word that inflects has to be passed in, not referenced.** A *term*
   reference cannot carry a runtime value — `{ -filled(gender: $gender) }` does
   not parse (`E0014 Expected literal`), and `{ -filled }` gets an empty scope
-  and always picks its default variant. A _message_ reference does inherit the
+  and always picks its default variant. A *message* reference does inherit the
   caller's arguments, but references never cross a bundle boundary: a locale
   that translates `style-filled` and not `style-filled-word` would render the
   literal `{style-filled-word}` rather than falling back to English. So the
@@ -3635,9 +3639,9 @@ hard way:
 - **A multiline pattern keeps its newlines.** Continuing a variant onto a
   further line puts a `\n` in the rendered string — including when that line
   opens a nested select. Keep each variant's content on one line; a select
-  nested _within_ that line is fine, and is how a message would sub-divide one
+  nested *within* that line is fine, and is how a message would sub-divide one
   of its variants. The same rule catches a subtler mistake: a `#` line indented
-  _under_ a message is not a comment, it is more of the pattern above it, so a
+  *under* a message is not a comment, it is more of the pattern above it, so a
   note explaining a wording choice has to sit above the message rather than
   beside the attribute it explains. `lint:i18n` fails on any pattern that
   renders a line break, which is what makes both of these findable before a
@@ -3651,30 +3655,30 @@ writing direction — it turned up first in Arabic and Uyghur and then in
 Hungarian, Finnish, Czech, Slovak and Romanian.
 
 A placeable is a value the catalog never sees. So a message may not depend on
-what that value turns out to _be_:
+what that value turns out to *be*:
 
-| The catalog wants                 | The language                       | Why it cannot                                                                              |
-| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------ |
-| a case ending on the value        | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
-| the definite article on the value | `ro`, `men`                        | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai»                           |
-| a preposition before the value    | `cs`, `sk`                         | «v»/«ve» and «s»/«se» vocalize according to what follows                                   |
-| a compound with the value         | `fi`                               | Finnish writes a compound as one word                                                      |
-| a case particle after the value   | `bo`, `dz`                         | the particle has four shapes, picked by the final letter of the syllable before it         |
-| the annexed state on the value    | `kab`, `zgh`, `shi`                | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest»     |
+| The catalog wants | The language | Why it cannot |
+| --- | --- | --- |
+| a case ending on the value | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
+| the definite article on the value | `ro`, `men` | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai» |
+| a preposition before the value | `cs`, `sk` | «v»/«ve» and «s»/«se» vocalize according to what follows |
+| a compound with the value | `fi` | Finnish writes a compound as one word |
+| a case particle after the value | `bo`, `dz` | the particle has four shapes, picked by the final letter of the syllable before it |
+| the annexed state on the value | `kab`, `zgh`, `shi` | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest» |
 
 Adjacency is not the problem. `{ $numSides }-kulmio` is correct Finnish for
 every side count, because `-kulmio` is the same whatever number lands in front
-of it. What cannot be written is _agreement_ with an unknown word.
+of it. What cannot be written is *agreement* with an unknown word.
 
 **Tibetan and Dzongkha are the table's sharpest entry, and the way out they
-take is the fifth one.** A Tibetan case particle is chosen by the _final letter
-of the syllable before it_: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
+take is the fifth one.** A Tibetan case particle is chosen by the *final letter
+of the syllable before it*: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
 genitive གི་, ཀྱི་, གྱི་ or ཡི་. Beside a placeable there is no syllable to
 look at. So `bo/content.ftl` and `dz/content.ftl` — the two files that
-_compose_ a phrase, and so the two that get to choose their particles — use
+*compose* a phrase, and so the two that get to choose their particles — use
 only the ones that have a single shape: དང་ for accompaniment, ལ་ (Dzongkha
-ལུ་) for location, ནང་ for containment. That is _prefer the free allomorph
-over the bound one_ applied to a particle rather than to a prefix, and the
+ལུ་) for location, ནང་ for containment. That is *prefer the free allomorph
+over the bound one* applied to a particle rather than to a prefix, and the
 third family to take that way out, after Kʼicheʼ and the Bisayan catalogs.
 
 **The other three files in each are where the way out runs out**, and it is
@@ -3702,7 +3706,7 @@ this rule and the third way out below to come off. Its adjectives follow the
 noun and the izafat links them, and unlike Persian's — an unwritten vowel after
 a consonant, which is why `locales/fa` lets the space carry it — Tajik's is
 written, as «-и». So `locales/tg` writes `{ $noun }и { $description }`, welding
-an affix onto a value whose _form_ the value decides, which nothing else here
+an affix onto a value whose *form* the value decides, which nothing else here
 does — the hyphenated endings `locales/hy` and `locales/ka` put on an
 identifier are welds too, but each has one shape whatever precedes it, so they
 fall under the paragraph above rather than this one. What makes Tajik's sound is
@@ -3720,7 +3724,7 @@ shape-changing affix onto a placeable and records the result as wrong, which
 is `locales/bo`'s answer rather than a new one: the Tibetan catalog's other
 three files write the default genitive after a placeable, right for most
 syllables and wrong for some, and say so. What is new is that this is the
-_ezafe_ case — the construction `locales/tg` mitigates and `locales/zza`
+*ezafe* case — the construction `locales/tg` mitigates and `locales/zza`
 avoids by writing the vowel into its `noun` table — failing in the open.
 Muslim Tat builds the same phrases Tajik
 does, and its ezafe is `-i` after a consonant and `-yi` after a vowel. Where
@@ -3757,13 +3761,13 @@ There are five ways out, and every catalog here takes one of them:
 
 **The three Berber catalogs sharpen the third of those into something new: make
 the position uniform, and one written form is right in all of them.** A Berber
-noun after a preposition goes into the _état d'annexion_, and `$pattern` is a
+noun after a preposition goes into the *état d'annexion*, and `$pattern` is a
 noun these catalogs never see — so no branch can inflect it. What they do
 instead is arrange that every one of the four places a fill pattern is placed
-puts it behind the _same_ preposition «s», including `style-fill`, where
+puts it behind the *same* preposition «s», including `style-fill`, where
 English has no preposition at all. `fill-style` then writes its words already
-annexed and cannot be wrong anywhere. That is _choose the words that land
-there_ with the extra step of choosing how many positions there are to choose
+annexed and cannot be wrong anywhere. That is *choose the words that land
+there* with the extra step of choosing how many positions there are to choose
 for, and `styleDescriptions.test.ts` pins two of the four so that a branch
 dropping the preposition fails rather than quietly producing an unannexed noun.
 
@@ -3771,7 +3775,7 @@ The same three catalogs also settle a question the affix table can otherwise
 make look decided: **an alternation that a clause position triggers is not
 automatically a `$role` fork.** The annexed state is exactly the kind of thing
 `$role` exists for, and all three select on `$gender` alone — because the state
-falls on the _noun_, and every noun a clause position lands on is one the
+falls on the *noun*, and every noun a clause position lands on is one the
 catalog writes out. A `$role` branch would render what the `$gender` branch
 underneath it already renders, which is `locales/gu`'s trap reached from
 Afro-Asiatic.
@@ -3783,7 +3787,7 @@ out right for `locales/tlh`'s reason rather than by luck — «ma-» has one sha
 and assimilates to nothing — and it is written on the colour arguments alone
 (`$color`, and `$background` beside it in `style-text`), because `line-width`
 and `line-style` write their words already marked and would come out doubled;
-so the table above stays a list of languages whose endings _change shape_, and
+so the table above stays a list of languages whose endings *change shape*, and
 gains a language whose beginnings do not.
 
 A select whose variants would land against such an affix carries the affix into
@@ -3800,23 +3804,23 @@ Czech turns up here as a ligature.
 `locales/ceb` and `locales/fil` reached it first and one at a time: Cebuano's
 header calls writing the uncontracted «nga» everywhere "the one place this seed
 is deliberately stiff", and `fil` escapes the ligature outright by selecting on
-the side count, whose two CLDR plural categories _are_ its two linkers. What the
+the side count, whose two CLDR plural categories *are* its two linkers. What the
 Austronesian batch adds is the five Philippine catalogs side by side, which is
 what shows that they do not all resolve it the same way:
 
-|              | The linker    | Decided by             | Resolution                                                   |
-| ------------ | ------------- | ---------------------- | ------------------------------------------------------------ |
+| | The linker | Decided by | Resolution |
+| --- | --- | --- | --- |
 | `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
-| `ilo`        | «a» / «nga»   | the word **after** it  | no invariant form exists; write «a» and name the exception   |
-| `pam`        | «a» / `-ng`   | the word **before** it | no invariant form exists; write «a» and name the exception   |
-| `bik`        | «na» / `-ng`  | the word **before** it | no invariant form exists; write «na» and name the exception  |
+| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
+| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
+| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
 
 Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
 free word in both positions, so writing it out is not a compromise but the form
 that can be written without knowing what stands beside it — the move `locales/ceb`
 already makes, and the same move `locales/quc` makes when it writes the free
 relational «rech» instead of the possessive prefix «u-»/«r-». That is the fifth
-way out listed above — _prefer the free allomorph over the bound one_ — and it
+way out listed above — *prefer the free allomorph over the bound one* — and it
 is stated as a rule here because three families now take it: the Bisayan
 catalogs, Kʼicheʼ, and the two Tibetan-script ones, which reach it for a case
 particle rather than for a linker.
@@ -3954,7 +3958,7 @@ A code is a permanent name — what a bug report cites, what a host reading
 `setDiagnosticsCallback` can filter on, and the anchor a documentation page
 will hang off (#1548). It rides on the record, and on the LSP `code` field for
 a positioned diagnostic — with the arguments alongside it in `data.args`, since
-a code names a message _template_ and it takes both to say which occurrence of
+a code names a message *template* and it takes both to say which occurrence of
 it this is. That pair is how the language server's `dedupeLspDiagnostics`
 recognizes two renderings of one diagnostic without comparing their text.
 Nothing renders the code itself yet, so the codes earn their keep as an
@@ -3966,7 +3970,7 @@ fails if one is renumbered, reused, or dropped from the registry. Retire a code
 in place; never recycle it.
 
 The lock is a committed file, not a service, so it enforces the contract only
-against the registry — deleting a code's line from _both_ files in one change
+against the registry — deleting a code's line from *both* files in one change
 passes the lint, exactly as deleting a `package-lock.json` entry does. That is
 what makes the lock worth reviewing: a diff that removes or edits an existing
 line, rather than only adding one at the end, is the thing to refuse.
@@ -3978,7 +3982,7 @@ severity — the emitting call site chooses the record's `type`.
 Two branches that each claim the next number collide in both the registry and
 the lock, which is the intended outcome: neither file can be auto-merged, so
 the conflict is resolved by hand. Give the later branch the next free number in
-_both_ files — the lock is sorted by code, so its entry moves with it, and the
+*both* files — the lock is sorted by code, so its entry moves with it, and the
 lint passes once the two agree again. Never resolve it by editing a code that
 is already on `main`.
 
@@ -4070,7 +4074,7 @@ npm run lint:i18n -w @doenet/i18n    # CI catalog check (also `npm run lint:i18n
 ```
 
 `lint:i18n` fails on: a catalog that doesn't parse (including entries the Fluent
-_runtime_ would silently drop as junk), an id defined twice within a locale, a
+*runtime* would silently drop as junk), an id defined twice within a locale, a
 catalog naming a `numberingSystem` on a Fluent builtin, a message whose value
 would render a line break, a catalog naming a plural category its own locale
 cannot select, a translated locale
@@ -4080,7 +4084,7 @@ exactly the inlined locales, a call site referencing a key that doesn't exist,
 an English key no source file references, a malformed diagnostic code, a code
 naming a message English lacks, a code used in source that the registry doesn't
 define, a registered code that nothing raises and that is not listed as
-retired, and any change to a code already issued. Keys _missing_ from a
+retired, and any change to a code already issued. Keys *missing* from a
 translation are reported as coverage, not failure — a partial translation is
 legitimate and falls back.
 
@@ -4103,7 +4107,7 @@ Two things can put one there, and the rule covers both:
 
 - **A locale CLDR knows, given a category it does not have.** `Intl.PluralRules`
   is the authority, and `resolvedOptions().pluralCategories` is the answer.
-- **A locale CLDR does not know.** Its tag resolves to the _runtime's_ default
+- **A locale CLDR does not know.** Its tag resolves to the *runtime's* default
   locale, so every category branch in it is selected by some other language's
   rules. More than a hundred locale directories are in this position, and none
   of them writes `zero`, `two`, `few` or `many`.
@@ -4135,14 +4139,14 @@ The tag is canonicalized before it is asked about, because ICU folds three
 directory names onto a macrolanguage — `kmr` to `ku`, `kpv` to `kv`, `mhr` to
 `chm` — and `kmr` genuinely inherits Kurdish's rules while the other two
 inherit nothing, their macrolanguages having no CLDR data either. Comparing the
-resolved tag against the _language_ subtag rather than the whole tag matters for
+resolved tag against the *language* subtag rather than the whole tag matters for
 the opposite reason: `zh-Hans` and `zh-Hant` both resolve to plain `zh`, which
 is their own data and not a fallback.
 
 `pluralVariantKeys`, `allowedPluralCategories` and
 `unselectablePluralCategories` in `scripts/catalogUtils.ts` are the rule, and
 `catalogLint.test.ts` holds it over the whole roster. The per-batch plural
-blocks in `chrome.test.ts` keep only the half the property cannot state: _why_
+blocks in `chrome.test.ts` keep only the half the property cannot state: *why*
 a particular language writes the branch it writes.
 
 ## Pseudo-localization
@@ -4197,7 +4201,7 @@ that are not prose: a contrast ratio is written `{ ratio }:1` with the `1` a
 literal in the catalog, a line number is read off a gutter the editor draws
 itself, an author's `styleNumber="3"` is quoted back at them. And mathematics
 is Latin-digit regardless — `MATH_NOTATION_LOCALE`, which #1528 keeps that way
-while it makes the _separator_ configurable. A document whose prose counted in
+while it makes the *separator* configurable. A document whose prose counted in
 one script and whose equations counted in another would be worse than either
 alone.
 
@@ -4234,7 +4238,7 @@ outside it. A nested `<document lang>` needs no state variable of its own —
 `renderedLang` is set exactly when the language changes, so where it is absent
 the direction cannot have changed either.
 
-Chrome drawn _inside_ the document is the reader's language in a box declared to
+Chrome drawn *inside* the document is the reader's language in a box declared to
 be the content's. `useChromeLangDir()` re-declares it — on the in-document error
 box, the feedback heading, the click-to-toggle text on a hint, a solution and a
 collapsible section, a pretzel's answer label, the summary-statistics caption,
@@ -4248,7 +4252,7 @@ drawn by the browser rather than by CSS. `DocViewer`'s error banner is built
 above the provider the hook reads, so it calls the same rule as the plain
 function `chromeLangDir(uiLocale, documentDirection)`.
 
-"The document" there means the _nearest_ one, not the activity: a nested
+"The document" there means the *nearest* one, not the activity: a nested
 `<document lang>` turns its own subtree around, so `section.tsx` re-mounts
 `DocumentDirectionProvider` around whatever it just declared. Otherwise chrome
 inside `<document lang="ar">` would compare itself against a left-to-right
@@ -4272,7 +4276,7 @@ rather than styled. MathJax needs nothing: its CHTML output already pins
 `direction: ltr` on `mjx-math` — but only on the mathematics itself, which is
 why the preview's scroll container still needs its own pin.
 
-A pin on a _block_ needs a width with it: an element as wide as its container
+A pin on a *block* needs a width with it: an element as wide as its container
 aligns its left-to-right contents to the container's left edge, stranding the
 widget at the far side of the page from the prose it belongs to.
 `ltrIslandProps()` in
@@ -4284,7 +4288,7 @@ instead of the column. An inline island, or one whose element already
 shrink-wraps, takes a bare `dir="ltr"`.
 
 The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
-because `Keyboard` returns a different element per style. The tray _around_
+because `Keyboard` returns a different element per style. The tray *around*
 them follows the reader.
 
 Everything else mirrors: the paginator, prose renderers, the feedback and hint
@@ -4307,20 +4311,20 @@ an Arabic sentence and the mathematics beside it count in the same characters.
 and almost nothing else, and the catalogs differ from each other far more than
 they differ from `de` or `es`:
 
-|                  | Adjectives       | Gender | Plural categories |
-| ---------------- | ---------------- | ------ | ----------------- |
-| `ar`             | follow the noun  | m/f    | six               |
-| `he`             | follow the noun  | m/f    | three             |
-| `fa`             | follow the noun  | none   | two               |
-| `ur`, `ps`, `sd` | precede the noun | m/f    | two               |
-| `ug`             | precede the noun | none   | two               |
-| `yi`             | precede the noun | m/f/n  | two               |
-| `ks`             | precede the noun | m/f    | two               |
-| `dv`             | precede the noun | none   | two               |
-| `ckb`            | follow the noun  | none   | two               |
-| `mzn`, `glk`     | precede the noun | none   | none in CLDR      |
-| `lrc`, `haz`     | follow the noun  | none   | none in CLDR      |
-| `bal`            | precede the noun | none   | two               |
+| | Adjectives | Gender | Plural categories |
+| --- | --- | --- | --- |
+| `ar` | follow the noun | m/f | six |
+| `he` | follow the noun | m/f | three |
+| `fa` | follow the noun | none | two |
+| `ur`, `ps`, `sd` | precede the noun | m/f | two |
+| `ug` | precede the noun | none | two |
+| `yi` | precede the noun | m/f/n | two |
+| `ks` | precede the noun | m/f | two |
+| `dv` | precede the noun | none | two |
+| `ckb` | follow the noun | none | two |
+| `mzn`, `glk` | precede the noun | none | none in CLDR |
+| `lrc`, `haz` | follow the noun | none | none in CLDR |
+| `bal` | precede the noun | none | two |
 
 The last three rows are the Silk Road batch's. Four of its five have no CLDR
 plural data at all — `mzn`, `glk`, `lrc` and `haz` — while `bal` has a category
@@ -4336,9 +4340,9 @@ is the closest thing to a parallel text for it and a correction to one is
 usually a correction to both. `ug` is Turkic and agrees with nothing, and `dv`
 is Indo-Aryan and agrees with nothing either — the two reach the same answer
 from opposite families. `ks` is the one of the sixteen whose catalog records a
-gap rather than a decision: it _does_ agree an adjective for gender and this
+gap rather than a decision: it *does* agree an adjective for gender and this
 seed does not, which its header says outright. `ckb` is the only one whose
-_sibling_ is on the roster in the other direction — `locales/kmr` is the same
+*sibling* is on the roster in the other direction — `locales/kmr` is the same
 macrolanguage in Latin, left to right — and the only one that solves the affix
 problem by writing the linker into its `noun` table; see [The Kurdish
 pair](#the-kurdish-pair). `yi` is Germanic, and it forks on `$role` for a
@@ -4380,7 +4384,7 @@ Three things recur across them, none a property of the direction:
   "are ignored" — most of these cover both with one form, and the select is
   dropped rather than written out twice identically. The count argument then
   goes unused, which is harmless: it stays in the English message for the
-  languages that need it. Where English changes the _noun_ as well, the branch
+  languages that need it. Where English changes the *noun* as well, the branch
   stays — and whether it has to is a fact about the language rather than about
   the script: Persian, Urdu and Uyghur leave a noun singular after a numeral —
   as do all five of the Silk Road's right-to-left catalogs — while Arabic,

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -12,14 +12,14 @@ This package is **never published**. Its `vite.config.ts` has no
 
 ## The two locales
 
-DoenetML separates the language of the *content* from the language of the
-*chrome*, because they genuinely differ: a Spanish-speaking student may work a
+DoenetML separates the language of the _content_ from the language of the
+_chrome_, because they genuinely differ: a Spanish-speaking student may work a
 French physics problem, and a French activity embedded in an English course
 should still say "thick red line" in French.
 
-| Setting          | Selects                                                 | Namespaces                |
-| ---------------- | ------------------------------------------------------- | ------------------------- |
-| `documentLocale` | Prose the core computes into the document               | `content`                 |
+| Setting          | Selects                                                  | Namespaces                        |
+| ---------------- | -------------------------------------------------------- | --------------------------------- |
+| `documentLocale` | Prose the core computes into the document                | `content`                         |
 | `uiLocale`       | Everything addressed to whoever is looking at the screen | `chrome`, `diagnostics`, `editor` |
 
 `<document lang>` wins over the `documentLocale` prop, which falls back to
@@ -67,43 +67,49 @@ locales/<locale>/
 ```
 
 English is the source of truth. Every translation —
-`ab`, `ace`, `ady`, `af`, `ak`, `alt`, `am`, `ar`, `arn`, `as`, `ast`,
-`av`, `ay`, `az`, `ba`, `bal`, `ban`, `bci`, `be`, `bem`, `bg`, `bho`,
-`bi`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`, `brx`, `bs`, `bua`, `bum`,
-`ca`, `ce`, `ceb`, `ch`, `chk`, `ckb`, `co`, `crh`, `cs`, `csb`, `cv`,
-`cy`, `da`, `dag`, `dar`, `de`, `dje`, `dng`, `doi`, `dsb`, `dv`, `dyo`,
-`dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`,
-`fi`, `fil`, `fit`, `fj`, `fo`, `fon`, `fr`, `fur`, `fy`, `ga`, `gaa`,
-`gag`, `gd`, `gil`, `gl`, `glk`, `gn`, `gsw`, `gu`, `ha`, `haw`, `haz`,
-`he`, `hi`, `hil`, `hnj`, `hr`, `hsb`, `ht`, `hu`, `hy`, `id`, `ig`,
-`ilo`, `inh`, `is`, `it`, `ja`, `jv`, `ka`, `kaa`, `kab`, `kbd`, `kbp`,
-`kca`, `kg`, `ki`, `kjh`, `kk`, `km`, `kmb`, `kmr`, `kn`, `ko`, `koi`,
-`kok`, `kos`, `kpe`, `kpv`, `kr`, `krc`, `kri`, `krl`, `ks`, `ksh`,
-`ktu`, `kum`, `ky`, `lb`, `lbe`, `lez`, `lg`, `li`, `lij`, `ln`, `lo`,
+`ab`, `ace`, `acf`, `ady`, `af`, `ak`, `alt`, `am`, `ar`, `arn`,
+`as`, `ast`, `av`, `ay`, `az`, `ba`, `bal`, `ban`, `bci`, `be`,
+`bem`, `bg`, `bho`, `bi`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`,
+`brx`, `bs`, `bua`, `bum`, `bzj`, `ca`, `cab`, `ce`, `ceb`, `ch`,
+`chk`, `ckb`, `co`, `crh`, `cs`, `csb`, `cv`, `cy`, `da`, `dag`,
+`dar`, `de`, `dje`, `djk`, `dng`, `doi`, `dsb`, `dv`, `dyo`, `dyu`,
+`dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`, `fi`,
+`fil`, `fit`, `fj`, `fo`, `fon`, `fr`, `fur`, `fy`, `ga`, `gaa`,
+`gag`, `gcf`, `gcr`, `gd`, `gil`, `gl`, `glk`, `gn`, `gsw`, `gu`,
+`ha`, `haw`, `haz`, `he`, `hi`, `hil`, `hnj`, `hr`, `hsb`, `ht`,
+`hu`, `hy`, `id`, `ig`, `ilo`, `inh`, `is`, `it`, `iu`, `ja`, `jam`,
+`jv`, `ka`, `kaa`, `kab`, `kbd`, `kbp`, `kca`, `kek`, `kg`, `ki`,
+`kjh`, `kk`, `kl`, `km`, `kmb`, `kmr`, `kn`, `ko`, `koi`, `kok`,
+`kos`, `kpe`, `kpv`, `kr`, `krc`, `kri`, `krl`, `ks`, `ksh`, `ktu`,
+`kum`, `ky`, `lb`, `lbe`, `lez`, `lg`, `li`, `lij`, `ln`, `lo`,
 `lom`, `lrc`, `lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `mdf`, `men`,
-`mg`, `mh`, `mhr`, `mi`, `min`, `mk`, `ml`, `mn`, `mni`, `mnk`, `mns`,
-`mos`, `mr`, `mrj`, `ms`, `mt`, `my`, `myv`, `mzn`, `nah`, `nap`, `nb`,
-`nds`, `ne`, `niu`, `nl`, `nn`, `nog`, `nso`, `ny`, `nyn`, `oc`, `oj`,
-`olo`, `om`, `or`, `os`, `pa`, `pam`, `pcm`, `pl`, `pms`, `pon`, `ps`,
-`pt`, `qu`, `quc`, `rar`, `rm`, `rn`, `ro`, `ru`, `rue`, `rw`, `sa`,
-`sah`, `sat`, `sc`, `scn`, `sco`, `sd`, `se`, `sg`, `sgh`, `shi`, `si`,
-`sjd`, `sk`, `sl`, `sm`, `sma`, `smj`, `smn`, `sms`, `sn`, `so`, `sq`,
-`sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`, `szl`, `ta`, `tab`, `te`,
-`tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`, `tly`, `tn`,
-`to`, `tpi`, `tr`, `ts`, `tt`, `ttt`, `tvl`, `ty`, `tyv`, `udm`, `ug`,
-`uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vec`, `vep`, `vi`, `vro`, `war`,
-`wbl`, `wls`, `wo`, `xal`, `xh`, `yi`, `yo`, `zgh`, `zh-Hans`, `zh-
-Hant`, `zu`, `zza`
+`mg`, `mh`, `mhr`, `mi`, `min`, `miq`, `mk`, `ml`, `mn`, `mni`,
+`mnk`, `mns`, `mos`, `mr`, `mrj`, `ms`, `mt`, `my`, `myv`, `mzn`,
+`nah`, `nap`, `nb`, `nds`, `ne`, `niu`, `nl`, `nn`, `nog`, `nso`,
+`ny`, `nyn`, `oc`, `oj`, `olo`, `om`, `or`, `os`, `pa`, `pam`, `pap`,
+`pcm`, `pl`, `pms`, `pon`, `ps`, `pt`, `qu`, `quc`, `rar`, `rm`,
+`rn`, `ro`, `ru`, `rue`, `rw`, `sa`, `sah`, `sat`, `sc`, `scn`,
+`sco`, `sd`, `se`, `sg`, `sgh`, `shi`, `si`, `sjd`, `sk`, `sl`, `sm`,
+`sma`, `smj`, `smn`, `sms`, `sn`, `so`, `sq`, `sr`, `srm`, `srn`,
+`ss`, `st`, `su`, `sus`, `sv`, `sw`, `szl`, `ta`, `tab`, `te`, `tem`,
+`tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`, `tly`, `tn`,
+`to`, `tpi`, `tr`, `ts`, `tt`, `ttt`, `tvl`, `ty`, `tyv`, `udm`,
+`ug`, `uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vec`, `vep`, `vi`,
+`vro`, `war`, `wbl`, `wls`, `wo`, `xal`, `xh`, `yi`, `yo`, `yua`,
+`zgh`, `zh-Hans`, `zh-Hant`, `zu`, `zza`
 — is an **unreviewed machine-generated seed**, which each file's own
 header says at the top, and which is what #1521's translation platform is for.
 None has been read by a speaker. Correcting one needs no permission and no
 coordination: a wrong string is just wrong, and the English is one key away.
 
-Two hundred and eight of them are deliberately partial. Two hundred and
-seven are partial in the same place — the two chemistry tables — while
-Klingon is partial almost everywhere, for a different reason: see
-[A language with no word for it](#a-language-with-no-word-for-it). The two
-hundred and seven are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
+Two hundred and twenty-three of them are deliberately partial. Two hundred
+and twenty-one are partial in the same place — the two chemistry tables —
+while two are partial more widely, each for its own reason: Klingon almost
+everywhere, for the reason in
+[A language with no word for it](#a-language-with-no-word-for-it), and
+Inuktitut over the geometry nouns as well, for the reason in
+[Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws).
+The two hundred and twenty-one are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -129,7 +135,10 @@ Tuvaluan, Rarotongan, Wallisian, Bislama, Scots, Swiss German, Colognian,
 Limburgish, Friulian, Venetian, Ligurian, Piedmontese, Neapolitan, Upper
 Sorbian, Lower Sorbian, Kashubian, Silesian, Rusyn, Crimean Tatar, Gagauz,
 Karakalpak, Khakas, Southern Altai, Balochi, Hazaragi, Muslim Tat, Zazaki,
-Shughni, Dungan and Wakhi
+Shughni, Dungan, Wakhi, Kalaallisut,
+Yucatec Maya, Qʼeqchiʼ, Garifuna, Mískito, Papiamentu, Sranan Tongo, Jamaican
+Creole, Guadeloupean Creole French, Saint Lucian Creole French, Guianese
+Creole French, Belize Kriol, Aukan and Saramaccan
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -142,7 +151,7 @@ Vietnamese school chemistry has moved from the transliterated names to the
 IUPAC forms, so in each case the fallback is already what the curriculum uses.
 The eight from the first sub-Saharan batch are that same case for a different
 reason: secondary science is taught in English, French or Afrikaans across all
-of them, so the fallback *is* the curriculum. Afrikaans and Swahili are the two
+of them, so the fallback _is_ the curriculum. Afrikaans and Swahili are the two
 of that batch that do have a settled list and supply it.
 
 The eight from the Southeast Asian and Pacific batch split three ways, and the
@@ -151,7 +160,7 @@ the language. Cebuano is the Filipino case again and for the same school
 system, and Malagasy the French-medium case; Samoan and Hawaiian have no
 settled list of all 118 to seed from, and neither does Māori, whose
 kura-taught science coins terms without having reached the whole table.
-Khmer, Lao and Sinhala are the one group where the language *does* have the
+Khmer, Lao and Sinhala are the one group where the language _does_ have the
 names — all three are taught chemistry in their own language, out of textbooks
 that print their own transcriptions — and what is missing is a convention this
 seed could reproduce rather than invent. An unreviewed guess written in a
@@ -172,7 +181,7 @@ Shona, Southern Sotho, Setswana, Tigrinya and Ganda — are partial too, and
 unlike the batches above them they split no ways at all: every one of the ten
 is the school-system case. Secondary science is taught in English across
 Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French
-across Senegal, Mali and both Congos, so in all ten the fallback *is* the
+across Senegal, Mali and both Congos, so in all ten the fallback _is_ the
 curriculum. That is a fact about ten education ministries rather than about ten
 languages, which is why it reads as one sentence here and takes a sentence of
 its own in each catalog's header.
@@ -184,7 +193,7 @@ textbooks, Asturian out of Spanish, Sardinian and Sicilian out of Italian,
 Western Frisian out of Dutch, Low German and Luxembourgish out of German —
 Luxembourg's upper grades in French as well — and Romansh-medium schooling
 stops below the grades where the periodic table is taught. Northern Sami is the
-one of the eleven where the schooling *is* in the language and the table still
+one of the eleven where the schooling _is_ in the language and the table still
 does not settle: a Sami pupil meets the Norwegian, Swedish or Finnish names
 depending on which side of a border the school is, and those three differ, so
 choosing any of them would report a fact about a border. Yiddish has the
@@ -209,7 +218,7 @@ Mexico, Guatemala, Chile and Argentina — and Haitian Creole out of French ones
 Every one of those seven reaches real classrooms, and Guarani reaches further
 than any other language in the batch, being co-official in Paraguay; but
 bilingual education in all seven is the primary grades and the language
-classroom, and secondary chemistry is not. So in all seven the fallback *is* the
+classroom, and secondary chemistry is not. So in all seven the fallback _is_ the
 curriculum, which is the same sentence the two sub-Saharan batches earned and
 for the same reason.
 
@@ -232,7 +241,7 @@ case — the Philippines from the intermediate grades, Guam and the Northern
 Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
 catalogs already record. Balinese, Minangkabau, Acehnese and Madurese are the
 Indonesian-medium case, and they differ from `jv` and `su` in an instructive
-way: those two *supply* the Indonesian names, because their own vocabulary for
+way: those two _supply_ the Indonesian names, because their own vocabulary for
 the substances agrees with Indonesian's often enough that the table reads as
 theirs. These four do not, and copying it whole would be neither language —
 Minangkabau says «ameh» where Indonesian says «emas» — so where `jv` and `su`
@@ -254,10 +263,10 @@ every shape the batches above them found, arriving together for the first
 time. Maithili, Bhojpuri, Konkani, Dogri, Manipuri, Kashmiri and Dzongkha are
 the school-system case, in six different school systems: secondary science is
 Hindi-, Nepali-, English-, Marathi- or Urdu-medium depending on the state or
-the country, so in all seven the fallback *is* the curriculum, and `locales/hi`,
+the country, so in all seven the fallback _is_ the curriculum, and `locales/hi`,
 `locales/ne`, `locales/mr` and `locales/ur` are the parallel texts each header
 names. Bodo and Sanskrit are the Samoan case: Bodo-medium schooling in Assam
-*does* run to the secondary grades, and Sanskrit has words for the metals it
+_does_ run to the secondary grades, and Sanskrit has words for the metals it
 knew, but neither has a settled list of all 118 to seed from. Santali is the
 Ojibwe shape — schooling in it stops below the grades where the table is
 taught, and no table waits on the other side — and Dhivehi is `locales/to`'s and
@@ -282,7 +291,7 @@ taught in English or Afrikaans in South Africa, English in Eswatini, Kenya and
 Zambia, Portuguese in Mozambique, French in the Central African Republic and
 across Fula's whole range but Nigeria, and Arabic and French in Morocco and
 Algeria, where Amazigh is taught as a subject rather than used as a medium. So
-in all twelve the fallback *is* the curriculum. That is a fact about those
+in all twelve the fallback _is_ the curriculum. That is a fact about those
 school systems rather than about twelve languages, which is why it reads as one
 paragraph here and takes a sentence of its own in each catalog's header.
 
@@ -298,7 +307,7 @@ answers.
 **All fifteen of the Caucasus and Kurdish batch are partial, and fourteen of
 the fifteen are partial for the school-system reason.** Secondary chemistry
 across the North Caucasus is taught in Russian, so for the twelve Cyrillic
-catalogs the fallback *is* the curriculum, exactly as it was for the twelve of
+catalogs the fallback _is_ the curriculum, exactly as it was for the twelve of
 the Russian Federation batch — one sentence for twelve education ministries
 that are really one.
 `locales/tly` is a two-country version of the same case and the only one that
@@ -309,7 +318,7 @@ existing at all — Turkish in Turkey, Arabic in Syria.
 
 **`locales/ckb` is the fifteenth and the one claim about a language, and it
 stands beside `locales/kmr` the way `locales/bo` stands beside `locales/dz`.**
-Central Kurdish *is* the medium of secondary science teaching in the Kurdistan
+Central Kurdish _is_ the medium of secondary science teaching in the Kurdistan
 Region of Iraq, and its schools print the periodic table in Sorani — so the
 names exist, and this is the Khmer and Tibetan case rather than the
 school-system one: what is missing is a settled convention this seed could
@@ -584,7 +593,7 @@ itself, CLDR has no Corsican-language data to answer with, and the fallback is
 English — so `endonym` equals `englishName`, the label drops its parenthesis,
 and the roster reads "Corsican" once rather than "Corsican (Corsican)". It is
 not the first to do that: `ak`, `ceb`, `fil`, `hnj`, `mg`, `mi`, `ny` and `sm`
-already read that way, and so do the several whose endonym genuinely *is* the
+already read that way, and so do the several whose endonym genuinely _is_ the
 English word — Afrikaans, Hausa, Igbo, Wolof. Nothing here hand-writes around
 either case, which is why the rule that makes `ny` read "Nyanja" is the rule
 that makes this read "Corsican".
@@ -594,7 +603,7 @@ than one individual language**, and doing so uncovered a real fallback bug rathe
 than merely needing a note.
 
 `qu`, `ay`, `gn` and `oj` are ISO 639-3 macrolanguages and `nah` is an ISO 639-3
-*collection* code: each covers a family of individual languages with codes of
+_collection_ code: each covers a family of individual languages with codes of
 their own. **CLDR's likely-subtags folds exactly one member of a macrolanguage to
 it and leaves the rest unresolvable.** So `quz` reached `qu` on ICU data alone
 and `quh` did not; `ojg` reached `oj` and `ojb` did not; `gug` reached `gn` and
@@ -622,7 +631,7 @@ too.
 
 Serving a related variety is a real compromise, and each of these catalogs says
 in its own header which written standard it is: Southern Quechua in the
-trivocalic orthography, Paraguayan Guarani in the *jopara* register, Central
+trivocalic orthography, Paraguayan Guarani in the _jopara_ register, Central
 Nahuatl in the SEP/INALI orthography, Ojibwe in the Fiero double-vowel
 orthography, Mapudungun in the Alfabeto Mapuche Unificado — which is a choice
 among three live orthographies rather than a neutral default, and its header says
@@ -677,7 +686,7 @@ untouched.
 ### Naming a catalog when a sibling member has one too
 
 A catalog is named after the **individual language it is written in**, not after
-the macrolanguage that language belongs to, whenever a *sibling* member of that
+the macrolanguage that language belongs to, whenever a _sibling_ member of that
 macrolanguage also has a catalog here.
 
 The rule exists because a macrolanguage tag makes a promise the file cannot
@@ -693,7 +702,7 @@ file.
 **An alias adds a fallback; it does not replace the tag.** `available` is not
 only this repository's roster — a host passes its own catalogs in as
 `localeResources`, and [the contract those have is that they
-win](#delivery). So `negotiateLocales` asks for the tag as written *and then*
+win](#delivery). So `negotiateLocales` asks for the tag as written _and then_
 its alias, in that order. Rewriting `ku` to `kmr` before matching would step
 over a host that had keyed a catalog on `ku`: its key would never be compared
 against anything, and its reader would get English while the translation sat in
@@ -705,7 +714,7 @@ which all three of these were.
 What an alias cannot do is tell the two tags apart. `normalizeLocaleTag` folds
 `kmr` to `ku` before negotiation runs — ICU's canonicalization again — so
 `<document lang="kmr">` and `<document lang="ku">` arrive as the same request,
-and a host offering catalogs under *both* keys is answered with the
+and a host offering catalogs under _both_ keys is answered with the
 macrolanguage's for either. That predates the aliases rather than following
 from them: `kmr` folded to `ku` before there was a `locales/kmr` to fold it
 onto. Undoing it would mean `normalizeLocaleTag` declining to canonicalize
@@ -725,12 +734,12 @@ new Intl.Locale("mhr").toString(); // "chm"
 `normalizeLocaleTag` runs that canonicalization, so a hand-typed `<document
 lang="kmr">` has already become `ku` before negotiation sees it. A directory
 named `kmr` is therefore unreachable under **both** names unless something maps
-the macrolanguage *forward* onto the member — which is what the `ku: "kmr"`,
+the macrolanguage _forward_ onto the member — which is what the `ku: "kmr"`,
 `kv: "kpv"` and `chm: "mhr"` rows in `LANGUAGE_ALIASES` do. Delete them as
 redundant and three catalogs fall to English with nothing to say why.
 
-That is the mirror of the `koi`/`mrj` case: there an alias had to be *removed*
-for a member's own catalog to win, here one has to be *added* for a member's own
+That is the mirror of the `koi`/`mrj` case: there an alias had to be _removed_
+for a member's own catalog to win, here one has to be _added_ for a member's own
 catalog to be reachable at all. `negotiate.test.ts` asserts both the
 canonicalization and the negotiation result, so neither half can be quietly
 dropped.
@@ -752,14 +761,14 @@ the ISO 639-1 code an author is most likely to type for no gain.
 Twelve languages, and the thing they add to this file is not any one of them
 but the **five Devanagari catalogs that answer the agreement question three
 different ways**. Sanskrit selects on `$gender` and `$role` and inflects for
-gender, number *and* case; Konkani selects on both with Marathi's three
+gender, number _and_ case; Konkani selects on both with Marathi's three
 genders; Dogri selects on `$gender` alone; Maithili and Bhojpuri select on
 neither. Hindi, Marathi and Nepali were already three more answers in the same
 letters. **A script says nothing about the fork**, which is the sharpest
 statement of that this repository has, and `styleDescriptions.test.ts` pins all
 five side by side so it cannot quietly stop being true.
 
-Dogri is the one worth reading closely, because it is *not* a claim that Dogri
+Dogri is the one worth reading closely, because it is _not_ a claim that Dogri
 does not inflect. Its masculine -आ adjectives take an oblique; none of the three
 clause positions reaches it, because the border and background are feminine and
 the text colour is a direct masculine. A `$role` branch would render what the
@@ -779,7 +788,7 @@ Hebrew's eight. **Tibetan and Dzongkha are the opposite extreme**: ICU reports
 exactly one category for each, so no message in either can select on a count and
 every counted message in both is written flat, the way `locales/ja` and
 `locales/th` write theirs. The `[0]` branches that survive are matched by
-*number* rather than by category — Fluent resolves an explicit number before it
+_number_ rather than by category — Fluent resolves an explicit number before it
 consults the plural rules, which is why a wording for none is still reachable.
 
 Three catalogs put their adjectives **after** the noun — Meitei and both
@@ -791,7 +800,7 @@ split is the shape of the complement, not the side the adjectives sit on.
 `bo` and `dz` are two directories rather than one with a script tag, and it is
 the `hr`-against-`sr` case a fifth time: two standard languages, two
 vocabularies, one script. `locales/dz` writes ཧོནམ where `locales/bo` writes
-སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for *opposite*
+སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for _opposite_
 reasons — see the chemistry paragraph above — which is the neatest illustration
 in the roster that the gap is a fact about a school system rather than about a
 script.
@@ -833,7 +842,7 @@ filled in with the real genders anyway, so that a speaker adding the fork has
 the table already and need only write the feminine forms. And `locales/dv` puts
 `piecewise-condition-if` on the wrong side of the mathematics: Dhivehi's
 conditional particle «ނަމަ» is clause-final and the renderer places that key
-*before* what it introduces, which no wording in the catalog can fix. That is
+_before_ what it introduces, which no wording in the catalog can fix. That is
 the `locales/tpi` shape — a distinction the composition messages do not expose
 — and splitting the key into a prefix and a suffix is a change to the worker
 that no existing catalog needs and this one would use.
@@ -852,7 +861,7 @@ any of the ten and get prose in it. (South African Sign Language, official
 since 2023, is the eleventh and has no written form to seed.)
 
 **Six more Bantu catalogs take the noun-class group from ten to sixteen**, and
-the thing they add is how *unevenly* a class concord lands. `locales/ts` is the
+the thing they add is how _unevenly_ a class concord lands. `locales/ts` is the
 case worth reading: Xitsonga has very few true adjectives, and almost
 everything English calls one is a noun joined with a possessive concord — so
 the class fork falls on «-kulu», «-tsongo» and the passive «-tateriwaka» and on
@@ -869,8 +878,8 @@ agrees with its noun's class through a **suffix**: «ɓaleewol» against a `ngol
 noun, «ɓaleere» against a `nde` one. `$gender` is a token set and nothing
 outside a catalog reads its values, so the argument needed no widening to reach
 a suffix any more than it needed widening to reach a noun class — which is the
-cleanest demonstration this file has that the mechanism is about *what a word
-agrees with* rather than about gender, prefixes, or Bantu.
+cleanest demonstration this file has that the mechanism is about _what a word
+agrees with_ rather than about gender, prefixes, or Bantu.
 
 **Luo and Sango select on neither argument, and they sit between catalogs that
 select on three classes each.** Dholuo is Nilotic and Sango Ubangian; neither has
@@ -878,7 +887,7 @@ gender or noun classes, and `locales/ki` and `locales/bem` on either side of
 them fork on `c3`, `c7` and `c9`. A region says as little about agreement
 as a script does. `locales/luo` adds one thing of its own: its relative
 particle «ma-» is written onto the front of the colour, including when the
-colour is a placeable, which makes it the roster's first *prefix* welded
+colour is a placeable, which makes it the roster's first _prefix_ welded
 onto a value the catalog never sees. That is sound for `locales/tlh`'s reason —
 «ma-» has one shape and never assimilates — and its header records the one case
 that would break it.
@@ -1041,13 +1050,13 @@ Ten of the eleven are the school-system case, in two mediums across eleven
 countries rather than one: English in Ghana, Nigeria and Uganda, French in
 Burundi, Burkina Faso, Côte d'Ivoire and both Congos, and English or French
 depending on the country for Kanuri, which spans four. So in all ten the
-fallback *is* the curriculum, which is a fact about those education ministries
+fallback _is_ the curriculum, which is a fact about those education ministries
 rather than about ten languages.
 
 **Mandinka is the eleventh and the one claim of a different kind.** It is
 spoken across three countries with three different mediums of secondary
 instruction — English in the Gambia, French in Senegal, Portuguese in
-Guinea-Bissau — so there is no one curriculum for a fallback to *be*, and
+Guinea-Bissau — so there is no one curriculum for a fallback to _be_, and
 choosing any of the three would report which side of which border a reader's
 school is on. `locales/se` reached exactly that place between Norway, Sweden
 and Finland; this is the Northern Sami case in West Africa, and it is the first
@@ -1056,7 +1065,7 @@ time a batch's chemistry paragraph has split since the South Asian one.
 ### The batch continued: a creole beside its lexifier
 
 Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne — six more from the same
-region, and where the eleven above were arranged around *where* a language puts
+region, and where the eleven above were arranged around _where_ a language puts
 its agreement, these six are arranged around a sharper question: **what can you
 learn from two catalogs that you cannot learn from either one alone?**
 
@@ -1070,12 +1079,12 @@ that «ya» turns out to be Kongo's class-9 row, frozen. The whole of the
 agreement in `locales/kg` is that one syllable, and the describing stem behind
 it never moves:
 
-| class | linker | black         | thick       |
-| ----- | ------ | ------------- | ----------- |
-| 5     | dya    | dya ndombe    | dya nene    |
-| 7     | kya    | kya ndombe    | kya nene    |
-| 9     | ya     | ya ndombe     | ya nene     |
-| 11    | lwa    | lwa ndombe    | lwa nene    |
+| class | linker | black      | thick    |
+| ----- | ------ | ---------- | -------- |
+| 5     | dya    | dya ndombe | dya nene |
+| 7     | kya    | kya ndombe | kya nene |
+| 9     | ya     | ya ndombe  | ya nene  |
+| 11    | lwa    | lwa ndombe | lwa nene |
 
 Putting `color.black` in the two files side by side is the shortest statement of
 what a creole did to its lexifier that this repository can make, and it cost
@@ -1105,7 +1114,7 @@ in Kabiyè, and as a separate word between the two in Tiv. Three positions, one
 argument, no change to anything outside those files.
 
 **`tem` is the one that can be checked without knowing the language.** Temne's
-concord is *alliterative*: the describing word takes the same prefix the noun
+concord is _alliterative_: the describing word takes the same prefix the noun
 itself carries, so a rendered description reads «kʌlayn kʌbana-bana kʌbana» —
 the same syllable three times. In every other noun-class catalog here the
 concord and the noun's own prefix are different morphs, and `noun-gender` has to
@@ -1130,15 +1139,15 @@ the map lists them, and `kng` because ICU already folds it.
 
 **`ktu` is deliberately absent from that list**, and it is the one exclusion
 here that is not simply "it has a catalog of its own" — though it does. Kituba
-is a creole *of* Kikongo rather than a variety of it, ISO 639-3 gives it a code
+is a creole _of_ Kikongo rather than a variety of it, ISO 639-3 gives it a code
 outside `kg`, and folding it would serve a Kituba reader a different language.
 `mkw`, Kituba of the Republic of the Congo, is left to miss for the same reason;
 answering it with `ktu` would be defensible and is not a membership fact, so it
-is not done. `negotiate.test.ts` asserts the exclusion on the *un-normalized*
+is not done. `negotiate.test.ts` asserts the exclusion on the _un-normalized_
 tag, which is the only form the mistake would be visible in.
 
 **`son` is the road not taken, and the test says why.** It is the macrolanguage
-over the Songhay varieties, and it is *not* aliased the way `man` was, because
+over the Songhay varieties, and it is _not_ aliased the way `man` was, because
 the justification `man`'s entry rests on does not exist here:
 `new Intl.Locale("son").maximize()` adds no region, so CLDR has no opinion about
 which variety a bare `son` means. Picking one would be the judgement these maps
@@ -1156,7 +1165,7 @@ again, and it is not an error.
 All six leave `element-name` and `element-anion-name` out. Four are the ordinary
 school-system case — the DRC, Benin and Togo teach secondary science in French,
 Sierra Leone in English — but `pcm` and `kri` are a shape no earlier batch had.
-Their lexifier *is* English, so the fallback is not merely the curriculum, it is
+Their lexifier _is_ English, so the fallback is not merely the curriculum, it is
 very nearly the language: filling those 130 keys in would produce entries
 character-identical to `locales/en` and claim a translation that had not
 happened. Leaving the gap visible is the honest answer, and it is the
@@ -1174,10 +1183,10 @@ class system, spoken next door to one another — and Umbundu prefixes the class
 straight onto the describing stem while Kimbundu leaves the stem alone and moves
 an agreeing connective in front of it:
 
-| | line (c9) | circle (c7) | point (c5) |
-| --- | --- | --- | --- |
-| `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene |
-| `kmb` | nlonji **ya** nene | kizenge **kya** nene | kimbanza **kya** nene |
+|       | line (c9)          | circle (c7)            | point (c5)            |
+| ----- | ------------------ | ---------------------- | --------------------- |
+| `umb` | ongoli **yi**nene  | ocilinganya **ci**nene | ondimbu **li**nene    |
+| `kmb` | nlonji **ya** nene | kizenge **kya** nene   | kimbanza **kya** nene |
 
 And Kimbundu's mechanism is `locales/kg`'s exactly — an agreeing «-a»
 connective a thousand kilometres north, in another country, differing only in
@@ -1189,7 +1198,7 @@ which makes it a fact about Bantu rather than about creolization.
 
 **`men` is the clearest instance of the affix rule in the tree.** Mende's
 definite marker is a suffix that attaches not to the noun but to whichever word
-*ends* the noun phrase, and a describing word follows its noun here — so a style
+_ends_ the noun phrase, and a describing word follows its noun here — so a style
 description ends in a placeable, and «{ $color }i» is exactly what
 [An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
 forbids. The catalog therefore leaves **every describing word indefinite**, so
@@ -1216,14 +1225,14 @@ for the readers.
 
 #### Negotiation: a second member-shaped macrolanguage, and a road still not taken
 
-`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a *member*
+`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a _member_
 catalog carrying its siblings, rather than a macrolanguage carrying its members.
 `ddn`, `hmb`, `khq`, `ses`, `tda` and `twq` reach Zarma, and ICU folds none of
 them on its own, so every one of those six depends on the entry existing.
 
 **`son` is still not aliased**, and that is the half worth reading. #1686
 recorded the reason when no Songhay catalog existed; Zarma's arrival makes the
-alias *possible* and no more justified. `man` earns its alias because CLDR
+alias _possible_ and no more justified. `man` earns its alias because CLDR
 decides for itself which member a bare macrolanguage means —
 `new Intl.Locale("man").maximize()` is `man-Latn-GM`, Mandinka's country.
 `new Intl.Locale("son").maximize()` adds no region at all, so CLDR has no
@@ -1237,7 +1246,7 @@ reader CLDR expects in Tifinagh is served Latin. That is `locales/kr`'s
 asymmetry with `kby` in Ajami and `locales/ff`'s in Adlam, and the answer is a
 second catalog rather than a change here.
 
-Three codes came *off* negative-control lists this batch — `men`, `umb` and
+Three codes came _off_ negative-control lists this batch — `men`, `umb` and
 `kmb` were all asserted to fall to English until they got catalogs of their own.
 That is the only thing that should ever shorten such a list, and `nyn` set the
 precedent two batches ago.
@@ -1274,19 +1283,19 @@ the translation dropped (`attract-to-without-nearest-point` and its two
 that changed which claim it made ("will **always** match a blank" became
 "matches **only** a blank"), a complaint that reversed
 (`function-domain-insufficient-dimensions` read "dimensions are not
-*required*"), and buttons whose word belonged to a different control — the
+_required_"), and buttons whose word belonged to a different control — the
 orbital spin arrows were labelled with `umb`'s, `kmb`'s and `dje`'s word for
-*point*, three lines from a real points control.
+_point_, three lines from a real points control.
 
 **What review deliberately did not fix is the larger finding**, and it is a
 limit of seeding rather than a bug in these four. Each catalog spreads one
-word across several English concepts that the UI shows *at the same time*:
-`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry *variant*,
-*version*, *type* and *style* together, and `men`'s «wotela» carries
-*variant*, *version* and *variable*, so in all four the editor's version
+word across several English concepts that the UI shows _at the same time_:
+`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry _variant_,
+_version_, _type_ and _style_ together, and `men`'s «wotela» carries
+_variant_, _version_ and _variable_, so in all four the editor's version
 footer and its variant picker are labelled identically. Three of the
-four also head the feedback panel with their word for *answer*, and all four
-use one noun for both *viewer* and *renderer*, so the whole-page failure and
+four also head the feedback panel with their word for _answer_, and all four
+use one noun for both _viewer_ and _renderer_, so the whole-page failure and
 the one-component failure read alike. Separating these needs new words chosen
 by someone who speaks the language; picking them here would be the
 substitution the chemistry tables are left out to avoid. They are named here
@@ -1320,7 +1329,7 @@ branches — Central Mande, and two Southwestern Mande sisters) fork on neither
 already made to seven Mande catalogs in a row; `kpe` and `lom` go further
 than `sus` by lacking even a definite or qualifier suffix, so Southwestern
 Mande genuinely marks nothing where Central Mande and Manding each mark one
-thing. `ewo` and `bum` are the pair that shows agreement can be *present* and
+thing. `ewo` and `bum` are the pair that shows agreement can be _present_ and
 still not written down: both are Beti-Pahuin Bantu with a real class-concord
 system, but `bum`'s header commits to two classes (`c1`/`c7`) it found enough
 colour-stem data to write with confidence, while `ewo`'s header explains why
@@ -1398,7 +1407,7 @@ Guinea depending on which is meant (`bci`, `sus`). `lom` is the one worth a
 sentence of its own: Loma is spoken across a border where the two sides teach
 science in different languages entirely — English in Liberia, French in
 Guinea — so, as `locales/mnk` and `locales/se` already established for a
-border of their own, there is no single curriculum for a fallback to *be*, and
+border of their own, there is no single curriculum for a fallback to _be_, and
 leaving both keys out serves each side of the border the same way English
 already partially does for the Liberian half.
 
@@ -1418,7 +1427,7 @@ forks.** Turkic, Mongolic, Uralic and Iranian all answer the agreement question
 with a flat "no": no grammatical gender, no inflected attributive adjective, so
 `noun-gender` returns one token and no message forks on it. `locales/ce` is
 Nakh, and Chechen has a real class system — nouns fall into classes marked by
-в-, й-, б- and д-, and an agreeing word carries the class at the *front*. So
+в-, й-, б- and д-, and an agreeing word carries the class at the _front_. So
 `locales/ce` writes a class table and forks `style-filled-word` on it, which
 `styleDescriptions.test.ts` pins across two classes. One script, twelve
 catalogs, one fork: a script says as little about agreement as a family or a
@@ -1444,7 +1453,7 @@ and waiting, so filling the table in costs a speaker one line per noun.
 
 **Two catalogs record a colour vocabulary that does not split where the style
 pipeline splits, and they are unrelated.** Sakha's «күөх» covers green and
-blue; Ossetian's «цъæх» covers green, blue *and* grey. The style pipeline needs
+blue; Ossetian's «цъæх» covers green, blue _and_ grey. The style pipeline needs
 those as separate words, so both catalogs write the modern compounds that split
 them — «от күөх» and «халлаан күөҕэ» for Sakha, «кæрдæгхуыз» and «æрвхуыз» for
 Ossetian — and both headers say plainly that this is a choice rather than a
@@ -1460,7 +1469,7 @@ plural perfectly well; what it does not do is keep it after a numeral, so a
 category would have nothing to choose between.
 
 **`locales/cv` is the roster's fourth `zero` category, and the interesting
-comparison is with the one it does *not* match.** `locales/ar`, `locales/cy`
+comparison is with the one it does _not_ match.** `locales/ar`, `locales/cy`
 and `locales/lv` are the other three; Arabic's and Welsh's `zero` fire for
 exactly 0, and so does Chuvash's, with `one` for exactly 1. Latvian's is the
 odd one out — it covers every number ending in 0 and the whole of the teens, so
@@ -1472,7 +1481,7 @@ first (`attempts-remaining`).
 
 **Five catalogs record the same limit, and it is word order rather than family
 that decides which.** `piecewise-condition-if` is placed by the renderer
-*before* the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
+_before_ the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
 Udmurt's «ке», Komi's «кӧ» and Mari's «гын» all close the clause they condition,
 so all five files record the `locales/dv` shape beside the key — a distinction
 the composition messages do not expose, which splitting the key into a prefix
@@ -1533,7 +1542,7 @@ and the Uralic north batches, and `negotiate.test.ts` pins each of them in the
 All twelve leave `element-name` and `element-anion-name` out, and — like the
 second sub-Saharan batch and the African and Berber one — they split no ways at
 all. Secondary chemistry across the Russian Federation is taught in Russian, so
-in all twelve the fallback *is* the curriculum. That is a fact about one
+in all twelve the fallback _is_ the curriculum. That is a fact about one
 education system rather than about twelve languages, which is why it reads as
 one sentence here and takes a sentence of its own in each catalog's header.
 
@@ -1599,14 +1608,14 @@ mechanism is not a class at all — see [The Kurdish pair](#the-kurdish-pair).
 
 **`locales/av` agrees more than Chechen does and still forks nothing, which is
 the sharpest thing in the batch.** Avar has three singular classes and a
-plural, the marker is a *suffix* rather than a prefix, and — unlike Chechen,
+plural, the marker is a _suffix_ rather than a prefix, and — unlike Chechen,
 where the colour and width words take no marker at all — **every attributive
 adjective carries it**. On the face of it every style word in the file should
 fork. None does, because every noun this core names is a thing rather than a
 person and so is class III: `[v]`, `[j]` and `[l]` would be variants nothing
 can select. That is the reachability rule `locales/ve`, `locales/ts`,
 `locales/ki` and `locales/bem` already apply to their unreached Bantu classes,
-arriving for the first time from a language that agrees *more* rather than
+arriving for the first time from a language that agrees _more_ rather than
 less. `locales/lbe` reaches the same place from four classes. `locales/dar` is
 the one of the three whose select is actually written out — `[v]` вицӀибси,
 `[r]` рицӀибси, `*[b]` бицӀибси, with only the last reachable — left standing
@@ -1661,7 +1670,7 @@ that direction is a fact about a script rather than about a language.
 
 #### Negotiation
 
-**`kmr` is a key in `MACROLANGUAGE_MEMBERS` that is a *member* rather than the
+**`kmr` is a key in `MACROLANGUAGE_MEMBERS` that is a _member_ rather than the
 macrolanguage, and still excludes one of its own siblings.** ISO 639-3 gives
 Kurdish three members — `ckb`, `kmr`, `sdh` — and this key names one of them
 and lists a second. `ckb` is left out because it has a catalog of its own, and
@@ -1728,7 +1737,7 @@ Each catalog's header says which language it is.
 #### What the batch could not do, and says so
 
 **`piecewise-condition-if` splits, and the wall is syntax rather than family.**
-The renderer places the key *before* the mathematics it introduces. Abkhaz,
+The renderer places the key _before_ the mathematics it introduces. Abkhaz,
 Adyghe, Kabardian and Lak all mark a condition on a clause-final verb form and
 have no free word to put in front, so all four record the `locales/sah` shape
 beside the key rather than inventing a workaround — the same limit five
@@ -1757,7 +1766,7 @@ so the only group in which the split is visible from the outside.
 
 **`locales/ady` and `locales/kbd` both record a limit the affix rule creates
 from the other direction.** A postnominal adjective in Circassian is normally
-written *together* with its noun as one word, and the noun is a placeable, so
+written _together_ with its noun as one word, and the noun is a placeable, so
 both catalogs write it as a separate word one space away from the compound a
 speaker would write. Splitting the key would not help: the affix belongs to
 whichever word lands last, and that word is a placeable too.
@@ -1799,7 +1808,7 @@ nouns rather than the one the rows spell out.
 **None of the fifteen forks on `$gender`, and the test says so rather than the
 headers.** No Uralic language has grammatical gender, so `noun-gender` returns
 one token in every file — the flat answer eleven of the Russian Federation's
-twelve gave. What is new is that it is *asserted*: the same suite checks that a
+twelve gave. What is new is that it is _asserted_: the same suite checks that a
 catalog's adjectives come out identical whatever noun follows them, which is
 exactly what `locales/inh` and `locales/kmr` fail — their descriptions come out
 in two different shapes depending on the noun — and it turns "this language
@@ -1809,7 +1818,7 @@ noun key can reach; that is the separate thing the "Dagestanian agreement that
 no message can reach" rows pin.)
 
 **Four catalogs do use `$role`, and none of them for gender.** Finnic
-adjectives agree in *case*, so `locales/vep`, `locales/olo`, `locales/krl` and
+adjectives agree in _case_, so `locales/vep`, `locales/olo`, `locales/krl` and
 `locales/fit` fork on the syntactic position the way `locales/fi` does — a
 nominative standing alone, an adessive inside a border clause. `locales/vro` is
 the honest failure beside them and says so in its own header: Võro needs the
@@ -1838,7 +1847,7 @@ speaker can pay it off in a dozen lines.
 
 **`sjd` is the family's fifth, and gets only `one` and `other`.** Kildin Sami
 has a dual as surely as the others do; what it does not have is CLDR plural
-data, so `Intl.PluralRules("sjd")` resolves against the *runtime's* default
+data, so `Intl.PluralRules("sjd")` resolves against the _runtime's_ default
 locale and a `[two]` branch in that catalog would be text nothing could select.
 Its header says so, `chrome.test.ts` pins both halves — the four resolving from
 their own data, `sjd` resolving from something else — and the assertion is made
@@ -1859,19 +1868,19 @@ has ever removed one.** `koi` (Komi-Permyak) was folded onto `locales/kpv` and
 batch, both correct at the time: neither had anywhere else to go, and a reader
 served a neighbouring standard beats a reader served English. The moment each
 had a catalog of its own the fold became the thing the map exists to prevent —
-`applyLanguageAlias` rewrites the tag *before* negotiation, so a `locales/koi`
+`applyLanguageAlias` rewrites the tag _before_ negotiation, so a `locales/koi`
 on disk would have been unreachable while every Komi-Permyak reader kept
 getting Zyrian.
 
 So `kv` was left listing `kpv` alone and `chm` listing `mhr` alone. That was
 `kmr` excluding `ckb` and `mnk` excluding `bam` and `dyu`, arriving for the
-first time as a *removal* rather than as an omission, and `negotiate.test.ts`
+first time as a _removal_ rather than as an omission, and `negotiate.test.ts`
 asserts it as a removal: `koi` and `mrj` reach themselves even when the
 neighbouring standard's catalog is also on offer.
 
 Those two one-member lists are gone now, and their disappearance finished the
 argument this batch started. A list folding a macrolanguage's last unwritten
-member onto a catalog written *in* that member is not a fold at all, so when
+member onto a catalog written _in_ that member is not a fold at all, so when
 the catalogs were renamed to `locales/kpv` and `locales/mhr` both rows became
 `LANGUAGE_ALIASES` entries instead. See [Naming a catalog when a sibling
 member has one too](#naming-a-catalog-when-a-sibling-member-has-one-too).
@@ -1924,7 +1933,7 @@ catalog's header says which language it is.
 #### What the batch could not do, and says so
 
 **`piecewise-condition-if` splits four against eleven, and the wall is syntax
-rather than branch.** The renderer places the key *before* the mathematics it
+rather than branch.** The renderer places the key _before_ the mathematics it
 introduces. Komi-Permyak's «кӧ», Hill Mari's «гӹнь», Khanty's «ки» and Mansi's
 «ке» are all clause-final enclitics, so all four record the `locales/dv` shape
 beside the key rather than inventing a workaround — the same limit
@@ -1952,7 +1961,7 @@ attested**, and each lists its coinages by name in its own header — the
 the least certain of the five Sami catalogs, for `locales/xal`'s reasons:
 severely endangered, small written output, Russian technical nouns where
 written Kildin uses them. `locales/sms` records that a large share of its
-lexicon is *derived* from Northern Sami by regular sound correspondence rather
+lexicon is _derived_ from Northern Sami by regular sound correspondence rather
 than found in Skolt, and names the two words it is least sure of. Correcting
 any of it needs no permission.
 
@@ -1981,8 +1990,8 @@ and territories without a single shared administration between them.
 
 `MACROLANGUAGE_MEMBERS` and `LANGUAGE_ALIASES` are **unchanged**, and after two
 batches that each turned on them that is worth saying rather than passing over.
-The Caucasus batch had to keep `ckb` *out* of a list it had never been in; the
-Uralic north had to take `koi` and `mrj` *out* of lists they were already in.
+The Caucasus batch had to keep `ckb` _out_ of a list it had never been in; the
+Uralic north had to take `koi` and `mrj` _out_ of lists they were already in.
 Here not one of the eleven is a macrolanguage, not one is a member of one, and
 not one was being folded onto a wider code — so every tag reached English on its
 own account before this batch and reaches its own catalog after it.
@@ -1999,7 +2008,7 @@ rows are pinned because the folding is ICU's rather than this repository's.
 This is the first batch of which that is true, and it inverts the Uralic north's
 finding. There, four Sami catalogs wrote a `[two]` branch because their own CLDR
 rules select it and a fifth could not; here the fifth case is the whole batch.
-`Intl.PluralRules` resolves all eleven tags against the *runtime's* default
+`Intl.PluralRules` resolves all eleven tags against the _runtime's_ default
 locale, so a category branch in any of these files would be text selected by
 English's rules on English's terms.
 
@@ -2029,14 +2038,14 @@ that range rather than papering over it:
 - **Translated.** `pon`, `mh`, `chk`, `niu`, `tkl`, `tvl`, `rar`, `wls`, `bi`
   write their own vocabulary throughout, leaning on a published dictionary each
   header names.
-- **Framed.** `kos` and `gil` write a catalog's *frame* in the language —
+- **Framed.** `kos` and `gil` write a catalog's _frame_ in the language —
   «Tia ku in…», «Wangin…», «ke sripen» — around English technical nouns, and
   say so.
 
 **A third tier was seeded and then dropped from the batch, which is worth
 recording rather than losing.** Nauruan (`na`), Yapese (`yap`), Palauan (`pau`)
 and Rotuman (`rtm`) began as correct frames with the whole technical lexicon
-declared as English loans, and a later pass recovered their *basic* vocabulary —
+declared as English loans, and a later pass recovered their _basic_ vocabulary —
 colour terms, thick and thin, the geometric nouns — from Josephs, Churchward and
 Jensen. That recovery reached `content.ftl` and stopped there, because the style
 tables are single words and the other three namespaces are sentences: their
@@ -2049,7 +2058,7 @@ variant key is in place in them, so nothing structural stands in the way; what
 they need is words.
 
 No word went in by guess. Where a dictionary gave nothing the English loan
-stands and is *declared* a loan rather than respelled by an invented loan
+stands and is _declared_ a loan rather than respelled by an invented loan
 phonology — `locales/kos` argues that case explicitly, on the grounds that
 `b c d g h j q v x z` are not Kosraean letters, so a loan should stay visibly a
 loan. `styleDescriptions.test.ts` pins the words that are the language beside
@@ -2076,7 +2085,7 @@ reach `[noun-tail]`, which is the widest use `[noun-tail]` has had in one batch.
 The other three fold it into the head: `mh`, `gil` and `tkl`, each because its
 own grammar puts it there. `tkl` is the interesting one, because it is
 Tuvaluan's closest relative here and `tvl` went the other way — a disagreement
-*inside* a subfamily, which no earlier batch's had, and both files state their
+_inside_ a subfamily, which no earlier batch's had, and both files state their
 choice so a reviewer can tell it is deliberate.
 
 A catalog that reaches `[noun-tail]` has to place the tail the same way in
@@ -2128,7 +2137,7 @@ nothing where it does not, and the seed cannot always tell which.
   `locales/ty` takes French ones.
 - Twelve near misses, and the Pacific's are sharper than the north's because its
   language boundaries do not follow its political ones. `kpg` and `nkr` are
-  *Polynesian* languages spoken inside the Federated States of Micronesia, so
+  _Polynesian_ languages spoken inside the Federated States of Micronesia, so
   neither the country's catalogs nor the family's is the right answer. `fud`
   (East Futunan) is this batch's `fkv` and sharper than `fkv` was: it is not
   merely a sister of a catalogued language but is spoken in the **same
@@ -2143,7 +2152,7 @@ nothing where it does not, and the seed cannot always tell which.
 
 Every string is machine-generated and unread by a speaker, and each catalog says
 so in its own header. Beyond the confidence scale above, `locales/chk` names
-«pwóón» — its word for *answer*, the highest-frequency word in the catalog — as
+«pwóón» — its word for _answer_, the highest-frequency word in the catalog — as
 one it could not confirm, and `locales/gil` names its colour line as its least
 certain. Each catalog lists its own coinages, and correcting any of it needs no
 permission.
@@ -2160,7 +2169,7 @@ Piedmontese (`pms`) and Neapolitan (`nap`); **Slavic** — Upper Sorbian
 It is the first batch assembled as **three families of five in one continent**
 rather than around an ocean, a script, a state or a family, and the shape is
 not decoration: nearly everything below divides along it, and the two places
-where it does *not* are the interesting ones.
+where it does _not_ are the interesting ones.
 
 #### One complete catalog, and fourteen school systems
 
@@ -2178,11 +2187,11 @@ Piedmont and Campania; in Standard German in German-speaking Switzerland and
 the Rhineland; in Dutch in Limburg; in Polish in Pomerania and Upper Silesia;
 in German in Lusatia; in English in Scotland; and in Slovak, Polish or
 Ukrainian across Rusyn's range depending on the state. So in all fourteen the
-fallback *is* the curriculum, and `locales/it`, `locales/de`, `locales/nl`,
+fallback _is_ the curriculum, and `locales/it`, `locales/de`, `locales/nl`,
 `locales/pl` and `locales/sk` are the parallel texts each header names.
 
 `locales/sco` is the batch's plainest case of it. For the other thirteen a
-school-system gap means the reader meets the table in a *neighbouring*
+school-system gap means the reader meets the table in a _neighbouring_
 language — a Friulian pupil in Italian, a Sorbian one in German. A Scots
 speaker meets it in **the fallback language itself**, which is not new in the
 roster: `pcm` and `kri` are the same coincidence for two English-lexified
@@ -2191,7 +2200,7 @@ language](#the-chemistry-gap-and-the-case-where-the-fallback-is-the-language)),
 and every catalog whose school system teaches in English — `gil`, `tpi`, `mh`,
 `tkl`, `tvl`, `niu` and `bi` among them — falls back to the language of the
 classroom rather than of a neighbouring state. What is particular to Scots is
-that English is also its *sister* language, which is the difficulty
+that English is also its _sister_ language, which is the difficulty
 `locales/sco`'s header is written around.
 
 #### The plural split, and three categories no catalog here had
@@ -2219,8 +2228,8 @@ fourth has one it deliberately leaves unwritten:
   the note on `dsb` beside `hsb` below.
 - **`ksh` writes a `zero`.** Colognian is the only locale in the batch whose
   own rules select one, and its header spells out the distinction that makes it
-  safe: an explicit `[0]` is matched against the *number*, a `[zero]` against
-  the *category*, and writing both into one selector would be two mechanisms
+  safe: an explicit `[0]` is matched against the _number_, a `[zero]` against
+  the _category_, and writing both into one selector would be two mechanisms
   competing for the same input. So the branch goes where English leaves a real
   count with no `[0]` already standing on it — `help-suggestions-footer` in
   `locales/ksh/editor.ftl` — and `attempts-remaining` keeps English's literal
@@ -2234,7 +2243,7 @@ fourth has one it deliberately leaves unwritten:
 three really do have a `few`/`many` split of their own. The branch that could
 be written is exactly the branch that would be got wrong.
 
-#### The batch that needed nothing from the maps, and the row that had to *stay*
+#### The batch that needed nothing from the maps, and the row that had to _stay_
 
 `MACROLANGUAGE_MEMBERS` and `LANGUAGE_ALIASES` are **unchanged**. Not one of
 the fifteen is a macrolanguage, not one is a member of one, and not one was
@@ -2255,7 +2264,7 @@ Those rows are pinned because the folding is ICU's rather than this
 repository's.
 
 **Alsatian is this batch's near miss that is not one.** `gsw-FR` is Alsatian,
-and ISO puts it *inside* `gsw` rather than beside it, so an Alsatian reader
+and ISO puts it _inside_ `gsw` rather than beside it, so an Alsatian reader
 reaches `locales/gsw` and is served the Zurich-based koine that catalog is
 written in. That is the trade region-stripping already makes for `es-MX`, and
 `locales/gsw`'s header says which variety it is so a reader can tell what they
@@ -2263,10 +2272,10 @@ were served.
 
 Twenty-one tags are left to miss, and this batch's near misses are the densest
 the roster has had, because Europe's regional languages sit in continua rather
-than on islands: `bar`, `swg` and `wae` beside `gsw` — `wae` spoken *inside
-Switzerland* and still a language with a code of its own; `pfl` and `yec`
+than on islands: `bar`, `swg` and `wae` beside `gsw` — `wae` spoken _inside
+Switzerland_ and still a language with a code of its own; `pfl` and `yec`
 beside `ksh`; `stq`, `frr`, `vls` and `zea` beside `li`; `lmo`, `rgn`, `cim`
-and `mhn` among the five Romance catalogs, with `cim` and `mhn` being *Germanic*
+and `mhn` among the five Romance catalogs, with `cim` and `mhn` being _Germanic_
 languages spoken inside Italy, so neither the country's catalogs nor the
 family's is the right answer; `mwl`, `ext`, `an` and `wa`; `sgs` and `ltg`;
 `pdc` and `hrx`.
@@ -2319,7 +2328,7 @@ existing catalog, and every one of the six is argued in a header instead.
   «ikkje», «kva», «frå», «eit», «sida», «berre», «nokon», «fleire».
 - **`dsb` beside `hsb`** is the batch's `tkl`/`tvl`: two standards close enough
   that a seed reading one while writing the other will reproduce its choices,
-  so the two catalogs are *expected* to look alike and **their agreement is not
+  so the two catalogs are _expected_ to look alike and **their agreement is not
   evidence either is right**. `locales/dsb`'s header names its own largest risk
   outright — the Upper-to-Lower correspondences («hdyž»→«gaž»,
   «dokelž»→«dokulaž», «dyrbi»→«musy», «njemóžu»→«njamóžom») are regular enough
@@ -2331,10 +2340,10 @@ existing catalog, and every one of the six is argued in a header instead.
   everyday words where the two part company, because those are what a reviewer
   can check in a second.
 - **`sco` beside `en`** is that shape at its limit. English is Scots's sister
-  language *and* its roofing language, so a seed with nothing to say falls into
+  language _and_ its roofing language, so a seed with nothing to say falls into
   English without anything looking wrong. `locales/pcm`, `locales/kri` and
   `locales/bi` meet the same trap from the other side, as creoles English
-  lexified; what no other catalog has is a *sister* language that is also the
+  lexified; what no other catalog has is a _sister_ language that is also the
   roof. `locales/sco`'s header answers it the way `locales/bi` answers it for
   an English-lexified creole: a word is written
   there because a Scots dictionary has it, not because it differs from English,
@@ -2493,7 +2502,7 @@ language with no macrolanguage over it; `srh` (Sarikoli) and `yah`
 (Judeo-Tat) beside `locales/ttt`, which `locales/ttt`'s header explicitly
 names as a separate written tradition rather than a variety of itself.
 
-**`prs` is the one that needs saying because it is *not* a near miss.**
+**`prs` is the one that needs saying because it is _not_ a near miss.**
 `Intl.getCanonicalLocales("prs")` returns `fa-AF`, so a Dari reader
 region-strips to `locales/fa` today and gets Iranian Persian. That is exactly
 the fact `locales/haz`'s chemistry argument turns on, below.
@@ -2523,7 +2532,7 @@ alike leave a noun unmarked after a numeral.
 not a count.** Ten catalogs — every one of the fifteen except `alt`, `kaa`,
 `kjh`, `ttt` and `sgh` — write exactly one `[one]`, and all ten write it in the
 same message: `field-function-wrong-num-outputs`, which forks on how many
-outputs a component *needs* ("one output" against "two outputs") rather than on
+outputs a component _needs_ ("one output" against "two outputs") rather than on
 a quantity the reader is looking at. `alt`, `kaa` and `kjh` write that same
 fork as the numeric literal `[1]`, which Fluent matches against the number
 before consulting any plural rule and which therefore does not depend on whose
@@ -2552,7 +2561,7 @@ teaches the periodic table in another language. The mediums are listed in
 [Catalog layout](#catalog-layout) above. Two of the twelve add something to
 that argument:
 
-- **`locales/haz`'s gap is a *missing sibling* rather than a missing list.**
+- **`locales/haz`'s gap is a _missing sibling_ rather than a missing list.**
   Hazaragi is a variety of Persian, so
   a Persian table is exactly the kind of loan the three below ship — but the
   table a Hazara pupil meets is the **Dari** one, which differs from
@@ -2575,11 +2584,11 @@ The complete tables the roster already had were each a language's own list —
 Afrikaans's, Bosnian's, Swahili's — or, in
 `locales/jv` and `locales/su`, an adapted one: those two take the Indonesian
 names their schools' textbooks print, but their `element-name` tables are
-*not* `locales/id`'s, because both keep their own words for the substances
+_not_ `locales/id`'s, because both keep their own words for the substances
 known long before the elements were. These three copy a neighbour's table
 **unchanged**, and argue for it: chemistry in Māzandarān, Gilan and Lorestan is **taught, examined and
 printed in Persian**, so the settled, checkable list of 118 names a
-Mazanderani, Gilaki or Luri speaker actually reads and writes *is* the Persian
+Mazanderani, Gilaki or Luri speaker actually reads and writes _is_ the Persian
 one. It is a loan the language genuinely uses rather than a nomenclature this
 seed invented, which is the only kind of table it may ship — and it serves a
 reader better than English, which is neither their school language nor their
@@ -2659,7 +2668,7 @@ welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable).
 invariant shape, so this is `{ $numSides }-kulmio`'s adjacency rather than
 `locales/tg`'s agreement, and all three of `locales/wbl`'s headers that
 mention the postpositions now say which of the two it is. `locales/gag` is the
-one place in the batch where the distinction had to be *acted* on: a Gagauz
+one place in the batch where the distinction had to be _acted_ on: a Gagauz
 ordinal suffix harmonizes with the vowels of the spoken numeral — «beșinci»
 but «dokuzuncu» — which a digit does not show, so the line and row numbers are
 written with a period after the figure, `{ $line }. satır`, exactly as
@@ -2681,11 +2690,11 @@ masculine and feminine, and spends the agreement in the `noun` table, so the
 attributive adjectives after the ezafe are invariable and nothing is left to
 fork. `locales/sgh` is the honest failure: Shughni distinguishes gender in the
 demonstratives, in some nouns and in parts of the verb, and its header says in
-as many words that the seed cannot assign the right gender to *line*, *curve*
-and *region* and would rather leave the agreement flat than get it wrong in
+as many words that the seed cannot assign the right gender to _line_, _curve_
+and _region_ and would rather leave the agreement flat than get it wrong in
 eighty places — with the note that the machinery is already wired for a
 speaker who fills `noun-gender` in. `locales/wbl` is a third shape again: it
-declines to write down "no gender" as a *finding*, because the Pamir languages
+declines to write down "no gender" as a _finding_, because the Pamir languages
 differ here, and says what it is actually confident of, which is that it has
 no reliable table to fork with.
 
@@ -2734,7 +2743,7 @@ or for software. All three tell a reviewer to expect to be **rewriting
 sentences, not correcting typos**. `locales/haz` records the mirror image:
 most of its vocabulary is shared with Dari word for word, and **a Dari word in
 that file is not an oversight** — the two places Hazaragi's own usage shows
-are «قد» for *with* and «بلدِ» for *for*.
+are «قد» for _with_ and «بلدِ» for _for_.
 
 **`locales/sgh` keeps a loan register for two whole namespaces.** Its
 `diagnostics.ftl` header says that Shughni has no written register for
@@ -2742,7 +2751,7 @@ compiler diagnostics at all, that a Shughni speaker who reads an error message
 reads it in Tajik or Russian, and that the file therefore keeps **that loan
 register** rather than inventing a Shughni one: the wording is Tajik almost
 throughout, with the Russian internationalisms Tajik itself uses, and **only
-the conjunctions are Shughni** — «ат» for *and*, «йо» for *or*. It calls
+the conjunctions are Shughni** — «ат» for _and_, «йо» for _or_. It calls
 itself a usable frame and not yet Shughni prose. That is the Oceania batch's
 "framed" tier stated for two whole namespaces rather than for a vocabulary.
 
@@ -2774,6 +2783,235 @@ reviewer to assume every line needs work.**
 Every string in all fifteen is machine-generated and unread by a speaker, and
 each file says so at the top. Correcting any of it needs no permission.
 
+### Fifteen catalogs of the Americas, and the line the lexifier draws
+
+The roster goes from 286 locales to 301: Kalaallisut (`kl`) and Inuktitut
+(`iu`) in the north; Yucatec Maya (`yua`), Qʼeqchiʼ (`kek`), Garifuna (`cab`)
+and Mískito (`miq`) in Mesoamerica and on the Caribbean coast of Central
+America; and **nine creoles** — Papiamentu (`pap`), Sranan Tongo (`srn`),
+Jamaican Creole (`jam`), Guadeloupean Creole French (`gcf`), Saint Lucian
+Creole French (`acf`), Guianese Creole French (`gcr`), Belize Kriol (`bzj`),
+Aukan (`djk`) and Saramaccan (`srm`).
+
+Nine of fifteen makes this the first batch a _contact_ language dominates, and
+that is what most of its properties turn out to be about. A creole is a hard
+case for nearly every list in this package: it belongs to no macrolanguage,
+CLDR mostly does not name it, its technical vocabulary comes from a language it
+is not a variety of, and two creoles of one lexifier can converge on a phrase
+without being one catalog.
+
+#### Six languages that could not be seeded, and why they are not here
+
+The batch was assembled as fifteen and six of the first fifteen were dropped:
+Navajo (`nv`), Cherokee (`chr`), Lakota (`lkt`), Mohawk (`moh`), Plains Cree
+(`cr`) and Miʼkmaq (`mic`). Seeded honestly they came to **6, 13, 16, 20, 26
+and 13 keys of 575** — against the 445 the rest of the batch reaches — and
+they were replaced by the six creoles rather than shipped at that size. The
+reasoning is recorded in #1655, which is the issue for all six, but one part of
+it belongs here because it bears on every future batch:
+
+**A loan register is only honest where a loan register exists.** `locales/sgh`
+records that a Shughni speaker reads a compiler error in Tajik or Russian and
+keeps that register openly, and this batch does the same thing nine times over
+— Danish in `kl`, Dutch in `srn` and `djk`, French in the three
+French-lexifier creoles. It does **not** transfer to Navajo or Mohawk. There
+is no Navajo technical register to record: a speaker doing mathematics does it
+in English and does not Navajo-ize _polygon_. Writing «pálagan» would not be a
+loan register but English respelled, which reads as translation to a tool, as
+noise to a speaker, and which a reviewer has to delete before they can begin.
+That is worse than the English fallback, which at least announces itself. The
+rule the batch settled on: **carry a loan register where speakers already carry
+one, and leave the key out where they do not.**
+
+`locales/iu` is the same judgement applied inside a catalog rather than to
+one — see the coverage note below.
+
+#### Coverage: thirteen at the ceiling, and one that stops short on purpose
+
+Thirteen of the fifteen sit at **445/575**, which is the whole catalog minus
+the two chemistry tables and the same figure the Silk Road batch reached.
+`pap` is there too. The chemistry reason is the school-system one for all
+fifteen and is stated in each `content.ftl` header: science is taught in Dutch
+in Curaçao, Bonaire and Suriname, in Danish in Greenland, in Spanish in Yucatán
+and Alta Verapaz, in French in Guadeloupe and French Guiana, and in English in
+Belize, Jamaica and Saint Lucia. In none of the fifteen is the fallback a
+guess about the language; it is the language the periodic table is actually
+taught in.
+
+**`iu` is at 373/575, and the 72-key difference is one decision.** Inuktitut
+has no settled syllabic forms for _matrix_, _interval_, _domain_, _variant_,
+_index_, _row_ or _column_, so the catalog writes those few technical nouns in
+roman letters inside a syllabic sentence — the `sgh` move — but it **omits the
+`noun` table whole**, all twenty geometry names, rather than doing the same
+thing twenty more times. Writing "line segment" in roman letters inside an
+Inuktitut catalog raises the coverage number without giving the reader anything
+the English fallback did not already give them. That is the one place in the
+roster where a catalog's own header argues that a _lower_ number is the better
+answer, and it is why `iu` is named separately in the count of partial catalogs
+above.
+
+The visible consequence is worth knowing before it surprises someone: a style
+description in Inuktitut comes out as «line thick dashed ᐊᐅᐸᖅᑐᖅ», three
+English words and a syllabic colour. That is the fallback working, not a bug,
+and `styleDescriptions.test.ts` leaves `iu` out of both word-order tables for
+exactly that reason — asserting an order over a phrase three quarters of which
+is English would be asserting English's order.
+
+#### Word order: the lexifier decides, and `pap` is the one that surprises
+
+Seven catalogs put the modifiers in front of the noun and seven put them
+behind, and **the line is drawn by the lexifier rather than by geography**. The
+English- and Dutch-lexifier creoles are prenominal — `jam`, `bzj`, `srn`, and
+the two Maroon creoles `djk` and `srm` — and so are `yua` and `kek`, which are
+Mayan and prenominal on their own account. The three French-lexifier creoles
+(`gcf`, `acf`, `gcr`) are postnominal because French is, and `cab` and `miq`
+because Garifuna and Mískito are.
+
+**`pap` is the one that would be guessed wrong from its neighbours.** It sits
+with the French-lexifier creoles rather than with the English- and
+Dutch-lexifier ones it shares a sea with, because its vocabulary is Iberian and
+an Iberian adjective follows its noun: «liña diki di strepi kòrá», the noun
+first.
+
+`kl` is the seventh postnominal catalog and is not a lexifier case at all.
+Kalaallisut builds the phrase by suffixing, so what comes out is a noun
+followed by agreeing participles — «titarneq silissooq avissaartorsimasoq
+aappaluttoq» — and the description is the _tail_ of the phrase rather than its
+head, which is the shape `style-with-noun` needs to be read against.
+
+#### Negotiation: the map's third kind of exclusion
+
+`MACROLANGUAGE_MEMBERS` gained exactly **one** entry, and it is there to record
+an exclusion rather than to rescue a member.
+
+`iu` is the only macrolanguage among the fifteen, and ISO 639-3 gives it two
+members: `ike` (Eastern Canadian Inuktitut) and `ikt` (Inuinnaqtun). ICU folds
+`ike` on its own, so `iu: ["ike"]` changes no negotiation result — it is the
+`quz` and `ojg` shape, a member written down so the list is the whole of a
+group. **`ikt` is left out, and the reason is the script**: Inuinnaqtun is
+written in roman letters and `locales/iu` is written wholly in syllabics, so
+folding it would hand a reader a catalog in a script they do not read. This map
+now excludes members for three different reasons, and they are worth keeping
+apart: `kbl` under `kr` and `alq` under `oj` because published membership does
+not cover them; `bam` and `dyu` under `mnk` because they have catalogs of their
+own; and `ikt` because the catalog cannot serve a member membership _does_
+cover.
+
+**Nine creoles and not one macrolanguage question between them.** That is the
+structural fact behind this section: a creole is not a member of its lexifier,
+so nothing folds `gcf` onto `fr` or `jam` onto `en`, and nothing should.
+`negotiate.test.ts` asserts the reverse direction as well — French stays on
+French — because the tempting mistake is to treat a lexifier catalog as a
+fallback for a creole that has none.
+
+`iu` maximizes to `iu-Cans-CA`, so CLDR and the catalog agree about the script
+and a reader arriving under a bare `iu` gets syllabics. `iu-Latn` is the `pa`,
+`sr` and `ha` asymmetry, and the answer to it is a second catalog rather than a
+rename of this one. The other fourteen maximize to `-Latn`.
+
+#### Nine names CLDR does not have, and nine endonyms
+
+`LOCALE_NAME_FALLBACKS` gained **nine** entries — `yua`, `cab`, `miq`, `gcf`,
+`acf`, `gcr`, `bzj`, `djk` and `srm` — which is more than any batch before it
+and is a fact about which languages CLDR carries rather than about how many
+speak these. ICU names `kl`, `iu`, `pap`, `srn` and `jam` and stops there; six
+of the nine gaps are creoles, and the three creoles ICU _does_ name are the
+three with national or quasi-official standing.
+
+Every one of the nine gets an endonym, which is where this block parts company
+with the Silk Road's. Each of these catalogs names its language exactly one way
+in all four of its files, so there is nothing to choose between and
+`locales/olo`'s admitted-gap shape — a label reading "Livvi-Karelian (olo)" —
+is needed nowhere here. The spellings are copied letter for letter from the
+catalogs' own headers, so a corrector who respells a catalog must respell its
+roster label with it.
+
+#### Plurals: three catalogs with rules, and the roster's fifth dual
+
+Three of the fifteen have CLDR plural data of their own — `iu`, `kl` and `pap`
+— and the other twelve resolve to the runtime's default locale, so any category
+branch they wrote would be selected by English's rules on English's terms. All
+twelve therefore write one unselected form wherever English forks a count.
+
+**`iu` is the reason that matters.** Inuktitut's rules give it `one`, `two` and
+`other`, and `attempts-remaining` writes all three with a different ending in
+each: ᐆᒃᑐᕐᓂᒃᓴᖅ, ᐆᒃᑐᕐᓂᒃᓵᒃ, ᐆᒃᑐᕐᓂᒃᓴᐃᑦ. Four catalogs on the roster had a
+`[two]` before it — `hsb`, `dsb` and two Sami catalogs — and none of them is in
+the Americas. A dual that repeated the plural would be a branch that renders
+and says nothing, which is the same defect as a `[one]` in a locale that cannot
+select one, met from the other side, so the test asserts the three forms differ
+rather than merely that three branches exist.
+
+#### One character, and the homoglyph question in a new form
+
+`locales/yua` and `locales/kek` state in their headers that the glottal stop
+and the ejectives are written with **U+02BC MODIFIER LETTER APOSTROPHE**
+throughout. In Mayan orthography that mark is a letter, not punctuation, and
+its look-alikes are U+2019 and ASCII U+0027 — indistinguishable on screen,
+substituted silently by any editor with smart quotes, and fatal to a search.
+`catalogLint.test.ts` holds both catalogs to it, the way it holds `alt`, `kjh`
+and `dng` to their Cyrillic inventories.
+
+The straight ASCII apostrophe is deliberately **not** forbidden there, and the
+reason is worth recording because it is the kind of thing a later tightening
+would get wrong: English's own messages quote enumerated values with straight
+quotes and write the derivative as `y'`, and both come through a translation
+unchanged. It is the curly one that would be a silent respelling of a Mayan
+letter.
+
+Two more claims of the same checkable kind: `locales/iu` writes no ᐦ (U+1426),
+the Cree final, since the Nunavut inventory uses ᕼ (U+157C) — a check that
+matters precisely because the batch ships no Cree catalog for it to have been
+copied from — and `locales/srm` allows exactly one accented letter beyond its
+`ë`/`ö` vowels, «á», the preverbal negator, whose accent marks the word rather
+than a tone. Saramaccan is tonal and this seed writes no tone at all; the
+headers say so in all four files, because a half-restored tone system would be
+worse than a stated absence.
+
+#### Two catalogs that agree, and are not one catalog
+
+`jam` and `bzj` produce the same words for a styled line — «tik dash-dash red
+lain» — and the same boolean words, «chruu» and «faals». Both are
+English-lexifier creoles written in a phonemic orthography, so short everyday
+words converge; that is the language, not a copy. What would be worth catching
+is a catalog duplicated under two tags, so the test asserts a _rate_ rather
+than a difference: two fifths of the values the two both define differ, and
+across all four namespaces four fifths do.
+
+The French-lexifier trio is the same question with a sharper answer. `gcf` and
+`gcr` render this phrase identically — the two languages agree on all four
+words — while `acf` differs by one sound, the etymological French /r/ that
+Saint Lucian writes «w»: «tiwè» against «tirè». Underneath, the three are not
+close: `gcr` writes the indefinite «roun» 129 times in its diagnostics where
+`gcf` writes it 4, and only 14 of their 203 shared diagnostics are identical.
+The three headers name the conventions that separate them, so a reviewer can
+tell an intrusion from a coincidence.
+
+#### What the headers admit
+
+Each catalog records where it stands. `locales/cab` marks itself the least
+certain of the fifteen and names the specific words — the colour terms
+«haruti», «wuriti», «funati» and the pair «buiti»/«mabuiti» — a speaker should
+check first. `locales/miq` records that its conditional marker «kaka» is
+clause-final in Mískito while the renderer places it before the inequality, so
+the message reads out of position: a defect in the composition rather than in
+the words, and one only a speaker could have spotted. `locales/jam` flags
+«pwaint» for _point_, built on Cassidy's «bwai» because English /ɔɪ/ has no
+letter in the five-vowel system, as the single most-repeated uncertain form in
+the catalog. `locales/gcr` records that it writes the equative «sé» throughout
+where Guianese also uses «sa».
+
+Three of the fifteen commit to an orthography over a live alternative and say
+so: `pap` writes the phonological spelling of Curaçao and Bonaire over Aruba's
+etymological one, `jam` the Cassidy–JLU system over the English-based spelling
+most written Jamaican actually uses, and `bzj` the National Kriol Council
+orthography over the same ad-hoc English practice. All three say the same
+thing about it — a reviewer who prefers the other system should **respell
+rather than retranslate**, and must convert all four files at once.
+
+Every string in all fifteen is machine-generated and unread by a speaker, and
+each file says so at the top. Correcting any of it needs no permission.
+
 ### A language with no word for it
 
 `tlh` is **Klingon**, and it is the roster's first constructed language. Nothing
@@ -2782,7 +3020,7 @@ an ISO 639-3 code, so it filters like any other individual language, needs no
 entry in `LANGUAGE_ALIASES`, and belongs to no macrolanguage. `Intl` knows the
 English name, so the roster reads **Klingon** — once, not twice, because CLDR
 has no `tlh`-language data to answer the endonym with and the fallback is the
-English name. That is the `co` case, with the twist that Klingon *has* a
+English name. That is the `co` case, with the twist that Klingon _has_ a
 well-known endonym («tlhIngan Hol») and CLDR simply does not carry it.
 
 pIqaD is ISO 15924 `Piqd`, so `tlh-Piqd` is a well-formed tag and reaches the
@@ -2793,7 +3031,7 @@ pIqaD. Quenya (`qya`), Sindarin (`sjn`) and the ISO 639-2 collection code `art`
 all fall to English, which is the membership rule working rather than a gap in
 it — none of them is a member of `tlh`. `negotiate.test.ts` holds all of that.
 
-What *is* new is the **shape of the gap**. Every other partial catalog leaves
+What _is_ new is the **shape of the gap**. Every other partial catalog leaves
 out the chemistry tables because a school system teaches chemistry in another
 language; the language has the words and the seed has no settled list to copy.
 Klingon is the first partial for a lexical reason — its lexicon is closed, since
@@ -2806,7 +3044,7 @@ The line it draws is stated once in `content.ftl` and applied everywhere:
 > description, and is written. A new root is an invention, and is not.
 
 Under it «nagHom» — «nagh» (rock) with the canon diminutive — is a fair way to
-say *dot*, and a word for *parabola* is not a translation of anything. It is the
+say _dot_, and a word for _parabola_ is not a translation of anything. It is the
 argument `locales/oj` already makes about coining 118 element names, generalized
 from one table to a whole catalog.
 
@@ -2817,9 +3055,9 @@ has released a mathematics register over the years, well after TKD, so «mey'»
 (point), «baSta'» (vector) and «chav» (function) all exist and are all used. So
 are «wa'chaw» (table), «wev» and «war» (row and column), «tenwal» (page) and
 «vorgh» (be previous), each of which an earlier draft either coined around or
-left to English. What is genuinely absent is smaller and stranger: *parabola*,
-*polyline*, *curve* as a noun, and the vocabulary of a document editor —
-*attribute*, *variant*, *matrix*, *snippet*, *accessibility*. **The lesson
+left to English. What is genuinely absent is smaller and stranger: _parabola_,
+_polyline_, _curve_ as a noun, and the vocabulary of a document editor —
+_attribute_, _variant_, _matrix_, _snippet_, _accessibility_. **The lesson
 generalizes past Klingon: "this language has no word for X" is a claim about a
 word list, and it needs checking against the word list.**
 
@@ -2831,7 +3069,7 @@ four colour terms are TKD entries. Some are Okrand's own but were released at a
 `qep'a'` or `qepHom'a'` gathering or posted to the old `startrek.klingon`
 newsgroup: «meyrI'», «me'cheD», «baSta'», «chav» in its mathematical sense,
 «vorgh», «wa'chaw», «wev», «war», «tenwal» and «nItlh 'echlet» (keyboard). And
-three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a *single*
+three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a _single_
 relayed answer on the KLI mailing list, one post of 2014.01.27, with no second
 attestation; «ghantoH» (example) and «nompuq» (reference) are the same. All
 three classes are used and none is removed, but the catalogs mark the third
@@ -2842,7 +3080,7 @@ is still his, and what a reader has to go on is one paraphrase. Telling them
 which entries those are is what lets a speaker overrule the right ones.
 
 `.diamond` is the instructive omission, because it is not a lexical gap at all.
-Okrand's note on «chanmon» (the gemstone) says the diamond *shape* is «meyrI'»,
+Okrand's note on «chanmon» (the gemstone) says the diamond _shape_ is «meyrI'»,
 which the catalog already spends on `square`. Writing it would make a square
 marker and a diamond marker report identically — the one distinction a shape
 noun exists to carry — so the key falls back to English instead. That is the
@@ -2901,7 +3139,7 @@ every consumer whether or not anyone reads it, and no single language earns
 that. English is exempt because every fallback chain ends there: it has to be
 present with no network, in every bundling variant.
 
-Note that `content` and `diagnostics` answer to *different* settings —
+Note that `content` and `diagnostics` answer to _different_ settings —
 `documentLocale` and `uiLocale` respectively — which is why `WORKER_NAMESPACES`
 is `content` alone. The worker knows only the content locale, and needs only
 that: it renders `content` itself, but for a diagnostic it emits a code and the
@@ -2938,7 +3176,7 @@ would offer the author English and nothing else.
 
 Neither list is exhaustive from an author's point of view: a deployment can
 hand over catalogs of its own as `localeResources`, which no build-time list
-can know about. So the roster *suggests* and never *enforces* — `lang` accepts
+can know about. So the roster _suggests_ and never _enforces_ — `lang` accepts
 any BCP-47 tag, and an unlisted one draws no diagnostic.
 
 ## Delivery
@@ -2946,7 +3184,7 @@ any BCP-47 tag, and an unlisted one draws no diagnostic.
 A locale that is not inlined still has to reach the browser. `load.ts` does
 that, and the viewer calls it for you: `useLocaleCatalogs` (in
 `@doenet/doenetml`'s `utils/i18n.tsx`) loads the catalogs for whatever tags are
-in play and merges them *under* the host's `localeResources`, so a deployment
+in play and merges them _under_ the host's `localeResources`, so a deployment
 correcting a shipped translation still wins. Adding `locales/pt/` and running
 `npm run codegen` is therefore the whole job — no list of languages to register
 anywhere, and `documentLocale="pt"` and `<document lang="pt">` both work with
@@ -2978,17 +3216,17 @@ catalogs to get one.
 Where the catalogs come from depends on the build, and the difference is real
 rather than cosmetic:
 
-| Build                     | Mechanism                                              |
-| ------------------------- | ------------------------------------------------------ |
-| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog   |
-| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle       |
-| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`           |
+| Build                     | Mechanism                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog                               |
+| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle                                   |
+| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`                                        |
 | `@doenet/doenetml-iframe` | Neither: what renders inside its iframe is a standalone bundle, which loads its own |
 
 The glob is what makes adding a language cost a directory. It is also why two
 builds need a different answer. The worker is one file — an IIFE started from
-a blob URL in some variants — so it cannot code-split, and *being reachable is
-enough*, whether or not anything calls it, to fold every catalog in. The
+a blob URL in some variants — so it cannot code-split, and _being reachable is
+enough_, whether or not anything calls it, to fold every catalog in. The
 standalone build is code-split, but serves its catalogs as plain
 runtime-fetched files all the same: as served assets they can be
 version-pinned, and the single-file `doenet-standalone-inline.js` variant
@@ -3056,7 +3294,7 @@ catalogs a context loads. `lint:i18n` enforces that.
 ### A variant key is an interface, not prose
 
 A key is not the only identifier a catalog has to leave alone. Fluent matches a
-variant by comparing the selector's value to the key *letter for letter*, so
+variant by comparing the selector's value to the key _letter for letter_, so
 `$parts`, `$role`, `$reason`, `$context` and the rest are symbols the core
 passes in and a translated key is not a translation — it is a branch nothing can
 reach:
@@ -3077,14 +3315,14 @@ chosen it. `locales/fit` shipped exactly that, having applied Meänkieli's
 `symbolicVariantKeys` in `scripts/catalogUtils.ts` lists the keys a catalog
 selects on, and `catalogLint.test.ts` holds every translation's list against
 English, one test per locale. Plural categories are excluded, because those are
-the keys a language *is* entitled to differ on: CLDR gives each its own set, so
+the keys a language _is_ entitled to differ on: CLDR gives each its own set, so
 a catalog resolving `one` and `other` where English resolves `one`, `two` and
 `other` is right rather than broken — see [The dual, and the one Sami language
 that cannot write it](#the-dual-and-the-one-sami-language-that-cannot-write-it).
 The check is a subset rather than an equality for the mirror-image reason: a
 catalog may legitimately select on more than English does — `locales/kmr` and the
 Dagestanian catalogs nest a `$gender` select inside `$parts`, and the four
-Finnic catalogs fork on `$role` — so what it forbids is a branch going *missing*,
+Finnic catalogs fork on `$role` — so what it forbids is a branch going _missing_,
 which is the only shape the failure takes.
 
 ## Call sites
@@ -3140,7 +3378,7 @@ shared by every viewer on the page, which context cannot cross, so it takes a
 Prose the core computes — style descriptions today — is content, so it follows
 `documentLocale` and is built where the core builds everything else. The
 translator arrives as the value of the `translator` dependency, which is a
-*factory* keyed by locale rather than a translator: the catalogs are fixed for
+_factory_ keyed by locale rather than a translator: the catalogs are fixed for
 a core's lifetime but the locale is not, since a nested `<document lang>` can
 differ from the one around it. A definition takes the `locale` of the document
 it sits in — an ordinary ancestor dependency, alongside `theme` — and asks the
@@ -3175,7 +3413,7 @@ that cannot be translated word for word. English writes adjectives before the
 noun and inserts an article before "border"; Spanish writes them after and
 agrees them with the noun's gender. So each description is assembled by a
 message that receives the pieces as arguments plus a `$parts` argument naming
-*which* pieces are present, and every adjective is handed `$gender`. An absent
+_which_ pieces are present, and every adjective is handed `$gender`. An absent
 piece selects a different branch rather than substituting an empty string —
 that is what lets a translation reorder and re-punctuate each combination on
 its own terms.
@@ -3192,7 +3430,7 @@ its fifth is `c12` — «akadomo», the point, is a diminutive there, as it is i
 Ganda. The reachability rule applies to the class tokens exactly as it does to
 `$role`: a catalog writes a branch for a class only if its own `noun-gender`
 can answer that class. That is why Swahili and Nyanja carry `c6` — the plural
-class, which their word for *text* or *border* lands in — and the other
+class, which their word for _text_ or _border_ lands in — and the other
 seventeen do not, and why Venda, Tsonga, Kikuyu and Bemba stop at `c3`, `c7`
 and `c9`: no noun the core names is class 5 in any of the four, so the ḽi-,
 leri-, i- and ili- forms are named in those catalogs' headers rather than
@@ -3202,7 +3440,7 @@ written as branches nothing can select.
 `locales/ff` writes «ɓaleewol» against a `ngol` noun and «ɓaleere» against a
 `nde` one, so the same argument that reaches the front of a Bantu adjective
 reaches the back of a Fula one. Nothing outside the catalog changed to allow
-that, which is the point: what `$gender` names is *what a word agrees with*,
+that, which is the point: what `$gender` names is _what a word agrees with_,
 not where the agreement is spelled.
 
 **The Gur pair spells it the same way from a different family**, which is what
@@ -3214,12 +3452,12 @@ which nouns a catalog happens to name, not about a family, which is what the
 nineteen Bantu catalogs have been saying all along in a script where it is
 easier to miss.
 
-Both write the *juxtaposed* construction, where the noun keeps its own class
+Both write the _juxtaposed_ construction, where the noun keeps its own class
 suffix and each modifier agrees with it, rather than the compound one, where
 the noun drops to its bare stem and the last modifier carries the suffix alone.
 That is the affix rule below: the last element of a description is often a
 placeable, and a suffix cannot be welded to a word the catalog never sees. It
-is *choose the words that land there* applied to a whole construction rather
+is _choose the words that land there_ applied to a whole construction rather
 than to one word.
 
 **Tiv writes it as a word of its own, which is the third place it can go.**
@@ -3253,7 +3491,7 @@ words are rendered in two places each — a border's adjectives, the background
 colour, and the text colour beside it — once standing alone as a state
 variable reports them and once embedded in a clause, and a language that
 inflects for case wants a different form in each. So every adjective is handed
-`$role` as well, naming the *position* the phrase is going into rather than
+`$role` as well, naming the _position_ the phrase is going into rather than
 the case it takes: which case a position governs is the catalog's business,
 exactly as `$gender`'s token set already is. `locales/en/content.ftl` lists the
 positions, and `be`, `bs`, `cs`, `de`, `el`, `et`, `fi`, `fo`, `hi`, `hr`,
@@ -3285,7 +3523,7 @@ The **Celtic four** — `ga`, `gd`, `cy`, `br` — reach that same answer from t
 other end. They mark an adjective heavily, but by mutating the front of it
 rather than by inflecting the end: a feminine singular noun softens whatever
 follows it, so «dearg» is «dhearg» in Irish, «coch» is «goch» in Welsh, and
-«du» is «zu» in Breton. That trigger is the *noun*, and the noun's gender is
+«du» is «zu» in Breton. That trigger is the _noun_, and the noun's gender is
 already a token these messages carry — so all four select on `$gender` alone
 and none of them writes a `$role` branch. Welsh goes one step past the other
 three: a handful of its adjectives have a feminine form of their own before the
@@ -3305,8 +3543,8 @@ width first. Each of those says so above its own `style-stroke`, for the same
 reason.
 
 Basque is the clean case of the opposite: it has a great many cases and selects
-on neither argument, because a Basque case is a suffix on the *last word of the
-whole noun phrase*. What a position asks for lands on a word `locales/eu`
+on neither argument, because a Basque case is a suffix on the _last word of the
+whole noun phrase_. What a position asks for lands on a word `locales/eu`
 writes — «batekin», «planoarekin» — rather than on the adjective, so the
 description reads the same in all four positions.
 
@@ -3347,7 +3585,7 @@ verb, «'ej» between them, and stands the whole clause in front of the noun:
 an attested pattern, since no canon example chains three relative clauses, and
 the catalog's header says so. That puts Klingon on the prenominal
 side with the Philippine catalogs and Tok Pisin, for a reason none of them
-shares, and it is why the catalog needs no `$role` fork — the *position* is
+shares, and it is why the catalog needs no `$role` fork — the _position_ is
 handled by the message that composes the phrase rather than by the word inside
 it, so its tables can hold bare verbs that double as the citation form a state
 variable reports.
@@ -3385,10 +3623,10 @@ the order of the adjectives, and `styleDescriptions.test.ts` pins both halves.
 Two further Fluent constraints shaped it, and both are easy to rediscover the
 hard way:
 
-- **A word that inflects has to be passed in, not referenced.** A *term*
+- **A word that inflects has to be passed in, not referenced.** A _term_
   reference cannot carry a runtime value — `{ -filled(gender: $gender) }` does
   not parse (`E0014 Expected literal`), and `{ -filled }` gets an empty scope
-  and always picks its default variant. A *message* reference does inherit the
+  and always picks its default variant. A _message_ reference does inherit the
   caller's arguments, but references never cross a bundle boundary: a locale
   that translates `style-filled` and not `style-filled-word` would render the
   literal `{style-filled-word}` rather than falling back to English. So the
@@ -3397,9 +3635,9 @@ hard way:
 - **A multiline pattern keeps its newlines.** Continuing a variant onto a
   further line puts a `\n` in the rendered string — including when that line
   opens a nested select. Keep each variant's content on one line; a select
-  nested *within* that line is fine, and is how a message would sub-divide one
+  nested _within_ that line is fine, and is how a message would sub-divide one
   of its variants. The same rule catches a subtler mistake: a `#` line indented
-  *under* a message is not a comment, it is more of the pattern above it, so a
+  _under_ a message is not a comment, it is more of the pattern above it, so a
   note explaining a wording choice has to sit above the message rather than
   beside the attribute it explains. `lint:i18n` fails on any pattern that
   renders a line break, which is what makes both of these findable before a
@@ -3413,30 +3651,30 @@ writing direction — it turned up first in Arabic and Uyghur and then in
 Hungarian, Finnish, Czech, Slovak and Romanian.
 
 A placeable is a value the catalog never sees. So a message may not depend on
-what that value turns out to *be*:
+what that value turns out to _be_:
 
-| The catalog wants | The language | Why it cannot |
-| --- | --- | --- |
-| a case ending on the value | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
-| the definite article on the value | `ro`, `men` | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai» |
-| a preposition before the value | `cs`, `sk` | «v»/«ve» and «s»/«se» vocalize according to what follows |
-| a compound with the value | `fi` | Finnish writes a compound as one word |
-| a case particle after the value | `bo`, `dz` | the particle has four shapes, picked by the final letter of the syllable before it |
-| the annexed state on the value | `kab`, `zgh`, `shi` | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest» |
+| The catalog wants                 | The language                       | Why it cannot                                                                              |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| a case ending on the value        | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
+| the definite article on the value | `ro`, `men`                        | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai»                           |
+| a preposition before the value    | `cs`, `sk`                         | «v»/«ve» and «s»/«se» vocalize according to what follows                                   |
+| a compound with the value         | `fi`                               | Finnish writes a compound as one word                                                      |
+| a case particle after the value   | `bo`, `dz`                         | the particle has four shapes, picked by the final letter of the syllable before it         |
+| the annexed state on the value    | `kab`, `zgh`, `shi`                | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest»     |
 
 Adjacency is not the problem. `{ $numSides }-kulmio` is correct Finnish for
 every side count, because `-kulmio` is the same whatever number lands in front
-of it. What cannot be written is *agreement* with an unknown word.
+of it. What cannot be written is _agreement_ with an unknown word.
 
 **Tibetan and Dzongkha are the table's sharpest entry, and the way out they
-take is the fifth one.** A Tibetan case particle is chosen by the *final letter
-of the syllable before it*: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
+take is the fifth one.** A Tibetan case particle is chosen by the _final letter
+of the syllable before it_: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
 genitive གི་, ཀྱི་, གྱི་ or ཡི་. Beside a placeable there is no syllable to
 look at. So `bo/content.ftl` and `dz/content.ftl` — the two files that
-*compose* a phrase, and so the two that get to choose their particles — use
+_compose_ a phrase, and so the two that get to choose their particles — use
 only the ones that have a single shape: དང་ for accompaniment, ལ་ (Dzongkha
-ལུ་) for location, ནང་ for containment. That is *prefer the free allomorph
-over the bound one* applied to a particle rather than to a prefix, and the
+ལུ་) for location, ནང་ for containment. That is _prefer the free allomorph
+over the bound one_ applied to a particle rather than to a prefix, and the
 third family to take that way out, after Kʼicheʼ and the Bisayan catalogs.
 
 **The other three files in each are where the way out runs out**, and it is
@@ -3464,7 +3702,7 @@ this rule and the third way out below to come off. Its adjectives follow the
 noun and the izafat links them, and unlike Persian's — an unwritten vowel after
 a consonant, which is why `locales/fa` lets the space carry it — Tajik's is
 written, as «-и». So `locales/tg` writes `{ $noun }и { $description }`, welding
-an affix onto a value whose *form* the value decides, which nothing else here
+an affix onto a value whose _form_ the value decides, which nothing else here
 does — the hyphenated endings `locales/hy` and `locales/ka` put on an
 identifier are welds too, but each has one shape whatever precedes it, so they
 fall under the paragraph above rather than this one. What makes Tajik's sound is
@@ -3482,7 +3720,7 @@ shape-changing affix onto a placeable and records the result as wrong, which
 is `locales/bo`'s answer rather than a new one: the Tibetan catalog's other
 three files write the default genitive after a placeable, right for most
 syllables and wrong for some, and say so. What is new is that this is the
-*ezafe* case — the construction `locales/tg` mitigates and `locales/zza`
+_ezafe_ case — the construction `locales/tg` mitigates and `locales/zza`
 avoids by writing the vowel into its `noun` table — failing in the open.
 Muslim Tat builds the same phrases Tajik
 does, and its ezafe is `-i` after a consonant and `-yi` after a vowel. Where
@@ -3519,13 +3757,13 @@ There are five ways out, and every catalog here takes one of them:
 
 **The three Berber catalogs sharpen the third of those into something new: make
 the position uniform, and one written form is right in all of them.** A Berber
-noun after a preposition goes into the *état d'annexion*, and `$pattern` is a
+noun after a preposition goes into the _état d'annexion_, and `$pattern` is a
 noun these catalogs never see — so no branch can inflect it. What they do
 instead is arrange that every one of the four places a fill pattern is placed
-puts it behind the *same* preposition «s», including `style-fill`, where
+puts it behind the _same_ preposition «s», including `style-fill`, where
 English has no preposition at all. `fill-style` then writes its words already
-annexed and cannot be wrong anywhere. That is *choose the words that land
-there* with the extra step of choosing how many positions there are to choose
+annexed and cannot be wrong anywhere. That is _choose the words that land
+there_ with the extra step of choosing how many positions there are to choose
 for, and `styleDescriptions.test.ts` pins two of the four so that a branch
 dropping the preposition fails rather than quietly producing an unannexed noun.
 
@@ -3533,7 +3771,7 @@ The same three catalogs also settle a question the affix table can otherwise
 make look decided: **an alternation that a clause position triggers is not
 automatically a `$role` fork.** The annexed state is exactly the kind of thing
 `$role` exists for, and all three select on `$gender` alone — because the state
-falls on the *noun*, and every noun a clause position lands on is one the
+falls on the _noun_, and every noun a clause position lands on is one the
 catalog writes out. A `$role` branch would render what the `$gender` branch
 underneath it already renders, which is `locales/gu`'s trap reached from
 Afro-Asiatic.
@@ -3545,7 +3783,7 @@ out right for `locales/tlh`'s reason rather than by luck — «ma-» has one sha
 and assimilates to nothing — and it is written on the colour arguments alone
 (`$color`, and `$background` beside it in `style-text`), because `line-width`
 and `line-style` write their words already marked and would come out doubled;
-so the table above stays a list of languages whose endings *change shape*, and
+so the table above stays a list of languages whose endings _change shape_, and
 gains a language whose beginnings do not.
 
 A select whose variants would land against such an affix carries the affix into
@@ -3562,23 +3800,23 @@ Czech turns up here as a ligature.
 `locales/ceb` and `locales/fil` reached it first and one at a time: Cebuano's
 header calls writing the uncontracted «nga» everywhere "the one place this seed
 is deliberately stiff", and `fil` escapes the ligature outright by selecting on
-the side count, whose two CLDR plural categories *are* its two linkers. What the
+the side count, whose two CLDR plural categories _are_ its two linkers. What the
 Austronesian batch adds is the five Philippine catalogs side by side, which is
 what shows that they do not all resolve it the same way:
 
-| | The linker | Decided by | Resolution |
-| --- | --- | --- | --- |
+|              | The linker    | Decided by             | Resolution                                                   |
+| ------------ | ------------- | ---------------------- | ------------------------------------------------------------ |
 | `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
-| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
-| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
-| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
+| `ilo`        | «a» / «nga»   | the word **after** it  | no invariant form exists; write «a» and name the exception   |
+| `pam`        | «a» / `-ng`   | the word **before** it | no invariant form exists; write «a» and name the exception   |
+| `bik`        | «na» / `-ng`  | the word **before** it | no invariant form exists; write «na» and name the exception  |
 
 Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
 free word in both positions, so writing it out is not a compromise but the form
 that can be written without knowing what stands beside it — the move `locales/ceb`
 already makes, and the same move `locales/quc` makes when it writes the free
 relational «rech» instead of the possessive prefix «u-»/«r-». That is the fifth
-way out listed above — *prefer the free allomorph over the bound one* — and it
+way out listed above — _prefer the free allomorph over the bound one_ — and it
 is stated as a rule here because three families now take it: the Bisayan
 catalogs, Kʼicheʼ, and the two Tibetan-script ones, which reach it for a case
 particle rather than for a linker.
@@ -3716,7 +3954,7 @@ A code is a permanent name — what a bug report cites, what a host reading
 `setDiagnosticsCallback` can filter on, and the anchor a documentation page
 will hang off (#1548). It rides on the record, and on the LSP `code` field for
 a positioned diagnostic — with the arguments alongside it in `data.args`, since
-a code names a message *template* and it takes both to say which occurrence of
+a code names a message _template_ and it takes both to say which occurrence of
 it this is. That pair is how the language server's `dedupeLspDiagnostics`
 recognizes two renderings of one diagnostic without comparing their text.
 Nothing renders the code itself yet, so the codes earn their keep as an
@@ -3728,7 +3966,7 @@ fails if one is renumbered, reused, or dropped from the registry. Retire a code
 in place; never recycle it.
 
 The lock is a committed file, not a service, so it enforces the contract only
-against the registry — deleting a code's line from *both* files in one change
+against the registry — deleting a code's line from _both_ files in one change
 passes the lint, exactly as deleting a `package-lock.json` entry does. That is
 what makes the lock worth reviewing: a diff that removes or edits an existing
 line, rather than only adding one at the end, is the thing to refuse.
@@ -3740,7 +3978,7 @@ severity — the emitting call site chooses the record's `type`.
 Two branches that each claim the next number collide in both the registry and
 the lock, which is the intended outcome: neither file can be auto-merged, so
 the conflict is resolved by hand. Give the later branch the next free number in
-*both* files — the lock is sorted by code, so its entry moves with it, and the
+_both_ files — the lock is sorted by code, so its entry moves with it, and the
 lint passes once the two agree again. Never resolve it by editing a code that
 is already on `main`.
 
@@ -3832,7 +4070,7 @@ npm run lint:i18n -w @doenet/i18n    # CI catalog check (also `npm run lint:i18n
 ```
 
 `lint:i18n` fails on: a catalog that doesn't parse (including entries the Fluent
-*runtime* would silently drop as junk), an id defined twice within a locale, a
+_runtime_ would silently drop as junk), an id defined twice within a locale, a
 catalog naming a `numberingSystem` on a Fluent builtin, a message whose value
 would render a line break, a catalog naming a plural category its own locale
 cannot select, a translated locale
@@ -3842,7 +4080,7 @@ exactly the inlined locales, a call site referencing a key that doesn't exist,
 an English key no source file references, a malformed diagnostic code, a code
 naming a message English lacks, a code used in source that the registry doesn't
 define, a registered code that nothing raises and that is not listed as
-retired, and any change to a code already issued. Keys *missing* from a
+retired, and any change to a code already issued. Keys _missing_ from a
 translation are reported as coverage, not failure — a partial translation is
 legitimate and falls back.
 
@@ -3865,7 +4103,7 @@ Two things can put one there, and the rule covers both:
 
 - **A locale CLDR knows, given a category it does not have.** `Intl.PluralRules`
   is the authority, and `resolvedOptions().pluralCategories` is the answer.
-- **A locale CLDR does not know.** Its tag resolves to the *runtime's* default
+- **A locale CLDR does not know.** Its tag resolves to the _runtime's_ default
   locale, so every category branch in it is selected by some other language's
   rules. More than a hundred locale directories are in this position, and none
   of them writes `zero`, `two`, `few` or `many`.
@@ -3897,14 +4135,14 @@ The tag is canonicalized before it is asked about, because ICU folds three
 directory names onto a macrolanguage — `kmr` to `ku`, `kpv` to `kv`, `mhr` to
 `chm` — and `kmr` genuinely inherits Kurdish's rules while the other two
 inherit nothing, their macrolanguages having no CLDR data either. Comparing the
-resolved tag against the *language* subtag rather than the whole tag matters for
+resolved tag against the _language_ subtag rather than the whole tag matters for
 the opposite reason: `zh-Hans` and `zh-Hant` both resolve to plain `zh`, which
 is their own data and not a fallback.
 
 `pluralVariantKeys`, `allowedPluralCategories` and
 `unselectablePluralCategories` in `scripts/catalogUtils.ts` are the rule, and
 `catalogLint.test.ts` holds it over the whole roster. The per-batch plural
-blocks in `chrome.test.ts` keep only the half the property cannot state: *why*
+blocks in `chrome.test.ts` keep only the half the property cannot state: _why_
 a particular language writes the branch it writes.
 
 ## Pseudo-localization
@@ -3959,7 +4197,7 @@ that are not prose: a contrast ratio is written `{ ratio }:1` with the `1` a
 literal in the catalog, a line number is read off a gutter the editor draws
 itself, an author's `styleNumber="3"` is quoted back at them. And mathematics
 is Latin-digit regardless — `MATH_NOTATION_LOCALE`, which #1528 keeps that way
-while it makes the *separator* configurable. A document whose prose counted in
+while it makes the _separator_ configurable. A document whose prose counted in
 one script and whose equations counted in another would be worse than either
 alone.
 
@@ -3996,7 +4234,7 @@ outside it. A nested `<document lang>` needs no state variable of its own —
 `renderedLang` is set exactly when the language changes, so where it is absent
 the direction cannot have changed either.
 
-Chrome drawn *inside* the document is the reader's language in a box declared to
+Chrome drawn _inside_ the document is the reader's language in a box declared to
 be the content's. `useChromeLangDir()` re-declares it — on the in-document error
 box, the feedback heading, the click-to-toggle text on a hint, a solution and a
 collapsible section, a pretzel's answer label, the summary-statistics caption,
@@ -4010,7 +4248,7 @@ drawn by the browser rather than by CSS. `DocViewer`'s error banner is built
 above the provider the hook reads, so it calls the same rule as the plain
 function `chromeLangDir(uiLocale, documentDirection)`.
 
-"The document" there means the *nearest* one, not the activity: a nested
+"The document" there means the _nearest_ one, not the activity: a nested
 `<document lang>` turns its own subtree around, so `section.tsx` re-mounts
 `DocumentDirectionProvider` around whatever it just declared. Otherwise chrome
 inside `<document lang="ar">` would compare itself against a left-to-right
@@ -4034,7 +4272,7 @@ rather than styled. MathJax needs nothing: its CHTML output already pins
 `direction: ltr` on `mjx-math` — but only on the mathematics itself, which is
 why the preview's scroll container still needs its own pin.
 
-A pin on a *block* needs a width with it: an element as wide as its container
+A pin on a _block_ needs a width with it: an element as wide as its container
 aligns its left-to-right contents to the container's left edge, stranding the
 widget at the far side of the page from the prose it belongs to.
 `ltrIslandProps()` in
@@ -4046,7 +4284,7 @@ instead of the column. An inline island, or one whose element already
 shrink-wraps, takes a bare `dir="ltr"`.
 
 The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
-because `Keyboard` returns a different element per style. The tray *around*
+because `Keyboard` returns a different element per style. The tray _around_
 them follows the reader.
 
 Everything else mirrors: the paginator, prose renderers, the feedback and hint
@@ -4069,20 +4307,20 @@ an Arabic sentence and the mathematics beside it count in the same characters.
 and almost nothing else, and the catalogs differ from each other far more than
 they differ from `de` or `es`:
 
-| | Adjectives | Gender | Plural categories |
-| --- | --- | --- | --- |
-| `ar` | follow the noun | m/f | six |
-| `he` | follow the noun | m/f | three |
-| `fa` | follow the noun | none | two |
-| `ur`, `ps`, `sd` | precede the noun | m/f | two |
-| `ug` | precede the noun | none | two |
-| `yi` | precede the noun | m/f/n | two |
-| `ks` | precede the noun | m/f | two |
-| `dv` | precede the noun | none | two |
-| `ckb` | follow the noun | none | two |
-| `mzn`, `glk` | precede the noun | none | none in CLDR |
-| `lrc`, `haz` | follow the noun | none | none in CLDR |
-| `bal` | precede the noun | none | two |
+|                  | Adjectives       | Gender | Plural categories |
+| ---------------- | ---------------- | ------ | ----------------- |
+| `ar`             | follow the noun  | m/f    | six               |
+| `he`             | follow the noun  | m/f    | three             |
+| `fa`             | follow the noun  | none   | two               |
+| `ur`, `ps`, `sd` | precede the noun | m/f    | two               |
+| `ug`             | precede the noun | none   | two               |
+| `yi`             | precede the noun | m/f/n  | two               |
+| `ks`             | precede the noun | m/f    | two               |
+| `dv`             | precede the noun | none   | two               |
+| `ckb`            | follow the noun  | none   | two               |
+| `mzn`, `glk`     | precede the noun | none   | none in CLDR      |
+| `lrc`, `haz`     | follow the noun  | none   | none in CLDR      |
+| `bal`            | precede the noun | none   | two               |
 
 The last three rows are the Silk Road batch's. Four of its five have no CLDR
 plural data at all — `mzn`, `glk`, `lrc` and `haz` — while `bal` has a category
@@ -4098,9 +4336,9 @@ is the closest thing to a parallel text for it and a correction to one is
 usually a correction to both. `ug` is Turkic and agrees with nothing, and `dv`
 is Indo-Aryan and agrees with nothing either — the two reach the same answer
 from opposite families. `ks` is the one of the sixteen whose catalog records a
-gap rather than a decision: it *does* agree an adjective for gender and this
+gap rather than a decision: it _does_ agree an adjective for gender and this
 seed does not, which its header says outright. `ckb` is the only one whose
-*sibling* is on the roster in the other direction — `locales/kmr` is the same
+_sibling_ is on the roster in the other direction — `locales/kmr` is the same
 macrolanguage in Latin, left to right — and the only one that solves the affix
 problem by writing the linker into its `noun` table; see [The Kurdish
 pair](#the-kurdish-pair). `yi` is Germanic, and it forks on `$role` for a
@@ -4142,7 +4380,7 @@ Three things recur across them, none a property of the direction:
   "are ignored" — most of these cover both with one form, and the select is
   dropped rather than written out twice identically. The count argument then
   goes unused, which is harmless: it stays in the English message for the
-  languages that need it. Where English changes the *noun* as well, the branch
+  languages that need it. Where English changes the _noun_ as well, the branch
   stays — and whether it has to is a fact about the language rather than about
   the script: Persian, Urdu and Uyghur leave a noun singular after a numeral —
   as do all five of the Silk Road's right-to-left catalogs — while Arabic,

--- a/packages/i18n/locales/acf/chrome.ftl
+++ b/packages/i18n/locales/acf/chrome.ftl
@@ -1,0 +1,170 @@
+# Saint Lucian Creole French (Kwéyòl) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The Saint Lucian and Dominican standard — the phonemic
+# spelling settled by the Mouvman Kwéyòl and used in the Kwéyòl dictionary,
+# the Bible translation and the Folk Research Centre's materials. Its marks,
+# as this catalog uses them: «é» for close [e] and «è» for open [ɛ]; «ò» for
+# open [ɔ]; «an», «on», «en» for the three nasal vowels; «ou» for [u]; «y» for
+# the glide; «tj» and «dj» for the palatals; «k» always for [k].
+#
+# **It is very close to the Martinican and Guadeloupean spelling** — the same
+# vowel letters, the same nasals, the same refusal of silent French letters —
+# and a Guadeloupean reader will follow this file without difficulty. **Two
+# conventions differ, and they are the two things to look at first:**
+#
+#   1. **Every etymological French /r/ is written «w».** Saint Lucian has no
+#      velar continuant at all, where Guadeloupean and Martinican keep one
+#      before an unrounded vowel. So «Kwéyòl» against Guadeloupean «kréyòl»,
+#      «wéponn» against «répons», «kwedi» against «kredi», «twavay» against
+#      «travay», «gwi» against «gri», «kòwèk» against «kòrèk», «éwè» against
+#      «erè». Where both write «w» already — «wouj», «wòch» — the two agree.
+#   2. **The determiner is a separate word and takes the full allomorph set.**
+#      GEREC hyphenates a generalized «-la» («répons-la», «paj-la»); this
+#      catalog writes «wéponn lan», «paj la», «fonksyon an», «kanva a» — «a»
+#      after an oral vowel, «la» after an oral consonant, «an» after a nasal
+#      vowel, «lan» after a nasal consonant. **A reviewer should check these
+#      first**: the allomorph is chosen from the noun's final segment, and a
+#      handful of the choices are judgement calls.
+#
+# The French-etymological spelling — «créole» for «Kwéyòl», «réponse» for
+# «wéponn» — is a different practice with a different aim, and **none of it is
+# mixed in here**. A few Guadeloupean words are also replaced by their Saint
+# Lucian equivalents: «pyès» for *none* where Guadeloupean says «pon»,
+# «anyen» for *nothing* where it says «ayen», «wè» for *see* where it says
+# «vwè».
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `acf`, and the language
+# would give it nothing to work with in any case: a Saint Lucian noun has one
+# form for one and for many. The plural is the preposed «sé» with the
+# postposed determiner («sé wéponn lan»), and a numeral in front of a bare
+# noun does the whole job on its own — «3 ésè», never `*ésèyo`. So **no
+# message in this file writes a `[one]`/`[other]` select**; each counted
+# message is one unselected form. `attempts-remaining` keeps its `[0]` branch,
+# because "none left" is a different sentence rather than a different form of
+# this one.
+#
+# **Loans.** The technical register is French, carried in creole grammar and
+# respelled by the Saint Lucian rules: «wéponn», «kwedi», «enfòmasyon»,
+# «matématik», «ekspwesyon», «apèsi», «estatistik», «kolòn», «entèval»,
+# «klavyé», «éwè», «avètisman», «aksésibilité», «vyolasyon», «inisyalizé»,
+# «anwéjistwé», «maksimòm», «disponib», «etikèt». Saint Lucia schools in
+# English, so the English loans arrive by a shorter road than they do in
+# Guadeloupe: «fidbak» (*feedback*) and «wandè» (*renderer*) are here for that
+# reason as much as for want of a creole word. «WCAG AA» is the standard's
+# name and is not a word. The grammar around all of them is creole: preverbal
+# «ka» for the progressive, «ké» for the future, «té» for the anterior, «pa»
+# for negation, «pé pa» for *cannot*, «ni» for *have*, «sé» for the equative
+# copula, and the postposed determiner throughout.
+#
+# **Confidence.** Saint Lucian has a settled orthography, a dictionary and a
+# translated Bible, but no written computing register at all: there is no
+# published Kwéyòl word for *renderer* or *feedback*, and the two above are
+# proposals. The determiner allomorphs are the other thing to read closely.
+#
+# Kwéyòl punctuates as English does: no space before `:`, `;`, `?` or `!`.
+
+
+## Answer submission
+
+answer-checking = Ka véwifyé…
+answer-submitting = Ka voyé…
+answer-checking-status = Ka véwifyé wéponn lan
+answer-submitting-status = Ka voyé wéponn lan
+answer-correct = Kòwèk
+answer-incorrect = Pa kòwèk
+answer-response-saved = Wéponn lan anwéjistwé
+answer-percent-credit = { $percent }% kwedi
+answer-percent-correct = { $percent }% kòwèk
+answer-percent-short = { $percent } %
+max-credit-available = Kwedi maksimòm disponib: { $percent }%
+# No `[one]`/`[other]` select: «ésè» is one word for one and for many, so both
+# categories would render the same string. The count still arrives and is
+# still formatted. `[0]` stays — it is its own sentence.
+attempts-remaining =
+    { $count ->
+        [0] pa ni ésè ki wété
+       *[other] { $count } ésè ki wété
+    }
+validation-correct = (Kòwèk)
+validation-incorrect = (Pa kòwèk)
+validation-partially-correct = (Kòwèk an pati)
+# No select, for the reason given above.
+answer-show-responses = Montwé { $count } wéponn ba { $answerId }
+
+## Disclosure panels
+
+feedback-heading = Fidbak
+collapsible-click-to-open = (kliké pou ouvè)
+collapsible-click-to-close = (kliké pou fèmé)
+collapsible-initializing = Ka inisyalizé…
+footnote-show = Montwé nòt anba paj la
+footnote-hide = Kaché nòt anba paj la
+description-more-information = plis enfòmasyon
+
+## Controls
+
+slider-previous = Avan
+slider-next = Apwé
+keyboard-open = Ouvè klavyé a
+keyboard-close = Fèmé klavyé a
+choice-input-remove-choice = Òté { $choice }
+matrix-remove-row = Òté on wanjé
+matrix-add-row = Ajouté on wanjé
+matrix-remove-column = Òté on kolòn
+matrix-add-column = Ajouté on kolòn
+subset-add-remove-points = Ajouté/Òté pwen
+subset-toggle-points-intervals = Chanjé ant pwen é entèval
+subset-move-points = Deplasé pwen
+subset-clear = Efasé
+orbital-add-row = Ajouté on wanjé
+orbital-remove-row = Òté on wanjé
+orbital-add-box = Ajouté on bwèt
+orbital-remove-box = Òté on bwèt
+orbital-add-up-arrow = Ajouté on flèch anlè
+orbital-add-down-arrow = Ajouté on flèch anba
+orbital-remove-arrow = Òté on flèch
+orbital-row-label = Etikèt pou wanjé { $row }
+pretzel-answer = Wéponn
+summary-statistics-caption = Estatistik wezimé pou { $column }
+
+## Math input
+
+math-input-preview-region = apèsi ekspwesyon matématik la
+math-input-preview = Apèsi
+math-input-invalid-expression = Ekspwesyon ki pa valab:
+
+## Document status
+
+viewer-initializing = Ka inisyalizé…
+
+## Errors
+
+error-heading = Éwè
+error-found-at =
+    { $span ->
+        [line] Yo twouvé-y an liy { $startLine }.
+       *[lines] Yo twouvé-y an liy { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Dokiman sala ni éwè adan-y!
+diagnostic-heading-error = Éwè
+diagnostic-heading-warning = Avètisman
+diagnostic-heading-information = Enfo
+diagnostic-heading-hint = Endikasyon
+accessibility-heading-level-1 = Vyolasyon aksésibilité WCAG AA
+accessibility-heading-level-2 = Alèt aksésibilité
+something-went-wrong = Ni on bagay ki pa maché.
+renderer-load-failed = on wandè pa wivé chajé. Souplé, wechajé paj la.
+core-start-failed = Dokiman sala pa pé démawé. Souplé, wechajé paj la.
+core-start-failed-busy = Dokiman sala pa pé démawé. Plizyè dokiman té ka démawé an menm tan, é sa pé pwan plis tan asi on aparèy ki pi lan. Rechajé paj la pé édé lè lòt dokiman an fin.
+core-start-failed-retry = Dokiman sala pa pé démawé.
+core-start-failed-busy-retry = Dokiman sala pa pé démawé. Plizyè dokiman té ka démawé an menm tan, é sa pé pwan plis tan asi on aparèy ki pi lan.
+core-start-retry = Eséyé ankò
+saved-state-unavailable = Twavay ou té anwéjistwé a pa pé chajé.

--- a/packages/i18n/locales/acf/content.ftl
+++ b/packages/i18n/locales/acf/content.ftl
@@ -1,0 +1,287 @@
+# Saint Lucian Creole French (Kwéyòl) content catalog: the prose the core
+# computes into the document. Selected by `documentLocale` — the language the
+# activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The Saint Lucian and Dominican standard, as `chrome.ftl`
+# sets it out letter by letter: «Kwéyòl», «wéponn», «yo», «sé». It is very
+# close to the Martinican and Guadeloupean spelling; the two conventions that
+# differ are that every etymological French /r/ is written «w» («kwéyé»,
+# «kwedi», «gwi», «twiyang», «wektang», «pawabòl»), and that the determiner is
+# a separate word taking «a» after an oral vowel, «la» after an oral
+# consonant, «an» after a nasal vowel and «lan» after a nasal consonant, where
+# GEREC hyphenates a generalized «-la». The French-etymological spelling is
+# **not mixed into this file**.
+#
+# **Word order: the modifier follows the noun.** Saint Lucian puts an
+# attributive adjective after its head — «liy wouj épé» is *thick red line*,
+# noun first — so the composition messages **reverse** the English order.
+# `style-with-noun` and `style-filled-with-noun` put «{ $noun }» in front of
+# «{ $description }», and `style-fill` postposes the pattern word onto the
+# colour («dyaman blé» for *blue diamonds*).
+#
+# **Nothing agrees, so nothing selects.** Saint Lucian has no grammatical
+# gender, no case and no adjective agreement: an adjective is one invariable
+# word wherever it stands. So not one message here forks on `$gender` or on
+# `$role`, and `noun-gender` answers a single token that nothing downstream
+# reads. What the composition messages do is order and choose, and that is the
+# whole of the work.
+#
+# `noun-regular-polygon` splits the way `locales/es` does, but for word order
+# rather than for agreement: the head is «poligòn wégilyé» and the side count
+# follows the adjectives as a relative clause, «ki ni N koté». That is the
+# `[noun-tail]` branch of `style-with-noun`.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `acf`, and there is
+# nothing for it to have: a noun has one form for one and for many. The plural
+# is the preposed «sé» with the postposed determiner («sé pwen an»), and a
+# numeral in front of a bare noun does the job alone. No message in this file
+# writes a `[one]`/`[other]` select, and `noun-regular-polygon` says «ki ni 1
+# koté» and «ki ni 5 koté» with the same word. `.exercise` and `.exercises`,
+# and `.problem` and `.problems`, are therefore the same word twice: that is
+# the language's nominal morphology, not a copy-paste slip.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# Saint Lucia schools its science in English, from an English curriculum and
+# English textbooks, so the periodic table a Saint Lucian pupil reads is
+# `locales/en`'s — which is what these two keys already fall back to. (In
+# Dominica, where the same orthography is used, the schooling is English as
+# well.) There is no published Kwéyòl list of the hundred and eighteen element
+# names, and writing one would be respelling somebody else's list and calling
+# the result a Kwéyòl nomenclature. `lint:i18n` reports the two keys as
+# missing coverage and that is the correct report. `ion-name-oxidation-state`
+# and the two invalid-symbol messages **are** covered — they are frames, not
+# vocabulary.
+#
+# **Loans.** French, respelled by the Saint Lucian rules: «poligòn»,
+# «pawabòl», «vektè», «fonksyon», «wektang», «twiyang», «segman», «dimi-dwat»,
+# «wéjyon», «vyolèt», «owizontal», «vètikal», «dyagonal», «aktivité»,
+# «définisyon», «egzanp», «egzèsis», «objektif», «pawagwaf», «Téyowèm»,
+# «solisyon», «kaskad», «tablo», «figi», «senbòl», «chimik», «yonik»,
+# «konpozé». «siyan» is the weakest word in the file: Saint Lucian has «blé»
+# and no settled word for cyan, and a speaker may well prefer «blé kléwé» or
+# simply the English. Everything around the loans is creole — «ki ni» for the
+# relative clause, «épi» for *with*, «san» for *without*, «sé» for the plural
+# and for the copula, «pa» for negation.
+#
+# **Confidence.** The colour words, the shape nouns and the section words are
+# ordinary Kwéyòl and are the least doubtful thing here. The style composition
+# is a judgement about word order that a speaker should read aloud; «siyan»
+# and «kaskad» are the two entries most likely to be replaced, and the
+# determiner allomorph on each noun is worth a second look.
+
+
+## Style vocabulary
+
+color =
+    .black = nwè
+    .white = blan
+    .gray = gwi
+    .red = wouj
+    .orange = zowanj
+    .yellow = jòn
+    .green = vèt
+    .cyan = siyan
+    .blue = blé
+    .purple = vyolèt
+    .pink = woz
+    .brown = mawon
+line-width =
+    .thick = épé
+    .thin = fen
+line-style =
+    .dashed = an tiwè
+    .dotted = an pwentiyé
+# Noun phrases. «liy» is one word for one line and for many, so these are not
+# plurals of anything — they are what the language says in both places.
+fill-style =
+    .horizontal = liy owizontal
+    .vertical = liy vètikal
+    .diagonal = liy dyagonal
+    .backdiagonal = liy dyagonal envès
+    .dots = pwen
+    .diamonds = dyaman
+noun =
+    .line = liy
+    .line-segment = segman
+    .ray = dimi-dwat
+    .vector = vektè
+    .curve = koub
+    .function = fonksyon
+    .slope-field = chan pant
+    .vector-field = chan vektè
+    .parabola = pawabòl
+    .polyline = liy bwizé
+    .polygon = poligòn
+    .triangle = twiyang
+    .rectangle = wektang
+    .circle = sèk
+    .region = wéjyon
+    .point = pwen
+    .square = kawé
+    .diamond = dyaman
+    .cross = kwa
+    .plus = plis
+# The head is the bare noun and the side count follows the adjectives as a
+# relative clause, so that the adjectives stay beside the noun they describe.
+# «koté» is invariant: «ki ni 1 koté», «ki ni 5 koté».
+noun-regular-polygon =
+    { $part ->
+        [tail] ki ni { $numSides } koté
+       *[head] poligòn wégilyé
+    }
+# One answer for every noun: Guadeloupean has no grammatical gender, so
+# nothing downstream has anything to agree with.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun first and the adjectives after it, which is the opposite of
+# English. The regular polygon's relative clause follows both.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = wanpli
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } épi { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } épi { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } épi { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+style-border-clause =
+    { $parts ->
+        [with-article] épi on bòdi { $border }
+        [and] é bòdi { $border }
+        [and-article] é on bòdi { $border }
+       *[with] épi bòdi { $border }
+    }
+# The pattern word is postposed straight onto the colour — «dyaman blé» — for
+# the same reason the adjectives are: the modifier follows its head, and there
+# is no agreement for a supporting noun to carry.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = san wanpli
+style-text =
+    { $parts ->
+        [background] { $color } épi on fon { $background }
+       *[plain] { $color }
+    }
+style-background-none = anyen
+
+## Boolean words
+
+boolean-true = vwé
+boolean-false = fo
+
+## Answer buttons
+
+answer-submit-label = Véwifyé twavay la
+answer-submit-label-no-correctness = Voyé wéponn lan
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are the same
+# word: the plural is the preposed «sé», and a heading does not carry it. Two
+# ids with one translation is what a language with no plural suffix looks like
+# here, not a copy-paste.
+section-name =
+    .activity = Aktivité
+    .aside = Nòt asi koté
+    .cascade = Kaskad
+    .definition = Définisyon
+    .example = Egzanp
+    .exercise = Egzèsis
+    .exercises = Egzèsis
+    .given-answer = Wéponn
+    .note = Nòt
+    .objectives = Objektif
+    .paragraphs = Pawagwaf
+    .part = Pati
+    .problem = Pwoblèm
+    .problems = Pwoblèm
+    .proof = Pwèv
+    .question = Kèsyon
+    .section = Seksyon
+    .solution = Solisyon
+    .task = Twavay
+    .theorem = Téyowèm
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Endikasyon
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+figure-name =
+    { $parts ->
+        [numbered] Figi { $enumeration }
+        [numbered-caption] Figi { $enumeration }{ ": " }
+        [unnumbered-caption] Figi{ ": " }
+       *[unnumbered] Figi
+    }
+
+## Paginator controls
+
+paginator-previous = Avan
+paginator-next = Apwé
+paginator-page = Paj
+paginator-page-status = { $pageLabel } { $currentPage } asi { $numPages }
+
+## Piecewise functions
+
+piecewise-condition-or = oben
+piecewise-condition-if = si
+piecewise-condition-otherwise = sinon
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Science in Guadeloupe is taught in French, from the French
+## curriculum: the periodic table on the classroom wall is French, and there
+## is no settled Guadeloupean table for a seed to reproduce. See the header.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Senbòl chimik ki pa valab
+chemistry-invalid-ionic-compound = Konpozé yonik ki pa valab
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blan
+math-embedded-input-blank-ordinal = blan { $ordinal } asi { $total }

--- a/packages/i18n/locales/acf/diagnostics.ftl
+++ b/packages/i18n/locales/acf/diagnostics.ftl
@@ -1,0 +1,705 @@
+# Saint Lucian Creole French (Kwéyòl) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The Saint Lucian and Dominican standard, as `chrome.ftl`
+# sets it out letter by letter. It is very close to the Martinican and
+# Guadeloupean spelling; the two conventions that differ are the «w» for every
+# etymological French /r/ («wéponn», «éwè», «atwibi», «wéféwans», «twouvé»,
+# «kowesponn») and the determiner written as a separate word with the full
+# allomorph set («fonksyon an», «sèk la», «pwen an», «kanva a») where GEREC
+# hyphenates a generalized «-la». The French-etymological spelling is not
+# mixed in.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# **Number.** No `[one]`/`[other]` select appears anywhere in this file. Saint
+# Lucian nouns do not inflect for number — «pwen», «entèval», «atwibi»,
+# «valè» are one word for one and for many — so a counted message whose only
+# difference in English is the noun's number renders one string here and the
+# select is dropped. The count still arrives and is still formatted.
+# `Intl.PluralRules` has no CLDR data for `acf` in any case. Where English's
+# two counts multiplied out to four sentences
+# (`function-domain-insufficient-dimensions`,
+# `function-iterates-input-output-mismatch`), Kwéyòl has one.
+#
+# The one place a numeric variable still selects is
+# `field-function-wrong-num-outputs`, and it is not a plural: its `[one]` and
+# `[other]` branches are two different sentences about two different
+# components — a slope at each point against a vector at each point — and
+# collapsing them would lose the advice, not just a suffix.
+#
+# **Loans.** French, respelled by the Saint Lucian rules: «konpozan»,
+# «atwibi», «varyab», «varyant», «endis», «valè», «sekans», «fonksyon»,
+# «entèval», «matwis», «ekwasyon», «pawabòl», «entèseksyon», «dépandans»,
+# «sikilè», «wéféwans», «kontwas», «definisyon», «anotasyon», «konvèsyon»,
+# «kopwim», «katyon», «anyon», «distwaktè», «wekisyon», «aksésibilité»,
+# «pliwyèl». English, which in Saint Lucia is the school language and so a
+# shorter road than it is in Guadeloupe: «tag», «prop», «blòk», «wandè»,
+# «kanva». The frame around them is creole throughout: «ka» for the
+# progressive, «ké» for the future, «té» for the anterior, «pa» for negation,
+# «pé pa» for *cannot*, «pòkò» for *not yet*, «yo» as the impersonal subject
+# that carries every passive, «sé» for the copula, and the postposed
+# determiner.
+#
+# **Confidence.** The error frames — «pa valab», «pé pa kalkilé», «yo pòkò
+# enplimanté», «yo ka inyowé» — are ordinary Kwéyòl and are the surest thing
+# here. The mathematical vocabulary is the French one respelled, which is what
+# a Kwéyòl-speaking teacher says around an English lesson; the computing
+# vocabulary («wandè», «kanva», «tibout kòd» in `editor.ftl`) is a proposal.
+#
+# Kwéyòl punctuates as English does: no space before `:`, `;`, `?` or `!`.
+
+
+## `<lineSegment>`
+
+# No select: «atwibi» is one word for one and for many, and «yo ka inyowé» is
+# the impersonal, which agrees with nothing. One string covers both English
+# categories. The count still arrives.
+line-segment-attributes-ignored-with-endpoints = yo ka inyowé { $attributes } lè dé bout espesifyé
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = yo ka inyowé { $attributes } lè on bout é on mitan espesifyé toulédé
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset pa ka fè anyen san on mitan
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liy ki ka pasé an pwen ki ni dimansyon yo pa détèwminé.
+
+line-points-too-few-dimensions = Liy la dwèt pasé an pwen ki ni omwen dé dimansyon.
+
+line-points-depend-on-variables = Liy la ka pasé an pwen ki ka dépann di varyab: { $variables }.
+
+line-equation-invalid-format = Fòma pa valab pou ekwasyon liy la an varyab { $variable1 } é { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Dimi-dwat la pweskwi pa through, endpoint é direction.  Yo ka inyowé through ki espesifyé a.
+
+ray-dimension-mismatch = numDimensions pa ka kowesponn adan dimi-dwat la.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektè a pweskwi pa head, tail é displacement.  Yo ka inyowé head ki espesifyé a.
+
+vector-dimension-mismatch = numDimensions pa ka kowesponn adan vektè a.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Pé pa atiwé asi on `<{ $component }>` paske i pa ni on varyab déta nearestPoint.
+
+constrain-to-without-nearest-point = Pé pa kontwenn asi on `<{ $component }>` paske i pa ni on varyab déta nearestPoint.
+
+constrain-to-interior-without-nearest-point = Pé pa kontwenn adan entewyè on `<{ $component }>` paske i pa ni on varyab déta nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = yo ka inyowé labelPosition pou on choiceInput ki pa inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Yo ka inyowé indices ki espesifyé pou choiceInput paske kantité endis pa ka kowesponn épi kantité pitit choice.
+
+pretzel-indices-count-mismatch = Yo ka inyowé indices ki espesifyé pou problem paske kantité endis pa ka kowesponn épi kantité pitit problem.
+
+shuffle-indices-count-mismatch = Yo ka inyowé indices ki espesifyé pou shuffle paske kantité endis pa ka kowesponn épi kantité konpozan.
+
+indices-ignored-out-of-range = Yo ka inyowé indices ki espesifyé pou { $component } paske kèk endis déwò limit la.
+
+pretzel-indices-repeated = Yo ka inyowé indices ki espesifyé pou pretzel paske kèk endis wépété.
+
+pretzel-circuit-first-index = Yo ka inyowé indices ki espesifyé pou pretzel an mòd circuit paske pwèmyé endis la dwèt sé 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Pou `<{ $component }>` maché épi pitit ki sé chenn kawaktè, ou dwèt espesifyé on atwibi `type`.
+
+invalid-type-defaulting-to-math = Tip { $type } pa valab pou konpozan { $component }. I dwèt sé yonn adan math, text, number oben boolean. Yo ka pwan math.
+
+string-not-valid-component-to-arrange = Chenn "{ $value }" pa on konpozan valab pou { $component }. Yo ka inyowé sa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tip { $type } pa valab, yo ka mèt tip la asi number.
+
+invalid-variable-value = Valè on varyab ki pa valab: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Endis varyant { $index } dwèt sé on nonm
+
+variant-index-must-be-integer = Endis varyant { $index } dwèt sé on antyé
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` pa enplimanté pou mizi absoli. Yo ka mèt lajè a wélatif.
+
+side-by-side-absolute-margins = `<{ $component }>` pa enplimanté pou mizi absoli. Yo ka mèt maj la wélatif.
+
+side-by-side-no-block-child = `<{ $component }>` pa valab: i dwèt ni omwen on pitit blòk.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Yo ka inyowé atwibi `for` asi on `<label>` gwafik.
+
+label-for-must-resolve-to-one = Atwibi `for` asi `<label>` dwèt wézoud asi yon sèl konpozan.
+
+label-for-unresolved = Atwibi `for` asi `<label>` pa pé wézoud asi on konpozan.
+
+label-for-answer-with-authored-inputs = Atwibi `for` asi `<label>` ka wéféwé a on `<answer>` ki ni antwé otè a ekwi limenm; wéféwé a antwé a diwèkteman.
+
+label-for-answer-without-input = Atwibi `for` asi `<label>` ka wéféwé a on `<answer>` ki pa ni antwé pou etikté.
+
+label-for-must-reference-input-or-answer = Atwibi `for` asi `<label>` dwèt wéféwé a on antwé oben a on wéponn.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Pou aksésibilité, `<{ $component }>` dwèt ni on deskwipsyon kout oben dwèt espesifyé kon dekowatif.
+
+accessibility-video-short-description = Pou aksésibilité, `<video>` dwèt ni on deskwipsyon kout.
+
+accessibility-input-short-description-or-label = Pou aksésibilité, `<{ $component }>` dwèt ni on deskwipsyon kout oben on etikèt.
+
+accessibility-answer-input-short-description-or-label = Pou aksésibilité, on `<answer>` ki ka kwéyé on antwé dwèt ni on deskwipsyon kout oben on etikèt.
+
+accessibility-short-description-contains-math = Deskwipsyon kout pa ta dwèt ni konpozan matématik kon `<{ $component }>` adan yo. Eplé tout matématik épi mo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } pa ni asé kontwas pou tèks tit seksyon an (mòd fè nwè) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1).
+       *[other] { $colorName } pa ni asé kontwas pou tèks tit seksyon an ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Yo pòkò enplimanté `<circle>` ki ka pasé an { $count } pwen adan ka a koté pwen an pa ni valè nimewik.
+
+circle-too-many-through-points = Pé pa kalkilé on sèk ki ka pasé an plis ki 3 pwen.
+
+circle-overprescribed-radius-center-points = Pé pa kalkilé on sèk ki ni weyon, sant é pwen espesifyé ansanm.
+
+circle-center-with-multiple-points = Pé pa kalkilé on sèk ki ni on sant espesifyé é ki ka pasé an plis ki 1 pwen.
+
+circle-radius-too-small = Pé pa kalkilé sèk la: piski distans ant dé pwen an sé { $distance }, weyon { $radius } ki espesifyé a twòp piti.
+
+circle-radius-with-many-points = Pé pa kwéyé on sèk ki ka pasé an plis ki dé pwen épi on weyon espesifyé.
+
+circle-invalid-center-or-through-points = Sant oben pwen sèk la pa valab.
+
+circle-radius-center-with-multiple-points = Pé pa kalkilé weyon on sèk ki ni on sant espesifyé é ki ka pasé an plis ki 1 pwen.
+
+circle-change-radius-non-numerical = Pé pa chanjé weyon on sèk ki ka pasé an pwen ki pa nimewik
+
+circle-radius-with-points-non-numerical = Pé pa kwéyé on sèk ki ka pasé an plis ki on pwen épi on weyon espesifyé lè valè nimewik la pa la.
+
+circle-change-center-non-numerical = Yo pòkò enplimanté chanjman sant on sèk ki ka pasé an pwen ki pa ni valè nimewik.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Guadeloupean has one,
+# because «entèval» and «antwé» are invariant. Both selects are dropped and
+# both counts still arrive and are still formatted.
+function-domain-insufficient-dimensions = Dimansyon domèn fonksyon an pa asé. Domèn an ni { $intervals } entèval mé fonksyon an ni { $inputs } antwé.
+
+function-domain-invalid-format = Fòma domèn fonksyon an pa valab.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Yo ka inyowé maksimòm fonksyon an ki pa nimewik.
+        [minimum] Yo ka inyowé minimòm fonksyon an ki pa nimewik.
+        [extremum] Yo ka inyowé ekstwemòm fonksyon an ki pa nimewik.
+        [point] Yo ka inyowé pwen fonksyon an ki pa nimewik.
+        [slope] Yo ka inyowé pant fonksyon an ki pa nimewik.
+       *[other] Yo ka inyowé { $type } fonksyon an ki pa nimewik.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Yo ka inyowé maksimòm fonksyon an ki vid.
+        [minimum] Yo ka inyowé minimòm fonksyon an ki vid.
+        [extremum] Yo ka inyowé ekstwemòm fonksyon an ki vid.
+        [point] Yo ka inyowé pwen fonksyon an ki vid.
+       *[other] Yo ka inyowé { $type } fonksyon an ki vid.
+    }
+
+function-points-too-close = Fonksyon an ni dé pwen ki twòp pwé yonn a lòt. Pé pa défini fonksyon an.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Itewasyon fonksyon posib sèlman si kantité antwé a fonksyon an égal kantité sòti a-y. Fonksyon sala ni { $inputs } antwé é { $outputs } sòti.
+
+## `<sequence>`
+
+sequence-invalid-length = Longè sekans la pa valab.  I dwèt sé on antyé ki pa negatif.
+
+sequence-invalid-step = Pa sekans la pa valab.  I dwèt sé on nonm pou on sekans tip { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" pa valab pou on sekans nonm.  I dwèt sé on nonm.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" pa valab pou on sekans lèt.  I dwèt sé on konbinezon lèt.
+
+sequence-invalid-endpoint = "{ $attribute }" pa valab pou sekans la.
+
+select-from-sequence-coprime-not-numbers = yo ka inyowé coprime paske sé pa nonm yo ka chwazi
+
+select-from-sequence-coprime-with-exclude-combinations = yo ka inyowé coprime paske excludeCombinations espesifyé
+
+## Resolving a `target`
+
+target-not-found = target pa valab pou `<{ $source }>`: pé pa twouvé target la.
+
+target-state-variable-not-found = target pa valab pou `<{ $source }>`: pé pa twouvé on varyab déta ki kwiyé "{ $property }" asi on `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Varyab `<odeSystem>` dwèt diféwan di varyab endepandan an.
+
+ode-system-duplicate-variable-names = Pé pa défini fonksyon RHS ODE épi non varyab dépandan ki wépété.
+
+ode-system-rhs-function-error = Pé pa défini fonksyon RHS ODE.  Éwè adan kwéyasyon fonksyon mathjs la.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Pé pa défini on ang ant { $count } liy
+
+angle-invalid-through-point = Pwen ki pa valab adan through on `<angle>`
+
+parabola-vertex-too-many-points = Yo pòkò enplimanté on pawabòl ki ni on somè é ki ka pasé an plis ki 1 pwen.
+
+parabola-too-many-points = Yo pòkò enplimanté on pawabòl ki ka pasé an plis ki 3 pwen.
+
+intersection-too-many-items = Yo pòkò enplimanté entèseksyon pou plis ki dé eleman
+
+## Other math components
+
+ionic-compound-not-two-ions = Yo pòkò enplimanté konpozé yonik pou dòt bagay ki dé yon.
+
+ionic-compound-needs-cation-and-anion = Konpozé yonik enplimanté sèlman pou on katyon é on anyon.
+
+solve-equations-cannot-evaluate = Pé pa wézoud ekwasyon an paske yo pa pé evalyé-y: { $equation }
+
+math-operators-operand-number-required = Ou dwèt espesifyé on operandNumber lè ou ka ekstwè on operand matématik.
+
+eigen-decomposition-failed = Yo pa pé kalkilé valè pwòp a matwis la
+
+## `<matchesPattern>`
+
+# No select: the English branches differ only in the number of «pawamèt», and
+# the sentence is turned impersonal so that neither a singular nor a plural
+# pronoun has to be chosen. The count still arrives.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: pawamèt { $parameters } pa ka pawet adan modèl la, kidonk sa ké toujou kowesponn épi on blan.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: pé pa entèpwété grid="{ $grid }". I dwèt sé none, medium, dense, oben dé nonm pozitif sepawé pa on espas, kon grid="1 0.5". Yo pa ka twasé pyès kadwiyaj.
+
+## `<slopeField>` and `<vectorField>`
+
+# The `$expected` select is not a plural: the two branches are two different
+# sentences about two different components. `$found` is turned impersonal so
+# that no plural branch is needed for it.
+field-function-wrong-num-outputs =
+    `<{ $component }>` bizwen on fonksyon ki ni { $expected ->
+        [one] on sèl sòti, pant y' an chak pwen, kon `y - x`
+       *[other] dé sòti, vektè a an chak pwen, kon `(y, -x)`
+    }, mé fonksyon yo bay la ni { $found } sòti. { $alternative ->
+        [none] Yo pa ka twasé anyen.
+       *[other] `<{ $alternative }>` sé konpozan an pou fonksyon sala. Yo pa ka twasé anyen.
+    }
+
+field-function-attribute-ignored-with-child = Yo ka inyowé atwibi `function` paske fonksyon an bay adan konpozan an tou; sé sila ki adan an yo ka pwan. Bay fonksyon an yon sèl fason.
+
+field-variables-ignored =
+    `<{ $component }>`: atwibi `variables` ka kwiyé varyab a on ekspwesyon ki ekwi diwèkteman adan konpozan an. { $reason ->
+        [function-child] Fonksyon an la bay kon on pitit `<function>`, ki ka kwiyé varyab a-y limenm, kidonk yo ka inyowé `variables`.
+       *[no-expression] Pa ni on ekspwesyon kon sa la, kidonk yo ka inyowé `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" pa sipòté adan wandè prefigure la; yo ka sèvi épi konpòtman pozisyon dwat la.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" pa sipòté adan wandè prefigure la; yo ka sèvi épi konpòtman pozisyon anlè a.
+
+prefigure-invalid-axis-bounds = `<graph>`: limit aks la pa valab pou konvèsyon prefigure; yo ka sèvi épi bbox pa défo (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lajè a pa valab pou konvèsyon prefigure; yo ka sèvi épi lajè dyagwam pa défo 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio pa valab pou konvèsyon prefigure; yo ka sèvi épi wapò aspè pa défo 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: espasman kadwiyaj la twòp fen pou limit aks la; yo ka kité kadwiyaj la déwò adan wandè prefigure la.
+
+prefigure-annotations-not-rendered = `<graph>`: yo pa ké wann anotasyon lè yo pa ka sèvi épi wandè PreFigure a.
+
+multiple-annotations-children = Yo twouvé plizyè pitit `<annotations>` adan `<graph>`; yo ka inyowé tout sof dènyé la.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Pé pa pwolonjé oben kopyé on tip konpozan yo pa ka wekonèt: { $type }.
+
+copy-prop-not-found = Yo pa pé twouvé prop { $property } asi on konpozan tip { $component }
+
+collect-no-source = Yo pa twouvé pyès sous pou collect.
+
+collect-invalid-component-type = Pé pa kolekté konpozan tip `<{ $component }>` paske sé on tip konpozan ki pa valab.
+
+reference-index-unavailable = Pé pa wéféwé a endis `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Pé pa kwiyé { $action } asi konpozan `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Doné a ni on fòm ki pa valab.  Wanjé a ni longè ki pa konsistan. Twouvé adan componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Doné a ni non kolòn ki wépété.  Twouvé adan componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Doné a ka manké on non kolòn.  Twouvé adan componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = On award pou wéponn sala basé asi wéponn a tag wéponn lan limenm voyé, é sa ké mennen adan on konpòtman ou pa té ka atann.
+
+answer-max-num-attempts-in-section-wide-check-work = Mèt `maxNumAttempts` asi on `<answer>` adan on kontenè ki ni `sectionWideCheckWork` pa ka fè anyen, paske sé kontenè a ki ka kontwolé kantité ésè. Mèt `maxNumAttempts` asi kontenè a pito.
+
+nested-section-wide-check-work-max-num-attempts = Mèt `maxNumAttempts` asi on kontenè ki ni `sectionWideCheckWork` é ki adan on dòt kontenè ki ni `sectionWideCheckWork` pa ka fè anyen, paske sé kontenè déwò a ki ka kontwolé kantité ésè. Mèt `maxNumAttempts` asi kontenè déwò a pito.
+
+# No select: «atwibi» is invariant and «pa ké fè anyen» agrees with nothing.
+answer-attributes-need-symbolic-equality = Atwibi { $attributes } pa ké fè anyen san symbolicEquality mété.
+
+answer-invalid-type = Tip pa valab pou wéponn lan: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Piski konpozan `<{ $component }>` pa ni on non, yo pé pa sèvi épi-y pou on atwibi module
+
+module-attribute-name-already-defined = Yo pé pa sèvi épi konpozan `<{ $component } name="{ $name }">` kon on atwibi pou on module paske tip konpozan `<module>` ni on atwibi "{ $name }" ki ja défini.
+
+conditional-content-condition-ignored = Yo ka inyowé atwibi `condition` asi on konpozan `<conditionalContent>` ki ni pitit case oben else.
+
+slider-markers-type-mismatch = Tip makè a pa ka kowesponn épi tip slider la.
+
+pretzel-problem-needs-statement-and-answer = pretzel pa valab: chak `<problem>` dwèt ni on `<statement>` é on `<answer>`.
+
+pretzel-circuit-first-problem-distractor = pretzel pa valab: an mode="circuit", pwèmyé `<problem>`-la pé pa sé on distwaktè.
+
+## Attribute values
+
+# No select: «valè» is invariant, and «yo ka inyowé sa» is impersonal, so one
+# string covers both English categories. The count still arrives.
+attribute-invalid-values = Valè { $values } pa valab pou atwibi `{ $attribute }`; yo ka inyowé sa.
+
+attribute-must-be-references = Valè `{ $value }` pa valab pou atwibi `{ $attribute }`. Atwibi a dwèt fòmé épi wéféwans ki ka koumansé épi on `$`.
+
+math-input-invalid-function-names = <mathInput>: yo ka inyowé non fonksyon ki pa valab adan { $attribute }: { $names }. Segman afichaj a chak non dwèt ni omwen 2 kawaktè (lèt oben tiwè); on sifiks `|<mathspeak alternative>` opsyonèl pé swiv.
+
+## Building components from the source
+
+component-type-invalid = Tip konpozan ki pa valab: `<{ $componentType }>`
+
+attribute-repeated = Pé pa wépété atwibi { $attribute }.
+
+attribute-invalid-for-component = Atwibi "{ $attribute }" pa valab pou on konpozan tip `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Définisyon stil { $styleNumber } pa ni asé kontwas pou { $context ->
+        [text-on-background] koulè tèks kont koulè fon
+        [high-contrast] koulè gwo kontwas kont kanva a
+        [line] koulè liy kont kanva a
+        [marker] koulè makè kont kanva a
+       *[text-on-canvas] koulè tèks kont kanva a
+    }{ $mode ->
+        [dark] { " (mòd fè nwè)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Kwak définisyon stil { $styleNumber } espesifyé koulè ki ka bay asé kontwas pou mòd klè, koulè mòd fè nwè a ki sòti adan valè sala pa ni asé kontwas pou koulè tèks kont koulè fon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1). { $suggestion ->
+        [available] Pou asiwé asé kontwas an mòd fè nwè, ou pé ogmanté kontwas mòd klè a (pa egzanp, mèt { $lightAttribute }="{ $lightColor }") oben wanplasé koulè mòd fè nwè a (pa egzanp, mèt { $darkAttribute }="{ $darkColor }").
+       *[none] Pou asiwé asé kontwas an mòd fè nwè, ogmanté kontwas mòd klè a oben wanplasé koulè ki sòti a épi textColorDarkMode é/oben backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Kwak définisyon stil { $styleNumber } espesifyé on koulè tèks ki ka bay asé kontwas pou mòd klè, koulè tèks mòd fè nwè a ki sòti adan valè sala pa ni asé kontwas kont kanva a ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1). { $suggestion ->
+        [available] Pou asiwé asé kontwas an mòd fè nwè, ou pé ogmanté kontwas mòd klè a (pa egzanp, mèt textColor="{ $lightColor }") oben wanplasé koulè mòd fè nwè a (pa egzanp, mèt textColorDarkMode="{ $darkColor }").
+       *[none] Pou asiwé asé kontwas an mòd fè nwè, ogmanté kontwas mòd klè a oben wanplasé koulè ki sòti a épi textColorDarkMode.
+    }
+
+section-multiple-style-palettes = On seksyon pé chwazi yon sèl <stylePalette>; yo ka sèvi épi dènyé la.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = pé pa détèwminé varyant inik a { $component } paske numToSelect pa on antyé ki pa negatif.
+
+variant-num-to-select-not-constant-number = pé pa détèwminé varyant inik a { $component } paske numToSelect pa on nonm konstan.
+
+variant-with-replacement-not-constant-boolean = pé pa détèwminé varyant inik a { $component } paske withReplacement pa on boulean konstan.
+
+variant-select-weight-disables-unique = Varyant inik pou select dezaktivé si ni on opsyon ki ni selectWeight oben selectForVariants espesifyé
+
+variant-coprime-undetermined = pé pa détèwminé varyant inik a { $component } paske yo pé pa détèwminé si coprime toujou fo.
+
+variant-attribute-not-constant = pé pa détèwminé varyant inik a { $component } paske { $attribute } pa on konstan.
+
+variant-attribute-not-number = pé pa détèwminé varyant inik a { $component } paske { $attribute } pa on nonm.
+
+variant-attribute-wrong-type-for-sequence =
+    pé pa détèwminé varyant inik a { $component } tip { $type } paske { $attribute } pa { $expected ->
+        [letters-combination] on konbinezon lèt
+        [math-expression] on ekspwesyon matématik valab
+        [integer] on antyé
+       *[number] on nonm
+    }.
+
+variant-length-not-integer = pé pa détèwminé varyant inik a { $component } paske length pa on antyé.
+
+variant-sort-not-implemented = yo pòkò enplimanté varyant inik a on { $component } épi sort
+
+variant-exclude-combinations-not-implemented = yo pòkò enplimanté varyant inik a on { $component } épi excludeCombinations
+
+variant-math-exclude-not-implemented = yo pòkò enplimanté varyant inik a on { $component } tip math épi exclude
+
+variant-non-constant-exclude-not-implemented = yo pòkò enplimanté varyant inik a on { $component } épi on exclude ki pa konstan
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: pa sipòté adan wandè prefigure a graph la; yo ka soté désandan an.
+
+prefigure-descendant-invalid-geometry = { $subject }: jeyometwi ki pa fini oben ki pa konplèt; yo ka soté désandan an.
+
+prefigure-curve-label-omitted = { $subject }: yo pa ka sipòté etikèt asi eleman koub ki konvèti; yo ka kité etikèt la déwò.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tip definisyon fonksyon koub '{ $definitionType }' pa sipòté; yo ka soté désandan an.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atwibi flipFunctions pa sipòté asi regionBetweenCurves; yo ka soté désandan an.
+
+prefigure-region-non-formula-child = { $subject }: sé sèlman pitit fonksyon tip fòmil yo ka sipòté asi regionBetweenCurves; yo ka soté désandan an.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' pa sipòté pou { $labelKind ->
+        [line-family] on etikèt fanmi liy
+       *[point] on etikèt pwen
+    }; yo ka sèvi épi aliyman PreFigure pa défo.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure pa ka sipòté stil wanpli '{ $fillStyle }'; yo ka tonbé asi on wanpli plen.
+
+prefigure-line-style-unknown = { $subject }: stil liy '{ $lineStyle }' yo pa konnèt kité déwò adan sòti PreFigure a.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: stil makè '{ $markerStyle }' ka kowesponn épi stil PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure pa ka sipòté stil makè '{ $markerStyle }'; yo ka sèvi épi stil pa défo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` pa valab; pé pa wézoud sib la. Yo ka kité anotasyon an déwò.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` wézoud asi plizyè sib; yo ka sèvi épi pwèmyé sib la.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` pa valab; sib la déwò graph ki ka kontni-y la. Yo ka kité anotasyon an déwò.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` pa valab; sib la pa on objè gwafik ki sipòté adan konvèsyon prefigure. Yo ka kité anotasyon an déwò.
+
+annotation-text-missing = `<annotation>`: `text` ka manké oben vid; yo ka bay on tèks vid.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Yo détekté on dépandans sikilè.
+       *[other] Yo détekté on dépandans sikilè ki ka enplitjé on konpozan `<{ $componentType }>`.
+    }
+
+reference-no-referent = Yo pa twouvé pyès wéféwan pou wéféwans la: `{ $reference }`
+
+reference-multiple-referents = Yo twouvé plizyè wéféwan pou wéféwans la: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fòma pa valab pou atwibi { $attribute } a on `<{ $componentType }>`.
+
+children-invalid = Pitit ki pa valab pou `<{ $componentType }>`: Yo twouvé pitit ki pa valab: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Valè `{ $value }` pa valab pou atwibi `{ $attribute }`, yo ka sèvi épi valè `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Yo pa twouvé vèsyon DoenetML { $version }.
+       *[other] Yo pa twouvé vèsyon DoenetML { $version }. Yo ka tonbé asi vèsyon { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ki pa valab: { $content }
+
+parse-tag-missing-close-tag = DoenetML ki pa valab: Tag `{ $tag }` pa ni tag fèmti. Yo té ka atann on tag ki ka fèmé tèt a-y oben on tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ki pa valab: Éwè adan tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ki pa valab: Atwibi `{ $attribute }` ki pa valab ka sanb ka manké on valè.
+
+parse-attribute-invalid = DoenetML ki pa valab: Atwibi `{ $attribute }` pa valab
+
+parse-attribute-value-invalid = DoenetML ki pa valab: Valè atwibi `{ $value }` pa valab
+
+parse-attribute-value-quote-mismatch = DoenetML ki pa valab: Valè atwibi `{ $value }` pa valab. Gimè a pa ka kowesponn. I ka sanb ou ka manké on `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML ki pa valab: Yo twouvé on tag san non tag, pa egzanp `<`
+
+parse-tag-not-closed = DoenetML ki pa valab: Tag `{ $tag }` pa té fèmé (i ka sanb on `>` ka manké).
+
+parse-self-closing-tag-name-missing = DoenetML ki pa valab: Yo twouvé on tag san non tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ki pa valab: Tag `{ $tag }` pa té fèmé (i ka sanb `/>` ka manké).
+
+parse-tag-invalid-attributes = DoenetML ki pa valab: Tag `{ $tag }` pa valab. I pé ni atwibi ki pa kòwèk.
+
+parse-close-tag-name-missing = DoenetML ki pa valab: Yo twouvé on tag fèmti san non tag, pa egzanp `</`
+
+parse-attribute-value-unquoted = Valè atwibi dwèt adan gimè: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ki pa valab: Yo twouvé tag fèmti `{ $tag }`, mé pa ni tag ouvèti ki ka kowesponn
+
+parse-close-tag-mismatched = DoenetML ki pa valab: Tag fèmti pa ka kowesponn. Yo té ka atann `</{ $expected }>`. Yo twouvé `{ $found }`
+
+parser-node-unconvertible = Yo pa pé konvèti nœud { $node } an nœud Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atwibi name='{ $name }' pa valab. { $reason ->
+        [characters] Non pé ni sèlman lèt, chif, tiwè anba oben tiwè.
+       *[start] Non dwèt koumansé épi on lèt.
+    }
+
+component-name-invalid-start = Non konpozan "{ $name }" pa valab. Non dwèt koumansé épi on lèt.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = On wéponn tip videoWatched dwèt ni on atwibi video
+
+answer-video-watched-video-not-reference = On wéponn tip videoWatched dwèt ni on atwibi video ki sé on wéféwans
+
+answer-name-not-single-text = Atwibi name a on wéponn dwèt ni yon sèl pitit tèks
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Yo pa pé jwenn DoenetML déwò a paske ni twòp nivo wekisyon. Es ni on wéféwans sikilè?
+
+external-doenetml-unavailable = Yo pa pé jwenn DoenetML adan { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ki pa valab jwenn adan { $attribute }="{ $uri }": i pa té ka kowesponn épi tip konpozan "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atwibi `{ $from }` démodé; sèvi épi `{ $to }` pito.
+       *[other] [deprecation] Atwibi `{ $from }` asi `<{ $component }>` démodé; sèvi épi `{ $to }` pito.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atwibi `{ $from }` démodé é yo ka inyowé-y paske `{ $to }` espesifyé tou.
+       *[other] [deprecation] Atwibi `{ $from }` asi `<{ $component }>` démodé é yo ka inyowé-y paske `{ $to }` espesifyé tou.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atwibi `{ $attribute }` asi `<{ $component }>` démodé é yo ka inyowé-y.
+
+deprecated-attribute-to-child = [deprecation] Atwibi `{ $attribute }` asi `<{ $component }>` démodé; sèvi épi on pitit `<{ $child }>` pito.
+
+deprecated-attribute-value-renamed = [deprecation] Valè `{ $value }` a atwibi `{ $attribute }` asi `<{ $component }>` démodé; sèvi épi `{ $to }` pito.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` pé mèt sèlman anglé an pliwyèl, kidonk tèks a-y ka wété kon i yé adan on dokiman ki ekwi an { $locale }. Ekwi fòm pliwyèl la diwèkteman, oben mèt li épi atwibi `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Eleman `<{ $tag }>` pa on eleman Doenet yo ka wekonèt.
+
+schema-element-not-allowed-at-root = Eleman `<{ $tag }>` pa pèmèt an wasin dokiman an.
+
+schema-element-not-allowed-inside = Eleman `<{ $tag }>` pa pèmèt adan `<{ $parent }>`.
+
+schema-attribute-unrecognized = Eleman `<{ $tag }>` pa ni on atwibi ki kwiyé `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atwibi `{ $attribute }` a eleman `<{ $tag }>` dwèt sé on lis koté chak atik sé yonn adan: { $allowed }
+       *[other] Atwibi `{ $attribute }` a eleman `<{ $tag }>` dwèt sé yonn adan: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Non varyant pa valab pou select.  Non varyant { $variantName } ka pawet adan { $numOptions } opsyon mé kantité pou chwazi sé { $numToSelect }.
+
+select-variant-name-without-options = Kèk varyant espesifyé pou select mé pa ni pyès opsyon espesifyé pou non varyant posib: { $variantName }.
+
+select-variant-name-not-possible = Non varyant { $variantName } ki espesifyé pou select pa on non varyant posib.
+
+select-too-few-options = Pé pa chwazi { $numToSelect } konpozan adan sèlman { $numOptions }.
+
+select-from-sequence-too-few-values = Pé pa chwazi { $numToSelect } valè adan on sekans longè { $length }.
+
+select-from-sequence-indices-count-mismatch = Kantité endis espesifyé pou select dwèt kowesponn épi kantité pou chwazi
+
+select-from-sequence-indices-not-integers = Tout endis espesifyé pou select dwèt sé antyé
+
+select-from-sequence-index-excluded = Endis selectfromsequence ki espesifyé a té eskli
+
+select-from-sequence-indices-excluded-combination = Endis selectfromsequence ki espesifyé a té on konbinezon eskli
+
+select-from-sequence-coprime-not-positive-integers = Pé pa chwazi konbinezon kopwim paske sé pa antyé pozitif yo ka chwazi.
+
+select-from-sequence-coprime-common-factor = Pé pa chwazi nonm kopwim. Tout valè posib la ka pataj on faktè komen. (Valè "from" oben "to" ki espesifyé dwèt kopwim épi "step".)
+
+select-from-sequence-coprime-single-number = Pé pa chwazi konbinezon kopwim adan yon sèl nonm ki pa 1.
+
+select-from-sequence-excluded-too-many-combinations = Plis ki 70% a konbinezon an eskli adan selectFromSequence
+
+select-from-sequence-coprime-none-found = Yo pa pé chwazi nonm kopwim. Tout valè posib la ka pataj on faktè komen.
+
+select-from-sequence-too-few-unique-values = Pé pa chwazi { $numToSelect } valè inik adan on sekans longè { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Pé pa chwazi { $numToSelect } valè adan on lis nonm pwèmyé longè { $numValues }
+
+select-prime-numbers-values-count-mismatch = Kantité valè espesifyé pou select dwèt kowesponn épi kantité pou chwazi
+
+select-prime-numbers-values-not-prime = Tout valè espesifyé pou select nonm pwèmyé dwèt adan lis nonm pwèmyé a
+
+select-prime-numbers-values-excluded-combination = Valè selectPrimeNumbers ki espesifyé a té on konbinezon eskli
+
+select-prime-numbers-excluded-too-many-combinations = Plis ki 70% a konbinezon an eskli adan selectPrimeNumbers
+
+select-random-combination-fluke = Pa on chans estwèmman wa, yo pa pé chwazi on konbinezon valè o aza
+
+select-random-value-fluke = Pa on chans estwèmman wa, yo pa pé chwazi on valè o aza
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` pa twasé adan matématik la; ekspwesyon an konpozé kon i té ye avan yo té pé mèt antwé adan-y. { $reason ->
+        [not-inline] Sé sèlman on choice input `inline` ki ka wantwé adan on ekspwesyon; san `inline` i sé on blòk bouton.
+        [expanded] On text input `expanded` sé on bwèt plizyè liy, ki twòp gwo pou chita adan on ekspwesyon.
+        [on-graph] Asi on graph ekspwesyon an twasé kon yon sèl imaj, ki pa ni plas pou on kontwòl.
+       *[relative-width] `width` a-y wélatif (on pousantaj oben `em`), ki pa ni anyen pou mizuwé kont adan on ekspwesyon. Bay lajè a an inité absoli, kon `px`, pito.
+    }

--- a/packages/i18n/locales/acf/editor.ftl
+++ b/packages/i18n/locales/acf/editor.ftl
@@ -1,0 +1,236 @@
+# Saint Lucian Creole French (Kwéyòl) editor and language-server surfaces.
+# Translated from `locales/en/editor.ftl`, which is the source of truth:
+# `lint:i18n` rejects a key that does not exist there, and reports a key that
+# exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The Saint Lucian and Dominican standard, as `chrome.ftl`
+# sets it out. It is very close to the Martinican and Guadeloupean spelling;
+# what differs is the «w» for every etymological French /r/ and the determiner
+# written as a separate word with the full allomorph set. The
+# French-etymological spelling is not mixed in.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# **Number.** No `[one]`/`[other]` select appears anywhere in this file. Saint
+# Lucian nouns do not inflect for number, so «vyolasyon» and «wékòmandasyon»
+# are the same word in both English branches; the select is dropped and the
+# count still arrives and is still formatted. `Intl.PluralRules` has no CLDR
+# data for `acf` either. `help-coordinates` is one unselected form for the
+# same reason.
+#
+# **Loans.** French, respelled by the Saint Lucian rules: «varyant»,
+# «Filtwé», «aksésibilité», «vyolasyon», «wékòmandasyon», «wapò», «vèsyon»,
+# «kontèks», «éwè», «avètisman», «enfo», «dyagnostik», «anotasyon», «opsyon»,
+# «fòmaté», «wéféwans», «wéféwan», «dokimantasyon», «atwibi», «konpozan»,
+# «pwopwiyété», «kòdoné», «valè», «stil», «tip», «idantifyan». One English
+# loan: «tag», the markup word, which arrives through the language itself. The
+# frame around them is creole: «ka» for the progressive, «pa» for negation,
+# «pé pa» for *cannot*, «sé» for the copula, «yo» for the impersonal subject,
+# and the postposed determiner («wapò a», «editè a»).
+#
+# **Confidence.** This is the file with the least support behind it: Saint
+# Lucia's computing is done in English, there is no written Kwéyòl computing
+# register at all, and «tibout kòd» for *snippet*, «antwé tablo» for *array
+# entry* and «wandè» in the sibling files are proposals rather than attested
+# terms. A reviewer should read those three first, and may well decide that a
+# straight English loan is the honest answer for each.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Wimèt a zéwo
+       *[update] Mèt ajou
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } vizyonè a
+       *[other] { $word } vizyonè a { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varyant
+editor-variant-filter = Filtwé…
+editor-variant-next = Chwazi varyant ki ka vin apwé
+editor-variant-previous = Chwazi varyant ki ka vin avan
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Yo twouvé on vyolasyon aksésibilité WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } wapò aksésibilité a.
+        [advisories] Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } wapò aksésibilité a. Yo pa twouvé pyès vyolasyon WCAG AA, mé ni dòt wékòmandasyon aksésibilité ki disponib.
+       *[clean] Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } wapò aksésibilité a. Yo pa twouvé pyès pwoblèm aksésibilité.
+    }
+
+# No select on `$count` inside the branches: «vyolasyon» and «wékòmandasyon»
+# are the same word for one and for many, so the two categories would render
+# the same string. The count still arrives and is still formatted.
+editor-accessibility-label =
+    { $status ->
+        [violations] Yo twouvé on vyolasyon aksésibilité WCAG AA. Yo twouvé { $count } vyolasyon WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } wapò aksésibilité a.
+        [advisories] Yo pa twouvé pyès vyolasyon WCAG AA. Yo twouvé { $count } dòt wékòmandasyon aksésibilité. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } wapò aksésibilité a.
+       *[clean] Yo pa twouvé pyès vyolasyon WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } wapò aksésibilité a.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Vèsyon DoenetML { $version }
+
+editor-tab-help = Èd ki ka dépann di kontèks
+editor-tab-help-short = Kontèks
+editor-tab-errors = Éwè
+editor-tab-warnings = Avètisman
+editor-tab-info = Enfo
+editor-tab-accessibility = Aksésibilité
+editor-tab-responses = Wéponn ki voyé
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsyon editè a
+editor-format-as-doenetml = Fòmaté kon DoenetML
+editor-format-as-xml = Fòmaté kon XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liy #{ $line }
+
+editor-no-errors = Pa ni éwè
+editor-no-warnings = Pa ni avètisman
+editor-no-info = Pa ni dyagnostik enfòmatif
+
+editor-show-info-annotations = Montwé dyagnostik enfòmatif adan editè a
+editor-show-accessibility-annotations = Montwé dyagnostik aksésibilité adan editè a
+
+editor-accessibility-learn-more = Apwann ki jan Doenet ka twété aksésibilité
+
+editor-accessibility-violations-heading = Vyolasyon aksésibilité ({ $standard })
+
+editor-accessibility-other-heading = Dòt pwoblèm aksésibilité
+editor-none-found = Yo pa twouvé anyen
+
+
+## Submitted responses
+
+editor-no-responses = Pòkò ni wéponn ki voyé
+editor-response-answer-id = Idantifyan wéponn
+editor-response-response = Wéponn
+editor-response-credit = Kwedi
+editor-response-submitted = Voyé
+
+
+## The context-help panel
+
+help-placeholder = Mèt kisò a asi on non tag, on atwibi, oben { $ref } pou dokimantasyon.
+
+help-unsupported-ref-chain = Èd pou wéféwans an plizyè moso kon { $example } pòkò disponib.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Yo pa twouvé pyès wéféwan pou wéféwans la: { $ref }.
+        [multiple] Yo twouvé plizyè wéféwan pou wéféwans la: { $ref }.
+       *[indeterminate] Yo pa pé détèwminé on wéféwan pou { $ref }.
+    }
+
+help-learn-about-references = Apwann asi wéféwans →
+help-reference-page = Paj wéféwans →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Adan { $element }
+       *[top] Asi nivo pli wo a
+    }{ $allowed ->
+        [none] { " — anyen pa ka wantwé la." }
+        [text] { " — tapé tèks la." }
+        [text-and-components] { " — tapé tèks la, oben eséyé:" }
+       *[components] { " — bagay pou eséyé:" }
+    }
+
+help-suggestions-footer = Pésé { $shortcut } pou wè tout { $total } konpozan an.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } sé on wéféwans ba { $target }.
+       *[other] { $ref } sé on wéféwans ba { $target } (liy { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Entwodwi pa { $owner } kon { $role }.
+       *[other] Entwodwi pa { $owner } an liy { $line } kon { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } sé on wéféwans ba pwopwiyété { $property } a konpozan { $element }.
+       *[other] { $ref } sé on wéféwans ba pwopwiyété { $property } a konpozan { $element } (liy { $line }).
+    }
+
+help-kind-attribute = atwibi
+help-kind-snippet = tibout kòd
+help-kind-array-entry = antwé tablo
+
+help-default = Valè pa défo:
+help-active-default = Valè pa défo aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valè ki pèmèt (yonn pa atik):
+       *[other] Valè ki pèmèt:
+    }
+
+help-suggested-values = Valè ki sijéwé:
+
+help-inserts = Ka mèt:
+
+# No select: «kòdoné» is the same word for one and for many, so both
+# categories would render the same string.
+help-coordinates = Kòdoné:
+
+help-type = Tip:
+
+help-resolved-style = Stil ki wézoud (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Non fonksyon ki wézoud:
+help-reset-list = Lis wimiz a zéwo asi antwé sala:
+help-added-on-input = Ajouté asi antwé sala:
+help-removed-on-input = Òté asi antwé sala:
+
+help-reset-overrides = { $reset } ka pwan plas { $additional } é { $removed }.

--- a/packages/i18n/locales/bzj/chrome.ftl
+++ b/packages/i18n/locales/bzj/chrome.ftl
@@ -1,0 +1,179 @@
+# Belize Kriol (Bileez Kriol) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** These four files are written in the **phonemic orthography
+# of the Belize Kriol Council / National Kriol Council of Belize**, the system
+# of the *Kriol-Inglish Dikshineri* and of «Di Nyoo Testiment». Its points:
+#
+#   * **Long vowels are doubled** — «chrii», «bloo», «griin», «sayv»; the
+#     diphthongs are written «ai ou ie uo oa ay».
+#   * **`ch` for English *tr-*** and **`j` for English *dr-*** — «chrai»
+#     (*try*), «chraiangl» (*triangle*), «jraa» (*draw*). This is the single
+#     most visible mark of the orthography and a reviewer should keep it.
+#   * **`k` for hard *c*** — «klik», «kalam», «kredit».
+#   * **No apostrophes anywhere**, and no silent English letters: «rait» not
+#     *right*, «noat» not *note*.
+#
+# The **English-based ad-hoc spelling** — writing Kriol words as though they
+# were the English words they descend from — is what most Belizeans actually
+# write day to day, and it is **not used anywhere in these four files**. That
+# is a deliberate choice of one system over the commoner practice, not an
+# oversight. A reviewer who prefers the English-based spelling should
+# **respell** these files rather than retranslate them: the grammar underneath
+# is the same either way.
+#
+# **Grammar.** Kriol grammar, not English words in English order. Tense and
+# aspect are preverbal markers — «mi» (past), «wahn» (future), «di»
+# (progressive), «dohn» (completive) — never suffixes; the negator is the
+# preverbal «noh», and it stacks («no chrai noh lef»); «wan» is the indefinite
+# article and «di» the definite one; «dehn» after a noun marks the plural;
+# «fi» is the purposive («klik fi oapn»). Serial verbs carry what English
+# carries with a preposition.
+#
+# **Number.** `Intl.PluralRules("bzj")` has **no CLDR data for `bzj`**: it
+# falls back and answers `['one', 'other']`, which is English's answer and not
+# a fact about Kriol. A Kriol noun after a numeral does not inflect — «chree
+# chrai», never a pluralized noun — so the `one` and `other` branches would be
+# word-for-word identical. Where that is so, this file writes **one unselected
+# form** rather than two identical branches. English's explicit `[0]` literal
+# in `attempts-remaining` matches the number itself, not a plural category, and
+# is kept.
+#
+# **Loans.** The computing and mathematics register is English, respelled into
+# Kriol phonology and carried in Kriol grammar: «kiiboad», «rispans»,
+# «kredit», «matriks», «vekta», «fongshan», «statistiks», «expreshan»,
+# «dakiument», «renderer», «infamayshan», «akseh» (*access*). Where a Kriol
+# word exists it is used instead — «chrai» for *attempt*, «rang» for
+# *incorrect*, «lef» for *remaining*, «tek out» for *remove*.
+#
+# **Confidence.** Kriol has a settled orthography and a dictionary but very
+# little written technical prose, so the loans above are respellings this seed
+# made rather than usage it found. The everyday words — «rait», «rang»,
+# «chrai», «oapn», «kloaz», «shoa», «lef» — are dictionary words and should
+# stand. Nothing in this file was left in English.
+
+
+answer-checking = Di chek...
+answer-submitting = Di sen...
+
+answer-checking-status = Di chek di ansa
+answer-submitting-status = Di sen di ansa
+
+answer-correct = Rait
+answer-incorrect = Rang
+
+answer-response-saved = Rispans Sayv
+
+answer-percent-credit = { $percent }% Kredit
+answer-percent-correct = { $percent }% Rait
+answer-percent-short = { $percent } %
+
+max-credit-available = Di moas kredit weh deh: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] no chrai noh lef
+       *[other] { $count } chrai lef
+    }
+
+validation-correct = (Rait)
+validation-incorrect = (Rang)
+validation-partially-correct = (Paat a it rait)
+
+answer-show-responses = Shoa { $count } rispans fi { $answerId }
+
+
+feedback-heading = Fiidbak
+
+collapsible-click-to-open = (klik fi oapn)
+collapsible-click-to-close = (klik fi kloaz)
+
+collapsible-initializing = Di staat op...
+
+footnote-show = Shoa di futnoat
+footnote-hide = Haid di futnoat
+
+description-more-information = moa infamayshan
+
+
+slider-previous = Bak
+slider-next = Neks
+
+keyboard-open = Oapn di Kiiboad
+keyboard-close = Kloaz di Kiiboad
+
+choice-input-remove-choice = Tek out { $choice }
+
+matrix-remove-row = Tek out wan roa
+matrix-add-row = Ad wan roa
+matrix-remove-column = Tek out wan kalam
+matrix-add-column = Ad wan kalam
+
+subset-add-remove-points = Ad/Tek out paint
+subset-toggle-points-intervals = Swich bitwiin paint ahn intaval
+subset-move-points = Muuv di Paint
+subset-clear = Klier
+
+orbital-add-row = Ad wan Roa
+orbital-remove-row = Tek out wan Roa
+orbital-add-box = Ad wan Baks
+orbital-remove-box = Tek out wan Baks
+orbital-add-up-arrow = Ad wan Aro weh Point Op
+orbital-add-down-arrow = Ad wan Aro weh Point Dong
+orbital-remove-arrow = Tek out di Aro
+
+orbital-row-label = Laybl fi roa { $row }
+
+pretzel-answer = Ansa
+
+summary-statistics-caption = Somari statistiks a { $column }
+
+
+math-input-preview-region = priviu a di mat expreshan
+math-input-preview = Priviu
+math-input-invalid-expression = Di expreshan noh gud:
+
+
+viewer-initializing = Di staat op...
+
+
+error-heading = Era
+
+error-found-at =
+    { $span ->
+        [line] Fain pahn lain { $startLine }.
+       *[lines] Fain pahn lain { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dis dakiument gat era eena it!
+
+diagnostic-heading-error = Era
+diagnostic-heading-warning = Waanin
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Hint
+
+accessibility-heading-level-1 = WCAG AA akseh-vaiyolayshan
+accessibility-heading-level-2 = Akseh-alert
+
+something-went-wrong = Sohnting gaan rang.
+
+renderer-load-failed = wan renderer noh mi lod. Pliiz lod di payj bak.
+
+core-start-failed = Dis dakiument noh mi ku staat. Pliiz lod di payj bak.
+
+core-start-failed-busy = Dis dakiument noh mi ku staat. Wahn hiip a dakiument mi di staat da di siem taim, ahn dat ku tek langa pahn wan sloa masheen. Wen di ada dakiument dehn dohn, den lod di payj bak — dat ku help.
+
+core-start-failed-retry = Dis dakiument noh mi ku staat.
+
+core-start-failed-busy-retry = Dis dakiument noh mi ku staat. Wahn hiip a dakiument mi di staat da di siem taim, ahn dat ku tek langa pahn wan sloa masheen.
+
+core-start-retry = Chrai wan neks taim
+
+saved-state-unavailable = Wi noh mi ku lod di wok weh yu mi sayv.

--- a/packages/i18n/locales/bzj/content.ftl
+++ b/packages/i18n/locales/bzj/content.ftl
@@ -1,0 +1,261 @@
+# Belize Kriol (Bileez Kriol) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. Translated from `locales/en/content.ftl`, which is the source of
+# truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The phonemic orthography of the Belize Kriol Council /
+# National Kriol Council of Belize — long vowels doubled («chrii», «griin»),
+# «ch» for English *tr-* and «j» for English *dr-* («chraiangl», «jraa»), «k»
+# for hard *c*, no apostrophes and no silent letters. The English-based ad-hoc
+# spelling that most Belizeans write day to day is **not used anywhere in
+# these four files** and must not be mixed into them; `chrome.ftl`'s header
+# sets the system out point by point. A reviewer who prefers the English-based
+# spelling should respell rather than retranslate.
+#
+# **Word order: the modifier comes before the noun.** Kriol puts an
+# attributive adjective in front of its head, as English does — «wan tik red
+# lain» is *a thick red line*, in that order. So every composition message
+# here **keeps the English order**: `style-with-noun` puts the description
+# first and the noun after it, `style-stroke` runs width, then dash pattern,
+# then colour, and `noun-regular-polygon` folds the side count into the head
+# with no tail, exactly as English does. Nothing in this file reverses.
+#
+# **No grammatical gender and no agreement.** Kriol adjectives do not inflect
+# for anything: there is no gender, no number agreement and no case. So no
+# message here forks on `$gender` or on `$role`, and `noun-gender` answers a
+# single token that nothing reads.
+#
+# **Number.** `Intl.PluralRules("bzj")` has no CLDR data for `bzj` and falls
+# back to English's `['one', 'other']`, which is not a fact about Kriol. A
+# Kriol noun after a numeral is unmarked — «chree paint», never a pluralized
+# noun; the plural is the postposed «dehn», used when a noun is definite
+# rather than when it is counted. So **nothing in this file selects on a
+# count**: where English writes a `[one]`/`[other]` select, this file writes
+# one unselected form.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# Science in Belize is schooled in English, from English textbooks and to an
+# English-language examination; there is no Kriol periodic table in use and no
+# settled Kriol spelling for the hundred and eighteen names. Respelling the
+# English list into Kriol phonology would be inventing a nomenclature, not
+# recording one. `lint:i18n` reports the two keys as missing coverage, and
+# that report is correct: they fall back to English, which is what a Belizean
+# science classroom uses anyway.
+#
+# **Loans.** The mathematical vocabulary is English carried in Kriol
+# orthography and Kriol grammar: «vekta», «fongshan», «parabola», «paligan»,
+# «palilain», «rektangl», «matriks», «definishan», «tiorem», «egzampl»,
+# «sekshan», «soalushan», «paragraf», «kaskayd», «kemikal», «ayanik». Where
+# Kriol has its own word it is used — «lain», «paint», «kerv», «serkl»,
+# «skweh», «daiman», «kraas», «baada», «bakgrong», «ful». Six colour names —
+# «arinj», «sayan», «perpl», «pink», «brong», «gray» — are respelled English
+# and are the least certain entries here.
+
+
+color =
+    .black = blak
+    .white = wait
+    .gray = gray
+    .red = red
+    .orange = arinj
+    .yellow = yela
+    .green = griin
+    .cyan = sayan
+    .blue = bloo
+    .purple = perpl
+    .pink = pink
+    .brown = brong
+
+line-width =
+    .thick = tik
+    .thin = tin
+
+line-style =
+    .dashed = dash-dash
+    .dotted = dat-dat
+
+fill-style =
+    .horizontal = lain weh gaan akraas
+    .vertical = lain weh gaan op ahn dong
+    .diagonal = lain weh gaan kaana
+    .backdiagonal = lain weh gaan di ada kaana
+    .dots = dat
+    .diamonds = daiman
+
+noun =
+    .line = lain
+    .line-segment = pees a lain
+    .ray = ray
+    .vector = vekta
+    .curve = kerv
+    .function = fongshan
+    .slope-field = sloap fiil
+    .vector-field = vekta fiil
+    .parabola = parabola
+    .polyline = palilain
+    .polygon = paligan
+    .triangle = chraiangl
+    .rectangle = rektangl
+    .circle = serkl
+    .region = riijan
+    .point = paint
+    .square = skweh
+    .diamond = daiman
+    .cross = kraas
+    .plus = plos
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] reglar paligan wid { $numSides } said
+    }
+
+noun-gender = neuter
+
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = ful
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } wid { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } wid { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wid { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] wid wan { $border } baada
+        [and] ahn { $border } baada
+        [and-article] ahn wan { $border } baada
+       *[with] wid { $border } baada
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = noh ful
+
+style-text =
+    { $parts ->
+        [background] { $color } wid wan { $background } bakgrong
+       *[plain] { $color }
+    }
+
+style-background-none = non
+
+
+boolean-true = chruu
+boolean-false = faals
+
+
+answer-submit-label = Chek di Wok
+
+answer-submit-label-no-correctness = Sen di Rispans
+
+
+section-name =
+    .activity = Aktiviti
+    .aside = Said Noat
+    .cascade = Kaskayd
+    .definition = Definishan
+    .example = Egzampl
+    .exercise = Egzasaiz
+    .exercises = Egzasaiz
+    .given-answer = Ansa
+    .note = Noat
+    .objectives = Objektiv
+    .paragraphs = Paragraf
+    .part = Paat
+    .problem = Prablem
+    .problems = Prablem
+    .proof = Pruuf
+    .question = Kweschan
+    .section = Sekshan
+    .solution = Soalushan
+    .task = Taask
+    .theorem = Tiorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Hint
+
+
+table-name =
+    { $parts ->
+        [numbered] Taybl { $enumeration }
+        [numbered-title] Taybl { $enumeration }{ ": " }
+        [unnumbered-title] Taybl{ ": " }
+       *[unnumbered] Taybl
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figa { $enumeration }
+        [numbered-caption] Figa { $enumeration }{ ": " }
+        [unnumbered-caption] Figa{ ": " }
+       *[unnumbered] Figa
+    }
+
+
+paginator-previous = Bak
+paginator-next = Neks
+paginator-page = Payj
+
+paginator-page-status = { $pageLabel } { $currentPage } outa { $numPages }
+
+
+piecewise-condition-or = ar
+
+piecewise-condition-if = if
+
+piecewise-condition-otherwise = if noh soh
+
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Di Kemikal Simbal Noh Gud
+chemistry-invalid-ionic-compound = Di Ayanik Kompoun Noh Gud
+
+
+math-embedded-input-blank = blangk
+
+math-embedded-input-blank-ordinal = blangk { $ordinal } outa { $total }

--- a/packages/i18n/locales/bzj/diagnostics.ftl
+++ b/packages/i18n/locales/bzj/diagnostics.ftl
@@ -1,0 +1,674 @@
+# Belize Kriol (Bileez Kriol) diagnostics: the errors and warnings the worker,
+# the parser and the language server put in front of whoever is looking at the
+# screen. Translated from `locales/en/diagnostics.ftl`, which is the source of
+# truth; the ids are reached by diagnostic code and are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The phonemic orthography of the Belize Kriol Council /
+# National Kriol Council of Belize, set out point by point in `chrome.ftl`'s
+# header: long vowels doubled, «ch» for English *tr-*, «j» for English *dr-*,
+# no apostrophes, no silent letters. The English-based ad-hoc spelling in
+# everyday use is not mixed into these files; a reviewer who prefers it should
+# respell rather than retranslate.
+#
+# **DoenetML identifiers stay in English.** Tag names, attribute names and
+# attribute values — `through`, `endpoint`, `midpointOffset`, `numDimensions`,
+# `maxNumAttempts`, `symbolicEquality`, `math`, `text`, `number`, `boolean`,
+# `none`, `medium`, `dense`, `from`, `to`, `step` — are the language, not
+# prose, and are written here exactly as English writes them. So are the
+# `[deprecation]` marker and the `Invalid DoenetML: ` opening's structure,
+# though its words are translated.
+#
+# **Number.** `Intl.PluralRules("bzj")` has no CLDR data for `bzj` and falls
+# back to English. A Kriol noun after a numeral does not inflect, so every
+# message English selects on a count — `line-segment-attributes-ignored-*`,
+# `function-domain-insufficient-dimensions`,
+# `function-iterates-input-output-mismatch`,
+# `matches-pattern-parameter-not-in-pattern`,
+# `answer-attributes-need-symbolic-equality`, `attribute-invalid-values` — is
+# written here as **one unselected form**. The one remaining `[one]` branch,
+# in `field-function-wrong-num-outputs`, is not a plural: it picks between two
+# different sentences about what a slope field and a vector field each need,
+# and dropping it would drop the advice.
+#
+# **Loans.** English respelled into Kriol phonology: «komponent»,
+# «atribyuut», «valyu», «dakiument», «vershan», «varyant», «indeks»,
+# «paramita», «expreshan», «funkshan», «matriks», «sekwens», «dimenshan»,
+# «kantras», «anotayshan», «skiima», «refrans», «prapati», «era». Where Kriol
+# has its own word it carries the sentence: «noh», «fain», «tek», «se»,
+# «jraa», «pas oava», «mos», «ku».
+#
+# **Confidence.** Kriol has no written technical prose of this kind, so every
+# noun above is a respelling this seed made. What a reviewer should read for is
+# the grammar: the negator «noh», the modal «ku» / «mos», and the absence of
+# English inflection. Nothing here was left in English.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } noh kount wen yu se tu endpoint
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } noh kount wen yu se wan endpoint ahn wan midpoint bofa dem
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset noh du notn if no midpoint noh deh
+
+## `<line>`
+
+line-points-undetermined-dimensions = Lain chruu paint weh wi noh noa how moch dimenshan dehn gat.
+
+line-points-too-few-dimensions = Di lain mos goh chruu paint weh gat tu dimenshan ar moa.
+
+line-points-depend-on-variables = Di lain goh chruu paint weh dipen pahn verabl: { $variables }.
+
+line-equation-invalid-format = Di fahmat fi di ikwayshan a di lain eena verabl { $variable1 } ahn { $variable2 } noh gud.
+
+## `<ray>`
+
+ray-overprescribed-through = Di ray get se wid through, endpoint ahn direction.  Wi pas oava di through weh yu se.
+
+ray-dimension-mismatch = Di numDimensions noh mach eena di ray.
+
+## `<vector>`
+
+vector-overprescribed-head = Di vekta get se wid head, tail ahn displacement.  Wi pas oava di head weh yu se.
+
+vector-dimension-mismatch = Di numDimensions noh mach eena di vekta.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Wi kyaahn atrak tu wan `<{ $component }>` bikaaz ih noh gat wan nearestPoint stayt verabl.
+
+constrain-to-without-nearest-point = Wi kyaahn konstrayn tu wan `<{ $component }>` bikaaz ih noh gat wan nearestPoint stayt verabl.
+
+constrain-to-interior-without-nearest-point = Wi kyaahn konstrayn tu eenside a wan `<{ $component }>` bikaaz ih noh gat wan nearestPoint stayt verabl.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition noh kount pahn wan choiceInput weh noh inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Wi pas oava di indices weh se fi di choiceInput bikaaz di nomba a indices noh mach di nomba a choice pikni.
+
+pretzel-indices-count-mismatch = Wi pas oava di indices weh se fi di problem bikaaz di nomba a indices noh mach di nomba a problem pikni.
+
+shuffle-indices-count-mismatch = Wi pas oava di indices weh se fi di shuffle bikaaz di nomba a indices noh mach di nomba a komponent.
+
+indices-ignored-out-of-range = Wi pas oava di indices weh se fi { $component } bikaaz som a dehn deh outa rayni.
+
+pretzel-indices-repeated = Wi pas oava di indices weh se fi di pretzel bikaaz som a dehn ripiit.
+
+pretzel-circuit-first-index = Wi pas oava di indices weh se fi di pretzel eena circuit moad bikaaz di fos indeks mos bee 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Fi `<{ $component }>` fi wok wid schring pikni, yu mos se wan `type` atribyuut.
+
+invalid-type-defaulting-to-math = Di type { $type } noh gud fi wan { $component } komponent. Ih mos bee math, text, number ar boolean. Wi wahn yuuz math.
+
+string-not-valid-component-to-arrange = Di schring "{ $value }" noh wan gud komponent fi { $component }. Wi pas oava it.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Di type { $type } noh gud, soh wi set di type tu number.
+
+invalid-variable-value = Di valyu a wan verabl noh gud: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Di varyant indeks { $index } mos bee wan nomba
+
+variant-index-must-be-integer = Di varyant indeks { $index } mos bee wan hoal nomba
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` noh mek fi abzalut mezhamant. Wi set di widt dehn tu relativ.
+
+side-by-side-absolute-margins = `<{ $component }>` noh mek fi abzalut mezhamant. Wi set di maajin dehn tu relativ.
+
+side-by-side-no-block-child = Dis `<{ $component }>` noh gud: ih mos gat wan blak pikni ar moa.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Di `for` atribyuut noh kount pahn wan grafikal `<label>`.
+
+label-for-must-resolve-to-one = Di `for` atribyuut pahn wan `<label>` mos poin tu jos wan komponent.
+
+label-for-unresolved = Di `for` atribyuut pahn wan `<label>` noh mi ku fain no komponent.
+
+label-for-answer-with-authored-inputs = Di `for` atribyuut pahn wan `<label>` di poin tu wan `<answer>` weh gat ih oan inpot rait out; poin schrayt tu di inpot.
+
+label-for-answer-without-input = Di `for` atribyuut pahn wan `<label>` di poin tu wan `<answer>` weh noh gat no inpot fi laybl.
+
+label-for-must-reference-input-or-answer = Di `for` atribyuut pahn wan `<label>` mos poin tu wan inpot ar wan answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Fi akseh, wan `<{ $component }>` mos gat wan shaat diskripshan ar ih mos se dekorativ.
+
+accessibility-video-short-description = Fi akseh, wan `<video>` mos gat wan shaat diskripshan.
+
+accessibility-input-short-description-or-label = Fi akseh, wan `<{ $component }>` mos gat wan shaat diskripshan ar wan laybl.
+
+accessibility-answer-input-short-description-or-label = Fi akseh, wan `<answer>` weh mek wan inpot mos gat wan shaat diskripshan ar wan laybl.
+
+accessibility-short-description-contains-math = Shaat diskripshan noh fi gat mat komponent laik `<{ $component }>` eena dehn. Spel out di mat wid werd.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } noh gat nof kantras fi di sekshan hedin teks (dark moad) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ih need { $threshold }:1 ar moa).
+       *[other] { $colorName } noh gat nof kantras fi di sekshan hedin teks ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ih need { $threshold }:1 ar moa).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wi noh mek wan `<circle>` chruu { $count } paint yet fi wen di paint dehn noh gat nomba valyu.
+
+circle-too-many-through-points = Wi kyaahn wok out wan serkl chruu moa dan 3 paint.
+
+circle-overprescribed-radius-center-points = Wi kyaahn wok out wan serkl wid radius, senta ahn chruu-paint aal chree se.
+
+circle-center-with-multiple-points = Wi kyaahn wok out wan serkl wid wan senta se weh goh chruu moa dan 1 paint.
+
+circle-radius-too-small = Wi kyaahn wok out di serkl: di distans bitwiin di tu paint da { $distance }, soh di radius { $radius } weh yu se too likl.
+
+circle-radius-with-many-points = Wi kyaahn mek wan serkl chruu moa dan tu paint wid wan radius se.
+
+circle-invalid-center-or-through-points = Di senta ar di chruu-paint dehn a di serkl noh gud.
+
+circle-radius-center-with-multiple-points = Wi kyaahn wok out di radius a wan serkl wid wan senta se weh goh chruu moa dan 1 paint.
+
+circle-change-radius-non-numerical = Wi kyaahn chaynj di radius a wan serkl weh gat chruu-paint weh noh gat nomba valyu
+
+circle-radius-with-points-non-numerical = Wi kyaahn mek wan serkl chruu moa dan wan paint wid wan radius se wen di paint dehn noh gat nomba valyu.
+
+circle-change-center-non-numerical = Wi noh mek wan way yet fi chaynj di senta a wan serkl weh goh chruu paint weh noh gat nomba valyu.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Di doamayn noh gat nof dimenshan fi di fongshan. Di doamayn gat { $intervals } intaval bot di fongshan gat { $inputs } inpot.
+
+function-domain-invalid-format = Di fahmat fi di doamayn a di fongshan noh gud.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Wi pas oava di maksimom a di fongshan bikaaz ih noh wan nomba.
+        [minimum] Wi pas oava di minimom a di fongshan bikaaz ih noh wan nomba.
+        [extremum] Wi pas oava di ekschriimom a di fongshan bikaaz ih noh wan nomba.
+        [point] Wi pas oava di paint a di fongshan bikaaz ih noh wan nomba.
+        [slope] Wi pas oava di sloap a di fongshan bikaaz ih noh wan nomba.
+       *[other] Wi pas oava di { $type } a di fongshan bikaaz ih noh wan nomba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Wi pas oava di maksimom a di fongshan bikaaz ih emti.
+        [minimum] Wi pas oava di minimom a di fongshan bikaaz ih emti.
+        [extremum] Wi pas oava di ekschriimom a di fongshan bikaaz ih emti.
+        [point] Wi pas oava di paint a di fongshan bikaaz ih emti.
+       *[other] Wi pas oava di { $type } a di fongshan bikaaz ih emti.
+    }
+
+function-points-too-close = Di fongshan gat tu paint weh deh too kloas tugeda. Wi kyaahn difain di fongshan.
+
+function-iterates-input-output-mismatch = Fongshan itarayt ku wok oanli if di nomba a inpot siem laik di nomba a outpot. Dis fongshan gat { $inputs } inpot ahn { $outputs } outpot.
+
+## `<sequence>`
+
+sequence-invalid-length = Di lent a di sekwens noh gud.  Ih mos bee wan hoal nomba weh noh negativ.
+
+sequence-invalid-step = Di step a di sekwens noh gud.  Ih mos bee wan nomba fi wan sekwens a type { $type }.
+
+sequence-invalid-endpoint-number = Di "{ $attribute }" a di nomba sekwens noh gud.  Ih mos bee wan nomba.
+
+sequence-invalid-endpoint-letters = Di "{ $attribute }" a di leta sekwens noh gud.  Ih mos bee wan leta kombinayshan.
+
+sequence-invalid-endpoint = Di "{ $attribute }" a di sekwens noh gud.
+
+select-from-sequence-coprime-not-numbers = wi pas oava coprime bikaaz wi noh di pik nomba
+
+select-from-sequence-coprime-with-exclude-combinations = wi pas oava coprime bikaaz excludeCombinations se
+
+## Resolving a `target`
+
+target-not-found = Di target fi `<{ $source }>` noh gud: wi kyaahn fain di target.
+
+target-state-variable-not-found = Di target fi `<{ $source }>` noh gud: wi kyaahn fain no stayt verabl naym "{ $property }" pahn wan `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Di verabl dehn a wan `<odeSystem>` mos difrant fahn di indipendent verabl.
+
+ode-system-duplicate-variable-names = Wi kyaahn difain ODE RHS fongshan wid di siem dipendent verabl naym tu taim.
+
+ode-system-rhs-function-error = Wi kyaahn difain di ODE RHS fongshan.  Era wen wi mi di mek di mathjs fongshan.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Wi kyaahn difain wan anggl bitwiin { $count } lain
+
+angle-invalid-through-point = Di paint eena di through a di `<angle>` noh gud
+
+parabola-vertex-too-many-points = Wi noh mek wan parabola wid wan verteks weh goh chruu moa dan 1 paint yet.
+
+parabola-too-many-points = Wi noh mek wan parabola chruu moa dan 3 paint yet.
+
+intersection-too-many-items = Wi noh mek intasekshan fi moa dan tu ting yet
+
+## Other math components
+
+ionic-compound-not-two-ions = Wi noh mek no ayanik kompoun fi notn oada dan tu ayan yet.
+
+ionic-compound-needs-cation-and-anion = Wi mek ayanik kompoun oanli fi wan kayan ahn wan anayan.
+
+solve-equations-cannot-evaluate = Wi kyaahn salv di ikwayshan bikaaz wi kyaahn wok it out: { $equation }
+
+math-operators-operand-number-required = Yu mos se wan operandNumber wen yu di tek out wan mat aparan.
+
+eigen-decomposition-failed = Wi kyaahn wok out di aiganvalyu a di matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: di paramita { $parameters } noh deh eena di patan, soh ih wahn aalwayz mach wan blangk.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: wi kyaahn andastan grid="{ $grid }". Ih mos bee none, medium, dense, ar tu pazitiv nomba wid wan spays bitwiin dehn, laik grid="1 0.5". Wi noh jraa no grid.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` need wan fongshan wid { $expected ->
+        [one] wan outpot, di sloap y' da evri paint, laik `y - x`
+       *[other] tu outpot, di vekta da evri paint, laik `(y, -x)`
+    }, bot di fongshan weh ih get gat { $found } outpot. { $alternative ->
+        [none] Wi noh jraa notn.
+       *[other] `<{ $alternative }>` da di komponent fi dat fongshan. Wi noh jraa notn.
+    }
+
+field-function-attribute-ignored-with-child = Wi pas oava di `function` atribyuut bikaaz di fongshan deh eenside di komponent tu; wi yuuz di wan eenside. Gi di fongshan oanli wan a di tu way.
+
+field-variables-ignored =
+    `<{ $component }>`: di `variables` atribyuut naym di verabl a wan expreshan weh rait schrayt eenside di komponent. { $reason ->
+        [function-child] Di fongshan yaa gi az wan `<function>` pikni, ahn dat naym ih oan verabl, soh wi pas oava `variables`.
+       *[no-expression] No soh expreshan noh deh yaa, soh wi pas oava `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: di prefigure renderer noh sopoat xLabelPosition="left"; wi wahn du laik right.
+
+prefigure-y-label-position-unsupported = `<graph>`: di prefigure renderer noh sopoat yLabelPosition="bottom"; wi wahn du laik top.
+
+prefigure-invalid-axis-bounds = `<graph>`: di aksis bong dehn noh gud fi di prefigure konvershan; wi wahn yuuz di difalt bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: di widt noh gud fi di prefigure konvershan; wi wahn yuuz di difalt daiagram widt 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: di aspectRatio noh gud fi di prefigure konvershan; wi wahn yuuz di difalt aspek rayshiyo 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: di grid spaysin too tait fi di aksis limit dehn; wi lef out di grid eena di prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: wi noh wahn jraa no anotayshan if wi noh di yuuz di PreFigure renderer.
+
+multiple-annotations-children = Wi fain moa dan wan `<annotations>` pikni eena di `<graph>`; wi pas oava aal a dehn seks di laas wan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Wi kyaahn ekstend ar kapi wan komponent taip weh wi noh noa: { $type }.
+
+copy-prop-not-found = Wi kyaahn fain di prop { $property } pahn wan komponent a taip { $component }
+
+collect-no-source = Wi noh fain no soas fi di collect.
+
+collect-invalid-component-type = Wi kyaahn kalek komponent a taip `<{ $component }>` bikaaz dat noh wan gud komponent taip.
+
+reference-index-unavailable = Wi kyaahn refrans di indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Wi kyaahn kaal { $action } pahn di komponent `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Di dayta shayp noh gud.  Di roa dehn noh di siem lent. Fain eena componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Di dayta gat di siem kalam naym tu taim.  Fain eena componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kalam naym mising eena di dayta.  Fain eena componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award fi dis ansa dipen pahn di answer tag ih oan rispans, ahn dat wahn mek ting hapm weh yu noh expek.
+
+answer-max-num-attempts-in-section-wide-check-work = If yu set `maxNumAttempts` pahn wan `<answer>` eenside wan kanteena weh gat `sectionWideCheckWork`, ih noh du notn, bikaaz di kanteena kanchroal di nomba a chrai. Set `maxNumAttempts` pahn di kanteena instead.
+
+nested-section-wide-check-work-max-num-attempts = If yu set `maxNumAttempts` pahn wan kanteena weh gat `sectionWideCheckWork` weh eenside wan neks kanteena weh gat `sectionWideCheckWork`, ih noh du notn, bikaaz di outa kanteena kanchroal di nomba a chrai. Set `maxNumAttempts` pahn di outa kanteena instead.
+
+answer-attributes-need-symbolic-equality = Di { $attributes } atribyuut noh wahn du notn if symbolicEquality noh set.
+
+answer-invalid-type = Di taip fi di ansa noh gud: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Bikaaz di komponent `<{ $component }>` noh gat no naym, wi kyaahn yuuz it fi wan module atribyuut
+
+module-attribute-name-already-defined = Wi kyaahn yuuz di komponent `<{ $component } name="{ $name }">` az wan atribyuut fi wan module bikaaz di `<module>` komponent taip aredi gat wan "{ $name }" atribyuut.
+
+conditional-content-condition-ignored = Di atribyuut `condition` noh kount pahn wan `<conditionalContent>` komponent weh gat case ar else pikni.
+
+slider-markers-type-mismatch = Di maaka taip noh mach di slaida taip.
+
+pretzel-problem-needs-statement-and-answer = Dis pretzel noh gud: evri `<problem>` mos gat wan `<statement>` ahn wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Dis pretzel noh gud: eena mode="circuit", di fos `<problem>` kyaahn bee wan dischrakta.
+
+## Attribute values
+
+attribute-invalid-values = Di valyu { $values } fi di atribyuut `{ $attribute }` noh gud; wi pas oava it.
+
+attribute-must-be-references = Di valyu `{ $value }` fi di atribyuut `{ $attribute }` noh gud. Di atribyuut mos mek out a refrans weh staat wid wan `$`.
+
+math-input-invalid-function-names = <mathInput>: wi pas oava fongshan naym weh noh gud eena { $attribute }: { $names }. Evri naym ih displie paat mos gat tu karakta ar moa (leta ar dash); wan `|<mathspeak alternative>` ku fala it if yu waahn.
+
+## Building components from the source
+
+component-type-invalid = Dis komponent taip noh gud: `<{ $componentType }>`
+
+attribute-repeated = Yu kyaahn ripiit di atribyuut { $attribute }.
+
+attribute-invalid-for-component = Di atribyuut "{ $attribute }" noh gud fi wan komponent a taip `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Stail definishan { $styleNumber } noh gat nof kantras fi { $context ->
+        [text-on-background] di teks kola agens di bakgrong kola
+        [high-contrast] di hai-kantras kola agens di kanvas
+        [line] di lain kola agens di kanvas
+        [marker] di maaka kola agens di kanvas
+       *[text-on-canvas] di teks kola agens di kanvas
+    }{ $mode ->
+        [dark] { " (dark moad)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ih need { $threshold }:1 ar moa).
+
+style-definition-dark-mode-text-background-contrast =
+    Chruu stail definishan { $styleNumber } se kola weh gat nof kantras fi light moad, di dark-moad kola weh kom outa dehn noh gat nof kantras fi di teks kola agens di bakgrong kola ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ih need { $threshold }:1 ar moa). { $suggestion ->
+        [available] Fi gat nof kantras eena dark moad, eeda mek di light-moad kantras moa (fi egzampl, set { $lightAttribute }="{ $lightColor }") ar oavarait di dark-moad kola (fi egzampl, set { $darkAttribute }="{ $darkColor }").
+       *[none] Fi gat nof kantras eena dark moad, mek di light-moad kantras moa ar oavarait di kola dehn wid textColorDarkMode ahn/ar backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Chruu stail definishan { $styleNumber } se wan teks kola weh gat nof kantras fi light moad, di dark-moad teks kola weh kom outa it noh gat nof kantras agens di kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ih need { $threshold }:1 ar moa). { $suggestion ->
+        [available] Fi gat nof kantras eena dark moad, eeda mek di light-moad kantras moa (fi egzampl, set textColor="{ $lightColor }") ar oavarait di dark-moad kola (fi egzampl, set textColorDarkMode="{ $darkColor }").
+       *[none] Fi gat nof kantras eena dark moad, mek di light-moad kantras moa ar oavarait di kola wid textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan sekshan ku pik oanli wan <stylePalette>; wi yuuz di laas wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = wi kyaahn wok out di yuniik varyant a { $component } bikaaz numToSelect noh wan hoal nomba weh noh negativ.
+
+variant-num-to-select-not-constant-number = wi kyaahn wok out di yuniik varyant a { $component } bikaaz numToSelect noh wan kanstant nomba.
+
+variant-with-replacement-not-constant-boolean = wi kyaahn wok out di yuniik varyant a { $component } bikaaz withReplacement noh wan kanstant boolean.
+
+variant-select-weight-disables-unique = Yuniik varyant fi select torn aaf if wan opshan gat selectWeight ar selectForVariants se
+
+variant-coprime-undetermined = wi kyaahn wok out di yuniik varyant a { $component } bikaaz wi kyaahn tel if coprime aalwayz faals.
+
+variant-attribute-not-constant = wi kyaahn wok out di yuniik varyant a { $component } bikaaz { $attribute } noh kanstant.
+
+variant-attribute-not-number = wi kyaahn wok out di yuniik varyant a { $component } bikaaz { $attribute } noh wan nomba.
+
+variant-attribute-wrong-type-for-sequence =
+    wi kyaahn wok out di yuniik varyant a { $component } a { $type } taip bikaaz { $attribute } noh { $expected ->
+        [letters-combination] wan kombinayshan a leta
+        [math-expression] wan gud mat expreshan
+        [integer] wan hoal nomba
+       *[number] wan nomba
+    }.
+
+variant-length-not-integer = wi kyaahn wok out di yuniik varyant a { $component } bikaaz di length noh wan hoal nomba.
+
+variant-sort-not-implemented = wi noh mek yuniik varyant fi wan { $component } wid sort yet
+
+variant-exclude-combinations-not-implemented = wi noh mek yuniik varyant fi wan { $component } wid excludeCombinations yet
+
+variant-math-exclude-not-implemented = wi noh mek yuniik varyant fi wan { $component } a taip math wid exclude yet
+
+variant-non-constant-exclude-not-implemented = wi noh mek yuniik varyant fi wan { $component } wid wan exclude weh noh kanstant yet
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: di graph prefigure renderer noh sopoat dis; wi skip di dishendant.
+
+prefigure-descendant-invalid-geometry = { $subject }: di jiamichri noh finait ar noh komplit; wi skip di dishendant.
+
+prefigure-curve-label-omitted = { $subject }: laybl noh wok pahn kerv weh konvert; wi lef out di laybl.
+
+prefigure-curve-unsupported-definition-type = { $subject }: wi noh sopoat di kerv fongshan definishan taip '{ $definitionType }'; wi skip di dishendant.
+
+prefigure-region-flip-functions-unsupported = { $subject }: wi noh sopoat di flipFunctions atribyuut pahn regionBetweenCurves; wi skip di dishendant.
+
+prefigure-region-non-formula-child = { $subject }: oanli fahmiula-taip pikni fongshan wok pahn regionBetweenCurves; wi skip di dishendant.
+
+prefigure-label-position-unsupported =
+    { $subject }: wi noh sopoat labelPosition '{ $labelPosition }' fi wan { $labelKind ->
+        [line-family] lain-famili laybl
+       *[point] paint laybl
+    }; wi yuuz di difalt PreFigure alainmant.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure noh sopoat di ful stail '{ $fillStyle }'; wi wahn yuuz wan salid ful.
+
+prefigure-line-style-unknown = { $subject }: wi lef out di lain stail '{ $lineStyle }' weh wi noh noa fahn di PreFigure outpot.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wi tern di maaka stail '{ $markerStyle }' eena di PreFigure stail 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure noh sopoat di maaka stail '{ $markerStyle }'; wi yuuz di difalt stail.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: di `ref` noh gud; wi kyaahn fain di target. Wi lef out di anotayshan.
+
+annotation-ref-multiple-targets = `<annotation>`: di `ref` poin tu moa dan wan target; wi yuuz di fos wan.
+
+annotation-ref-outside-graph = `<annotation>`: di `ref` noh gud; di target deh outside a di graph. Wi lef out di anotayshan.
+
+annotation-ref-unsupported-target = `<annotation>`: di `ref` noh gud; di target noh wan grafikal ting weh di prefigure konvershan sopoat. Wi lef out di anotayshan.
+
+annotation-text-missing = `<annotation>`: di `text` mising ar emti; wi wahn put out emti teks.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wi fain wan serkl dipendensi.
+       *[other] Wi fain wan serkl dipendensi weh involv wan `<{ $componentType }>` komponent.
+    }
+
+reference-no-referent = Wi noh fain notn weh dis refrans di poin tu: `{ $reference }`
+
+reference-multiple-referents = Wi fain moa dan wan ting weh dis refrans di poin tu: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Di fahmat fi di atribyuut { $attribute } a `<{ $componentType }>` noh gud.
+
+children-invalid = Di pikni fi `<{ $componentType }>` noh gud: wi fain pikni weh noh gud: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Di valyu `{ $value }` fi di atribyuut `{ $attribute }` noh gud, soh wi yuuz di valyu `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wi noh fain DoenetML vershan { $version }.
+       *[other] Wi noh fain DoenetML vershan { $version }. Wi wahn yuuz vershan { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Dis DoenetML noh gud: { $content }
+
+parse-tag-missing-close-tag = Dis DoenetML noh gud: Di tag `{ $tag }` noh gat no kloazin tag. Wi expek wan tag weh kloaz ihself ar wan `</{ $tagName }>` tag.
+
+parse-tag-error = Dis DoenetML noh gud: Era eena di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Dis DoenetML noh gud: Di atribyuut `{ $attribute }` noh gud — luk laik ih mising wan valyu.
+
+parse-attribute-invalid = Dis DoenetML noh gud: Di atribyuut `{ $attribute }` noh gud
+
+parse-attribute-value-invalid = Dis DoenetML noh gud: Di atribyuut valyu `{ $value }` noh gud
+
+parse-attribute-value-quote-mismatch = Dis DoenetML noh gud: Di atribyuut valyu `{ $value }` noh gud. Di koat maak noh mach. Luk laik yu mising wan `{ $quote }`
+
+parse-open-tag-name-missing = Dis DoenetML noh gud: Wi fain wan tag widoutn no tag naym, laik `<`
+
+parse-tag-not-closed = Dis DoenetML noh gud: Di tag `{ $tag }` noh kloaz (luk laik wan `>` mising).
+
+parse-self-closing-tag-name-missing = Dis DoenetML noh gud: Wi fain wan tag widoutn no tag naym `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Dis DoenetML noh gud: Di tag `{ $tag }` noh kloaz (luk laik `/>` mising).
+
+parse-tag-invalid-attributes = Dis DoenetML noh gud: Di tag `{ $tag }` noh gud. Ih mait gat rang atribyuut.
+
+parse-close-tag-name-missing = Dis DoenetML noh gud: Wi fain wan kloazin tag widoutn no tag naym, laik `</`
+
+parse-attribute-value-unquoted = Atribyuut valyu mos deh eena koat maak: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Dis DoenetML noh gud: Wi fain di kloazin tag `{ $tag }`, bot no oapnin tag noh deh fi it
+
+parse-close-tag-mismatched = Dis DoenetML noh gud: Di kloazin tag noh mach. Wi mi expek `</{ $expected }>`. Wi fain `{ $found }`
+
+parser-node-unconvertible = Wi kyaahn konvert di noad { $node } eena wan Dast noad.
+
+## Names
+
+name-attribute-invalid =
+    Di atribyuut name='{ $name }' noh gud. { $reason ->
+        [characters] Naym ku gat oanli leta, nomba, ondaskoa ar haifn.
+       *[start] Naym mos staat wid wan leta.
+    }
+
+component-name-invalid-start = Di komponent naym "{ $name }" noh gud. Naym mos staat wid wan leta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Wan answer a taip videoWatched mos gat wan video atribyuut
+
+answer-video-watched-video-not-reference = Wan answer a taip videoWatched mos gat wan video atribyuut weh da wan refrans
+
+answer-name-not-single-text = Di answer name atribyuut mos gat jos wan teks pikni
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Wi kyaahn get di eksternal DoenetML bikaaz too moch levl a rikershan. Yu tink wan serkl refrans deh?
+
+external-doenetml-unavailable = Wi kyaahn get no DoenetML fahn { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Di DoenetML weh wi get fahn { $attribute }="{ $uri }" noh gud: ih noh mach di komponent taip "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Di atribyuut `{ $from }` doan yuuz noh moa; yuuz `{ $to }` instead.
+       *[other] [deprecation] Di atribyuut `{ $from }` pahn `<{ $component }>` doan yuuz noh moa; yuuz `{ $to }` instead.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Di atribyuut `{ $from }` doan yuuz noh moa ahn ih noh kount bikaaz `{ $to }` se tu.
+       *[other] [deprecation] Di atribyuut `{ $from }` pahn `<{ $component }>` doan yuuz noh moa ahn ih noh kount bikaaz `{ $to }` se tu.
+    }
+
+deprecated-attribute-ignored = [deprecation] Di atribyuut `{ $attribute }` pahn `<{ $component }>` doan yuuz noh moa ahn ih noh kount.
+
+deprecated-attribute-to-child = [deprecation] Di atribyuut `{ $attribute }` pahn `<{ $component }>` doan yuuz noh moa; yuuz wan `<{ $child }>` pikni instead.
+
+deprecated-attribute-value-renamed = [deprecation] Di valyu `{ $value }` a di atribyuut `{ $attribute }` pahn `<{ $component }>` doan yuuz noh moa; yuuz `{ $to }` instead.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ku pluralaiz oanli Inglish, soh ih teks tan siem eena wan dakiument weh rait eena { $locale }. Rait di plural fahm schrayt, ar set it wid di `pluralForm` atribyuut.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Di eliment `<{ $tag }>` noh wan Doenet eliment weh wi noa.
+
+schema-element-not-allowed-at-root = Di eliment `<{ $tag }>` kyaahn deh da di ruut a di dakiument.
+
+schema-element-not-allowed-inside = Di eliment `<{ $tag }>` kyaahn deh eenside a `<{ $parent }>`.
+
+schema-attribute-unrecognized = Di eliment `<{ $tag }>` noh gat no atribyuut naym `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Di atribyuut `{ $attribute }` a di eliment `<{ $tag }>` mos bee wan lis weh evri aitem da wan a dehn ya: { $allowed }
+       *[other] Di atribyuut `{ $attribute }` a di eliment `<{ $tag }>` mos bee wan a dehn ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Di varyant naym fi di select noh gud.  Di varyant naym { $variantName } shoa op eena { $numOptions } opshan bot di nomba fi pik da { $numToSelect }.
+
+select-variant-name-without-options = Som varyant se fi di select bot no opshan noh se fi di varyant naym: { $variantName }.
+
+select-variant-name-not-possible = Di varyant naym { $variantName } weh se fi di select noh wan varyant naym weh ku hapm.
+
+select-too-few-options = Wi kyaahn pik { $numToSelect } komponent outa oanli { $numOptions }.
+
+select-from-sequence-too-few-values = Wi kyaahn pik { $numToSelect } valyu outa wan sekwens a lent { $length }.
+
+select-from-sequence-indices-count-mismatch = Di nomba a indices weh se fi di select mos mach di nomba fi pik
+
+select-from-sequence-indices-not-integers = Aal di indices weh se fi di select mos bee hoal nomba
+
+select-from-sequence-index-excluded = Wan indeks a selectfromsequence se weh mi ekskluud
+
+select-from-sequence-indices-excluded-combination = Indices a selectfromsequence se weh mi wan ekskluud kombinayshan
+
+select-from-sequence-coprime-not-positive-integers = Wi kyaahn pik koaprime kombinayshan bikaaz wi noh di pik pazitiv hoal nomba.
+
+select-from-sequence-coprime-common-factor = Wi kyaahn pik koaprime nomba. Aal di valyu dehn shier wan koman fakta. (Di valyu weh se fi "from" ar "to" mos bee koaprime wid "step".)
+
+select-from-sequence-coprime-single-number = Wi kyaahn pik koaprime kombinayshan outa wan singl nomba weh noh 1.
+
+select-from-sequence-excluded-too-many-combinations = Moa dan 70% a di kombinayshan eena selectFromSequence mi ekskluud
+
+select-from-sequence-coprime-none-found = Wi noh mi ku pik koaprime nomba. Aal di valyu dehn shier wan koman fakta.
+
+select-from-sequence-too-few-unique-values = Wi kyaahn pik { $numToSelect } yuniik valyu outa wan sekwens a lent { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Wi kyaahn pik { $numToSelect } valyu outa wan lis a praim nomba a lent { $numValues }
+
+select-prime-numbers-values-count-mismatch = Di nomba a valyu weh se fi di select mos mach di nomba fi pik
+
+select-prime-numbers-values-not-prime = Aal di valyu weh se fi select praim nomba mos deh eena di lis a praim nomba
+
+select-prime-numbers-values-excluded-combination = Di valyu a selectPrimeNumbers weh se mi wan ekskluud kombinayshan
+
+select-prime-numbers-excluded-too-many-combinations = Moa dan 70% a di kombinayshan eena selectPrimeNumbers mi ekskluud
+
+select-random-combination-fluke = Bai wan chaans weh haadli evah hapm, wi noh mi ku pik wan kombinayshan a randam valyu
+
+select-random-value-fluke = Bai wan chaans weh haadli evah hapm, wi noh mi ku pik wan randam valyu
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    Wi noh jraa di `<{ $component }>` eenside di mat; wi taipset di expreshan laik how ih mi bee bifoa inpot mi ku goh eenside. { $reason ->
+        [not-inline] Oanli wan `inline` chais inpot fit eenside wan expreshan; widoutn `inline` ih da wan blak a botn.
+        [expanded] Wan `expanded` teks inpot da wan baks wid moa dan wan lain, ahn dat too big fi sidong eenside wan expreshan.
+        [on-graph] Pahn wan graph, wi jraa di expreshan az wan singl pikcha, ahn dat noh gat no ruum fi wan kanchroal.
+       *[relative-width] Ih `width` da relativ (wan persent ar `em`), ahn dat noh gat notn fi mezha agens eenside wan expreshan. Gi di widt eena abzalut yuunit, laik `px`, instead.
+    }

--- a/packages/i18n/locales/bzj/editor.ftl
+++ b/packages/i18n/locales/bzj/editor.ftl
@@ -1,0 +1,213 @@
+# Belize Kriol (Bileez Kriol) editor and language-server surfaces: the footer,
+# the diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel. Translated from `locales/en/editor.ftl`, which is the
+# source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The phonemic orthography of the Belize Kriol Council /
+# National Kriol Council of Belize, set out point by point in `chrome.ftl`'s
+# header: long vowels doubled, «ch» for English *tr-*, «j» for English *dr-*,
+# no apostrophes, no silent letters. The English-based ad-hoc spelling in
+# everyday use is not mixed into these files; a reviewer who prefers it should
+# respell rather than retranslate.
+#
+# **Number.** `Intl.PluralRules("bzj")` has no CLDR data for `bzj` and falls
+# back to English. A Kriol noun after a numeral does not inflect, so
+# `editor-accessibility-label` and `help-coordinates` — the two messages
+# English selects on a count — are written here as **one unselected form**
+# each, with the count still interpolated. No plural branch appears anywhere
+# in this file.
+#
+# **Loans.** English respelled into Kriol phonology and carried in Kriol
+# grammar: «era», «waanin», «info», «akseh» (*access*), «vaiyolayshan»,
+# «rekamendayshan», «varyant», «fiilta», «kompoanent», «atribyuut»,
+# «snipet», «aray», «koaadinet», «fahmat», «vershan», «dakiumentayshan»,
+# «rifrans», «rispans», «kredit». `WCAG`, `DoenetML`, `XML` and `styleNumber`
+# are names and stay as written, as do the attribute names in
+# `help-reset-overrides`.
+#
+# **Confidence.** This is the file with the least everyday Kriol in it —
+# almost every noun is a technical loan. The verbs, the negation and the
+# preverbal markers are Kriol throughout («noh mi ku fain», «klik fi oapn»,
+# «put yu kersa»), and that is what a reviewer should read for. Nothing was
+# left in English.
+
+
+editor-update-viewer =
+    { $action ->
+        [reset] Riset
+       *[update] Opdayt
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } di Viuwa
+       *[other] { $word } di Viuwa { $shortcut }
+    }
+
+
+editor-variant = Varyant
+
+editor-variant-filter = Fiilta...
+
+editor-variant-next = Pik di neks varyant
+
+editor-variant-previous = Pik di varyant bifoa
+
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wi fain wan WCAG AA akseh-vaiyolayshan. Klik fi { $action ->
+            [close] kloaz
+           *[open] oapn
+        } di akseh-riport.
+        [advisories] Klik fi { $action ->
+            [close] kloaz
+           *[open] oapn
+        } di akseh-riport. Wi noh fain no WCAG AA vaiyolayshan, bot wi gat moa akseh-rekamendayshan.
+       *[clean] Klik fi { $action ->
+            [close] kloaz
+           *[open] oapn
+        } di akseh-riport. Wi noh fain no akseh-prablem.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wi fain wan WCAG AA akseh-vaiyolayshan. Wi fain { $count } WCAG AA vaiyolayshan. Klik fi { $action ->
+            [close] kloaz
+           *[open] oapn
+        } di akseh-riport.
+        [advisories] Wi noh fain no WCAG AA vaiyolayshan. Wi fain { $count } moa akseh-rekamendayshan. Klik fi { $action ->
+            [close] kloaz
+           *[open] oapn
+        } di akseh-riport.
+       *[clean] Wi noh fain no WCAG AA vaiyolayshan. Klik fi { $action ->
+            [close] kloaz
+           *[open] oapn
+        } di akseh-riport.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+editor-version-title = DoenetML vershan { $version }
+
+editor-tab-help = Help weh fala weh yu di du
+editor-tab-help-short = Konteks
+editor-tab-errors = Era
+editor-tab-warnings = Waanin
+editor-tab-info = Info
+editor-tab-accessibility = Akseh
+editor-tab-responses = Rispans weh sen aredi
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editta apshan
+editor-format-as-doenetml = Fahmat az DoenetML
+editor-format-as-xml = Fahmat az XML
+
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = No Era
+editor-no-warnings = No Waanin
+editor-no-info = No Info Dayagnastik
+
+editor-show-info-annotations = Shoa di info dayagnastik dehn eena di editta
+editor-show-accessibility-annotations = Shoa di akseh-dayagnastik dehn eena di editta
+
+editor-accessibility-learn-more = Lorn how Doenet tek kier a akseh
+
+editor-accessibility-violations-heading = Akseh-vaiyolayshan ({ $standard })
+
+editor-accessibility-other-heading = Ada akseh-prablem
+editor-none-found = Wi noh fain non
+
+
+editor-no-responses = No rispans noh sen yet
+editor-response-answer-id = Ansa Id
+editor-response-response = Rispans
+editor-response-credit = Kredit
+editor-response-submitted = Sen
+
+
+help-placeholder = Put yu kersa pahn wan tag naym, wan atribyuut, ar { $ref } fi si di dakiumentayshan.
+
+help-unsupported-ref-chain = Wi noh gat help yet fi rifrans weh gat moa dan wan paat, laik { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wi noh fain notn weh { $ref } di poin tu.
+        [multiple] Wi fain moa dan wan ting weh { $ref } di poin tu.
+       *[indeterminate] Wi noh ku fain out weh { $ref } di poin tu.
+    }
+
+help-learn-about-references = Lorn bowt rifrans →
+help-reference-page = Rifrans payj →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Eena { $element }
+       *[top] Da di tap levl
+    }{ $allowed ->
+        [none] { " — notn noh goh yaa." }
+        [text] { " — taip teks yaa." }
+        [text-and-components] { " — taip teks yaa, ar chrai:" }
+       *[components] { " — sohnting fi chrai:" }
+    }
+
+help-suggestions-footer = Prehs { $shortcut } fi si aal { $total } kompoanent.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } da wan rifrans tu { $target }.
+       *[other] { $ref } da wan rifrans tu { $target } (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } bring dis in az { $role }.
+       *[other] { $owner } bring dis in pahn lain { $line } az { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } da wan rifrans tu di { $property } prapati a { $element }.
+       *[other] { $ref } da wan rifrans tu di { $property } prapati a { $element } (lain { $line }).
+    }
+
+help-kind-attribute = atribyuut
+help-kind-snippet = snipet
+help-kind-array-entry = aray entri
+
+help-default = Difalt:
+help-active-default = Aktiv difalt:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valyu weh alou (wan pa aitem):
+       *[other] Valyu weh alou:
+    }
+
+help-suggested-values = Valyu weh wi sojes:
+
+help-inserts = Wa it put in:
+
+help-coordinates = Koaadinet:
+
+help-type = Taip:
+
+help-resolved-style = Stail weh kom out (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fongshan naym weh kom out:
+help-reset-list = Riset di lis pahn dis inpot:
+help-added-on-input = Wa ad pahn dis inpot:
+help-removed-on-input = Wa tek out pahn dis inpot:
+
+help-reset-overrides = { $reset } beet { $additional } ahn { $removed }.

--- a/packages/i18n/locales/cab/chrome.ftl
+++ b/packages/i18n/locales/cab/chrome.ftl
@@ -1,0 +1,198 @@
+# Garifuna viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Translated from `locales/en/chrome.ftl`, which is the source
+# of truth: `lint:i18n` rejects a key that does not exist there, and reports a
+# key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography used across the four Garifuna
+# communities — Honduras, Belize, Guatemala and Nicaragua — and taught in the
+# bilingual schools of Honduras and Belize:
+# `a b ch d e f g h i k l m n ñ o p r s t u ü w y`. Three notes.
+#
+#   * **`ü` is a letter of its own**, the high central vowel, and is written
+#     with the diaeresis everywhere it occurs: «buiti» has none, «ürüwa» and
+#     «álügüdahani» have three between them. It is not a variant spelling of
+#     `u` and the two are not interchangeable.
+#   * **The falling tone is not written.** Garifuna distinguishes tone, and the
+#     standard orthography leaves it unmarked; where an acute appears in these
+#     files it is the Spanish-style stress accent Honduran practice uses on
+#     some words («álügüdahani»), not a tone mark. A reviewer should not read
+#     the absence of accents as an error.
+#   * `c`, `j`, `q`, `v`, `x` and `z` are **not** in the alphabet; a Spanish
+#     loan that would use them is respelled — «tekladu» for *teclado*,
+#     «espresion» for *expresión*, «adbertensia» for *advertencia*, «asulu»
+#     for *azul*.
+#
+# The language is named «Garifuna» in all four of these files. The spelling
+# «Garínagu» is the name of the people rather than of the language and is not
+# used here.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `cab`; it falls back to
+# the default locale and reports `one` and `other`, categories Garifuna does not
+# select. Wherever English writes a `[one]`/`[other]` pair this file writes
+# **one unselected form** — `answer-show-responses` is the case. English's
+# explicit `[0]` literal in `attempts-remaining` matches the number itself
+# rather than a plural category and is kept. Selects on non-numeric variables
+# (`$span`) keep every branch English has.
+#
+# **Loans.** Garifuna has no native software register, but it borrows for
+# exactly this register in school and everyday speech — Spanish in Honduras,
+# Guatemala and Nicaragua, English in Belize. The technical nouns here are
+# **Spanish loans respelled to the Garifuna alphabet and carried in a Garifuna
+# frame**: «respuesta», «tekladu», «matrisi», «kolumna», «fila», «intentu»,
+# «erroru», «adbertensia», «informasion», «dokumentu», «estadístika»,
+# «espresion», «renderisadóru», «aksesibilidá». The frame around them is
+# Garifuna: the second-person imperative prefix `b-` on the loan verbs
+# («Bagregaru» add, «Bakitaru» remove, «Bakambiaru» change, «Bakargaru» load),
+# «lidan» in, «lun» to, «luma» with, «anihein» there is, «úati» there is none,
+# «mama» the negative copula, «siñá» cannot, and the privative `ma-` of
+# «mabuiti». A Belizean speaker may prefer the English loan in any of these
+# slots — *keyboard*, *matrix*, *error* — and should feel free to substitute,
+# but the whole file has to move together.
+#
+# **Confidence, and it is low.** «buiti» and its privative «mabuiti», the two
+# verdicts on a submitted answer, carry a great deal of this file and are worth
+# a speaker's check before anything is built on them. So are four frame words
+# used throughout: «arihini» (looking, for *checking*), «arúfudahani»
+# (showing), «arámudahani» (hiding) and «lúeigiñe» (again). Buttons that
+# English writes as bare verbs — *Open Keyboard*, *Close Keyboard* — are
+# reframed as show and hide, which is what the Garifuna verbs here can say
+# plainly. `error-found-at` says where the error is rather than that it was
+# found: the locative sentence is safe and the passive is not.
+
+
+## Answer submission
+
+answer-checking = Arihini...
+answer-submitting = Ichugúni...
+
+answer-checking-status = Arihini respuesta
+answer-submitting-status = Ichugúni respuesta
+
+answer-correct = Buiti
+answer-incorrect = Mabuiti
+
+answer-response-saved = Aguardaruni respuesta
+
+answer-percent-credit = { $percent }% puntu
+answer-percent-correct = { $percent }% buiti
+answer-percent-short = { $percent } %
+
+max-credit-available = Puntu wéiriti: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] úati intentu
+       *[other] { $count } intentu lárigiñe
+    }
+
+validation-correct = (Buiti)
+validation-incorrect = (Mabuiti)
+validation-partially-correct = (Parti buiti)
+
+answer-show-responses = Barúfuda { $count } respuesta lun { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Uganu
+
+collapsible-click-to-open = (bafara lun arihini)
+collapsible-click-to-close = (bafara lun arámudahani)
+
+collapsible-initializing = Agumeseha...
+
+footnote-show = Barúfuda nota
+footnote-hide = Barámuda nota
+
+description-more-information = informasion ámuñegu
+
+
+## Controls
+
+slider-previous = Furumiñe
+slider-next = Lárigi
+
+keyboard-open = Barúfuda tekladu
+keyboard-close = Barámuda tekladu
+
+choice-input-remove-choice = Bakitaru { $choice }
+
+matrix-remove-row = Bakitaru fila
+matrix-add-row = Bagregaru fila
+matrix-remove-column = Bakitaru kolumna
+matrix-add-column = Bagregaru kolumna
+
+subset-add-remove-points = Bagregaru/Bakitaru puntu
+subset-toggle-points-intervals = Bakambiaru puntu luma interbalu
+subset-move-points = Bamubaru puntu
+subset-clear = Balimpiaru
+
+orbital-add-row = Bagregaru fila
+orbital-remove-row = Bakitaru fila
+orbital-add-box = Bagregaru kaha
+orbital-remove-box = Bakitaru kaha
+orbital-add-up-arrow = Bagregaru flecha ariba
+orbital-add-down-arrow = Bagregaru flecha abahu
+orbital-remove-arrow = Bakitaru flecha
+
+orbital-row-label = Etiketa lun fila { $row }
+
+pretzel-answer = Respuesta
+
+summary-statistics-caption = Estadístika lun { $column }
+
+
+## Math input
+
+math-input-preview-region = arihini furumiñe lun espresion matemátika
+math-input-preview = Arihini furumiñe
+math-input-invalid-expression = Espresion mabuiti:
+
+
+## Document status
+
+viewer-initializing = Agumeseha...
+
+
+## Errors
+
+error-heading = Erroru
+
+# Says where the error is rather than that it was found: the locative sentence
+# is the one this seed can write plainly.
+error-found-at =
+    { $span ->
+        [line] Lidan línia { $startLine }.
+       *[lines] Lidan línia { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Anihein erroru lidan dokumentu le!
+
+diagnostic-heading-error = Erroru
+diagnostic-heading-warning = Adbertensia
+diagnostic-heading-information = Informasion
+diagnostic-heading-hint = Pista
+
+accessibility-heading-level-1 = Erroru aksesibilidá WCAG AA
+accessibility-heading-level-2 = Adbertensia aksesibilidá
+
+something-went-wrong = Anihein ában katei mabuiti.
+
+renderer-load-failed = mama lakargarun ában renderisadóru. Bakargaru páhina lúeigiñe.
+
+core-start-failed = Siñá lagumeserun dokumentu le. Bakargaru páhina lúeigiñe.
+
+core-start-failed-busy = Siñá lagumeserun dokumentu le. Saragu dokumentu agumeseha lidan ában dan, ligía lasandiragunbei dan wéiri lidan ában kompiutadora yebe. Danme lagumucha amu dokumentu, gayarabei líderaguni bakargarun páhina lúeigiñe.
+
+core-start-failed-retry = Siñá lagumeserun dokumentu le.
+
+core-start-failed-busy-retry = Siñá lagumeserun dokumentu le. Saragu dokumentu agumeseha lidan ában dan, ligía lasandiragunbei dan wéiri lidan ában kompiutadora yebe.
+
+core-start-retry = Bafuranguagüda lúeigiñe
+
+saved-state-unavailable = Siñá lakargarun badagimanu aguardaruati.

--- a/packages/i18n/locales/cab/content.ftl
+++ b/packages/i18n/locales/cab/content.ftl
@@ -1,0 +1,318 @@
+# Garifuna content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+# English, in `locales/en/content.ftl`, is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage. Message ids and `.attribute` suffixes are
+# never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography used across the four Garifuna
+# communities — Honduras, Belize, Guatemala and Nicaragua — and taught in the
+# bilingual schools of Honduras and Belize:
+# `a b ch d e f g h i k l m n ñ o p r s t u ü w y`. Three notes.
+#
+#   * **`ü` is a letter of its own**, the high central vowel, and is written
+#     with the diaeresis everywhere it occurs. It is not a variant spelling of
+#     `u` and the two are not interchangeable.
+#   * **The falling tone is not written.** Garifuna distinguishes tone, and the
+#     standard orthography leaves it unmarked; where an acute appears here it is
+#     the Spanish-style stress accent Honduran practice uses on some words
+#     («álügüdahani», «púntu»), not a tone mark. A reviewer should not read the
+#     absence of accents as an error.
+#   * `c`, `j`, `q`, `v`, `x` and `z` are **not** in the alphabet. Every Spanish
+#     loan below is respelled around that: «asulu» for *azul*, «bekitoru» for
+#     *vector*, «sírkulu» for *círculo*, «krusu» for *cruz*, «rehion» for
+#     *región*, «kuadradu» for *cuadrado*.
+#
+# The language is named «Garifuna» in all four of these files. «Garínagu» is the
+# name of the people rather than of the language and is not used.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `cab`; it falls back to
+# the default locale and reports `one` and `other`, categories Garifuna does not
+# select. No message here writes a `{ $n -> }` or `{ $count -> }` select on a
+# count: wherever English has a `[one]`/`[other]` pair this file writes **one
+# unselected form**. Selects on non-numeric variables — `$parts`, `$part` — are
+# not plural selects and keep every branch English has.
+#
+# **Word order.** The modifier **follows** the noun in Garifuna, as it does in
+# Spanish. The composition messages therefore **reverse English's order**:
+# `style-with-noun` and `style-filled-with-noun` put `{ $noun }` before
+# `{ $description }`, `style-fill` puts `{ $pattern }` before `{ $color }`, and
+# `fill-style` reads «línia orisontal», not the other way round. `style-stroke`
+# is a bare stack of adjectives with no noun in it, so it keeps English's
+# internal order.
+#
+# `noun-gender` answers one token. Garifuna marks gender on some nouns, but no
+# adjective in this catalog agrees with a placeable whose gender the catalog can
+# see, so nothing selects on the answer and no message writes a `$gender` or
+# `$role` select.
+#
+# **Loans.** Garifuna has no native software or mathematical register, but it
+# borrows freely for exactly this register in school and everyday speech —
+# Spanish in Honduras, Guatemala and Nicaragua, English in Belize. This seed
+# writes the technical nouns as **Spanish loans respelled to the Garifuna
+# alphabet and carried in a Garifuna frame**: «bekitoru», «funsion»,
+# «polígunu», «rektángulu», «parábola», «matrisi», «seksion», «tabla»,
+# «fígura», «páhina», «respuesta». The frame around them is Garifuna — «lidan»
+# in, «lun» to, «luma» with, «lídangiñe» from, «úati» there is none, «mama» the
+# negative copula, and the privative `ma-` of «mabuiti». A Belizean speaker may
+# well prefer the English loan in every one of these slots — *vector*,
+# *function*, *section* — and should feel free to substitute it, but the whole
+# file has to move together.
+#
+# **Confidence, and it is low.** Garifuna is the least-documented of the four
+# languages in this batch.
+#
+#   * The three native colour words «haruti» (white), «wuriti» (black) and
+#     «funati» (red) and the «buiti»/«mabuiti» pair are the words a speaker
+#     should check first; everything built on them depends on them.
+#   * The other nine colours are Spanish loans, because Garifuna's own colour
+#     words either vary between the Honduran and Belizean communities or have
+#     already given way to the loan in speech. They are recorded as loans, not
+#     as decisions.
+#   * `element-name` and `element-anion-name` — the 118 chemical elements and
+#     their anions — are left out entirely: chemistry is schooled in Spanish or
+#     English and there is no published Garifuna list.
+#   * `noun.slope-field`, `noun.vector-field` and `noun.polyline` have no
+#     Garifuna word at all; they are written as Spanish loans rather than
+#     omitted, since a loan is what a speaker would actually say.
+
+
+## Style vocabulary
+
+color =
+    .black = wuriti
+    .white = haruti
+    .gray = grisi
+    .red = funati
+    .orange = naranha
+    .yellow = amariyu
+    .green = berde
+    .cyan = sian
+    .blue = asulu
+    .purple = moradu
+    .pink = rosadu
+    .brown = kafe
+
+line-width =
+    .thick = grúesu
+    .thin = delgadu
+
+line-style =
+    .dashed = rayadu
+    .dotted = puntiadu
+
+# Noun phrases, and the modifier follows the head: «línia orisontal».
+fill-style =
+    .horizontal = línia orisontal
+    .vertical = línia bertikal
+    .diagonal = línia diagonal
+    .backdiagonal = línia diagonal inbersa
+    .dots = puntu
+    .diamonds = rombu
+
+noun =
+    .line = línia
+    .line-segment = segmentu
+    .ray = rayu
+    .vector = bekitoru
+    .curve = kurba
+    .function = funsion
+    .slope-field = kampu pendiente
+    .vector-field = kampu bekitoru
+    .parabola = parábola
+    .polyline = polilínia
+    .polygon = polígunu
+    .triangle = triángulu
+    .rectangle = rektángulu
+    .circle = sírkulu
+    .region = rehion
+    .point = puntu
+    .square = kuadradu
+    .diamond = rombu
+    .cross = krusu
+    .plus = másu
+
+# The side count follows the head, as every other modifier does, so the whole
+# noun sits in the `head` branch and the `tail` stays empty.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] polígunu regular lau { $numSides } ladu
+    }
+
+noun-gender = neutru
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# Reversed against English: the noun leads and the description follows it.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = yenu
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } luma { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+# Reversed likewise: «sírkulu yenu asulu luma rombu».
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } luma { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } luma { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «luma» is both the comitative and the ordinary conjunction, so the `and` and
+# `with` branches read alike; «ában» is the numeral one, standing where English
+# wants its article.
+style-border-clause =
+    { $parts ->
+        [with-article] luma ában borde { $border }
+        [and] luma borde { $border }
+        [and-article] luma ában borde { $border }
+       *[with] luma borde { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = mama yenu
+
+style-text =
+    { $parts ->
+        [background] { $color } luma ában fondu { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = úati
+
+
+## Boolean words
+##
+## `true` and `false` are DoenetML syntax and stay English in the source; only
+## the displayed words move.
+
+boolean-true = inarüni
+boolean-false = mama inarüni
+
+
+## Answer buttons
+
+# «Barihi badagimanu» — "look at your work"; «Bíchiga barespuesta» — "give your
+# response". Both are ordinary second-person imperatives.
+answer-submit-label = Barihi badagimanu
+answer-submit-label-no-correctness = Bíchiga barespuesta
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Wadagimanu
+    .aside = Aparte
+    .cascade = Kaskada
+    .definition = Definision
+    .example = Ehemplu
+    .exercise = Ehersisiu
+    .exercises = Ehersisiugu
+    .given-answer = Respuesta
+    .note = Nota
+    .objectives = Obhetibugu
+    .paragraphs = Párrafugu
+    .part = Parti
+    .problem = Problema
+    .problems = Problemagu
+    .proof = Prueba
+    .question = Álügüdahani
+    .section = Seksion
+    .solution = Solusion
+    .task = Tarea
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Pista
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Fígura { $enumeration }
+        [numbered-caption] Fígura { $enumeration }{ ": " }
+        [unnumbered-caption] Fígura{ ": " }
+       *[unnumbered] Fígura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Furumiñe
+paginator-next = Lárigi
+paginator-page = Páhina
+
+paginator-page-status = { $pageLabel } { $currentPage } lídangiñe { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = o
+piecewise-condition-if = anhein
+piecewise-condition-otherwise = anhein mama
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are omitted: chemistry is schooled in
+## Spanish or in English and there is no published Garifuna list of the 118
+## elements. The three keys below are prose rather than element names.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Símbolu kímiku mabuiti
+chemistry-invalid-ionic-compound = Konpuestu ióniku mabuiti
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blanku
+math-embedded-input-blank-ordinal = blanku { $ordinal } lídangiñe { $total }

--- a/packages/i18n/locales/cab/diagnostics.ftl
+++ b/packages/i18n/locales/cab/diagnostics.ftl
@@ -1,0 +1,556 @@
+# Garifuna diagnostics: the errors and warnings the core, the parser and the
+# language server report about a document. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage. Message ids are never translated — only the
+# text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Element names, attribute names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `styleNumber` — are part of the language rather than
+# prose and stay in English exactly as written, as does anything quoted back
+# from the author's own source. Every `{ $identifier }` placeable is left
+# spelled exactly as English spells it, and no Garifuna affix is ever welded
+# onto one.
+#
+# **Orthography.** The standard Latin orthography of Honduras, Belize,
+# Guatemala and Nicaragua: `a b ch d e f g h i k l m n ñ o p r s t u ü w y`.
+# **`ü` is a letter of its own**, the high central vowel, written with the
+# diaeresis everywhere it occurs and not interchangeable with `u`. **The
+# falling tone is not written**: Garifuna distinguishes tone and the standard
+# orthography leaves it unmarked, so an acute here is the Spanish-style stress
+# accent Honduran practice uses on some words, not a tone mark — a reviewer
+# should not read the absence of accents as an error. `c`, `j`, `q`, `v`, `x`
+# and `z` are not in the alphabet, so every loan below is respelled around
+# them: «bekitoru», «matrisi», «sekuensia», «funsion», «konbinasion»,
+# «kontraste».
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `cab`; it falls back to
+# the default locale and reports `one` and `other`, categories Garifuna does not
+# select. Every place English writes a `[one]`/`[other]` pair is written here as
+# **one unselected form**, keeping the count placeable where English has it —
+# Garifuna does not mark a noun for number after a numeral, so the two English
+# branches would have been identical anyway. Selects on non-numeric variables
+# (`$mode`, `$type`, `$reason`, `$expected`, `$suggestion`, `$fallback`,
+# `$component`, `$componentType`, `$isList`, `$labelKind`, `$context`) are not
+# plural selects and keep every branch English has, with the same branch keys.
+# `NUMBER(...)` calls are kept exactly as English writes them.
+#
+# **This file is a loan register in a Garifuna frame.** Garifuna has no written
+# register for compiler diagnostics: there is no school subject, no manual and
+# no body of technical prose in the language to draw the vocabulary from, and a
+# Garifuna speaker who reads an error message today reads it in **Spanish**, or
+# in **English** in Belize. This catalog therefore keeps that loan register
+# rather than inventing a Garifuna one. The technical nouns are Spanish loans
+# respelled to the Garifuna alphabet — «atributu», «balu», «númeru»,
+# «bekitoru», «komponente», «funsion», «matrisi», «barianti», «sekuensia»,
+# «referensia», «interbalu», «kordenada», «entéru» — and the sentence frame
+# around them is Garifuna:
+#
+#   * «siñá» — cannot. It opens every "Cannot …" message.
+#   * «lunti lan» — must be. It opens every "Must be a …" message.
+#   * «mabuiti» — the privative of «buiti», *good*. It follows the noun and
+#     carries every "Invalid …": «atributu mabuiti», «balu mabuiti».
+#   * «úati» — there is none; «anihein» — there is.
+#   * «mama» — the negative copula.
+#   * «mádügün wamá» — we have not made it, for "Haven't implemented".
+#   * «ignorarúati» — it is ignored; «Ignorarúa» — ignoring. A Spanish verb
+#     stem carrying Garifuna verbal morphology, which is what this register
+#     does in speech.
+#
+# It is a usable frame; it is not yet settled Garifuna technical prose, and a
+# speaker should overwrite it freely. A Belizean reader may prefer the English
+# loan in every noun slot here.
+#
+# **Confidence, and it is low.** Garifuna is the least-documented of the four
+# languages in this batch. «buiti»/«mabuiti», «siñá», «úati», «anihein» and
+# «lunti» carry the whole file and are the words to check first, together with
+# «ígirúati» (it is left out), «aráfaguati» (it is found) and «gabáñabei» (it
+# has), which recur in dozens of sentences. All 220 keys are written; nothing
+# in this file falls back to English. Nothing here is a translation of the
+# mathematics — the notation, the identifiers and the author's own quoted words
+# stand as they are; it is a translation of the sentence around them.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = ignorarúati { $attributes } danme ichugúwa biama puntu lagumuhóun
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ignorarúati { $attributes } danme ichugúwa ában puntu lagumuhóun luma ában puntu lidan lanigi
+line-segment-midpoint-offset-without-midpoint = úati lidiseti midpointOffset danme úati ában puntu lidan lanigi
+
+## `<line>`
+
+line-points-undetermined-dimensions = Línia luagu puntu mama subudiwati hadimension.
+line-points-too-few-dimensions = Lunti lan línia luagu puntu to gadimensionti biama o ámuñegu.
+line-points-depend-on-variables = Línia luagu puntu to lasandiragubei bariable: { $variables }.
+line-equation-invalid-format = Fórmatu mabuiti lun ekuasion línia lidan bariable { $variable1 } luma { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ichugúwati rayu luma through, endpoint luma direction.  Ignorarúa through.
+ray-dimension-mismatch = Mama lafuriaruni numDimensions lidan rayu.
+
+## `<vector>`
+
+vector-overprescribed-head = Ichugúwati bekitoru luma head, tail luma displacement.  Ignorarúa head.
+vector-dimension-mismatch = Mama lafuriaruni numDimensions lidan bekitoru.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Siñá latraerun luagu ában `<{ $component }>`, ladüga úati lubaránigi nearestPoint.
+constrain-to-without-nearest-point = Siñá lakonstreñirún luagu ában `<{ $component }>`, ladüga úati lubaránigi nearestPoint.
+constrain-to-interior-without-nearest-point = Siñá lakonstreñirún lidan tidoun ában `<{ $component }>`, ladüga úati lubaránigi nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ignorarúati labelPosition lun ában choiceInput mama inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ignorarúa índise ichugúwati lun choiceInput, ladüga mama lafuriaruni haruweiri índise luma haruweiri choice.
+pretzel-indices-count-mismatch = Ignorarúa índise ichugúwati lun problem, ladüga mama lafuriaruni haruweiri índise luma haruweiri problem.
+shuffle-indices-count-mismatch = Ignorarúa índise ichugúwati lun shuffle, ladüga mama lafuriaruni haruweiri índise luma haruweiri komponente.
+indices-ignored-out-of-range = Ignorarúa índise ichugúwati lun { $component }, ladüga anihein índise lagüdübei lubéi.
+pretzel-indices-repeated = Ignorarúa índise ichugúwati lun pretzel, ladüga anihein índise abürühóuti biama wéyaasu.
+pretzel-circuit-first-index = Ignorarúa índise ichugúwati lun pretzel lidan circuit, ladüga lunti lan 1 lan índise furumiñeti.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Lun ladagimarun `<{ $component }>` luma isaani string, lunti lan ichugúwa ában atributu `type`.
+invalid-type-defaulting-to-math = Tipu mabuiti { $type } lun komponente { $component }. Lunti lan ában lidan math, text, number o boolean. Lásiruna math.
+string-not-valid-component-to-arrange = String "{ $value }" mama ában komponente buiti lun { $component }. Ignorarúa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipu mabuiti { $type }, lásiruna number.
+invalid-variable-value = Balu mabuiti lun ában bariable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Lunti lan númeru lan índise barianti { $index }
+variant-index-must-be-integer = Lunti lan entéru lan índise barianti { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Mádügün wamá `<{ $component }>` lun medida absoluta. Lásiruna anchura relatiba.
+side-by-side-absolute-margins = Mádügün wamá `<{ $component }>` lun medida absoluta. Lásiruna marhen relatiba.
+side-by-side-no-block-child = `<{ $component }>` mabuiti: lunti lan gabáñabei ában isaani block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = ignorarúati atributu `for` luagu ában `<label>` gráfiku.
+label-for-must-resolve-to-one = Lunti lan atributu `for` luagu `<label>` larihín ában komponente lubéi.
+label-for-unresolved = Siñá larihín ában komponente lun atributu `for` luagu `<label>`.
+label-for-answer-with-authored-inputs = Atributu `for` luagu `<label>` labahüdaña ában `<answer>` gabáñabei entrada abürühóuti; babahüda entrada lungua.
+label-for-answer-without-input = Atributu `for` luagu `<label>` labahüdaña ában `<answer>` úati lentrada lun letiketun.
+label-for-must-reference-input-or-answer = Lunti lan atributu `for` luagu `<label>` labahüdüni ában entrada o ában respuesta.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Lun aksesibilidá, lunti lan gabáñabei `<{ $component }>` ában deskripsion gürigüwati o abürühóun keisi decorative.
+accessibility-video-short-description = Lun aksesibilidá, lunti lan gabáñabei `<video>` ában deskripsion gürigüwati.
+accessibility-input-short-description-or-label = Lun aksesibilidá, lunti lan gabáñabei `<{ $component }>` ában deskripsion gürigüwati o ában etiketa.
+accessibility-answer-input-short-description-or-label = Lun aksesibilidá, lunti lan gabáñabei ában `<answer>` ladügübei ában entrada ában deskripsion gürigüwati o ában etiketa.
+accessibility-short-description-contains-math = Mabuiti lan gabáñabei deskripsion gürigüwati komponente matemátika keisi `<{ $component }>`. Babüriha matemátika lau dimurei.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Úati lubéi lakontrastun { $colorName } lun uganu lidan iri seksion (lidan modu wuriti) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; lunti lan { $threshold }:1 lubéi).
+       *[other] Úati lubéi lakontrastun { $colorName } lun uganu lidan iri seksion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; lunti lan { $threshold }:1 lubéi).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Mádügün wamá `<circle>` luagu { $count } puntu danme úati hanúmeru puntu.
+circle-too-many-through-points = Siñá lakalkularun sírkulu luagu ámuñegu darí 3 puntu.
+circle-overprescribed-radius-center-points = Siñá lakalkularun sírkulu luma radiu, sentru luma puntu ichugúwati.
+circle-center-with-multiple-points = Siñá lakalkularun sírkulu luma sentru ichugúwati luagu ámuñegu darí 1 puntu.
+circle-radius-too-small = Siñá lakalkularun sírkulu: ladüga { $distance } lan lidise biama puntu, mürüsün lan radiu ichugúwati { $radius }.
+circle-radius-with-many-points = Siñá ladügün sírkulu luagu ámuñegu darí biama puntu luma ában radiu ichugúwati.
+circle-invalid-center-or-through-points = Sentru o puntu mabuiti lun sírkulu.
+circle-radius-center-with-multiple-points = Siñá lakalkularun radiu lun sírkulu luma sentru ichugúwati luagu ámuñegu darí 1 puntu.
+circle-radius-with-points-non-numerical = Siñá lakambiarun radiu lun sírkulu luagu puntu úati hanúmeru
+circle-change-radius-non-numerical = Siñá lakambiarun radiu lun sírkulu luagu puntu úati hanúmeru
+circle-change-center-non-numerical = Mádügün wamá lakambiarun sentru lun sírkulu luagu puntu úati hanúmeru.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Úati lubéi dimension lun dominiu lun funsion. Gabáñabei dominiu { $intervals } interbalu, gama lumoun gabáñabei funsion { $inputs } entrada.
+function-domain-invalid-format = Fórmatu mabuiti lun dominiu lun funsion.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ignorarúa máksimu úati lanúmeru lun funsion.
+        [minimum] Ignorarúa mínimu úati lanúmeru lun funsion.
+        [extremum] Ignorarúa estremu úati lanúmeru lun funsion.
+        [point] Ignorarúa puntu úati lanúmeru lun funsion.
+        [slope] Ignorarúa pendiente úati lanúmeru lun funsion.
+       *[other] Ignorarúa { $type } úati lanúmeru lun funsion.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ignorarúa máksimu bagante lun funsion.
+        [minimum] Ignorarúa mínimu bagante lun funsion.
+        [extremum] Ignorarúa estremu bagante lun funsion.
+        [point] Ignorarúa puntu bagante lun funsion.
+       *[other] Ignorarúa { $type } bagante lun funsion.
+    }
+
+function-points-too-close = Gabáñabei funsion biama puntu yarafa lun ában ában. Siñá ladügün funsion.
+function-iterates-input-output-mismatch = Gayarabei literarun funsion sun dan lubéi ában lan haruweiri entrada luma haruweiri salida. Gabáñabei funsion le { $inputs } entrada luma { $outputs } salida.
+
+## `<sequence>`
+
+sequence-invalid-length = Lunguti mabuiti lun sekuensia.  Lunti lan entéru mama mürüsünti darí 0.
+sequence-invalid-step = Pasu mabuiti lun sekuensia.  Lunti lan númeru lun sekuensia tipu { $type }.
+sequence-invalid-endpoint-number = "{ $attribute }" mabuiti lun sekuensia númeru.  Lunti lan númeru.
+sequence-invalid-endpoint-letters = "{ $attribute }" mabuiti lun sekuensia lediha.  Lunti lan ában dagaruni lediha.
+sequence-invalid-endpoint = "{ $attribute }" mabuiti lun sekuensia.
+select-from-sequence-coprime-not-numbers = ignorarúati coprime, ladüga mama númeru lanúadirún
+select-from-sequence-coprime-with-exclude-combinations = ignorarúati coprime, ladüga ichugúwati excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Target mabuiti lun `<{ $source }>`: siñá larihín target.
+target-state-variable-not-found = Target mabuiti lun `<{ $source }>`: siñá larihín ában bariable liri "{ $property }" luagu ában `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Lunti lan ámu lan hariñagun bariable lun `<odeSystem>` luma bariable independiente.
+ode-system-duplicate-variable-names = Siñá ladügün funsion RHS lun ODE luma iri bariable abürühóuti biama wéyaasu.
+ode-system-rhs-function-error = Siñá ladügün funsion RHS lun ODE.  Anihein erroru lidan ladügǘn funsion mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Siñá ladügün ában ángulu lidan { $count } línia
+angle-invalid-through-point = Puntu mabuiti lidan through lun `<angle>`
+parabola-vertex-too-many-points = Mádügün wamá parábola luma bértise luagu ámuñegu darí 1 puntu.
+parabola-too-many-points = Mádügün wamá parábola luagu ámuñegu darí 3 puntu.
+intersection-too-many-items = Mádügün wamá intersekesion lun ámuñegu darí biama katei
+
+## Other math components
+
+ionic-compound-not-two-ions = Mádügün wamá konpuestu ióniku lun ámu katei ma biama ion.
+ionic-compound-needs-cation-and-anion = Adügüwati konpuestu ióniku lun ában katión luma ában anión lumuti.
+solve-equations-cannot-evaluate = Siñá larasurun ekuasion, ladüga siñá lakalkularun ekuasion: { $equation }
+math-operators-operand-number-required = Lunti lan ichugúwa ában operandNumber danme lanúadirún ában operandu matemátika.
+eigen-decomposition-failed = Siñá lakalkularun balu propiu lun matrisi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: úati parámetru { $parameters } lidan patrón, ligía lasüdiragunbei ában bagante súnwandan.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: siñá lasubudirún grid="{ $grid }". Lunti lan none, medium, dense, o biama númeru mama mürüsünti darí 0 dagarǘwati luma ában espasiu, keisi grid="1 0.5". Úati grid abürühóun.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    Mégeiti `<{ $component }>` ában funsion luma { $expected ->
+        [one] ában salida, pendiente y' lidan kada puntu, keisi `y - x`
+       *[other] biama salida, bekitoru lidan kada puntu, keisi `(y, -x)`
+    }, gama lumoun gabáñabei funsion ichugúwati { $found } salida. { $alternative ->
+        [none] Úati katei abürühóun.
+       *[other] `<{ $alternative }>` lan komponente lun funsion ligía. Úati katei abürühóun.
+    }
+
+field-function-attribute-ignored-with-child = ignorarúati atributu `function`, ladüga ichugúwati funsion tidan komponente giñe; lidan tidoun lan layusurúa. Bíchiga funsion lidan ában lubéi lidangiñe biama.
+
+field-variables-ignored =
+    `<{ $component }>`: labahüdaña atributu `variables` bariable lun ában espresion abürühóuti tidan komponente. { $reason ->
+        [function-child] Ichugúwati funsion ya keisi ában isaani `<function>`, labahüdaña ligía hariñagun bariable lungua, ligía lignorarúnbei `variables`.
+       *[no-expression] Úati espresion ligía ya, ligía lignorarúnbei `variables`.
+    }
+
+## PreFigure renderer
+##
+## `prefigure` and `PreFigure` are the renderer's own name and stay in English,
+## as do the attribute names and the example values quoted back at the author.
+
+prefigure-x-label-position-unsupported = `<graph>`: mígirunti xLabelPosition="left" lidan renderisadóru prefigure; layusurúa lubéi luagu ligibugiñe.
+prefigure-y-label-position-unsupported = `<graph>`: mígirunti yLabelPosition="bottom" lidan renderisadóru prefigure; layusurúa lubéi luagu lidügübei.
+prefigure-invalid-axis-bounds = `<graph>`: mabuiti lan lagumuhóun ehe lun lakambiarún lun prefigure; layusurúa bbox (-10,-10,10,10).
+prefigure-invalid-width = `<graph>`: mabuiti lan anchura lun lakambiarún lun prefigure; layusurúa anchura 425.
+prefigure-invalid-aspect-ratio = `<graph>`: mabuiti lan aspectRatio lun lakambiarún lun prefigure; layusurúa aspectRatio 1.
+prefigure-grid-spacing-too-fine = `<graph>`: mürüsün lan lidise grid lun lagumuhóun ehe; ígirúati grid lidan renderisadóru prefigure.
+prefigure-annotations-not-rendered = `<graph>`: siñá labürühóun anotasion danme mama layusurún renderisadóru PreFigure.
+
+multiple-annotations-children = Aráfaguati saragu isaani `<annotations>` lidan `<graph>`; ignorarúati sun ma lagumuhóun.
+
+## PreFigure conversion
+##
+## `{ $subject }` holds only a tag name, a component name and punctuation, and
+## is composed in code; it stays exactly as it arrives.
+
+prefigure-descendant-unsupported = { $subject }: mígirunti lidan renderisadóru prefigure lun graph; ígirúati isaani.
+prefigure-descendant-invalid-geometry = { $subject }: heometría mabuiti o mama gumuhóuti; ígirúati isaani.
+prefigure-curve-label-omitted = { $subject }: mígirunti etiketa luagu elementu curve kambiarúati; ígirúati etiketa.
+prefigure-curve-unsupported-definition-type = { $subject }: mígirunti tipu definision curve '{ $definitionType }'; ígirúati isaani.
+prefigure-region-flip-functions-unsupported = { $subject }: mígirunti atributu flipFunctions luagu regionBetweenCurves; ígirúati isaani.
+prefigure-region-non-formula-child = { $subject }: funsion tipu formula lumuti lan gayarabei luagu regionBetweenCurves; ígirúati isaani.
+
+prefigure-label-position-unsupported =
+    { $subject }: mígirunti labelPosition '{ $labelPosition }' lun { $labelKind ->
+        [line-family] etiketa lun ában línia
+       *[point] etiketa lun ában puntu
+    }; layusurúa lubéi lidan PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: mígirunti estilu yenu '{ $fillStyle }' lidan PreFigure; layusurúa ában yenu buiti.
+prefigure-line-style-unknown = { $subject }: mama subudiwati lan estilu línia '{ $lineStyle }'; ígirúati lídangiñe PreFigure.
+prefigure-marker-style-mapped-to-diamond = { $subject }: kambiarúati estilu marka '{ $markerStyle }' lun estilu PreFigure 'diamond'.
+prefigure-marker-style-unsupported = { $subject }: mígirunti estilu marka '{ $markerStyle }' lidan PreFigure; layusurúa lubéi.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` mabuiti; siñá larihín target. Ígirúati anotasion.
+annotation-ref-multiple-targets = `<annotation>`: aráfaguati saragu target lun `ref`; layusurúa furumiñeti.
+annotation-ref-outside-graph = `<annotation>`: `ref` mabuiti; lárigiñe graph lan target. Ígirúati anotasion.
+annotation-ref-unsupported-target = `<annotation>`: `ref` mabuiti; mama ában katei gráfiku gayarabei lan target lidan lakambiarún lun prefigure. Ígirúati anotasion.
+annotation-text-missing = `<annotation>`: úati o bagante lan `text`; abürühóuti uganu bagante.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Siñá lakopiarun ában tipu komponente mama subudiwati: { $type }.
+copy-prop-not-found = Siñá larihín prop { $property } luagu ában komponente tipu { $component }
+collect-no-source = Úati fuente lun collect.
+collect-invalid-component-type = Siñá lakolektarun komponente tipu `<{ $component }>`, ladüga tipu mabuiti lan.
+reference-index-unavailable = Siñá labahüdün índise `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Siñá layusurún { $action } luagu komponente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Fórma mabuiti lun datu.  Mama lafuriaruni lunguti fila. Aráfaguati lidan componentIdx :{ $componentIdx }
+data-frame-duplicate-column-names = Anihein iri kolumna abürühóuti biama wéyaasu.  Aráfaguati lidan componentIdx :{ $componentIdx }
+data-frame-missing-column-name = Úati liri ában kolumna lidan datu.  Aráfaguati lidan componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ában award lun respuesta to lasandiragubei lungua respuesta ichugúwati lun answer, ligía ladügübei katei mama emeragúati.
+answer-max-num-attempts-in-section-wide-check-work = Úati lidiseti lichugún `maxNumAttempts` luagu ában `<answer>` tidan ában kontenedóru luma `sectionWideCheckWork`, ladüga kontenedóru lan lanügübei haruweiri intentu. Bíchiga `maxNumAttempts` luagu kontenedóru lubéi.
+nested-section-wide-check-work-max-num-attempts = Úati lidiseti lichugún `maxNumAttempts` luagu ában kontenedóru luma `sectionWideCheckWork` tidan ámu kontenedóru luma `sectionWideCheckWork`, ladüga kontenedóru tidoungiñe lan lanügübei haruweiri intentu. Bíchiga `maxNumAttempts` luagu kontenedóru tidoungiñe.
+answer-attributes-need-symbolic-equality = Úati lidiseti atributu { $attributes } danme mama ichugúwa symbolicEquality.
+answer-invalid-type = Tipu mabuiti lun respuesta: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ladüga úati liri komponente `<{ $component }>`, siñá layusurún keisi ában atributu lun ában module
+module-attribute-name-already-defined = Siñá layusurún komponente `<{ $component } name="{ $name }">` keisi ában atributu lun ában module, ladüga gabáñabei komponente `<module>` ában atributu "{ $name }" giñe.
+conditional-content-condition-ignored = ignorarúati atributu `condition` luagu ában komponente `<conditionalContent>` gabáñabei isaani case o else.
+slider-markers-type-mismatch = Mama lafuriaruni tipu markers luma tipu slider.
+pretzel-problem-needs-statement-and-answer = Pretzel mabuiti: lunti lan gabáñabei kada `<problem>` ában `<statement>` luma ában `<answer>`.
+pretzel-circuit-first-problem-distractor = Pretzel mabuiti: lidan mode="circuit", siñá lan distractor lan `<problem>` furumiñeti.
+
+## Attribute values
+
+attribute-invalid-values = Balu mabuiti { $values } lun atributu `{ $attribute }`; ignorarúa.
+attribute-must-be-references = Balu mabuiti `{ $value }` lun atributu `{ $attribute }`. Lunti lan adügǘwa atributu luma referensia to lagumeserubei luma ában `$`.
+math-input-invalid-function-names = <mathInput>: ignorarúati iri funsion mabuiti lidan { $attribute }: { $names }. Lunti lan gabáñabei liri kada ában biama lediha lubéi (lediha o guión); gayarabei lárigiñe ában `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Tipu komponente mabuiti: `<{ $componentType }>`
+attribute-repeated = Siñá labürühóun atributu { $attribute } biama wéyaasu.
+attribute-invalid-for-component = Atributu mabuiti "{ $attribute }" lun ában komponente tipu `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Úati lubéi lakontrastun estilu { $styleNumber } lun { $context ->
+        [text-on-background] kolor uganu luagu kolor fondu
+        [high-contrast] kolor kontraste wéiriti luagu liensu
+        [line] kolor línia luagu liensu
+        [marker] kolor marka luagu liensu
+       *[text-on-canvas] kolor uganu luagu liensu
+    }{ $mode ->
+        [dark] { " (lidan modu wuriti)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; lunti lan { $threshold }:1 lubéi).
+
+style-definition-dark-mode-text-background-contrast =
+    Ában lubéi buiti lan lakontrastun kolor ichugúwati lun estilu { $styleNumber } lidan modu haruti, úati lubéi lakontrastun kolor uganu luagu kolor fondu lidan modu wuriti adügüwati lídangiñe balu ligía ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; lunti lan { $threshold }:1 lubéi). { $suggestion ->
+        [available] Lun lubéi lan kontraste lidan modu wuriti, o bawéiriduagüda kontraste lidan modu haruti (keisi { $lightAttribute }="{ $lightColor }") o basánsira kolor lidan modu wuriti (keisi { $darkAttribute }="{ $darkColor }").
+       *[none] Lun lubéi lan kontraste lidan modu wuriti, bawéiriduagüda kontraste lidan modu haruti o basánsira kolor adügüwati luma textColorDarkMode o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ában lubéi buiti lan lakontrastun kolor uganu ichugúwati lun estilu { $styleNumber } lidan modu haruti, úati lubéi lakontrastun kolor uganu lidan modu wuriti adügüwati lídangiñe balu ligía luagu liensu ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; lunti lan { $threshold }:1 lubéi). { $suggestion ->
+        [available] Lun lubéi lan kontraste lidan modu wuriti, o bawéiriduagüda kontraste lidan modu haruti (keisi textColor="{ $lightColor }") o basánsira kolor lidan modu wuriti (keisi textColorDarkMode="{ $darkColor }").
+       *[none] Lun lubéi lan kontraste lidan modu wuriti, bawéiriduagüda kontraste lidan modu haruti o basánsira kolor adügüwati luma textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Gayarabei lanúadirún ában seksion ában <stylePalette> lumuti; layusurúa lagumuhóun.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = siñá lasubudirún barianti lumuti lun { $component }, ladüga mama entéru mama mürüsünti darí 0 lan numToSelect.
+variant-num-to-select-not-constant-number = siñá lasubudirún barianti lumuti lun { $component }, ladüga mama númeru mama kambiaruati lan numToSelect.
+variant-with-replacement-not-constant-boolean = siñá lasubudirún barianti lumuti lun { $component }, ladüga mama boolean mama kambiaruati lan withReplacement.
+variant-select-weight-disables-unique = Úati barianti lumuti lun select danme anihein ában opsion luma selectWeight o selectForVariants ichugúwati
+variant-coprime-undetermined = siñá lasubudirún barianti lumuti lun { $component }, ladüga siñá lasubudirún mama inarüni lan coprime súnwandan.
+variant-attribute-not-constant = siñá lasubudirún barianti lumuti lun { $component }, ladüga mama kambiaruati lan { $attribute }.
+variant-attribute-not-number = siñá lasubudirún barianti lumuti lun { $component }, ladüga mama númeru lan { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    siñá lasubudirún barianti lumuti lun { $component } tipu { $type }, ladüga mama { $expected ->
+        [letters-combination] ában dagaruni lediha
+        [math-expression] ában espresion matemátika buiti
+        [integer] ában entéru
+       *[number] ában númeru
+    } lan { $attribute }.
+
+variant-length-not-integer = siñá lasubudirún barianti lumuti lun { $component }, ladüga mama entéru lan length.
+variant-sort-not-implemented = mádügün wamá barianti lumuti lun ában { $component } luma sort
+variant-exclude-combinations-not-implemented = mádügün wamá barianti lumuti lun ában { $component } luma excludeCombinations
+variant-math-exclude-not-implemented = mádügün wamá barianti lumuti lun ában { $component } tipu math luma exclude
+variant-non-constant-exclude-not-implemented = mádügün wamá barianti lumuti lun ában { $component } luma exclude kambiaruati
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Aráfaguati ában dependensia sirkular.
+       *[other] Aráfaguati ában dependensia sirkular luma komponente `<{ $componentType }>`.
+    }
+
+reference-no-referent = Úati katei lun referensia: `{ $reference }`
+reference-multiple-referents = Saragu katei lun referensia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fórmatu mabuiti lun atributu { $attribute } lun `<{ $componentType }>`.
+children-invalid = Isaani mabuiti lun `<{ $componentType }>`: aráfaguati isaani mabuiti: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Balu mabuiti `{ $value }` lun atributu `{ $attribute }`, layusurúa balu `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Siñá larihín bersion DoenetML { $version }.
+       *[other] Siñá larihín bersion DoenetML { $version }. Layusurúa bersion { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML mabuiti: { $content }
+parse-tag-missing-close-tag = DoenetML mabuiti: Úati letiketu lagumuhóun etiketa `{ $tag }`. Lunti lan ában etiketa lagumeirubei lungua o ában etiketa `</{ $tagName }>`.
+parse-tag-error = DoenetML mabuiti: Anihein erroru lidan etiketa `<{ $tagName }>`
+parse-attribute-missing-value = DoenetML mabuiti: Úati lubalu atributu mabuiti `{ $attribute }`.
+parse-attribute-invalid = DoenetML mabuiti: Atributu mabuiti `{ $attribute }`
+parse-attribute-value-invalid = DoenetML mabuiti: Balu atributu mabuiti `{ $value }`
+parse-attribute-value-quote-mismatch = DoenetML mabuiti: Balu atributu mabuiti `{ $value }`. Mama lafuriaruni marka komiya. Ában lubéi bun ában `{ $quote }`
+parse-open-tag-name-missing = DoenetML mabuiti: Aráfaguati ában etiketa úati liri, keisi `<`
+parse-tag-not-closed = DoenetML mabuiti: Mama lagumuhóun etiketa `{ $tag }` (ában lubéi bun ában `>`).
+parse-self-closing-tag-name-missing = DoenetML mabuiti: Aráfaguati ában etiketa úati liri `<{ $content }>`
+parse-self-closing-tag-not-closed = DoenetML mabuiti: Mama lagumuhóun etiketa `{ $tag }` (ában lubéi bun `/>`).
+parse-tag-invalid-attributes = DoenetML mabuiti: Mabuiti lan etiketa `{ $tag }`. Gayarabei lan mabuiti lan latributu.
+parse-close-tag-name-missing = DoenetML mabuiti: Aráfaguati ában etiketa lagumuhóun úati liri, keisi `</`
+parse-attribute-value-unquoted = Lunti lan lidan marka komiya lan balu atributu: `{ $attribute }="{ $value }"`
+parse-close-tag-without-open-tag = DoenetML mabuiti: Aráfaguati etiketa lagumuhóun `{ $tag }`, gama lumoun úati letiketu lagumeserubei
+parse-close-tag-mismatched = DoenetML mabuiti: Mama lafuriaruni etiketa lagumuhóun. Lunti lan `</{ $expected }>`. Aráfaguati `{ $found }`
+parser-node-unconvertible = Siñá lakambiarun nodu { $node } lun ában nodu Dast.
+
+## Names
+
+name-attribute-invalid =
+    Iri mabuiti name='{ $name }'. { $reason ->
+        [characters] Gayarabei gabáñabei iri lediha, númeru, guión lidoungiñe o guión lumuti.
+       *[start] Lunti lan lagumeserun iri luma ában lediha.
+    }
+
+component-name-invalid-start = Iri komponente mabuiti "{ $name }". Lunti lan lagumeserun iri luma ában lediha.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Lunti lan gabáñabei ában respuesta tipu videoWatched ában atributu video
+answer-video-watched-video-not-reference = Lunti lan referensia lan atributu video lun ában respuesta tipu videoWatched
+answer-name-not-single-text = Lunti lan gabáñabei atributu name lun respuesta ában isaani text lumuti
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Siñá larihín DoenetML lídangiñe fiyeigiñe, ladüga saragu lan lanügün lungua. Anihein san ában referensia sirkular?
+external-doenetml-unavailable = Siñá larihín DoenetML lídangiñe { $attribute }="{ $uri }"
+external-doenetml-type-mismatch = DoenetML mabuiti larihín lídangiñe { $attribute }="{ $uri }": mama lafuriaruni luma tipu komponente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Wéiyaasu lan atributu `{ $from }`; bayusura `{ $to }` lubéi.
+       *[other] [deprecation] Wéiyaasu lan atributu `{ $from }` luagu `<{ $component }>`; bayusura `{ $to }` lubéi.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Wéiyaasu lan atributu `{ $from }`, ignorarúati ladüga ichugúwati `{ $to }` giñe.
+       *[other] [deprecation] Wéiyaasu lan atributu `{ $from }` luagu `<{ $component }>`, ignorarúati ladüga ichugúwati `{ $to }` giñe.
+    }
+
+deprecated-attribute-ignored = [deprecation] Wéiyaasu lan atributu `{ $attribute }` luagu `<{ $component }>`, ignorarúati.
+deprecated-attribute-to-child = [deprecation] Wéiyaasu lan atributu `{ $attribute }` luagu `<{ $component }>`; bayusura ában isaani `<{ $child }>` lubéi.
+deprecated-attribute-value-renamed = [deprecation] Wéiyaasu lan balu `{ $value }` lun atributu `{ $attribute }` luagu `<{ $component }>`; bayusura `{ $to }` lubéi.
+
+
+## Language coverage
+
+pluralize-english-only = Gayarabei ladügün `<pluralize>` plural lidan inglisi lumuti, ligía lígirunbei luganu keisi lan lidan ában dokumentu abürühóuti lidan { $locale }. Babüriha fórma plural lungua, o bíchiga lau atributu `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Mama ában elementu Doenet subudiwati `<{ $tag }>`.
+schema-element-not-allowed-at-root = Mígirunti elementu `<{ $tag }>` lidan lidügübei dokumentu.
+schema-element-not-allowed-inside = Mígirunti elementu `<{ $tag }>` tidan `<{ $parent }>`.
+schema-attribute-unrecognized = Úati ában atributu liri `{ $attribute }` luagu elementu `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Lunti lan ában lista lan atributu `{ $attribute }` lun elementu `<{ $tag }>`, ában lidan to lubéi kada katei: { $allowed }
+       *[other] Lunti lan ában lidan to lubéi atributu `{ $attribute }` lun elementu `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Iri barianti mabuiti lun select.  Aráfaguati iri barianti { $variantName } lidan { $numOptions } opsion, gama lumoun { $numToSelect } lan haruweiri lanúadirún.
+select-variant-name-without-options = Ichugúwati barianti lun select, gama lumoun úati opsion lun iri barianti gayarabei: { $variantName }.
+select-variant-name-not-possible = Mama ában iri barianti gayarabei iri barianti { $variantName } ichugúwati lun select.
+select-too-few-options = Siñá lanúadirún { $numToSelect } komponente lídangiñe { $numOptions } lumuti.
+select-from-sequence-too-few-values = Siñá lanúadirún { $numToSelect } balu lídangiñe ában sekuensia lunguti { $length }.
+select-from-sequence-indices-count-mismatch = Lunti lan lafuriaruni haruweiri índise ichugúwati lun select luma haruweiri lanúadirún
+select-from-sequence-indices-not-integers = Lunti lan entéru lan sun índise ichugúwati lun select
+select-from-sequence-index-excluded = Ichugúwati ában índise lun selectfromsequence úati lubéi
+select-from-sequence-indices-excluded-combination = Ichugúwati índise lun selectfromsequence ában konbinasion úati lubéi
+select-from-sequence-coprime-not-positive-integers = Siñá lanúadirún konbinasion coprime, ladüga mama entéru wéiriti darí 0 lanúadirún.
+select-from-sequence-coprime-common-factor = Siñá lanúadirún númeru coprime. Gabáñabei sun balu gayarabei ában faktóru ában. (Lunti lan coprime lan balu ichugúwati lun "from" o "to" luma "step".)
+select-from-sequence-coprime-single-number = Siñá lanúadirún konbinasion coprime lídangiñe ában númeru lumuti mama 1 lan.
+select-from-sequence-excluded-too-many-combinations = Úati lubéi ámuñegu darí 70% konbinasion lidan selectFromSequence
+select-from-sequence-coprime-none-found = Siñá lanúadirún númeru coprime. Gabáñabei sun balu gayarabei ában faktóru ában.
+select-from-sequence-too-few-unique-values = Siñá lanúadirún { $numToSelect } balu lumuti lídangiñe ában sekuensia lunguti { $numPossibleValues }
+select-prime-numbers-too-few-values = Siñá lanúadirún { $numToSelect } balu lídangiñe ában lista númeru primu lunguti { $numValues }
+select-prime-numbers-values-count-mismatch = Lunti lan lafuriaruni haruweiri balu ichugúwati lun select luma haruweiri lanúadirún
+select-prime-numbers-values-not-prime = Lunti lan tidan lista númeru primu lan sun balu ichugúwati lun select
+select-prime-numbers-values-excluded-combination = Ichugúwati balu lun selectPrimeNumbers ában konbinasion úati lubéi
+select-prime-numbers-excluded-too-many-combinations = Úati lubéi ámuñegu darí 70% konbinasion lidan selectPrimeNumbers
+select-random-combination-fluke = Lidan ában katei mama emeragúati, siñá lanúadirún ában konbinasion balu asaruwati
+select-random-value-fluke = Lidan ában katei mama emeragúati, siñá lanúadirún ában balu asaruwati
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    Mama labürühóun `<{ $component }>` tidan matemátika; abürühóuti espresion keisi lan lubaragiñe. { $reason ->
+        [not-inline] Ában choice input `inline` lumuti lan lasandirubei tidan ában espresion; danme úati `inline`, ában dagaruni butón lan.
+        [expanded] Ában text input `expanded` ában kaha saragu-línia lan, wéiri lan lun lasandirun tidan ában espresion.
+        [on-graph] Luagu ában graph, abürühóuti espresion keisi ában dibuhu lumuti, úati lubéi espasiu lun ában kontrol.
+       *[relative-width] Relatiba lan `width` (ában porsientu o `em`), úati katei lun lamesurarún tidan ában espresion. Bíchiga anchura lidan medida absoluta, keisi `px`.
+    }

--- a/packages/i18n/locales/cab/editor.ftl
+++ b/packages/i18n/locales/cab/editor.ftl
@@ -1,0 +1,248 @@
+# Garifuna editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker, the accessibility button and the context-help
+# panel beside them. Translated from `locales/en/editor.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage. Message ids
+# are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography of Honduras, Belize,
+# Guatemala and Nicaragua: `a b ch d e f g h i k l m n ñ o p r s t u ü w y`.
+# **`ü` is a letter of its own**, the high central vowel, written with the
+# diaeresis everywhere it occurs, and is not interchangeable with `u`. **The
+# falling tone is not written**: Garifuna distinguishes tone and the standard
+# orthography leaves it unmarked, so an acute here is the Spanish-style stress
+# accent Honduran practice uses on some words, not a tone mark — a reviewer
+# should not read the absence of accents as an error. `c`, `j`, `q`, `v`, `x`
+# and `z` are not in the alphabet, so a loan that would use them is respelled:
+# «barianti» for *variante*, «bersion» for *versión*, «espresion* is elsewhere,
+# «aksesibilidá» for *accesibilidad*, «kordenada» for *coordenada*.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `cab`; it falls back to
+# the default locale and reports `one` and `other`, categories Garifuna does not
+# select. Both counted messages here — `editor-accessibility-label` and
+# `help-coordinates` — are therefore written as **one unselected form**, with
+# the `$count` placeable kept exactly where English has it in the first and the
+# select dropped entirely in the second. Selects on non-numeric variables
+# (`$action`, `$status`, `$shortcut`, `$reason`, `$location`, `$allowed`,
+# `$line`, `$perItem`) are not plural selects and keep every branch English has.
+#
+# **Loans.** The technical nouns are **Spanish loans respelled to the Garifuna
+# alphabet and carried in a Garifuna frame**: «barianti», «bersion»,
+# «atributu», «referensia», «snipeti», «erroru», «adbertensia»,
+# «informasion», «aksesibilidá», «dokumentasion», «balu», «kordenada»,
+# «rekomendasion». The frame is Garifuna — «lidan» in, «lun» to, «luma» with,
+# «lídangiñe» from, «úati» there is none, «anihein» there is, «mama» the
+# negative copula, «siñá» cannot, «lunti» must — and the second-person
+# imperative prefix `b-` sits on the loan verbs («Bafara» press, «Barúfuda»
+# show, «Banúadira» choose). A Belizean speaker may prefer the English loan in
+# any of these slots and should feel free to substitute, but the whole file has
+# to move together.
+#
+# `WCAG AA`, `styleNumber`, `DoenetML`, the `$version` number and every
+# attribute name stay in English exactly as English writes them.
+#
+# **Confidence, and it is low.** «buiti»/«mabuiti», «úati» and «siñá» carry
+# much of this file and are worth a speaker's check, as do «arúfudahani»
+# (showing), «arámudahani» (hiding), «banúadira» (choose) and «bafara» (press),
+# which stand in for the English *open*, *close*, *select* and *click*. Nothing
+# in this file is omitted; all 64 keys are written. Three of them —
+# `editor-tab-with-count`, `help-name-summary` and
+# `help-style-number-annotation` — are punctuation and placeables with no prose
+# in them, and are reproduced as English has them because there is nothing in
+# them to move.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Bagiribuda
+       *[update] Baséinsuna
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } arihini
+       *[other] { $word } arihini { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Barianti
+editor-variant-filter = Bafiltraru...
+editor-variant-next = Banúadira barianti lárigi
+editor-variant-previous = Banúadira barianti furumiñe
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Aráfagua ában erroru aksesibilidá WCAG AA. Bafara lun { $action ->
+            [close] arámudahani
+           *[open] arúfudahani
+        } informe aksesibilidá.
+        [advisories] Bafara lun { $action ->
+            [close] arámudahani
+           *[open] arúfudahani
+        } informe aksesibilidá. Úati erroru WCAG AA, gama lumoun anihein rekomendasion aksesibilidá ámuñegu.
+       *[clean] Bafara lun { $action ->
+            [close] arámudahani
+           *[open] arúfudahani
+        } informe aksesibilidá. Úati katei mabuiti lidan aksesibilidá.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Aráfagua ában erroru aksesibilidá WCAG AA. Aráfagua { $count } erroru WCAG AA. Bafara lun { $action ->
+            [close] arámudahani
+           *[open] arúfudahani
+        } informe aksesibilidá.
+        [advisories] Úati erroru WCAG AA. Aráfagua { $count } rekomendasion aksesibilidá ámuñegu. Bafara lun { $action ->
+            [close] arámudahani
+           *[open] arúfudahani
+        } informe aksesibilidá.
+       *[clean] Úati erroru WCAG AA. Bafara lun { $action ->
+            [close] arámudahani
+           *[open] arúfudahani
+        } informe aksesibilidá.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersion DoenetML { $version }
+
+editor-tab-help = Adundehani lidan lubéi bagia
+editor-tab-help-short = Lidan
+editor-tab-errors = Erroru
+editor-tab-warnings = Adbertensia
+editor-tab-info = Informasion
+editor-tab-accessibility = Aksesibilidá
+editor-tab-responses = Respuesta ichugúati
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsion lun editóru
+editor-format-as-doenetml = Bafórmatiaru keisi DoenetML
+editor-format-as-xml = Bafórmatiaru keisi XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Línia #{ $line }
+
+editor-no-errors = Úati erroru
+editor-no-warnings = Úati adbertensia
+editor-no-info = Úati informasion
+
+editor-show-info-annotations = Barúfuda informasion lidan editóru
+editor-show-accessibility-annotations = Barúfuda aksesibilidá lidan editóru
+
+editor-accessibility-learn-more = Barihi ida liña Doenet lidan aksesibilidá
+
+editor-accessibility-violations-heading = Erroru aksesibilidá ({ $standard })
+
+editor-accessibility-other-heading = Katei ámu lidan aksesibilidá
+editor-none-found = Úati
+
+
+## Submitted responses
+
+editor-no-responses = Úati respuesta ichugúati
+editor-response-answer-id = Id lun respuesta
+editor-response-response = Respuesta
+editor-response-credit = Puntu
+editor-response-submitted = Ichugúati
+
+
+## The context-help panel
+
+help-placeholder = Bíchuga kursóru luagu ában etiketa, atributu, o { $ref } lun bariha dokumentasion.
+
+help-unsupported-ref-chain = Úati adundehani lun referensia saragu-parti keisi { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Úati katei lun referensia to: { $ref }.
+        [multiple] Saragu katei lun referensia to: { $ref }.
+       *[indeterminate] Siñá lasubudirún ka katei lun { $ref }.
+    }
+
+help-learn-about-references = Barihi luagu referensia →
+help-reference-page = Páhina referensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Lidan { $element }
+       *[top] Lidan lidügübei sun
+    }{ $allowed ->
+        [none] { " — úati katei larumugun ya." }
+        [text] { " — babüriha uganu ya." }
+        [text-and-components] { " — babüriha uganu ya, o barihi to:" }
+       *[components] { " — katei lun barihin:" }
+    }
+
+help-suggestions-footer = Bafara { $shortcut } lun barihin sun { $total } komponente.
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ában referensia lun { $target }.
+       *[other] { $ref } ában referensia lun { $target } (línia { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Adügüwati lidan { $owner } keisi { $role }.
+       *[other] Adügüwati lidan { $owner } lidan línia { $line } keisi { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ában referensia lun propiedá { $property } lun { $element }.
+       *[other] { $ref } ában referensia lun propiedá { $property } lun { $element } (línia { $line }).
+    }
+
+# Punctuation standing on its own: `$name` is empty where the panel has already
+# printed the name, so the dash has to read as the whole message.
+help-name-summary = { $name } — { $summary }
+
+help-kind-attribute = atributu
+help-kind-snippet = snipeti
+help-kind-array-entry = ában lidan areglu
+
+help-default = Lubéi mama arúfudǘwa:
+help-active-default = Lubéi arúfudǘwaali:
+
+# `styleNumber` is the attribute's own name and stays as written; the string
+# literal protects the leading space.
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Balu larumugun (ában lun kada ában):
+       *[other] Balu larumugun:
+    }
+
+help-suggested-values = Balu arúfudǘwati:
+
+help-inserts = Larumuguña:
+
+help-coordinates = Kordenada:
+
+help-type = Tipu:
+
+help-resolved-style = Estilu adügüwaali (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Iri funsion adügüwaali:
+help-reset-list = Lista agiribudǘwati lidan entrada to:
+help-added-on-input = Aragüwati lidan entrada to:
+help-removed-on-input = Akitarúati lidan entrada to:
+
+help-reset-overrides = { $reset } lasánsiruña { $additional } luma { $removed }.

--- a/packages/i18n/locales/djk/chrome.ftl
+++ b/packages/i18n/locales/djk/chrome.ftl
@@ -1,0 +1,186 @@
+# Aukan / Ndyuka (Okanisi tongo), the Eastern Maroon Creole of the Tapanahoni
+# and the Lawa in Suriname and French Guiana. Viewer chrome, translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **SIL Ndyuka orthography**, the one the Ndyuka
+# dictionary and the Ndyuka scriptures are written in. Its points:
+#
+#   * **A doubled vowel writes length** — «puu» (*take out*), «kibii»
+#     (*keep*), «dii» (*three*), «wooko» (*work*), «gaan» (*big*), «ondoo»
+#     (*under*), «neen» (*name*), «baaka» (*black*). A single vowel is short.
+#     This is the mark of the orthography and a reviewer should keep it.
+#   * **No consonant + `r` clusters.** Ndyuka has none, and where Sranan Tongo
+#     writes one Ndyuka writes a plain consonant with a long vowel:
+#     «gaantangi» not *grantangi*, «kiin» not *krin*, «taa» not *tra*,
+#     «pooberi» not *proberi*, «kediti» not *krediti*. Any `Cr` cluster
+#     anywhere in these four files is an error.
+#   * **`u`, never «oe»**, and **`y`, never «j»**, as in the Surinamese
+#     spelling conventions generally.
+#   * **Tone is not written.** Ndyuka has contrastive tone and this
+#     orthography leaves it unmarked, as the dictionary and the scriptures do.
+#     That is stated plainly rather than passed over: it is the orthography's
+#     own convention, not an omission this seed made.
+#
+# Sranan Tongo is a different language and its spellings are **not mixed into
+# these files**; `locales/srn` is its own catalog. Saramaccan, in
+# `locales/srm`, is a third language again — the two are related but not two
+# spellings of one text, and a reviewer who finds a Saramaccan «ta» or «bi»
+# here should treat it as a bug.
+#
+# **Grammar.** Ndyuka grammar carries every sentence. Tense and aspect are the
+# preverbal markers «e» (imperfective), «be» (past), «o» (future), «sa»
+# (able), «mu» (must), with «kaba» for the completive; negation is the
+# preverbal «no» and it precedes the marker («a no e wooko»); «anga» is *and*
+# and *with*; «fu» is the purposive and the possessive; «den» is the plural
+# and «di» the definite article; «na» is the equative copula and «de» the
+# locative. Serial verbs do the work English does with prepositions.
+#
+# **Number.** `Intl.PluralRules("djk")` has **no CLDR data for `djk`**: it
+# falls back and answers `['one', 'other']`, which is English's answer and not
+# a fact about Ndyuka. A Ndyuka noun after a numeral is unmarked — «tu
+# pooberi», never a pluralized noun; the plural is the preposed «den», used
+# for definiteness rather than for counting. So the `one` and `other` branches
+# would be word-for-word identical, and where that is so this file writes
+# **one unselected form**. English's explicit `[0]` literal in
+# `attempts-remaining` matches the number itself, not a plural category, and
+# is kept.
+#
+# **Loans.** The computing register is Dutch and English, reshaped to Ndyuka
+# phonology and carried in Ndyuka grammar: «kiibodu» (*keyboard*), «kediti»
+# (*credit*), «statistiki», «matematika», «ekispresi», «dokumenti»,
+# «infoomasi», «pagina», «masiin», «futunota», «vekitoo», «funsi», «renderer»
+# (left as the code's own name), «WCAG» and «aksesibiliteiti». Everyday words
+# are Ndyuka: «piki» (*answer*), «leti» / «fowtu» (*right* / *wrong*),
+# «pooberi» (*try*), «tan» (*remain*), «sori» (*show*), «opo» / «tapu»
+# (*open* / *close*), «puu» / «poti» (*remove* / *add*), «kiin» (*clear*).
+#
+# **Confidence.** Ndyuka has a dictionary, a scripture translation and very
+# little written technical prose, so the loans above are shapes this seed
+# derived from Ndyuka phonology rather than usage it found. The grammar and
+# the everyday words are the part to trust. Nothing here was left in English.
+
+
+answer-checking = E luku...
+answer-submitting = E seni...
+
+answer-checking-status = E luku a piki
+answer-submitting-status = E seni a piki
+
+answer-correct = Leti
+answer-incorrect = Fowtu
+
+answer-response-saved = A piki kibii kaba
+
+answer-percent-credit = { $percent }% kediti
+answer-percent-correct = { $percent }% leti
+answer-percent-short = { $percent } %
+
+max-credit-available = A moo hei kediti: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] no wan pooberi no tan moo
+       *[other] { $count } pooberi tan
+    }
+
+validation-correct = (Leti)
+validation-incorrect = (Fowtu)
+validation-partially-correct = (Wan pisi leti)
+
+answer-show-responses = Sori { $count } piki gi { $answerId }
+
+
+feedback-heading = Piki fu a wooko
+
+collapsible-click-to-open = (kiliki fu opo)
+collapsible-click-to-close = (kiliki fu tapu)
+
+collapsible-initializing = E bigin...
+
+footnote-show = Sori a futunota
+footnote-hide = Kibii a futunota
+
+description-more-information = moo infoomasi
+
+
+slider-previous = Baka
+slider-next = Fesi
+
+keyboard-open = Opo a kiibodu
+keyboard-close = Tapu a kiibodu
+
+choice-input-remove-choice = Puu { $choice }
+
+matrix-remove-row = Puu wan lei
+matrix-add-row = Poti wan lei
+matrix-remove-column = Puu wan kolon
+matrix-add-column = Poti wan kolon
+
+subset-add-remove-points = Poti/Puu punt
+subset-toggle-points-intervals = Kenki punt anga intavalu
+subset-move-points = Seke den punt
+subset-clear = Kiin
+
+orbital-add-row = Poti wan lei
+orbital-remove-row = Puu wan lei
+orbital-add-box = Poti wan bokisi
+orbital-remove-box = Puu wan bokisi
+orbital-add-up-arrow = Poti wan peili di e go a tapu
+orbital-add-down-arrow = Poti wan peili di e go a ondoo
+orbital-remove-arrow = Puu a peili
+
+orbital-row-label = Neen gi lei { $row }
+
+pretzel-answer = Piki
+
+summary-statistics-caption = Sotu statistiki fu { $column }
+
+
+math-input-preview-region = luku fosi fu a matematika-ekispresi
+math-input-preview = Luku fosi
+math-input-invalid-expression = A ekispresi no bun:
+
+
+viewer-initializing = E bigin...
+
+
+error-heading = Fowtu
+
+error-found-at =
+    { $span ->
+        [line] Feni a lin { $startLine }.
+       *[lines] Feni a lin { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = A dokumenti ya abi fowtu a ini!
+
+diagnostic-heading-error = Fowtu
+diagnostic-heading-warning = Wasikoi
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Tipi
+
+accessibility-heading-level-1 = WCAG AA aksesibiliteiti-fowtu
+accessibility-heading-level-2 = Aksesibiliteiti-wasikoi
+
+something-went-wrong = Wan sani go fowtu.
+
+renderer-load-failed = wan renderer no man lai. Gaantangi, lai a pagina baka.
+
+core-start-failed = A dokumenti ya no man bigin. Gaantangi, lai a pagina baka.
+
+core-start-failed-busy = A dokumenti ya no man bigin. Somen dokumenti be e bigin a wan pisi ten, da a sa teke moo langa a wan safi masiin. Te den taa dokumenti kaba, da a sa yeepi efu i lai a pagina baka.
+
+core-start-failed-retry = A dokumenti ya no man bigin.
+
+core-start-failed-busy-retry = A dokumenti ya no man bigin. Somen dokumenti be e bigin a wan pisi ten, da a sa teke moo langa a wan safi masiin.
+
+core-start-retry = Pooberi baka
+
+saved-state-unavailable = A wooko di i be kibii no man lai.

--- a/packages/i18n/locales/djk/content.ftl
+++ b/packages/i18n/locales/djk/content.ftl
@@ -1,0 +1,262 @@
+# Aukan / Ndyuka (Okanisi tongo) content catalog: the prose the core computes
+# into the document. Selected by `documentLocale` — the language the activity
+# was written in. Translated from `locales/en/content.ftl`, which is the
+# source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The SIL Ndyuka orthography: a **doubled vowel writes
+# length** («puu», «kibii», «wooko», «gaan», «baaka»); there are **no
+# consonant + `r` clusters** at all, so «kiin» not *krin*, «taa» not *tra*,
+# «gaantangi» not *grantangi*; «u» never «oe» and «y» never «j»; and **tone is
+# not written**, as the Ndyuka dictionary and scriptures leave it. Ndyuka is a
+# tone language and that is a real loss the orthography accepts, stated here
+# rather than passed over. Sranan Tongo spellings and Saramaccan spellings are
+# **not mixed into these files**; `chrome.ftl`'s header sets the system out
+# point by point.
+#
+# **Word order: the modifier comes before the noun.** Ndyuka puts an
+# attributive adjective in front of its head — «wan deki lebi lin» is *a thick
+# red line*, in that order. So every composition message here **keeps the
+# English order**: `style-with-noun` puts the description first and the noun
+# after it, and `style-stroke` runs width, then dash pattern, then colour.
+# `noun-regular-polygon` is the one that moves: Ndyuka counts a side with a
+# following «anga { $numSides } sei», so the count follows the noun instead of
+# preceding it as English's «5-sided» does. It still goes in the `head`
+# branch, because it stays beside the noun rather than after the adjectives.
+#
+# **No grammatical gender and no agreement.** Ndyuka adjectives do not inflect
+# for gender, number or case, so no message here forks on `$gender` or on
+# `$role`, and `noun-gender` answers a single token that nothing reads.
+#
+# **Number.** `Intl.PluralRules("djk")` has no CLDR data for `djk` and falls
+# back to English's `['one', 'other']`, which is not a fact about Ndyuka. A
+# noun after a numeral is unmarked — «dii punt»; the plural marker «den» is
+# preposed and marks definiteness, not counting. So **nothing in this file
+# selects on a count**.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# Science in Suriname is schooled in Dutch, from Dutch textbooks; there is no
+# Ndyuka periodic table in use and no settled Ndyuka spelling for the hundred
+# and eighteen names. Reshaping the Dutch list to Ndyuka phonology would be
+# inventing a nomenclature rather than recording one. `lint:i18n` reports the
+# two keys as missing coverage, and that report is correct: they fall back to
+# English.
+#
+# **Loans.** Dutch and English reshaped to Ndyuka phonology: «vekitoo»,
+# «funsi», «palabola», «poligon», «polilin», «definisi», «teorema»,
+# «eksempee», «seksi», «palagaaf», «kaskade», «nota», «bewisi», «tabel»,
+# «figuu», «pagina», «intavalu», «kediti». Ndyuka's own words carry the rest:
+# «lin», «punt», «lontu» (*circle*), «diiuku» (*triangle*, literally
+# three-corner), «fokanti» (*square*, four-corner), «kookotu lin» (*curved
+# line*), «kanti» (*border*), «bakagoon» (*background*), «fuu» (*full*),
+# «tuu» / «falisi». Seven colour names — «asisi kula», «alanya kula», «syan»,
+# «paasi», «loosu», «boon», «geli» — are the least certain entries here; a
+# reviewer should check them first.
+
+
+color =
+    .black = baaka
+    .white = weti
+    .gray = asisi kula
+    .red = lebi
+    .orange = alanya kula
+    .yellow = geli
+    .green = guun
+    .cyan = syan
+    .blue = buluu
+    .purple = paasi
+    .pink = loosu
+    .brown = boon
+
+line-width =
+    .thick = deki
+    .thin = fini
+
+line-style =
+    .dashed = koti-koti
+    .dotted = punt-punt
+
+fill-style =
+    .horizontal = lin di e go langalanga
+    .vertical = lin di e go tapu-ondoo
+    .diagonal = lin di e go a kaanti
+    .backdiagonal = lin di e go a taa kaanti
+    .dots = punt
+    .diamonds = diamanti
+
+noun =
+    .line = lin
+    .line-segment = pisi lin
+    .ray = sitaali
+    .vector = vekitoo
+    .curve = kookotu lin
+    .function = funsi
+    .slope-field = helin-feeld
+    .vector-field = vekitoo-feeld
+    .parabola = palabola
+    .polyline = polilin
+    .polygon = poligon
+    .triangle = diiuku
+    .rectangle = langa fokanti
+    .circle = lontu
+    .region = peesi
+    .point = punt
+    .square = fokanti
+    .diamond = diamanti
+    .cross = kooisi
+    .plus = pulusi
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] gelijki poligon anga { $numSides } sei
+    }
+
+noun-gender = neuter
+
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = fuu
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } anga { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } anga { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } anga { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] anga wan { $border } kanti
+        [and] anga { $border } kanti
+        [and-article] anga wan { $border } kanti
+       *[with] anga { $border } kanti
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = no fuu
+
+style-text =
+    { $parts ->
+        [background] { $color } anga wan { $background } bakagoon
+       *[plain] { $color }
+    }
+
+style-background-none = no wan
+
+
+boolean-true = tuu
+boolean-false = falisi
+
+
+answer-submit-label = Luku a wooko
+
+answer-submit-label-no-correctness = Seni a piki
+
+
+section-name =
+    .activity = Aktiviteiti
+    .aside = Sei-toli
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Eksempee
+    .exercise = Oefeni
+    .exercises = Den oefeni
+    .given-answer = Piki
+    .note = Nota
+    .objectives = Den dulu
+    .paragraphs = Palagaaf
+    .part = Pisi
+    .problem = Pooblema
+    .problems = Den pooblema
+    .proof = Bewisi
+    .question = Akisi
+    .section = Seksi
+    .solution = Lusu
+    .task = Opodaakiti
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Tipi
+
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figuu { $enumeration }
+        [numbered-caption] Figuu { $enumeration }{ ": " }
+        [unnumbered-caption] Figuu{ ": " }
+       *[unnumbered] Figuu
+    }
+
+
+paginator-previous = Baka
+paginator-next = Fesi
+paginator-page = Pagina
+
+paginator-page-status = { $pageLabel } { $currentPage } fu { $numPages }
+
+
+piecewise-condition-or = noso
+
+piecewise-condition-if = efu
+
+piecewise-condition-otherwise = efu a no so
+
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = A kemi-maiki no bun
+chemistry-invalid-ionic-compound = A ioniki mokisani no bun
+
+
+math-embedded-input-blank = leigi peesi
+
+math-embedded-input-blank-ordinal = leigi peesi { $ordinal } fu { $total }

--- a/packages/i18n/locales/djk/diagnostics.ftl
+++ b/packages/i18n/locales/djk/diagnostics.ftl
@@ -1,0 +1,676 @@
+# Aukan / Ndyuka (Okanisi tongo) diagnostics: the errors and warnings the
+# worker, the parser and the language server put in front of whoever is looking
+# at the screen. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth; the ids are reached by diagnostic code and are never
+# translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The SIL Ndyuka orthography: a doubled vowel writes length
+# («puu», «wooko», «gaan»), there are no consonant + `r` clusters at all
+# («kiin», «taa», «gaantangi», «pooberi»), «u» never «oe», «y» never «j», and
+# **tone is not written** — Ndyuka is a tone language and this orthography
+# leaves tone unmarked, as the dictionary and the scriptures do. Sranan Tongo
+# and Saramaccan spellings are not mixed into these files; `chrome.ftl`'s
+# header sets the system out point by point.
+#
+# **DoenetML identifiers stay in English.** Tag names, attribute names and
+# attribute values — `through`, `endpoint`, `midpointOffset`, `numDimensions`,
+# `maxNumAttempts`, `symbolicEquality`, `math`, `text`, `number`, `boolean`,
+# `none`, `medium`, `dense`, `from`, `to`, `step` — are the language, not
+# prose, and are written here exactly as English writes them, as is the
+# `[deprecation]` marker.
+#
+# **Number.** `Intl.PluralRules("djk")` has no CLDR data for `djk` and falls
+# back to English. A Ndyuka noun after a numeral does not inflect, so every
+# message English selects on a count — `line-segment-attributes-ignored-*`,
+# `function-domain-insufficient-dimensions`,
+# `function-iterates-input-output-mismatch`,
+# `matches-pattern-parameter-not-in-pattern`,
+# `answer-attributes-need-symbolic-equality`, `attribute-invalid-values` — is
+# written here as **one unselected form**. The one remaining `[one]` branch,
+# in `field-function-wrong-num-outputs`, is not a plural: it picks between two
+# different sentences about what a slope field and a vector field each need,
+# and dropping it would drop the advice.
+#
+# **Loans.** Dutch and English reshaped to Ndyuka phonology: «komponenti»,
+# «atribut», «waarde», «dokumenti», «vesi», «vaariant», «indeksi»,
+# «palamita», «ekispresi», «funsi», «matriksi», «sekwensi», «dimensi»,
+# «kontlasi», «anotasi», «sikema», «refeensi», «fowtu». Ndyuka's own words
+# carry the sentences: «no man» (*cannot*), «mu» (*must*), «feni» (*find*),
+# «teki», «poti», «puu», «sori», «teli» (*count*), «bun» / «no bun».
+#
+# **Confidence.** Ndyuka has no written technical prose of this kind, so every
+# loan above is a shape derived by rule rather than one found in use. What a
+# reviewer should read for is the grammar: the preverbal «e» / «be» / «o» /
+# «sa» / «mu», the negator «no» in front of them, and «anga» for *and*.
+# Nothing here was left in English.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } no e teli te tu endpoint poti
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } no e teli te wan endpoint anga wan midpoint poti ala tu
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset no e du noti efu no wan midpoint no de
+
+## `<line>`
+
+line-points-undetermined-dimensions = A lin e go pasa punt di wi no sabi omeni dimensi den abi.
+
+line-points-too-few-dimensions = A lin mu pasa punt di abi tu dimensi efu moo.
+
+line-points-depend-on-variables = A lin e pasa punt di e anga den vaariabel ya: { $variables }.
+
+line-equation-invalid-format = A foomati fu a ekwasi fu a lin a ini den vaariabel { $variable1 } anga { $variable2 } no bun.
+
+## `<ray>`
+
+ray-overprescribed-through = A sitaali poti anga through, endpoint anga direction.  Wi no e teli a through di poti.
+
+ray-dimension-mismatch = A numDimensions no e fiti a ini a sitaali.
+
+## `<vector>`
+
+vector-overprescribed-head = A vekitoo poti anga head, tail anga displacement.  Wi no e teli a head di poti.
+
+vector-dimension-mismatch = A numDimensions no e fiti a ini a vekitoo.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Wi no man hali go a wan `<{ $component }>` bika a no abi wan nearestPoint stati-vaariabel.
+
+constrain-to-without-nearest-point = Wi no man tai go a wan `<{ $component }>` bika a no abi wan nearestPoint stati-vaariabel.
+
+constrain-to-interior-without-nearest-point = Wi no man tai go a ini wan `<{ $component }>` bika a no abi wan nearestPoint stati-vaariabel.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition no e teli a wan choiceInput di a no inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Wi no e teli den indices di poti gi a choiceInput bika a nomu fu den indices no e fiti a nomu fu den choice pikin.
+
+pretzel-indices-count-mismatch = Wi no e teli den indices di poti gi a problem bika a nomu fu den indices no e fiti a nomu fu den problem pikin.
+
+shuffle-indices-count-mismatch = Wi no e teli den indices di poti gi a shuffle bika a nomu fu den indices no e fiti a nomu fu den komponenti.
+
+indices-ignored-out-of-range = Wi no e teli den indices di poti gi { $component } bika son fu den de a doo fu a peesi.
+
+pretzel-indices-repeated = Wi no e teli den indices di poti gi a pretzel bika son fu den de tu leisi.
+
+pretzel-circuit-first-index = Wi no e teli den indices di poti gi a pretzel a ini circuit fasi bika a fosi indeksi mu de 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Fu `<{ $component }>` sa wooko anga sitringi pikin, i mu poti wan `type` atribut.
+
+invalid-type-defaulting-to-math = A type { $type } no bun gi wan { $component } komponenti. A mu de math, text, number efuso boolean. Wi o teki math.
+
+string-not-valid-component-to-arrange = A sitringi "{ $value }" a no wan bun komponenti fu { $component }. Wi no e teli en.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = A type { $type } no bun, da wi e seti a type na number.
+
+invalid-variable-value = A waarde fu wan vaariabel no bun: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = A vaariant-indeksi { $index } mu de wan nomu
+
+variant-index-must-be-integer = A vaariant-indeksi { $index } mu de wan hii nomu
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` no meki gi abesoluut marki. Wi e seti den bereedi na relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` no meki gi abesoluut marki. Wi e seti den kanti na relatif.
+
+side-by-side-no-block-child = A `<{ $component }>` ya no bun: a mu abi wan blaka pikin efu moo.
+
+## `<label>`
+
+label-for-ignored-on-graphical = A `for` atribut no e teli a wan gaafiki `<label>`.
+
+label-for-must-resolve-to-one = A `for` atribut a wan `<label>` mu sori soso wan komponenti.
+
+label-for-unresolved = A `for` atribut a wan `<label>` no man feni no wan komponenti.
+
+label-for-answer-with-authored-inputs = A `for` atribut a wan `<label>` e sori wan `<answer>` di abi en eigi inputu sikiifi; sori a inputu srefi.
+
+label-for-answer-without-input = A `for` atribut a wan `<label>` e sori wan `<answer>` di no abi no wan inputu fu neen.
+
+label-for-must-reference-input-or-answer = A `for` atribut a wan `<label>` mu sori wan inputu efuso wan answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Fu a aksesibiliteiti, wan `<{ $component }>` mu abi wan syatu deskipsi efuso a mu poti enke decorative.
+
+accessibility-video-short-description = Fu a aksesibiliteiti, wan `<video>` mu abi wan syatu deskipsi.
+
+accessibility-input-short-description-or-label = Fu a aksesibiliteiti, wan `<{ $component }>` mu abi wan syatu deskipsi efuso wan neen.
+
+accessibility-answer-input-short-description-or-label = Fu a aksesibiliteiti, wan `<answer>` di e meki wan inputu mu abi wan syatu deskipsi efuso wan neen.
+
+accessibility-short-description-contains-math = Syatu deskipsi no mu abi matematika-komponenti enke `<{ $component }>` a ini. Sikiifi a matematika anga wowtu.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } no abi nofo kontlasi gi a seksi-edeneen tekisi (dark fasi) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu { $threshold }:1 efu moo).
+       *[other] { $colorName } no abi nofo kontlasi gi a seksi-edeneen tekisi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu { $threshold }:1 efu moo).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wi no meki wan `<circle>` di e pasa { $count } punt ete gi a situwasi pe den punt no abi nomu-waarde.
+
+circle-too-many-through-points = Wi no man wooko wan lontu di e pasa moo enke 3 punt.
+
+circle-overprescribed-radius-center-points = Wi no man wooko wan lontu te radius, center anga through-punt poti ala dii.
+
+circle-center-with-multiple-points = Wi no man wooko wan lontu anga wan center di poti di e pasa moo enke 1 punt.
+
+circle-radius-too-small = Wi no man wooko a lontu: a pasi tuka den tu punt na { $distance }, da a radius { $radius } di poti pikin tumusi.
+
+circle-radius-with-many-points = Wi no man meki wan lontu di e pasa moo enke tu punt anga wan radius di poti.
+
+circle-invalid-center-or-through-points = A center efuso den through-punt fu a lontu no bun.
+
+circle-radius-center-with-multiple-points = Wi no man wooko a radius fu wan lontu anga wan center di poti di e pasa moo enke 1 punt.
+
+circle-change-radius-non-numerical = Wi no man kenki a radius fu wan lontu di abi through-punt di no abi nomu-waarde
+
+circle-radius-with-points-non-numerical = Wi no man meki wan lontu di e pasa moo enke wan punt anga wan radius di poti te den punt no abi nomu-waarde.
+
+circle-change-center-non-numerical = Wi no meki wan fasi ete fu kenki a center fu wan lontu di e pasa punt di no abi nomu-waarde.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = A domein no abi nofo dimensi gi a funsi. A domein abi { $intervals } intavalu ma a funsi abi { $inputs } inputu.
+
+function-domain-invalid-format = A foomati fu a domein fu a funsi no bun.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Wi no e teli a moo hei punt fu a funsi bika a no wan nomu.
+        [minimum] Wi no e teli a moo lagi punt fu a funsi bika a no wan nomu.
+        [extremum] Wi no e teli a ekisteemu fu a funsi bika a no wan nomu.
+        [point] Wi no e teli a punt fu a funsi bika a no wan nomu.
+        [slope] Wi no e teli a helin fu a funsi bika a no wan nomu.
+       *[other] Wi no e teli a { $type } fu a funsi bika a no wan nomu.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Wi no e teli a moo hei punt fu a funsi bika a leigi.
+        [minimum] Wi no e teli a moo lagi punt fu a funsi bika a leigi.
+        [extremum] Wi no e teli a ekisteemu fu a funsi bika a leigi.
+        [point] Wi no e teli a punt fu a funsi bika a leigi.
+       *[other] Wi no e teli a { $type } fu a funsi bika a leigi.
+    }
+
+function-points-too-close = A funsi abi tu punt di de tumusi koosube fu makandii. Wi no man meki a funsi.
+
+function-iterates-input-output-mismatch = Funsi-iterasi sa wooko soso efu a nomu fu den inputu de a srefi enke a nomu fu den outputu. A funsi ya abi { $inputs } inputu anga { $outputs } outputu.
+
+## `<sequence>`
+
+sequence-invalid-length = A langa fu a sekwensi no bun.  A mu de wan hii nomu di no negatif.
+
+sequence-invalid-step = A step fu a sekwensi no bun.  A mu de wan nomu gi wan sekwensi fu type { $type }.
+
+sequence-invalid-endpoint-number = A "{ $attribute }" fu a nomu-sekwensi no bun.  A mu de wan nomu.
+
+sequence-invalid-endpoint-letters = A "{ $attribute }" fu a letu-sekwensi no bun.  A mu de wan mokisi fu letu.
+
+sequence-invalid-endpoint = A "{ $attribute }" fu a sekwensi no bun.
+
+select-from-sequence-coprime-not-numbers = wi no e teli coprime bika wi no e teki nomu
+
+select-from-sequence-coprime-with-exclude-combinations = wi no e teli coprime bika excludeCombinations poti
+
+## Resolving a `target`
+
+target-not-found = A target gi `<{ $source }>` no bun: wi no man feni a target.
+
+target-state-variable-not-found = A target gi `<{ $source }>` no bun: wi no man feni no wan stati-vaariabel di nen "{ $property }" a wan `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Den vaariabel fu wan `<odeSystem>` mu de taa fasi enke a onafanki vaariabel.
+
+ode-system-duplicate-variable-names = Wi no man meki ODE RHS funsi anga a srefi dependenti vaariabel-neen tu leisi.
+
+ode-system-rhs-function-error = Wi no man meki a ODE RHS funsi.  Fowtu di wi be e meki a mathjs funsi.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Wi no man meki wan uku tuka { $count } lin
+
+angle-invalid-through-point = A punt a ini a through fu a `<angle>` no bun
+
+parabola-vertex-too-many-points = Wi no meki wan palabola anga wan vertex di e pasa moo enke 1 punt ete.
+
+parabola-too-many-points = Wi no meki wan palabola di e pasa moo enke 3 punt ete.
+
+intersection-too-many-items = Wi no meki intaseksi gi moo enke tu sani ete
+
+## Other math components
+
+ionic-compound-not-two-ions = Wi no meki no ioniki mokisani gi wan taa sani boiti tu ion ete.
+
+ionic-compound-needs-cation-and-anion = Wi meki ioniki mokisani soso gi wan kation anga wan anion.
+
+solve-equations-cannot-evaluate = Wi no man lusu a ekwasi bika wi no man wooko en: { $equation }
+
+math-operators-operand-number-required = I mu poti wan operandNumber te i e puu wan matematika-operanti.
+
+eigen-decomposition-failed = Wi no man wooko den eigenwaarde fu a matriksi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: a palamita { $parameters } no de a ini a patoon, da a o fiti wan leigi peesi ala ten.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: wi no man fusutan grid="{ $grid }". A mu de none, medium, dense, efuso tu positif nomu anga wan peesi tuka den, enke grid="1 0.5". Wi no e teke no wan grid.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` abi fanowdu wan funsi anga { $expected ->
+        [one] wan outputu, a helin y' a ibii punt, enke `y - x`
+       *[other] tu outputu, a vekitoo a ibii punt, enke `(y, -x)`
+    }, ma a funsi di a kisi abi { $found } outputu. { $alternative ->
+        [none] Wi no e teke no wan sani.
+       *[other] `<{ $alternative }>` na a komponenti gi a funsi dati. Wi no e teke no wan sani.
+    }
+
+field-function-attribute-ignored-with-child = Wi no e teli a `function` atribut bika a funsi de a ini a komponenti tu; wi e teki a wan di de a ini. Gi a funsi soso wan fu den tu fasi.
+
+field-variables-ignored =
+    `<{ $component }>`: a `variables` atribut e nen den vaariabel fu wan ekispresi di sikiifi a ini a komponenti srefi. { $reason ->
+        [function-child] A funsi ya gi enke wan `<function>` pikin, di e nen en eigi vaariabel, da wi no e teli `variables`.
+       *[no-expression] No wan sowan ekispresi no de ya, da wi no e teli `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: a prefigure renderer no e teki xLabelPosition="left"; wi o wooko enke right.
+
+prefigure-y-label-position-unsupported = `<graph>`: a prefigure renderer no e teki yLabelPosition="bottom"; wi o wooko enke top.
+
+prefigure-invalid-axis-bounds = `<graph>`: den asi-marki no bun gi a prefigure kenki; wi o teki a difoolti bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: a bereedi no bun gi a prefigure kenki; wi o teki a difoolti diagram-bereedi 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: a aspectRatio no bun gi a prefigure kenki; wi o teki a difoolti aspek-ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: a grid-peesi fini tumusi gi den asi-marki; wi e libi a grid a doo a ini a prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: wi no o teke no wan anotasi efu wi no e wooko anga a PreFigure renderer.
+
+multiple-annotations-children = Wi feni moo enke wan `<annotations>` pikin a ini a `<graph>`; wi no e teli den ala boiti a laste wan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Wi no man langa efuso kopi wan komponenti-sortu di wi no sabi: { $type }.
+
+copy-prop-not-found = Wi no man feni a prop { $property } a wan komponenti fu sortu { $component }
+
+collect-no-source = Wi no feni no wan source gi a collect.
+
+collect-invalid-component-type = Wi no man kolekiti komponenti fu sortu `<{ $component }>` bika dati a no wan bun komponenti-sortu.
+
+reference-index-unavailable = Wi no man sori a indeksi `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Wi no man kai { $action } a a komponenti `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = A fomu fu a data no bun.  Den lei no abi a srefi langa. Feni a ini componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = A data abi a srefi kolon-neen tu leisi.  Feni a ini componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kolon-neen mankei a ini a data.  Feni a ini componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award gi a piki ya e anga a answer tag en eigi piki di seni, da sani o pasa di yu no o fusutan.
+
+answer-max-num-attempts-in-section-wide-check-work = Efu i seti `maxNumAttempts` a wan `<answer>` a ini wan bakisi di abi `sectionWideCheckWork`, a no e du noti, bika a bakisi e tii a nomu fu den pooberi. Seti `maxNumAttempts` a a bakisi.
+
+nested-section-wide-check-work-max-num-attempts = Efu i seti `maxNumAttempts` a wan bakisi di abi `sectionWideCheckWork` di de a ini wan taa bakisi di abi `sectionWideCheckWork`, a no e du noti, bika a bakisi a doose e tii a nomu fu den pooberi. Seti `maxNumAttempts` a a bakisi a doose.
+
+answer-attributes-need-symbolic-equality = A { $attributes } atribut no o du noti efu symbolicEquality no seti.
+
+answer-invalid-type = A sortu gi a piki no bun: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Bika a komponenti `<{ $component }>` no abi no wan neen, wi no man wooko en gi wan module atribut
+
+module-attribute-name-already-defined = Wi no man wooko a komponenti `<{ $component } name="{ $name }">` enke wan atribut gi wan module bika a `<module>` komponenti-sortu abi wan "{ $name }" atribut kaba.
+
+conditional-content-condition-ignored = A atribut `condition` no e teli a wan `<conditionalContent>` komponenti di abi case efuso else pikin.
+
+slider-markers-type-mismatch = A maiki-sortu no e fiti a slider-sortu.
+
+pretzel-problem-needs-statement-and-answer = A pretzel ya no bun: ibii `<problem>` mu abi wan `<statement>` anga wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = A pretzel ya no bun: a ini mode="circuit", a fosi `<problem>` no man de wan distractor.
+
+## Attribute values
+
+attribute-invalid-values = A waarde { $values } gi a atribut `{ $attribute }` no bun; wi no e teli en.
+
+attribute-must-be-references = A waarde `{ $value }` gi a atribut `{ $attribute }` no bun. A atribut mu meki fu refeensi di e bigin anga wan `$`.
+
+math-input-invalid-function-names = <mathInput>: wi no e teli funsi-neen di no bun a ini { $attribute }: { $names }. Ibii neen en sori-pisi mu abi tu tekin efu moo (letu efuso sitreki); wan `|<mathspeak alternative>` sa kon baka en efu i wani.
+
+## Building components from the source
+
+component-type-invalid = A komponenti-sortu ya no bun: `<{ $componentType }>`
+
+attribute-repeated = I no man poti a atribut { $attribute } tu leisi.
+
+attribute-invalid-for-component = A atribut "{ $attribute }" no bun gi wan komponenti fu sortu `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Sitali-definisi { $styleNumber } no abi nofo kontlasi gi { $context ->
+        [text-on-background] a tekisi-kula agensi a bakagoon-kula
+        [high-contrast] a hei-kontlasi kula agensi a kanvasi
+        [line] a lin-kula agensi a kanvasi
+        [marker] a maiki-kula agensi a kanvasi
+       *[text-on-canvas] a tekisi-kula agensi a kanvasi
+    }{ $mode ->
+        [dark] { " (dark fasi)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu { $threshold }:1 efu moo).
+
+style-definition-dark-mode-text-background-contrast =
+    Aladi sitali-definisi { $styleNumber } poti kula di abi nofo kontlasi gi light fasi, den dark-fasi kula di kon fu den no abi nofo kontlasi gi a tekisi-kula agensi a bakagoon-kula ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu { $threshold }:1 efu moo). { $suggestion ->
+        [available] Fu abi nofo kontlasi a ini dark fasi, meki a light-fasi kontlasi moo gaan (fu eksempee, seti { $lightAttribute }="{ $lightColor }") efuso kenki a dark-fasi kula (fu eksempee, seti { $darkAttribute }="{ $darkColor }").
+       *[none] Fu abi nofo kontlasi a ini dark fasi, meki a light-fasi kontlasi moo gaan efuso kenki den kula di kon fu den anga textColorDarkMode anga/efuso backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Aladi sitali-definisi { $styleNumber } poti wan tekisi-kula di abi nofo kontlasi gi light fasi, a dark-fasi tekisi-kula di kon fu en no abi nofo kontlasi agensi a kanvasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu { $threshold }:1 efu moo). { $suggestion ->
+        [available] Fu abi nofo kontlasi a ini dark fasi, meki a light-fasi kontlasi moo gaan (fu eksempee, seti textColor="{ $lightColor }") efuso kenki a dark-fasi kula (fu eksempee, seti textColorDarkMode="{ $darkColor }").
+       *[none] Fu abi nofo kontlasi a ini dark fasi, meki a light-fasi kontlasi moo gaan efuso kenki a kula di kon fu en anga textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan seksi sa teki soso wan <stylePalette>; wi e teki a laste wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = wi no man wooko den apaiti vaariant fu { $component } bika numToSelect a no wan hii nomu di no negatif.
+
+variant-num-to-select-not-constant-number = wi no man wooko den apaiti vaariant fu { $component } bika numToSelect a no wan konstanti nomu.
+
+variant-with-replacement-not-constant-boolean = wi no man wooko den apaiti vaariant fu { $component } bika withReplacement a no wan konstanti boolean.
+
+variant-select-weight-disables-unique = Den apaiti vaariant gi select e tapu efu wan opsi abi selectWeight efuso selectForVariants poti
+
+variant-coprime-undetermined = wi no man wooko den apaiti vaariant fu { $component } bika wi no man sabi efu coprime na falisi ala ten.
+
+variant-attribute-not-constant = wi no man wooko den apaiti vaariant fu { $component } bika { $attribute } a no konstanti.
+
+variant-attribute-not-number = wi no man wooko den apaiti vaariant fu { $component } bika { $attribute } a no wan nomu.
+
+variant-attribute-wrong-type-for-sequence =
+    wi no man wooko den apaiti vaariant fu { $component } fu { $type } sortu bika { $attribute } a no { $expected ->
+        [letters-combination] wan mokisi fu letu
+        [math-expression] wan bun matematika-ekispresi
+        [integer] wan hii nomu
+       *[number] wan nomu
+    }.
+
+variant-length-not-integer = wi no man wooko den apaiti vaariant fu { $component } bika a length a no wan hii nomu.
+
+variant-sort-not-implemented = wi no meki apaiti vaariant gi wan { $component } anga sort ete
+
+variant-exclude-combinations-not-implemented = wi no meki apaiti vaariant gi wan { $component } anga excludeCombinations ete
+
+variant-math-exclude-not-implemented = wi no meki apaiti vaariant gi wan { $component } fu sortu math anga exclude ete
+
+variant-non-constant-exclude-not-implemented = wi no meki apaiti vaariant gi wan { $component } anga wan exclude di no konstanti ete
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: a graph prefigure renderer no e teki disi; wi e pasa a bakapikin.
+
+prefigure-descendant-invalid-geometry = { $subject }: a jometri no finiti efuso a no kaba; wi e pasa a bakapikin.
+
+prefigure-curve-label-omitted = { $subject }: neen no e wooko a kookotu lin di kenki; wi e libi a neen a doo.
+
+prefigure-curve-unsupported-definition-type = { $subject }: wi no e teki a kookotu-lin funsi-definisi sortu '{ $definitionType }'; wi e pasa a bakapikin.
+
+prefigure-region-flip-functions-unsupported = { $subject }: wi no e teki a flipFunctions atribut a regionBetweenCurves; wi e pasa a bakapikin.
+
+prefigure-region-non-formula-child = { $subject }: soso fomula-sortu pikin funsi e wooko a regionBetweenCurves; wi e pasa a bakapikin.
+
+prefigure-label-position-unsupported =
+    { $subject }: wi no e teki labelPosition '{ $labelPosition }' gi wan { $labelKind ->
+        [line-family] lin-famii neen
+       *[point] punt-neen
+    }; wi e teki a difoolti PreFigure fasi.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure no e teki a fuu-sitali '{ $fillStyle }'; wi o teki wan sodoo fuu.
+
+prefigure-line-style-unknown = { $subject }: wi e libi a lin-sitali '{ $lineStyle }' di wi no sabi a doo fu a PreFigure outputu.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wi kenki a maiki-sitali '{ $markerStyle }' go a ini a PreFigure sitali 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure no e teki a maiki-sitali '{ $markerStyle }'; wi e teki a difoolti sitali.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: a `ref` no bun; wi no man feni a target. Wi e libi a anotasi a doo.
+
+annotation-ref-multiple-targets = `<annotation>`: a `ref` e sori moo enke wan target; wi e teki a fosi wan.
+
+annotation-ref-outside-graph = `<annotation>`: a `ref` no bun; a target de a doose fu a graph. Wi e libi a anotasi a doo.
+
+annotation-ref-unsupported-target = `<annotation>`: a `ref` no bun; a target a no wan gaafiki sani di a prefigure kenki e teki. Wi e libi a anotasi a doo.
+
+annotation-text-missing = `<annotation>`: a `text` mankei efuso a leigi; wi o puu leigi tekisi.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wi feni wan lontu dependensi.
+       *[other] Wi feni wan lontu dependensi di e anga wan `<{ $componentType }>` komponenti.
+    }
+
+reference-no-referent = Wi no feni no wan sani di a refeensi ya e sori: `{ $reference }`
+
+reference-multiple-referents = Wi feni moo enke wan sani di a refeensi ya e sori: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = A foomati fu a atribut { $attribute } fu `<{ $componentType }>` no bun.
+
+children-invalid = Den pikin gi `<{ $componentType }>` no bun: wi feni pikin di no bun: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = A waarde `{ $value }` gi a atribut `{ $attribute }` no bun, da wi e teki a waarde `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wi no feni DoenetML vesi { $version }.
+       *[other] Wi no feni DoenetML vesi { $version }. Wi o teki vesi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = A DoenetML ya no bun: { $content }
+
+parse-tag-missing-close-tag = A DoenetML ya no bun: A tag `{ $tag }` no abi no wan tapu-tag. Wi be e fuuwakiti wan tag di e tapu ensrefi efuso wan `</{ $tagName }>` tag.
+
+parse-tag-error = A DoenetML ya no bun: Fowtu a ini a tag `<{ $tagName }>`
+
+parse-attribute-missing-value = A DoenetML ya no bun: A atribut `{ $attribute }` no bun — a gei taki wan waarde mankei.
+
+parse-attribute-invalid = A DoenetML ya no bun: A atribut `{ $attribute }` no bun
+
+parse-attribute-value-invalid = A DoenetML ya no bun: A atribut-waarde `{ $value }` no bun
+
+parse-attribute-value-quote-mismatch = A DoenetML ya no bun: A atribut-waarde `{ $value }` no bun. Den koti-maiki no e fiti makandii. A gei taki wan `{ $quote }` mankei.
+
+parse-open-tag-name-missing = A DoenetML ya no bun: Wi feni wan tag sondee tag-neen, enke `<`
+
+parse-tag-not-closed = A DoenetML ya no bun: A tag `{ $tag }` no tapu (a gei taki wan `>` mankei).
+
+parse-self-closing-tag-name-missing = A DoenetML ya no bun: Wi feni wan tag sondee tag-neen `<{ $content }>`
+
+parse-self-closing-tag-not-closed = A DoenetML ya no bun: A tag `{ $tag }` no tapu (a gei taki `/>` mankei).
+
+parse-tag-invalid-attributes = A DoenetML ya no bun: A tag `{ $tag }` no bun. A sa abi fowtu atribut.
+
+parse-close-tag-name-missing = A DoenetML ya no bun: Wi feni wan tapu-tag sondee tag-neen, enke `</`
+
+parse-attribute-value-unquoted = Atribut-waarde mu de a ini koti-maiki: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = A DoenetML ya no bun: Wi feni a tapu-tag `{ $tag }`, ma no wan opo-tag no de gi en
+
+parse-close-tag-mismatched = A DoenetML ya no bun: A tapu-tag no e fiti. Wi be e fuuwakiti `</{ $expected }>`. Wi feni `{ $found }`
+
+parser-node-unconvertible = Wi no man kenki a nodu { $node } go a wan Dast nodu.
+
+## Names
+
+name-attribute-invalid =
+    A atribut name='{ $name }' no bun. { $reason ->
+        [characters] Neen sa abi soso letu, nomu, ondooteki efuso sitreki.
+       *[start] Neen mu bigin anga wan letu.
+    }
+
+component-name-invalid-start = A komponenti-neen "{ $name }" no bun. Neen mu bigin anga wan letu.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Wan answer fu sortu videoWatched mu abi wan video atribut
+
+answer-video-watched-video-not-reference = Wan answer fu sortu videoWatched mu abi wan video atribut di na wan refeensi
+
+answer-name-not-single-text = A answer name atribut mu abi soso wan tekisi-pikin
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Wi no man kisi a doosee DoenetML bika tumusi somen lo fu rekursi. Wan lontu refeensi de?
+
+external-doenetml-unavailable = Wi no man kisi no wan DoenetML fu { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = A DoenetML di wi kisi fu { $attribute }="{ $uri }" no bun: a no e fiti a komponenti-sortu "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] A atribut `{ $from }` no e wooko moo; wooko `{ $to }` a en peesi.
+       *[other] [deprecation] A atribut `{ $from }` a `<{ $component }>` no e wooko moo; wooko `{ $to }` a en peesi.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] A atribut `{ $from }` no e wooko moo, da wi no e teli en, bika `{ $to }` poti tu.
+       *[other] [deprecation] A atribut `{ $from }` a `<{ $component }>` no e wooko moo, da wi no e teli en, bika `{ $to }` poti tu.
+    }
+
+deprecated-attribute-ignored = [deprecation] A atribut `{ $attribute }` a `<{ $component }>` no e wooko moo, da wi no e teli en.
+
+deprecated-attribute-to-child = [deprecation] A atribut `{ $attribute }` a `<{ $component }>` no e wooko moo; wooko wan `<{ $child }>` pikin a en peesi.
+
+deprecated-attribute-value-renamed = [deprecation] A waarde `{ $value }` fu a atribut `{ $attribute }` a `<{ $component }>` no e wooko moo; wooko `{ $to }` a en peesi.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` sa meki soso Ingiisi wowtu kon somen, da a tekisi fu en e tan a srefi a ini wan dokumenti di sikiifi a ini { $locale }. Sikiifi a somen-fasi srefi, efuso poti en anga a `pluralForm` atribut.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = A elementi `<{ $tag }>` a no wan Doenet elementi di wi sabi.
+
+schema-element-not-allowed-at-root = A elementi `<{ $tag }>` no man de a a lutu fu a dokumenti.
+
+schema-element-not-allowed-inside = A elementi `<{ $tag }>` no man de a ini `<{ $parent }>`.
+
+schema-attribute-unrecognized = A elementi `<{ $tag }>` no abi no wan atribut di nen `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] A atribut `{ $attribute }` fu a elementi `<{ $tag }>` mu de wan lisi pe ibii sani na wan fu den ya: { $allowed }
+       *[other] A atribut `{ $attribute }` fu a elementi `<{ $tag }>` mu de wan fu den ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = A vaariant-neen gi a select no bun.  A vaariant-neen { $variantName } de a ini { $numOptions } opsi ma a nomu fu teki na { $numToSelect }.
+
+select-variant-name-without-options = Son vaariant poti gi a select ma no wan opsi no poti gi a vaariant-neen: { $variantName }.
+
+select-variant-name-not-possible = A vaariant-neen { $variantName } di poti gi a select a no wan vaariant-neen di sa de.
+
+select-too-few-options = Wi no man teki { $numToSelect } komponenti fu soso { $numOptions }.
+
+select-from-sequence-too-few-values = Wi no man teki { $numToSelect } waarde fu wan sekwensi di langa { $length }.
+
+select-from-sequence-indices-count-mismatch = A nomu fu den indices di poti gi a select mu fiti a nomu fu teki
+
+select-from-sequence-indices-not-integers = Ala den indices di poti gi a select mu de hii nomu
+
+select-from-sequence-index-excluded = Wan indeksi fu selectfromsequence poti di be puu a doo
+
+select-from-sequence-indices-excluded-combination = Den indices fu selectfromsequence di poti be na wan mokisi di puu a doo
+
+select-from-sequence-coprime-not-positive-integers = Wi no man teki koopime mokisi bika wi no e teki positif hii nomu.
+
+select-from-sequence-coprime-common-factor = Wi no man teki koopime nomu. Ala den waarde abi a srefi fakitoo. (Den waarde di poti gi "from" efuso "to" mu de koopime anga "step".)
+
+select-from-sequence-coprime-single-number = Wi no man teki koopime mokisi fu wan enkii nomu di a no 1.
+
+select-from-sequence-excluded-too-many-combinations = Moo enke 70% fu den mokisi a ini selectFromSequence be puu a doo
+
+select-from-sequence-coprime-none-found = Wi no man teki koopime nomu. Ala den waarde abi a srefi fakitoo.
+
+select-from-sequence-too-few-unique-values = Wi no man teki { $numToSelect } apaiti waarde fu wan sekwensi di langa { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Wi no man teki { $numToSelect } waarde fu wan lisi fu paim nomu di langa { $numValues }
+
+select-prime-numbers-values-count-mismatch = A nomu fu den waarde di poti gi a select mu fiti a nomu fu teki
+
+select-prime-numbers-values-not-prime = Ala den waarde di poti gi select paim nomu mu de a ini a lisi fu paim nomu
+
+select-prime-numbers-values-excluded-combination = Den waarde fu selectPrimeNumbers di poti be na wan mokisi di puu a doo
+
+select-prime-numbers-excluded-too-many-combinations = Moo enke 70% fu den mokisi a ini selectPrimeNumbers be puu a doo
+
+select-random-combination-fluke = Anga wan kansi di haadi haadi e pasa, wi no man teki wan mokisi fu lukiluki waarde
+
+select-random-value-fluke = Anga wan kansi di haadi haadi e pasa, wi no man teki wan lukiluki waarde
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    Wi no e teke a `<{ $component }>` a ini a matematika; wi e seti a ekispresi enke fa a be de fosi inputu be sa go a ini. { $reason ->
+        [not-inline] Soso wan `inline` choice inputu e fiti a ini wan ekispresi; sondee `inline` a na wan blaka fu kanapu.
+        [expanded] Wan `expanded` tekisi inputu na wan bokisi anga moo enke wan lin, da a bigi tumusi fu sidon a ini wan ekispresi.
+        [on-graph] A wan graph, wi e teke a ekispresi enke wan enkii peentje, da no wan peesi no de gi wan kanapu.
+       *[relative-width] En `width` na relatif (wan pesenti efuso `em`), da noti no de fu marki en agensi a ini wan ekispresi. Gi a bereedi a ini abesoluut marki, enke `px`.
+    }

--- a/packages/i18n/locales/djk/editor.ftl
+++ b/packages/i18n/locales/djk/editor.ftl
@@ -1,0 +1,216 @@
+# Aukan / Ndyuka (Okanisi tongo) editor and language-server surfaces: the
+# footer, the diagnostics panel, the variant picker, the accessibility button
+# and the context-help panel. Translated from `locales/en/editor.ftl`, which is
+# the source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The SIL Ndyuka orthography: a doubled vowel writes length
+# («puu», «wooko», «gaan»), there are no consonant + `r` clusters at all
+# («kiin», «taa», «gaantangi»), «u» never «oe», «y» never «j», and **tone is
+# not written** — Ndyuka is tonal and the orthography leaves tone unmarked, as
+# the dictionary and the scriptures do. Sranan Tongo and Saramaccan spellings
+# are not mixed in; `chrome.ftl`'s header sets the system out point by point.
+#
+# **Grammar.** Preverbal «e» / «be» / «o» / «sa» / «mu» carry tense, aspect
+# and modality; «no» negates and precedes them; «anga» is *and* and *with*;
+# «fu» is the purposive. No English sentence order survives here.
+#
+# **Number.** `Intl.PluralRules("djk")` has no CLDR data for `djk` and falls
+# back to English. A Ndyuka noun after a numeral does not inflect, so
+# `editor-accessibility-label` and `help-coordinates` — the two messages
+# English selects on a count — are written here as **one unselected form**
+# each, with the count still interpolated. No plural branch appears anywhere
+# in this file.
+#
+# **Loans.** Dutch and English reshaped to Ndyuka phonology: «fowtu»,
+# «wasikoi», «info», «aksesibiliteiti», «vaariant», «filteri», «komponenti»,
+# «atribut», «snipiti», «kolodinaati», «foomati», «vesi» (*version*),
+# «dokumentasi», «lin», «kediti», «piki». `WCAG`, `DoenetML`, `XML` and
+# `styleNumber` are names and stay as written, as do the attribute names in
+# `help-reset-overrides`.
+#
+# **Confidence.** This is the file with the least everyday Ndyuka in it —
+# almost every noun is a technical loan reshaped by rule rather than a form
+# this seed found in use. The verbs, the negation and the preverbal markers
+# are Ndyuka throughout, and that is what a reviewer should read for. Nothing
+# was left in English.
+
+
+editor-update-viewer =
+    { $action ->
+        [reset] Seti baka
+       *[update] Nyunsu
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } a luku-peesi
+       *[other] { $word } a luku-peesi { $shortcut }
+    }
+
+
+editor-variant = Vaariant
+
+editor-variant-filter = Filteri...
+
+editor-variant-next = Teke a taa vaariant di e kon
+
+editor-variant-previous = Teke a vaariant di be pasa
+
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wi feni wan WCAG AA aksesibiliteiti-fowtu. Kiliki fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteiti-lepoti.
+        [advisories] Kiliki fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteiti-lepoti. Wi no feni no wan WCAG AA fowtu, ma wi abi moo sani fu taigi yu fu a aksesibiliteiti.
+       *[clean] Kiliki fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteiti-lepoti. Wi no feni no wan aksesibiliteiti-pooblema.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wi feni wan WCAG AA aksesibiliteiti-fowtu. Wi feni { $count } WCAG AA fowtu. Kiliki fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteiti-lepoti.
+        [advisories] Wi no feni no wan WCAG AA fowtu. Wi feni { $count } moo sani fu taigi yu fu a aksesibiliteiti. Kiliki fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteiti-lepoti.
+       *[clean] Wi no feni no wan WCAG AA fowtu. Kiliki fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteiti-lepoti.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+editor-version-title = DoenetML vesi { $version }
+
+editor-tab-help = Yeepi di e fiti a peesi pe i de
+editor-tab-help-short = Konteksi
+editor-tab-errors = Fowtu
+editor-tab-warnings = Wasikoi
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibiliteiti
+editor-tab-responses = Piki di seni kaba
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editoo-fasi
+editor-format-as-doenetml = Foomati enke DoenetML
+editor-format-as-xml = Foomati enke XML
+
+
+editor-diagnostic-line = Lin #{ $line }
+
+editor-no-errors = No wan fowtu
+editor-no-warnings = No wan wasikoi
+editor-no-info = No wan info-lepoti
+
+editor-show-info-annotations = Sori den info-lepoti a ini a editoo
+editor-show-accessibility-annotations = Sori den aksesibiliteiti-lepoti a ini a editoo
+
+editor-accessibility-learn-more = Leli fa Doenet e wooko anga aksesibiliteiti
+
+editor-accessibility-violations-heading = Aksesibiliteiti-fowtu ({ $standard })
+
+editor-accessibility-other-heading = Taa aksesibiliteiti-pooblema
+editor-none-found = Wi no feni no wan
+
+
+editor-no-responses = No wan piki no seni ete
+editor-response-answer-id = Piki Id
+editor-response-response = Piki
+editor-response-credit = Kediti
+editor-response-submitted = Seni
+
+
+help-placeholder = Poti a kosoo a wan tag-neen, wan atribut, efuso { $ref } fu si a dokumentasi.
+
+help-unsupported-ref-chain = Yeepi gi wan lengi refeensi enke { $example } no de ete.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wi no feni no wan sani di { $ref } e sori.
+        [multiple] Wi feni moo enke wan sani di { $ref } e sori.
+       *[indeterminate] Wi no man sabi san { $ref } e sori.
+    }
+
+help-learn-about-references = Leli fu den refeensi →
+help-reference-page = Refeensi-pagina →
+
+help-suggestions-header =
+    { $location ->
+        [inside] A ini { $element }
+       *[top] A tapu fu ala sani
+    }{ $allowed ->
+        [none] { " — no wan sani no e go ya." }
+        [text] { " — sikiifi tekisi ya." }
+        [text-and-components] { " — sikiifi tekisi ya, efuso pooberi:" }
+       *[components] { " — sani fu pooberi:" }
+    }
+
+help-suggestions-footer = Poti { $shortcut } fu si ala { $total } komponenti.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } na wan refeensi gi { $target }.
+       *[other] { $ref } na wan refeensi gi { $target } (lin { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } tyai en kon enke { $role }.
+       *[other] { $owner } tyai en kon a lin { $line } enke { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } na wan refeensi gi a { $property } fasi fu { $element }.
+       *[other] { $ref } na wan refeensi gi a { $property } fasi fu { $element } (lin { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = snipiti
+help-kind-array-entry = aray-sani
+
+help-default = Difoolti:
+help-active-default = Difoolti di e wooko:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Waarde di i sa gebooiki (wan gi ibii sani):
+       *[other] Waarde di i sa gebooiki:
+    }
+
+help-suggested-values = Waarde di wi e taigi yu:
+
+help-inserts = San a e poti:
+
+help-coordinates = Kolodinaati:
+
+help-type = Sortu:
+
+help-resolved-style = A sitali di kon a doo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Den funsi-neen di kon a doo:
+help-reset-list = Seti a lisi baka a ini a inputu ya:
+help-added-on-input = San poti a ini a inputu ya:
+help-removed-on-input = San puu a ini a inputu ya:
+
+help-reset-overrides = { $reset } e wini { $additional } anga { $removed }.

--- a/packages/i18n/locales/gcf/chrome.ftl
+++ b/packages/i18n/locales/gcf/chrome.ftl
@@ -1,0 +1,159 @@
+# Guadeloupean Creole French (kréyòl gwadloupéyen) viewer chrome. Translated
+# from `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The GEREC standard — the phonemic Latin orthography worked
+# out at the Groupe d'Études et de Recherches en Espace Créolophone at the
+# Université des Antilles and used in Guadeloupean schoolbooks, dictionaries
+# and the Antillean press. Its marks, as this catalog uses them: «é» for close
+# [e] and «è» for open [ɛ]; «ò» for open [ɔ]; «an», «on», «en» for the three
+# nasal vowels; «ou» for [u]; «y» for the glide; «w» for [w], including where
+# French wrote `r` before a rounded vowel («wouj», «wòch»); «r» elsewhere for
+# the velar continuant («répons», «gri»); «tj» and «dj» for the palatals; «k»
+# always for [k], so French `qu` and `c` are both written «k» («kalkilé»).
+# Silent French letters are not written: «tan», not `temps`.
+#
+# The French-etymological spelling — writing «créole» for «kréyòl», «réponse»
+# for «répons» — is a different practice with a different aim, and **none of
+# it is mixed in here**. Where a word is a loan it is respelled by GEREC's own
+# rules rather than left in its French dress.
+#
+# **The determiner is postposed and hyphenated**, which is the most visible
+# thing on the page: «répons-la» *the answer*, «paj-la» *the page*,
+# «klavyé-la» *the keyboard*, «dokiman-lasa» *this document*. GEREC writes the
+# hyphen; a reader used to Haitian, which writes «repons lan» open, will
+# notice it first.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `gcf`, and the language
+# would give it nothing to work with in any case: a Guadeloupean noun has one
+# form for one and for many. The plural is the preposed «sé» with the
+# postposed determiner («sé répons-la»), and a numeral in front of a bare noun
+# does the whole job on its own — «3 ésè», never `*ésèyo`. So **no message in
+# this file writes a `[one]`/`[other]` select**; each counted message is one
+# unselected form. `attempts-remaining` keeps its `[0]` branch, because
+# "none left" is a different sentence rather than a different form of this
+# one.
+#
+# **Loans.** The technical register is French, carried in creole grammar and
+# respelled by GEREC: «répons», «kredi», «enfòmasyon», «matématik»,
+# «ekspresyon», «apèsi», «estatistik», «kolòn», «entèval», «klavyé», «erè»,
+# «avètisman», «aksésibilité», «vyolasyon», «inisyalizé», «anrejistré»,
+# «maksimòm», «disponib», «etikèt», «orbital». Two are English, taken through
+# the same door the language takes them through in speech: «fidbak»
+# (*feedback*) and «randè» (*renderer*); «WCAG AA» is the standard's name and
+# is not a word. The grammar around all of them is creole: preverbal «ka» for
+# the progressive, «pa» for negation, «pé pa» for *cannot*, «ni» for *have*,
+# and the postposed determiner throughout.
+#
+# **Confidence.** Guadeloupean has a settled orthography and a real written
+# literature, but very little written computing register: nobody has published
+# a Guadeloupean word for *renderer* or *feedback*, and the two above are the
+# loan a speaker would actually say rather than a coinage this seed invented.
+# A reviewer should read them as proposals.
+#
+# Creole punctuates as English does: no space before `:`, `;`, `?` or `!`.
+# That is one of the places the orthography deliberately parted from French.
+
+
+## Answer submission
+
+answer-checking = Ka vérifyé…
+answer-submitting = Ka voyé…
+answer-checking-status = Ka vérifyé répons-la
+answer-submitting-status = Ka voyé répons-la
+answer-correct = Kòrèk
+answer-incorrect = Pa kòrèk
+answer-response-saved = Répons-la anrejistré
+answer-percent-credit = { $percent }% kredi
+answer-percent-correct = { $percent }% kòrèk
+answer-percent-short = { $percent } %
+max-credit-available = Kredi maksimòm disponib: { $percent }%
+# No `[one]`/`[other]` select: «ésè» is one word for one and for many, so both
+# categories would render the same string. The count still arrives and is
+# still formatted. `[0]` stays — it is its own sentence.
+attempts-remaining =
+    { $count ->
+        [0] pa ni ésè ki rété
+       *[other] { $count } ésè ki rété
+    }
+validation-correct = (Kòrèk)
+validation-incorrect = (Pa kòrèk)
+validation-partially-correct = (Kòrèk an pati)
+# No select, for the reason given above.
+answer-show-responses = Montré { $count } répons ba { $answerId }
+
+## Disclosure panels
+
+feedback-heading = Fidbak
+collapsible-click-to-open = (kliké pou ouvè)
+collapsible-click-to-close = (kliké pou fèmé)
+collapsible-initializing = Ka inisyalizé…
+footnote-show = Montré nòt anba paj-la
+footnote-hide = Kaché nòt anba paj-la
+description-more-information = plis enfòmasyon
+
+## Controls
+
+slider-previous = Avan
+slider-next = Apré
+keyboard-open = Ouvè klavyé-la
+keyboard-close = Fèmé klavyé-la
+choice-input-remove-choice = Òté { $choice }
+matrix-remove-row = Òté on ranjé
+matrix-add-row = Ajouté on ranjé
+matrix-remove-column = Òté on kolòn
+matrix-add-column = Ajouté on kolòn
+subset-add-remove-points = Ajouté/Òté pwen
+subset-toggle-points-intervals = Chanjé ant pwen é entèval
+subset-move-points = Deplasé pwen
+subset-clear = Efasé
+orbital-add-row = Ajouté on ranjé
+orbital-remove-row = Òté on ranjé
+orbital-add-box = Ajouté on bwèt
+orbital-remove-box = Òté on bwèt
+orbital-add-up-arrow = Ajouté on flèch anlè
+orbital-add-down-arrow = Ajouté on flèch anba
+orbital-remove-arrow = Òté on flèch
+orbital-row-label = Etikèt pou ranjé { $row }
+pretzel-answer = Répons
+summary-statistics-caption = Estatistik rezimé pou { $column }
+
+## Math input
+
+math-input-preview-region = apèsi ekspresyon matématik-la
+math-input-preview = Apèsi
+math-input-invalid-expression = Ekspresyon ki pa valab:
+
+## Document status
+
+viewer-initializing = Ka inisyalizé…
+
+## Errors
+
+error-heading = Erè
+error-found-at =
+    { $span ->
+        [line] Yo trouvé-y an liy { $startLine }.
+       *[lines] Yo trouvé-y an liy { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Dokiman-lasa ni erè adan-y!
+diagnostic-heading-error = Erè
+diagnostic-heading-warning = Avètisman
+diagnostic-heading-information = Enfo
+diagnostic-heading-hint = Endikasyon
+accessibility-heading-level-1 = Vyolasyon aksésibilité WCAG AA
+accessibility-heading-level-2 = Alèt aksésibilité
+something-went-wrong = Ni on bagay ki pa maché.
+renderer-load-failed = on randè pa rivé chajé. Souplé, rechajé paj-la.
+core-start-failed = Dokiman-lasa pa pé démaré. Souplé, rechajé paj-la.
+core-start-failed-busy = Dokiman-lasa pa pé démaré. Plizyè dokiman té ka démaré an menm tan, é sa pé pran plis tan asi on aparèy ki pi lan. Rechajé paj-la pé édé lè lòt dokiman-la fin.
+core-start-failed-retry = Dokiman-lasa pa pé démaré.
+core-start-failed-busy-retry = Dokiman-lasa pa pé démaré. Plizyè dokiman té ka démaré an menm tan, é sa pé pran plis tan asi on aparèy ki pi lan.
+core-start-retry = Eséyé ankò
+saved-state-unavailable = Travay ou té anrejistré-la pa pé chajé.

--- a/packages/i18n/locales/gcf/content.ftl
+++ b/packages/i18n/locales/gcf/content.ftl
@@ -1,0 +1,280 @@
+# Guadeloupean Creole French (kréyòl gwadloupéyen) content catalog: the prose
+# the core computes into the document. Selected by `documentLocale` — the
+# language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The GEREC standard, as `chrome.ftl` sets it out letter by
+# letter: «kréyòl», «répons», «wouj», «blé», «sé», «an». It is the phonemic
+# orthography used in Guadeloupean schoolbooks and dictionaries. The
+# French-etymological spelling — «créole», «rouge», «réponse» — is a different
+# practice and **none of it is mixed into this file**. Every loan below is
+# respelled by GEREC's rules rather than left in French dress.
+#
+# **Word order: the modifier follows the noun.** Guadeloupean puts an
+# attributive adjective after its head — «liy wouj épé» is *thick red line*,
+# noun first — so the composition messages **reverse** the English order.
+# `style-with-noun` and `style-filled-with-noun` put «{ $noun }» in front of
+# «{ $description }», and `style-fill` postposes the pattern word onto the
+# colour («dyaman blé» for *blue diamonds*).
+#
+# **Nothing agrees, so nothing selects.** Guadeloupean has no grammatical
+# gender, no case and no adjective agreement: an adjective is one invariable
+# word wherever it stands. So not one message here forks on `$gender` or on
+# `$role`, and `noun-gender` answers a single token that nothing downstream
+# reads. What the composition messages do is order and choose, and that is the
+# whole of the work.
+#
+# `noun-regular-polygon` splits the way `locales/es` does, but for word order
+# rather than for agreement: the head is «poligòn régilyé» and the side count
+# follows the adjectives as a relative clause, «ki ni N koté». That is the
+# `[noun-tail]` branch of `style-with-noun`.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `gcf`, and there is
+# nothing for it to have: a noun has one form for one and for many. The plural
+# is the preposed «sé» with the postposed determiner («sé pwen-la»), and a
+# numeral in front of a bare noun does the job alone. No message in this file
+# writes a `[one]`/`[other]` select, and `noun-regular-polygon` says «ki ni 1
+# koté» and «ki ni 5 koté» with the same word. `.exercise` and `.exercises`,
+# and `.problem` and `.problems`, are therefore the same word twice: that is
+# the language's nominal morphology, not a copy-paste slip.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# Science in Guadeloupe is schooled in French, from the French national
+# curriculum and French textbooks, so the periodic table a Guadeloupean pupil
+# reads is `locales/fr`'s. There is no published Guadeloupean list of the
+# hundred and eighteen element names, and writing one would be respelling the
+# French list and calling the result a Guadeloupean nomenclature.
+# `lint:i18n` reports the two keys as missing coverage and that is the correct
+# report. `ion-name-oxidation-state` and the two invalid-symbol messages
+# **are** covered — they are frames, not vocabulary.
+#
+# **Loans.** French, respelled: «poligòn», «parabòl», «vektè», «fonksyon»,
+# «rektang», «triyang», «segman», «dimi-dwat», «réjyon», «vyolèt», «orizontal»,
+# «vètikal», «dyagonal», «aktivité», «définisyon», «egzanp», «egzèsis»,
+# «objektif», «paragraf», «téyorèm», «solisyon», «kaskad», «tablo», «figi»,
+# «senbòl», «chimik», «yonik», «konpozé». «siyan» is the weakest word in the
+# file: Guadeloupean has «blé» and no settled word for cyan, and a speaker may
+# well prefer «blé kler». Everything around the loans is creole — «ki ni» for
+# the relative clause, «épi» for *with*, «san» for *without*, «sé» for the
+# plural, «pa» for negation.
+#
+# **Confidence.** The colour words, the shape nouns and the section words are
+# ordinary Guadeloupean and are the least doubtful thing here. The style
+# composition is a judgement about word order that a speaker should read
+# aloud; «siyan» and «kaskad» are the two entries most likely to be replaced.
+
+
+## Style vocabulary
+
+color =
+    .black = nwè
+    .white = blan
+    .gray = gri
+    .red = wouj
+    .orange = zoranj
+    .yellow = jòn
+    .green = vèt
+    .cyan = siyan
+    .blue = blé
+    .purple = vyolèt
+    .pink = woz
+    .brown = maron
+line-width =
+    .thick = épé
+    .thin = fen
+line-style =
+    .dashed = an tirè
+    .dotted = an pwentiyé
+# Noun phrases. «liy» is one word for one line and for many, so these are not
+# plurals of anything — they are what the language says in both places.
+fill-style =
+    .horizontal = liy orizontal
+    .vertical = liy vètikal
+    .diagonal = liy dyagonal
+    .backdiagonal = liy dyagonal envès
+    .dots = pwen
+    .diamonds = dyaman
+noun =
+    .line = liy
+    .line-segment = segman
+    .ray = dimi-dwat
+    .vector = vektè
+    .curve = koub
+    .function = fonksyon
+    .slope-field = chan pant
+    .vector-field = chan vektè
+    .parabola = parabòl
+    .polyline = liy brizé
+    .polygon = poligòn
+    .triangle = triyang
+    .rectangle = rektang
+    .circle = sèk
+    .region = réjyon
+    .point = pwen
+    .square = karé
+    .diamond = dyaman
+    .cross = kwa
+    .plus = plis
+# The head is the bare noun and the side count follows the adjectives as a
+# relative clause, so that the adjectives stay beside the noun they describe.
+# «koté» is invariant: «ki ni 1 koté», «ki ni 5 koté».
+noun-regular-polygon =
+    { $part ->
+        [tail] ki ni { $numSides } koté
+       *[head] poligòn régilyé
+    }
+# One answer for every noun: Guadeloupean has no grammatical gender, so
+# nothing downstream has anything to agree with.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun first and the adjectives after it, which is the opposite of
+# English. The regular polygon's relative clause follows both.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = ranpli
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } épi { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } épi { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } épi { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+style-border-clause =
+    { $parts ->
+        [with-article] épi on bòdi { $border }
+        [and] é bòdi { $border }
+        [and-article] é on bòdi { $border }
+       *[with] épi bòdi { $border }
+    }
+# The pattern word is postposed straight onto the colour — «dyaman blé» — for
+# the same reason the adjectives are: the modifier follows its head, and there
+# is no agreement for a supporting noun to carry.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = san ranpli
+style-text =
+    { $parts ->
+        [background] { $color } épi on fon { $background }
+       *[plain] { $color }
+    }
+style-background-none = ayen
+
+## Boolean words
+
+boolean-true = vré
+boolean-false = fo
+
+## Answer buttons
+
+answer-submit-label = Vérifyé travay-la
+answer-submit-label-no-correctness = Voyé répons-la
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are the same
+# word: the plural is the preposed «sé», and a heading does not carry it. Two
+# ids with one translation is what a language with no plural suffix looks like
+# here, not a copy-paste.
+section-name =
+    .activity = Aktivité
+    .aside = Nòt asi koté
+    .cascade = Kaskad
+    .definition = Définisyon
+    .example = Egzanp
+    .exercise = Egzèsis
+    .exercises = Egzèsis
+    .given-answer = Répons
+    .note = Nòt
+    .objectives = Objektif
+    .paragraphs = Paragraf
+    .part = Pati
+    .problem = Pwoblèm
+    .problems = Pwoblèm
+    .proof = Prèv
+    .question = Kèsyon
+    .section = Seksyon
+    .solution = Solisyon
+    .task = Travay
+    .theorem = Téyorèm
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Endikasyon
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+figure-name =
+    { $parts ->
+        [numbered] Figi { $enumeration }
+        [numbered-caption] Figi { $enumeration }{ ": " }
+        [unnumbered-caption] Figi{ ": " }
+       *[unnumbered] Figi
+    }
+
+## Paginator controls
+
+paginator-previous = Avan
+paginator-next = Apré
+paginator-page = Paj
+paginator-page-status = { $pageLabel } { $currentPage } asi { $numPages }
+
+## Piecewise functions
+
+piecewise-condition-or = oben
+piecewise-condition-if = si
+piecewise-condition-otherwise = sinon
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Science in Guadeloupe is taught in French, from the French
+## curriculum: the periodic table on the classroom wall is French, and there
+## is no settled Guadeloupean table for a seed to reproduce. See the header.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Senbòl chimik ki pa valab
+chemistry-invalid-ionic-compound = Konpozé yonik ki pa valab
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blan
+math-embedded-input-blank-ordinal = blan { $ordinal } asi { $total }

--- a/packages/i18n/locales/gcf/diagnostics.ftl
+++ b/packages/i18n/locales/gcf/diagnostics.ftl
@@ -1,0 +1,697 @@
+# Guadeloupean Creole French (kréyòl gwadloupéyen) diagnostics. Translated
+# from `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The GEREC standard, as `chrome.ftl` sets it out letter by
+# letter. The French-etymological spelling is not mixed in.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# **Number.** No `[one]`/`[other]` select appears anywhere in this file.
+# Guadeloupean nouns do not inflect for number — «pwen», «entèval», «atribi»,
+# «valè» are one word for one and for many — so a counted message whose only
+# difference in English is the noun's number renders one string here and the
+# select is dropped. The count still arrives and is still formatted.
+# `Intl.PluralRules` has no CLDR data for `gcf` in any case. Where English's
+# two counts multiplied out to four sentences
+# (`function-domain-insufficient-dimensions`,
+# `function-iterates-input-output-mismatch`), Guadeloupean has one.
+#
+# The one place a numeric variable still selects is
+# `field-function-wrong-num-outputs`, and it is not a plural: its `[one]` and
+# `[other]` branches are two different sentences about two different
+# components — a slope at each point against a vector at each point — and
+# collapsing them would lose the advice, not just a suffix.
+#
+# **Loans.** French, respelled by GEREC: «konpozan», «atribi», «varyab»,
+# «varyant», «endis», «valè», «sekans», «fonksyon», «entèval», «matris»,
+# «ekwasyon», «parabòl», «entèseksyon», «depandans», «sikilè», «référans»,
+# «kontras», «definisyon», «anotasyon», «konvèsyon», «koprim», «katyon»,
+# «anyon», «distraktè», «rekisyon», «aksésibilité», «pliryèl». English, through
+# the markup itself: «tag», «prop», «blòk», «randè», «kanva». The frame around
+# them is creole throughout: «ka» for the progressive, «ké» for the future,
+# «té» for the anterior, «pa» for negation, «pé pa» for *cannot*, «pòkò» for
+# *not yet*, «yo» as the impersonal subject that carries every passive, and
+# the postposed hyphenated determiner («liy-la», «sèk-la», «kontenè-la»).
+#
+# **Confidence.** The error frames — «pa valab», «pé pa kalkilé», «yo pòkò
+# enplimanté», «yo ka inyoré» — are ordinary Guadeloupean and are the surest
+# thing here. The mathematical vocabulary is the French one respelled, which
+# is what a Guadeloupean teacher says in the classroom; the computing
+# vocabulary («randè», «kanva», «tibout kòd» in `editor.ftl`) is a proposal.
+#
+# Creole punctuates as English does: no space before `:`, `;`, `?` or `!`.
+
+
+## `<lineSegment>`
+
+# No select: «atribi» is one word for one and for many, and «yo ka inyoré» is
+# the impersonal, which agrees with nothing. One string covers both English
+# categories. The count still arrives.
+line-segment-attributes-ignored-with-endpoints = yo ka inyoré { $attributes } lè dé bout espesifyé
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = yo ka inyoré { $attributes } lè on bout é on mitan espesifyé toulédé
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset pa ka fè ayen san on mitan
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liy ki ka pasé an pwen ki ni dimansyon yo pa détèrminé.
+
+line-points-too-few-dimensions = Liy-la dwèt pasé an pwen ki ni omwen dé dimansyon.
+
+line-points-depend-on-variables = Liy-la ka pasé an pwen ki ka dépann di varyab: { $variables }.
+
+line-equation-invalid-format = Fòma pa valab pou ekwasyon liy-la an varyab { $variable1 } é { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Dimi-dwat-la preskri pa through, endpoint é direction.  Yo ka inyoré through ki espesifyé-la.
+
+ray-dimension-mismatch = numDimensions pa ka koresponn adan dimi-dwat-la.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektè-la preskri pa head, tail é displacement.  Yo ka inyoré head ki espesifyé-la.
+
+vector-dimension-mismatch = numDimensions pa ka koresponn adan vektè-la.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Pé pa atiré asi on `<{ $component }>` paske i pa ni on varyab déta nearestPoint.
+
+constrain-to-without-nearest-point = Pé pa kontrenn asi on `<{ $component }>` paske i pa ni on varyab déta nearestPoint.
+
+constrain-to-interior-without-nearest-point = Pé pa kontrenn adan enteryè on `<{ $component }>` paske i pa ni on varyab déta nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = yo ka inyoré labelPosition pou on choiceInput ki pa inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Yo ka inyoré indices ki espesifyé pou choiceInput paske kantité endis pa ka koresponn épi kantité pitit choice.
+
+pretzel-indices-count-mismatch = Yo ka inyoré indices ki espesifyé pou problem paske kantité endis pa ka koresponn épi kantité pitit problem.
+
+shuffle-indices-count-mismatch = Yo ka inyoré indices ki espesifyé pou shuffle paske kantité endis pa ka koresponn épi kantité konpozan.
+
+indices-ignored-out-of-range = Yo ka inyoré indices ki espesifyé pou { $component } paske kèk endis déwò limit-la.
+
+pretzel-indices-repeated = Yo ka inyoré indices ki espesifyé pou pretzel paske kèk endis répété.
+
+pretzel-circuit-first-index = Yo ka inyoré indices ki espesifyé pou pretzel an mòd circuit paske prèmyé endis-la dwèt sé 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Pou `<{ $component }>` maché épi pitit ki sé chenn karaktè, ou dwèt espesifyé on atribi `type`.
+
+invalid-type-defaulting-to-math = Tip { $type } pa valab pou konpozan { $component }. I dwèt sé yonn adan math, text, number oben boolean. Yo ka pran math.
+
+string-not-valid-component-to-arrange = Chenn "{ $value }" pa on konpozan valab pou { $component }. Yo ka inyoré sa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tip { $type } pa valab, yo ka mèt tip-la asi number.
+
+invalid-variable-value = Valè on varyab ki pa valab: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Endis varyant { $index } dwèt sé on nonm
+
+variant-index-must-be-integer = Endis varyant { $index } dwèt sé on antyé
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` pa enplimanté pou mizi absoli. Yo ka mèt lajè-la relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` pa enplimanté pou mizi absoli. Yo ka mèt maj-la relatif.
+
+side-by-side-no-block-child = `<{ $component }>` pa valab: i dwèt ni omwen on pitit blòk.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Yo ka inyoré atribi `for` asi on `<label>` grafik.
+
+label-for-must-resolve-to-one = Atribi `for` asi `<label>` dwèt rézoud asi yon sèl konpozan.
+
+label-for-unresolved = Atribi `for` asi `<label>` pa pé rézoud asi on konpozan.
+
+label-for-answer-with-authored-inputs = Atribi `for` asi `<label>` ka référé a on `<answer>` ki ni antré otè-la ekri limenm; référé a antré-la dirèkteman.
+
+label-for-answer-without-input = Atribi `for` asi `<label>` ka référé a on `<answer>` ki pa ni antré pou etikté.
+
+label-for-must-reference-input-or-answer = Atribi `for` asi `<label>` dwèt référé a on antré oben a on répons.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Pou aksésibilité, `<{ $component }>` dwèt ni on deskripsyon kout oben dwèt espesifyé kon dekoratif.
+
+accessibility-video-short-description = Pou aksésibilité, `<video>` dwèt ni on deskripsyon kout.
+
+accessibility-input-short-description-or-label = Pou aksésibilité, `<{ $component }>` dwèt ni on deskripsyon kout oben on etikèt.
+
+accessibility-answer-input-short-description-or-label = Pou aksésibilité, on `<answer>` ki ka kréyé on antré dwèt ni on deskripsyon kout oben on etikèt.
+
+accessibility-short-description-contains-math = Deskripsyon kout pa ta dwèt ni konpozan matématik kon `<{ $component }>` adan yo. Eplé tout matématik épi mo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } pa ni asé kontras pou tèks tit seksyon-la (mòd fè nwè) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1).
+       *[other] { $colorName } pa ni asé kontras pou tèks tit seksyon-la ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Yo pòkò enplimanté `<circle>` ki ka pasé an { $count } pwen adan ka-la éti pwen-la pa ni valè nimerik.
+
+circle-too-many-through-points = Pé pa kalkilé on sèk ki ka pasé an plis ki 3 pwen.
+
+circle-overprescribed-radius-center-points = Pé pa kalkilé on sèk ki ni reyon, sant é pwen espesifyé ansanm.
+
+circle-center-with-multiple-points = Pé pa kalkilé on sèk ki ni on sant espesifyé é ki ka pasé an plis ki 1 pwen.
+
+circle-radius-too-small = Pé pa kalkilé sèk-la: piski distans ant dé pwen-la sé { $distance }, reyon { $radius } ki espesifyé-la twòp piti.
+
+circle-radius-with-many-points = Pé pa kréyé on sèk ki ka pasé an plis ki dé pwen épi on reyon espesifyé.
+
+circle-invalid-center-or-through-points = Sant oben pwen sèk-la pa valab.
+
+circle-radius-center-with-multiple-points = Pé pa kalkilé reyon on sèk ki ni on sant espesifyé é ki ka pasé an plis ki 1 pwen.
+
+circle-change-radius-non-numerical = Pé pa chanjé reyon on sèk ki ka pasé an pwen ki pa nimerik
+
+circle-radius-with-points-non-numerical = Pé pa kréyé on sèk ki ka pasé an plis ki on pwen épi on reyon espesifyé lè valè nimerik-la pa la.
+
+circle-change-center-non-numerical = Yo pòkò enplimanté chanjman sant on sèk ki ka pasé an pwen ki pa ni valè nimerik.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Guadeloupean has one,
+# because «entèval» and «antré» are invariant. Both selects are dropped and
+# both counts still arrive and are still formatted.
+function-domain-insufficient-dimensions = Dimansyon domèn fonksyon-la pa asé. Domèn-la ni { $intervals } entèval mé fonksyon-la ni { $inputs } antré.
+
+function-domain-invalid-format = Fòma domèn fonksyon-la pa valab.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Yo ka inyoré maksimòm fonksyon-la ki pa nimerik.
+        [minimum] Yo ka inyoré minimòm fonksyon-la ki pa nimerik.
+        [extremum] Yo ka inyoré ekstremòm fonksyon-la ki pa nimerik.
+        [point] Yo ka inyoré pwen fonksyon-la ki pa nimerik.
+        [slope] Yo ka inyoré pant fonksyon-la ki pa nimerik.
+       *[other] Yo ka inyoré { $type } fonksyon-la ki pa nimerik.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Yo ka inyoré maksimòm fonksyon-la ki vid.
+        [minimum] Yo ka inyoré minimòm fonksyon-la ki vid.
+        [extremum] Yo ka inyoré ekstremòm fonksyon-la ki vid.
+        [point] Yo ka inyoré pwen fonksyon-la ki vid.
+       *[other] Yo ka inyoré { $type } fonksyon-la ki vid.
+    }
+
+function-points-too-close = Fonksyon-la ni dé pwen ki twòp pré yonn a lòt. Pé pa défini fonksyon-la.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasyon fonksyon posib sèlman si kantité antré a fonksyon-la égal kantité sòti a-y. Fonksyon-lasa ni { $inputs } antré é { $outputs } sòti.
+
+## `<sequence>`
+
+sequence-invalid-length = Longè sekans-la pa valab.  I dwèt sé on antyé ki pa negatif.
+
+sequence-invalid-step = Pa sekans-la pa valab.  I dwèt sé on nonm pou on sekans tip { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" pa valab pou on sekans nonm.  I dwèt sé on nonm.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" pa valab pou on sekans lèt.  I dwèt sé on konbinezon lèt.
+
+sequence-invalid-endpoint = "{ $attribute }" pa valab pou sekans-la.
+
+select-from-sequence-coprime-not-numbers = yo ka inyoré coprime paske sé pa nonm yo ka chwazi
+
+select-from-sequence-coprime-with-exclude-combinations = yo ka inyoré coprime paske excludeCombinations espesifyé
+
+## Resolving a `target`
+
+target-not-found = target pa valab pou `<{ $source }>`: pé pa trouvé target-la.
+
+target-state-variable-not-found = target pa valab pou `<{ $source }>`: pé pa trouvé on varyab déta ki kryé "{ $property }" asi on `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Varyab `<odeSystem>` dwèt diféran di varyab endepandan-la.
+
+ode-system-duplicate-variable-names = Pé pa défini fonksyon RHS ODE épi non varyab dépandan ki répété.
+
+ode-system-rhs-function-error = Pé pa défini fonksyon RHS ODE.  Erè adan kréyasyon fonksyon mathjs-la.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Pé pa défini on ang ant { $count } liy
+
+angle-invalid-through-point = Pwen ki pa valab adan through on `<angle>`
+
+parabola-vertex-too-many-points = Yo pòkò enplimanté on parabòl ki ni on somè é ki ka pasé an plis ki 1 pwen.
+
+parabola-too-many-points = Yo pòkò enplimanté on parabòl ki ka pasé an plis ki 3 pwen.
+
+intersection-too-many-items = Yo pòkò enplimanté entèseksyon pou plis ki dé eleman
+
+## Other math components
+
+ionic-compound-not-two-ions = Yo pòkò enplimanté konpozé yonik pou dòt bagay ki dé yon.
+
+ionic-compound-needs-cation-and-anion = Konpozé yonik enplimanté sèlman pou on katyon é on anyon.
+
+solve-equations-cannot-evaluate = Pé pa rézoud ekwasyon-la paske yo pa pé evalyé-y: { $equation }
+
+math-operators-operand-number-required = Ou dwèt espesifyé on operandNumber lè ou ka ekstrè on operand matématik.
+
+eigen-decomposition-failed = Yo pa pé kalkilé valè pwòp a matris-la
+
+## `<matchesPattern>`
+
+# No select: the English branches differ only in the number of «paramèt», and
+# the sentence is turned impersonal so that neither a singular nor a plural
+# pronoun has to be chosen. The count still arrives.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramèt { $parameters } pa ka paret adan modèl-la, kidonk sa ké toujou koresponn épi on blan.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: pé pa entèprété grid="{ $grid }". I dwèt sé none, medium, dense, oben dé nonm pozitif separé pa on espas, kon grid="1 0.5". Yo pa ka trasé pon kadriyaj.
+
+## `<slopeField>` and `<vectorField>`
+
+# The `$expected` select is not a plural: the two branches are two different
+# sentences about two different components. `$found` is turned impersonal so
+# that no plural branch is needed for it.
+field-function-wrong-num-outputs =
+    `<{ $component }>` bizwen on fonksyon ki ni { $expected ->
+        [one] on sèl sòti, pant y' an chak pwen, kon `y - x`
+       *[other] dé sòti, vektè-la an chak pwen, kon `(y, -x)`
+    }, mé fonksyon yo bay la ni { $found } sòti. { $alternative ->
+        [none] Yo pa ka trasé ayen.
+       *[other] `<{ $alternative }>` sé konpozan-la pou fonksyon-lasa. Yo pa ka trasé ayen.
+    }
+
+field-function-attribute-ignored-with-child = Yo ka inyoré atribi `function` paske fonksyon-la bay adan konpozan-la tou; sé sila ki adan-la yo ka pran. Bay fonksyon-la yon sèl fason.
+
+field-variables-ignored =
+    `<{ $component }>`: atribi `variables` ka kryé varyab a on ekspresyon ki ekri dirèkteman adan konpozan-la. { $reason ->
+        [function-child] Fonksyon-la la bay kon on pitit `<function>`, ki ka kryé varyab a-y limenm, kidonk yo ka inyoré `variables`.
+       *[no-expression] Pa ni on ekspresyon kon sa la, kidonk yo ka inyoré `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" pa sipòté adan randè prefigure-la; yo ka sèvi épi konpòtman pozisyon dwat-la.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" pa sipòté adan randè prefigure-la; yo ka sèvi épi konpòtman pozisyon anlè-la.
+
+prefigure-invalid-axis-bounds = `<graph>`: limit aks-la pa valab pou konvèsyon prefigure; yo ka sèvi épi bbox pa défo (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lajè-la pa valab pou konvèsyon prefigure; yo ka sèvi épi lajè dyagram pa défo 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio pa valab pou konvèsyon prefigure; yo ka sèvi épi rapò aspè pa défo 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: espasman kadriyaj-la twòp fen pou limit aks-la; yo ka kité kadriyaj-la déwò adan randè prefigure-la.
+
+prefigure-annotations-not-rendered = `<graph>`: yo pa ké rann anotasyon lè yo pa ka sèvi épi randè PreFigure-la.
+
+multiple-annotations-children = Yo trouvé plizyè pitit `<annotations>` adan `<graph>`; yo ka inyoré tout sof dènyé-la.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Pé pa pwolonjé oben kopyé on tip konpozan yo pa ka rekonèt: { $type }.
+
+copy-prop-not-found = Yo pa pé trouvé prop { $property } asi on konpozan tip { $component }
+
+collect-no-source = Yo pa trouvé pon sous pou collect.
+
+collect-invalid-component-type = Pé pa kolekté konpozan tip `<{ $component }>` paske sé on tip konpozan ki pa valab.
+
+reference-index-unavailable = Pé pa référé a endis `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Pé pa kryé { $action } asi konpozan `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Doné-la ni on fòm ki pa valab.  Ranjé-la ni longè ki pa konsistan. Trouvé adan componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Doné-la ni non kolòn ki répété.  Trouvé adan componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Doné-la ka manké on non kolòn.  Trouvé adan componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = On award pou répons-lasa basé asi répons a tag répons-la limenm voyé, é sa ké mennen adan on konpòtman ou pa té ka atann.
+
+answer-max-num-attempts-in-section-wide-check-work = Mèt `maxNumAttempts` asi on `<answer>` adan on kontenè ki ni `sectionWideCheckWork` pa ka fè ayen, paske sé kontenè-la ki ka kontrolé kantité ésè. Mèt `maxNumAttempts` asi kontenè-la pito.
+
+nested-section-wide-check-work-max-num-attempts = Mèt `maxNumAttempts` asi on kontenè ki ni `sectionWideCheckWork` é ki adan on dòt kontenè ki ni `sectionWideCheckWork` pa ka fè ayen, paske sé kontenè déwò-la ki ka kontrolé kantité ésè. Mèt `maxNumAttempts` asi kontenè déwò-la pito.
+
+# No select: «atribi» is invariant and «pa ké fè ayen» agrees with nothing.
+answer-attributes-need-symbolic-equality = Atribi { $attributes } pa ké fè ayen san symbolicEquality mété.
+
+answer-invalid-type = Tip pa valab pou répons-la: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Piski konpozan `<{ $component }>` pa ni on non, yo pé pa sèvi épi-y pou on atribi module
+
+module-attribute-name-already-defined = Yo pé pa sèvi épi konpozan `<{ $component } name="{ $name }">` kon on atribi pou on module paske tip konpozan `<module>` ni on atribi "{ $name }" ki ja défini.
+
+conditional-content-condition-ignored = Yo ka inyoré atribi `condition` asi on konpozan `<conditionalContent>` ki ni pitit case oben else.
+
+slider-markers-type-mismatch = Tip makè-la pa ka koresponn épi tip slider-la.
+
+pretzel-problem-needs-statement-and-answer = pretzel pa valab: chak `<problem>` dwèt ni on `<statement>` é on `<answer>`.
+
+pretzel-circuit-first-problem-distractor = pretzel pa valab: an mode="circuit", prèmyé `<problem>`-la pé pa sé on distraktè.
+
+## Attribute values
+
+# No select: «valè» is invariant, and «yo ka inyoré sa» is impersonal, so one
+# string covers both English categories. The count still arrives.
+attribute-invalid-values = Valè { $values } pa valab pou atribi `{ $attribute }`; yo ka inyoré sa.
+
+attribute-must-be-references = Valè `{ $value }` pa valab pou atribi `{ $attribute }`. Atribi-la dwèt fòmé épi référans ki ka koumansé épi on `$`.
+
+math-input-invalid-function-names = <mathInput>: yo ka inyoré non fonksyon ki pa valab adan { $attribute }: { $names }. Segman afichaj a chak non dwèt ni omwen 2 karaktè (lèt oben tirè); on sifiks `|<mathspeak alternative>` opsyonèl pé swiv.
+
+## Building components from the source
+
+component-type-invalid = Tip konpozan ki pa valab: `<{ $componentType }>`
+
+attribute-repeated = Pé pa répété atribi { $attribute }.
+
+attribute-invalid-for-component = Atribi "{ $attribute }" pa valab pou on konpozan tip `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Définisyon stil { $styleNumber } pa ni asé kontras pou { $context ->
+        [text-on-background] koulè tèks kont koulè fon
+        [high-contrast] koulè gwo kontras kont kanva-la
+        [line] koulè liy kont kanva-la
+        [marker] koulè makè kont kanva-la
+       *[text-on-canvas] koulè tèks kont kanva-la
+    }{ $mode ->
+        [dark] { " (mòd fè nwè)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Kwak définisyon stil { $styleNumber } espesifyé koulè ki ka bay asé kontras pou mòd klè, koulè mòd fè nwè-la ki sòti adan valè-lasa pa ni asé kontras pou koulè tèks kont koulè fon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1). { $suggestion ->
+        [available] Pou asiré asé kontras an mòd fè nwè, ou pé ogmanté kontras mòd klè-la (pa egzanp, mèt { $lightAttribute }="{ $lightColor }") oben ranplasé koulè mòd fè nwè-la (pa egzanp, mèt { $darkAttribute }="{ $darkColor }").
+       *[none] Pou asiré asé kontras an mòd fè nwè, ogmanté kontras mòd klè-la oben ranplasé koulè ki sòti-la épi textColorDarkMode é/oben backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Kwak définisyon stil { $styleNumber } espesifyé on koulè tèks ki ka bay asé kontras pou mòd klè, koulè tèks mòd fè nwè-la ki sòti adan valè-lasa pa ni asé kontras kont kanva-la ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i ka mandé omwen { $threshold }:1). { $suggestion ->
+        [available] Pou asiré asé kontras an mòd fè nwè, ou pé ogmanté kontras mòd klè-la (pa egzanp, mèt textColor="{ $lightColor }") oben ranplasé koulè mòd fè nwè-la (pa egzanp, mèt textColorDarkMode="{ $darkColor }").
+       *[none] Pou asiré asé kontras an mòd fè nwè, ogmanté kontras mòd klè-la oben ranplasé koulè ki sòti-la épi textColorDarkMode.
+    }
+
+section-multiple-style-palettes = On seksyon pé chwazi yon sèl <stylePalette>; yo ka sèvi épi dènyé-la.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = pé pa détèrminé varyant inik a { $component } paske numToSelect pa on antyé ki pa negatif.
+
+variant-num-to-select-not-constant-number = pé pa détèrminé varyant inik a { $component } paske numToSelect pa on nonm konstan.
+
+variant-with-replacement-not-constant-boolean = pé pa détèrminé varyant inik a { $component } paske withReplacement pa on boulean konstan.
+
+variant-select-weight-disables-unique = Varyant inik pou select dezaktivé si ni on opsyon ki ni selectWeight oben selectForVariants espesifyé
+
+variant-coprime-undetermined = pé pa détèrminé varyant inik a { $component } paske yo pé pa détèrminé si coprime toujou fo.
+
+variant-attribute-not-constant = pé pa détèrminé varyant inik a { $component } paske { $attribute } pa on konstan.
+
+variant-attribute-not-number = pé pa détèrminé varyant inik a { $component } paske { $attribute } pa on nonm.
+
+variant-attribute-wrong-type-for-sequence =
+    pé pa détèrminé varyant inik a { $component } tip { $type } paske { $attribute } pa { $expected ->
+        [letters-combination] on konbinezon lèt
+        [math-expression] on ekspresyon matématik valab
+        [integer] on antyé
+       *[number] on nonm
+    }.
+
+variant-length-not-integer = pé pa détèrminé varyant inik a { $component } paske length pa on antyé.
+
+variant-sort-not-implemented = yo pòkò enplimanté varyant inik a on { $component } épi sort
+
+variant-exclude-combinations-not-implemented = yo pòkò enplimanté varyant inik a on { $component } épi excludeCombinations
+
+variant-math-exclude-not-implemented = yo pòkò enplimanté varyant inik a on { $component } tip math épi exclude
+
+variant-non-constant-exclude-not-implemented = yo pòkò enplimanté varyant inik a on { $component } épi on exclude ki pa konstan
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: pa sipòté adan randè prefigure a graph-la; yo ka soté désandan-la.
+
+prefigure-descendant-invalid-geometry = { $subject }: jeyometri ki pa fini oben ki pa konplèt; yo ka soté désandan-la.
+
+prefigure-curve-label-omitted = { $subject }: yo pa ka sipòté etikèt asi eleman koub ki konvèti; yo ka kité etikèt-la déwò.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tip definisyon fonksyon koub '{ $definitionType }' pa sipòté; yo ka soté désandan-la.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribi flipFunctions pa sipòté asi regionBetweenCurves; yo ka soté désandan-la.
+
+prefigure-region-non-formula-child = { $subject }: sé sèlman pitit fonksyon tip fòmil yo ka sipòté asi regionBetweenCurves; yo ka soté désandan-la.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' pa sipòté pou { $labelKind ->
+        [line-family] on etikèt fanmi liy
+       *[point] on etikèt pwen
+    }; yo ka sèvi épi aliyman PreFigure pa défo.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure pa ka sipòté stil ranpli '{ $fillStyle }'; yo ka tonbé asi on ranpli plen.
+
+prefigure-line-style-unknown = { $subject }: stil liy '{ $lineStyle }' yo pa konnèt kité déwò adan sòti PreFigure-la.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: stil makè '{ $markerStyle }' ka koresponn épi stil PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure pa ka sipòté stil makè '{ $markerStyle }'; yo ka sèvi épi stil pa défo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` pa valab; pé pa rézoud sib-la. Yo ka kité anotasyon-la déwò.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` rézoud asi plizyè sib; yo ka sèvi épi prèmyé sib-la.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` pa valab; sib-la déwò graph ki ka kontni-y la. Yo ka kité anotasyon-la déwò.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` pa valab; sib-la pa on objè grafik ki sipòté adan konvèsyon prefigure. Yo ka kité anotasyon-la déwò.
+
+annotation-text-missing = `<annotation>`: `text` ka manké oben vid; yo ka bay on tèks vid.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Yo détekté on dépandans sikilè.
+       *[other] Yo détekté on dépandans sikilè ki ka enplitjé on konpozan `<{ $componentType }>`.
+    }
+
+reference-no-referent = Yo pa trouvé pon référan pou référans-la: `{ $reference }`
+
+reference-multiple-referents = Yo trouvé plizyè référan pou référans-la: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fòma pa valab pou atribi { $attribute } a on `<{ $componentType }>`.
+
+children-invalid = Pitit ki pa valab pou `<{ $componentType }>`: Yo trouvé pitit ki pa valab: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Valè `{ $value }` pa valab pou atribi `{ $attribute }`, yo ka sèvi épi valè `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Yo pa trouvé vèsyon DoenetML { $version }.
+       *[other] Yo pa trouvé vèsyon DoenetML { $version }. Yo ka tonbé asi vèsyon { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ki pa valab: { $content }
+
+parse-tag-missing-close-tag = DoenetML ki pa valab: Tag `{ $tag }` pa ni tag fèmti. Yo té ka atann on tag ki ka fèmé tèt a-y oben on tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ki pa valab: Erè adan tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ki pa valab: Atribi `{ $attribute }` ki pa valab ka sanb ka manké on valè.
+
+parse-attribute-invalid = DoenetML ki pa valab: Atribi `{ $attribute }` pa valab
+
+parse-attribute-value-invalid = DoenetML ki pa valab: Valè atribi `{ $value }` pa valab
+
+parse-attribute-value-quote-mismatch = DoenetML ki pa valab: Valè atribi `{ $value }` pa valab. Gimè-la pa ka koresponn. I ka sanb ou ka manké on `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML ki pa valab: Yo trouvé on tag san non tag, pa egzanp `<`
+
+parse-tag-not-closed = DoenetML ki pa valab: Tag `{ $tag }` pa té fèmé (i ka sanb on `>` ka manké).
+
+parse-self-closing-tag-name-missing = DoenetML ki pa valab: Yo trouvé on tag san non tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ki pa valab: Tag `{ $tag }` pa té fèmé (i ka sanb `/>` ka manké).
+
+parse-tag-invalid-attributes = DoenetML ki pa valab: Tag `{ $tag }` pa valab. I pé ni atribi ki pa kòrèk.
+
+parse-close-tag-name-missing = DoenetML ki pa valab: Yo trouvé on tag fèmti san non tag, pa egzanp `</`
+
+parse-attribute-value-unquoted = Valè atribi dwèt adan gimè: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ki pa valab: Yo trouvé tag fèmti `{ $tag }`, mé pa ni tag ouvèti ki ka koresponn
+
+parse-close-tag-mismatched = DoenetML ki pa valab: Tag fèmti pa ka koresponn. Yo té ka atann `</{ $expected }>`. Yo trouvé `{ $found }`
+
+parser-node-unconvertible = Yo pa pé konvèti nœud { $node } an nœud Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribi name='{ $name }' pa valab. { $reason ->
+        [characters] Non pé ni sèlman lèt, chif, tirè anba oben tirè.
+       *[start] Non dwèt koumansé épi on lèt.
+    }
+
+component-name-invalid-start = Non konpozan "{ $name }" pa valab. Non dwèt koumansé épi on lèt.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = On répons tip videoWatched dwèt ni on atribi video
+
+answer-video-watched-video-not-reference = On répons tip videoWatched dwèt ni on atribi video ki sé on référans
+
+answer-name-not-single-text = Atribi name a on répons dwèt ni yon sèl pitit tèks
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Yo pa pé jwenn DoenetML déwò-la paske ni twòp nivo rekisyon. Es ni on référans sikilè?
+
+external-doenetml-unavailable = Yo pa pé jwenn DoenetML adan { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ki pa valab jwenn adan { $attribute }="{ $uri }": i pa té ka koresponn épi tip konpozan "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribi `{ $from }` démodé; sèvi épi `{ $to }` pito.
+       *[other] [deprecation] Atribi `{ $from }` asi `<{ $component }>` démodé; sèvi épi `{ $to }` pito.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribi `{ $from }` démodé é yo ka inyoré-y paske `{ $to }` espesifyé tou.
+       *[other] [deprecation] Atribi `{ $from }` asi `<{ $component }>` démodé é yo ka inyoré-y paske `{ $to }` espesifyé tou.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribi `{ $attribute }` asi `<{ $component }>` démodé é yo ka inyoré-y.
+
+deprecated-attribute-to-child = [deprecation] Atribi `{ $attribute }` asi `<{ $component }>` démodé; sèvi épi on pitit `<{ $child }>` pito.
+
+deprecated-attribute-value-renamed = [deprecation] Valè `{ $value }` a atribi `{ $attribute }` asi `<{ $component }>` démodé; sèvi épi `{ $to }` pito.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` pé mèt sèlman anglé an pliryèl, kidonk tèks a-y ka rété kon i yé adan on dokiman ki ekri an { $locale }. Ekri fòm pliryèl-la dirèkteman, oben mèt li épi atribi `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Eleman `<{ $tag }>` pa on eleman Doenet yo ka rekonèt.
+
+schema-element-not-allowed-at-root = Eleman `<{ $tag }>` pa pèmèt an rasin dokiman-la.
+
+schema-element-not-allowed-inside = Eleman `<{ $tag }>` pa pèmèt adan `<{ $parent }>`.
+
+schema-attribute-unrecognized = Eleman `<{ $tag }>` pa ni on atribi ki kryé `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribi `{ $attribute }` a eleman `<{ $tag }>` dwèt sé on lis éti chak atik sé yonn adan: { $allowed }
+       *[other] Atribi `{ $attribute }` a eleman `<{ $tag }>` dwèt sé yonn adan: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Non varyant pa valab pou select.  Non varyant { $variantName } ka paret adan { $numOptions } opsyon mé kantité pou chwazi sé { $numToSelect }.
+
+select-variant-name-without-options = Kèk varyant espesifyé pou select mé pa ni pon opsyon espesifyé pou non varyant posib: { $variantName }.
+
+select-variant-name-not-possible = Non varyant { $variantName } ki espesifyé pou select pa on non varyant posib.
+
+select-too-few-options = Pé pa chwazi { $numToSelect } konpozan adan sèlman { $numOptions }.
+
+select-from-sequence-too-few-values = Pé pa chwazi { $numToSelect } valè adan on sekans longè { $length }.
+
+select-from-sequence-indices-count-mismatch = Kantité endis espesifyé pou select dwèt koresponn épi kantité pou chwazi
+
+select-from-sequence-indices-not-integers = Tout endis espesifyé pou select dwèt sé antyé
+
+select-from-sequence-index-excluded = Endis selectfromsequence ki espesifyé-la té eskli
+
+select-from-sequence-indices-excluded-combination = Endis selectfromsequence ki espesifyé-la té on konbinezon eskli
+
+select-from-sequence-coprime-not-positive-integers = Pé pa chwazi konbinezon koprim paske sé pa antyé pozitif yo ka chwazi.
+
+select-from-sequence-coprime-common-factor = Pé pa chwazi nonm koprim. Tout valè posib-la ka pataj on faktè komen. (Valè "from" oben "to" ki espesifyé dwèt koprim épi "step".)
+
+select-from-sequence-coprime-single-number = Pé pa chwazi konbinezon koprim adan yon sèl nonm ki pa 1.
+
+select-from-sequence-excluded-too-many-combinations = Plis ki 70% a konbinezon-la eskli adan selectFromSequence
+
+select-from-sequence-coprime-none-found = Yo pa pé chwazi nonm koprim. Tout valè posib-la ka pataj on faktè komen.
+
+select-from-sequence-too-few-unique-values = Pé pa chwazi { $numToSelect } valè inik adan on sekans longè { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Pé pa chwazi { $numToSelect } valè adan on lis nonm prèmyé longè { $numValues }
+
+select-prime-numbers-values-count-mismatch = Kantité valè espesifyé pou select dwèt koresponn épi kantité pou chwazi
+
+select-prime-numbers-values-not-prime = Tout valè espesifyé pou select nonm prèmyé dwèt adan lis nonm prèmyé-la
+
+select-prime-numbers-values-excluded-combination = Valè selectPrimeNumbers ki espesifyé-la té on konbinezon eskli
+
+select-prime-numbers-excluded-too-many-combinations = Plis ki 70% a konbinezon-la eskli adan selectPrimeNumbers
+
+select-random-combination-fluke = Pa on chans estrèmman ra, yo pa pé chwazi on konbinezon valè o aza
+
+select-random-value-fluke = Pa on chans estrèmman ra, yo pa pé chwazi on valè o aza
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` pa trasé adan matématik-la; ekspresyon-la konpozé kon i té ye avan yo té pé mèt antré adan-y. { $reason ->
+        [not-inline] Sé sèlman on choice input `inline` ki ka rantré adan on ekspresyon; san `inline` i sé on blòk bouton.
+        [expanded] On text input `expanded` sé on bwèt plizyè liy, ki twòp gwo pou chita adan on ekspresyon.
+        [on-graph] Asi on graph ekspresyon-la trasé kon yon sèl imaj, ki pa ni plas pou on kontwòl.
+       *[relative-width] `width` a-y relatif (on pousantaj oben `em`), ki pa ni ayen pou mizuré kont adan on ekspresyon. Bay lajè-la an inité absoli, kon `px`, pito.
+    }

--- a/packages/i18n/locales/gcf/editor.ftl
+++ b/packages/i18n/locales/gcf/editor.ftl
@@ -1,0 +1,232 @@
+# Guadeloupean Creole French (kréyòl gwadloupéyen) editor and language-server
+# surfaces. Translated from `locales/en/editor.ftl`, which is the source of
+# truth: `lint:i18n` rejects a key that does not exist there, and reports a key
+# that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The GEREC standard, as `chrome.ftl` sets it out. The
+# French-etymological spelling is not mixed in.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# **Number.** No `[one]`/`[other]` select appears anywhere in this file.
+# Guadeloupean nouns do not inflect for number, so «vyolasyon» and
+# «rékòmandasyon» are the same word in both English branches; the select is
+# dropped and the count still arrives and is still formatted. `Intl.PluralRules`
+# has no CLDR data for `gcf` either. `help-coordinates` is one unselected form
+# for the same reason.
+#
+# **Loans.** French, respelled by GEREC: «varyant», «filtré», «aksésibilité»,
+# «vyolasyon», «rékòmandasyon», «rapò», «vèsyon», «kontèks», «erè»,
+# «avètisman», «enfo», «dyagnostik», «anotasyon», «opsyon», «fòmaté»,
+# «référans», «référan», «dokimantasyon», «atribi», «konpozan», «pwopriyété»,
+# «kòdoné», «valè», «stil», «tip», «idantifyan». One English loan: «tag», the
+# markup word, which arrives through the language itself. The frame around
+# them is creole: «ka» for the progressive, «pa» for negation, «pé pa» for
+# *cannot*, «yo» for the impersonal subject, and the postposed determiner
+# («rapò-la», «editè-la»).
+#
+# **Confidence.** This is the file with the least support behind it: there is
+# almost no written Guadeloupean computing register, and «tibout kòd» for
+# *snippet*, «antré tablo» for *array entry* and «randè» in the sibling files
+# are proposals rather than attested terms. A reviewer should read those three
+# first.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Rimèt a zéro
+       *[update] Mèt ajou
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } vizyonè-la
+       *[other] { $word } vizyonè-la { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varyant
+editor-variant-filter = Filtré…
+editor-variant-next = Chwazi varyant ki ka vin apré
+editor-variant-previous = Chwazi varyant ki ka vin avan
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Yo trouvé on vyolasyon aksésibilité WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-la.
+        [advisories] Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-la. Yo pa trouvé pon vyolasyon WCAG AA, mé ni dòt rékòmandasyon aksésibilité ki disponib.
+       *[clean] Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-la. Yo pa trouvé pon pwoblèm aksésibilité.
+    }
+
+# No select on `$count` inside the branches: «vyolasyon» and «rékòmandasyon»
+# are the same word for one and for many, so the two categories would render
+# the same string. The count still arrives and is still formatted.
+editor-accessibility-label =
+    { $status ->
+        [violations] Yo trouvé on vyolasyon aksésibilité WCAG AA. Yo trouvé { $count } vyolasyon WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-la.
+        [advisories] Yo pa trouvé pon vyolasyon WCAG AA. Yo trouvé { $count } dòt rékòmandasyon aksésibilité. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-la.
+       *[clean] Yo pa trouvé pon vyolasyon WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-la.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Vèsyon DoenetML { $version }
+
+editor-tab-help = Èd ki ka dépann di kontèks
+editor-tab-help-short = Kontèks
+editor-tab-errors = Erè
+editor-tab-warnings = Avètisman
+editor-tab-info = Enfo
+editor-tab-accessibility = Aksésibilité
+editor-tab-responses = Répons ki voyé
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsyon editè-la
+editor-format-as-doenetml = Fòmaté kon DoenetML
+editor-format-as-xml = Fòmaté kon XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liy #{ $line }
+
+editor-no-errors = Pa ni erè
+editor-no-warnings = Pa ni avètisman
+editor-no-info = Pa ni dyagnostik enfòmatif
+
+editor-show-info-annotations = Montré dyagnostik enfòmatif adan editè-la
+editor-show-accessibility-annotations = Montré dyagnostik aksésibilité adan editè-la
+
+editor-accessibility-learn-more = Aprann ki jan Doenet ka trété aksésibilité
+
+editor-accessibility-violations-heading = Vyolasyon aksésibilité ({ $standard })
+
+editor-accessibility-other-heading = Dòt pwoblèm aksésibilité
+editor-none-found = Yo pa trouvé ayen
+
+
+## Submitted responses
+
+editor-no-responses = Pòkò ni répons ki voyé
+editor-response-answer-id = Idantifyan répons
+editor-response-response = Répons
+editor-response-credit = Kredi
+editor-response-submitted = Voyé
+
+
+## The context-help panel
+
+help-placeholder = Mèt kisò-la asi on non tag, on atribi, oben { $ref } pou dokimantasyon.
+
+help-unsupported-ref-chain = Èd pou référans an plizyè moso kon { $example } pòkò disponib.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Yo pa trouvé pon référan pou référans-la: { $ref }.
+        [multiple] Yo trouvé plizyè référan pou référans-la: { $ref }.
+       *[indeterminate] Yo pa pé détèrminé on référan pou { $ref }.
+    }
+
+help-learn-about-references = Aprann asi référans →
+help-reference-page = Paj référans →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Adan { $element }
+       *[top] Asi nivo pli wo-la
+    }{ $allowed ->
+        [none] { " — ayen pa ka rantré la." }
+        [text] { " — tapé tèks la." }
+        [text-and-components] { " — tapé tèks la, oben eséyé:" }
+       *[components] { " — bagay pou eséyé:" }
+    }
+
+help-suggestions-footer = Pésé { $shortcut } pou vwè tout { $total } konpozan-la.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } sé on référans ba { $target }.
+       *[other] { $ref } sé on référans ba { $target } (liy { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Entrodwi pa { $owner } kon { $role }.
+       *[other] Entrodwi pa { $owner } an liy { $line } kon { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } sé on référans ba pwopriyété { $property } a konpozan { $element }.
+       *[other] { $ref } sé on référans ba pwopriyété { $property } a konpozan { $element } (liy { $line }).
+    }
+
+help-kind-attribute = atribi
+help-kind-snippet = tibout kòd
+help-kind-array-entry = antré tablo
+
+help-default = Valè pa défo:
+help-active-default = Valè pa défo aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valè ki pèmèt (yonn pa atik):
+       *[other] Valè ki pèmèt:
+    }
+
+help-suggested-values = Valè ki sijéré:
+
+help-inserts = Ka mèt:
+
+# No select: «kòdoné» is the same word for one and for many, so both
+# categories would render the same string.
+help-coordinates = Kòdoné:
+
+help-type = Tip:
+
+help-resolved-style = Stil ki rézoud (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Non fonksyon ki rézoud:
+help-reset-list = Lis rimiz a zéro asi antré-lasa:
+help-added-on-input = Ajouté asi antré-lasa:
+help-removed-on-input = Òté asi antré-lasa:
+
+help-reset-overrides = { $reset } ka pran plas { $additional } é { $removed }.

--- a/packages/i18n/locales/gcr/chrome.ftl
+++ b/packages/i18n/locales/gcr/chrome.ftl
@@ -1,0 +1,170 @@
+# Guianese Creole French (kriyòl gwiyanè) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The orthography of French Guiana — the phonemic Latin
+# spelling used in the Guianese dictionaries, in the schoolbooks produced for
+# the *langues et cultures régionales* option, and in the Guianese press:
+# «kriyòl», «kaz», «lò», «roun». Its marks, as this catalog uses them: «é» for
+# close [e] and «è» for open [ɛ]; «ò» for open [ɔ]; «an», «on», «en» for the
+# three nasal vowels; «ou» for [u]; «y» for the glide; «w» for [w], including
+# where French wrote `r` before a rounded vowel («wouj»); «r» elsewhere
+# («répons», «gri»); «tj» and «dj» for the palatals; «k» always for [k].
+# Silent French letters are not written.
+#
+# **Its relation to the Antillean standards.** Guianese is written on the same
+# principles as GEREC's Guadeloupean and Martinican orthography and as the
+# Saint Lucian one — the same vowel letters, the same nasals, the same «k» —
+# so all three catalogs look alike on the page. The language underneath is
+# where they part, and three differences run through every file here:
+#
+#   1. **The pronouns.** Guianese has «mo» *I*, «to» *you*, «li» *he/she/it*,
+#      «nou», «zòt», «yé» *they*, against Antillean «an/mwen», «ou», «i»,
+#      «nou», «zòt», «yo». «yé» carries every impersonal passive in these
+#      files, and «to» is the reader the imperatives address.
+#   2. **The indefinite article is «roun»**, not Antillean «on» or «an» —
+#      «roun pwen», «roun atribi», «roun sèl konpozan».
+#   3. **The definite determiner is a single postposed «-a»**, «-an» after a
+#      nasal vowel, hyphenated: «kaz-a», «répons-a», «paj-a», «fonksyon-an»,
+#      «dokiman-an». Antillean has the four-way «a / la / an / lan»;
+#      Guianese does not.
+#
+# Guianese also says «lò» where the Antilles say «lè» (*when*), «asou» for
+# *on*, «annan» for *in*, «arien» for *nothing*, and «pa pouvé» for *cannot*
+# where Guadeloupean says «pé pa». The French-etymological spelling — «créole»
+# for «kriyòl», «réponse» for «répons» — is a different practice with a
+# different aim, and **none of it is mixed in here**.
+#
+# One point a reviewer should settle: this catalog writes the equative copula
+# «sé» throughout, on the Antillean pattern. Guianese also uses «sa» in that
+# slot, and a speaker may prefer it in some or all of these sentences.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `gcr`, and the language
+# would give it nothing to work with in any case: a Guianese noun has one form
+# for one and for many. The plural is the preposed «sé» with the postposed
+# determiner («sé répons-a»), and a numeral in front of a bare noun does the
+# whole job on its own — «3 ésè», never `*ésèyé`. So **no message in this file
+# writes a `[one]`/`[other]` select**; each counted message is one unselected
+# form. `attempts-remaining` keeps its `[0]` branch, because "none left" is a
+# different sentence rather than a different form of this one.
+#
+# **Loans.** The technical register is French, carried in creole grammar and
+# respelled by the Guianese rules: «répons», «kredi», «enfòmasyon»,
+# «matématik», «ekspresyon», «apèsi», «estatistik», «kolòn», «entèval»,
+# «klavyé», «erè», «avètisman», «aksésibilité», «vyolasyon», «inisyalizé»,
+# «anrejistré», «maksimòm», «disponib», «etikèt». Two are English: «fidbak»
+# (*feedback*) and «randè» (*renderer*). «WCAG AA» is the standard's name and
+# is not a word. The grammar around all of them is creole: preverbal «ka» for
+# the progressive, «ké» for the future, «té» for the anterior, «pa» for
+# negation, «ni» for *have*, and the postposed determiner throughout.
+#
+# **Confidence.** Guianese has a settled orthography and a body of published
+# writing, but no written computing register: «randè» and «fidbak» are the
+# loan a speaker would say rather than a coinage this seed invented, and
+# should be read as proposals.
+#
+# Kriyòl punctuates as English does: no space before `:`, `;`, `?` or `!`.
+
+
+## Answer submission
+
+answer-checking = Ka vérifyé…
+answer-submitting = Ka voyé…
+answer-checking-status = Ka vérifyé répons-a
+answer-submitting-status = Ka voyé répons-a
+answer-correct = Kòrèk
+answer-incorrect = Pa kòrèk
+answer-response-saved = Répons-a anrejistré
+answer-percent-credit = { $percent }% kredi
+answer-percent-correct = { $percent }% kòrèk
+answer-percent-short = { $percent } %
+max-credit-available = Kredi maksimòm disponib: { $percent }%
+# No `[one]`/`[other]` select: «ésè» is one word for one and for many, so both
+# categories would render the same string. The count still arrives and is
+# still formatted. `[0]` stays — it is its own sentence.
+attempts-remaining =
+    { $count ->
+        [0] pa ni ésè ki rété
+       *[other] { $count } ésè ki rété
+    }
+validation-correct = (Kòrèk)
+validation-incorrect = (Pa kòrèk)
+validation-partially-correct = (Kòrèk an pati)
+# No select, for the reason given above.
+answer-show-responses = Montré { $count } répons ba { $answerId }
+
+## Disclosure panels
+
+feedback-heading = Fidbak
+collapsible-click-to-open = (kliké pou ouvè)
+collapsible-click-to-close = (kliké pou fèmé)
+collapsible-initializing = Ka inisyalizé…
+footnote-show = Montré nòt anba paj-a
+footnote-hide = Kaché nòt anba paj-a
+description-more-information = plis enfòmasyon
+
+## Controls
+
+slider-previous = Avan
+slider-next = Apré
+keyboard-open = Ouvè klavyé-a
+keyboard-close = Fèmé klavyé-a
+choice-input-remove-choice = Òté { $choice }
+matrix-remove-row = Òté roun ranjé
+matrix-add-row = Ajouté roun ranjé
+matrix-remove-column = Òté roun kolòn
+matrix-add-column = Ajouté roun kolòn
+subset-add-remove-points = Ajouté/Òté pwen
+subset-toggle-points-intervals = Chanjé ant pwen é entèval
+subset-move-points = Deplasé pwen
+subset-clear = Efasé
+orbital-add-row = Ajouté roun ranjé
+orbital-remove-row = Òté roun ranjé
+orbital-add-box = Ajouté roun bwèt
+orbital-remove-box = Òté roun bwèt
+orbital-add-up-arrow = Ajouté roun flèch anlè
+orbital-add-down-arrow = Ajouté roun flèch anba
+orbital-remove-arrow = Òté roun flèch
+orbital-row-label = Etikèt pou ranjé { $row }
+pretzel-answer = Répons
+summary-statistics-caption = Estatistik rezimé pou { $column }
+
+## Math input
+
+math-input-preview-region = apèsi ekspresyon matématik-a
+math-input-preview = Apèsi
+math-input-invalid-expression = Ekspresyon ki pa valab:
+
+## Document status
+
+viewer-initializing = Ka inisyalizé…
+
+## Errors
+
+error-heading = Erè
+error-found-at =
+    { $span ->
+        [line] Yo trouvé-y an liy { $startLine }.
+       *[lines] Yo trouvé-y an liy { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Dokiman-an ni erè annan-y!
+diagnostic-heading-error = Erè
+diagnostic-heading-warning = Avètisman
+diagnostic-heading-information = Enfo
+diagnostic-heading-hint = Endikasyon
+accessibility-heading-level-1 = Vyolasyon aksésibilité WCAG AA
+accessibility-heading-level-2 = Alèt aksésibilité
+something-went-wrong = Ni roun bagay ki pa maché.
+renderer-load-failed = roun randè pa rivé chajé. Souplé, rechajé paj-a.
+core-start-failed = Dokiman-an pa pouvé démaré. Souplé, rechajé paj-a.
+core-start-failed-busy = Dokiman-an pa pouvé démaré. Plizyè dokiman té ka démaré an menm tan, é sa pouvé pran plis tan asou roun aparèy ki pi lan. Rechajé paj-a pouvé édé lò lòt dokiman-an fin.
+core-start-failed-retry = Dokiman-an pa pouvé démaré.
+core-start-failed-busy-retry = Dokiman-an pa pouvé démaré. Plizyè dokiman té ka démaré an menm tan, é sa pouvé pran plis tan asou roun aparèy ki pi lan.
+core-start-retry = Eséyé ankò
+saved-state-unavailable = Travay to té anrejistré-a pa pouvé chajé.

--- a/packages/i18n/locales/gcr/content.ftl
+++ b/packages/i18n/locales/gcr/content.ftl
@@ -1,0 +1,282 @@
+# Guianese Creole French (kriyòl gwiyanè) content catalog: the prose the core
+# computes into the document. Selected by `documentLocale` — the language the
+# activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The orthography of French Guiana, as `chrome.ftl` sets it
+# out letter by letter: «kriyòl», «kaz», «lò», «roun», «répons». It is written
+# on the same principles as GEREC's Guadeloupean and Martinican spelling and
+# as the Saint Lucian one, and looks much like them on the page; what parts
+# them is the language — Guianese has the pronouns «mo to li nou zòt yé», the
+# indefinite article «roun», and a single postposed definite «-a» («-an» after
+# a nasal vowel) where the Antilles have the four-way «a / la / an / lan». The
+# French-etymological spelling is **not mixed into this file**.
+#
+# **Word order: the modifier follows the noun.** Guianese puts an attributive
+# adjective after its head — «liy wouj épé» is *thick red line*, noun first —
+# so the composition messages **reverse** the English order.
+# `style-with-noun` and `style-filled-with-noun` put «{ $noun }» in front of
+# «{ $description }», and `style-fill` postposes the pattern word onto the
+# colour («dyaman blé» for *blue diamonds*).
+#
+# **Nothing agrees, so nothing selects.** Guianese has no grammatical gender,
+# no case and no adjective agreement: an adjective is one invariable word
+# wherever it stands. So not one message here forks on `$gender` or on
+# `$role`, and `noun-gender` answers a single token that nothing downstream
+# reads. What the composition messages do is order and choose, and that is the
+# whole of the work.
+#
+# `noun-regular-polygon` splits the way `locales/es` does, but for word order
+# rather than for agreement: the head is «poligòn régilyé» and the side count
+# follows the adjectives as a relative clause, «ki ni N koté». That is the
+# `[noun-tail]` branch of `style-with-noun`.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `gcr`, and there is
+# nothing for it to have: a noun has one form for one and for many. The plural
+# is the preposed «sé» with the postposed determiner («sé pwen-an»), and a
+# numeral in front of a bare noun does the job alone. No message in this file
+# writes a `[one]`/`[other]` select, and `noun-regular-polygon` says «ki ni 1
+# koté» and «ki ni 5 koté» with the same word. `.exercise` and `.exercises`,
+# and `.problem` and `.problems`, are therefore the same word twice: that is
+# the language's nominal morphology, not a copy-paste slip.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# Science in French Guiana is schooled in French, from the French national
+# curriculum and French textbooks, so the periodic table a Guianese pupil
+# reads is `locales/fr`'s. There is no published Guianese list of the hundred
+# and eighteen element names, and writing one would be respelling the French
+# list and calling the result a Guianese nomenclature. `lint:i18n` reports the
+# two keys as missing coverage and that is the correct report.
+# `ion-name-oxidation-state` and the two invalid-symbol messages **are**
+# covered — they are frames, not vocabulary.
+#
+# **Loans.** French, respelled: «poligòn», «parabòl», «vektè», «fonksyon»,
+# «rektang», «triyang», «segman», «dimi-dwat», «réjyon», «vyolèt»,
+# «orizontal», «vètikal», «dyagonal», «aktivité», «définisyon», «egzanp»,
+# «egzèsis», «objektif», «paragraf», «téyorèm», «solisyon», «kaskad»,
+# «tablo», «figi», «senbòl», «chimik», «yonik», «konpozé». «siyan» is the
+# weakest word in the file: Guianese has «blé» and no settled word for cyan,
+# and a speaker may well prefer «blé kler». Everything around the loans is
+# creole — «ki ni» for the relative clause, «épi» for *with*, «san» for
+# *without*, «sé» for the plural, «pa» for negation.
+#
+# **Confidence.** The colour words, the shape nouns and the section words are
+# ordinary Guianese and are the least doubtful thing here. The style
+# composition is a judgement about word order that a speaker should read
+# aloud; «siyan» and «kaskad» are the two entries most likely to be replaced.
+
+
+## Style vocabulary
+
+color =
+    .black = nwè
+    .white = blan
+    .gray = gri
+    .red = wouj
+    .orange = zoranj
+    .yellow = jòn
+    .green = vèt
+    .cyan = siyan
+    .blue = blé
+    .purple = vyolèt
+    .pink = woz
+    .brown = maron
+line-width =
+    .thick = épé
+    .thin = fen
+line-style =
+    .dashed = an tirè
+    .dotted = an pwentiyé
+# Noun phrases. «liy» is one word for one line and for many, so these are not
+# plurals of anything — they are what the language says in both places.
+fill-style =
+    .horizontal = liy orizontal
+    .vertical = liy vètikal
+    .diagonal = liy dyagonal
+    .backdiagonal = liy dyagonal envès
+    .dots = pwen
+    .diamonds = dyaman
+noun =
+    .line = liy
+    .line-segment = segman
+    .ray = dimi-dwat
+    .vector = vektè
+    .curve = koub
+    .function = fonksyon
+    .slope-field = chan pant
+    .vector-field = chan vektè
+    .parabola = parabòl
+    .polyline = liy brizé
+    .polygon = poligòn
+    .triangle = triyang
+    .rectangle = rektang
+    .circle = sèk
+    .region = réjyon
+    .point = pwen
+    .square = karé
+    .diamond = dyaman
+    .cross = kwa
+    .plus = plis
+# The head is the bare noun and the side count follows the adjectives as a
+# relative clause, so that the adjectives stay beside the noun they describe.
+# «koté» is invariant: «ki ni 1 koté», «ki ni 5 koté».
+noun-regular-polygon =
+    { $part ->
+        [tail] ki ni { $numSides } koté
+       *[head] poligòn régilyé
+    }
+# One answer for every noun: Guadeloupean has no grammatical gender, so
+# nothing downstream has anything to agree with.
+noun-gender = neuter
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun first and the adjectives after it, which is the opposite of
+# English. The regular polygon's relative clause follows both.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = ranpli
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } épi { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } épi { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } épi { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+style-border-clause =
+    { $parts ->
+        [with-article] épi roun bòdi { $border }
+        [and] é bòdi { $border }
+        [and-article] é roun bòdi { $border }
+       *[with] épi bòdi { $border }
+    }
+# The pattern word is postposed straight onto the colour — «dyaman blé» — for
+# the same reason the adjectives are: the modifier follows its head, and there
+# is no agreement for a supporting noun to carry.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = san ranpli
+style-text =
+    { $parts ->
+        [background] { $color } épi roun fon { $background }
+       *[plain] { $color }
+    }
+style-background-none = arien
+
+## Boolean words
+
+boolean-true = vré
+boolean-false = fo
+
+## Answer buttons
+
+answer-submit-label = Vérifyé travay-a
+answer-submit-label-no-correctness = Voyé répons-a
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are the same
+# word: the plural is the preposed «sé», and a heading does not carry it. Two
+# ids with one translation is what a language with no plural suffix looks like
+# here, not a copy-paste.
+section-name =
+    .activity = Aktivité
+    .aside = Nòt asou koté
+    .cascade = Kaskad
+    .definition = Définisyon
+    .example = Egzanp
+    .exercise = Egzèsis
+    .exercises = Egzèsis
+    .given-answer = Répons
+    .note = Nòt
+    .objectives = Objektif
+    .paragraphs = Paragraf
+    .part = Pati
+    .problem = Pwoblèm
+    .problems = Pwoblèm
+    .proof = Prèv
+    .question = Kèsyon
+    .section = Seksyon
+    .solution = Solisyon
+    .task = Travay
+    .theorem = Téyorèm
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Endikasyon
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+figure-name =
+    { $parts ->
+        [numbered] Figi { $enumeration }
+        [numbered-caption] Figi { $enumeration }{ ": " }
+        [unnumbered-caption] Figi{ ": " }
+       *[unnumbered] Figi
+    }
+
+## Paginator controls
+
+paginator-previous = Avan
+paginator-next = Apré
+paginator-page = Paj
+paginator-page-status = { $pageLabel } { $currentPage } asou { $numPages }
+
+## Piecewise functions
+
+piecewise-condition-or = oben
+piecewise-condition-if = si
+piecewise-condition-otherwise = sinon
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Science in Guadeloupe is taught in French, from the French
+## curriculum: the periodic table on the classroom wall is French, and there
+## is no settled Guadeloupean table for a seed to reproduce. See the header.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Senbòl chimik ki pa valab
+chemistry-invalid-ionic-compound = Konpozé yonik ki pa valab
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blan
+math-embedded-input-blank-ordinal = blan { $ordinal } asou { $total }

--- a/packages/i18n/locales/gcr/diagnostics.ftl
+++ b/packages/i18n/locales/gcr/diagnostics.ftl
@@ -1,0 +1,704 @@
+# Guianese Creole French (kriyòl gwiyanè) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The orthography of French Guiana, as `chrome.ftl` sets it
+# out letter by letter. It is written on the same principles as GEREC's
+# Guadeloupean spelling and as the Saint Lucian one; what parts them is the
+# language — the pronoun «yé» that carries every impersonal passive below, the
+# indefinite «roun», the single postposed definite «-a» / «-an», «lò» for
+# *when* and «pa pouvé» for *cannot*. The French-etymological spelling is not
+# mixed in.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# **Number.** No `[one]`/`[other]` select appears anywhere in this file.
+# Guianese nouns do not inflect for number — «pwen», «entèval», «atribi»,
+# «valè» are one word for one and for many — so a counted message whose only
+# difference in English is the noun's number renders one string here and the
+# select is dropped. The count still arrives and is still formatted.
+# `Intl.PluralRules` has no CLDR data for `gcr` in any case. Where English's
+# two counts multiplied out to four sentences
+# (`function-domain-insufficient-dimensions`,
+# `function-iterates-input-output-mismatch`), Guianese has one.
+#
+# The one place a numeric variable still selects is
+# `field-function-wrong-num-outputs`, and it is not a plural: its `[one]` and
+# `[other]` branches are two different sentences about two different
+# components — a slope at each point against a vector at each point — and
+# collapsing them would lose the advice, not just a suffix.
+#
+# **Loans.** French, respelled: «konpozan», «atribi», «varyab», «varyant»,
+# «endis», «valè», «sekans», «fonksyon», «entèval», «matris», «ekwasyon»,
+# «parabòl», «entèseksyon», «dépandans», «sikilè», «référans», «kontras»,
+# «definisyon», «anotasyon», «konvèsyon», «koprim», «katyon», «anyon»,
+# «distraktè», «rekisyon», «aksésibilité», «pliryèl». English, through the
+# markup itself: «tag», «prop», «blòk», «randè», «kanva». The frame around
+# them is creole throughout: «ka» for the progressive, «ké» for the future,
+# «té» for the anterior, «pa» for negation, «pa pouvé» for *cannot*, «pòkò»
+# for *not yet*, «yé» as the impersonal subject, «roun» as the indefinite
+# article, and the postposed hyphenated determiner («liy-a», «sèk-a»,
+# «fonksyon-an»).
+#
+# **Confidence.** The error frames — «pa valab», «pa pouvé kalkilé», «yé pòkò
+# enplimanté», «yé ka inyoré» — are ordinary Guianese and are the surest thing
+# here. The mathematical vocabulary is the French one respelled, which is what
+# a Guianese teacher says in the classroom; the computing vocabulary
+# («randè», «kanva», «tibout kòd» in `editor.ftl`) is a proposal. The equative
+# copula is written «sé» throughout; a speaker may prefer «sa».
+#
+# Kriyòl punctuates as English does: no space before `:`, `;`, `?` or `!`.
+
+
+## `<lineSegment>`
+
+# No select: «atribi» is one word for one and for many, and «yé ka inyoré» is
+# the impersonal, which agrees with nothing. One string covers both English
+# categories. The count still arrives.
+line-segment-attributes-ignored-with-endpoints = yé ka inyoré { $attributes } lò dé bout espesifyé
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = yé ka inyoré { $attributes } lò roun bout é roun mitan espesifyé toulédé
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset pa ka fè arien san roun mitan
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liy ki ka pasé an pwen ki ni dimansyon yé pa détèrminé.
+
+line-points-too-few-dimensions = Liy-a divèt pasé an pwen ki ni omwen dé dimansyon.
+
+line-points-depend-on-variables = Liy-a ka pasé an pwen ki ka dépann di varyab: { $variables }.
+
+line-equation-invalid-format = Fòma pa valab pou ekwasyon liy-a an varyab { $variable1 } é { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Dimi-dwat-a preskri pa through, endpoint é direction.  Yo ka inyoré through ki espesifyé-a.
+
+ray-dimension-mismatch = numDimensions pa ka koresponn annan dimi-dwat-a.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektè-a preskri pa head, tail é displacement.  Yo ka inyoré head ki espesifyé-a.
+
+vector-dimension-mismatch = numDimensions pa ka koresponn annan vektè-a.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Pa pouvé atiré asou roun `<{ $component }>` paske li pa ni roun varyab déta nearestPoint.
+
+constrain-to-without-nearest-point = Pa pouvé kontrenn asou roun `<{ $component }>` paske li pa ni roun varyab déta nearestPoint.
+
+constrain-to-interior-without-nearest-point = Pa pouvé kontrenn annan enteryè roun `<{ $component }>` paske li pa ni roun varyab déta nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = yé ka inyoré labelPosition pou roun choiceInput ki pa inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Yo ka inyoré indices ki espesifyé pou choiceInput paske kantité endis pa ka koresponn épi kantité pitit choice.
+
+pretzel-indices-count-mismatch = Yo ka inyoré indices ki espesifyé pou problem paske kantité endis pa ka koresponn épi kantité pitit problem.
+
+shuffle-indices-count-mismatch = Yo ka inyoré indices ki espesifyé pou shuffle paske kantité endis pa ka koresponn épi kantité konpozan.
+
+indices-ignored-out-of-range = Yo ka inyoré indices ki espesifyé pou { $component } paske kèk endis déwò limit-a.
+
+pretzel-indices-repeated = Yo ka inyoré indices ki espesifyé pou pretzel paske kèk endis répété.
+
+pretzel-circuit-first-index = Yo ka inyoré indices ki espesifyé pou pretzel an mòd circuit paske prèmyé endis-a divèt sé 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Pou `<{ $component }>` maché épi pitit ki sé chenn karaktè, to divèt espesifyé roun atribi `type`.
+
+invalid-type-defaulting-to-math = Tip { $type } pa valab pou konpozan { $component }. I divèt sé roun annan math, text, number oben boolean. Yo ka pran math.
+
+string-not-valid-component-to-arrange = Chenn "{ $value }" pa roun konpozan valab pou { $component }. Yo ka inyoré sa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tip { $type } pa valab, yé ka mèt tip-a asou number.
+
+invalid-variable-value = Valè roun varyab ki pa valab: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Endis varyant { $index } divèt sé roun nonm
+
+variant-index-must-be-integer = Endis varyant { $index } divèt sé roun antyé
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` pa enplimanté pou mizi absoli. Yo ka mèt lajè-a relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` pa enplimanté pou mizi absoli. Yo ka mèt maj-a relatif.
+
+side-by-side-no-block-child = `<{ $component }>` pa valab: li divèt ni omwen roun pitit blòk.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Yo ka inyoré atribi `for` asou roun `<label>` grafik.
+
+label-for-must-resolve-to-one = Atribi `for` asou `<label>` divèt rézoud asou yon sèl konpozan.
+
+label-for-unresolved = Atribi `for` asou `<label>` pa pouvé rézoud asou roun konpozan.
+
+label-for-answer-with-authored-inputs = Atribi `for` asou `<label>` ka référé a roun `<answer>` ki ni antré otè-a ekri limenm; référé a antré-a dirèkteman.
+
+label-for-answer-without-input = Atribi `for` asou `<label>` ka référé a roun `<answer>` ki pa ni antré pou etikté.
+
+label-for-must-reference-input-or-answer = Atribi `for` asou `<label>` divèt référé a roun antré oben a roun répons.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Pou aksésibilité, `<{ $component }>` divèt ni roun deskripsyon kout oben divèt espesifyé kon dekoratif.
+
+accessibility-video-short-description = Pou aksésibilité, `<video>` divèt ni roun deskripsyon kout.
+
+accessibility-input-short-description-or-label = Pou aksésibilité, `<{ $component }>` divèt ni roun deskripsyon kout oben roun etikèt.
+
+accessibility-answer-input-short-description-or-label = Pou aksésibilité, roun `<answer>` ki ka kréyé roun antré divèt ni roun deskripsyon kout oben roun etikèt.
+
+accessibility-short-description-contains-math = Deskripsyon kout pa ta divèt ni konpozan matématik kon `<{ $component }>` annan yé. Eplé tout matématik épi mo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } pa ni asé kontras pou tèks tit seksyon-an (mòd fè nwè) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; li ka mandé omwen { $threshold }:1).
+       *[other] { $colorName } pa ni asé kontras pou tèks tit seksyon-an ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; li ka mandé omwen { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Yo pòkò enplimanté `<circle>` ki ka pasé an { $count } pwen annan ka-a koté pwen-an pa ni valè nimerik.
+
+circle-too-many-through-points = Pa pouvé kalkilé roun sèk ki ka pasé an plis ki 3 pwen.
+
+circle-overprescribed-radius-center-points = Pa pouvé kalkilé roun sèk ki ni reyon, sant é pwen espesifyé ansanm.
+
+circle-center-with-multiple-points = Pa pouvé kalkilé roun sèk ki ni roun sant espesifyé é ki ka pasé an plis ki 1 pwen.
+
+circle-radius-too-small = Pa pouvé kalkilé sèk-a: paske distans ant dé pwen-an sé { $distance }, reyon { $radius } ki espesifyé-a twòp piti.
+
+circle-radius-with-many-points = Pa pouvé kréyé roun sèk ki ka pasé an plis ki dé pwen épi roun reyon espesifyé.
+
+circle-invalid-center-or-through-points = Sant oben pwen sèk-a pa valab.
+
+circle-radius-center-with-multiple-points = Pa pouvé kalkilé reyon roun sèk ki ni roun sant espesifyé é ki ka pasé an plis ki 1 pwen.
+
+circle-change-radius-non-numerical = Pa pouvé chanjé reyon roun sèk ki ka pasé an pwen ki pa nimerik
+
+circle-radius-with-points-non-numerical = Pa pouvé kréyé roun sèk ki ka pasé an plis ki roun pwen épi roun reyon espesifyé lò valè nimerik-a pa la.
+
+circle-change-center-non-numerical = Yo pòkò enplimanté chanjman sant roun sèk ki ka pasé an pwen ki pa ni valè nimerik.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Guadeloupean has one,
+# because «entèval» and «antré» are invariant. Both selects are dropped and
+# both counts still arrive and are still formatted.
+function-domain-insufficient-dimensions = Dimansyon domèn fonksyon-an pa asé. Domèn-an ni { $intervals } entèval mé fonksyon-an ni { $inputs } antré.
+
+function-domain-invalid-format = Fòma domèn fonksyon-an pa valab.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Yo ka inyoré maksimòm fonksyon-an ki pa nimerik.
+        [minimum] Yo ka inyoré minimòm fonksyon-an ki pa nimerik.
+        [extremum] Yo ka inyoré ekstremòm fonksyon-an ki pa nimerik.
+        [point] Yo ka inyoré pwen fonksyon-an ki pa nimerik.
+        [slope] Yo ka inyoré pant fonksyon-an ki pa nimerik.
+       *[other] Yo ka inyoré { $type } fonksyon-an ki pa nimerik.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Yo ka inyoré maksimòm fonksyon-an ki vid.
+        [minimum] Yo ka inyoré minimòm fonksyon-an ki vid.
+        [extremum] Yo ka inyoré ekstremòm fonksyon-an ki vid.
+        [point] Yo ka inyoré pwen fonksyon-an ki vid.
+       *[other] Yo ka inyoré { $type } fonksyon-an ki vid.
+    }
+
+function-points-too-close = Fonksyon-an ni dé pwen ki twòp pré roun a lòt. Pa pouvé défini fonksyon-an.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasyon fonksyon posib sèlman si kantité antré a fonksyon-an égal kantité sòti a-y. Fonksyon-an ni { $inputs } antré é { $outputs } sòti.
+
+## `<sequence>`
+
+sequence-invalid-length = Longè sekans-a pa valab.  I divèt sé roun antyé ki pa negatif.
+
+sequence-invalid-step = Pa sekans-a pa valab.  I divèt sé roun nonm pou roun sekans tip { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" pa valab pou roun sekans nonm.  I divèt sé roun nonm.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" pa valab pou roun sekans lèt.  I divèt sé roun konbinezon lèt.
+
+sequence-invalid-endpoint = "{ $attribute }" pa valab pou sekans-a.
+
+select-from-sequence-coprime-not-numbers = yé ka inyoré coprime paske sé pa nonm yé ka chwazi
+
+select-from-sequence-coprime-with-exclude-combinations = yé ka inyoré coprime paske excludeCombinations espesifyé
+
+## Resolving a `target`
+
+target-not-found = target pa valab pou `<{ $source }>`: pa pouvé trouvé target-a.
+
+target-state-variable-not-found = target pa valab pou `<{ $source }>`: pa pouvé trouvé roun varyab déta ki rélé "{ $property }" asou roun `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Varyab `<odeSystem>` divèt diféran di varyab endepandan-an.
+
+ode-system-duplicate-variable-names = Pa pouvé défini fonksyon RHS ODE épi non varyab dépandan ki répété.
+
+ode-system-rhs-function-error = Pa pouvé défini fonksyon RHS ODE.  Erè annan kréyasyon fonksyon mathjs-a.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Pa pouvé défini roun ang ant { $count } liy
+
+angle-invalid-through-point = Pwen ki pa valab annan through roun `<angle>`
+
+parabola-vertex-too-many-points = Yo pòkò enplimanté roun parabòl ki ni roun somè é ki ka pasé an plis ki 1 pwen.
+
+parabola-too-many-points = Yo pòkò enplimanté roun parabòl ki ka pasé an plis ki 3 pwen.
+
+intersection-too-many-items = Yo pòkò enplimanté entèseksyon pou plis ki dé eleman
+
+## Other math components
+
+ionic-compound-not-two-ions = Yo pòkò enplimanté konpozé yonik pou dòt bagay ki dé yon.
+
+ionic-compound-needs-cation-and-anion = Konpozé yonik enplimanté sèlman pou roun katyon é roun anyon.
+
+solve-equations-cannot-evaluate = Pa pouvé rézoud ekwasyon-an paske yé pa pouvé evalyé-y: { $equation }
+
+math-operators-operand-number-required = Ou divèt espesifyé roun operandNumber lò to ka ekstrè roun operand matématik.
+
+eigen-decomposition-failed = Yo pa pouvé kalkilé valè pwòp a matris-a
+
+## `<matchesPattern>`
+
+# No select: the English branches differ only in the number of «paramèt», and
+# the sentence is turned impersonal so that neither a singular nor a plural
+# pronoun has to be chosen. The count still arrives.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramèt { $parameters } pa ka paret annan modèl-a, kidonk sa ké toujou koresponn épi roun blan.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: pa pouvé entèprété grid="{ $grid }". I divèt sé none, medium, dense, oben dé nonm pozitif separé pa roun espas, kon grid="1 0.5". Yo pa ka trasé pyès kadriyaj.
+
+## `<slopeField>` and `<vectorField>`
+
+# The `$expected` select is not a plural: the two branches are two different
+# sentences about two different components. `$found` is turned impersonal so
+# that no plural branch is needed for it.
+field-function-wrong-num-outputs =
+    `<{ $component }>` bizwen roun fonksyon ki ni { $expected ->
+        [one] roun sèl sòti, pant y' an chak pwen, kon `y - x`
+       *[other] dé sòti, vektè-a an chak pwen, kon `(y, -x)`
+    }, mé fonksyon yé bay la ni { $found } sòti. { $alternative ->
+        [none] Yo pa ka trasé arien.
+       *[other] `<{ $alternative }>` sé konpozan-an pou fonksyon-an. Yo pa ka trasé arien.
+    }
+
+field-function-attribute-ignored-with-child = Yo ka inyoré atribi `function` paske fonksyon-an bay annan konpozan-an tou; sé sila ki annan-an yé ka pran. Bay fonksyon-an yon sèl fason.
+
+field-variables-ignored =
+    `<{ $component }>`: atribi `variables` ka rélé varyab a roun ekspresyon ki ekri dirèkteman annan konpozan-an. { $reason ->
+        [function-child] Fonksyon-an la bay kon roun pitit `<function>`, ki ka rélé varyab a-y limenm, kidonk yé ka inyoré `variables`.
+       *[no-expression] Pa ni roun ekspresyon kon sa la, kidonk yé ka inyoré `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" pa sipòté annan randè prefigure-a; yé ka sèvi épi konpòtman pozisyon dwat-a.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" pa sipòté annan randè prefigure-a; yé ka sèvi épi konpòtman pozisyon anlè-a.
+
+prefigure-invalid-axis-bounds = `<graph>`: limit aks-a pa valab pou konvèsyon prefigure; yé ka sèvi épi bbox pa défo (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lajè-a pa valab pou konvèsyon prefigure; yé ka sèvi épi lajè dyagram pa défo 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio pa valab pou konvèsyon prefigure; yé ka sèvi épi rapò aspè pa défo 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: espasman kadriyaj-a twòp fen pou limit aks-a; yé ka kité kadriyaj-a déwò annan randè prefigure-a.
+
+prefigure-annotations-not-rendered = `<graph>`: yé pa ké rann anotasyon lò yé pa ka sèvi épi randè PreFigure-a.
+
+multiple-annotations-children = Yo trouvé plizyè pitit `<annotations>` annan `<graph>`; yé ka inyoré tout sof dènyé-a.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Pa pouvé pwolonjé oben kopyé roun tip konpozan yé pa ka rekonèt: { $type }.
+
+copy-prop-not-found = Yo pa pouvé trouvé prop { $property } asou roun konpozan tip { $component }
+
+collect-no-source = Yo pa trouvé pyès sous pou collect.
+
+collect-invalid-component-type = Pa pouvé kolekté konpozan tip `<{ $component }>` paske sé roun tip konpozan ki pa valab.
+
+reference-index-unavailable = Pa pouvé référé a endis `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Pa pouvé rélé { $action } asou konpozan `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Doné-a ni roun fòm ki pa valab.  Ranjé-a ni longè ki pa konsistan. Trouvé annan componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Doné-a ni non kolòn ki répété.  Trouvé annan componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Doné-a ka manké roun non kolòn.  Trouvé annan componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Roun award pou répons-a basé asou répons a tag répons-a limenm voyé, é sa ké mennen annan roun konpòtman to pa té ka atann.
+
+answer-max-num-attempts-in-section-wide-check-work = Mèt `maxNumAttempts` asou roun `<answer>` annan roun kontenè ki ni `sectionWideCheckWork` pa ka fè arien, paske sé kontenè-a ki ka kontrolé kantité ésè. Mèt `maxNumAttempts` asou kontenè-a pito.
+
+nested-section-wide-check-work-max-num-attempts = Mèt `maxNumAttempts` asou roun kontenè ki ni `sectionWideCheckWork` é ki annan roun dòt kontenè ki ni `sectionWideCheckWork` pa ka fè arien, paske sé kontenè déwò-a ki ka kontrolé kantité ésè. Mèt `maxNumAttempts` asou kontenè déwò-a pito.
+
+# No select: «atribi» is invariant and «pa ké fè arien» agrees with nothing.
+answer-attributes-need-symbolic-equality = Atribi { $attributes } pa ké fè arien san symbolicEquality mété.
+
+answer-invalid-type = Tip pa valab pou répons-a: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Paske konpozan `<{ $component }>` pa ni roun non, yé pa pouvé sèvi épi-y pou roun atribi module
+
+module-attribute-name-already-defined = Yo pa pouvé sèvi épi konpozan `<{ $component } name="{ $name }">` kon roun atribi pou roun module paske tip konpozan `<module>` ni roun atribi "{ $name }" ki ja défini.
+
+conditional-content-condition-ignored = Yo ka inyoré atribi `condition` asou roun konpozan `<conditionalContent>` ki ni pitit case oben else.
+
+slider-markers-type-mismatch = Tip makè-a pa ka koresponn épi tip slider-a.
+
+pretzel-problem-needs-statement-and-answer = pretzel pa valab: chak `<problem>` divèt ni roun `<statement>` é roun `<answer>`.
+
+pretzel-circuit-first-problem-distractor = pretzel pa valab: an mode="circuit", prèmyé `<problem>`-la pa pouvé sé roun distraktè.
+
+## Attribute values
+
+# No select: «valè» is invariant, and «yé ka inyoré sa» is impersonal, so one
+# string covers both English categories. The count still arrives.
+attribute-invalid-values = Valè { $values } pa valab pou atribi `{ $attribute }`; yé ka inyoré sa.
+
+attribute-must-be-references = Valè `{ $value }` pa valab pou atribi `{ $attribute }`. Atribi-a divèt fòmé épi référans ki ka koumansé épi roun `$`.
+
+math-input-invalid-function-names = <mathInput>: yé ka inyoré non fonksyon ki pa valab annan { $attribute }: { $names }. Segman afichaj a chak non divèt ni omwen 2 karaktè (lèt oben tirè); roun sifiks `|<mathspeak alternative>` opsyonèl pouvé swiv.
+
+## Building components from the source
+
+component-type-invalid = Tip konpozan ki pa valab: `<{ $componentType }>`
+
+attribute-repeated = Pa pouvé répété atribi { $attribute }.
+
+attribute-invalid-for-component = Atribi "{ $attribute }" pa valab pou roun konpozan tip `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Définisyon stil { $styleNumber } pa ni asé kontras pou { $context ->
+        [text-on-background] koulè tèks kont koulè fon
+        [high-contrast] koulè gwo kontras kont kanva-a
+        [line] koulè liy kont kanva-a
+        [marker] koulè makè kont kanva-a
+       *[text-on-canvas] koulè tèks kont kanva-a
+    }{ $mode ->
+        [dark] { " (mòd fè nwè)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; li ka mandé omwen { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Kwak définisyon stil { $styleNumber } espesifyé koulè ki ka bay asé kontras pou mòd klè, koulè mòd fè nwè-a ki sòti annan valè-a pa ni asé kontras pou koulè tèks kont koulè fon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; li ka mandé omwen { $threshold }:1). { $suggestion ->
+        [available] Pou asiré asé kontras an mòd fè nwè, to pouvé ogmanté kontras mòd klè-a (pa egzanp, mèt { $lightAttribute }="{ $lightColor }") oben ranplasé koulè mòd fè nwè-a (pa egzanp, mèt { $darkAttribute }="{ $darkColor }").
+       *[none] Pou asiré asé kontras an mòd fè nwè, ogmanté kontras mòd klè-a oben ranplasé koulè ki sòti-a épi textColorDarkMode é/oben backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Kwak définisyon stil { $styleNumber } espesifyé roun koulè tèks ki ka bay asé kontras pou mòd klè, koulè tèks mòd fè nwè-a ki sòti annan valè-a pa ni asé kontras kont kanva-a ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; li ka mandé omwen { $threshold }:1). { $suggestion ->
+        [available] Pou asiré asé kontras an mòd fè nwè, to pouvé ogmanté kontras mòd klè-a (pa egzanp, mèt textColor="{ $lightColor }") oben ranplasé koulè mòd fè nwè-a (pa egzanp, mèt textColorDarkMode="{ $darkColor }").
+       *[none] Pou asiré asé kontras an mòd fè nwè, ogmanté kontras mòd klè-a oben ranplasé koulè ki sòti-a épi textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Roun seksyon pouvé chwazi yon sèl <stylePalette>; yé ka sèvi épi dènyé-a.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = pa pouvé détèrminé varyant inik a { $component } paske numToSelect pa roun antyé ki pa negatif.
+
+variant-num-to-select-not-constant-number = pa pouvé détèrminé varyant inik a { $component } paske numToSelect pa roun nonm konstan.
+
+variant-with-replacement-not-constant-boolean = pa pouvé détèrminé varyant inik a { $component } paske withReplacement pa roun boulean konstan.
+
+variant-select-weight-disables-unique = Varyant inik pou select dezaktivé si ni roun opsyon ki ni selectWeight oben selectForVariants espesifyé
+
+variant-coprime-undetermined = pa pouvé détèrminé varyant inik a { $component } paske yé pa pouvé détèrminé si coprime toujou fo.
+
+variant-attribute-not-constant = pa pouvé détèrminé varyant inik a { $component } paske { $attribute } pa roun konstan.
+
+variant-attribute-not-number = pa pouvé détèrminé varyant inik a { $component } paske { $attribute } pa roun nonm.
+
+variant-attribute-wrong-type-for-sequence =
+    pa pouvé détèrminé varyant inik a { $component } tip { $type } paske { $attribute } pa { $expected ->
+        [letters-combination] roun konbinezon lèt
+        [math-expression] roun ekspresyon matématik valab
+        [integer] roun antyé
+       *[number] roun nonm
+    }.
+
+variant-length-not-integer = pa pouvé détèrminé varyant inik a { $component } paske length pa roun antyé.
+
+variant-sort-not-implemented = yé pòkò enplimanté varyant inik a roun { $component } épi sort
+
+variant-exclude-combinations-not-implemented = yé pòkò enplimanté varyant inik a roun { $component } épi excludeCombinations
+
+variant-math-exclude-not-implemented = yé pòkò enplimanté varyant inik a roun { $component } tip math épi exclude
+
+variant-non-constant-exclude-not-implemented = yé pòkò enplimanté varyant inik a roun { $component } épi roun exclude ki pa konstan
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: pa sipòté annan randè prefigure a graph-a; yé ka soté désandan-an.
+
+prefigure-descendant-invalid-geometry = { $subject }: jeyometri ki pa fini oben ki pa konplèt; yé ka soté désandan-an.
+
+prefigure-curve-label-omitted = { $subject }: yé pa ka sipòté etikèt asou eleman koub ki konvèti; yé ka kité etikèt-a déwò.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tip definisyon fonksyon koub '{ $definitionType }' pa sipòté; yé ka soté désandan-an.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribi flipFunctions pa sipòté asou regionBetweenCurves; yé ka soté désandan-an.
+
+prefigure-region-non-formula-child = { $subject }: sé sèlman pitit fonksyon tip fòmil yé ka sipòté asou regionBetweenCurves; yé ka soté désandan-an.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' pa sipòté pou { $labelKind ->
+        [line-family] roun etikèt fanmi liy
+       *[point] roun etikèt pwen
+    }; yé ka sèvi épi aliyman PreFigure pa défo.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure pa ka sipòté stil ranpli '{ $fillStyle }'; yé ka tonbé asou roun ranpli plen.
+
+prefigure-line-style-unknown = { $subject }: stil liy '{ $lineStyle }' yé pa konnèt kité déwò annan sòti PreFigure-a.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: stil makè '{ $markerStyle }' ka koresponn épi stil PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure pa ka sipòté stil makè '{ $markerStyle }'; yé ka sèvi épi stil pa défo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` pa valab; pa pouvé rézoud sib-a. Yo ka kité anotasyon-an déwò.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` rézoud asou plizyè sib; yé ka sèvi épi prèmyé sib-a.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` pa valab; sib-a déwò graph ki ka kontni-y la. Yo ka kité anotasyon-an déwò.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` pa valab; sib-a pa roun objè grafik ki sipòté annan konvèsyon prefigure. Yo ka kité anotasyon-an déwò.
+
+annotation-text-missing = `<annotation>`: `text` ka manké oben vid; yé ka bay roun tèks vid.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Yo détekté roun dépandans sikilè.
+       *[other] Yo détekté roun dépandans sikilè ki ka enplitjé roun konpozan `<{ $componentType }>`.
+    }
+
+reference-no-referent = Yo pa trouvé pyès référan pou référans-a: `{ $reference }`
+
+reference-multiple-referents = Yo trouvé plizyè référan pou référans-a: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fòma pa valab pou atribi { $attribute } a roun `<{ $componentType }>`.
+
+children-invalid = Pitit ki pa valab pou `<{ $componentType }>`: Yo trouvé pitit ki pa valab: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Valè `{ $value }` pa valab pou atribi `{ $attribute }`, yé ka sèvi épi valè `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Yo pa trouvé vèsyon DoenetML { $version }.
+       *[other] Yo pa trouvé vèsyon DoenetML { $version }. Yo ka tonbé asou vèsyon { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ki pa valab: { $content }
+
+parse-tag-missing-close-tag = DoenetML ki pa valab: Tag `{ $tag }` pa ni tag fèmti. Yo té ka atann roun tag ki ka fèmé tèt a-y oben roun tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ki pa valab: Erè annan tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ki pa valab: Atribi `{ $attribute }` ki pa valab ka sanb ka manké roun valè.
+
+parse-attribute-invalid = DoenetML ki pa valab: Atribi `{ $attribute }` pa valab
+
+parse-attribute-value-invalid = DoenetML ki pa valab: Valè atribi `{ $value }` pa valab
+
+parse-attribute-value-quote-mismatch = DoenetML ki pa valab: Valè atribi `{ $value }` pa valab. Gimè-a pa ka koresponn. I ka sanb to ka manké roun `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML ki pa valab: Yo trouvé roun tag san non tag, pa egzanp `<`
+
+parse-tag-not-closed = DoenetML ki pa valab: Tag `{ $tag }` pa té fèmé (li ka sanb roun `>` ka manké).
+
+parse-self-closing-tag-name-missing = DoenetML ki pa valab: Yo trouvé roun tag san non tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ki pa valab: Tag `{ $tag }` pa té fèmé (li ka sanb `/>` ka manké).
+
+parse-tag-invalid-attributes = DoenetML ki pa valab: Tag `{ $tag }` pa valab. I pouvé ni atribi ki pa kòrèk.
+
+parse-close-tag-name-missing = DoenetML ki pa valab: Yo trouvé roun tag fèmti san non tag, pa egzanp `</`
+
+parse-attribute-value-unquoted = Valè atribi divèt annan gimè: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ki pa valab: Yo trouvé tag fèmti `{ $tag }`, mé pa ni tag ouvèti ki ka koresponn
+
+parse-close-tag-mismatched = DoenetML ki pa valab: Tag fèmti pa ka koresponn. Yo té ka atann `</{ $expected }>`. Yo trouvé `{ $found }`
+
+parser-node-unconvertible = Yo pa pouvé konvèti nœud { $node } an nœud Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribi name='{ $name }' pa valab. { $reason ->
+        [characters] Non pouvé ni sèlman lèt, chif, tirè anba oben tirè.
+       *[start] Non divèt koumansé épi roun lèt.
+    }
+
+component-name-invalid-start = Non konpozan "{ $name }" pa valab. Non divèt koumansé épi roun lèt.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Roun répons tip videoWatched divèt ni roun atribi video
+
+answer-video-watched-video-not-reference = Roun répons tip videoWatched divèt ni roun atribi video ki sé roun référans
+
+answer-name-not-single-text = Atribi name a roun répons divèt ni yon sèl pitit tèks
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Yo pa pouvé jwenn DoenetML déwò-a paske ni twòp nivo rekisyon. Es ni roun référans sikilè?
+
+external-doenetml-unavailable = Yo pa pouvé jwenn DoenetML annan { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ki pa valab jwenn annan { $attribute }="{ $uri }": li pa té ka koresponn épi tip konpozan "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribi `{ $from }` démodé; sèvi épi `{ $to }` pito.
+       *[other] [deprecation] Atribi `{ $from }` asou `<{ $component }>` démodé; sèvi épi `{ $to }` pito.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribi `{ $from }` démodé é yé ka inyoré-y paske `{ $to }` espesifyé tou.
+       *[other] [deprecation] Atribi `{ $from }` asou `<{ $component }>` démodé é yé ka inyoré-y paske `{ $to }` espesifyé tou.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribi `{ $attribute }` asou `<{ $component }>` démodé é yé ka inyoré-y.
+
+deprecated-attribute-to-child = [deprecation] Atribi `{ $attribute }` asou `<{ $component }>` démodé; sèvi épi roun pitit `<{ $child }>` pito.
+
+deprecated-attribute-value-renamed = [deprecation] Valè `{ $value }` a atribi `{ $attribute }` asou `<{ $component }>` démodé; sèvi épi `{ $to }` pito.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` pouvé mèt sèlman anglé an pliryèl, kidonk tèks a-y ka rété kon li yé annan roun dokiman ki ekri an { $locale }. Ekri fòm pliryèl-a dirèkteman, oben mèt li épi atribi `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Eleman `<{ $tag }>` pa roun eleman Doenet yé ka rekonèt.
+
+schema-element-not-allowed-at-root = Eleman `<{ $tag }>` pa pèmèt an rasin dokiman-an.
+
+schema-element-not-allowed-inside = Eleman `<{ $tag }>` pa pèmèt annan `<{ $parent }>`.
+
+schema-attribute-unrecognized = Eleman `<{ $tag }>` pa ni roun atribi ki rélé `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribi `{ $attribute }` a eleman `<{ $tag }>` divèt sé roun lis koté chak atik sé roun annan: { $allowed }
+       *[other] Atribi `{ $attribute }` a eleman `<{ $tag }>` divèt sé roun annan: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Non varyant pa valab pou select.  Non varyant { $variantName } ka paret annan { $numOptions } opsyon mé kantité pou chwazi sé { $numToSelect }.
+
+select-variant-name-without-options = Kèk varyant espesifyé pou select mé pa ni pyès opsyon espesifyé pou non varyant posib: { $variantName }.
+
+select-variant-name-not-possible = Non varyant { $variantName } ki espesifyé pou select pa roun non varyant posib.
+
+select-too-few-options = Pa pouvé chwazi { $numToSelect } konpozan annan sèlman { $numOptions }.
+
+select-from-sequence-too-few-values = Pa pouvé chwazi { $numToSelect } valè annan roun sekans longè { $length }.
+
+select-from-sequence-indices-count-mismatch = Kantité endis espesifyé pou select divèt koresponn épi kantité pou chwazi
+
+select-from-sequence-indices-not-integers = Tout endis espesifyé pou select divèt sé antyé
+
+select-from-sequence-index-excluded = Endis selectfromsequence ki espesifyé-a té eskli
+
+select-from-sequence-indices-excluded-combination = Endis selectfromsequence ki espesifyé-a té roun konbinezon eskli
+
+select-from-sequence-coprime-not-positive-integers = Pa pouvé chwazi konbinezon koprim paske sé pa antyé pozitif yé ka chwazi.
+
+select-from-sequence-coprime-common-factor = Pa pouvé chwazi nonm koprim. Tout valè posib-a ka pataj roun faktè komen. (Valè "from" oben "to" ki espesifyé divèt koprim épi "step".)
+
+select-from-sequence-coprime-single-number = Pa pouvé chwazi konbinezon koprim annan yon sèl nonm ki pa 1.
+
+select-from-sequence-excluded-too-many-combinations = Plis ki 70% a konbinezon-an eskli annan selectFromSequence
+
+select-from-sequence-coprime-none-found = Yo pa pouvé chwazi nonm koprim. Tout valè posib-a ka pataj roun faktè komen.
+
+select-from-sequence-too-few-unique-values = Pa pouvé chwazi { $numToSelect } valè inik annan roun sekans longè { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Pa pouvé chwazi { $numToSelect } valè annan roun lis nonm prèmyé longè { $numValues }
+
+select-prime-numbers-values-count-mismatch = Kantité valè espesifyé pou select divèt koresponn épi kantité pou chwazi
+
+select-prime-numbers-values-not-prime = Tout valè espesifyé pou select nonm prèmyé divèt annan lis nonm prèmyé-a
+
+select-prime-numbers-values-excluded-combination = Valè selectPrimeNumbers ki espesifyé-a té roun konbinezon eskli
+
+select-prime-numbers-excluded-too-many-combinations = Plis ki 70% a konbinezon-an eskli annan selectPrimeNumbers
+
+select-random-combination-fluke = Pa roun chans estrèmman ra, yé pa pouvé chwazi roun konbinezon valè o aza
+
+select-random-value-fluke = Pa roun chans estrèmman ra, yé pa pouvé chwazi roun valè o aza
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` pa trasé annan matématik-a; ekspresyon-an konpozé kon li té ye avan yé té pouvé mèt antré annan-y. { $reason ->
+        [not-inline] Sé sèlman roun choice input `inline` ki ka rantré annan roun ekspresyon; san `inline` li sé roun blòk bouton.
+        [expanded] Roun text input `expanded` sé roun bwèt plizyè liy, ki twòp gwo pou chita annan roun ekspresyon.
+        [on-graph] Asou roun graph ekspresyon-an trasé kon yon sèl imaj, ki pa ni plas pou roun kontwòl.
+       *[relative-width] `width` a-y relatif (roun pousantaj oben `em`), ki pa ni arien pou mizuré kont annan roun ekspresyon. Bay lajè-a an inité absoli, kon `px`, pito.
+    }

--- a/packages/i18n/locales/gcr/editor.ftl
+++ b/packages/i18n/locales/gcr/editor.ftl
@@ -1,0 +1,236 @@
+# Guianese Creole French (kriyòl gwiyanè) editor and language-server surfaces.
+# Translated from `locales/en/editor.ftl`, which is the source of truth:
+# `lint:i18n` rejects a key that does not exist there, and reports a key that
+# exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The orthography of French Guiana, as `chrome.ftl` sets it
+# out. It is written on the same principles as the Antillean standards; the
+# pronoun set «mo to li nou zòt yé», the indefinite «roun» and the single
+# postposed definite «-a» / «-an» are what part it from them. The
+# French-etymological spelling is not mixed in.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# **Number.** No `[one]`/`[other]` select appears anywhere in this file.
+# Guianese nouns do not inflect for number, so «vyolasyon» and
+# «rékòmandasyon» are the same word in both English branches; the select is
+# dropped and the count still arrives and is still formatted.
+# `Intl.PluralRules` has no CLDR data for `gcr` either. `help-coordinates` is
+# one unselected form for the same reason.
+#
+# **Loans.** French, respelled: «varyant», «filtré», «aksésibilité»,
+# «vyolasyon», «rékòmandasyon», «rapò», «vèsyon», «kontèks», «erè»,
+# «avètisman», «enfo», «dyagnostik», «anotasyon», «opsyon», «fòmaté»,
+# «référans», «référan», «dokimantasyon», «atribi», «konpozan»,
+# «pwopriyété», «kòdoné», «valè», «stil», «tip», «idantifyan». One English
+# loan: «tag», the markup word, which arrives through the language itself. The
+# frame around them is creole: «ka» for the progressive, «pa» for negation,
+# «pa pouvé» for *cannot*, «yé» for the impersonal subject, «to» for the
+# reader the imperatives address, and the postposed determiner («rapò-a»,
+# «editè-a»).
+#
+# **Confidence.** This is the file with the least support behind it: there is
+# almost no written Guianese computing register, and «tibout kòd» for
+# *snippet*, «antré tablo» for *array entry* and «randè» in the sibling files
+# are proposals rather than attested terms. A reviewer should read those three
+# first.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Rimèt a zéro
+       *[update] Mèt ajou
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } vizyonè-a
+       *[other] { $word } vizyonè-a { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varyant
+editor-variant-filter = Filtré…
+editor-variant-next = Chwazi varyant ki ka vin apré
+editor-variant-previous = Chwazi varyant ki ka vin avan
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Yo trouvé roun vyolasyon aksésibilité WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-a.
+        [advisories] Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-a. Yo pa trouvé pyès vyolasyon WCAG AA, mé ni dòt rékòmandasyon aksésibilité ki disponib.
+       *[clean] Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-a. Yo pa trouvé pyès pwoblèm aksésibilité.
+    }
+
+# No select on `$count` inside the branches: «vyolasyon» and «rékòmandasyon»
+# are the same word for one and for many, so the two categories would render
+# the same string. The count still arrives and is still formatted.
+editor-accessibility-label =
+    { $status ->
+        [violations] Yo trouvé roun vyolasyon aksésibilité WCAG AA. Yo trouvé { $count } vyolasyon WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-a.
+        [advisories] Yo pa trouvé pyès vyolasyon WCAG AA. Yo trouvé { $count } dòt rékòmandasyon aksésibilité. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-a.
+       *[clean] Yo pa trouvé pyès vyolasyon WCAG AA. Kliké pou { $action ->
+            [close] fèmé
+           *[open] ouvè
+        } rapò aksésibilité-a.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Vèsyon DoenetML { $version }
+
+editor-tab-help = Èd ki ka dépann di kontèks
+editor-tab-help-short = Kontèks
+editor-tab-errors = Erè
+editor-tab-warnings = Avètisman
+editor-tab-info = Enfo
+editor-tab-accessibility = Aksésibilité
+editor-tab-responses = Répons ki voyé
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsyon editè-a
+editor-format-as-doenetml = Fòmaté kon DoenetML
+editor-format-as-xml = Fòmaté kon XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liy #{ $line }
+
+editor-no-errors = Pa ni erè
+editor-no-warnings = Pa ni avètisman
+editor-no-info = Pa ni dyagnostik enfòmatif
+
+editor-show-info-annotations = Montré dyagnostik enfòmatif annan editè-a
+editor-show-accessibility-annotations = Montré dyagnostik aksésibilité annan editè-a
+
+editor-accessibility-learn-more = Aprann ki jan Doenet ka trété aksésibilité
+
+editor-accessibility-violations-heading = Vyolasyon aksésibilité ({ $standard })
+
+editor-accessibility-other-heading = Dòt pwoblèm aksésibilité
+editor-none-found = Yo pa trouvé arien
+
+
+## Submitted responses
+
+editor-no-responses = Pòkò ni répons ki voyé
+editor-response-answer-id = Idantifyan répons
+editor-response-response = Répons
+editor-response-credit = Kredi
+editor-response-submitted = Voyé
+
+
+## The context-help panel
+
+help-placeholder = Mèt kisò-a asou roun non tag, roun atribi, oben { $ref } pou dokimantasyon.
+
+help-unsupported-ref-chain = Èd pou référans an plizyè moso kon { $example } pòkò disponib.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Yo pa trouvé pyès référan pou référans-a: { $ref }.
+        [multiple] Yo trouvé plizyè référan pou référans-a: { $ref }.
+       *[indeterminate] Yo pa pouvé détèrminé roun référan pou { $ref }.
+    }
+
+help-learn-about-references = Aprann asou référans →
+help-reference-page = Paj référans →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Annan { $element }
+       *[top] Asou nivo pli wo-a
+    }{ $allowed ->
+        [none] { " — arien pa ka rantré la." }
+        [text] { " — tapé tèks la." }
+        [text-and-components] { " — tapé tèks la, oben eséyé:" }
+       *[components] { " — bagay pou eséyé:" }
+    }
+
+help-suggestions-footer = Pésé { $shortcut } pou wè tout { $total } konpozan-an.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } sé roun référans ba { $target }.
+       *[other] { $ref } sé roun référans ba { $target } (liy { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Entrodwi pa { $owner } kon { $role }.
+       *[other] Entrodwi pa { $owner } an liy { $line } kon { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } sé roun référans ba pwopriyété { $property } a konpozan { $element }.
+       *[other] { $ref } sé roun référans ba pwopriyété { $property } a konpozan { $element } (liy { $line }).
+    }
+
+help-kind-attribute = atribi
+help-kind-snippet = tibout kòd
+help-kind-array-entry = antré tablo
+
+help-default = Valè pa défo:
+help-active-default = Valè pa défo aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valè ki pèmèt (roun pa atik):
+       *[other] Valè ki pèmèt:
+    }
+
+help-suggested-values = Valè ki sijéré:
+
+help-inserts = Ka mèt:
+
+# No select: «kòdoné» is the same word for one and for many, so both
+# categories would render the same string.
+help-coordinates = Kòdoné:
+
+help-type = Tip:
+
+help-resolved-style = Stil ki rézoud (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Non fonksyon ki rézoud:
+help-reset-list = Lis rimiz a zéro asou antré-a:
+help-added-on-input = Ajouté asou antré-a:
+help-removed-on-input = Òté asou antré-a:
+
+help-reset-overrides = { $reset } ka pran plas { $additional } é { $removed }.

--- a/packages/i18n/locales/iu/chrome.ftl
+++ b/packages/i18n/locales/iu/chrome.ftl
@@ -1,0 +1,165 @@
+# Inuktitut (ᐃᓄᒃᑎᑐᑦ) viewer chrome. Translated from `locales/en/chrome.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** **Canadian Aboriginal syllabics** (Unicode U+1400–U+167F),
+# the script of Nunavut and the one the territory legislates, schools and
+# broadcasts in. The **Latin qaliujaaqpait orthography** — the one Inuinnaqtun
+# is written in, and the one many Nunavik documents use — **is not mixed into
+# these four files anywhere**; no Inuktitut word below is spelled in roman
+# letters. The Latin that does appear is either DoenetML source — element
+# names, attribute names, anything quoted back from the author — or an
+# English technical loan, which the paragraph on loans below sets out.
+#
+# The series used here are the fifteen of the Nunavut standard: ᐊᐃᐅ, ᐸᐱᐳ,
+# ᑕᑎᑐ, ᑲᑭᑯ, ᒐᒋᒍ, ᒪᒥᒧ, ᓇᓂᓄ, ᓴᓯᓱ, ᓚᓕᓗ, ᔭᔨᔪ, ᕙᕕᕗ, ᕋᕆᕈ, ᖃᕿᖁ, ᖓᖏᖑ, ᕼ.
+# Two things a reviewer should check by codepoint rather than by eye:
+#
+#   * **ᙱ (U+1671, NNGI) and ᙵ (U+1675, NNGA)** are the doubled *nng*, and
+#     they are distinct from ᖏ (U+158F) and ᖓ (U+1593). This catalog writes
+#     «ᓈᒻᒪᙱᑦᑐᖅ» with U+1671, because that is the word — a negative in *-nngit-*
+#     — and not U+158F.
+#   * **ᕼ (U+157C, NUNAVUT H)** is the Inuktitut *h*. It is **not** ᐦ
+#     (U+1426), which is the Cree final *h* and belongs in `locales/cr`, and
+#     not ᕻ (U+157B), which is the Nunavik final. Nothing below uses U+1426.
+#
+# The finals used are ᑉ ᑦ ᒃ ᒡ ᒻ ᓐ ᔅ ᓪ ᔾ ᕝ ᕐ ᖅ ᖕ.
+#
+# **Number, and the dual.** `Intl.PluralRules("iu")` selects **one**, **two**
+# and **other**, and the `two` is not decoration: Inuktitut has a real
+# **dual**, a separate number between the singular and the plural, marked by
+# its own ending — «ᐆᒃᑐᕐᓂᒃᓴᖅ» one attempt, «ᐆᒃᑐᕐᓂᒃᓵᒃ» two, «ᐆᒃᑐᕐᓂᒃᓴᐃᑦ»
+# three or more. So **every message that selects on a count writes all three
+# branches**, and the `[two]` branch is a different word from the other two
+# rather than a copy of the plural. This is the only catalog in its batch with
+# a dual, and getting the dual endings right is the single most useful thing a
+# speaker could correct here. English's explicit `[0]` literal matches the
+# number itself and is kept.
+#
+# **Suffixes and placeables.** Inuktitut marks case with an ending, and an
+# ending cannot be welded onto `{ $choice }` or `{ $startLine }`, whose final
+# sound this catalog never sees. No `{ $x }`-ᒥ appears anywhere in these four
+# files; the sentence is built around the argument with separate words.
+#
+# **Loans, and one coinage named as one.** Where Inuktitut has no settled word
+# and no settled syllabic transliteration — *row*, *column*, *box*,
+# *interval* on the matrix, orbital and subset controls — the English word is
+# written **in roman letters inside a syllabic sentence**, with the verb
+# around it in Inuktitut: «row ᐃᓚᒋᐊᕐᓗᒍ». That is the `locales/sgh` decision,
+# and it is preferred to inventing a syllabic spelling a reader would have to
+# undo.
+#
+# `diagnostic-heading-warning` is the one **coinage** in these four files and
+# is flagged as one: «ᐅᔾᔨᖅᓱᖁᔨᔾᔪᑦ» is transparently built (*be careful* + the
+# instrument-of-asking ending) but is not an attested term, and it labels
+# every warning in the editor. A reviewer should check it first.
+
+## Answer submission
+
+answer-checking = ᖃᐅᔨᓴᖅᑐᖅ...
+answer-submitting = ᐊᐅᓪᓚᖅᑎᑕᐅᔪᖅ...
+answer-checking-status = ᑭᐅᔾᔪᑎ ᖃᐅᔨᓴᖅᑕᐅᔪᖅ
+answer-submitting-status = ᑭᐅᔾᔪᑎ ᐊᐅᓪᓚᖅᑎᑕᐅᔪᖅ
+answer-correct = ᓈᒻᒪᒃᑐᖅ
+answer-incorrect = ᓈᒻᒪᙱᑦᑐᖅ
+answer-response-saved = ᑭᐅᔾᔪᑎ ᑐᖅᑯᖅᑕᐅᔪᖅ
+answer-percent-credit = { $percent }% ᐱᔭᒃᓴᖅ
+answer-percent-correct = { $percent }% ᓈᒻᒪᒃᑐᖅ
+answer-percent-short = { $percent } %
+max-credit-available = ᐊᖏᓛᖅ ᐱᔭᒃᓴᖅ: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] ᐆᒃᑐᕐᓂᒃᓴᖃᙱᑦᑐᖅ
+        [one] ᓱᓕ ᐆᒃᑐᕐᓂᒃᓴᖅ { $count }
+        [two] ᓱᓕ ᐆᒃᑐᕐᓂᒃᓵᒃ { $count }
+       *[other] ᓱᓕ ᐆᒃᑐᕐᓂᒃᓴᐃᑦ { $count }
+    }
+validation-correct = (ᓈᒻᒪᒃᑐᖅ)
+validation-incorrect = (ᓈᒻᒪᙱᑦᑐᖅ)
+validation-partially-correct = (ᐃᓚᖓᒍᑦ ᓈᒻᒪᒃᑐᖅ)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } ᑭᐅᔾᔪᑎᖓ { $count } ᑕᑯᒃᓴᐅᑎᑦᑎᒋᑦ
+        [two] { $answerId } ᑭᐅᔾᔪᑏᒃ { $count } ᑕᑯᒃᓴᐅᑎᑦᑎᒋᑦ
+       *[other] { $answerId } ᑭᐅᔾᔪᑏᑦ { $count } ᑕᑯᒃᓴᐅᑎᑦᑎᒋᑦ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = ᐅᖃᐅᓯᒃᓴᑦ
+collapsible-click-to-open = (ᐅᒃᑯᐃᕐᓗᒍ ᓇᕿᓪᓗᒍ)
+collapsible-click-to-close = (ᒪᑐᓗᒍ ᓇᕿᓪᓗᒍ)
+collapsible-initializing = ᐱᒋᐊᖅᑐᖅ...
+footnote-show = ᐊᑖᓂ ᑎᑎᖅᑲᖅ ᑕᑯᒃᓴᐅᑎᑦᑎᒋᑦ
+footnote-hide = ᐊᑖᓂ ᑎᑎᖅᑲᖅ ᒪᑐᒍ
+description-more-information = ᐊᓯᖏᑦ ᑐᑭᓯᒋᐊᕈᑏᑦ
+
+
+## Controls
+
+slider-previous = ᓯᕗᓪᓕᖅ
+slider-next = ᑭᖑᓪᓕᖅ
+keyboard-open = ᓇᕿᑦᑕᐅᑏᑦ ᐅᒃᑯᐃᕐᓗᒋᑦ
+keyboard-close = ᓇᕿᑦᑕᐅᑏᑦ ᒪᑐᓗᒋᑦ
+choice-input-remove-choice = { $choice } ᐲᔭᕐᓗᒍ
+matrix-remove-row = row ᐲᔭᕐᓗᒍ
+matrix-add-row = row ᐃᓚᒋᐊᕐᓗᒍ
+matrix-remove-column = column ᐲᔭᕐᓗᒍ
+matrix-add-column = column ᐃᓚᒋᐊᕐᓗᒍ
+subset-add-remove-points = ᐃᓚᒋᐊᕐᓗᒋᑦ ᐲᔭᕐᓗᒋᓪᓘᓐᓃᑦ
+subset-toggle-points-intervals = interval-ᖏᓐᓄᑦ ᐊᓯᔾᔨᕐᓗᒋᑦ
+subset-move-points = ᓅᑦᑎᕐᓗᒋᑦ
+subset-clear = ᐲᔭᐃᓗᑎᑦ
+orbital-add-row = row ᐃᓚᒋᐊᕐᓗᒍ
+orbital-remove-row = row ᐲᔭᕐᓗᒍ
+orbital-add-box = box ᐃᓚᒋᐊᕐᓗᒍ
+orbital-remove-box = box ᐲᔭᕐᓗᒍ
+orbital-add-up-arrow = ᖁᒻᒧᐊᖅᑐᖅ ᐃᓚᒋᐊᕐᓗᒍ
+orbital-add-down-arrow = ᐊᑦᑑᒃᑐᖅ ᐃᓚᒋᐊᕐᓗᒍ
+orbital-remove-arrow = ᐲᔭᕐᓗᒍ
+orbital-row-label = row { $row }-ᒧᑦ ᐊᑎᖓ
+pretzel-answer = ᑭᐅᔾᔪᑎ
+summary-statistics-caption = { $column } ᒥᒃᓵᓄᑦ ᑭᓯᑦᓯᐅᑏᑦ
+
+
+## Math input
+
+math-input-preview-region = ᓈᓴᐅᓯᕆᓂᖅ ᑕᑯᒃᓴᐅᑎᑕᐅᔪᖅ
+math-input-preview = ᑕᑯᒃᓴᐅᑎᑕᐅᔪᖅ
+math-input-invalid-expression = ᓈᓴᐅᓯᕆᓂᖅ ᑕᒻᒪᖅᓯᒪᔪᖅ:
+
+
+## Document status
+
+viewer-initializing = ᐱᒋᐊᖅᑐᖅ...
+
+
+## Errors
+
+error-heading = ᑕᒻᒪᕐᓂᖅ
+error-found-at =
+    { $span ->
+        [line] ᓇᓂᔭᐅᔪᖅ ᑎᑎᕋᖅᓯᒪᔪᒥ { $startLine }.
+       *[lines] ᓇᓂᔭᐅᔪᖅ ᑎᑎᕋᖅᓯᒪᔪᓂ { $startLine }–{ $endLine }.
+    }
+document-contains-errors = ᑖᓐᓇ ᑎᑎᖅᑲᖅ ᑕᒻᒪᕐᓂᖃᖅᑐᖅ!
+diagnostic-heading-error = ᑕᒻᒪᕐᓂᖅ
+diagnostic-heading-warning = ᐅᔾᔨᖅᓱᖁᔨᔾᔪᑦ
+diagnostic-heading-information = ᑐᑭᓯᒋᐊᕈᑏᑦ
+diagnostic-heading-hint = ᐃᑲᔫᑦ
+accessibility-heading-level-1 = WCAG AA ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᒪᓕᒃᑕᐅᙱᑦᑐᖅ
+accessibility-heading-level-2 = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᑐᑭᓯᒋᐊᕈᑦ
+something-went-wrong = ᑕᒻᒪᖅᓯᒪᔪᖅ.
+renderer-load-failed = ᑕᑯᒃᓴᐅᑎᑦᑎᔾᔪᑎ ᐱᔭᐅᔪᓐᓇᙱᑦᑐᖅ. ᒪᒃᐱᒐᖅ ᓄᑖᙳᖅᑎᒃᑯ.
+core-start-failed = ᑖᓐᓇ ᑎᑎᖅᑲᖅ ᐱᒋᐊᖅᑎᑕᐅᔪᓐᓇᙱᑦᑐᖅ. ᒪᒃᐱᒐᖅ ᓄᑖᙳᖅᑎᒃᑯ.
+core-start-failed-busy = ᑖᓐᓇ ᑎᑎᖅᑲᖅ ᐱᒋᐊᖅᑎᑕᐅᔪᓐᓇᙱᑦᑐᖅ. ᑎᑎᖅᑲᑦ ᐊᒥᓱᑦ ᐊᑕᐅᑦᑎᒃᑯᑦ ᐱᒋᐊᖅᑎᑕᐅᓚᐅᖅᑐᑦ. ᐊᓯᖏᑦ ᐱᔭᕇᖅᐸᑕ ᒪᒃᐱᒐᖅ ᓄᑖᙳᖅᑎᒃᑯ.
+core-start-failed-retry = ᑖᓐᓇ ᑎᑎᖅᑲᖅ ᐱᒋᐊᖅᑎᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+core-start-failed-busy-retry = ᑖᓐᓇ ᑎᑎᖅᑲᖅ ᐱᒋᐊᖅᑎᑕᐅᔪᓐᓇᙱᑦᑐᖅ. ᑎᑎᖅᑲᑦ ᐊᒥᓱᑦ ᐊᑕᐅᑦᑎᒃᑯᑦ ᐱᒋᐊᖅᑎᑕᐅᓚᐅᖅᑐᑦ.
+core-start-retry = ᐆᒃᑐᒃᑲᓐᓂᕆᑦ
+saved-state-unavailable = ᑐᖅᑯᖅᑕᐅᓯᒪᔪᑎᑦ ᐱᔭᐅᔪᓐᓇᙱᑦᑐᑦ.

--- a/packages/i18n/locales/iu/content.ftl
+++ b/packages/i18n/locales/iu/content.ftl
@@ -34,7 +34,7 @@
 #   * **`line-width`, `line-style`, `fill-style`** — same reason: no settled
 #     words for thick against thin, dashed against dotted, or the six hatch
 #     patterns.
-#   * **`color` keeps five of twelve.** Inuktitut does not partition the
+#   * **`color` keeps six of twelve.** Inuktitut does not partition the
 #     spectrum where English does, and «ᑐᖑᔪᖅᑐᖅ» covers what English splits
 #     into blue and green. It is written here as `.blue` only, and `.green` is
 #     **left out** rather than given a second guess at the same stem. `.gray`,
@@ -48,6 +48,16 @@
 #   * **`piecewise-condition-if` and `-otherwise`** — Inuktitut marks a
 #     condition with a verb mood, not with a word that stands alone in front
 #     of an equation. «ᐅᕝᕙᓘᓐᓃᑦ» for *or* is a real word and is kept.
+#   * **`style-border-clause` and `style-text`** follow `line-style` and
+#     `fill-style` out: each is a frame whose whole job is to join words this
+#     file does not have.
+#   * **`chemistry-invalid-symbol` and `chemistry-invalid-ionic-compound`**
+#     are left out too. The rest of the batch keeps those two — they are
+#     frames rather than vocabulary — but here they would name a chemistry
+#     whose element table is absent, so they fall back with it.
+#
+#     `ion-name-oxidation-state` *is* written; it composes a numeral and needs
+#     no element name. `noun-regular-polygon` goes out with `noun`.
 
 
 ## Style vocabulary

--- a/packages/i18n/locales/iu/content.ftl
+++ b/packages/i18n/locales/iu/content.ftl
@@ -1,0 +1,191 @@
+# Inuktitut (ᐃᓄᒃᑎᑐᑦ) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in. Translated from `locales/en/content.ftl`, which is the source of
+# truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** Canadian Aboriginal syllabics, the Nunavut standard. The
+# **Latin qaliujaaqpait orthography is not mixed in**: every Inuktitut word
+# below is in syllabics, and the roman letters that appear are DoenetML
+# source. ᙱ (U+1671) is the doubled *nng* and is not ᖏ (U+158F); ᕼ (U+157C) is
+# the Inuktitut *h* and is not the Cree final ᐦ (U+1426). `chrome.ftl` sets
+# the series and the finals out in full.
+#
+# **Number.** `iu` selects **one**, **two** and **other** — Inuktitut has a
+# real dual. Nothing in this file selects on a count, so no plural branch
+# appears here; `chrome.ftl` and `editor.ftl` carry them, and `chrome.ftl`
+# explains the dual.
+#
+# **Word order.** Inuktitut is the reverse of English here. A describing word
+# is a verb — «ᐊᐅᐸᖅᑐᖅ» is *it is red*, not *red* — and it **follows** what it
+# describes. So every composition message below puts `{ $noun }` first and the
+# description after it, where English puts the description first.
+#
+# **What is left out, and why.**
+#
+#   * **`noun` is omitted entirely.** Inuktitut has no settled published set
+#     of geometry names — line segment, ray, slope field, polyline, parabola —
+#     and coining twenty of them in syllabics is exactly what this seed must
+#     not do. The composition frames below are still translated, so a
+#     partly-covered document reads in Inuktitut word order with the English
+#     shape name in it.
+#   * **`line-width`, `line-style`, `fill-style`** — same reason: no settled
+#     words for thick against thin, dashed against dotted, or the six hatch
+#     patterns.
+#   * **`color` keeps five of twelve.** Inuktitut does not partition the
+#     spectrum where English does, and «ᑐᖑᔪᖅᑐᖅ» covers what English splits
+#     into blue and green. It is written here as `.blue` only, and `.green` is
+#     **left out** rather than given a second guess at the same stem. `.gray`,
+#     `.orange`, `.cyan`, `.purple` and `.pink` are left out for the same
+#     reason: there is no settled term to reproduce.
+#   * **`element-name` and `element-anion-name` are omitted entirely.**
+#     Science is schooled in Nunavut in English, and there is no published
+#     Inuktitut set of all 118 element names.
+#   * **`table-name`** — the word for a data table is not settled; `<figure>`
+#     is, and «ᑎᑎᖅᑐᒐᖅ» is written for it.
+#   * **`piecewise-condition-if` and `-otherwise`** — Inuktitut marks a
+#     condition with a verb mood, not with a word that stands alone in front
+#     of an equation. «ᐅᕝᕙᓘᓐᓃᑦ» for *or* is a real word and is kept.
+
+
+## Style vocabulary
+
+color =
+    .black = ᕿᕐᓂᖅᑐᖅ
+    .white = ᖃᑯᖅᑕᖅ
+    .red = ᐊᐅᐸᖅᑐᖅ
+    .yellow = ᖁᖅᓲᖅᑐᖅ
+    .blue = ᑐᖑᔪᖅᑐᖅ
+    .brown = ᑲᔪᖅᑐᖅ
+
+noun-gender = neuter
+
+
+## Style composition
+##
+## `{ $noun }` leads and the description follows it, which is Inuktitut order
+## and the reverse of English.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = ᐃᒪᖃᖅᑐᖅ
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ᐃᒪᖃᙱᑦᑐᖅ
+
+style-background-none = ᐱᖃᙱᑦᑐᖅ
+
+
+## Boolean words
+
+boolean-true = ᓱᓕᔪᖅ
+boolean-false = ᓱᓕᙱᑦᑐᖅ
+
+
+## Answer buttons
+
+answer-submit-label = ᖃᐅᔨᓴᕐᓗᒍ
+answer-submit-label-no-correctness = ᑭᐅᔾᔪᑎ ᐊᐅᓪᓚᖅᑎᓪᓗᒍ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ᐱᓕᕆᐊᖅ
+    .definition = ᑐᑭᖓ
+    .exercise = ᐆᒃᑐᕐᓂᖅ
+    .exercises = ᐆᒃᑐᕐᓃᑦ
+    .given-answer = ᑭᐅᔾᔪᑎ
+    .objectives = ᑐᕌᒐᐃᑦ
+    .problem = ᐊᒃᓱᕈᕐᓇᖅᑐᖅ
+    .problems = ᐊᒃᓱᕈᕐᓇᖅᑐᑦ
+    .question = ᐊᐱᖅᑯᑦ
+    .section = ᐃᓚᖓ
+    .task = ᐱᓕᕆᐊᒃᓴᖅ
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = ᐃᑲᔫᑦ
+
+
+## Tables and figures
+
+figure-name =
+    { $parts ->
+        [numbered] ᑎᑎᖅᑐᒐᖅ { $enumeration }
+        [numbered-caption] ᑎᑎᖅᑐᒐᖅ { $enumeration }{ ": " }
+        [unnumbered-caption] ᑎᑎᖅᑐᒐᖅ{ ": " }
+       *[unnumbered] ᑎᑎᖅᑐᒐᖅ
+    }
+
+
+## Paginator controls
+##
+## "3 of 5" would be a case ending on `{ $numPages }` in Inuktitut, and an
+## ending cannot be welded onto a placeable, so the status is written with a
+## stroke between the two counts instead of with a word.
+
+paginator-previous = ᓯᕗᓪᓕᖅ
+paginator-next = ᑭᖑᓪᓕᖅ
+paginator-page = ᒪᒃᐱᒐᖅ
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ᐅᕝᕙᓘᓐᓃᑦ
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = ᐃᒪᖃᙱᑦᑐᖅ
+math-embedded-input-blank-ordinal = ᐃᒪᖃᙱᑦᑐᖅ { $ordinal } / { $total }

--- a/packages/i18n/locales/iu/diagnostics.ftl
+++ b/packages/i18n/locales/iu/diagnostics.ftl
@@ -41,13 +41,18 @@
 # Tajik and Russian loans, and it is deliberate: an invented syllabic spelling
 # would be harder for a speaker to repair than a visible loan.
 #
-# What is still **left out** is the handful of messages whose whole content is
-# such vocabulary — the three `style-definition-*` contrast messages, the
-# `<dataFrame>` shape messages beyond the three below, and
+# What is still **left out** is the ten messages whose whole content is such
+# vocabulary: the three `style-definition-*` contrast messages; the three
+# `<selectFromSequence>`/`<selectPrimeNumbers>` messages about coprimality and
+# primality; `field-function-wrong-num-outputs` and `field-variables-ignored`,
+# which are a paragraph of vector-field vocabulary each;
+# `prefigure-label-position-unsupported`; and
 # `math-input-invalid-function-names`, whose talk of a display segment and a
 # mathspeak alternative has no Inuktitut equivalent at any level. Those fall
 # back to English, and they are the first thing a speaker with a
-# mathematics-teaching background could repay.
+# mathematics-teaching background could repay. The three `<dataFrame>` shape
+# messages are *not* among them — they are written below, being about rows and
+# columns rather than about mathematics.
 
 
 ## `<lineSegment>`

--- a/packages/i18n/locales/iu/diagnostics.ftl
+++ b/packages/i18n/locales/iu/diagnostics.ftl
@@ -1,0 +1,652 @@
+# Inuktitut (ᐃᓄᒃᑎᑐᑦ) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** Canadian Aboriginal syllabics, the Nunavut standard. The
+# Latin qaliujaaqpait orthography is not mixed in: every Inuktitut word below
+# is in syllabics. ᙱ (U+1671) is the doubled *nng* and is not ᖏ (U+158F); ᕼ
+# (U+157C) is the Inuktitut *h* and is not the Cree final ᐦ (U+1426), which
+# appears nowhere in this file. `chrome.ftl` sets the series and the finals
+# out in full.
+#
+# **Number.** `iu` selects **one**, **two** and **other** — Inuktitut has a
+# real dual, with an ending of its own. Every count select below writes all
+# three branches. No `few`, `many` or `zero` branch appears; the locale cannot
+# select one. `chrome.ftl` explains the dual at length.
+#
+# **Suffixes and placeables.** An Inuktitut case ending cannot be welded onto
+# a placeable whose final sound this catalog never sees, so no `{ $x }`-ᒥ
+# appears anywhere below. Every sentence is built around its arguments with
+# separate words, which is why several of them read as two short clauses where
+# English reads as one long one.
+#
+# **A loan register with a syllabic frame.** The sentences here are ordinary
+# sentences — something was not found, something is ignored, something must be
+# a whole number, something is not yet built — and Inuktitut says all of them.
+# The *nouns* inside them are another matter: *matrix*, *eigenvalue*,
+# *coprime*, *domain*, *interval*, *variant*, *index*, *radius*, *option*
+# have no settled Inuktitut word and no settled syllabic transliteration
+# either, so they are written **in roman letters, as loans**, inside a
+# syllabic sentence. That is the same decision `locales/sgh` records for its
+# Tajik and Russian loans, and it is deliberate: an invented syllabic spelling
+# would be harder for a speaker to repair than a visible loan.
+#
+# What is still **left out** is the handful of messages whose whole content is
+# such vocabulary — the three `style-definition-*` contrast messages, the
+# `<dataFrame>` shape messages beyond the three below, and
+# `math-input-invalid-function-names`, whose talk of a display segment and a
+# mathspeak alternative has no Inuktitut equivalent at any level. Those fall
+# back to English, and they are the first thing a speaker with a
+# mathematics-teaching background could repay.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } ᐊᑐᖅᑕᐅᙱᑦᑐᖅ, endpoint ᒪᕐᕉᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑎᒃ
+        [two] { $attributes } ᐊᑐᖅᑕᐅᙱᑦᑑᒃ, endpoint ᒪᕐᕉᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑎᒃ
+       *[other] { $attributes } ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, endpoint ᒪᕐᕉᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑎᒃ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } ᐊᑐᖅᑕᐅᙱᑦᑐᖅ, endpoint ᐊᒻᒪ midpoint ᑕᒪᕐᒥᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑎᒃ
+        [two] { $attributes } ᐊᑐᖅᑕᐅᙱᑦᑑᒃ, endpoint ᐊᒻᒪ midpoint ᑕᒪᕐᒥᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑎᒃ
+       *[other] { $attributes } ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, endpoint ᐊᒻᒪ midpoint ᑕᒪᕐᒥᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑎᒃ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ᐊᑐᕐᓂᖃᙱᑦᑐᖅ midpoint ᐱᖃᙱᑉᐸᑦ
+
+## `<ray>`
+
+ray-overprescribed-through = through, endpoint ᐊᒻᒪ direction ᐱᖓᓲᓪᓗᑎᒃ ᓇᓗᓇᐃᖅᑕᐅᔪᑦ. through ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+## `<vector>`
+
+vector-overprescribed-head = head, tail ᐊᒻᒪ displacement ᐱᖓᓲᓪᓗᑎᒃ ᓇᓗᓇᐃᖅᑕᐅᔪᑦ. head ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ, nearestPoint ᐱᖃᙱᒻᒪᑦ.
+
+constrain-to-without-nearest-point = `<{ $component }>` ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ, nearestPoint ᐱᖃᙱᒻᒪᑦ.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` ᐃᓗᐊ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ, nearestPoint ᐱᖃᙱᒻᒪᑦ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ᐊᑐᖅᑕᐅᙱᑦᑐᖅ inline-ᒥᐅᙱᑦᑐᒥ choiceInput
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ᐊᑐᖅᑕᐅᔪᒪᒃᐸᑦ `type` ᓇᓗᓇᐃᖅᑕᐅᔭᕆᐊᖃᖅᑐᖅ.
+
+string-not-valid-component-to-arrange = "{ $value }" { $component }-ᒧᑦ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ. ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+## Types and variables
+
+invalid-variable-value = ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $value }`
+
+## `<sideBySide>`
+
+side-by-side-no-block-child = `<{ $component }>` ᑕᒻᒪᖅᓯᒪᔪᖅ: ᐊᑕᐅᓯᖅ ᐊᒥᓲᓂᖅᓴᓪᓘᓐᓃᑦ block ᐱᖃᖅᑕᕆᐊᓕᒃ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = `<label>` ᑎᑎᖅᑐᒐᐅᑉ ᐃᓗᐊᓂ `for` ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+label-for-must-resolve-to-one = `<label>` `for` ᐊᑕᐅᓯᕐᒧᑦ ᑐᕌᖅᑕᕆᐊᓕᒃ.
+
+label-for-unresolved = `<label>` `for` ᓇᓂᔭᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+label-for-answer-without-input = `<label>` `for` `<answer>`-ᒧᑦ ᑐᕌᖅᑐᖅ, ᑭᓯᐊᓂ ᑖᓐᓇ ᑎᑎᕋᖅᑕᐅᕕᖃᙱᑦᑐᖅ.
+
+label-for-must-reference-input-or-answer = `<label>` `for` ᑎᑎᕋᖅᑕᐅᕕᖕᒧᑦ ᐅᕝᕙᓘᓐᓃᑦ `<answer>`-ᒧᑦ ᑐᕌᖅᑕᕆᐊᓕᒃ.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ `<{ $component }>` ᐅᓂᒃᑳᕐᔪᐊᖃᕆᐊᓕᒃ ᐅᕝᕙᓘᓐᓃᑦ decorative-ᒧᑦ ᓇᓗᓇᐃᖅᑕᐅᔭᕆᐊᓕᒃ.
+
+accessibility-video-short-description = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ `<video>` ᐅᓂᒃᑳᕐᔪᐊᖃᕆᐊᓕᒃ.
+
+accessibility-input-short-description-or-label = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ `<{ $component }>` ᐅᓂᒃᑳᕐᔪᐊᖃᕆᐊᓕᒃ ᐅᕝᕙᓘᓐᓃᑦ label-ᖃᕆᐊᓕᒃ.
+
+accessibility-answer-input-short-description-or-label = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ `<answer>` ᑎᑎᕋᖅᑕᐅᕕᖃᖅᑎᑦᑎᔪᖅ ᐅᓂᒃᑳᕐᔪᐊᖃᕆᐊᓕᒃ ᐅᕝᕙᓘᓐᓃᑦ label-ᖃᕆᐊᓕᒃ.
+
+accessibility-short-description-contains-math = ᐅᓂᒃᑳᕐᔪᐊᑦ ᓈᓴᐅᓯᕆᓂᕐᒧᑦ `<{ $component }>`-ᒥᒃ ᐱᖃᖅᑐᒃᓴᐅᙱᑦᑐᑦ. ᓈᓴᐅᓯᕆᓂᖅ ᐅᖃᐅᓯᕐᓂᒃ ᑎᑎᕋᕐᓗᒍ.
+
+## `<circle>`
+
+circle-too-many-through-points = ᐊᒥᓲᓂᖅᓴᐃᑦ ᐱᖓᓱᓂᑦ ᐊᖅᑯᑎᒋᓪᓗᒋᑦ ᐊᔪᕐᓇᖅᑐᖅ.
+
+circle-overprescribed-radius-center-points = radius, center ᐊᒻᒪ ᐊᖅᑯᑎᖏᑦ ᑕᒪᕐᒥᒃ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑕ ᐊᔪᕐᓇᖅᑐᖅ.
+
+circle-invalid-center-or-through-points = center ᐅᕝᕙᓘᓐᓃᑦ ᐊᖅᑯᑎᖏᑦ ᑕᒻᒪᖅᓯᒪᔪᑦ.
+
+## `<function>`
+
+function-domain-invalid-format = ᑕᒻᒪᖅᓯᒪᔪᖅ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] maximum ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [minimum] minimum ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [extremum] extremum ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [point] ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [slope] slope ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+       *[other] { $type } ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] maximum ᐃᒪᖃᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [minimum] minimum ᐃᒪᖃᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [extremum] extremum ᐃᒪᖃᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [point] ᐃᒪᖃᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+       *[other] { $type } ᐃᒪᖃᙱᒻᒪᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+    }
+
+## `<sequence>`
+
+sequence-invalid-endpoint = "{ $attribute }" ᑕᒻᒪᖅᓯᒪᔪᖅ.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ᑕᒻᒪᖅᓯᒪᔪᖅ. ᑭᓯᑦᓯᐅᑎᐅᔭᕆᐊᓕᒃ.
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` target ᓇᓂᔭᐅᙱᑦᑐᖅ.
+
+target-state-variable-not-found = `<{ $source }>` target ᑕᒻᒪᖅᓯᒪᔪᖅ: `<{ $component }>` "{ $property }"-ᒥᒃ ᐱᖃᙱᑦᑐᖅ.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines =
+    { $count ->
+        [one] ᐊᖅᑯᑎ { $count } ᐊᑯᓐᓂᖓᓂ angle ᐊᔪᕐᓇᖅᑐᖅ
+        [two] ᐊᖅᑯᑏᒃ { $count } ᐊᑯᓐᓂᖓᓂ angle ᐊᔪᕐᓇᖅᑐᖅ
+       *[other] ᐊᖅᑯᑏᑦ { $count } ᐊᑯᓐᓂᖓᓂ angle ᐊᔪᕐᓇᖅᑐᖅ
+    }
+
+angle-invalid-through-point = `<angle>` through ᑕᒻᒪᖅᓯᒪᔪᖅ
+
+parabola-vertex-too-many-points = ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: vertex ᐊᒻᒪ ᐊᑕᐅᓯᕐᒥᑦ ᐊᒥᓲᓂᖅᓴᑦ.
+
+parabola-too-many-points = ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᐱᖓᓱᓂᑦ ᐊᒥᓲᓂᖅᓴᑦ.
+
+intersection-too-many-items = ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᒪᕐᕉᓐᓂᑦ ᐊᒥᓲᓂᖅᓴᑦ
+
+## Other math components
+
+solve-equations-cannot-evaluate = ᐊᔪᕐᓇᖅᑐᖅ: { $equation }
+
+math-operators-operand-number-required = operandNumber ᓇᓗᓇᐃᖅᑕᐅᔭᕆᐊᓕᒃ.
+
+## `<graph>`
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure ᐊᑐᙱᑉᐸᑦ `<annotations>` ᑕᑯᒃᓴᐅᔾᔮᙱᑦᑐᑦ.
+
+multiple-annotations-children = `<graph>`-ᒥ `<annotations>` ᐊᒥᓱᑦ ᓇᓂᔭᐅᔪᑦ; ᑭᖑᓪᓕᖅᐹᖅ ᑭᓯᐊᓂ ᐊᑐᖅᑕᐅᔪᖅ.
+
+## Referring to other components
+
+copy-prop-not-found = { $component }-ᒥ { $property } ᓇᓂᔭᐅᙱᑦᑐᖅ
+
+collect-no-source = collect-ᒧᑦ source ᓇᓂᔭᐅᙱᑦᑐᖅ.
+
+collect-invalid-component-type = `<{ $component }>` collect-ᑕᐅᔪᓐᓇᙱᑦᑐᖅ, ᑕᒻᒪᖅᓯᒪᒻᒪᑦ.
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }`-ᒥ { $action } ᐊᔪᕐᓇᖅᑐᖅ
+
+## `<answer>` and scoring
+
+answer-invalid-type = ᑭᐅᔾᔪᑎᐅᑉ type ᑕᒻᒪᖅᓯᒪᔪᖅ: { $type }
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } ᐊᑐᕐᓂᖃᙱᑦᑐᖅ symbolicEquality ᓇᓗᓇᐃᖅᑕᐅᙱᑉᐸᑦ.
+        [two] { $attributes } ᐊᑐᕐᓂᖃᙱᑦᑑᒃ symbolicEquality ᓇᓗᓇᐃᖅᑕᐅᙱᑉᐸᑦ.
+       *[other] { $attributes } ᐊᑐᕐᓂᖃᙱᑦᑐᑦ symbolicEquality ᓇᓗᓇᐃᖅᑕᐅᙱᑉᐸᑦ.
+    }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` ᐊᑎᖃᙱᒻᒪᑦ `<module>`-ᒧᑦ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ
+
+conditional-content-condition-ignored = `<conditionalContent>` case ᐅᕝᕙᓘᓐᓃᑦ else ᐱᖃᖅᐸᑦ `condition` ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+pretzel-problem-needs-statement-and-answer = `<problem>` ᐊᑕᐅᓯᕐᒥᒃ `<statement>`-ᖃᕆᐊᓕᒃ ᐊᑕᐅᓯᕐᒥᒡᓗ `<answer>`-ᖃᕆᐊᓕᒃ.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }`-ᒧᑦ { $values } ᑕᒻᒪᖅᓯᒪᔪᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+        [two] `{ $attribute }`-ᒧᑦ { $values } ᑕᒻᒪᖅᓯᒪᔫᒃ; ᐊᑐᖅᑕᐅᙱᑦᑑᒃ.
+       *[other] `{ $attribute }`-ᒧᑦ { $values } ᑕᒻᒪᖅᓯᒪᔪᑦ; ᐊᑐᖅᑕᐅᙱᑦᑐᑦ.
+    }
+
+attribute-must-be-references = `{ $attribute }`-ᒧᑦ `{ $value }` ᑕᒻᒪᖅᓯᒪᔪᖅ. `$`-ᒥᒃ ᐱᒋᐊᖅᑐᖃᕆᐊᓕᒃ.
+
+## Building components from the source
+
+component-type-invalid = ᑕᒻᒪᖅᓯᒪᔪᖅ: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } ᖁᓕᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+attribute-invalid-for-component = `<{ $componentType }>`-ᒧᑦ "{ $attribute }" ᑕᒻᒪᖅᓯᒪᔪᖅ.
+
+section-multiple-style-palettes = ᐃᓚᖓ <stylePalette>-ᒥᒃ ᐊᑕᐅᓯᕐᒥᒃ ᑭᓯᐊᓂ ᓂᕈᐊᕈᓐᓇᖅᑐᖅ; ᑭᖑᓪᓕᖅᐹᖅ ᐊᑐᖅᑕᐅᔪᖅ.
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: PreFigure-ᒥ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-curve-label-omitted = { $subject }: label ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ᑕᒻᒪᖅᓯᒪᔪᖅ; ᓇᓂᔭᐅᔪᓐᓇᙱᑦᑐᖅ. ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ᐊᒥᓱᓄᑦ ᑐᕌᖅᑐᖅ; ᓯᕗᓪᓕᖅ ᐊᑐᖅᑕᐅᔪᖅ.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` `<graph>`-ᐅᑉ ᓯᓚᑖᓃᑦᑐᖅ. ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᒧᑦ ᑐᕌᖅᑐᖅ. ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+annotation-text-missing = `<annotation>`: `text` ᐊᒥᒐᖅᑐᖅ.
+
+## Composites and references
+
+reference-no-referent = ᓇᓂᔭᐅᙱᑦᑐᖅ: `{ $reference }`
+
+reference-multiple-referents = ᐊᒥᓱᑦ ᓇᓂᔭᐅᔪᑦ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>`-ᒧᑦ { $attribute } ᑕᒻᒪᖅᓯᒪᔪᖅ.
+
+children-invalid = `<{ $componentType }>`-ᒧᑦ ᑕᒻᒪᖅᓯᒪᔪᑦ ᓇᓂᔭᐅᔪᑦ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }`-ᒧᑦ `{ $value }` ᑕᒻᒪᖅᓯᒪᔪᖅ, `{ $default }` ᐊᑐᖅᑕᐅᔪᖅ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } ᓇᓂᔭᐅᙱᑦᑐᖅ.
+       *[other] DoenetML { $version } ᓇᓂᔭᐅᙱᑦᑐᖅ. { $fallback } ᐊᑐᖅᑕᐅᔪᖅ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: { $content }
+
+parse-tag-missing-close-tag = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $tag }` ᒪᑐᐃᖅᑕᐅᙱᑦᑐᖅ. `</{ $tagName }>` ᐱᔭᕆᐊᖃᖅᑐᖅ.
+
+parse-tag-error = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `<{ $tagName }>`-ᒥ ᑕᒻᒪᕐᓂᖅ
+
+parse-attribute-missing-value = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $attribute }` ᐊᒥᒐᖅᑐᖅ.
+
+parse-attribute-invalid = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $attribute }` ᑕᒻᒪᖅᓯᒪᔪᖅ
+
+parse-attribute-value-invalid = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $value }` ᑕᒻᒪᖅᓯᒪᔪᖅ
+
+parse-attribute-value-quote-mismatch = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $value }` ᑕᒻᒪᖅᓯᒪᔪᖅ. `{ $quote }` ᐊᒥᒐᖅᑐᖅ
+
+parse-open-tag-name-missing = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: ᐊᑎᖃᙱᑦᑐᖅ ᓇᓂᔭᐅᔪᖅ, ᓲᕐᓗ `<`
+
+parse-tag-not-closed = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $tag }` ᒪᑐᐃᖅᑕᐅᙱᑦᑐᖅ (`>` ᐊᒥᒐᖅᑐᖅ).
+
+parse-self-closing-tag-name-missing = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: ᐊᑎᖃᙱᑦᑐᖅ ᓇᓂᔭᐅᔪᖅ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $tag }` ᒪᑐᐃᖅᑕᐅᙱᑦᑐᖅ (`/>` ᐊᒥᒐᖅᑐᖅ).
+
+parse-tag-invalid-attributes = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $tag }` ᑕᒻᒪᖅᓯᒪᔪᖅ.
+
+parse-close-tag-name-missing = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: ᐊᑎᖃᙱᑦᑐᖅ ᓇᓂᔭᐅᔪᖅ, ᓲᕐᓗ `</`
+
+parse-close-tag-without-open-tag = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `{ $tag }` ᓇᓂᔭᐅᔪᖅ, ᑭᓯᐊᓂ ᐅᒃᑯᐃᖅᓯᔪᖃᙱᑦᑐᖅ
+
+parse-close-tag-mismatched = DoenetML ᑕᒻᒪᖅᓯᒪᔪᖅ: `</{ $expected }>` ᐱᔭᕆᐊᖃᖅᑐᖅ. `{ $found }` ᓇᓂᔭᐅᔪᖅ
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' ᑕᒻᒪᖅᓯᒪᔪᖅ. { $reason ->
+        [characters] ᐊᑏᑦ ᑎᑎᕋᐅᓯᕐᓂᒃ, ᑭᓯᑦᓯᐅᑎᓂᒃ, underscore-ᓂᒃ ᐅᕝᕙᓘᓐᓃᑦ hyphen-ᓂᒃ ᑭᓯᐊᓂ ᐱᖃᕈᓐᓇᖅᑐᑦ.
+       *[start] ᐊᑏᑦ ᑎᑎᕋᐅᓯᕐᒥᒃ ᐱᒋᐊᕆᐊᓖᑦ.
+    }
+
+component-name-invalid-start = ᐊᑎᖓ "{ $name }" ᑕᒻᒪᖅᓯᒪᔪᖅ. ᐊᑏᑦ ᑎᑎᕋᐅᓯᕐᒥᒃ ᐱᒋᐊᕆᐊᓖᑦ.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = type videoWatched video-ᖃᕆᐊᓕᒃ
+
+answer-name-not-single-text = name ᐊᑕᐅᓯᕐᒥᒃ ᑎᑎᕋᖅᓯᒪᔪᖃᕆᐊᓕᒃ
+
+## Referencing another document
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" ᐱᔭᐅᔪᓐᓇᙱᑦᑐᖅ
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` ᐊᑐᕈᓐᓃᖅᑐᖅ; `{ $to }` ᐊᑐᕐᓗᒍ.
+       *[other] [deprecation] `<{ $component }>`-ᒥ `{ $from }` ᐊᑐᕈᓐᓃᖅᑐᖅ; `{ $to }` ᐊᑐᕐᓗᒍ.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` ᐊᑐᕈᓐᓃᖅᑐᖅ ᐊᑐᖅᑕᐅᙱᑦᑐᕐᓗ, `{ $to }` ᐊᒻᒪᓗ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑦ.
+       *[other] [deprecation] `<{ $component }>`-ᒥ `{ $from }` ᐊᑐᕈᓐᓃᖅᑐᖅ ᐊᑐᖅᑕᐅᙱᑦᑐᕐᓗ, `{ $to }` ᐊᒻᒪᓗ ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑦ.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-ᒥ `{ $attribute }` ᐊᑐᕈᓐᓃᖅᑐᖅ ᐊᑐᖅᑕᐅᙱᑦᑐᕐᓗ.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-ᒥ `{ $attribute }` ᐊᑐᕈᓐᓃᖅᑐᖅ; `<{ $child }>` ᐊᑐᕐᓗᒍ.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-ᒥ `{ $attribute }`-ᒧᑦ `{ $value }` ᐊᑐᕈᓐᓃᖅᑐᖅ; `{ $to }` ᐊᑐᕐᓗᒍ.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` Doenet-ᒧᑦ ᐃᓕᓴᕆᔭᐅᙱᑦᑐᖅ.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` ᑎᑎᖅᑲᐅᑉ ᐱᒋᐊᕐᕕᖓᓂ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+schema-element-not-allowed-inside = `<{ $tag }>` `<{ $parent }>`-ᐅᑉ ᐃᓗᐊᓂ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+schema-attribute-unrecognized = `<{ $tag }>` `{ $attribute }`-ᒥᒃ ᐱᖃᙱᑦᑐᖅ.
+
+
+## The `<select>` family's error boxes
+
+select-from-sequence-indices-not-integers = select-ᒧᑦ ᑕᒪᕐᒥᒃ ᑭᓯᑦᓯᐅᑎᐅᔭᕆᐊᓖᑦ
+
+select-random-combination-fluke = ᐊᔪᕐᓇᖅᑐᖅ
+
+select-random-value-fluke = ᐊᔪᕐᓇᖅᑐᖅ
+
+## Further messages
+##
+## From here on the sentences lean on the loan convention the header sets
+## out: the frame is Inuktitut and the technical noun that has no settled
+## syllabic form stays in roman letters, as `matrix`, `interval`, `domain`,
+## `variant`, `index` and `coprime` do below.
+
+line-points-undetermined-dimensions = ᐊᖅᑯᑎᖏᑦ dimension-ᖏᑦ ᓇᓗᓇᖅᑐᑦ.
+
+line-points-too-few-dimensions = ᐊᖅᑯᑎᖏᑦ ᒪᕐᕉᓐᓂᒃ dimension-ᖃᕆᐊᓖᑦ.
+
+line-points-depend-on-variables = ᐊᖅᑯᑎᖏᑦ variable-ᓄᑦ ᑐᙵᕗᑦ: { $variables }.
+
+line-equation-invalid-format = variable-ᐃᑦ { $variable1 } ᐊᒻᒪ { $variable2 } ᑕᒻᒪᖅᓯᒪᔪᑦ.
+
+ray-dimension-mismatch = numDimensions ᓈᒻᒪᙱᑦᑐᖅ.
+
+vector-dimension-mismatch = numDimensions ᓈᒻᒪᙱᑦᑐᖅ.
+
+choice-input-indices-count-mismatch = choiceInput-ᒧᑦ index-ᖏᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, ᐊᒥᓲᓂᖏᑦ ᓈᒻᒪᙱᒻᒪᑕ.
+
+pretzel-indices-count-mismatch = problem-ᒧᑦ index-ᖏᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, ᐊᒥᓲᓂᖏᑦ ᓈᒻᒪᙱᒻᒪᑕ.
+
+shuffle-indices-count-mismatch = shuffle-ᒧᑦ index-ᖏᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, ᐊᒥᓲᓂᖏᑦ ᓈᒻᒪᙱᒻᒪᑕ.
+
+indices-ignored-out-of-range = { $component }-ᒧᑦ index-ᖏᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, ᐃᓚᖏᑦ ᓯᓚᑖᓃᒻᒪᑕ.
+
+pretzel-indices-repeated = pretzel-ᒧᑦ index-ᖏᑦ ᐊᑐᖅᑕᐅᙱᑦᑐᑦ, ᐃᓚᖏᑦ ᖁᓕᖅᑕᐅᒻᒪᑕ.
+
+pretzel-circuit-first-index = pretzel-ᒧᑦ circuit-ᒥ index ᓯᕗᓪᓕᖅ 1-ᐅᔭᕆᐊᓕᒃ; ᐊᑐᖅᑕᐅᙱᑦᑐᑦ.
+
+invalid-type-defaulting-to-math = { $component }-ᒧᑦ type { $type } ᑕᒻᒪᖅᓯᒪᔪᖅ. math, text, number ᐅᕝᕙᓘᓐᓃᑦ boolean-ᐅᔭᕆᐊᓕᒃ. math ᐊᑐᖅᑕᐅᔪᖅ.
+
+invalid-type-defaulting-to-number = type { $type } ᑕᒻᒪᖅᓯᒪᔪᖅ, number ᐊᑐᖅᑕᐅᔪᖅ.
+
+variant-index-must-be-number = variant-ᐅᑉ index-ᖓ { $index } ᑭᓯᑦᓯᐅᑎᐅᔭᕆᐊᓕᒃ
+
+variant-index-must-be-integer = variant-ᐅᑉ index-ᖓ { $index } ᑭᓯᑦᓯᐅᑎᑦᓯᐊᕙᐅᔭᕆᐊᓕᒃ
+
+side-by-side-absolute-widths = `<{ $component }>` ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ; ᓯᓕᓐᓂᖏᑦ ᐊᔾᔨᒌᒃᑎᑕᐅᔪᑦ.
+
+side-by-side-absolute-margins = `<{ $component }>` ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ; ᓯᓈᖏᑦ ᐊᔾᔨᒌᒃᑎᑕᐅᔪᑦ.
+
+label-for-answer-with-authored-inputs = `<label>` `for` `<answer>`-ᒧᑦ ᑐᕌᖅᑐᖅ, ᑭᓯᐊᓂ ᑖᓐᓇ ᑎᑎᕋᖅᑕᐅᕕᖃᖅᑐᖅ; ᑎᑎᕋᖅᑕᐅᕕᖓᓄᑦ ᑐᕌᕐᓗᑎᑦ.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ᐃᓚᖓᑕ ᓂᕈᐊᖓᓄᑦ ᓈᒻᒪᙱᑦᑐᖅ (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 ᐱᔭᕆᐊᖃᖅᑐᖅ).
+       *[other] { $colorName } ᐃᓚᖓᑕ ᓂᕈᐊᖓᓄᑦ ᓈᒻᒪᙱᑦᑐᖅ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 ᐱᔭᕆᐊᖃᖅᑐᖅ).
+    }
+
+circle-through-points-non-numerical =
+    { $count ->
+        [one] ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᐊᖅᑯᑎ { $count } ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑦ.
+        [two] ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᐊᖅᑯᑏᒃ { $count } ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑎᒃ.
+       *[other] ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᐊᖅᑯᑏᑦ { $count } ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑕ.
+    }
+
+circle-center-with-multiple-points = center ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑦ ᐊᑕᐅᓯᕐᒥᑦ ᐊᒥᓲᓂᖅᓴᑦ ᐊᔪᕐᓇᖅᑐᑦ.
+
+circle-radius-too-small = ᐊᔪᕐᓇᖅᑐᖅ: ᐊᖅᑯᑏᒃ ᐅᖓᓯᓐᓂᖓ { $distance }, radius { $radius } ᒥᑭᓗᐊᖅᑐᖅ.
+
+circle-radius-with-many-points = radius ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑦ ᒪᕐᕉᓐᓂᑦ ᐊᒥᓲᓂᖅᓴᑦ ᐊᔪᕐᓇᖅᑐᑦ.
+
+circle-radius-center-with-multiple-points = center ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑦ ᐊᑕᐅᓯᕐᒥᑦ ᐊᒥᓲᓂᖅᓴᑦ ᐊᔪᕐᓇᖅᑐᑦ.
+
+circle-change-radius-non-numerical = ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑕ radius ᐊᓯᔾᔨᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ
+
+circle-radius-with-points-non-numerical = ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑕ ᐊᔪᕐᓇᖅᑐᖅ.
+
+circle-change-center-non-numerical = ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑕ center ᐊᓯᔾᔨᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
+        [two] domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
+       *[other] domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
+    }
+
+function-points-too-close = ᐊᖅᑯᑏᒃ ᖃᓂᓗᐊᖅᑑᒃ. ᐊᔪᕐᓇᖅᑐᖅ.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
+        [two] input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
+       *[other] input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
+    }
+
+sequence-invalid-length = ᑕᑭᓂᖓ ᑕᒻᒪᖅᓯᒪᔪᖅ. ᑭᓯᑦᓯᐅᑎᑦᓯᐊᕙᐅᔭᕆᐊᓕᒃ.
+
+sequence-invalid-step = step ᑕᒻᒪᖅᓯᒪᔪᖅ. type { $type }-ᒧᑦ ᑭᓯᑦᓯᐅᑎᐅᔭᕆᐊᓕᒃ.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ᑕᒻᒪᖅᓯᒪᔪᖅ. ᑎᑎᕋᐅᓯᕐᓂᒃ ᐱᖃᕆᐊᓕᒃ.
+
+select-from-sequence-coprime-not-numbers = coprime ᐊᑐᖅᑕᐅᙱᑦᑐᖅ, ᑭᓯᑦᓯᐅᑏᑦ ᓂᕈᐊᖅᑕᐅᙱᒻᒪᑕ
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ᐊᑐᖅᑕᐅᙱᑦᑐᖅ, excludeCombinations ᓇᓗᓇᐃᖅᑕᐅᒻᒪᑦ
+
+ode-system-variables-match-independent = `<odeSystem>` variable-ᖏᑦ independent variable-ᒥᒃ ᐊᔾᔨᒌᙱᑦᑐᒃᓴᐅᔪᑦ.
+
+ode-system-duplicate-variable-names = variable-ᐃᑦ ᐊᑏᑦ ᖁᓕᖅᑕᐅᔪᑦ. ᐊᔪᕐᓇᖅᑐᖅ.
+
+ode-system-rhs-function-error = ᐊᔪᕐᓇᖅᑐᖅ. mathjs ᑕᒻᒪᖅᓯᒪᔪᖅ.
+
+ionic-compound-not-two-ions = ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ion ᒪᕐᕉᒃ ᑭᓯᐊᓂ.
+
+ionic-compound-needs-cation-and-anion = cation ᐊᑕᐅᓯᖅ ᐊᒻᒪ anion ᐊᑕᐅᓯᖅ ᑭᓯᐊᓂ.
+
+eigen-decomposition-failed = matrix-ᐅᑉ eigenvalue-ᖏᑦ ᐊᔪᕐᓇᖅᑐᑦ
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } pattern-ᒥ ᐱᖃᙱᑦᑐᖅ.
+        [two] `<matchesPattern>`: parameter { $parameters } pattern-ᒥ ᐱᖃᙱᑦᑑᒃ.
+       *[other] `<matchesPattern>`: parameter { $parameters } pattern-ᒥ ᐱᖃᙱᑦᑐᑦ.
+    }
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ᑐᑭᓯᔭᐅᔪᓐᓇᙱᑦᑐᖅ. none, medium, dense ᐅᕝᕙᓘᓐᓃᑦ ᑭᓯᑦᓯᐅᑏᒃ ᒪᕐᕉᒃ, ᓲᕐᓗ grid="1 0.5". grid ᑎᑎᖅᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+field-function-attribute-ignored-with-child = `function` ᐊᑐᖅᑕᐅᙱᑦᑐᖅ, ᐃᓗᐊᓃᑦᑐᖅ ᐊᑐᖅᑕᐅᒻᒪᑦ. ᐊᑕᐅᓯᐊᕐᓗᒍ ᑎᑎᕋᕐᓗᒍ.
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" PreFigure-ᒥ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" PreFigure-ᒥ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+prefigure-invalid-axis-bounds = `<graph>`: PreFigure-ᒧᑦ ᑕᒻᒪᖅᓯᒪᔪᖅ; (-10,-10,10,10) ᐊᑐᖅᑕᐅᔪᖅ.
+
+prefigure-invalid-width = `<graph>`: ᓯᓕᓐᓂᖓ ᑕᒻᒪᖅᓯᒪᔪᖅ; 425 ᐊᑐᖅᑕᐅᔪᖅ.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ᑕᒻᒪᖅᓯᒪᔪᖅ; 1 ᐊᑐᖅᑕᐅᔪᖅ.
+
+prefigure-grid-spacing-too-fine = `<graph>`: grid ᐊᑯᓐᓂᖏᑦ ᒥᑭᓗᐊᖅᑐᑦ; grid ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-descendant-invalid-geometry = { $subject }: ᑕᒻᒪᖅᓯᒪᔪᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-curve-unsupported-definition-type = { $subject }: '{ $definitionType }' ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-region-flip-functions-unsupported = { $subject }: flipFunctions ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-region-non-formula-child = { $subject }: formula-ᖃᖅᑐᑦ ᑭᓯᐊᓂ ᐊᑐᖅᑕᐅᔪᓐᓇᖅᑐᑦ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' PreFigure-ᒥ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+prefigure-line-style-unknown = { $subject }: '{ $lineStyle }' ᐃᓕᓴᕆᔭᐅᙱᑦᑐᖅ; ᐊᑐᖅᑕᐅᙱᑦᑐᖅ.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' PreFigure-ᒥ 'diamond'-ᒧᑦ ᐊᓯᔾᔨᖅᑕᐅᔪᖅ.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' PreFigure-ᒥ ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+copy-unrecognized-component-type = ᐃᓕᓴᕆᔭᐅᙱᑦᑐᖅ: { $type }.
+
+reference-index-unavailable = index `{ $reference }` ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ
+
+data-frame-inconsistent-row-lengths = ᑕᒻᒪᖅᓯᒪᔪᖅ. ᑕᑭᓂᖏᑦ ᐊᔾᔨᒌᙱᑦᑐᑦ. componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = ᐊᑏᑦ ᖁᓕᖅᑕᐅᔪᑦ. componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = ᐊᑎᖃᙱᑦᑐᖅ. componentIdx :{ $componentIdx }
+
+answer-award-depends-on-own-response = ᑖᓐᓇ award ᑭᐅᔾᔪᑎᒥᓄᑦ ᑐᙵᕗᖅ, ᑕᒻᒪᖅᓯᒪᔪᒃᓴᐅᔪᖅ.
+
+answer-max-num-attempts-in-section-wide-check-work = sectionWideCheckWork-ᒥ `maxNumAttempts` ᐊᑐᕐᓂᖃᙱᑦᑐᖅ. ᓯᓚᑖᓄᑦ ᑎᑎᕋᕐᓗᒍ.
+
+nested-section-wide-check-work-max-num-attempts = sectionWideCheckWork ᐃᓗᐊᓂ `maxNumAttempts` ᐊᑐᕐᓂᖃᙱᑦᑐᖅ. ᓯᓚᑖᓄᑦ ᑎᑎᕋᕐᓗᒍ.
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ, `<module>` "{ $name }"-ᒥᒃ ᐱᖃᕋᒥ.
+
+slider-markers-type-mismatch = marker-ᐃᑦ type-ᖓ slider-ᐅᑉ type-ᖓᓄᑦ ᓈᒻᒪᙱᑦᑐᖅ.
+
+pretzel-circuit-first-problem-distractor = mode="circuit"-ᒥ `<problem>` ᓯᕗᓪᓕᖅ distractor-ᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+variant-num-to-select-not-non-negative-integer = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, numToSelect ᑭᓯᑦᓯᐅᑎᑦᓯᐊᕙᐅᙱᒻᒪᑦ.
+
+variant-num-to-select-not-constant-number = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, numToSelect ᐊᓯᔾᔨᖅᐸᒻᒪᑦ.
+
+variant-with-replacement-not-constant-boolean = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, withReplacement ᐊᓯᔾᔨᖅᐸᒻᒪᑦ.
+
+variant-select-weight-disables-unique = selectWeight ᐅᕝᕙᓘᓐᓃᑦ selectForVariants ᐱᖃᖅᐸᑦ ᐊᔪᕐᓇᖅᑐᖅ
+
+variant-coprime-undetermined = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, coprime ᓇᓗᓇᖅᑐᖅ.
+
+variant-attribute-not-constant = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, { $attribute } ᐊᓯᔾᔨᖅᐸᒻᒪᑦ.
+
+variant-attribute-not-number = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, { $attribute } ᑭᓯᑦᓯᐅᑎᐅᙱᒻᒪᑦ.
+
+variant-attribute-wrong-type-for-sequence =
+    { $component } { $type }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, { $attribute } { $expected ->
+        [letters-combination] ᑎᑎᕋᐅᓯᕐᓂᒃ
+        [math-expression] ᓈᓴᐅᓯᕆᓂᕐᒥᒃ
+        [integer] ᑭᓯᑦᓯᐅᑎᑦᓯᐊᕙᖕᒥᒃ
+       *[number] ᑭᓯᑦᓯᐅᑎᒥᒃ
+    } ᐱᖃᙱᒻᒪᑦ.
+
+variant-length-not-integer = { $component }-ᒧᑦ ᐊᔪᕐᓇᖅᑐᖅ, length ᑭᓯᑦᓯᐅᑎᑦᓯᐊᕙᐅᙱᒻᒪᑦ.
+
+variant-sort-not-implemented = { $component } sort-ᖃᖅᑐᖅ ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ
+
+variant-exclude-combinations-not-implemented = { $component } excludeCombinations-ᖃᖅᑐᖅ ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ
+
+variant-math-exclude-not-implemented = { $component } math-ᒥᒃ exclude-ᖃᖅᑐᖅ ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ
+
+variant-non-constant-exclude-not-implemented = { $component } exclude ᐊᓯᔾᔨᖅᐸᒃᑐᖅ ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] ᐊᒻᒪᓗᒃᑑᔪᖅ ᓇᓂᔭᐅᔪᖅ.
+       *[other] `<{ $componentType }>`-ᒥ ᐊᒻᒪᓗᒃᑑᔪᖅ ᓇᓂᔭᐅᔪᖅ.
+    }
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>`-ᒥ `{ $attribute }` ᐅᑯᓇᙵᑦ ᐱᖃᕆᐊᓕᒃ: { $allowed }
+       *[other] `<{ $tag }>`-ᒥ `{ $attribute }` ᐅᑯᓇᙵᑦ ᐊᑕᐅᓯᖅ: { $allowed }
+    }
+
+external-doenetml-recursion-limit = ᐊᔪᕐᓇᖅᑐᖅ, ᐅᑎᖅᑕᖅᑐᖅ. ᐊᒻᒪᓗᒃᑑᔪᖃᖅᐸ?
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" "{ $componentType }"-ᒧᑦ ᓈᒻᒪᙱᑦᑐᖅ
+
+pluralize-english-only = `<pluralize>` ᖃᓪᓗᓈᑎᑐᑦ ᑭᓯᐊᓂ ᐊᑐᖅᑕᐅᔪᓐᓇᖅᑐᖅ, ᑕᐃᒫᒃ { $locale }-ᒥ ᐊᓯᔾᔨᖅᑕᐅᙱᑦᑐᖅ. `pluralForm` ᐊᑐᕐᓗᒍ.
+
+answer-video-watched-video-not-reference = type videoWatched video-ᖓ ᑐᕌᕈᑕᐅᔭᕆᐊᓕᒃ
+
+parser-node-unconvertible = { $node } ᐊᓯᔾᔨᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+parse-attribute-value-unquoted = ᐅᔾᔨᖅᓱᖅᑐᓕᒫᖅ: `{ $attribute }="{ $value }"`
+
+select-variant-name-option-count-mismatch = variant { $variantName } option { $numOptions }-ᓂ ᓇᓂᔭᐅᔪᖅ, ᓂᕈᐊᒐᒃᓴᐃᑦ { $numToSelect }. ᓈᒻᒪᙱᑦᑐᖅ.
+
+select-variant-name-without-options = variant { $variantName }-ᒧᑦ option-ᖃᙱᑦᑐᖅ.
+
+select-variant-name-not-possible = variant { $variantName } ᐊᑐᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
+
+select-too-few-options = { $numOptions }-ᓂᑦ { $numToSelect } ᓂᕈᐊᖅᑕᐅᔪᓐᓇᙱᑦᑐᑦ.
+
+select-from-sequence-too-few-values = ᑕᑭᓂᖓ { $length }-ᒥᑦ { $numToSelect } ᓂᕈᐊᖅᑕᐅᔪᓐᓇᙱᑦᑐᑦ.
+
+select-from-sequence-indices-count-mismatch = index-ᐃᑦ ᐊᒥᓲᓂᖏᑦ ᓂᕈᐊᒐᒃᓴᐃᑦ ᐊᒥᓲᓂᖏᓐᓄᑦ ᓈᒻᒪᒋᐊᓖᑦ
+
+select-from-sequence-index-excluded = index ᐊᓯᐅᔨᔭᐅᓯᒪᔪᖅ
+
+select-from-sequence-indices-excluded-combination = index-ᐃᑦ ᐊᓯᐅᔨᔭᐅᓯᒪᔪᑦ
+
+select-from-sequence-coprime-not-positive-integers = coprime ᐊᔪᕐᓇᖅᑐᖅ, ᑭᓯᑦᓯᐅᑏᑦ ᓈᒻᒪᙱᒻᒪᑕ.
+
+select-from-sequence-coprime-single-number = coprime ᐊᑕᐅᓯᕐᒥᑦ ᐊᔪᕐᓇᖅᑐᖅ.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-ᒥ 70%-ᖏᑦ ᐅᖓᑖᓄᑦ ᐊᓯᐅᔨᔭᐅᓯᒪᔪᑦ
+
+select-from-sequence-too-few-unique-values = ᑕᑭᓂᖓ { $numPossibleValues }-ᒥᑦ { $numToSelect } ᐊᔪᕐᓇᖅᑐᑦ
+
+select-prime-numbers-too-few-values = { $numValues }-ᒥᑦ { $numToSelect } ᐊᔪᕐᓇᖅᑐᑦ
+
+select-prime-numbers-values-count-mismatch = ᐊᒥᓲᓂᖏᑦ ᓂᕈᐊᒐᒃᓴᐃᑦ ᐊᒥᓲᓂᖏᓐᓄᑦ ᓈᒻᒪᒋᐊᓖᑦ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers ᐊᓯᐅᔨᔭᐅᓯᒪᔪᖅ
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-ᒥ 70%-ᖏᑦ ᐅᖓᑖᓄᑦ ᐊᓯᐅᔨᔭᐅᓯᒪᔪᑦ
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` ᓈᓴᐅᓯᕆᓂᐅᑉ ᐃᓗᐊᓂ ᑎᑎᖅᑐᖅᑕᐅᙱᑦᑐᖅ. { $reason ->
+        [not-inline] `inline` ᑭᓯᐊᓂ ᐃᓗᐊᓄᑦ ᓈᒻᒪᒃᑐᖅ.
+        [expanded] `expanded` ᐊᖏᔪᐊᓘᒻᒪᑦ ᐃᓗᐊᓄᑦ ᓈᒻᒪᙱᑦᑐᖅ.
+        [on-graph] `<graph>`-ᒥ ᐊᔾᔨᖑᐊᑐᐊᖑᒻᒪᑦ ᐃᓂᖃᙱᑦᑐᖅ.
+       *[relative-width] `width` ᐊᔾᔨᒌᙱᒻᒪᑦ; `px`-ᒥᒃ ᑎᑎᕋᕐᓗᒍ.
+    }

--- a/packages/i18n/locales/iu/diagnostics.ftl
+++ b/packages/i18n/locales/iu/diagnostics.ftl
@@ -456,21 +456,17 @@ circle-radius-with-points-non-numerical = ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑕ ᐊ�
 
 circle-change-center-non-numerical = ᓱᓕ ᐋᖅᑭᒃᑕᐅᓯᒪᙱᑦᑐᖅ: ᑭᓯᑦᓯᐅᑎᖃᙱᒻᒪᑕ center ᐊᓯᔾᔨᖅᑕᐅᔪᓐᓇᙱᑦᑐᖅ.
 
-function-domain-insufficient-dimensions =
-    { $intervals ->
-        [one] domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
-        [two] domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
-       *[other] domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
-    }
+# The count select is dropped rather than written three ways over: neither
+# «interval» nor «input» is an Inuktitut noun that could take a dual or
+# plural ending, so all three branches would have been the same sentence.
+function-domain-insufficient-dimensions = domain-ᒥ interval { $intervals }, ᑭᓯᐊᓂ input { $inputs }. ᓈᒻᒪᙱᑦᑐᖅ.
 
 function-points-too-close = ᐊᖅᑯᑏᒃ ᖃᓂᓗᐊᖅᑑᒃ. ᐊᔪᕐᓇᖅᑐᖅ.
 
-function-iterates-input-output-mismatch =
-    { $inputs ->
-        [one] input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
-        [two] input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
-       *[other] input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
-    }
+# Dropped for the same reason as `function-domain-insufficient-dimensions`
+# above: «input» and «output» are roman-letter loans that take no Inuktitut
+# number ending, so the three branches would have repeated one another.
+function-iterates-input-output-mismatch = input { $inputs } ᐊᒻᒪ output { $outputs } ᐊᔾᔨᒌᙱᒻᒪᑎᒃ ᐊᔪᕐᓇᖅᑐᖅ.
 
 sequence-invalid-length = ᑕᑭᓂᖓ ᑕᒻᒪᖅᓯᒪᔪᖅ. ᑭᓯᑦᓯᐅᑎᑦᓯᐊᕙᐅᔭᕆᐊᓕᒃ.
 

--- a/packages/i18n/locales/iu/editor.ftl
+++ b/packages/i18n/locales/iu/editor.ftl
@@ -32,8 +32,9 @@
 # context-help panel that is a whole sentence of language-server vocabulary —
 # `help-placeholder`, `help-unsupported-ref-chain`, `help-unresolved-ref`,
 # `help-ref-is-reference`, `help-ref-derived-from`,
-# `help-property-is-reference`, `help-suggestions-header` and
-# `help-suggestions-footer` — which falls back to English.
+# `help-property-is-reference`, `help-resolved-style`,
+# `help-suggestions-header` and `help-suggestions-footer` — nine keys, which
+# fall back to English.
 
 
 ## The viewer's controls

--- a/packages/i18n/locales/iu/editor.ftl
+++ b/packages/i18n/locales/iu/editor.ftl
@@ -86,11 +86,7 @@ editor-accessibility-label =
             [close] ᒪᑐᓗᒍ
            *[open] ᐅᒃᑯᐃᕐᓗᒍ
         } ᓇᕿᓪᓗᒍ.
-        [advisories] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᖃᙱᑦᑐᖅ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᖃᐅᓯᒃᓴᖅ { $count ->
-            [one] { $count }
-            [two] { $count }
-           *[other] { $count }
-        } ᓇᓂᔭᐅᔪᑦ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+        [advisories] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᖃᙱᑦᑐᖅ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᖃᐅᓯᒃᓴᖅ { $count } ᓇᓂᔭᐅᔪᑦ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
             [close] ᒪᑐᓗᒍ
            *[open] ᐅᒃᑯᐃᕐᓗᒍ
         } ᓇᕿᓪᓗᒍ.

--- a/packages/i18n/locales/iu/editor.ftl
+++ b/packages/i18n/locales/iu/editor.ftl
@@ -1,0 +1,181 @@
+# Inuktitut (ᐃᓄᒃᑎᑐᑦ) editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay exactly as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** Canadian Aboriginal syllabics, the Nunavut standard; the
+# Latin qaliujaaqpait orthography is not mixed in. ᙱ (U+1671) is the doubled
+# *nng*, not ᖏ (U+158F); ᕼ (U+157C) is the Inuktitut *h*, not the Cree final ᐦ
+# (U+1426). `chrome.ftl` sets the series and the finals out in full. A hyphen
+# onto a *literal* Latin identifier is used where the sentence needs a case —
+# «DoenetML-ᒥᑎᑐᑦ» — but never onto a placeable, whose final sound this catalog
+# never sees.
+#
+# **Number.** `iu` selects **one**, **two** and **other**, and the `two` is a
+# real dual with its own ending. `editor-accessibility-label` writes all three
+# branches; `chrome.ftl` explains the dual at length.
+#
+# **This is the thinnest of the four files, and the reason is specific.** The
+# editor is a developer surface, and much of what it names — a *variant*, a
+# *snippet*, an *array entry*, a *function*, an *attribute* — has no Inuktitut
+# word in use and no settled syllabic transliteration either. Those words are
+# written **in roman letters inside a syllabic sentence**, as `chrome.ftl` and
+# `diagnostics.ftl` do, rather than being coined. `editor-tab-warnings` and
+# `editor-no-warnings` use «ᐅᔾᔨᖅᓱᖁᔨᔾᔪᑦ», which `chrome.ftl` flags as this
+# batch's one coinage. What is still **left out** is the part of the
+# context-help panel that is a whole sentence of language-server vocabulary —
+# `help-placeholder`, `help-unsupported-ref-chain`, `help-unresolved-ref`,
+# `help-ref-is-reference`, `help-ref-derived-from`,
+# `help-property-is-reference`, `help-suggestions-header` and
+# `help-suggestions-footer` — which falls back to English.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ᐅᑎᖅᑎᒃᑯ
+       *[update] ᓄᑖᙳᖅᑎᒃᑯ
+    }
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] ᑕᑯᒃᓴᐅᑎᑦᑎᔾᔪᑎ { $word }
+       *[other] ᑕᑯᒃᓴᐅᑎᑦᑎᔾᔪᑎ { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = variant
+editor-variant-filter = ᖃᐅᔨᒃᑲᐃᓗᑎᑦ...
+editor-variant-next = variant ᑭᖑᓪᓕᖅ ᓂᕈᐊᕐᓗᒍ
+editor-variant-previous = variant ᓯᕗᓪᓕᖅ ᓂᕈᐊᕐᓗᒍ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᒪᓕᒃᑕᐅᙱᑦᑐᖅ ᓇᓂᔭᐅᔪᖅ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+            [close] ᒪᑐᓗᒍ
+           *[open] ᐅᒃᑯᐃᕐᓗᒍ
+        } ᓇᕿᓪᓗᒍ.
+        [advisories] ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+            [close] ᒪᑐᓗᒍ
+           *[open] ᐅᒃᑯᐃᕐᓗᒍ
+        } ᓇᕿᓪᓗᒍ. WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᖃᙱᑦᑐᖅ, ᑭᓯᐊᓂ ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᖃᐅᓯᒃᓴᖃᖅᑐᖅ.
+       *[clean] ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+            [close] ᒪᑐᓗᒍ
+           *[open] ᐅᒃᑯᐃᕐᓗᒍ
+        } ᓇᕿᓪᓗᒍ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐊᒃᓱᕈᕐᓇᖅᑐᖃᙱᑦᑐᖅ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᒪᓕᒃᑕᐅᙱᑦᑐᖅ ᓇᓂᔭᐅᔪᖅ. { $count ->
+            [one] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᖅ { $count }
+            [two] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑑᒃ { $count }
+           *[other] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᑦ { $count }
+        } ᓇᓂᔭᐅᔪᑦ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+            [close] ᒪᑐᓗᒍ
+           *[open] ᐅᒃᑯᐃᕐᓗᒍ
+        } ᓇᕿᓪᓗᒍ.
+        [advisories] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᖃᙱᑦᑐᖅ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᖃᐅᓯᒃᓴᖅ { $count ->
+            [one] { $count }
+            [two] { $count }
+           *[other] { $count }
+        } ᓇᓂᔭᐅᔪᑦ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+            [close] ᒪᑐᓗᒍ
+           *[open] ᐅᒃᑯᐃᕐᓗᒍ
+        } ᓇᕿᓪᓗᒍ.
+       *[clean] WCAG AA ᒪᓕᒃᑕᐅᙱᑦᑐᖃᙱᑦᑐᖅ. ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐅᓂᒃᑳᖅ { $action ->
+            [close] ᒪᑐᓗᒍ
+           *[open] ᐅᒃᑯᐃᕐᓗᒍ
+        } ᓇᕿᓪᓗᒍ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML { $version }
+
+editor-tab-help = ᐃᑲᔫᑦ
+editor-tab-help-short = ᐃᑲᔫᑦ
+editor-tab-errors = ᑕᒻᒪᕐᓃᑦ
+editor-tab-warnings = ᐅᔾᔨᖅᓱᖁᔨᔾᔪᑏᑦ
+editor-tab-info = ᑐᑭᓯᒋᐊᕈᑏᑦ
+editor-tab-accessibility = ᐊᑐᕈᓐᓇᕐᓂᖅ
+editor-tab-responses = ᑭᐅᔾᔪᑏᑦ ᐊᐅᓪᓚᖅᑎᑕᐅᓯᒪᔪᑦ
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = ᐊᑐᕈᓐᓇᖅᑐᑦ
+editor-format-as-doenetml = DoenetML-ᒥᑎᑐᑦ ᐋᖅᑭᒃᓱᐃᓗᒍ
+editor-format-as-xml = XML-ᒥᑎᑐᑦ ᐋᖅᑭᒃᓱᐃᓗᒍ
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = ᑎᑎᕋᖅᓯᒪᔪᖅ #{ $line }
+
+editor-no-errors = ᑕᒻᒪᕐᓂᖃᙱᑦᑐᖅ
+editor-no-warnings = ᐅᔾᔨᖅᓱᖁᔨᔾᔪᑎᖃᙱᑦᑐᖅ
+editor-no-info = ᑐᑭᓯᒋᐊᕈᑎᖃᙱᑦᑐᖅ
+
+editor-show-info-annotations = ᑐᑭᓯᒋᐊᕈᑏᑦ ᑕᑯᒃᓴᐅᑎᑦᑎᒋᑦ
+editor-show-accessibility-annotations = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᑐᑭᓯᒋᐊᕈᑏᑦ ᑕᑯᒃᓴᐅᑎᑦᑎᒋᑦ
+
+editor-accessibility-learn-more = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᑐᑭᓯᒋᐊᒃᑲᓐᓂᕆᑦ
+editor-accessibility-violations-heading = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᒪᓕᒃᑕᐅᙱᑦᑐᑦ ({ $standard })
+editor-accessibility-other-heading = ᐊᑐᕈᓐᓇᕐᓂᕐᒧᑦ ᐊᓯᖏᑦ
+editor-none-found = ᓇᓂᔭᐅᙱᑦᑐᖅ
+
+
+## Submitted responses
+
+editor-no-responses = ᓱᓕ ᑭᐅᔾᔪᑎᖃᙱᑦᑐᖅ
+editor-response-answer-id = ᑭᐅᔾᔪᑎᐅᑉ ᐊᑎᖓ
+editor-response-response = ᑭᐅᔾᔪᑎ
+editor-response-credit = ᐱᔭᒃᓴᖅ
+editor-response-submitted = ᐊᐅᓪᓚᖅᑎᑕᐅᔪᖅ
+
+
+## The context-help panel
+
+help-learn-about-references = ᑐᑭᓯᒋᐊᒃᑲᓐᓂᕆᑦ →
+help-reference-page = ᒪᒃᐱᒐᖅ →
+
+help-name-summary = { $name } — { $summary }
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-default = ᐊᑐᖅᑕᐅᕙᒃᑐᖅ:
+help-active-default = ᒫᓐᓇ ᐊᑐᖅᑕᐅᔪᖅ:
+help-suggested-values = ᐊᑐᕈᓐᓇᖅᑐᑦ:
+help-type = ᓱᓇᐅᓂᖓ:
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array ᐃᓚᖓ
+help-inserts = ᐃᓚᓯᔾᔪᑏᑦ:
+help-resolved-function-names = function ᐊᑏᑦ:
+help-reset-list = ᐅᑎᖅᑎᑕᐅᔪᑦ:
+help-added-on-input = ᐃᓚᒋᐊᖅᑕᐅᔪᑦ:
+help-removed-on-input = ᐲᔭᖅᑕᐅᔪᑦ:
+help-reset-overrides = { $reset } { $additional } ᐊᒻᒪ { $removed } ᓯᕗᓕᖅᐹ.
+help-allowed-values =
+    { $perItem ->
+        [true] ᐊᑐᕈᓐᓇᖅᑐᑦ (ᐊᑕᐅᓯᐊᖅᖢᑎᒃ):
+       *[other] ᐊᑐᕈᓐᓇᖅᑐᑦ:
+    }
+help-coordinates =
+    { $count ->
+        [one] ᓇᓗᓇᐃᒃᑯᑕᖅ:
+        [two] ᓇᓗᓇᐃᒃᑯᑏᒃ:
+       *[other] ᓇᓗᓇᐃᒃᑯᑏᑦ:
+    }

--- a/packages/i18n/locales/jam/chrome.ftl
+++ b/packages/i18n/locales/jam/chrome.ftl
@@ -1,0 +1,171 @@
+# Jamaican Creole (Patwa, «Jamiekan») viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** These four files are written in the **Cassidy phonemic
+# orthography** (Cassidy 1961, as regularized by the Jamaican Language Unit at
+# UWI Mona). They are not written in English-based spelling. Most everyday
+# written Jamaican — song lyrics, social media, advertising, published
+# dialogue in novels and newspapers — uses English spelling conventions
+# instead, so this catalog does not look like what a Jamaican reader usually
+# sees written. A reviewer who decides the English-based system is wanted here
+# would **respell** the whole catalog rather than retranslate it: the words and
+# the grammar would stand, only the letters would move. That is why the choice
+# has to be made once and applied to all four files together, and why a file
+# half in one system and half in the other is the one outcome to avoid.
+#
+# The parts of the system that carry the load here, because they are what a
+# reader trips over:
+#
+#   * **Five vowels**, `i e a o u`, each with one value. The **long vowels are
+#     written doubled** — `ii`, `aa`, `uu`: «tii» *tea*, «taak» *talk*,
+#     «tuu» *two*, «griin» *green*, «bluu» *blue*.
+#   * **Three diphthongs**, `ie`, `ai`, `ou`: «niem» *name*, «brait» *bright*,
+#     «tou» *toe*. So *make* is «miek», *time* is «taim», *show* is «shuo».
+#   * **Palatal onsets written `ky` and `gy`**: «kyaan» *cannot*, «gyal»
+#     *girl*, «kyar» *car*.
+#   * **`h` is written only where it is pronounced.** «uman» *woman*, «aid»
+#     *hide*, «elp» *help*, against «hous» *house* and «hat» *hot*. The letter
+#     is not restored by English analogy, and it is not dropped by analogy
+#     either: it goes where the word is said with one.
+#   * **No apostrophes** stand in for "missing" English letters. The system
+#     spells what is said, not what English would have spelled: «lef», not
+#     «lef'»; «don», not «done»; «dem», not «'em».
+#
+# **No diacritics are used** anywhere in these files. Every character is a
+# plain ASCII letter.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data of its own for `jam`; the
+# probe resolves it to `en-US` and reports `['one', 'other']`. Jamaican Creole
+# does not inflect a noun after a numeral — «tuu buk», never a pluralized
+# noun — and marks plurality with the postposed particle «dem» («di buk dem»),
+# which a count does not trigger. So the `one` and `other` branches would be
+# word-for-word identical here, and where that is so this file writes **one
+# unselected form** instead of two identical branches. English's explicit
+# `[0]` literal in `attempts-remaining` matches the number itself, not a
+# plural category, and is kept as a branch.
+#
+# **Loans, named.** The technical vocabulary comes from English, as it does in
+# Jamaican generally, and is written in Cassidy spelling with Jamaican grammar
+# around it: «kompuonent», «atribyut», «fongkshan», «vekta», «espreshan»,
+# «kiibuod», «priivyuu», «dokyument», «renda», «kredit». The words doing the
+# grammatical work are Jamaican: «a» for the progressive and for the equative
+# copula, «de» for location, «did» for past, «wi» for future, «mos» for
+# obligation, «fi» for purpose and possession, «no»/«naa» for negation,
+# «kyaan» for *cannot*, «no av» for *does not have*.
+#
+# So the technical vocabulary in this file is **an English loan set carried in
+# Jamaican Creole's own grammar and written in Cassidy spelling**. The loans
+# are the words the language actually uses for these things; the sentences
+# around them are Jamaican, not English. A Cassidy-spelled English loan is
+# correct here. An English sentence anywhere in these four files is a defect.
+
+
+## Answer submission
+
+answer-checking = A chek...
+answer-submitting = A sen...
+answer-checking-status = A chek di ansa
+answer-submitting-status = A sen di ansa
+answer-correct = Korek
+answer-incorrect = No korek
+answer-response-saved = Ansa Siev
+answer-percent-credit = { $percent }% Kredit
+answer-percent-correct = { $percent }% Korek
+answer-percent-short = { $percent } %
+max-credit-available = Muos kredit yu kyan get: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] no chans no lef
+       *[other] { $count } chans lef
+    }
+validation-correct = (Korek)
+validation-incorrect = (No korek)
+validation-partially-correct = (Paat a it korek)
+answer-show-responses = Shuo { $count } ansa we sen gi { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Fiidbak
+collapsible-click-to-open = (klik fi uopn it)
+collapsible-click-to-close = (klik fi kluoz it)
+collapsible-initializing = A staat op...
+footnote-show = Shuo di futnuot
+footnote-hide = Aid di futnuot
+description-more-information = muo infarmieshan
+
+
+## Controls
+
+slider-previous = Bak
+slider-next = Neks
+keyboard-open = Uopn Di Kiibuod
+keyboard-close = Kluoz Di Kiibuod
+choice-input-remove-choice = Tek we { $choice }
+matrix-remove-row = Tek we wan ruo
+matrix-add-row = Put wan ruo
+matrix-remove-column = Tek we wan kolom
+matrix-add-column = Put wan kolom
+subset-add-remove-points = Put/Tek we pwaint
+subset-toggle-points-intervals = Swich bitwiin pwaint an intovol
+subset-move-points = Muuv Di Pwaint Dem
+subset-clear = Kliar
+orbital-add-row = Put Wan Ruo
+orbital-remove-row = Tek We Wan Ruo
+orbital-add-box = Put Wan Baks
+orbital-remove-box = Tek We Wan Baks
+orbital-add-up-arrow = Put Wan Aro We Point Op
+orbital-add-down-arrow = Put Wan Aro We Point Dong
+orbital-remove-arrow = Tek We Wan Aro
+orbital-row-label = Liebl fi ruo { $row }
+pretzel-answer = Ansa
+summary-statistics-caption = Somri statistiks fi { $column }
+
+
+## Math input
+
+math-input-preview-region = priivyuu a di mat espreshan
+math-input-preview = Priivyuu
+math-input-invalid-expression = Di espreshan no valid:
+
+
+## Document status
+
+viewer-initializing = A staat op...
+
+
+## Errors
+
+error-heading = Era
+
+error-found-at =
+    { $span ->
+        [line] Fain pan lain { $startLine }.
+       *[lines] Fain pan lain { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dis dokyument av era iina it!
+
+diagnostic-heading-error = Era
+diagnostic-heading-warning = Waanin
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Hint
+
+accessibility-heading-level-1 = WCAG AA Aksesibiliti Vaiolieshan
+accessibility-heading-level-2 = Aksesibiliti alat
+
+something-went-wrong = Sitn gaan rang.
+renderer-load-failed = wan renda kyaan luod. Du, riluod di piej.
+core-start-failed = Dis dokyument kyaan staat. Du, riluod di piej.
+core-start-failed-busy = Dis dokyument kyaan staat. Nof dokyument did a staat di siem taim, an dat kyan tek langa pan wan sluo divais. Riluod di piej kyan elp wans di ada dokyument dem don.
+core-start-failed-retry = Dis dokyument kyaan staat.
+core-start-failed-busy-retry = Dis dokyument kyaan staat. Nof dokyument did a staat di siem taim, an dat kyan tek langa pan wan sluo divais.
+core-start-retry = Chrai agen
+saved-state-unavailable = Wi kyaan luod di wok we yu did siev.

--- a/packages/i18n/locales/jam/content.ftl
+++ b/packages/i18n/locales/jam/content.ftl
@@ -1,0 +1,296 @@
+# Jamaican Creole (Patwa, «Jamiekan») content catalog: the prose the core
+# computes into the document. Selected by `documentLocale` — the language the
+# activity was written in, not the reader's UI language.
+#
+# `locales/en/content.ftl` is the source of truth: `lint:i18n` rejects a key
+# that does not exist there. Message ids and `.attribute` suffixes are never
+# translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** This file is written in the **Cassidy phonemic
+# orthography** (Cassidy 1961, as regularized by the Jamaican Language Unit at
+# UWI Mona), the same system as the other three files in this directory. It is
+# not written in English-based spelling. Most everyday written Jamaican — song
+# lyrics, social media, advertising, published dialogue — uses English
+# spelling conventions instead, so this catalog does not look like what a
+# Jamaican reader usually sees written. A reviewer who chooses the
+# English-based system would **respell** the entire catalog rather than
+# retranslate it, so that choice has to be made once and applied to all four
+# files together. `chrome.ftl`'s header sets the system out: five vowels
+# `i e a o u`, long vowels doubled («tii», «taak», «tuu»), three diphthongs
+# `ie ai ou` («niem», «brait», «tou»), palatal `ky` and `gy` («kyaan»,
+# «gyal»), `h` written only where it is pronounced, and no apostrophes for
+# "missing" English letters. No diacritics are used.
+#
+# Two Cassidy spellings appear a great deal in this file and are worth naming
+# so they are not read as slips: English *tr-* is «chr-» in Jamaican, so
+# *triangle* is «chraiangl» and *true* is «chruu»; and English *dr-* is «jr-».
+#
+# **Word order: the modifier comes before the noun.** A Jamaican Creole
+# attributive adjective stands in front of its head, exactly as in English —
+# «big hous», «red lain», «tik red lain». So every composition message here
+# **keeps the English order**; none of them is reversed.
+#
+# **No agreement.** Jamaican Creole has no grammatical gender and an
+# attributive adjective takes no ending, so no message in this file forks on
+# `$gender` or `$role`. `noun-gender` answers a single token that nothing
+# reads.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data of its own for `jam`; the
+# probe resolves it to `en-US` and reports `['one', 'other']`. Jamaican Creole
+# does not inflect a noun after a numeral — «tuu buk» — and marks plurality
+# with the postposed particle «dem» («di buk dem»), which a count does not
+# trigger. The two branches would therefore be word-for-word identical, which
+# is why no count-driven select is written anywhere in these four files.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the two English keys this file does not cover.
+# School science in Jamaica is taught in English, from English textbooks and
+# to English-language examinations; there is no settled Jamaican Creole
+# periodic table and no published Cassidy spelling for the hundred and
+# eighteen element names. Writing one out would be inventing a nomenclature
+# and presenting it as an existing one. `lint:i18n` reports the two keys as
+# missing coverage and that is the correct report. `ion-name-oxidation-state`,
+# `chemistry-invalid-symbol` and `chemistry-invalid-ionic-compound` **are**
+# covered: they are frames, not vocabulary.
+#
+# **Loans kept, rather than coined.** The mathematical and technical
+# vocabulary comes from English, which is normal for Jamaican and is not a
+# defect; it is written in Cassidy spelling with Jamaican grammar around it:
+# «fongkshan», «vekta», «paligan», «parabola», «rektangl», «sorkl», «kov»,
+# «riijan», «kompuonent», «atribyut», «sekshan», «definishan», «tiirem».
+# **«saian»** for *cyan* is the weakest word in the file — there is no settled
+# Jamaican word for it, and a speaker may prefer a phrase built on «bluu». So
+# is **«pwaint»** for *point*: the vowel of English *point* has no separate
+# letter in the five-vowel system, and «pwaint» is the shape Cassidy's «bwai»
+# *boy* implies. A reviewer should look at both of those first.
+#
+# The technical vocabulary here is **an English loan set carried in Jamaican
+# Creole's own grammar and written in Cassidy spelling**. The loans are the
+# words the language actually uses; the sentences around them are Jamaican,
+# not English. A Cassidy-spelled English loan is correct. An English sentence
+# anywhere in these four files is a defect.
+
+
+## Style vocabulary
+
+color =
+    .black = blak
+    .white = wait
+    .gray = grie
+    .red = red
+    .orange = arinj
+    .yellow = yelo
+    .green = griin
+    .cyan = saian
+    .blue = bluu
+    .purple = popl
+    .pink = pink
+    .brown = brong
+
+line-width =
+    .thick = tik
+    .thin = tin
+
+line-style =
+    .dashed = dash-dash
+    .dotted = dat-dat
+
+fill-style =
+    .horizontal = arizantal lain
+    .vertical = votikal lain
+    .diagonal = daiaganal lain
+    .backdiagonal = bakwod daiaganal lain
+    .dots = dat
+    .diamonds = daiman
+
+noun =
+    .line = lain
+    .line-segment = lain sigment
+    .ray = rie
+    .vector = vekta
+    .curve = kov
+    .function = fongkshan
+    .slope-field = sluop fiil
+    .vector-field = vekta fiil
+    .parabola = parabola
+    .polyline = palilain
+    .polygon = paligan
+    .triangle = chraiangl
+    .rectangle = rektangl
+    .circle = sorkl
+    .region = riijan
+    .point = pwaint
+    .square = skwier
+    .diamond = daiman
+    .cross = kraas
+    .plus = plos
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides }-said reglar paligan
+    }
+
+noun-gender = nyuuta
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = ful-op
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } wid { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } wid { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wid { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] wid wan { $border } baada
+        [and] an { $border } baada
+        [and-article] an wan { $border } baada
+       *[with] wid { $border } baada
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = no ful op
+
+style-text =
+    { $parts ->
+        [background] { $color } wid wan { $background } bakgrong
+       *[plain] { $color }
+    }
+
+style-background-none = non
+
+
+## Boolean words
+
+boolean-true = chruu
+boolean-false = faals
+
+
+## Answer buttons
+
+answer-submit-label = Chek Di Wok
+answer-submit-label-no-correctness = Sen Di Ansa
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktiviti
+    .aside = Said Nuot
+    .cascade = Kaskied
+    .definition = Definishan
+    .example = Egzampl
+    .exercise = Egzasaiz
+    .exercises = Egzasaiz Dem
+    .given-answer = Ansa
+    .note = Nuot
+    .objectives = Objektiv Dem
+    .paragraphs = Parigraaf Dem
+    .part = Paat
+    .problem = Prablem
+    .problems = Prablem Dem
+    .proof = Pruuf
+    .question = Kwestyan
+    .section = Sekshan
+    .solution = Soluushan
+    .task = Taask
+    .theorem = Tiirem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Hint
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tiebl { $enumeration }
+        [numbered-title] Tiebl { $enumeration }{ ": " }
+        [unnumbered-title] Tiebl{ ": " }
+       *[unnumbered] Tiebl
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figa { $enumeration }
+        [numbered-caption] Figa { $enumeration }{ ": " }
+        [unnumbered-caption] Figa{ ": " }
+       *[unnumbered] Figa
+    }
+
+
+## Paginator controls
+
+paginator-previous = Bak
+paginator-next = Neks
+paginator-page = Piej
+
+paginator-page-status = { $pageLabel } { $currentPage } outa { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ar
+piecewise-condition-if = if
+piecewise-condition-otherwise = adawaiz
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kemikal Simbal We No Valid
+chemistry-invalid-ionic-compound = Aianik Kompong We No Valid
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blangk
+
+math-embedded-input-blank-ordinal = blangk { $ordinal } outa { $total }

--- a/packages/i18n/locales/jam/diagnostics.ftl
+++ b/packages/i18n/locales/jam/diagnostics.ftl
@@ -1,0 +1,692 @@
+# Jamaican Creole (Patwa, «Jamiekan») diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `styleNumber`, `prefigure`/`PreFigure`, `WCAG AA`,
+# `[deprecation]` — are part of the language, not prose, and stay in English
+# exactly as written. So does anything quoted back from the author's own
+# source. The backticks, angle brackets and quote marks around them are
+# punctuation the code depends on and are reproduced exactly.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **Cassidy phonemic orthography** (Cassidy 1961, as
+# regularized by the Jamaican Language Unit at UWI Mona) is what is written in
+# these four files. It is not English-based spelling. Most everyday written
+# Jamaican — song lyrics, social media, advertising, published dialogue — uses
+# English spelling conventions instead, so this catalog does not look like
+# what a Jamaican reader usually sees written. A reviewer who chooses the
+# English-based system would **respell** the entire catalog rather than
+# retranslate it: the wording would stand and only the letters would move,
+# which is why the choice has to be made once and applied to all four files
+# together. `chrome.ftl` sets the system out in full — five vowels
+# `i e a o u` with the long vowels doubled («tii», «taak», «tuu»), the three
+# diphthongs `ie ai ou` («niem», «brait», «tou»), palatal `ky` and `gy`
+# («kyaan», «gyal»), `h` written only where it is pronounced, and no
+# apostrophes standing in for "missing" English letters. No diacritics are
+# used.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data of its own for `jam`; the
+# probe resolves it to `en-US` and reports `['one', 'other']`. A Jamaican
+# Creole noun after a numeral is unmarked — «tuu buk» — and plurality is
+# marked by the postposed particle «dem», which a count does not trigger. The
+# two branches would be word-for-word identical here, so every count-driven
+# select in the English is written as **one unselected form**. The one place a
+# select on a number is kept is `field-function-wrong-num-outputs`, where the
+# `$expected` branches say two different things about the function rather than
+# the same thing twice.
+#
+# Selects that are not plural selects — `$reason`, `$mode`, `$type`,
+# `$component`, `$componentType`, `$suggestion`, `$context`, `$fallback`,
+# `$isList`, `$labelKind`, `$expected`, `$subject` — are kept, and every
+# branch of them is translated.
+#
+# **Grammar around the loans.** The technical nouns are English, in Cassidy
+# spelling: «kompuonent», «atribyut», «elimant», «vieryabl», «fongkshan»,
+# «siikwens», «matriks», «indeks», «refrans», «anatieshan», «kanchraas».
+# The sentences around them are Jamaican: «kyaan» for *cannot*, «no av» for
+# *does not have*, «mos» for *must*, «wi» for the future, «no»/«naa» for
+# negation, «fi» for purpose and possession, «a» for the equative copula and
+# the progressive, «de» for location, «se» for the complementizer. Two words
+# a reviewer should look at first: **«dipriket»** for *deprecated*, which is a
+# bare loan and has no currency outside software, and **«kanchraas»** for
+# *contrast*, which is regular Cassidy but is not a word most readers will
+# have seen written.
+#
+# What that amounts to is **an English loan set carried in Jamaican Creole's
+# own grammar and written in Cassidy spelling**. The loans are the words the
+# language actually uses for these things; the sentences around them are
+# Jamaican, not English. A Cassidy-spelled English loan is correct here. An
+# English sentence anywhere in these four files is a defect.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } get ignaar wen tuu endpoint spesifai
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } get ignaar wen wan endpoint an wan midpoint bot spesifai
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset no du notn if no midpoint no de-de
+
+## `<line>`
+
+line-points-undetermined-dimensions = Lain chruu pwaint we wi kyaan wok out di dimenshan fa.
+
+line-points-too-few-dimensions = Lain mos go chruu pwaint we av at liis tuu dimenshan.
+
+line-points-depend-on-variables = Lain a go chruu pwaint we dipen pan vieryabl: { $variables }.
+
+line-equation-invalid-format = Di faamat fi di ikwieshan a di lain no valid iina vieryabl { $variable1 } an { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Di rie spesifai wid through, endpoint an direction bot.  Wi a ignaar di through we gi.
+
+ray-dimension-mismatch = Di numDimensions no machop iina di rie.
+
+## `<vector>`
+
+vector-overprescribed-head = Di vekta spesifai wid head, tail an displacement aal chrii.  Wi a ignaar di head we gi.
+
+vector-dimension-mismatch = Di numDimensions no machop iina di vekta.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Kyaan achraak tu wan `<{ $component }>` kaaz it no av no nearestPoint stiet vieryabl.
+
+constrain-to-without-nearest-point = Kyaan kanchriein tu wan `<{ $component }>` kaaz it no av no nearestPoint stiet vieryabl.
+
+constrain-to-interior-without-nearest-point = Kyaan kanchriein tu di iinsaid a wan `<{ $component }>` kaaz it no av no nearestPoint stiet vieryabl.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition get ignaar pan wan choiceInput we no inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Wi a ignaar di indeks dem we spesifai fi choiceInput kaaz di nomba a indeks no machop wid di nomba a choice chail.
+
+pretzel-indices-count-mismatch = Wi a ignaar di indeks dem we spesifai fi di prablem kaaz di nomba a indeks no machop wid di nomba a prablem chail.
+
+shuffle-indices-count-mismatch = Wi a ignaar di indeks dem we spesifai fi shuffle kaaz di nomba a indeks no machop wid di nomba a kompuonent.
+
+indices-ignored-out-of-range = Wi a ignaar di indeks dem we spesifai fi { $component } kaaz som a dem outa rienj.
+
+pretzel-indices-repeated = Wi a ignaar di indeks dem we spesifai fi pretzel kaaz som a dem ripiit.
+
+pretzel-circuit-first-index = Wi a ignaar di indeks dem we spesifai fi pretzel iina circuit muod kaaz di fos indeks mos bi 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Fi mek `<{ $component }>` wok wid string chail, wan `type` atribyut mos spesifai.
+
+invalid-type-defaulting-to-math = Di type { $type } no valid fi di { $component } kompuonent. It mos bi math, text, number ar boolean. Wi a difaalt tu math.
+
+string-not-valid-component-to-arrange = Di string "{ $value }" no wan valid kompuonent fi { $component }. Wi a ignaar it.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Di type { $type } no valid, so wi a set di type tu number.
+
+invalid-variable-value = Di valyu a di vieryabl no valid: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Di vieryant indeks { $index } mos bi wan nomba
+
+variant-index-must-be-integer = Di vieryant indeks { $index } mos bi wan intija
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` no impliment fi absaluut mezhament. Wi a set di widt dem tu relativ.
+
+side-by-side-absolute-margins = `<{ $component }>` no impliment fi absaluut mezhament. Wi a set di maajin dem tu relativ.
+
+side-by-side-no-block-child = `<{ $component }>` no valid: it mos av at liis wan blak chail.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Di `for` atribyut pan wan graafikal `<label>` get ignaar.
+
+label-for-must-resolve-to-one = Di `for` atribyut pan `<label>` mos point tu wan wan kompuonent.
+
+label-for-unresolved = Wi kyaan wok out wich kompuonent di `for` atribyut pan `<label>` a point tu.
+
+label-for-answer-with-authored-inputs = Di `for` atribyut pan `<label>` a point tu wan `<answer>` we di aata rait di input fa demself; point tu di input diirek.
+
+label-for-answer-without-input = Di `for` atribyut pan `<label>` a point tu wan `<answer>` we no av no input fi liebl.
+
+label-for-must-reference-input-or-answer = Di `for` atribyut pan `<label>` mos point tu wan input ar wan answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Fi aksesibiliti, `<{ $component }>` mos av wan shaat dekripshan ar it mos spesifai az decorative.
+
+accessibility-video-short-description = Fi aksesibiliti, `<video>` mos av wan shaat dekripshan.
+
+accessibility-input-short-description-or-label = Fi aksesibiliti, `<{ $component }>` mos av wan shaat dekripshan ar wan liebl.
+
+accessibility-answer-input-short-description-or-label = Fi aksesibiliti, wan `<answer>` we a mek wan input mos av wan shaat dekripshan ar wan liebl.
+
+accessibility-short-description-contains-math = Shaat dekripshan no fi av mat kompuonent iina dem, laik `<{ $component }>`. Spel out di mat wid wod.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } no av inof kanchraas fi di sekshan edin tex (daak muod) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; it niid at liis { $threshold }:1).
+       *[other] { $colorName } no av inof kanchraas fi di sekshan edin tex ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; it niid at liis { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wi no impliment `<circle>` chruu { $count } pwaint yet fi wen di pwaint dem no av no nomba valyu.
+
+circle-too-many-through-points = Kyaan wok out wan sorkl chruu muo dan 3 pwaint.
+
+circle-overprescribed-radius-center-points = Kyaan wok out wan sorkl wen di radius, di senta an di chruu-pwaint dem aal spesifai.
+
+circle-center-with-multiple-points = Kyaan wok out wan sorkl wid wan spesifai senta we go chruu muo dan 1 pwaint.
+
+circle-radius-too-small = Kyaan wok out di sorkl: siin se di distans bitwiin di tuu pwaint a { $distance }, di radius { $radius } we spesifai tuu likl.
+
+circle-radius-with-many-points = Kyaan mek wan sorkl chruu muo dan tuu pwaint wid wan spesifai radius.
+
+circle-invalid-center-or-through-points = Di senta ar di chruu-pwaint dem a di sorkl no valid.
+
+circle-radius-center-with-multiple-points = Kyaan wok out di radius a wan sorkl wid wan spesifai senta we go chruu muo dan 1 pwaint.
+
+circle-radius-with-points-non-numerical = Kyaan mek wan sorkl chruu muo dan wan pwaint wid wan spesifai radius wen di pwaint dem no av no nomba valyu.
+
+circle-change-radius-non-numerical = Kyaan chienj di radius a wan sorkl we go chruu pwaint we no av no nomba valyu
+
+circle-change-center-non-numerical = Wi no impliment chienjin di senta a wan sorkl we go chruu pwaint we no av no nomba valyu.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Di duumien fi di fongkshan no av inof dimenshan. Di duumien av { $intervals } intovol bot di fongkshan av { $inputs } input.
+
+function-domain-invalid-format = Di faamat fi di duumien a di fongkshan no valid.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Wi a ignaar di maksimom a di fongkshan kaaz it no a nomba.
+        [minimum] Wi a ignaar di minimom a di fongkshan kaaz it no a nomba.
+        [extremum] Wi a ignaar di ekschiimom a di fongkshan kaaz it no a nomba.
+        [point] Wi a ignaar di pwaint a di fongkshan kaaz it no a nomba.
+        [slope] Wi a ignaar di sluop a di fongkshan kaaz it no a nomba.
+       *[other] Wi a ignaar di { $type } a di fongkshan kaaz it no a nomba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Wi a ignaar di maksimom a di fongkshan kaaz it emti.
+        [minimum] Wi a ignaar di minimom a di fongkshan kaaz it emti.
+        [extremum] Wi a ignaar di ekschiimom a di fongkshan kaaz it emti.
+        [point] Wi a ignaar di pwaint a di fongkshan kaaz it emti.
+       *[other] Wi a ignaar di { $type } a di fongkshan kaaz it emti.
+    }
+
+function-points-too-close = Di fongkshan av tuu pwaint we tuu niez tugeda. Wi kyaan difain di fongkshan.
+
+function-iterates-input-output-mismatch = Fongkshan itaret ongl wok if di nomba a input di siem az di nomba a outpit. Dis fongkshan av { $inputs } input an { $outputs } outpit.
+
+## `<sequence>`
+
+sequence-invalid-length = Di lent a di siikwens no valid.  It mos bi wan intija we no negativ.
+
+sequence-invalid-step = Di step a di siikwens no valid.  It mos bi wan nomba fi wan siikwens a di { $type } taip.
+
+sequence-invalid-endpoint-number = Di "{ $attribute }" a di nomba siikwens no valid.  It mos bi wan nomba.
+
+sequence-invalid-endpoint-letters = Di "{ $attribute }" a di leta siikwens no valid.  It mos bi wan kombinieshan a leta.
+
+sequence-invalid-endpoint = Di "{ $attribute }" a di siikwens no valid.
+
+select-from-sequence-coprime-not-numbers = coprime get ignaar kaaz wi no a pik nomba
+
+select-from-sequence-coprime-with-exclude-combinations = coprime get ignaar kaaz excludeCombinations spesifai
+
+## Resolving a `target`
+
+target-not-found = Di target fi `<{ $source }>` no valid: wi kyaan fain di taagit.
+
+target-state-variable-not-found = Di target fi `<{ $source }>` no valid: wi kyaan fain no stiet vieryabl niem "{ $property }" pan wan `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Di vieryabl dem a `<odeSystem>` mos difarant fram di indipendent vieryabl.
+
+ode-system-duplicate-variable-names = Wi kyaan difain ODE RHS fongkshan wid di siem dipendent vieryabl niem tuu taim.
+
+ode-system-rhs-function-error = Kyaan difain di ODE RHS fongkshan.  Wan era gwaan wen wi did a mek di mathjs fongkshan.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Kyaan difain wan angl bitwiin { $count } lain
+
+angle-invalid-through-point = Wan pwaint iina di through a `<angle>` no valid
+
+parabola-vertex-too-many-points = Wi no impliment wan parabola wid wan vortiks we go chruu muo dan 1 pwaint yet.
+
+parabola-too-many-points = Wi no impliment wan parabola chruu muo dan 3 pwaint yet.
+
+intersection-too-many-items = Wi no impliment intasekshan fi muo dan tuu tin yet
+
+## Other math components
+
+ionic-compound-not-two-ions = Wi no impliment aianik kompong fi notn ada dan tuu aian yet.
+
+ionic-compound-needs-cation-and-anion = Aianik kompong ongl impliment fi wan kataian an wan anaian.
+
+solve-equations-cannot-evaluate = Kyaan salv di ikwieshan kaaz wi kyaan wok out di ikwieshan: { $equation }
+
+math-operators-operand-number-required = Yu mos spesifai wan operandNumber wen yu a tek out wan mat aparan.
+
+eigen-decomposition-failed = Wi kyaan wok out di aiganvalyu dem a di matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: di parameter { $parameters } no de iina di patan, so it wi aalwiez mach wan blangk.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: wi kyaan riid grid="{ $grid }". It mos bi none, medium, dense, ar tuu pazitiv nomba wid wan spies bitwiin dem, laik grid="1 0.5". No grid naa jraa.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` niid wan fongkshan wid { $expected ->
+        [one] wan outpit, di sluop y' a ich pwaint, laik `y - x`
+       *[other] tuu outpit, di vekta a ich pwaint, laik `(y, -x)`
+    }, bot di fongkshan we it get av { $found } outpit. { $alternative ->
+        [none] Notn naa jraa.
+       *[other] A `<{ $alternative }>` a di kompuonent fi dat fongkshan. Notn naa jraa.
+    }
+
+field-function-attribute-ignored-with-child = Di `function` atribyut get ignaar kaaz di fongkshan gi iinsaid di kompuonent tu; a di wan iinsaid wi a yuuz. Gi di fongkshan wan wie ongl.
+
+field-variables-ignored =
+    `<{ $component }>`: di `variables` atribyut niem di vieryabl dem a wan espreshan we rait diirek iinsaid di kompuonent. { $reason ->
+        [function-child] Di fongkshan ya gi az wan `<function>` chail, we niem im uona vieryabl, so `variables` get ignaar.
+       *[no-expression] No sich espreshan no gi ya so, so `variables` get ignaar.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" no sopaat iina di prefigure renda; wi a yuuz di right-position bihievya.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" no sopaat iina di prefigure renda; wi a yuuz di top-position bihievya.
+
+prefigure-invalid-axis-bounds = `<graph>`: di aksis bound dem no valid fi di prefigure konvorshan; wi a yuuz di difaalt bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: di widt no valid fi di prefigure konvorshan; wi a yuuz di difaalt daiagram widt 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: di aspectRatio no valid fi di prefigure konvorshan; wi a yuuz di difaalt aspek rieshyo 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: di spies bitwiin di grid lain dem tuu fain fi di aksis limit; di grid lef out a di prefigure renda.
+
+prefigure-annotations-not-rendered = `<graph>`: anatieshan naa renda wen yu no a yuuz di PreFigure renda.
+
+multiple-annotations-children = Wi fain muo dan wan `<annotations>` chail iina `<graph>`; aal a dem bot di laas wan get ignaar.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Kyaan ekstend ar kapi wan kompuonent taip wi no nuo: { $type }.
+
+copy-prop-not-found = Wi kyaan fain di prop { $property } pan wan kompuonent a taip { $component }
+
+collect-no-source = Wi kyaan fain no suos fi collect.
+
+collect-invalid-component-type = Kyaan kalek kompuonent a taip `<{ $component }>` kaaz dat no wan valid kompuonent taip.
+
+reference-index-unavailable = Kyaan refrans di indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Kyaan kaal { $action } pan di kompuonent `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Di dieta shiep no valid.  Di ruo dem no av di siem lent. Fain iina componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Di dieta av di siem kolom niem muo dan wans.  Fain iina componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kolom niem mis outa di dieta.  Fain iina componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award fi dis ansa bies pan di answer tag uon ansa we sen, an dat wi mek it bihiev iina wie yu no ekspek.
+
+answer-max-num-attempts-in-section-wide-check-work = Wen yu set `maxNumAttempts` pan wan `<answer>` we iina wan kanteina wid `sectionWideCheckWork`, it no du notn, kaaz a di kanteina kanchruol di nomba a chans. Set `maxNumAttempts` pan di kanteina instid.
+
+nested-section-wide-check-work-max-num-attempts = Wen yu set `maxNumAttempts` pan wan kanteina wid `sectionWideCheckWork` we iina wan neda kanteina wid `sectionWideCheckWork`, it no du notn, kaaz a di outa kanteina kanchruol di nomba a chans. Set `maxNumAttempts` pan di outa kanteina instid.
+
+answer-attributes-need-symbolic-equality = Di { $attributes } atribyut naa du notn if symbolicEquality no set.
+
+answer-invalid-type = Di taip fi di ansa no valid: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Kaaz di kompuonent `<{ $component }>` no av no niem, it kyaan yuuz fi wan module atribyut
+
+module-attribute-name-already-defined = Di kompuonent `<{ $component } name="{ $name }">` kyaan yuuz az wan atribyut fi wan module kaaz di `<module>` kompuonent taip aredi av wan "{ $name }" atribyut difain.
+
+conditional-content-condition-ignored = Di `condition` atribyut get ignaar pan wan `<conditionalContent>` kompuonent we av case ar else chail.
+
+slider-markers-type-mismatch = Di maaka taip no machop wid di slaida taip.
+
+pretzel-problem-needs-statement-and-answer = Di pretzel no valid: ich `<problem>` mos av wan `<statement>` an wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Di pretzel no valid: iina mode="circuit", di fos `<problem>` kyaan bi wan dischrakta.
+
+## Attribute values
+
+attribute-invalid-values = Di valyu { $values } no valid fi di atribyut `{ $attribute }`; wi a ignaar it.
+
+attribute-must-be-references = Di valyu `{ $value }` no valid fi di atribyut `{ $attribute }`. Di atribyut mos mek op a refrans we staat wid wan `$`.
+
+math-input-invalid-function-names = <mathInput>: wi ignaar di fongkshan niem dem we no valid iina { $attribute }: { $names }. Ich niem displie paat mos av at liis 2 karakta (leta ar dash); wan `|<mathspeak alternative>` sofiks kyan kom aafta it if yu waahn.
+
+## Building components from the source
+
+component-type-invalid = Di kompuonent taip no valid: `<{ $componentType }>`
+
+attribute-repeated = Yu kyaan ripiit di atribyut { $attribute }.
+
+attribute-invalid-for-component = Di atribyut "{ $attribute }" no valid fi wan kompuonent a taip `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Stail definishan { $styleNumber } no av inof kanchraas fi { $context ->
+        [text-on-background] di tex kola agens di bakgrong kola
+        [high-contrast] di ai-kanchraas kola agens di kanvas
+        [line] di lain kola agens di kanvas
+        [marker] di maaka kola agens di kanvas
+       *[text-on-canvas] di tex kola agens di kanvas
+    }{ $mode ->
+        [dark] { " (daak muod)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; it niid at liis { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Iivn dou stail definishan { $styleNumber } spesifai kola we av inof kanchraas fi lait muod, di daak-muod kola we kom outa dem valyu no av inof kanchraas fi di tex kola agens di bakgrong kola ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; it niid at liis { $threshold }:1). { $suggestion ->
+        [available] Fi mek shuor se yu av inof kanchraas iina daak muod, ada yu mek di lait-muod kanchraas biga (fi egzampl, set { $lightAttribute }="{ $lightColor }") ar yu uovaraid di daak-muod kola (fi egzampl, set { $darkAttribute }="{ $darkColor }").
+       *[none] Fi mek shuor se yu av inof kanchraas iina daak muod, mek di lait-muod kanchraas biga ar uovaraid di kola dem wid textColorDarkMode an/ar backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Iivn dou stail definishan { $styleNumber } spesifai wan tex kola we av inof kanchraas fi lait muod, di daak-muod tex kola we kom outa dat valyu no av inof kanchraas agens di kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; it niid at liis { $threshold }:1). { $suggestion ->
+        [available] Fi mek shuor se yu av inof kanchraas iina daak muod, ada yu mek di lait-muod kanchraas biga (fi egzampl, set textColor="{ $lightColor }") ar yu uovaraid di daak-muod kola (fi egzampl, set textColorDarkMode="{ $darkColor }").
+       *[none] Fi mek shuor se yu av inof kanchraas iina daak muod, mek di lait-muod kanchraas biga ar uovaraid di kola we kom outa it wid textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan sekshan kyan pik wan wan <stylePalette>; wi a yuuz di laas wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz numToSelect no wan intija we no negativ.
+
+variant-num-to-select-not-constant-number = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz numToSelect no wan kanstant nomba.
+
+variant-with-replacement-not-constant-boolean = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz withReplacement no wan kanstant boolean.
+
+variant-select-weight-disables-unique = Yuuniik vieryant fi select torn aaf if wan a di opshan av selectWeight ar selectForVariants spesifai
+
+variant-coprime-undetermined = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz wi kyaan wok out se coprime aalwiez false.
+
+variant-attribute-not-constant = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz { $attribute } no kanstant.
+
+variant-attribute-not-number = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz { $attribute } no wan nomba.
+
+variant-attribute-wrong-type-for-sequence =
+    wi kyaan wok out di yuuniik vieryant dem a { $component } a di { $type } taip kaaz { $attribute } no { $expected ->
+        [letters-combination] wan kombinieshan a leta
+        [math-expression] wan valid mat espreshan
+        [integer] wan intija
+       *[number] wan nomba
+    }.
+
+variant-length-not-integer = wi kyaan wok out di yuuniik vieryant dem a { $component } kaaz length no wan intija.
+
+variant-sort-not-implemented = wi no impliment yuuniik vieryant fi wan { $component } wid sort yet
+
+variant-exclude-combinations-not-implemented = wi no impliment yuuniik vieryant fi wan { $component } wid excludeCombinations yet
+
+variant-math-exclude-not-implemented = wi no impliment yuuniik vieryant fi wan { $component } a taip math wid exclude yet
+
+variant-non-constant-exclude-not-implemented = wi no impliment yuuniik vieryant fi wan { $component } wid wan exclude we no kanstant yet
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: no sopaat iina di graph prefigure renda; wi skip di disendant.
+
+prefigure-descendant-invalid-geometry = { $subject }: di jiaametri no finait ar it no komplit; wi skip di disendant.
+
+prefigure-curve-label-omitted = { $subject }: liebl no sopaat pan kov elimant we konvot; wi lef out di liebl.
+
+prefigure-curve-unsupported-definition-type = { $subject }: di kov fongkshan definishan taip '{ $definitionType }' no sopaat; wi skip di disendant.
+
+prefigure-region-flip-functions-unsupported = { $subject }: di flipFunctions atribyut no sopaat pan regionBetweenCurves; wi skip di disendant.
+
+prefigure-region-non-formula-child = { $subject }: a ongl chail fongkshan a di formula taip sopaat pan regionBetweenCurves; wi skip di disendant.
+
+prefigure-label-position-unsupported =
+    { $subject }: di labelPosition '{ $labelPosition }' no sopaat fi wan { $labelKind ->
+        [line-family] liebl a di lain famili
+       *[point] pwaint liebl
+    }; wi a yuuz di difaalt PreFigure alainment.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure no sopaat di fil stail '{ $fillStyle }'; wi a jrap bak tu wan salid fil.
+
+prefigure-line-style-unknown = { $subject }: wi no nuo di lain stail '{ $lineStyle }', so it lef out a di PreFigure outpit.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wi map di maaka stail '{ $markerStyle }' tu di PreFigure stail 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure no sopaat di maaka stail '{ $markerStyle }'; wi a yuuz di difaalt stail.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: di `ref` no valid; wi kyaan fain di taagit. Wi lef out di anatieshan.
+
+annotation-ref-multiple-targets = `<annotation>`: di `ref` point tu muo dan wan taagit; wi a yuuz di fos wan.
+
+annotation-ref-outside-graph = `<annotation>`: di `ref` no valid; di taagit de outsaid a di graph we uol it. Wi lef out di anatieshan.
+
+annotation-ref-unsupported-target = `<annotation>`: di `ref` no valid; di taagit no wan graafikal abjek we di prefigure konvorshan sopaat. Wi lef out di anatieshan.
+
+annotation-text-missing = `<annotation>`: di `text` mis ar it emti; wi a put out emti tex.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wi fain wan sorkila dipendensi.
+       *[other] Wi fain wan sorkila dipendensi we av di `<{ $componentType }>` kompuonent iina it.
+    }
+
+reference-no-referent = Wi kyaan fain notn fi di refrans: `{ $reference }`
+
+reference-multiple-referents = Wi fain muo dan wan tin fi di refrans: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Di faamat fi di atribyut { $attribute } a `<{ $componentType }>` no valid.
+
+children-invalid = Di chail dem fi `<{ $componentType }>` no valid: wi fain dem ya chail we no valid: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Di valyu `{ $value }` no valid fi di atribyut `{ $attribute }`, so wi a yuuz di valyu `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wi kyaan fain DoenetML vorshan { $version }.
+       *[other] Wi kyaan fain DoenetML vorshan { $version }. Wi a jrap bak tu vorshan { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML we no valid: { $content }
+
+parse-tag-missing-close-tag = DoenetML we no valid: Di tag `{ $tag }` no av no kluozin tag. Wi did ekspek wan self-kluozin tag ar wan `</{ $tagName }>` tag.
+
+parse-tag-error = DoenetML we no valid: Wan era iina di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML we no valid: Di atribyut `{ $attribute }` no valid — luk laik it mis wan valyu.
+
+parse-attribute-invalid = DoenetML we no valid: Di atribyut `{ $attribute }` no valid
+
+parse-attribute-value-invalid = DoenetML we no valid: Di atribyut valyu `{ $value }` no valid
+
+parse-attribute-value-quote-mismatch = DoenetML we no valid: Di atribyut valyu `{ $value }` no valid. Di kwuot maak dem no machop. Luk laik yu mis wan `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML we no valid: Wi fain wan tag widout no tag niem, laik `<`
+
+parse-tag-not-closed = DoenetML we no valid: Di tag `{ $tag }` neva kluoz (luk laik wan `>` mis).
+
+parse-self-closing-tag-name-missing = DoenetML we no valid: Wi fain wan tag widout no tag niem `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML we no valid: Di tag `{ $tag }` neva kluoz (luk laik `/>` mis).
+
+parse-tag-invalid-attributes = DoenetML we no valid: Di tag `{ $tag }` no valid. It kyan bi se di atribyut dem rang.
+
+parse-close-tag-name-missing = DoenetML we no valid: Wi fain wan kluozin tag widout no tag niem, laik `</`
+
+parse-attribute-value-unquoted = Atribyut valyu mos av kwuot maak roun dem: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML we no valid: Wi fain di kluozin tag `{ $tag }`, bot no uopnin tag no de-de fi it
+
+parse-close-tag-mismatched = DoenetML we no valid: Di kluozin tag no machop. Wi did ekspek `</{ $expected }>`. Wi fain `{ $found }`
+
+parser-node-unconvertible = Wi kyaan konvot di nuod { $node } tu wan Dast nuod.
+
+## Names
+
+name-attribute-invalid =
+    Di atribyut name='{ $name }' no valid. { $reason ->
+        [characters] Niem kyan av leta, nomba, onderskuor ar haifn ongl.
+       *[start] Niem mos staat wid wan leta.
+    }
+
+component-name-invalid-start = Di kompuonent niem "{ $name }" no valid. Niem mos staat wid wan leta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Wan answer a taip videoWatched mos av wan video atribyut
+
+answer-video-watched-video-not-reference = Wan answer a taip videoWatched mos av wan video atribyut we a wan refrans
+
+answer-name-not-single-text = Di answer name atribyut mos av wan wan text chail
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Wi kyaan get di ekstonal DoenetML kaaz tuu moch liivl a rikorshan. Yu tink se wan sorkila refrans de-de?
+
+external-doenetml-unavailable = Wi kyaan get di DoenetML fram { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Di DoenetML we wi get fram { $attribute }="{ $uri }" no valid: it no machop wid di kompuonent taip "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Di atribyut `{ $from }` dipriket; yuuz `{ $to }` instid.
+       *[other] [deprecation] Di atribyut `{ $from }` pan `<{ $component }>` dipriket; yuuz `{ $to }` instid.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Di atribyut `{ $from }` dipriket an it get ignaar kaaz `{ $to }` spesifai tu.
+       *[other] [deprecation] Di atribyut `{ $from }` pan `<{ $component }>` dipriket an it get ignaar kaaz `{ $to }` spesifai tu.
+    }
+
+deprecated-attribute-ignored = [deprecation] Di atribyut `{ $attribute }` pan `<{ $component }>` dipriket an it get ignaar.
+
+deprecated-attribute-to-child = [deprecation] Di atribyut `{ $attribute }` pan `<{ $component }>` dipriket; yuuz wan `<{ $child }>` chail instid.
+
+deprecated-attribute-value-renamed = [deprecation] Di valyu `{ $value }` a di atribyut `{ $attribute }` pan `<{ $component }>` dipriket; yuuz `{ $to }` instid.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` kyan ongl mek Ingglish wod pluural, so di tex lef jos az di aata taip it iina wan dokyument we rait iina { $locale }. Rait di pluural faam yuself, ar set it wid di `pluralForm` atribyut.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Di elimant `<{ $tag }>` no wan Doenet elimant wi nuo.
+
+schema-element-not-allowed-at-root = Di elimant `<{ $tag }>` no alou a di ruut a di dokyument.
+
+schema-element-not-allowed-inside = Di elimant `<{ $tag }>` no alou iinsaid `<{ $parent }>`.
+
+schema-attribute-unrecognized = Di elimant `<{ $tag }>` no av no atribyut niem `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Di atribyut `{ $attribute }` a di elimant `<{ $tag }>` mos bi wan lis we ich aitem a wan a dem ya: { $allowed }
+       *[other] Di atribyut `{ $attribute }` a di elimant `<{ $tag }>` mos bi wan a dem ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Di vieryant niem fi select no valid.  Di vieryant niem { $variantName } de iina { $numOptions } opshan bot di nomba fi pik a { $numToSelect }.
+
+select-variant-name-without-options = Som vieryant spesifai fi select bot no opshan no spesifai fi di vieryant niem we kyan de-de: { $variantName }.
+
+select-variant-name-not-possible = Di vieryant niem { $variantName } we spesifai fi select no wan vieryant niem we kyan de-de.
+
+select-too-few-options = Kyaan pik { $numToSelect } kompuonent outa ongl { $numOptions }.
+
+select-from-sequence-too-few-values = Kyaan pik { $numToSelect } valyu outa wan siikwens we lent a { $length }.
+
+select-from-sequence-indices-count-mismatch = Di nomba a indeks we spesifai fi select mos machop wid di nomba fi pik
+
+select-from-sequence-indices-not-integers = Aal a di indeks we spesifai fi select mos bi intija
+
+select-from-sequence-index-excluded = Di indeks we spesifai fi selectfromsequence did ekskluud
+
+select-from-sequence-indices-excluded-combination = Di indeks dem we spesifai fi selectfromsequence did wan kombinieshan we ekskluud
+
+select-from-sequence-coprime-not-positive-integers = Kyaan pik kuopraim kombinieshan kaaz wi no a pik pazitiv intija.
+
+select-from-sequence-coprime-common-factor = Kyaan pik kuopraim nomba. Aal a di valyu dem shier wan kaman fakta. (Di valyu we spesifai fi "from" ar "to" mos bi kuopraim wid "step".)
+
+select-from-sequence-coprime-single-number = Kyaan pik kuopraim kombinieshan outa wan wan nomba we no a 1.
+
+select-from-sequence-excluded-too-many-combinations = Muo dan 70% a di kombinieshan dem ekskluud iina selectFromSequence
+
+select-from-sequence-coprime-none-found = Wi kyaan pik kuopraim nomba. Aal a di valyu dem shier wan kaman fakta.
+
+select-from-sequence-too-few-unique-values = Kyaan pik { $numToSelect } yuuniik valyu outa wan siikwens we lent a { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Kyaan pik { $numToSelect } valyu outa wan lis a praim nomba we lent a { $numValues }
+
+select-prime-numbers-values-count-mismatch = Di nomba a valyu we spesifai fi select mos machop wid di nomba fi pik
+
+select-prime-numbers-values-not-prime = Aal a di valyu we spesifai fi select praim nomba mos de iina di lis a praim
+
+select-prime-numbers-values-excluded-combination = Di valyu dem we spesifai fi selectPrimeNumbers did wan kombinieshan we ekskluud
+
+select-prime-numbers-excluded-too-many-combinations = Muo dan 70% a di kombinieshan dem ekskluud iina selectPrimeNumbers
+
+select-random-combination-fluke = Bai wan flook we kyaan aadli apm, wi kyaan pik wan kombinieshan a randam valyu
+
+select-random-value-fluke = Bai wan flook we kyaan aadli apm, wi kyaan pik wan randam valyu
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` naa jraa iinsaid di mat; di espreshan sethop jos laik ou it did bi bifuo input kuda go iinsaid. { $reason ->
+        [not-inline] A ongl wan `inline` choice input fit iinsaid wan espreshan; widout `inline` it a wan blak a bokn.
+        [expanded] Wan `expanded` text input a wan baks wid muo dan wan lain, an dat tuu big fi sidong iinsaid wan espreshan.
+        [on-graph] Pan wan graph, di espreshan jraa az wan wan pikcha, we no av no ruum fi wan kanchruol.
+       *[relative-width] Im `width` a relativ (wan porsentij ar `em`), an dat no av notn fi mezha agens iinsaid wan espreshan. Gi di widt iina absaluut yuunit, laik `px`, instid.
+    }

--- a/packages/i18n/locales/jam/editor.ftl
+++ b/packages/i18n/locales/jam/editor.ftl
@@ -1,0 +1,235 @@
+# Jamaican Creole (Patwa, «Jamiekan») editor and language-server surfaces.
+# Translated from `locales/en/editor.ftl`, which is the source of truth:
+# `lint:i18n` rejects a key that does not exist there, and reports a key that
+# exists there but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay exactly as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **Cassidy phonemic orthography** (Cassidy 1961, as
+# regularized by the Jamaican Language Unit at UWI Mona), the same system as
+# the other three files here. It is not English-based spelling. Most everyday
+# written Jamaican — lyrics, social media, advertising, published dialogue —
+# uses English spelling conventions instead, so this catalog does not look
+# like what a Jamaican reader usually sees written. A reviewer who chooses the
+# English-based system would **respell** the whole catalog rather than
+# retranslate it, so the choice must be made once and applied to all four
+# files together. `chrome.ftl` sets the system out in full: five vowels
+# `i e a o u` with the long vowels doubled, the three diphthongs `ie ai ou`,
+# palatal `ky` and `gy`, `h` written only where it is pronounced, and no
+# apostrophes. No diacritics are used.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data of its own for `jam`; the
+# probe resolves it to `en-US` and reports `['one', 'other']`. A Jamaican
+# Creole noun after a numeral is unmarked, so the two branches would be
+# word-for-word identical and each count message here is written as **one
+# unselected form**. The selects that remain — on `$action`, `$status`,
+# `$shortcut`, `$reason`, `$location`, `$allowed`, `$perItem`, `$line` — are
+# not plural selects, and every branch of them is translated.
+#
+# **This is the thinnest of the four files**, in the sense that most of what
+# it names is a developer surface with no established Jamaican word: «vieryant»,
+# «filta», «faamat», «kompuonent», «atribyut», «taip», «snipit», «arie»,
+# «fongkshan», «vorshan», «dayagnostik», «kuaadinet» and «aksesibiliti» are
+# English loans in Cassidy spelling, kept rather than coined. The grammar
+# around them is Jamaican — «fi» for purpose, «no» for negation, «wi» for the
+# future — and a reviewer should read the sentences for that rather than for
+# the nouns.
+#
+# What this file holds is **an English loan set carried in Jamaican Creole's
+# own grammar and written in Cassidy spelling**: the loans are the words the
+# language actually uses, and the sentences around them are Jamaican, not
+# English. A Cassidy-spelled English loan is correct. An English sentence
+# anywhere in these four files is a defect.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Riset
+       *[update] Opdiet
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Di Vyuuwa
+       *[other] { $word } Di Vyuuwa { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Vieryant
+editor-variant-filter = Filta...
+editor-variant-next = Pik di neks vieryant
+editor-variant-previous = Pik di vieryant bifuo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wi fain wan WCAG AA aksesibiliti vaiolieshan. Klik fi { $action ->
+            [close] kluoz
+           *[open] uopn
+        } di aksesibiliti riepuot.
+        [advisories] Klik fi { $action ->
+            [close] kluoz
+           *[open] uopn
+        } di aksesibiliti riepuot. Wi no fain no WCAG AA vaiolieshan, bot wi av som muo aksesibiliti advais fi yu.
+       *[clean] Klik fi { $action ->
+            [close] kluoz
+           *[open] uopn
+        } di aksesibiliti riepuot. Wi no fain no aksesibiliti prablem.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wi fain wan WCAG AA aksesibiliti vaiolieshan. Wi fain { $count } WCAG AA vaiolieshan. Klik fi { $action ->
+            [close] kluoz
+           *[open] uopn
+        } di aksesibiliti riepuot.
+        [advisories] Wi no fain no WCAG AA vaiolieshan. Wi fain { $count } muo aksesibiliti advais. Klik fi { $action ->
+            [close] kluoz
+           *[open] uopn
+        } di aksesibiliti riepuot.
+       *[clean] Wi no fain no WCAG AA vaiolieshan. Klik fi { $action ->
+            [close] kluoz
+           *[open] uopn
+        } di aksesibiliti riepuot.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML vorshan { $version }
+
+editor-tab-help = Elp fi wa di korsa de pan
+editor-tab-help-short = Kanteks
+editor-tab-errors = Era
+editor-tab-warnings = Waanin
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibiliti
+editor-tab-responses = Ansa we sen
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Eda opshan
+editor-format-as-doenetml = Faamat az DoenetML
+editor-format-as-xml = Faamat az XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = No Era
+editor-no-warnings = No Waanin
+editor-no-info = No Info Dayagnostik
+
+editor-show-info-annotations = Shuo info dayagnostik iina di eda
+editor-show-accessibility-annotations = Shuo aksesibiliti dayagnostik iina di eda
+
+editor-accessibility-learn-more = Lorn ou Doenet luk pan aksesibiliti
+
+editor-accessibility-violations-heading = Aksesibiliti vaiolieshan ({ $standard })
+
+editor-accessibility-other-heading = Ada aksesibiliti prablem
+editor-none-found = Wi no fain non
+
+
+## Submitted responses
+
+editor-no-responses = No ansa no sen yet
+editor-response-answer-id = Ansa Id
+editor-response-response = Ansa
+editor-response-credit = Kredit
+editor-response-submitted = Sen
+
+
+## The context-help panel
+
+help-placeholder = Put di korsa pan wan tag niem, wan atribyut, ar { $ref } fi get di dakyumentieshan.
+
+help-unsupported-ref-chain = Elp fi refrans we av muo dan wan paat, laik { $example }, no de-de yet.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wi kyaan fain notn fi di refrans: { $ref }.
+        [multiple] Wi fain muo dan wan tin fi di refrans: { $ref }.
+       *[indeterminate] Wi kyaan wok out wa { $ref } a taak bout.
+    }
+
+help-learn-about-references = Lorn bout refrans →
+help-reference-page = Refrans piej →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Iinsaid { $element }
+       *[top] A di tap liivl
+    }{ $allowed ->
+        [none] { " — notn no go ya so." }
+        [text] { " — taip tex ya so." }
+        [text-and-components] { " — taip tex ya so, ar chrai:" }
+       *[components] { " — sitn fi chrai:" }
+    }
+
+help-suggestions-footer = Pres { $shortcut } fi si aal { $total } kompuonent.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } a wan refrans tu { $target }.
+       *[other] { $ref } a wan refrans tu { $target } (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } bring it iin az { $role }.
+       *[other] { $owner } bring it iin pan lain { $line } az { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } a wan refrans tu di { $property } prapati fi { $element }.
+       *[other] { $ref } a wan refrans tu di { $property } prapati fi { $element } (lain { $line }).
+    }
+
+help-kind-attribute = atribyut
+help-kind-snippet = snipit
+help-kind-array-entry = arie entri
+
+help-default = Difaalt:
+help-active-default = Aktiv difaalt:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valyu we alou (wan fi ich aitem):
+       *[other] Valyu we alou:
+    }
+
+help-suggested-values = Valyu we wi sojes:
+
+help-inserts = It put iin:
+
+help-coordinates = Kuaadinet:
+
+help-type = Taip:
+
+help-resolved-style = Stail we wok out (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fongkshan niem we wok out:
+help-reset-list = Riset di lis pan dis input:
+help-added-on-input = Put aan pan dis input:
+help-removed-on-input = Tek we pan dis input:
+
+help-reset-overrides = { $reset } uovaraid { $additional } an { $removed }.

--- a/packages/i18n/locales/kek/chrome.ftl
+++ b/packages/i18n/locales/kek/chrome.ftl
@@ -1,0 +1,181 @@
+# Qʼeqchiʼ viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The alphabet of the Academia de Lenguas Mayas de Guatemala
+# (ALMG), which is the orthography Qʼeqchiʼ is officially written in today:
+# `a aa bʼ ch chʼ e ee h i ii j k kʼ l m n o oo p q qʼ r s t tʼ tz tzʼ u uu w x y`.
+# Three properties of it matter for reading these files.
+#
+#   * **The ejectives are digraphs made with `ʼ`** — `bʼ chʼ kʼ qʼ tʼ tzʼ` — and
+#     the same character writes the glottal stop. It is U+02BC MODIFIER LETTER
+#     APOSTROPHE `ʼ`, not U+2019 RIGHT SINGLE QUOTATION MARK `’` and not U+0027
+#     APOSTROPHE `'`; the three are homoglyphs in most fonts, so a reviewer who
+#     retypes «inkʼaʼ» should check the codepoint and not the shape.
+#   * **`q` and `k` are two different sounds**, uvular and velar, and both are
+#     written with the letter they are pronounced with.
+#   * **Long vowels are written doubled**, «aa ee ii oo uu».
+#
+# The colonial-era spellings are **not mixed in anywhere in these four files**:
+# no `qu` for `k`, no `hu` for `w`, no `k` standing for the uvular `q`, no `4`
+# or `ɜ` for an ejective.
+#
+# The language is named «Qʼeqchiʼ» in all four of these files, spelled exactly
+# that way.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `kek`; it falls back to
+# the default locale and reports `one` and `other`, categories Qʼeqchiʼ does not
+# select. A Qʼeqchiʼ noun after a numeral is not marked for plural, so wherever
+# English writes a `[one]`/`[other]` pair this file writes **one unselected
+# form**. English's explicit `[0]` literal in `attempts-remaining` matches the
+# number itself rather than a plural category, and is kept.
+#
+# **Loans.** Qʼeqchiʼ has no native software register, and the register it does
+# use for this material in school and in daily speech is Spanish. The technical
+# nouns here are therefore Spanish loans written to ALMG spelling — «teklado»,
+# «matris», «kolumna», «estadistika», «punto», «interbalo», «nota», «bersion» —
+# carried inside an ordinary Qʼeqchiʼ sentence frame: native verbs («isi»,
+# «kʼe», «te», «tzʼap», «kʼutbʼesi»), the negator «inkʼaʼ», the existential
+# negation «maakʼaʼ», and Qʼeqchiʼ word order. No novel native compound is
+# coined for a thing the language has no word for.
+#
+# **Confidence.** Every key in the English catalog is answered here. The
+# weakest wordings are the error sentences, which are longer than anything
+# Qʼeqchiʼ ordinarily writes about a machine, and «okenk» for *accessibility*,
+# which is a description rather than an established term.
+
+
+## Answer submission
+
+answer-checking = Yook chi ilmank...
+answer-submitting = Yook chi taqlamank...
+
+answer-checking-status = Yook chi ilmank li sumenk
+answer-submitting-status = Yook chi taqlamank li sumenk
+
+answer-correct = Us
+answer-incorrect = Inkʼaʼ us
+
+answer-response-saved = Xkʼuulamank li sumenk
+
+answer-percent-credit = { $percent }% punto
+answer-percent-correct = { $percent }% us
+answer-percent-short = { $percent } %
+
+max-credit-available = Xnimal punto naru xtawbʼal: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] maakʼaʼ chik yalok
+       *[other] { $count } yalok chik wan
+    }
+
+validation-correct = (Us)
+validation-incorrect = (Inkʼaʼ us)
+validation-partially-correct = (Jachal us)
+
+answer-show-responses = Kʼutbʼesi { $count } sumenk re { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Naʼlebʼ
+
+collapsible-click-to-open = (kʼe li klik re teebʼal)
+collapsible-click-to-close = (kʼe li klik re tzʼapbʼal)
+
+collapsible-initializing = Yook chi tikibʼaak...
+
+footnote-show = Kʼutbʼesi li nota
+footnote-hide = Muq li nota
+
+description-more-information = esil chik
+
+
+## Controls
+
+slider-previous = Junxil
+slider-next = Moqon
+
+keyboard-open = Te li teklado
+keyboard-close = Tzʼap li teklado
+
+choice-input-remove-choice = Isi { $choice }
+
+matrix-remove-row = Isi jun tasal
+matrix-add-row = Kʼe jun tasal
+matrix-remove-column = Isi jun kolumna
+matrix-add-column = Kʼe jun kolumna
+
+subset-add-remove-points = Kʼe malaj isi punto
+subset-toggle-points-intervals = Jala punto ut interbalo
+subset-move-points = Kʼam li punto
+subset-clear = Sacha chixjunil
+
+orbital-add-row = Kʼe jun tasal
+orbital-remove-row = Isi jun tasal
+orbital-add-box = Kʼe jun kaxa
+orbital-remove-box = Isi jun kaxa
+orbital-add-up-arrow = Kʼe jun tzimaj chi taqeʼk
+orbital-add-down-arrow = Kʼe jun tzimaj chi kubʼeek
+orbital-remove-arrow = Isi li tzimaj
+
+orbital-row-label = Xkʼabaʼ li tasal { $row }
+
+pretzel-answer = Sumenk
+
+summary-statistics-caption = Estadistika chirix { $column }
+
+
+## Math input
+
+math-input-preview-region = kʼutbʼil chi ubʼej li matematika
+math-input-preview = Kʼutbʼil chi ubʼej
+math-input-invalid-expression = Inkʼaʼ us li matematika:
+
+
+## Document status
+
+viewer-initializing = Yook chi tikibʼaak...
+
+
+## Errors
+
+error-heading = Paltil
+
+error-found-at =
+    { $span ->
+        [line] Xtawmank saʼ li raqal { $startLine }.
+       *[lines] Xtawmank saʼ eb li raqal { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Wan paltil saʼ li hu aʼin!
+
+diagnostic-heading-error = Paltil
+diagnostic-heading-warning = Reetal
+diagnostic-heading-information = Esil
+diagnostic-heading-hint = Tenqʼ
+
+accessibility-heading-level-1 = Paltil chirix li WCAG AA
+accessibility-heading-level-2 = Reetal chirix li okenk
+
+something-went-wrong = Wan jun li inkʼaʼ us xkʼulman.
+
+renderer-load-failed = inkʼaʼ xkʼulunk jun li renderer. Bʼaanu usilal, taqla wiʼ chik li perel.
+
+core-start-failed = Inkʼaʼ xtiklaak li hu aʼin. Bʼaanu usilal, taqla wiʼ chik li perel.
+
+core-start-failed-busy = Inkʼaʼ xtiklaak li hu aʼin. Kʼiila hu yookeb chi tiklaak saʼ junaj kutan, ut naru nabʼayk chiru jun chʼiichʼ inkʼaʼ kaw. Naru natenqʼan xtaqlankil wiʼ chik li perel naq akeʼraqeʼ chik li jun chik hu.
+
+core-start-failed-retry = Inkʼaʼ xtiklaak li hu aʼin.
+
+core-start-failed-busy-retry = Inkʼaʼ xtiklaak li hu aʼin. Kʼiila hu yookeb chi tiklaak saʼ junaj kutan, ut naru nabʼayk chiru jun chʼiichʼ inkʼaʼ kaw.
+
+core-start-retry = Yal wiʼ chik
+
+saved-state-unavailable = Inkʼaʼ xkʼulunk li kʼanjel kʼuulanbʼil aawe.

--- a/packages/i18n/locales/kek/content.ftl
+++ b/packages/i18n/locales/kek/content.ftl
@@ -1,0 +1,286 @@
+# Qʼeqchiʼ content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+# English, in `locales/en/content.ftl`, is the source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The ALMG alphabet; see `chrome.ftl`'s header for the
+# inventory and for the ejective digraphs. Every apostrophe in a message value
+# here is U+02BC MODIFIER LETTER APOSTROPHE `ʼ`, never U+2019 `’` and never
+# U+0027 `'`; the three are homoglyphs in most fonts, so a reviewer who retypes
+# a word should check the codepoint rather than the shape. `q` and `k` are two
+# different sounds and each keeps its own letter, and long vowels are doubled.
+# The colonial-era spellings are not mixed in: no `qu` for `k`, no `hu` for
+# `w`, no `k` standing for uvular `q`, no `4` or `ɜ` for an ejective. The
+# language is named «Qʼeqchiʼ», spelled exactly that way.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `kek` and falls back to
+# the default locale, reporting `one` and `other` — categories Qʼeqchiʼ does not
+# select. A noun after a numeral is not marked for plural, so nothing here
+# writes a plural select; `noun-regular-polygon` carries `{ $numSides }` in one
+# unselected form.
+#
+# **Word order.** The modifier **precedes** the noun in Qʼeqchiʼ — «raxsutzʼ»,
+# a green cloud — so the composition messages keep English's order rather than
+# reversing it: `style-stroke`, `style-with-noun`, `style-filled*` and
+# `style-fill` all put the description in front of the thing described, and
+# `noun-regular-polygon` holds the side count in its `[head]` with an empty
+# `[tail]`. The one place the order is not simply English's is the possessive
+# prefix, the constraint `locales/quc`'s header describes and which Qʼeqchiʼ
+# shares: «rix», a border, is already a possessed form, and a pattern cannot be
+# attached to a shape by a prefix that would have to see `{ $pattern }`'s first
+# sound. So a pattern is joined with «rikʼin», the free comitative, and nothing
+# is welded onto a placeable.
+#
+# **Loans.** The geometry and layout nouns are Spanish loans written to ALMG
+# spelling — «sirkulo», «bektor», «punto», «funsion», «parabola», «poligono»,
+# «rektangulo», «rombo», «kampo», «tabla», «figura», «seksion», «teorema»,
+# «definision», «ehersisio», «obhetibo», «parrapo», «prweba», «kaskada» — set
+# inside a Qʼeqchiʼ frame with native verbs and native modifiers. Where a shape
+# does have a Qʼeqchiʼ name it keeps it: «raqal» a line, «oxibʼ xukut» a
+# triangle, «kaahibʼ xukut» a square, «naʼajej» a region, «nujenaq» filled.
+#
+# **Colour.** «rax» spans what English splits into green and blue and takes
+# `.green` here. `.blue` is filled with «asul», the Spanish loan present-day
+# speech actually uses; that is a record of current usage, not a translation of
+# the English word, and the seam between the two categories is real. The same
+# seam is recorded in `locales/quc`, which resolves it the same way.
+#
+# **Gender.** Qʼeqchiʼ has no grammatical gender and no adjective agreement, so
+# `noun-gender` answers a single token and nothing in this file selects on it,
+# nor on `$role`.
+#
+# **Confidence.** `element-name` and `element-anion-name` are left out: chemistry
+# is schooled in Spanish and there is no published Qʼeqchiʼ list of the 118
+# elements, so those keys fall back to English. Everything else is answered.
+# The weakest entries are `.cascade`, `.aside` and `.objectives` in
+# `section-name`, which name a written-document register Qʼeqchiʼ is only
+# beginning to have.
+
+
+## Style vocabulary
+
+color =
+    .black = qʼeq
+    .white = saq
+    .gray = qʼeqsaq
+    .red = kaq
+    .orange = kaqqʼan
+    .yellow = qʼan
+    .green = rax
+    .cyan = syan
+    .blue = asul
+    .purple = morad
+    .pink = kaqsaq
+    .brown = kape
+
+line-width =
+    .thick = pim
+    .thin = jay
+
+line-style =
+    .dashed = jachbʼil
+    .dotted = tzʼuubʼ
+
+fill-style =
+    .horizontal = raqal orisontal
+    .vertical = raqal bertikal
+    .diagonal = raqal diagonal
+    .backdiagonal = raqal diagonal sukʼisinbʼil
+    .dots = tzʼuubʼ
+    .diamonds = rombo
+
+noun =
+    .line = raqal
+    .line-segment = jachal raqal
+    .ray = raqal junpakʼal
+    .vector = bektor
+    .curve = kotkʼo raqal
+    .function = funsion
+    .slope-field = kampo re pendiente
+    .vector-field = kampo re bektor
+    .parabola = parabola
+    .polyline = polilinea
+    .polygon = poligono
+    .triangle = oxibʼ xukut
+    .rectangle = rektangulo
+    .circle = sirkulo
+    .region = naʼajej
+    .point = punto
+    .square = kaahibʼ xukut
+    .diamond = rombo
+    .cross = kurus
+    .plus = mas
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } xukut poligono regular
+    }
+
+noun-gender = junaj
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = nujenaq
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } rikʼin { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } rikʼin { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } rikʼin { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] rikʼin jun { $border } rix
+        [and] ut { $border } rix
+        [and-article] ut jun { $border } rix
+       *[with] rikʼin { $border } rix
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = inkʼaʼ nujenaq
+
+style-text =
+    { $parts ->
+        [background] { $color } rikʼin jun { $background } chi rix
+       *[plain] { $color }
+    }
+
+style-background-none = maakʼaʼ
+
+
+## Boolean words
+
+boolean-true = yaal
+boolean-false = moko yaal ta
+
+
+## Answer buttons
+
+answer-submit-label = Ilomaq li kʼanjel
+answer-submit-label-no-correctness = Taqla li sumenk
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kʼanjelank
+    .aside = Tzʼaqonk chi xkʼatq
+    .cascade = Kaskada
+    .definition = Definision
+    .example = Eetalil
+    .exercise = Ehersisio
+    .exercises = Ehersisio
+    .given-answer = Sumenk
+    .note = Nota
+    .objectives = Obhetibo
+    .paragraphs = Parrapo
+    .part = Jachal
+    .problem = Chʼaʼajkilal
+    .problems = Chʼaʼajkilal
+    .proof = Prweba
+    .question = Patzʼom
+    .section = Seksion
+    .solution = Sumenkil
+    .task = Kʼanjelil
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Tenqʼ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
+       *[unnumbered] Figura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Junxil
+paginator-next = Moqon
+paginator-page = Perel
+
+paginator-page-status = { $pageLabel } { $currentPage } re { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = malaj
+
+piecewise-condition-if = wi
+
+piecewise-condition-otherwise = wi inkʼaʼ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are omitted: chemistry is schooled in
+## Spanish in Alta Verapaz and the Petén, and there is no published Qʼeqchiʼ
+## list of the 118 elements to translate them from.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Inkʼaʼ us li reetalil kimiko
+chemistry-invalid-ionic-compound = Inkʼaʼ us li kʼuubʼanbʼil ioniko
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blanko
+
+math-embedded-input-blank-ordinal = blanko { $ordinal } re { $total }

--- a/packages/i18n/locales/kek/content.ftl
+++ b/packages/i18n/locales/kek/content.ftl
@@ -6,10 +6,12 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # **Orthography.** The ALMG alphabet; see `chrome.ftl`'s header for the
-# inventory and for the ejective digraphs. Every apostrophe in a message value
-# here is U+02BC MODIFIER LETTER APOSTROPHE `ʼ`, never U+2019 `’` and never
-# U+0027 `'`; the three are homoglyphs in most fonts, so a reviewer who retypes
-# a word should check the codepoint rather than the shape. `q` and `k` are two
+# inventory and for the ejective digraphs. Every apostrophe inside a Qʼeqchiʼ
+# word is U+02BC MODIFIER LETTER APOSTROPHE `ʼ`, never U+2019 `’`; the two are
+# homoglyphs in most fonts, so a reviewer who retypes a word should check the
+# codepoint rather than the shape. Straight ASCII `'` is English's own
+# punctuation carried through where a message quotes a value, and is not a
+# Qʼeqchiʼ letter. `q` and `k` are two
 # different sounds and each keeps its own letter, and long vowels are doubled.
 # The colonial-era spellings are not mixed in: no `qu` for `k`, no `hu` for
 # `w`, no `k` standing for uvular `q`, no `4` or `ɜ` for an ejective. The

--- a/packages/i18n/locales/kek/diagnostics.ftl
+++ b/packages/i18n/locales/kek/diagnostics.ftl
@@ -1,0 +1,675 @@
+# Qʼeqchiʼ diagnostics: the errors and warnings the core, the parser and the
+# schema checker report about a document. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Element names, attribute names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `styleNumber` — are part of the language rather than
+# prose and stay in English exactly as written, as does anything quoted back
+# from the author's own source.
+#
+# **Orthography.** The ALMG alphabet; see `chrome.ftl`'s header for the
+# inventory. Every apostrophe in a message value is U+02BC MODIFIER LETTER
+# APOSTROPHE `ʼ`, not U+2019 `’` and not U+0027 `'`; the three are homoglyphs
+# in most fonts, so a reviewer should check the codepoint rather than the
+# shape. `q` and `k` are two different sounds, uvular and velar, each written
+# with its own letter, and long vowels are doubled. No colonial-era spelling is
+# mixed in: no `qu` for `k`, no `hu` for `w`, no `k` standing for uvular `q`,
+# no `4` or `ɜ` for an ejective. The language is named «Qʼeqchiʼ», spelled
+# exactly that way.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `kek`; it falls back to
+# the default locale and reports `one` and `other`, categories Qʼeqchiʼ does not
+# select. A noun after a numeral is not marked for plural, so every place
+# English writes a `[one]`/`[other]` pair is written here as **one unselected
+# form** and the count select is dropped. The selects that remain —
+# `$component`, `$reason`, `$type`, `$mode`, `$context`, `$suggestion`,
+# `$expected`, `$labelKind`, `$isList`, `$alternative`, `$fallback`,
+# `$componentType` — are not plural selects and keep exactly English's
+# branches.
+#
+# **Loans.** This is a loan register in a native frame, as `locales/sgh`
+# records for Shughni. Qʼeqchiʼ has no written vocabulary for compiler
+# diagnostics; the register a Qʼeqchiʼ speaker actually reads this material in
+# is Spanish. So the technical nouns are Spanish loans written to ALMG spelling
+# — «atributo», «komponente», «balor», «numero», «bektor», «sirkulo», «matris»,
+# «funsion», «referensia», «bariante», «sekwensia», «interbalo», «dominio»,
+# «indise», «kolor», «estilo», «kontraste», «parametro», «koordenada» — and the
+# sentence around them is Qʼeqchiʼ: native verbs, the negator «inkʼaʼ», the
+# existential negation «maakʼaʼ», «tento» for obligation, «rikʼin» and «chirix»
+# for the relations, and Qʼeqchiʼ word order. Nothing is coined.
+#
+# **Confidence.** Every key is answered. The frame is usable and the identifiers
+# are safe; the prose is not yet idiomatic Qʼeqchiʼ writing, and a speaker
+# should overwrite it freely. The long contrast-ratio sentences and the
+# PreFigure warnings are the least natural, because they describe machinery
+# with no Qʼeqchiʼ name at all.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = Inkʼaʼ nakʼanjelak { $attributes } naq wiibʼ li endpoint kʼeebʼil
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Inkʼaʼ nakʼanjelak { $attributes } naq kʼeebʼil jun endpoint ut jun midpoint
+
+line-segment-midpoint-offset-without-midpoint = Maakʼaʼ naxbʼaanu midpointOffset chi maakʼaʼ jun midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = Raqal chi ru punto li inkʼaʼ nawbʼil xdimension.
+
+line-points-too-few-dimensions = Tento naq li raqal taanumeʼq chi ru punto wibʼ chi dimension chi ubʼej.
+
+line-points-depend-on-variables = Li raqal naxik chi ru punto li wan saʼ xbʼeen eb li bariable: { $variables }.
+
+line-equation-invalid-format = Inkʼaʼ us li formato re li ekwasion re li raqal saʼ eb li bariable { $variable1 } ut { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Li raqal junpakʼal kʼeebʼil rikʼin through, endpoint ut direction.  Nakanabʼaak li through kʼeebʼil.
+
+ray-dimension-mismatch = Inkʼaʼ nakʼuulun li numDimensions saʼ li raqal junpakʼal.
+
+## `<vector>`
+
+vector-overprescribed-head = Li bektor kʼeebʼil rikʼin head, tail ut displacement.  Nakanabʼaak li head kʼeebʼil.
+
+vector-dimension-mismatch = Inkʼaʼ nakʼuulun li numDimensions saʼ li bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Inkʼaʼ naru xjilbʼal chi ru jun `<{ $component }>` xbʼaan naq maakʼaʼ xbariable re estado nearestPoint.
+
+constrain-to-without-nearest-point = Inkʼaʼ naru xtaqlankil chi ru jun `<{ $component }>` xbʼaan naq maakʼaʼ xbariable re estado nearestPoint.
+
+constrain-to-interior-without-nearest-point = Inkʼaʼ naru xtaqlankil saʼ xsaʼ jun `<{ $component }>` xbʼaan naq maakʼaʼ xbariable re estado nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Inkʼaʼ nakʼanjelak labelPosition saʼ jun choiceInput inkʼaʼ inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Nakanabʼaak li indise kʼeebʼil re li choiceInput xbʼaan naq inkʼaʼ juntaqʼeet li rajlankil li indise rikʼin li rajlankil li choice.
+
+pretzel-indices-count-mismatch = Nakanabʼaak li indise kʼeebʼil re li problem xbʼaan naq inkʼaʼ juntaqʼeet li rajlankil li indise rikʼin li rajlankil li problem.
+
+shuffle-indices-count-mismatch = Nakanabʼaak li indise kʼeebʼil re li shuffle xbʼaan naq inkʼaʼ juntaqʼeet li rajlankil li indise rikʼin li rajlankil li komponente.
+
+indices-ignored-out-of-range = Nakanabʼaak li indise kʼeebʼil re { $component } xbʼaan naq wan indise chi ru li naʼajej.
+
+pretzel-indices-repeated = Nakanabʼaak li indise kʼeebʼil re li pretzel xbʼaan naq wan indise kʼeebʼil wiʼ chik.
+
+pretzel-circuit-first-index = Nakanabʼaak li indise kʼeebʼil re li pretzel saʼ li mode circuit xbʼaan naq tento naq li xbʼeen indise aʼan 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Re naq taakʼanjelaq `<{ $component }>` rikʼin tzʼiibʼ, tento xkʼeebʼal li atributo `type`.
+
+invalid-type-defaulting-to-math = Inkʼaʼ us li tipo { $type } re li komponente { $component }. Tento naq aʼan math, text, number malaj boolean. Nakʼeemank math.
+
+string-not-valid-component-to-arrange = Li tzʼiibʼ "{ $value }" moko komponente ta us re { $component }. Nakanabʼaak.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Inkʼaʼ us li tipo { $type }, nakʼeemank number.
+
+invalid-variable-value = Inkʼaʼ us xbʼalor jun bariable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Tento naq li indise re li bariante { $index } aʼan jun numero
+
+variant-index-must-be-integer = Tento naq li indise re li bariante { $index } aʼan jun numero entero
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` inkʼaʼ yiibʼanbʼil re li bisok absoluto. Nakʼeemank li ruuchil chi relatibo.
+
+side-by-side-absolute-margins = `<{ $component }>` inkʼaʼ yiibʼanbʼil re li bisok absoluto. Nakʼeemank li margen chi relatibo.
+
+side-by-side-no-block-child = Inkʼaʼ us `<{ $component }>`: tento naq wan junaq xkʼulaʼal chi bloke.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Inkʼaʼ nakʼanjelak li atributo `for` saʼ jun `<label>` grafiko.
+
+label-for-must-resolve-to-one = Tento naq li atributo `for` saʼ `<label>` taakʼamoq chi ru junaj ajwiʼ komponente.
+
+label-for-unresolved = Inkʼaʼ xtawmank chanru naxkʼam chi ru jun komponente li atributo `for` saʼ `<label>`.
+
+label-for-answer-with-authored-inputs = Li atributo `for` saʼ `<label>` naxye jun `<answer>` li wan tzʼiibʼanbʼil rokebʼaal; kʼe li referensia chi ru li okebʼaal.
+
+label-for-answer-without-input = Li atributo `for` saʼ `<label>` naxye jun `<answer>` li maakʼaʼ rokebʼaal re xkʼabʼaʼinkil.
+
+label-for-must-reference-input-or-answer = Tento naq li atributo `for` saʼ `<label>` taaxye junaq okebʼaal malaj junaq sumenk.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Re li okenk, tento naq `<{ $component }>` wan xkaʼchʼinal esil malaj naq taayeemanq naq aʼan yal re rilbʼal.
+
+accessibility-video-short-description = Re li okenk, tento naq wan xkaʼchʼinal esil li `<video>`.
+
+accessibility-input-short-description-or-label = Re li okenk, tento naq wan xkaʼchʼinal esil malaj xkʼabaʼ li `<{ $component }>`.
+
+accessibility-answer-input-short-description-or-label = Re li okenk, tento naq wan xkaʼchʼinal esil malaj xkʼabaʼ jun `<answer>` li naxyoʼobʼtesi jun okebʼaal.
+
+accessibility-short-description-contains-math = Inkʼaʼ us naq li kaʼchʼinal esil taakʼuulanq komponente re matematika joʼ `<{ $component }>`. Tzʼiibʼa li matematika rikʼin aatin.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Maakʼaʼ xkontraste { $colorName } re li tzʼiibʼ saʼ xjolomil li seksion (saʼ li qʼeq) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; tento { $threshold }:1 chi ubʼej).
+       *[other] Maakʼaʼ xkontraste { $colorName } re li tzʼiibʼ saʼ xjolomil li seksion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; tento { $threshold }:1 chi ubʼej).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Toj maajiʼ yiibʼanbʼil li `<circle>` chi ru { $count } punto naq maakʼaʼ xbʼalor chi numero eb li punto.
+
+circle-too-many-through-points = Inkʼaʼ naru xyiibʼankil li sirkulo chi ru numenaq oxibʼ punto.
+
+circle-overprescribed-radius-center-points = Inkʼaʼ naru xyiibʼankil li sirkulo rikʼin radio, sentro ut punto kʼeebʼil chixjunil.
+
+circle-center-with-multiple-points = Inkʼaʼ naru xyiibʼankil li sirkulo rikʼin sentro kʼeebʼil chi ru numenaq jun punto.
+
+circle-radius-too-small = Inkʼaʼ naru xyiibʼankil li sirkulo: xbʼaan naq { $distance } li najtil saʼ xyanq li wiibʼ punto, kaʼchʼin chi ru li radio kʼeebʼil { $radius }.
+
+circle-radius-with-many-points = Inkʼaʼ naru xyoʼobʼtesinkil li sirkulo chi ru numenaq wiibʼ punto rikʼin jun radio kʼeebʼil.
+
+circle-invalid-center-or-through-points = Inkʼaʼ us xsentro malaj li punto naxnumsi li sirkulo.
+
+circle-radius-center-with-multiple-points = Inkʼaʼ naru xbʼisbʼal xradio li sirkulo rikʼin sentro kʼeebʼil chi ru numenaq jun punto.
+
+circle-radius-with-points-non-numerical = Inkʼaʼ naru xyoʼobʼtesinkil li sirkulo chi ru numenaq jun punto rikʼin jun radio kʼeebʼil naq maakʼaʼ xbʼalor chi numero.
+
+circle-change-radius-non-numerical = Inkʼaʼ naru xjalbʼal xradio li sirkulo naq maakʼaʼ xbʼalor chi numero eb li punto
+
+circle-change-center-non-numerical = Toj maajiʼ yiibʼanbʼil xjalbʼal xsentro li sirkulo chi ru punto li maakʼaʼ xbʼalor chi numero.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Maakʼaʼ xdimension li dominio re li funsion. Li dominio wan { $intervals } interbalo chi ru, abʼan li funsion wan { $inputs } okebʼaal chi ru.
+
+function-domain-invalid-format = Inkʼaʼ us li formato re li dominio re li funsion.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nakanabʼaak li maximum re li funsion xbʼaan naq moko numero ta.
+        [minimum] Nakanabʼaak li minimum re li funsion xbʼaan naq moko numero ta.
+        [extremum] Nakanabʼaak li extremum re li funsion xbʼaan naq moko numero ta.
+        [point] Nakanabʼaak li punto re li funsion xbʼaan naq moko numero ta.
+        [slope] Nakanabʼaak li pendiente re li funsion xbʼaan naq moko numero ta.
+       *[other] Nakanabʼaak li { $type } re li funsion xbʼaan naq moko numero ta.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nakanabʼaak li maximum re li funsion xbʼaan naq maakʼaʼ chi saʼ.
+        [minimum] Nakanabʼaak li minimum re li funsion xbʼaan naq maakʼaʼ chi saʼ.
+        [extremum] Nakanabʼaak li extremum re li funsion xbʼaan naq maakʼaʼ chi saʼ.
+        [point] Nakanabʼaak li punto re li funsion xbʼaan naq maakʼaʼ chi saʼ.
+       *[other] Nakanabʼaak li { $type } re li funsion xbʼaan naq maakʼaʼ chi saʼ.
+    }
+
+function-points-too-close = Wan wiibʼ punto jiljo chi ribʼil ribʼ saʼ li funsion. Inkʼaʼ naru xkʼeebʼal xnaʼlebʼ li funsion.
+
+function-iterates-input-output-mismatch = Naru ajwiʼ xyoʼobʼtesinkil li iterate re li funsion naq juntaqʼeet li rajlankil li okebʼaal rikʼin li rajlankil li elebʼaal. Li funsion aʼin wan { $inputs } okebʼaal ut { $outputs } elebʼaal chi ru.
+
+## `<sequence>`
+
+sequence-invalid-length = Inkʼaʼ us xnimal li sekwensia.  Tento naq aʼan jun numero entero moko kubʼenaq ta chi ru maakʼaʼ.
+
+sequence-invalid-step = Inkʼaʼ us li step re li sekwensia.  Tento naq aʼan jun numero re jun sekwensia re li tipo { $type }.
+
+sequence-invalid-endpoint-number = Inkʼaʼ us li "{ $attribute }" re jun sekwensia re numero.  Tento naq aʼan jun numero.
+
+sequence-invalid-endpoint-letters = Inkʼaʼ us li "{ $attribute }" re jun sekwensia re letra.  Tento naq aʼan jun chʼutubʼ letra.
+
+sequence-invalid-endpoint = Inkʼaʼ us li "{ $attribute }" re li sekwensia.
+
+select-from-sequence-coprime-not-numbers = Nakanabʼaak li coprime xbʼaan naq moko numero ta li nasikʼmank
+
+select-from-sequence-coprime-with-exclude-combinations = Nakanabʼaak li coprime xbʼaan naq kʼeebʼil li excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Inkʼaʼ us li target re `<{ $source }>`: inkʼaʼ xtawmank li target.
+
+target-state-variable-not-found = Inkʼaʼ us li target re `<{ $source }>`: inkʼaʼ xtawmank junaq bariable re estado xkʼabaʼ "{ $property }" saʼ jun `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Tento naq jalan eb xbariable li `<odeSystem>` chi ru li bariable independiente.
+
+ode-system-duplicate-variable-names = Inkʼaʼ naru xkʼeebʼal xnaʼlebʼ li funsion RHS re li ODE rikʼin xkʼabaʼ bariable kʼeebʼil wiʼ chik.
+
+ode-system-rhs-function-error = Inkʼaʼ naru xkʼeebʼal xnaʼlebʼ li funsion RHS re li ODE.  Wan paltil chi xyoʼobʼtesinkil li funsion mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Inkʼaʼ naru xkʼeebʼal xnaʼlebʼ jun xukut saʼ xyanq { $count } raqal
+
+angle-invalid-through-point = Inkʼaʼ us li punto saʼ li through re `<angle>`
+
+parabola-vertex-too-many-points = Toj maajiʼ yiibʼanbʼil li parabola rikʼin bertise chi ru numenaq jun punto.
+
+parabola-too-many-points = Toj maajiʼ yiibʼanbʼil li parabola chi ru numenaq oxibʼ punto.
+
+intersection-too-many-items = Toj maajiʼ yiibʼanbʼil li xnumsinkil ribʼ chi ru numenaq wiibʼ
+
+## Other math components
+
+ionic-compound-not-two-ions = Toj maajiʼ yiibʼanbʼil li kʼuubʼanbʼil ioniko rikʼin jalan chi ru wiibʼ ion.
+
+ionic-compound-needs-cation-and-anion = Yal rikʼin jun kation ut jun anion yiibʼanbʼil li kʼuubʼanbʼil ioniko.
+
+solve-equations-cannot-evaluate = Inkʼaʼ naru xsumenkil li ekwasion xbʼaan naq inkʼaʼ xbʼisbʼal: { $equation }
+
+math-operators-operand-number-required = Tento xkʼeebʼal jun operandNumber naq nakʼamek jun operando re matematika.
+
+eigen-decomposition-failed = Inkʼaʼ xbʼisbʼal li eigenvalue re li matris
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: li parametro { $parameters } inkʼaʼ nakʼulunk saʼ li patron, joʼkan naq junelik taaxkʼul jun blanko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: inkʼaʼ naru xtawbʼal ru grid="{ $grid }". Tento naq aʼan none, medium, dense, malaj wiibʼ numero moko kubʼenaq ta jachbʼil rikʼin jun naʼajej, joʼ grid="1 0.5". Maakʼaʼ grid natzʼiibʼamank.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` naxkʼe jun funsion rikʼin { $expected } elebʼaal — jun ajwiʼ, li pendiente y' saʼ li junjunq punto joʼ `y - x`, malaj wiibʼ, li bektor saʼ li junjunq punto joʼ `(y, -x)` — abʼan li funsion kʼeebʼil re wan { $found } elebʼaal chi ru. { $alternative ->
+        [none] Maakʼaʼ natzʼiibʼamank.
+       *[other] `<{ $alternative }>` aʼan li komponente re li funsion aʼan. Maakʼaʼ natzʼiibʼamank.
+    }
+
+field-function-attribute-ignored-with-child = Nakanabʼaak li atributo `function` xbʼaan naq kʼeebʼil ajwiʼ li funsion saʼ xsaʼ li komponente; aʼan li wan saʼ xsaʼ nakʼanjelak. Kʼe li funsion junpakʼal ajwiʼ.
+
+field-variables-ignored =
+    `<{ $component }>`: li atributo `variables` naxkʼabʼaʼi eb li okebʼaal re jun tzʼiibʼ matematika kʼeebʼil saʼ xsaʼ li komponente. { $reason ->
+        [function-child] Li funsion arin kʼeebʼil joʼ jun `<function>` xkʼulaʼal, ut aʼan naxkʼabʼaʼi xjunes eb xbariable, joʼkan naq nakanabʼaak li `variables`.
+       *[no-expression] Maakʼaʼ jun tzʼiibʼ joʼkan arin, joʼkan naq nakanabʼaak li `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: inkʼaʼ nakʼanjelak li xLabelPosition="left" saʼ li prefigure renderer; nakʼeemank joʼ right.
+
+prefigure-y-label-position-unsupported = `<graph>`: inkʼaʼ nakʼanjelak li yLabelPosition="bottom" saʼ li prefigure renderer; nakʼeemank joʼ top.
+
+prefigure-invalid-axis-bounds = `<graph>`: inkʼaʼ us xraqbʼal li ehe re li jalok chi prefigure; nakʼeemank li bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: inkʼaʼ us li ruuchil re li jalok chi prefigure; nakʼeemank li ruuchil 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: inkʼaʼ us li aspectRatio re li jalok chi prefigure; nakʼeemank li aspect ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jiljo chi ribʼil ribʼ li raqal re li grid chi ru xraqbʼal li ehe; nakanabʼaak li grid saʼ li prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: inkʼaʼ natzʼiibʼamank li annotation naq inkʼaʼ nakʼanjelak li PreFigure renderer.
+
+multiple-annotations-children = Kʼiila `<annotations>` xkʼulaʼal xtawmank saʼ li `<graph>`; nakanabʼaak chixjunil kaʼajwiʼ li rosoʼjik.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Inkʼaʼ naru xnimobʼresinkil malaj xkʼulubʼankil jun tipo komponente inkʼaʼ nawbʼil ru: { $type }.
+
+copy-prop-not-found = Inkʼaʼ xtawmank li prop { $property } saʼ jun komponente re li tipo { $component }
+
+collect-no-source = Inkʼaʼ xtawmank bʼar naru xchʼutubʼankil.
+
+collect-invalid-component-type = Inkʼaʼ naru xchʼutubʼankil komponente re li tipo `<{ $component }>` xbʼaan naq moko tipo ta us.
+
+reference-index-unavailable = Inkʼaʼ naru xyeebʼal li indise `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Inkʼaʼ naru xbʼoqbʼal { $action } saʼ li komponente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Inkʼaʼ us li ruuchil li datos.  Inkʼaʼ juntaqʼeet xnimal eb li tasal. Xtawmank saʼ li componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Wan xkʼabaʼ kolumna kʼeebʼil wiʼ chik saʼ li datos.  Xtawmank saʼ li componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Maakʼaʼ xkʼabaʼ jun kolumna saʼ li datos.  Xtawmank saʼ li componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Jun li award re li sumenk aʼin wan saʼ xbʼeen xsumenkil ajwiʼ li answer, ut aʼan naxkʼam chaq li inkʼaʼ yeebʼil.
+
+answer-max-num-attempts-in-section-wide-check-work = Maakʼaʼ naxbʼaanu xkʼeebʼal li `maxNumAttempts` saʼ jun `<answer>` li wan saʼ jun kʼuubʼaal rikʼin `sectionWideCheckWork`, xbʼaan naq li kʼuubʼaal naxkʼe li rajlankil li yalok. Kʼe li `maxNumAttempts` saʼ li kʼuubʼaal.
+
+nested-section-wide-check-work-max-num-attempts = Maakʼaʼ naxbʼaanu xkʼeebʼal li `maxNumAttempts` saʼ jun kʼuubʼaal rikʼin `sectionWideCheckWork` li wan saʼ jun chik kʼuubʼaal rikʼin `sectionWideCheckWork`, xbʼaan naq li kʼuubʼaal chi rix naxkʼe li rajlankil li yalok. Kʼe li `maxNumAttempts` saʼ li kʼuubʼaal chi rix.
+
+answer-attributes-need-symbolic-equality = Maakʼaʼ naxbʼaanu li atributo { $attributes } chi maakʼaʼ kʼeebʼil li symbolicEquality.
+
+answer-invalid-type = Inkʼaʼ us li tipo re li sumenk: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Xbʼaan naq maakʼaʼ xkʼabaʼ li komponente `<{ $component }>`, inkʼaʼ naru nakʼanjelak joʼ atributo re jun module
+
+module-attribute-name-already-defined = Inkʼaʼ naru nakʼanjelak li komponente `<{ $component } name="{ $name }">` joʼ atributo re jun module xbʼaan naq li tipo komponente `<module>` ak wan xatributo "{ $name }".
+
+conditional-content-condition-ignored = Nakanabʼaak li atributo `condition` saʼ jun komponente `<conditionalContent>` li wan xkʼulaʼal case malaj else.
+
+slider-markers-type-mismatch = Inkʼaʼ nakʼuulun xtipo li marker rikʼin xtipo li slider.
+
+pretzel-problem-needs-statement-and-answer = Inkʼaʼ us li pretzel: tento naq li junjunq `<problem>` wan jun `<statement>` ut jun `<answer>` chi saʼ.
+
+pretzel-circuit-first-problem-distractor = Inkʼaʼ us li pretzel: saʼ li mode="circuit", inkʼaʼ naru naʼok chi distractor li xbʼeen `<problem>`.
+
+## Attribute values
+
+attribute-invalid-values = Inkʼaʼ us li balor { $values } re li atributo `{ $attribute }`; nakanabʼaak.
+
+attribute-must-be-references = Inkʼaʼ us li balor `{ $value }` re li atributo `{ $attribute }`. Tento naq li atributo taakʼuubʼamanq rikʼin referensia li nakeʼtikla rikʼin jun `$`.
+
+math-input-invalid-function-names = <mathInput>: nakanabʼaak xkʼabaʼ funsion inkʼaʼ us saʼ { $attribute }: { $names }. Tento naq wan wiibʼ karakter chi ubʼej (letra malaj raqal) saʼ xkʼutbʼal li junjunq kʼabʼaʼej; naru ajwiʼ naxik jun `|<mathspeak alternative>` chi rix.
+
+## Building components from the source
+
+component-type-invalid = Inkʼaʼ us li tipo komponente: `<{ $componentType }>`
+
+attribute-repeated = Inkʼaʼ naru xkʼeebʼal wiʼ chik li atributo { $attribute }.
+
+attribute-invalid-for-component = Inkʼaʼ us li atributo "{ $attribute }" re jun komponente re li tipo `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Maakʼaʼ xkontraste li estilo { $styleNumber } re { $context ->
+        [text-on-background] xkolor li tzʼiibʼ chi ru xkolor li rix
+        [high-contrast] li kolor kaw chi ru li ruuchil
+        [line] xkolor li raqal chi ru li ruuchil
+        [marker] xkolor li marker chi ru li ruuchil
+       *[text-on-canvas] xkolor li tzʼiibʼ chi ru li ruuchil
+    }{ $mode ->
+        [dark] { " (saʼ li qʼeq)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; tento { $threshold }:1 chi ubʼej).
+
+style-definition-dark-mode-text-background-contrast =
+    Us xkontraste li kolor kʼeebʼil re li estilo { $styleNumber } saʼ li saq, abʼan maakʼaʼ xkontraste xkolor li tzʼiibʼ chi ru xkolor li rix saʼ li qʼeq li nachal chaq saʼ li balor aʼan ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; tento { $threshold }:1 chi ubʼej). { $suggestion ->
+        [available] Re naq taawanq xkontraste saʼ li qʼeq, nimobʼresi li kontraste saʼ li saq (joʼ eetalil, kʼe { $lightAttribute }="{ $lightColor }") malaj jala li kolor saʼ li qʼeq (joʼ eetalil, kʼe { $darkAttribute }="{ $darkColor }").
+       *[none] Re naq taawanq xkontraste saʼ li qʼeq, nimobʼresi li kontraste saʼ li saq malaj jala li kolor rikʼin textColorDarkMode ut/malaj backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Us xkontraste xkolor li tzʼiibʼ kʼeebʼil re li estilo { $styleNumber } saʼ li saq, abʼan maakʼaʼ xkontraste chi ru li ruuchil li kolor saʼ li qʼeq li nachal chaq saʼ li balor aʼan ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; tento { $threshold }:1 chi ubʼej). { $suggestion ->
+        [available] Re naq taawanq xkontraste saʼ li qʼeq, nimobʼresi li kontraste saʼ li saq (joʼ eetalil, kʼe textColor="{ $lightColor }") malaj jala li kolor saʼ li qʼeq (joʼ eetalil, kʼe textColorDarkMode="{ $darkColor }").
+       *[none] Re naq taawanq xkontraste saʼ li qʼeq, nimobʼresi li kontraste saʼ li saq malaj jala li kolor rikʼin textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Junaj ajwiʼ <stylePalette> naru naxsikʼ jun seksion; nakʼanjelak li rosoʼjik.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq li numToSelect moko numero entero ta moko kubʼenaq ta chi ru maakʼaʼ.
+
+variant-num-to-select-not-constant-number = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq li numToSelect moko numero ta xaqxo.
+
+variant-with-replacement-not-constant-boolean = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq li withReplacement moko boolean ta xaqxo.
+
+variant-select-weight-disables-unique = Inkʼaʼ nakʼanjelak xjunes bariante re li select naq wan jun option rikʼin selectWeight malaj selectForVariants kʼeebʼil
+
+variant-coprime-undetermined = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq inkʼaʼ naru xnawbʼal naq junelik false li coprime.
+
+variant-attribute-not-constant = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq li { $attribute } moko xaqxo ta.
+
+variant-attribute-not-number = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq li { $attribute } moko numero ta.
+
+variant-attribute-wrong-type-for-sequence =
+    inkʼaʼ naru xnawbʼal xjunes bariante re { $component } re li tipo { $type } xbʼaan naq li { $attribute } moko { $expected ->
+        [letters-combination] jun chʼutubʼ letra
+        [math-expression] jun tzʼiibʼ matematika us
+        [integer] jun numero entero
+       *[number] jun numero
+    } ta.
+
+variant-length-not-integer = inkʼaʼ naru xnawbʼal xjunes bariante re { $component } xbʼaan naq li length moko numero entero ta.
+
+variant-sort-not-implemented = toj maajiʼ yiibʼanbʼil xjunes bariante re jun { $component } rikʼin sort
+
+variant-exclude-combinations-not-implemented = toj maajiʼ yiibʼanbʼil xjunes bariante re jun { $component } rikʼin excludeCombinations
+
+variant-math-exclude-not-implemented = toj maajiʼ yiibʼanbʼil xjunes bariante re jun { $component } re li tipo math rikʼin exclude
+
+variant-non-constant-exclude-not-implemented = toj maajiʼ yiibʼanbʼil xjunes bariante re jun { $component } rikʼin jun exclude moko xaqxo ta
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: inkʼaʼ nakʼanjelak saʼ li graph prefigure renderer; nakanabʼaak li xkʼulaʼal.
+
+prefigure-descendant-invalid-geometry = { $subject }: inkʼaʼ tzʼaqal malaj maakʼaʼ xraqbʼal li geometria; nakanabʼaak li xkʼulaʼal.
+
+prefigure-curve-label-omitted = { $subject }: inkʼaʼ nakʼanjelak li kʼabʼaʼej saʼ li kotkʼo raqal jalanbʼil; nakanabʼaak li kʼabʼaʼej.
+
+prefigure-curve-unsupported-definition-type = { $subject }: inkʼaʼ nakʼanjelak li tipo naʼlebʼ '{ $definitionType }' re li kotkʼo raqal; nakanabʼaak li xkʼulaʼal.
+
+prefigure-region-flip-functions-unsupported = { $subject }: inkʼaʼ nakʼanjelak li atributo flipFunctions saʼ li regionBetweenCurves; nakanabʼaak li xkʼulaʼal.
+
+prefigure-region-non-formula-child = { $subject }: kaʼajwiʼ funsion re li tipo formula nakʼanjelak joʼ xkʼulaʼal li regionBetweenCurves; nakanabʼaak li xkʼulaʼal.
+
+prefigure-label-position-unsupported =
+    { $subject }: inkʼaʼ nakʼanjelak li labelPosition '{ $labelPosition }' re { $labelKind ->
+        [line-family] jun kʼabʼaʼej re raqal
+       *[point] jun kʼabʼaʼej re punto
+    }; nakʼeemank li kʼuubʼanbʼil re PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: inkʼaʼ nakʼanjelak li estilo re nujenaq '{ $fillStyle }' saʼ li PreFigure; nakʼeemank jun nujenaq junaj.
+
+prefigure-line-style-unknown = { $subject }: inkʼaʼ nawbʼil ru li estilo raqal '{ $lineStyle }' ut nakanabʼaak saʼ li PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: li estilo marker '{ $markerStyle }' xjalmank chi ru li estilo PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: inkʼaʼ nakʼanjelak li estilo marker '{ $markerStyle }' saʼ li PreFigure; nakʼeemank li estilo kʼeebʼil chi junelik.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: inkʼaʼ us li `ref`; inkʼaʼ xtawmank li target. Nakanabʼaak li annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: kʼiila target xtaw li `ref`; nakʼanjelak li xbʼeen.
+
+annotation-ref-outside-graph = `<annotation>`: inkʼaʼ us li `ref`; li target wan chi rix li graph. Nakanabʼaak li annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: inkʼaʼ us li `ref`; li target moko komponente ta grafiko li nakʼanjelak saʼ li jalok chi prefigure. Nakanabʼaak li annotation.
+
+annotation-text-missing = `<annotation>`: maakʼaʼ malaj maakʼaʼ chi saʼ li `text`; natzʼiibʼamank jun tzʼiibʼ maakʼaʼ chi saʼ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Xtawmank jun kʼuubʼaal nasutin chi ribʼil ribʼ.
+       *[other] Xtawmank jun kʼuubʼaal nasutin chi ribʼil ribʼ rikʼin li komponente `<{ $componentType }>`.
+    }
+
+reference-no-referent = Inkʼaʼ xtawmank kʼaʼru naxye li referensia: `{ $reference }`
+
+reference-multiple-referents = Kʼiila li naxye li referensia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Inkʼaʼ us li formato re li atributo { $attribute } re `<{ $componentType }>`.
+
+children-invalid = Inkʼaʼ us eb li xkʼulaʼal re `<{ $componentType }>`: xtawmank xkʼulaʼal inkʼaʼ us: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Inkʼaʼ us li balor `{ $value }` re li atributo `{ $attribute }`, nakʼanjelak li balor `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Inkʼaʼ xtawmank li bersion { $version } re DoenetML.
+       *[other] Inkʼaʼ xtawmank li bersion { $version } re DoenetML. Nakʼeemank li bersion { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Inkʼaʼ us li DoenetML: { $content }
+
+parse-tag-missing-close-tag = Inkʼaʼ us li DoenetML: Maakʼaʼ xtzʼapbʼal li etiketa `{ $tag }`. Tento jun etiketa naxtzʼap ribʼ malaj jun etiketa `</{ $tagName }>`.
+
+parse-tag-error = Inkʼaʼ us li DoenetML: Wan paltil saʼ li etiketa `<{ $tagName }>`
+
+parse-attribute-missing-value = Inkʼaʼ us li DoenetML: Chanchan naq maakʼaʼ xbʼalor li atributo `{ $attribute }`.
+
+parse-attribute-invalid = Inkʼaʼ us li DoenetML: Inkʼaʼ us li atributo `{ $attribute }`
+
+parse-attribute-value-invalid = Inkʼaʼ us li DoenetML: Inkʼaʼ us xbʼalor li atributo `{ $value }`
+
+parse-attribute-value-quote-mismatch = Inkʼaʼ us li DoenetML: Inkʼaʼ us xbʼalor li atributo `{ $value }`. Inkʼaʼ nakeʼxkʼul ribʼ li reetalil. Chanchan naq maakʼaʼ jun `{ $quote }`
+
+parse-open-tag-name-missing = Inkʼaʼ us li DoenetML: Xtawmank jun etiketa chi maakʼaʼ xkʼabaʼ, joʼ `<`
+
+parse-tag-not-closed = Inkʼaʼ us li DoenetML: Inkʼaʼ xtzʼapmank li etiketa `{ $tag }` (chanchan naq maakʼaʼ jun `>`).
+
+parse-self-closing-tag-name-missing = Inkʼaʼ us li DoenetML: Xtawmank jun etiketa chi maakʼaʼ xkʼabaʼ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Inkʼaʼ us li DoenetML: Inkʼaʼ xtzʼapmank li etiketa `{ $tag }` (chanchan naq maakʼaʼ jun `/>`).
+
+parse-tag-invalid-attributes = Inkʼaʼ us li DoenetML: Inkʼaʼ us li etiketa `{ $tag }`. Maare inkʼaʼ us eb li ratributo.
+
+parse-close-tag-name-missing = Inkʼaʼ us li DoenetML: Xtawmank jun etiketa re tzʼapok chi maakʼaʼ xkʼabaʼ, joʼ `</`
+
+parse-attribute-value-unquoted = Tento naq eb xbʼalor li atributo teʼwanq saʼ reetalil: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Inkʼaʼ us li DoenetML: Xtawmank li etiketa re tzʼapok `{ $tag }`, abʼan maakʼaʼ li etiketa re teebʼal
+
+parse-close-tag-mismatched = Inkʼaʼ us li DoenetML: Inkʼaʼ nakʼuulun li etiketa re tzʼapok. Tento `</{ $expected }>`. Xtawmank `{ $found }`
+
+parser-node-unconvertible = Inkʼaʼ naru xjalbʼal li nodo { $node } chi Dast nodo.
+
+## Names
+
+name-attribute-invalid =
+    Inkʼaʼ us li atributo name='{ $name }'. { $reason ->
+        [characters] Yal letra, numero, raqal saʼ ubʼej malaj raqal naru wan saʼ jun kʼabʼaʼej.
+       *[start] Tento naq nateʼtikla rikʼin jun letra eb li kʼabʼaʼej.
+    }
+
+component-name-invalid-start = Inkʼaʼ us xkʼabaʼ li komponente "{ $name }". Tento naq nateʼtikla rikʼin jun letra eb li kʼabʼaʼej.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Tento naq wan jun atributo video li sumenk re li tipo videoWatched
+
+answer-video-watched-video-not-reference = Tento naq li atributo video re li sumenk re li tipo videoWatched aʼan jun referensia
+
+answer-name-not-single-text = Tento naq junaj ajwiʼ xkʼulaʼal chi tzʼiibʼ li atributo name re li sumenk
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Inkʼaʼ naru xkʼambʼal chaq li DoenetML chi rix xbʼaan naq kʼiihal xsutinkil ribʼ. Ma wan jun referensia nasutin chi ribʼil ribʼ?
+
+external-doenetml-unavailable = Inkʼaʼ naru xkʼambʼal chaq li DoenetML saʼ { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Inkʼaʼ us li DoenetML kʼamom chaq saʼ { $attribute }="{ $uri }": inkʼaʼ xkʼul ribʼ rikʼin li tipo komponente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Aakʼ chik li atributo `{ $from }`; kʼe `{ $to }` chi ru.
+       *[other] [deprecation] Aakʼ chik li atributo `{ $from }` saʼ `<{ $component }>`; kʼe `{ $to }` chi ru.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Aakʼ chik li atributo `{ $from }` ut nakanabʼaak xbʼaan naq kʼeebʼil ajwiʼ li `{ $to }`.
+       *[other] [deprecation] Aakʼ chik li atributo `{ $from }` saʼ `<{ $component }>` ut nakanabʼaak xbʼaan naq kʼeebʼil ajwiʼ li `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Aakʼ chik li atributo `{ $attribute }` saʼ `<{ $component }>` ut nakanabʼaak.
+
+deprecated-attribute-to-child = [deprecation] Aakʼ chik li atributo `{ $attribute }` saʼ `<{ $component }>`; kʼe jun `<{ $child }>` xkʼulaʼal chi ru.
+
+deprecated-attribute-value-renamed = [deprecation] Aakʼ chik li balor `{ $value }` re li atributo `{ $attribute }` saʼ `<{ $component }>`; kʼe `{ $to }` chi ru.
+
+
+## Language coverage
+
+pluralize-english-only = Yal saʼ Inglees naru naxkʼe chi kʼiihal li `<pluralize>`, joʼkan naq inkʼaʼ najalmank li tzʼiibʼ saʼ jun hu tzʼiibʼanbʼil saʼ { $locale }. Tzʼiibʼa aajwal li kʼiihal, malaj kʼe rikʼin li atributo `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Li elemento `<{ $tag }>` moko elemento ta nawbʼil ru xbʼaan Doenet.
+
+schema-element-not-allowed-at-root = Inkʼaʼ naru naxik li elemento `<{ $tag }>` saʼ xtiklajik li hu.
+
+schema-element-not-allowed-inside = Inkʼaʼ naru naxik li elemento `<{ $tag }>` saʼ xsaʼ `<{ $parent }>`.
+
+schema-attribute-unrecognized = Maakʼaʼ jun ratributo xkʼabaʼ `{ $attribute }` li elemento `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Tento naq li atributo `{ $attribute }` re li elemento `<{ $tag }>` aʼan jun lista ut naq li junjunq re aʼan jun re aʼin: { $allowed }
+       *[other] Tento naq li atributo `{ $attribute }` re li elemento `<{ $tag }>` aʼan jun re aʼin: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Inkʼaʼ us xkʼabaʼ li bariante re li select.  Li kʼabʼaʼej { $variantName } nakʼulunk saʼ { $numOptions } option abʼan { $numToSelect } li tento xsikʼbʼal.
+
+select-variant-name-without-options = Wan bariante kʼeebʼil re li select abʼan maakʼaʼ option kʼeebʼil re li kʼabʼaʼej bariante: { $variantName }.
+
+select-variant-name-not-possible = Li kʼabʼaʼej bariante { $variantName } kʼeebʼil re li select inkʼaʼ naru naʼok chi bariante.
+
+select-too-few-options = Inkʼaʼ naru xsikʼbʼal { $numToSelect } komponente saʼ xyanq { $numOptions } ajwiʼ.
+
+select-from-sequence-too-few-values = Inkʼaʼ naru xsikʼbʼal { $numToSelect } balor saʼ jun sekwensia re { $length } xnimal.
+
+select-from-sequence-indices-count-mismatch = Tento naq juntaqʼeet li rajlankil li indise kʼeebʼil re li select rikʼin li rajlankil li tento xsikʼbʼal
+
+select-from-sequence-indices-not-integers = Tento naq numero entero chixjunil li indise kʼeebʼil re li select
+
+select-from-sequence-index-excluded = Kʼeebʼil jun indise re li selectfromsequence li isinbʼil
+
+select-from-sequence-indices-excluded-combination = Kʼeebʼil eb li indise re li selectfromsequence li isinbʼil chi chʼutchʼu
+
+select-from-sequence-coprime-not-positive-integers = Inkʼaʼ naru xsikʼbʼal chʼutubʼ coprime xbʼaan naq moko numero entero ta taqenaq chi ru maakʼaʼ li nasikʼmank.
+
+select-from-sequence-coprime-common-factor = Inkʼaʼ naru xsikʼbʼal numero coprime. Chixjunil li balor wan junaj xfaktor. (Tento naq eb li balor kʼeebʼil re "from" malaj "to" teʼwanq chi coprime rikʼin li "step".)
+
+select-from-sequence-coprime-single-number = Inkʼaʼ naru xsikʼbʼal chʼutubʼ coprime saʼ junaj ajwiʼ numero li moko 1 ta.
+
+select-from-sequence-excluded-too-many-combinations = Isinbʼil numenaq 70% re li chʼutubʼ saʼ li selectFromSequence
+
+select-from-sequence-coprime-none-found = Inkʼaʼ xtawmank numero coprime. Chixjunil li balor wan junaj xfaktor.
+
+select-from-sequence-too-few-unique-values = Inkʼaʼ naru xsikʼbʼal { $numToSelect } balor jalan jalanq saʼ jun sekwensia re { $numPossibleValues } xnimal
+
+select-prime-numbers-too-few-values = Inkʼaʼ naru xsikʼbʼal { $numToSelect } balor saʼ jun lista numero primo re { $numValues } xnimal
+
+select-prime-numbers-values-count-mismatch = Tento naq juntaqʼeet li rajlankil li balor kʼeebʼil re li select rikʼin li rajlankil li tento xsikʼbʼal
+
+select-prime-numbers-values-not-prime = Tento naq chixjunil li balor kʼeebʼil re li select numero primo taawanq saʼ li lista numero primo
+
+select-prime-numbers-values-excluded-combination = Eb li balor kʼeebʼil re li selectPrimeNumbers aʼan jun chʼutubʼ isinbʼil
+
+select-prime-numbers-excluded-too-many-combinations = Isinbʼil numenaq 70% re li chʼutubʼ saʼ li selectPrimeNumbers
+
+select-random-combination-fluke = Xbʼaan jun kʼaʼuxl inkʼaʼ nakʼulman, inkʼaʼ xsikʼmank jun chʼutubʼ balor sikʼbʼil chi maakʼaʼ xnaʼlebʼ
+
+select-random-value-fluke = Xbʼaan jun kʼaʼuxl inkʼaʼ nakʼulman, inkʼaʼ xsikʼmank jun balor sikʼbʼil chi maakʼaʼ xnaʼlebʼ
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    Inkʼaʼ natzʼiibʼamank `<{ $component }>` saʼ xsaʼ li matematika; natzʼiibʼamank li tzʼiibʼ matematika joʼ chanru chaq junxil. { $reason ->
+        [not-inline] Kaʼajwiʼ jun choice input `inline` naru naʼok saʼ jun tzʼiibʼ matematika; chi maakʼaʼ li `inline` aʼan jun bloke boton.
+        [expanded] Jun text input `expanded` aʼan jun kaxa kʼiila raqal, ut nim chi ru li naru naʼok saʼ jun tzʼiibʼ matematika.
+        [on-graph] Saʼ jun graph natzʼiibʼamank li tzʼiibʼ matematika joʼ junaj eetalil, ut maakʼaʼ naʼajej re jun okebʼaal.
+       *[relative-width] Relatibo li `width` (jun porsiento malaj `em`), ut maakʼaʼ chi ru naru nabʼisman saʼ jun tzʼiibʼ matematika. Kʼe li ruuchil chi absoluto, joʼ `px`.
+    }

--- a/packages/i18n/locales/kek/diagnostics.ftl
+++ b/packages/i18n/locales/kek/diagnostics.ftl
@@ -14,10 +14,11 @@
 # from the author's own source.
 #
 # **Orthography.** The ALMG alphabet; see `chrome.ftl`'s header for the
-# inventory. Every apostrophe in a message value is U+02BC MODIFIER LETTER
-# APOSTROPHE `ʼ`, not U+2019 `’` and not U+0027 `'`; the three are homoglyphs
-# in most fonts, so a reviewer should check the codepoint rather than the
-# shape. `q` and `k` are two different sounds, uvular and velar, each written
+# inventory. Every apostrophe inside a Qʼeqchiʼ word is U+02BC MODIFIER LETTER
+# APOSTROPHE `ʼ`, not U+2019 `’`; the two are homoglyphs in most fonts, so a
+# reviewer should check the codepoint rather than the shape. Straight ASCII
+# `'` is English's own punctuation carried through where a message quotes a
+# value back to the author, and is not a Qʼeqchiʼ letter. `q` and `k` are two different sounds, uvular and velar, each written
 # with its own letter, and long vowels are doubled. No colonial-era spelling is
 # mixed in: no `qu` for `k`, no `hu` for `w`, no `k` standing for uvular `q`,
 # no `4` or `ɜ` for an ejective. The language is named «Qʼeqchiʼ», spelled

--- a/packages/i18n/locales/kek/editor.ftl
+++ b/packages/i18n/locales/kek/editor.ftl
@@ -1,0 +1,230 @@
+# Qʼeqchiʼ editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker, the accessibility button and the context-help
+# panel. Translated from `locales/en/editor.ftl`, which is the source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The ALMG alphabet; see `chrome.ftl`'s header for the
+# inventory. Every apostrophe in a message value is U+02BC MODIFIER LETTER
+# APOSTROPHE `ʼ`, not U+2019 `’` and not U+0027 `'` — the three are homoglyphs
+# in most fonts, so check the codepoint rather than the shape. `q` and `k` are
+# two different sounds and keep separate letters; long vowels are doubled. No
+# colonial-era spelling is mixed in: no `qu` for `k`, no `hu` for `w`, no `k`
+# standing for uvular `q`, no `4` or `ɜ` for an ejective. The language is named
+# «Qʼeqchiʼ», spelled exactly that way.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `kek`; it falls back to
+# the default locale and reports `one` and `other`, which Qʼeqchiʼ does not
+# select. A noun after a numeral is not marked for plural, so the two counted
+# messages — `editor-accessibility-label` and `help-coordinates` — are written
+# as **one unselected form** and the `$count` select English wraps them in is
+# dropped. The selects on `$status`, `$action`, `$shortcut`, `$reason`,
+# `$location`, `$allowed`, `$line` and `$perItem` are not plural selects and
+# are kept with exactly English's branches.
+#
+# **Loans.** The editor vocabulary is Spanish, adapted to ALMG spelling, inside
+# a Qʼeqchiʼ frame: «bariante», «atributo», «komponente», «balor», «referensia»,
+# «propiedad», «estilo», «funsion», «koordenada», «tipo», «lista», «areglo»,
+# «kodigo», «bersion», «kursor», «etiketa». The verbs, the negations («inkʼaʼ»,
+# «maakʼaʼ») and the word order around them are Qʼeqchiʼ. `WCAG AA`,
+# `DoenetML`, `XML`, `styleNumber` and every key combination stay as English
+# writes them.
+#
+# **Confidence.** Every key is answered. «Okenk» for *accessibility* is a
+# description — "entering, getting in" — rather than an established term, and is
+# the entry most in need of a speaker's judgement; «paltil» for *error* and
+# «reetal» for *warning* are ordinary words carrying a technical load they do
+# not ordinarily carry.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Sukʼisi
+       *[update] Akʼobʼresi
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } li ilobʼaal
+       *[other] { $word } li ilobʼaal { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Bariante
+
+editor-variant-filter = Sikʼ...
+
+editor-variant-next = Sikʼ li moqon bariante
+
+editor-variant-previous = Sikʼ li junxil bariante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Xtawmank jun paltil chirix li WCAG AA. Kʼe li klik re { $action ->
+            [close] xtzʼapbʼal
+           *[open] xteebʼal
+        } li esil chirix li okenk.
+        [advisories] Kʼe li klik re { $action ->
+            [close] xtzʼapbʼal
+           *[open] xteebʼal
+        } li esil chirix li okenk. Maakʼaʼ paltil chirix li WCAG AA xtawmank, abʼan wan chik naʼlebʼ chirix li okenk.
+       *[clean] Kʼe li klik re { $action ->
+            [close] xtzʼapbʼal
+           *[open] xteebʼal
+        } li esil chirix li okenk. Maakʼaʼ chʼaʼajkilal chirix li okenk xtawmank.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Xtawmank jun paltil chirix li WCAG AA. { $count } paltil chirix li WCAG AA xtawmank. Kʼe li klik re { $action ->
+            [close] xtzʼapbʼal
+           *[open] xteebʼal
+        } li esil chirix li okenk.
+        [advisories] Maakʼaʼ paltil chirix li WCAG AA xtawmank. { $count } naʼlebʼ chik chirix li okenk xtawmank. Kʼe li klik re { $action ->
+            [close] xtzʼapbʼal
+           *[open] xteebʼal
+        } li esil chirix li okenk.
+       *[clean] Maakʼaʼ paltil chirix li WCAG AA xtawmank. Kʼe li klik re { $action ->
+            [close] xtzʼapbʼal
+           *[open] xteebʼal
+        } li esil chirix li okenk.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersion re DoenetML { $version }
+
+editor-tab-help = Tenqʼ chirix li wan saʼ ru
+editor-tab-help-short = Tenqʼ
+editor-tab-errors = Paltil
+editor-tab-warnings = Reetal
+editor-tab-info = Esil
+editor-tab-accessibility = Okenk
+editor-tab-responses = Sumenk taqlanbʼil
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Xnaʼlebʼ li tzʼiibʼlebʼaal
+editor-format-as-doenetml = Kʼuubʼ joʼ DoenetML
+editor-format-as-xml = Kʼuubʼ joʼ XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Raqal #{ $line }
+
+editor-no-errors = Maakʼaʼ paltil
+editor-no-warnings = Maakʼaʼ reetal
+editor-no-info = Maakʼaʼ esil
+
+editor-show-info-annotations = Kʼutbʼesi li esil saʼ li tzʼiibʼlebʼaal
+editor-show-accessibility-annotations = Kʼutbʼesi li esil chirix li okenk saʼ li tzʼiibʼlebʼaal
+
+editor-accessibility-learn-more = Tzol chanru naxkʼe reetal li okenk li Doenet
+
+editor-accessibility-violations-heading = Paltil chirix li okenk ({ $standard })
+
+editor-accessibility-other-heading = Jun chik chʼaʼajkilal chirix li okenk
+editor-none-found = Maakʼaʼ
+
+
+## Submitted responses
+
+editor-no-responses = Toj maakʼaʼ sumenk taqlanbʼil
+editor-response-answer-id = Xkʼabaʼ li sumenk
+editor-response-response = Sumenk
+editor-response-credit = Punto
+editor-response-submitted = Taqlanbʼil
+
+
+## The context-help panel
+
+help-placeholder = Kʼe li kursor saʼ xkʼabaʼ jun etiketa, jun atributo, malaj { $ref } re xtawbʼal li esil.
+
+help-unsupported-ref-chain = Toj maajiʼ nakʼanjelak li tenqʼ chirix eb li referensia kʼiila jachal joʼ { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Inkʼaʼ xtawmank kʼaʼru naxye li referensia: { $ref }.
+        [multiple] Kʼiila li naxye li referensia: { $ref }.
+       *[indeterminate] Inkʼaʼ naru xnawbʼal kʼaʼru naxye { $ref }.
+    }
+
+help-learn-about-references = Tzol chirix eb li referensia →
+help-reference-page = Perel re referensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Saʼ { $element }
+       *[top] Saʼ xbʼeen naʼajej
+    }{ $allowed ->
+        [none] { " — maakʼaʼ naru naxik arin." }
+        [text] { " — tzʼiibʼa tzʼiibʼ arin." }
+        [text-and-components] { " — tzʼiibʼa tzʼiibʼ arin, malaj yal:" }
+       *[components] { " — kʼaʼru naru taayal:" }
+    }
+
+help-suggestions-footer = Kʼe { $shortcut } re rilbʼal chixjunil li { $total } komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } aʼan jun referensia re { $target }.
+       *[other] { $ref } aʼan jun referensia re { $target } (raqal { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Kʼeebʼil xbʼaan { $owner } joʼ { $role }.
+       *[other] Kʼeebʼil xbʼaan { $owner } saʼ li raqal { $line } joʼ { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } aʼan jun referensia re li propiedad { $property } re { $element }.
+       *[other] { $ref } aʼan jun referensia re li propiedad { $property } re { $element } (raqal { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = jachal kodigo
+help-kind-array-entry = jachal re li areglo
+
+help-default = Kʼeebʼil chi junelik:
+help-active-default = Yoo chi kʼanjelak chi junelik:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Balor naru (jun re li junjunq):
+       *[other] Balor naru:
+    }
+
+help-suggested-values = Balor kʼeebʼil chi rilbʼal:
+
+help-inserts = Naxkʼe:
+
+help-coordinates = Koordenada:
+
+help-type = Tipo:
+
+help-resolved-style = Estilo kʼuubʼanbʼil (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Xkʼabaʼ eb li funsion kʼuubʼanbʼil:
+help-reset-list = Sukʼisi li lista saʼ li okebʼaal aʼin:
+help-added-on-input = Kʼeebʼil saʼ li okebʼaal aʼin:
+help-removed-on-input = Isinbʼil saʼ li okebʼaal aʼin:
+
+help-reset-overrides = { $reset } naxnumsi { $additional } ut { $removed }.

--- a/packages/i18n/locales/kek/editor.ftl
+++ b/packages/i18n/locales/kek/editor.ftl
@@ -6,9 +6,11 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # **Orthography.** The ALMG alphabet; see `chrome.ftl`'s header for the
-# inventory. Every apostrophe in a message value is U+02BC MODIFIER LETTER
-# APOSTROPHE `ʼ`, not U+2019 `’` and not U+0027 `'` — the three are homoglyphs
-# in most fonts, so check the codepoint rather than the shape. `q` and `k` are
+# inventory. Every apostrophe inside a Qʼeqchiʼ word is U+02BC MODIFIER LETTER
+# APOSTROPHE `ʼ`, not U+2019 `’` — the two are homoglyphs in most fonts, so
+# check the codepoint rather than the shape. Straight ASCII `'` is English's
+# own punctuation carried through where a message quotes a value, and is not a
+# Qʼeqchiʼ letter. `q` and `k` are
 # two different sounds and keep separate letters; long vowels are doubled. No
 # colonial-era spelling is mixed in: no `qu` for `k`, no `hu` for `w`, no `k`
 # standing for uvular `q`, no `4` or `ɜ` for an ejective. The language is named

--- a/packages/i18n/locales/kl/chrome.ftl
+++ b/packages/i18n/locales/kl/chrome.ftl
@@ -1,0 +1,149 @@
+# Kalaallisut (Greenlandic) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **1973 orthography**, which is the one Greenland has
+# taught, printed and legislated in since it replaced Kleinschmidt's. Its
+# letters are `a e f g i j k l m n o p q r s t u v` plus the loan letters
+# `b c d h w x y z æ ø å`, which appear only inside Danish loans. The
+# Kleinschmidt letter **ĸ (U+0138, kra) is not used anywhere in these four
+# files**: every one of its occurrences is written `q`, as the 1973 reform
+# directs — «qujanaq», never «ĸujanaĸ». Doubled vowels and consonants are
+# written out (`aa`, `ii`, `uu`, `rr`, `ll`, `tt`), because in this
+# orthography length is spelling rather than an accent, and no accented vowel
+# occurs in Kalaallisut words here.
+#
+# **Number.** `Intl.PluralRules("kl")` resolves to `kl` and selects **one**
+# and **other**, and Kalaallisut earns both: a counted noun takes the plural
+# ending — «misileraaneq ataaseq» beside «misileraanerit marluk» — so the two
+# branches are genuinely different words and both are written. No `few` or
+# `many` branch appears; the locale cannot select one. English's explicit
+# `[0]` literal matches the number itself and is kept.
+#
+# **Compounding.** Kalaallisut builds a sentence by suffixing, and much of
+# what English says with a separate word is an ending here. That works
+# against the placeables: an ending cannot be welded onto `{ $choice }` or
+# `{ $answerId }`, whose final sound this catalog never sees. So wherever a
+# case ending would have attached to an argument, the sentence is built
+# around it with separate words instead — «{ $choice } peeruk», not a
+# case-marked form of the argument. That is a recorded debt, not a style.
+#
+# **Confidence.** The four files below are seeded from the modern
+# administrative and school register, which Kalaallisut genuinely has: the
+# vocabulary of Greenland's own school system, Inatsisartut's published
+# Greenlandic, and KNR. Where that register has no settled Kalaallisut word,
+# the **Danish loan** is written rather than a coinage, in Greenlandic
+# spelling. «Tastatur» is such a loan and is the word in use. So are
+# «rækki», «søjli», «kassi» and «pili» on the matrix and orbital controls, and
+# «punkti» and «intervalli» on the subset strip: Greenland's school
+# mathematics is taught in Danish terms, and those are the words a reader
+# would meet.
+
+## Answer submission
+
+answer-checking = Misissorneqarpoq...
+answer-submitting = Nassiunneqarpoq...
+answer-checking-status = Akissut misissorneqarpoq
+answer-submitting-status = Akissut nassiunneqarpoq
+answer-correct = Eqqortoq
+answer-incorrect = Eqqunngitsoq
+answer-response-saved = Akissut toqqorneqarpoq
+answer-percent-credit = { $percent }% poointit
+answer-percent-correct = { $percent }% eqqortoq
+answer-percent-short = { $percent } %
+max-credit-available = Poointit annerpaamik pisinnaasat: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] misileraanerit sinneruttut peqanngillat
+        [one] { $count } misileraaneq sinneruppoq
+       *[other] { $count } misileraanerit sinnerupput
+    }
+validation-correct = (Eqqortoq)
+validation-incorrect = (Eqqunngitsoq)
+validation-partially-correct = (Ilaatigut eqqortoq)
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } akissutaa { $count } takutiguk
+       *[other] { $answerId } akissutai { $count } takutikkit
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Oqaaseqaatit
+collapsible-click-to-open = (ammarniarlugu tooruk)
+collapsible-click-to-close = (matuniarlugu tooruk)
+collapsible-initializing = Aallartinneqarpoq...
+footnote-show = Ataani allassimasoq takutiguk
+footnote-hide = Ataani allassimasoq matuuk
+description-more-information = paasissutissat allat
+
+
+## Controls
+
+slider-previous = Siulia
+slider-next = Tullia
+keyboard-open = Tastatur ammaruk
+keyboard-close = Tastatur matuuk
+choice-input-remove-choice = { $choice } peeruk
+matrix-remove-row = Rækki peeruk
+matrix-add-row = Rækki ilanngullugu
+matrix-remove-column = Søjli peeruk
+matrix-add-column = Søjli ilanngullugu
+subset-add-remove-points = Punktit ilanngullugit imaluunniit peerlugit
+subset-toggle-points-intervals = Punktit intervallillu akornanni allanngortiguk
+subset-move-points = Punktit nuutikkit
+subset-clear = Peerukkit
+orbital-add-row = Rækki ilanngullugu
+orbital-remove-row = Rækki peeruk
+orbital-add-box = Kassi ilanngullugu
+orbital-remove-box = Kassi peeruk
+orbital-add-up-arrow = Pili qulamukartoq ilanngullugu
+orbital-add-down-arrow = Pili ammukartoq ilanngullugu
+orbital-remove-arrow = Pili peeruk
+orbital-row-label = Rækkimut { $row } ateq
+pretzel-answer = Akissut
+summary-statistics-caption = { $column } pillugu naatsorsuutit
+
+
+## Math input
+
+math-input-preview-region = matematikkikkut allakkat takutinnerat
+math-input-preview = Takutitsineq
+math-input-invalid-expression = Matematikkikkut allakkat eqqunngitsut:
+
+
+## Document status
+
+viewer-initializing = Aallartinneqarpoq...
+
+
+## Errors
+
+error-heading = Kukkuneq
+error-found-at =
+    { $span ->
+        [line] Nassaarineqarpoq linjemi { $startLine }.
+       *[lines] Nassaarineqarpoq linjeni { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Allakkani makkunani kukkunerpassuit!
+diagnostic-heading-error = Kukkuneq
+diagnostic-heading-warning = Mianersoqqussut
+diagnostic-heading-information = Paasissutissat
+diagnostic-heading-hint = Ikiuut
+accessibility-heading-level-1 = WCAG AA atorsinnaanermut unioqqutitsineq
+accessibility-heading-level-2 = Atorsinnaanermut mianersoqqussut
+something-went-wrong = Kukkuneqarpoq.
+renderer-load-failed = takutitsissut aallerneqarsinnaanngilaq. Quppernera nutaanngortikkiuk.
+core-start-failed = Allakkat makku aallartinneqarsinnaanngillat. Quppernera nutaanngortikkiuk.
+core-start-failed-busy = Allakkat makku aallartinneqarsinnaanngillat. Allakkat arlallit ataatsikkut aallartinneqarput, tamannalu qarasaasiami sukkanngitsumi sivisunerusinnaavoq. Allat naammassippata quppernera nutaanngortikkuit ikiorsinnaavoq.
+core-start-failed-retry = Allakkat makku aallartinneqarsinnaanngillat.
+core-start-failed-busy-retry = Allakkat makku aallartinneqarsinnaanngillat. Allakkat arlallit ataatsikkut aallartinneqarput, tamannalu qarasaasiami sukkanngitsumi sivisunerusinnaavoq.
+core-start-retry = Misileqqiguk
+saved-state-unavailable = Suliatit toqqorsimasat atuarneqarsinnaanngillat.

--- a/packages/i18n/locales/kl/content.ftl
+++ b/packages/i18n/locales/kl/content.ftl
@@ -1,0 +1,282 @@
+# Kalaallisut (Greenlandic) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. Translated from `locales/en/content.ftl`, which is the source of
+# truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The 1973 orthography. The Kleinschmidt letter **ĸ (U+0138)
+# does not appear in this file at all**; every such sound is written `q`.
+# Length is written by doubling — `aa ii uu ll rr tt` — and no accented vowel
+# occurs in a Kalaallisut word here. `chrome.ftl` sets the letters out in full.
+#
+# **Number.** `kl` selects **one** and **other**, and both are real: a counted
+# noun takes the plural ending. Nothing in this file selects on a count, so no
+# plural branch appears here; `chrome.ftl` and `editor.ftl` carry them.
+#
+# **Word order.** Kalaallisut is the reverse of English here. A describing
+# word is a participial verb and it **follows** the noun — «titarneq
+# aappaluttoq», literally "a line, it is red" — so every composition message
+# below puts `{ $noun }` first and the description after it, where English
+# puts the description first. That reversal is the single most visible
+# difference between this file and the English it was made from.
+#
+# **The comitative is a suffix, and it shapes three messages.** English's
+# "with a red border" is marked in Kalaallisut by an ending — `-mik` — and an
+# ending cannot be welded onto a placeable whose final sound this catalog
+# never sees. So `style-border-clause` carries the ending on a **literal**
+# word instead: «{ $border } killermik peqarluni», where *killermik* is the
+# word for a border in the comitative and the argument stands beside it
+# uninflected. `style-text` sets its background off with a comma for the same
+# reason, and `style-filled` keeps its pattern by juxtaposition — a real
+# Greenlandic option, not a workaround.
+#
+# **Confidence, stated plainly.** The colour and shape vocabulary here is the
+# everyday one and is sound. What is left out is left out on purpose:
+#
+#   * **The nine colours Kalaallisut has terms of its own for are written in
+#     Kalaallisut.** `.orange`, `.cyan` and `.purple` are the three the
+#     language does not partition the way English does, and they are written
+#     as the **Danish loans** «orangi», «cyani» and «lilla» rather than as
+#     coined Kalaallisut compounds — those are the words a speaker uses.
+#   * **The geometric vocabulary is Danish loans in Greenlandic spelling**,
+#     because Greenland's school mathematics is taught in Danish terms:
+#     «linjestykki», «vektori», «kurvi», «funktioni», «parabeli», «polygoni»,
+#     «trekanti», «rektangeli», «kvadrati», «rombi», «punkti». Where
+#     Kalaallisut has its own word it is used instead — «titarneq» for a
+#     line, «ammalortoq» for a circle, «sumiiffik» for a region.
+#   * **`element-name` and `element-anion-name` are omitted entirely.**
+#     Chemistry is schooled in Greenland in Danish, and there is no published
+#     Greenlandic set of all 118 element names to reproduce.
+#   * **`piecewise-condition-if`** is the Danish «for» that Greenlandic school
+#     mathematics writes in front of a domain, not a Kalaallisut word:
+#     Kalaallisut marks a condition with a verb mood, which cannot stand alone
+#     before an equation. `-or` («imaluunniit») and `-otherwise` («allatut»)
+#     are Kalaallisut.
+
+
+## Style vocabulary
+
+color =
+    .black = qernertoq
+    .white = qaqortoq
+    .gray = qasertoq
+    .red = aappaluttoq
+    .yellow = sungaartoq
+    .green = qorsuk
+    .blue = tungujortoq
+    .pink = aappilaartoq
+    .brown = kajortoq
+    .orange = orangi
+    .cyan = cyani
+    .purple = lilla
+
+line-width =
+    .thick = silissooq
+    .thin = silikitsoq
+
+line-style =
+    .dashed = avissaartorsimasoq
+    .dotted = punktilik
+
+fill-style =
+    .horizontal = titarnerit vandrette
+    .vertical = titarnerit lodrette
+    .diagonal = titarnerit diagonale
+    .backdiagonal = titarnerit diagonale akerlianik
+    .dots = punktit
+    .diamonds = rombit
+
+noun =
+    .line = titarneq
+    .line-segment = linjestykki
+    .ray = stråli
+    .vector = vektori
+    .curve = kurvi
+    .function = funktioni
+    .slope-field = hældningsfelti
+    .vector-field = vektorfelti
+    .parabola = parabeli
+    .polyline = polylinje
+    .polygon = polygoni
+    .triangle = trekanti
+    .rectangle = rektangeli
+    .circle = ammalortoq
+    .region = sumiiffik
+    .point = punkti
+    .square = kvadrati
+    .diamond = rombi
+    .cross = krysi
+    .plus = plusi
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] polygoni regulæri sanianik { $numSides }
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+##
+## `{ $noun }` leads and the description follows it, which is Kalaallisut
+## order and the reverse of English.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = immersorsimasoq
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } killermik peqarluni
+        [and] aamma { $border } killermik peqarluni
+        [and-article] aamma { $border } killermik peqarluni
+       *[with] { $border } killermik peqarluni
+    }
+
+style-unfilled = immersorsimanngitsoq
+
+style-text =
+    { $parts ->
+        [background] { $color }, tunuliaqutaalu { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = peqanngilaq
+
+
+## Boolean words
+
+boolean-true = ilumoortoq
+boolean-false = ilumoornngitsoq
+
+
+## Answer buttons
+
+answer-submit-label = Misissoruk
+answer-submit-label-no-correctness = Akissut nassiuguk
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Sammisaq
+    .aside = Saniatigut
+    .cascade = Kaskadi
+    .definition = Nassuiaat
+    .example = Assersuut
+    .exercise = Sungiusaat
+    .exercises = Sungiusaatit
+    .given-answer = Akissut
+    .note = Nalunaarut
+    .objectives = Anguniagassat
+    .paragraphs = Immikkoortut
+    .part = Ilaa
+    .problem = Ajornartorsiut
+    .problems = Ajornartorsiutit
+    .proof = Uppernarsaat
+    .question = Apeqqut
+    .section = Immikkoortoq
+    .solution = Aaqqiissut
+    .task = Suliassaq
+    .theorem = Teoremi
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Ikiuut
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Skema { $enumeration }
+        [numbered-title] Skema { $enumeration }{ ": " }
+        [unnumbered-title] Skema{ ": " }
+       *[unnumbered] Skema
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Titartagaq { $enumeration }
+        [numbered-caption] Titartagaq { $enumeration }{ ": " }
+        [unnumbered-caption] Titartagaq{ ": " }
+       *[unnumbered] Titartagaq
+    }
+
+
+## Paginator controls
+##
+## "3 of 5" is an ablative ending in Kalaallisut and cannot be welded onto
+## `{ $numPages }`, so the status is written with a stroke between the two
+## counts instead of with a word.
+
+paginator-previous = Siulia
+paginator-next = Tullia
+paginator-page = Qupperneq
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = imaluunniit
+piecewise-condition-if = for
+piecewise-condition-otherwise = allatut
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Kemikkut nalunaaqut eqqunngitsoq
+chemistry-invalid-ionic-compound = Ionimik ataqatigiissitaq eqqunngitsoq
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = imaqanngitsoq
+math-embedded-input-blank-ordinal = imaqanngitsoq { $ordinal } / { $total }

--- a/packages/i18n/locales/kl/diagnostics.ftl
+++ b/packages/i18n/locales/kl/diagnostics.ftl
@@ -1,0 +1,717 @@
+# Kalaallisut (Greenlandic) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The 1973 orthography. The Kleinschmidt letter **ĸ (U+0138)
+# appears nowhere in these four files**; every such sound is written `q`.
+# Length is written by doubling — `aa ii uu ll rr tt`. `chrome.ftl` sets the
+# letters out in full.
+#
+# **Number.** `Intl.PluralRules("kl")` selects **one** and **other**, and both
+# are real: a counted noun takes the plural ending, so the two branches differ
+# in more than the digit. No `few`, `many`, `two` or `zero` branch appears
+# anywhere in these files, because the locale cannot select one.
+#
+# **A Danish loan register with a Kalaallisut frame.** The sentences here are
+# ordinary sentences — "it was not found", "it must be a whole number", "it is
+# ignored" — and Kalaallisut says all of them. The *nouns* inside them are
+# another matter: «komponenti», «attributi», «funktioni», «variabeli»,
+# «punkti», «linje», «matrixi», «indeksi», «sekvensi», «dimensioni»,
+# «versioni», «formati», «domæni» and «koordinati» are Danish loans written in
+# Greenlandic spelling, and they are what a Greenlandic speaker working with
+# software actually says. They are kept as loans, and are not offered as
+# translations of anything.
+#
+# **Suffixes and placeables.** A Kalaallisut case ending cannot be welded onto
+# a placeable whose final sound this catalog never sees, so no `{ $x }`-mik or
+# `{ $x }`-mut appears anywhere below; the sentence is built around the
+# argument with separate words instead. A hyphen onto a *literal* identifier
+# is fine and is used — «DoenetML-ip».
+#
+# **Coverage.** Every coded message in the English catalog is answered here.
+# The two that lean hardest on loans are `math-input-invalid-function-names`,
+# whose talk of a display segment and a mathspeak alternative has no
+# Greenlandic equivalent at all, and
+# `select-from-sequence-excluded-too-many-combinations`; both are worth a
+# reviewer's attention before the rest.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } sumiginnarneqarpoq endpoint marluk aalajangersarneqarmata
+       *[other] { $attributes } sumiginnarneqarput endpoint marluk aalajangersarneqarmata
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } sumiginnarneqarpoq endpoint aamma midpoint tamarmik aalajangersarneqarmata
+       *[other] { $attributes } sumiginnarneqarput endpoint aamma midpoint tamarmik aalajangersarneqarmata
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset sunniuteqanngilaq midpoint peqanngippat
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linje punktinik dimensioneqarnerat aalajangersimanngitsunik ingerlavoq.
+
+line-points-too-few-dimensions = Linje punktinik minnerpaamik marlunnik dimensionilinnik ingerlassaaq.
+
+line-points-depend-on-variables = Linje punktinik variabelinut attuumassuteqartunik ingerlavoq: { $variables }.
+
+line-equation-invalid-format = Linjep equationianut formati eqqunngitsoq variabelini { $variable1 } aamma { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ray through, endpoint aamma direction pingasut aalajangersarpaat. Through sumiginnarneqarpoq.
+
+ray-dimension-mismatch = numDimensions ray-mi naapertuutinngilaq.
+
+## `<vector>`
+
+vector-overprescribed-head = Vector head, tail aamma displacement pingasut aalajangersarpaat. Head sumiginnarneqarpoq.
+
+vector-dimension-mismatch = numDimensions vector-imi naapertuutinngilaq.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` attract-figinissaa ajornarpoq, nearestPoint peqanngimmat.
+
+constrain-to-without-nearest-point = `<{ $component }>` constrain-figinissaa ajornarpoq, nearestPoint peqanngimmat.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` iluanut constrain-figinissaa ajornarpoq, nearestPoint peqanngimmat.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition sumiginnarneqarpoq inline-iunngitsumi choiceInput
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-imut indeksit sumiginnarneqarput, amerlassusaat choice-inik qitornaqarnera naapertunngimmagu.
+
+pretzel-indices-count-mismatch = problem-imut indeksit sumiginnarneqarput, amerlassusaat problem-inik qitornaqarnera naapertunngimmagu.
+
+shuffle-indices-count-mismatch = shuffle-imut indeksit sumiginnarneqarput, amerlassusaat komponentit amerlassusaannut naapertunngimmat.
+
+indices-ignored-out-of-range = { $component }-imut indeksit sumiginnarneqarput, ilaasa killiit qaangimmatigit.
+
+pretzel-indices-repeated = pretzel-imut indeksit sumiginnarneqarput, ilaat uteqqinneqarmata.
+
+pretzel-circuit-first-index = pretzel-imut circuit-imiittumut indeksit sumiginnarneqarput, indeksi siulleq 1 tassaassammat.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` string-inik qitornalik atorniassappat `type` attributi aalajangersarneqassaaq.
+
+invalid-type-defaulting-to-math = { $component }-imut type { $type } eqqunngilaq. math, text, number imaluunniit boolean tassaassaaq. math atorneqassaaq.
+
+string-not-valid-component-to-arrange = String "{ $value }" { $component }-imut atorsinnaanngilaq. Sumiginnarneqarpoq.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } eqqunngilaq, type number-inngortinneqarpoq.
+
+invalid-variable-value = Variabelip nalia eqqunngilaq: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant-ip indeksia { $index } kisitsittuussaaq
+
+variant-index-must-be-integer = Variant-ip indeksia { $index } kisitsit ilivitsuussaaq
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` uuttortaatinut aalajangersimasunut piareersimanngilaq. Silissusaat immikkut naleqqiussamik aalajangersarneqarput.
+
+side-by-side-absolute-margins = `<{ $component }>` uuttortaatinut aalajangersimasunut piareersimanngilaq. Sinaakkutsit immikkut naleqqiussamik aalajangersarneqarput.
+
+side-by-side-no-block-child = `<{ $component }>` eqqunngilaq: minnerpaamik ataatsimik block-imik qitornaqassaaq.
+
+## `<label>`
+
+label-for-ignored-on-graphical = `<label>` titartagaasumi `for` attributi sumiginnarneqarpoq.
+
+label-for-must-resolve-to-one = `<label>` `for` attributia komponentimut ataatsimut naapissaaq.
+
+label-for-unresolved = `<label>` `for` attributia komponentimut naapinneqarsinnaanngilaq.
+
+label-for-answer-with-authored-inputs = `<label>` `for` attributia `<answer>`-imut input-iliortitanut innersuivoq; input namminermik innersuutigiuk.
+
+label-for-answer-without-input = `<label>` `for` attributia `<answer>`-imut input-eqanngitsumut innersuivoq.
+
+label-for-must-reference-input-or-answer = `<label>` `for` attributia input imaluunniit answer innersuutigissavaa.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Atorsinnaanissaa pillugu `<{ $component }>` nassuiaammik naatsumik peqassaaq imaluunniit decorative-itut aalajangersarneqassaaq.
+
+accessibility-video-short-description = Atorsinnaanissaa pillugu `<video>` nassuiaammik naatsumik peqassaaq.
+
+accessibility-input-short-description-or-label = Atorsinnaanissaa pillugu `<{ $component }>` nassuiaammik naatsumik imaluunniit label-imik peqassaaq.
+
+accessibility-answer-input-short-description-or-label = Atorsinnaanissaa pillugu `<answer>` input-iliortoq nassuiaammik naatsumik imaluunniit label-imik peqassaaq.
+
+accessibility-short-description-contains-math = Nassuiaatit naatsut matematikkikkut komponentinik soorlu `<{ $component }>` imaqassanngillat. Matematikki oqaatsinik allaguk.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } immikkoortup qulequtaanut naleqqiussineq naammanngilaq (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; minnerpaamik { $threshold }:1 pisariaqarpoq).
+       *[other] { $colorName } immikkoortup qulequtaanut naleqqiussineq naammanngilaq ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; minnerpaamik { $threshold }:1 pisariaqarpoq).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` punktit { $count } aqqutigalugit suli piareersimanngilaq punktit kisitsitinik nalilinngippata.
+
+circle-too-many-through-points = Ammalortoq punktit pingasut amerlanerusut aqqutigalugit naatsorsorneqarsinnaanngilaq.
+
+circle-overprescribed-radius-center-points = Ammalortoq radius, center aamma punktit aalajangersarneqarsimatillugit naatsorsorneqarsinnaanngilaq.
+
+circle-center-with-multiple-points = Ammalortoq center aalajangersarneqarsimatillugu punkti ataaseq amerlaneruleraangat naatsorsorneqarsinnaanngilaq.
+
+circle-radius-too-small = Ammalortoq naatsorsorneqarsinnaanngilaq: punktit marluk akornanni ungasissuseq { $distance } tikillugu, radius aalajangersarneqarsimasoq { $radius } mikinerungaarpoq.
+
+circle-radius-with-many-points = Ammalortoq punktit marluk amerlanerusut aqqutigalugit radius aalajangersarneqarsimatillugu pilersinneqarsinnaanngilaq.
+
+circle-invalid-center-or-through-points = Ammalortup center-ia imaluunniit punktii eqqunngillat.
+
+circle-radius-center-with-multiple-points = Ammalortup radiusia center aalajangersarneqarsimatillugu punkti ataaseq amerlaneruleraangat naatsorsorneqarsinnaanngilaq.
+
+circle-change-radius-non-numerical = Ammalortup radiusia allanngortinneqarsinnaanngilaq punktit kisitsitinik nalilinngippata
+
+circle-radius-with-points-non-numerical = Ammalortoq punkti ataaseq amerlanerusut aqqutigalugit radius aalajangersarneqarsimatillugu pilersinneqarsinnaanngilaq kisitsitinik nalilinngippata.
+
+circle-change-center-non-numerical = Ammalortup center-ia allanngortinnissaa suli piareersimanngilaq punktit kisitsitinik nalilinngippata.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Funktionip domænianut dimensionit naammanngillat. Domæni interval { $intervals }-limmik peqarpoq, funktionili { $inputs ->
+            [one] input { $inputs }
+           *[other] input-it { $inputs }
+        } peqarpoq.
+       *[other] Funktionip domænianut dimensionit naammanngillat. Domæni interval-it { $intervals } peqarpoq, funktionili { $inputs ->
+            [one] input { $inputs }
+           *[other] input-it { $inputs }
+        } peqarpoq.
+    }
+
+function-domain-invalid-format = Funktionip domænianut formati eqqunngilaq.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Funktionip maximum-ia kisitsitinik nalilik pinnagu sumiginnarneqarpoq.
+        [minimum] Funktionip minimum-ia kisitsitinik nalilik pinnagu sumiginnarneqarpoq.
+        [extremum] Funktionip extremum-ia kisitsitinik nalilik pinnagu sumiginnarneqarpoq.
+        [point] Funktionip punktia kisitsitinik nalilik pinnagu sumiginnarneqarpoq.
+        [slope] Funktionip slope-ia kisitsitinik nalilik pinnagu sumiginnarneqarpoq.
+       *[other] Funktionip { $type } kisitsitinik nalilik pinnagu sumiginnarneqarpoq.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Funktionip maximum-ia imaqanngitsoq sumiginnarneqarpoq.
+        [minimum] Funktionip minimum-ia imaqanngitsoq sumiginnarneqarpoq.
+        [extremum] Funktionip extremum-ia imaqanngitsoq sumiginnarneqarpoq.
+        [point] Funktionip punktia imaqanngitsoq sumiginnarneqarpoq.
+       *[other] Funktionip { $type } imaqanngitsoq sumiginnarneqarpoq.
+    }
+
+function-points-too-close = Funktioni punktinik marlunnik qanittuararsuunnik imaqarpoq. Funktioni aalajangersarneqarsinnaanngilaq.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Funktionip iterate-i input-it amerlassusaat output-it amerlassusaannut naapertuuppata taamaallaat pisinnaapput. Funktioni una { $inputs } input-eqarpoq { $outputs ->
+            [one] output-ilu { $outputs }
+           *[other] output-ilu { $outputs }
+        }.
+       *[other] Funktionip iterate-i input-it amerlassusaat output-it amerlassusaannut naapertuuppata taamaallaat pisinnaapput. Funktioni una { $inputs } input-eqarpoq { $outputs ->
+            [one] output-ilu { $outputs }
+           *[other] output-ilu { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sekvensip takissusaa eqqunngilaq. Kisitsit ilivitsoq mikinerunngitsoq nulli tassaassaaq.
+
+sequence-invalid-step = Sekvensip step-ia eqqunngilaq. type { $type }-imut sekvensimi kisitsittuussaaq.
+
+sequence-invalid-endpoint-number = Kisitsitinik sekvensimi "{ $attribute }" eqqunngilaq. Kisitsittuussaaq.
+
+sequence-invalid-endpoint-letters = Naqinnernik sekvensimi "{ $attribute }" eqqunngilaq. Naqinnernik ataqatigiissaaq.
+
+sequence-invalid-endpoint = Sekvensimi "{ $attribute }" eqqunngilaq.
+
+select-from-sequence-coprime-not-numbers = coprime sumiginnarneqarpoq, kisitsitit toqqarneqanngimmata
+
+select-from-sequence-coprime-with-exclude-combinations = coprime sumiginnarneqarpoq, excludeCombinations aalajangersarneqarmat
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` target-ia eqqunngilaq: nassaarineqarsinnaanngilaq.
+
+target-state-variable-not-found = `<{ $source }>` target-ia eqqunngilaq: `<{ $component }>` "{ $property }"-imik state-variabeleqanngilaq.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` variabelii variabelimit independent-imit allaassuteqassapput.
+
+ode-system-duplicate-variable-names = ODE RHS funktionit variabelinik taakkiisunik aalajangersarneqarsinnaanngillat.
+
+ode-system-rhs-function-error = ODE RHS funktioni aalajangersarneqarsinnaanngilaq. mathjs funktionimik pilersitsinermi kukkuneq.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Linjet { $count } akornanni angle aalajangersarneqarsinnaanngilaq
+
+angle-invalid-through-point = `<angle>` through-ianiittoq punkti eqqunngilaq
+
+parabola-vertex-too-many-points = Parabola vertex-ilik punkti ataaseq amerlanerusut aqqutigalugit suli piareersimanngilaq.
+
+parabola-too-many-points = Parabola punktit pingasut amerlanerusut aqqutigalugit suli piareersimanngilaq.
+
+intersection-too-many-items = Intersection pisut marluk amerlanerusunut suli piareersimanngilaq
+
+## Other math components
+
+ionic-compound-not-two-ions = Ioninik marlunnik peqanngitsoq ionimik ataqatigiissitaq suli piareersimanngilaq.
+
+ionic-compound-needs-cation-and-anion = Ionimik ataqatigiissitaq kation ataaseq anion ataasillu taamaallaat piareersimavoq.
+
+solve-equations-cannot-evaluate = Equation aaqqinneqarsinnaanngilaq, naatsorsorneqarsinnaanngimmat: { $equation }
+
+math-operators-operand-number-required = Math-imi operand tigussagaanni operandNumber aalajangersarneqassaaq.
+
+eigen-decomposition-failed = Matrixip eigenvalue-i naatsorsorneqarsinnaanngillat
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameteri { $parameters } pattern-imiinngilaq, taamaattumik imaqanngitsumut naapertuutissaaq.
+       *[other] `<matchesPattern>`: parameterit { $parameters } pattern-imiinngillat, taamaattumik imaqanngitsumut naapertuutissapput.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" paasineqarsinnaanngilaq. none, medium, dense imaluunniit kisitsitit marluk pikkut avissaartinneqarsimasut tassaassaaq, soorlu grid="1 0.5". Grid titartanneqanngilaq.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` funktionimik pisariaqartitsivoq { $expected ->
+        [one] output ataaseq, tassa slope y' punktini tamani, soorlu `y - x`
+       *[other] output marluk, tassa vector punktini tamani, soorlu `(y, -x)`
+    }, funktionili tunniunneqartoq { $found ->
+        [one] output { $found } peqarpoq
+       *[other] output-inik { $found } peqarpoq
+    }. { $alternative ->
+        [none] Titartanneqartoqanngilaq.
+       *[other] `<{ $alternative }>` tassaavoq funktionimut tamatumunnga komponenti. Titartanneqartoqanngilaq.
+    }
+
+field-function-attribute-ignored-with-child = `function` attributi sumiginnarneqarpoq, funktioni komponentip iluaniillu tunniunneqarmat; ilua atorneqarpoq. Funktioni ataasiinnarmik tunniuguk.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` attributi komponentip iluani allanneqarsimasup variabelii taasarpai. { $reason ->
+        [function-child] Funktioni maani `<function>`-imik qitornaavoq, namminerlu variabelini taasarpai, taamaattumik `variables` sumiginnarneqarpoq.
+       *[no-expression] Taama ittoq maani tunniunneqanngilaq, taamaattumik `variables` sumiginnarneqarpoq.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" prefigure-mi atorneqarsinnaanngilaq; right-itut iliuuseqartoqarpoq.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" prefigure-mi atorneqarsinnaanngilaq; top-itut iliuuseqartoqarpoq.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure-imut akse-killiit eqqunngillat; bbox nalinginnaasoq (-10,-10,10,10) atorneqarpoq.
+
+prefigure-invalid-width = `<graph>`: prefigure-imut silissusaa eqqunngilaq; silissuseq nalinginnaasoq 425 atorneqarpoq.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure-imut aspectRatio eqqunngilaq; naleqqiussineq nalinginnaasoq 1 atorneqarpoq.
+
+prefigure-grid-spacing-too-fine = `<graph>`: grid-ip akunneri akse-killiinut mikinerungaarput; prefigure-mi grid ilanngunneqanngilaq.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure atornagu annotation-it takutinneqassanngillat.
+
+multiple-annotations-children = `<graph>`-imi `<annotations>` qitornat arlallit nassaarineqarput; kingulleq kisiat atorneqarpoq.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Komponentip suussusia ilisimaneqanngitsoq extend- imaluunniit copy-neqarsinnaanngilaq: { $type }.
+
+copy-prop-not-found = { $component }-imik suussuseqartumi prop { $property } nassaarineqarsinnaanngilaq
+
+collect-no-source = Collect-imut source nassaarineqanngilaq.
+
+collect-invalid-component-type = `<{ $component }>` komponentit collect-neqarsinnaanngillat, suussusia eqqunngimmat.
+
+reference-index-unavailable = Indeksi `{ $reference }` innersuutigineqarsinnaanngilaq
+
+## `<callAction>`
+
+component-action-unavailable = Komponentimi `{ $reference }` { $action } atortinneqarsinnaanngilaq
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data-p ilusaa eqqunngilaq. Sanilerissat takissusaat assigiinngillat. Nassaarineqarpoq componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data-p sanaartukkanik taakkiisunik aqqeqarpoq. Nassaarineqarpoq componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data-p sanaartukkap ateranik amigaateqarpoq. Nassaarineqarpoq componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Akissummut uuma award-ia akissutip namminerisaanut tunngavoq, tamannalu ilimagineqanngitsumik iliuuseqarnermik kinguneqassaaq.
+
+answer-max-num-attempts-in-section-wide-check-work = `<answer>`-imi sectionWideCheckWork-imik imalimmi `maxNumAttempts` sunniuteqanngilaq, misileraanerit amerlassusaat imalimmit aqunneqarmata. `maxNumAttempts` imalimmut aalajangersaruk.
+
+nested-section-wide-check-work-max-num-attempts = sectionWideCheckWork-imik imalimmi allami sectionWideCheckWork-imik imalimmiittumi `maxNumAttempts` sunniuteqanngilaq, misileraanerit amerlassusaat silataani imalimmit aqunneqarmata. `maxNumAttempts` silataaniittumut aalajangersaruk.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Attributi { $attributes } symbolicEquality aalajangersarneqanngippat sunniuteqassanngilaq.
+       *[other] Attributit { $attributes } symbolicEquality aalajangersarneqanngippat sunniuteqassanngillat.
+    }
+
+answer-invalid-type = Akissummut type eqqunngilaq: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Komponenti `<{ $component }>` ateqanngimmat module-ip attributiatut atorneqarsinnaanngilaq
+
+module-attribute-name-already-defined = Komponenti `<{ $component } name="{ $name }">` module-ip attributiatut atorneqarsinnaanngilaq, `<module>` komponentip "{ $name }" attributitut pigereermagu.
+
+conditional-content-condition-ignored = `<conditionalContent>` case- imaluunniit else-imik qitornalimmi `condition` attributi sumiginnarneqarpoq.
+
+slider-markers-type-mismatch = Marker-it type-iat slider-ip type-ianut naapertuutinngilaq.
+
+pretzel-problem-needs-statement-and-answer = Pretzel eqqunngilaq: `<problem>` tamarmik ataatsimik `<statement>`-eqassapput ataatsimillu `<answer>`-eqassallutik.
+
+pretzel-circuit-first-problem-distractor = Pretzel eqqunngilaq: mode="circuit"-imi `<problem>` siulleq distractor-iusinnaanngilaq.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Attributimut `{ $attribute }` naleq { $values } eqqunngilaq; sumiginnarneqarpoq.
+       *[other] Attributimut `{ $attribute }` nalit { $values } eqqunngillat; sumiginnarneqarput.
+    }
+
+attribute-must-be-references = Attributimut `{ $attribute }` naleq `{ $value }` eqqunngilaq. Attributi `$`-mik aallartitsisunik innersuussuteqassaaq.
+
+math-input-invalid-function-names = <mathInput>: { $attribute }-imi funktionit aqqi eqqunngitsut sumiginnarneqarput: { $names }. Ateq tamaat takutinneqartoq minnerpaamik naqinnernik marlunnik (naqinnerit imaluunniit hyphen-it) peqassaaq; kingorna `|<mathspeak alternative>` ilanngunneqarsinnaavoq.
+
+## Building components from the source
+
+component-type-invalid = Komponentip suussusia eqqunngilaq: `<{ $componentType }>`
+
+attribute-repeated = Attributi { $attribute } uteqqinneqarsinnaanngilaq.
+
+attribute-invalid-for-component = `<{ $componentType }>`-imik suussuseqartumut attributi "{ $attribute }" eqqunngilaq.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Style-ip aalajangersagaa { $styleNumber } naleqqiussinermik naammanngitsumik peqarpoq { $context ->
+        [text-on-background] allakkat qalipaataat tunuliaqutamut
+        [high-contrast] high-contrast qalipaat canvas-imut
+        [line] linjep qalipaataa canvas-imut
+        [marker] marker-ip qalipaataa canvas-imut
+       *[text-on-canvas] allakkat qalipaataat canvas-imut
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; minnerpaamik { $threshold }:1 pisariaqarpoq).
+
+style-definition-dark-mode-text-background-contrast =
+    Style-ip aalajangersagaa { $styleNumber } light mode-imut qalipaatinik naammattunik peqaraluartoq, dark mode-imut qalipaatit taakkunannga pinngortitat allakkat qalipaataannut tunuliaqutamullu naleqqiussinermik naammanngitsumik peqarput ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; minnerpaamik { $threshold }:1 pisariaqarpoq). { $suggestion ->
+        [available] Dark mode-imi naleqqiussineq naammassalluni, light mode-ip naleqqiussinera annertusiguk (soorlu { $lightAttribute }="{ $lightColor }") imaluunniit dark mode-ip qalipaataa allanngortiguk (soorlu { $darkAttribute }="{ $darkColor }").
+       *[none] Dark mode-imi naleqqiussineq naammassalluni, light mode-ip naleqqiussinera annertusiguk imaluunniit qalipaatit textColorDarkMode aamma/imaluunniit backgroundColorDarkMode atorlugit allanngortikkit.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Style-ip aalajangersagaa { $styleNumber } light mode-imut allakkanik qalipaatinik naammattunik peqaraluartoq, dark mode-imut allakkat qalipaataat taassumannga pinngortitaq canvas-imut naleqqiussinermik naammanngitsumik peqarpoq ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; minnerpaamik { $threshold }:1 pisariaqarpoq). { $suggestion ->
+        [available] Dark mode-imi naleqqiussineq naammassalluni, light mode-ip naleqqiussinera annertusiguk (soorlu textColor="{ $lightColor }") imaluunniit dark mode-ip qalipaataa allanngortiguk (soorlu textColorDarkMode="{ $darkColor }").
+       *[none] Dark mode-imi naleqqiussineq naammassalluni, light mode-ip naleqqiussinera annertusiguk imaluunniit qalipaat textColorDarkMode atorlugu allanngortiguk.
+    }
+
+section-multiple-style-palettes = Immikkoortoq <stylePalette> ataaseq kisiat toqqarsinnaavaa; kingulleq atorneqarpoq.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, numToSelect kisitsit ilivitsoq mikinerunngitsoq nulli pinnagu.
+
+variant-num-to-select-not-constant-number = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, numToSelect kisitsit allanngunngitsoq pinnagu.
+
+variant-with-replacement-not-constant-boolean = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, withReplacement boolean allanngunngitsoq pinnagu.
+
+variant-select-weight-disables-unique = Select-imut variant-it immikkut ittut atorunnaarput selectWeight imaluunniit selectForVariants aalajangersarneqarsimappat
+
+variant-coprime-undetermined = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, coprime tamatigut false-iusoq aalajangersarneqarsinnaanngimmat.
+
+variant-attribute-not-constant = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, { $attribute } allanngunngitsuunngimmat.
+
+variant-attribute-not-number = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, { $attribute } kisitsittuunngimmat.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type }-imik suussuseqartup { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, { $attribute } { $expected ->
+        [letters-combination] naqinnernik ataqatigiissitaq
+        [math-expression] matematikkikkut allataq eqqortoq
+        [integer] kisitsit ilivitsoq
+       *[number] kisitsit
+    } pinnagu.
+
+variant-length-not-integer = { $component }-ip variant-i immikkut ittut aalajangersarneqarsinnaanngillat, length kisitsit ilivitsoq pinnagu.
+
+variant-sort-not-implemented = { $component } sort-ilik variant-inik immikkut ittunik suli piareersimanngilaq
+
+variant-exclude-combinations-not-implemented = { $component } excludeCombinations-ilik variant-inik immikkut ittunik suli piareersimanngilaq
+
+variant-math-exclude-not-implemented = { $component } math-imik suussuseqartoq exclude-ilik variant-inik immikkut ittunik suli piareersimanngilaq
+
+variant-non-constant-exclude-not-implemented = { $component } exclude allanngortartumik peqartoq variant-inik immikkut ittunik suli piareersimanngilaq
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph-imi prefigure-mi atorneqarsinnaanngilaq; kingornussaq qaangerneqarpoq.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometria naammanngitsoq imaluunniit killeqanngitsoq; kingornussaq qaangerneqarpoq.
+
+prefigure-curve-label-omitted = { $subject }: curve-inut nuutitanut label-it atorneqarsinnaanngillat; label ilanngunneqanngilaq.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve-ip funktionianut aalajangersaammik suussusia '{ $definitionType }' atorneqarsinnaanngilaq; kingornussaq qaangerneqarpoq.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-imi flipFunctions attributi atorneqarsinnaanngilaq; kingornussaq qaangerneqarpoq.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-imi formula-mik suussuseqartut funktionit qitornat kisiisa atorneqarsinnaapput; kingornussaq qaangerneqarpoq.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' atorneqarsinnaanngilaq { $labelKind ->
+        [line-family] linje-ilaannut label
+       *[point] punktimut label
+    }; PreFigure-ip inissinnera nalinginnaasoq atorneqarpoq.
+
+prefigure-fill-style-unsupported = { $subject }: fill style '{ $fillStyle }' PreFigure-imi atorneqarsinnaanngilaq; immersuineq nalinginnaasoq atorneqarpoq.
+
+prefigure-line-style-unknown = { $subject }: linjep ilusaa '{ $lineStyle }' ilisimaneqanngilaq, PreFigure-imut ilanngunneqanngilaq.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }' PreFigure-imi 'diamond'-imut nuunneqarpoq.
+
+prefigure-marker-style-unsupported = { $subject }: marker style '{ $markerStyle }' PreFigure-imi atorneqarsinnaanngilaq; ilusaq nalinginnaasoq atorneqarpoq.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` eqqunngilaq; anguniagaq nassaarineqarsinnaanngilaq. Annotation ilanngunneqanngilaq.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` anguniaganut arlalinnut naapippoq; siulleq atorneqarpoq.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` eqqunngilaq; anguniagaq graph-ip avataaniippoq. Annotation ilanngunneqanngilaq.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` eqqunngilaq; anguniagaq prefigure-imi titartagaasunut ilaanngilaq. Annotation ilanngunneqanngilaq.
+
+annotation-text-missing = `<annotation>`: `text` amigaappoq imaluunniit imaqanngilaq; allakkat imaqanngitsut atorneqarput.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Ammalortumik attuumassuteqarneq paasineqarpoq.
+       *[other] `<{ $componentType }>` komponentimik ilaqartumik ammalortumik attuumassuteqarneq paasineqarpoq.
+    }
+
+reference-no-referent = Innersuussutimut referent nassaarineqanngilaq: `{ $reference }`
+
+reference-multiple-referents = Innersuussutimut referent-it arlallit nassaarineqarput: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>`-ip attributianut { $attribute } formati eqqunngilaq.
+
+children-invalid = `<{ $componentType }>`-imut qitornat eqqunngillat: qitornat eqqunngitsut nassaarineqarput: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Attributimut `{ $attribute }` naleq `{ $value }` eqqunngilaq, naleq `{ $default }` atorneqarpoq
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML versioni { $version } nassaarineqanngilaq.
+       *[other] DoenetML versioni { $version } nassaarineqanngilaq. Versioni { $fallback } atorneqassaaq
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML eqqunngilaq: { $content }
+
+parse-tag-missing-close-tag = DoenetML eqqunngilaq: Tag `{ $tag }` matuisumik tag-eqanngilaq. Namminermik matuisumik tag imaluunniit `</{ $tagName }>` tag naatsorsuutigineqarpoq.
+
+parse-tag-error = DoenetML eqqunngilaq: Tag `<{ $tagName }>`-imi kukkuneq
+
+parse-attribute-missing-value = DoenetML eqqunngilaq: Attributi `{ $attribute }` eqqunngilaq, nalimmik amigaateqartoq.
+
+parse-attribute-invalid = DoenetML eqqunngilaq: Attributi `{ $attribute }` eqqunngilaq
+
+parse-attribute-value-invalid = DoenetML eqqunngilaq: Attributip nalia `{ $value }` eqqunngilaq
+
+parse-attribute-value-quote-mismatch = DoenetML eqqunngilaq: Attributip nalia `{ $value }` eqqunngilaq. Ussatit naapertuutinngillat. `{ $quote }` amigaassasoq isumaqarpoq
+
+parse-open-tag-name-missing = DoenetML eqqunngilaq: Tag ateqanngitsoq nassaarineqarpoq, soorlu `<`
+
+parse-tag-not-closed = DoenetML eqqunngilaq: Tag `{ $tag }` matuneqanngilaq (`>` amigaassasoq isumaqarpoq).
+
+parse-self-closing-tag-name-missing = DoenetML eqqunngilaq: Tag ateqanngitsoq nassaarineqarpoq `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML eqqunngilaq: Tag `{ $tag }` matuneqanngilaq (`/>` amigaassasoq isumaqarpoq).
+
+parse-tag-invalid-attributes = DoenetML eqqunngilaq: Tag `{ $tag }` eqqunngilaq. Attributinik eqqunngitsunik peqarsinnaavoq.
+
+parse-close-tag-name-missing = DoenetML eqqunngilaq: Matuisoq tag ateqanngitsoq nassaarineqarpoq, soorlu `</`
+
+parse-attribute-value-unquoted = Attributit nalii ussatinut ilineqassapput: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML eqqunngilaq: Matuisoq tag `{ $tag }` nassaarineqarpoq, ammaanerali tag peqanngilaq
+
+parse-close-tag-mismatched = DoenetML eqqunngilaq: Matuisoq tag naapertuutinngilaq. `</{ $expected }>` naatsorsuutigineqarpoq. `{ $found }` nassaarineqarpoq
+
+parser-node-unconvertible = Node { $node } Dast node-imut nuunneqarsinnaanngilaq.
+
+## Names
+
+name-attribute-invalid =
+    Attributip atia name='{ $name }' eqqunngilaq. { $reason ->
+        [characters] Aqqit naqinnernik, kisitsisinik, underscore-inik imaluunniit hyphen-inik kisiisa imaqarsinnaapput.
+       *[start] Aqqit naqinnermik aallartissapput.
+    }
+
+component-name-invalid-start = Komponentip atia "{ $name }" eqqunngilaq. Aqqit naqinnermik aallartissapput.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = type videoWatched-imik akissut video attributeqassaaq
+
+answer-video-watched-video-not-reference = type videoWatched-imik akissummi video attributi innersuussutaassaaq
+
+answer-name-not-single-text = Akissutip name attributia ataatsimik text-imik qitornaqassaaq
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Avataaniit DoenetML aaneqarsinnaanngilaq, uteqqiinerit amerlangaarmata. Ammalortumik innersuussuteqarpa?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }"-miit DoenetML aaneqarsinnaanngilaq
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }"-miit DoenetML aajuk eqqunngilaq: komponentip suussusianut "{ $componentType }" naapertuutinngilaq
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attributi `{ $from }` atorunnaarsinneqarpoq; taassuma taarsiullugu `{ $to }` atoruk.
+       *[other] [deprecation] `<{ $component }>`-imi attributi `{ $from }` atorunnaarsinneqarpoq; taassuma taarsiullugu `{ $to }` atoruk.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attributi `{ $from }` atorunnaarsinneqarpoq sumiginnarneqarlunilu, `{ $to }` aamma aalajangersarneqarmat.
+       *[other] [deprecation] `<{ $component }>`-imi attributi `{ $from }` atorunnaarsinneqarpoq sumiginnarneqarlunilu, `{ $to }` aamma aalajangersarneqarmat.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-imi attributi `{ $attribute }` atorunnaarsinneqarpoq sumiginnarneqarlunilu.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-imi attributi `{ $attribute }` atorunnaarsinneqarpoq; taassuma taarsiullugu `<{ $child }>` qitornatut atoruk.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-imi attributip `{ $attribute }` nalia `{ $value }` atorunnaarsinneqarpoq; taassuma taarsiullugu `{ $to }` atoruk.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` tuluttut kisiat amerlanngortitsisinnaavoq, taamaattumik allakkani { $locale }-mik oqaatsilinni allakkat allanngortinneqanngillat. Amerlanngortitaq nammineq allaguk, imaluunniit `pluralForm` attributikkut aalajangersaruk.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Element `<{ $tag }>` Doenet-imut ilisimaneqanngilaq.
+
+schema-element-not-allowed-at-root = Element `<{ $tag }>` allakkat aallaqqaataanni akuersissutaanngilaq.
+
+schema-element-not-allowed-inside = Element `<{ $tag }>` `<{ $parent }>`-ip iluani akuersissutaanngilaq.
+
+schema-attribute-unrecognized = Element `<{ $tag }>` `{ $attribute }`-imik attributeqanngilaq.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Element `<{ $tag }>`-ip attributia `{ $attribute }` allattorsimaffiussaaq, ilaasa tamarmik ukunannga ataaseq: { $allowed }
+       *[other] Element `<{ $tag }>`-ip attributia `{ $attribute }` ukunannga ataaseq tassaassaaq: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select-imut variant-ip atia eqqunngilaq. Variant-ip atia { $variantName } option-ini { $numOptions } takkuppoq, toqqagassalli amerlassusaat { $numToSelect }.
+
+select-variant-name-without-options = Select-imut variant-it ilaat aalajangersarneqarput, variant-ip atianulli { $variantName } option-eqanngilaq.
+
+select-variant-name-not-possible = Select-imut aalajangersagaq variant-ip atia { $variantName } pisinnaanngilaq.
+
+select-too-few-options = Komponentit { $numToSelect } taamaallaat { $numOptions }-init toqqarneqarsinnaanngillat.
+
+select-from-sequence-too-few-values = Nalit { $numToSelect } takissusaa { $length }-imik sekvensimit toqqarneqarsinnaanngillat.
+
+select-from-sequence-indices-count-mismatch = Select-imut indeksit amerlassusaat toqqagassat amerlassusaannut naapertuussapput
+
+select-from-sequence-indices-not-integers = Select-imut indeksit tamarmik kisitsisit ilivitsuussapput
+
+select-from-sequence-index-excluded = selectfromsequence-imut indeksi aalajangersarneqarsimasoq peerneqarsimavoq
+
+select-from-sequence-indices-excluded-combination = selectfromsequence-imut indeksit aalajangersarneqarsimasut ataqatigiissitaq peerneqarsimasoq
+
+select-from-sequence-coprime-not-positive-integers = Coprime ataqatigiissitat toqqarneqarsinnaanngillat, kisitsisit ilivitsut pisut toqqarneqanngimmata.
+
+select-from-sequence-coprime-common-factor = Coprime kisitsisit toqqarneqarsinnaanngillat. Nalit tamarmik faktorimik ataatsimik ataatsimoortumik peqarput. ("from" imaluunniit "to" nalit "step"-imut coprime-iussapput.)
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-imi ataqatigiissitat 70%-it sinnerlugit peerneqarput
+
+select-from-sequence-coprime-single-number = Coprime ataqatigiissitat kisitsimit ataatsimit 1-iunngitsumit toqqarneqarsinnaanngillat.
+
+select-from-sequence-coprime-none-found = Coprime kisitsisit toqqarneqarsinnaanngillat. Nalit tamarmik faktorimik ataatsimoortumik peqarput.
+
+select-from-sequence-too-few-unique-values = Nalit immikkut ittut { $numToSelect } takissusaa { $numPossibleValues }-imik sekvensimit toqqarneqarsinnaanngillat
+
+select-prime-numbers-too-few-values = Nalit { $numToSelect } prime-kisitsisit takissusaat { $numValues } iluanniit toqqarneqarsinnaanngillat
+
+select-prime-numbers-values-count-mismatch = Select-imut nalit amerlassusaat toqqagassat amerlassusaannut naapertuussapput
+
+select-prime-numbers-values-not-prime = Select prime number-imut nalit tamarmik prime-kisitsisini allattorsimassapput
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers-imut nalit aalajangersarneqarsimasut ataqatigiissitaq peerneqarsimasoq
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-imi ataqatigiissitat 70%-it sinnerlugit peerneqarput
+
+select-random-combination-fluke = Pinngitsoornermik ilimanaatsuararsuarmik nalit toqqarneqartut ataqatigiissitaq toqqarneqarsinnaanngilaq
+
+select-random-value-fluke = Pinngitsoornermik ilimanaatsuararsuarmik naleq toqqarneqarsinnaanngilaq
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` matematikkip iluani titartanneqanngilaq; allakkat ilusilerneqarput input-it ilanngunneqarsinnaanngitsutut. { $reason ->
+        [not-inline] `inline`-iusoq choice input kisiat allakkat iluanut naammappoq; `inline`-iunngippat naqitat katersugaataapput.
+        [expanded] `expanded`-iusoq text input allattoqarfittut arlalinnik titeqarpoq, allakkat iluanut angitigingaartoq.
+        [on-graph] Graph-imi allakkat assittut ataatsitut titartanneqarput, aqutsissummullu inissaqanngilaq.
+       *[relative-width] `width`-ia naleqqiussamik aalajangersarneqarpoq (procent imaluunniit `em`), allakkat iluanilu uuttortagassaqanngilaq. Silissuseq uuttortaatinik aalajangersimasunik, soorlu `px`, aalajangersaruk.
+    }

--- a/packages/i18n/locales/kl/diagnostics.ftl
+++ b/packages/i18n/locales/kl/diagnostics.ftl
@@ -231,17 +231,10 @@ function-ignoring-empty =
 
 function-points-too-close = Funktioni punktinik marlunnik qanittuararsuunnik imaqarpoq. Funktioni aalajangersarneqarsinnaanngilaq.
 
-function-iterates-input-output-mismatch =
-    { $inputs ->
-        [one] Funktionip iterate-i input-it amerlassusaat output-it amerlassusaannut naapertuuppata taamaallaat pisinnaapput. Funktioni una { $inputs } input-eqarpoq { $outputs ->
-            [one] output-ilu { $outputs }
-           *[other] output-ilu { $outputs }
-        }.
-       *[other] Funktionip iterate-i input-it amerlassusaat output-it amerlassusaannut naapertuuppata taamaallaat pisinnaapput. Funktioni una { $inputs } input-eqarpoq { $outputs ->
-            [one] output-ilu { $outputs }
-           *[other] output-ilu { $outputs }
-        }.
-    }
+# Both of English's count selects are dropped rather than written twice over:
+# «input-eqarpoq» and «output-ilu» do not change with the count here — the
+# number word carries it — so a branch would have repeated itself.
+function-iterates-input-output-mismatch = Funktionip iterate-i input-it amerlassusaat output-it amerlassusaannut naapertuuppata taamaallaat pisinnaapput. Funktioni una { $inputs } input-eqarpoq output-ilu { $outputs }.
 
 ## `<sequence>`
 

--- a/packages/i18n/locales/kl/editor.ftl
+++ b/packages/i18n/locales/kl/editor.ftl
@@ -85,10 +85,7 @@ editor-accessibility-label =
             [close] matuniarlugu
            *[open] ammarniarlugu
         } tooruk.
-        [advisories] WCAG AA unioqqutitsinernik nassaarineqanngilaq. Atorsinnaanermut siunnersuutit allat { $count ->
-            [one] { $count }
-           *[other] { $count }
-        } nassaarineqarput. Atorsinnaanermut nalunaarusiaq { $action ->
+        [advisories] WCAG AA unioqqutitsinernik nassaarineqanngilaq. Atorsinnaanermut siunnersuutit allat { $count } nassaarineqarput. Atorsinnaanermut nalunaarusiaq { $action ->
             [close] matuniarlugu
            *[open] ammarniarlugu
         } tooruk.

--- a/packages/i18n/locales/kl/editor.ftl
+++ b/packages/i18n/locales/kl/editor.ftl
@@ -1,0 +1,227 @@
+# Kalaallisut (Greenlandic) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay exactly as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The 1973 orthography; **ĸ (U+0138) appears nowhere**, and
+# every such sound is written `q`. Length is written by doubling.
+# `chrome.ftl` sets the letters out in full. A Danish loan keeps its Danish
+# spelling where it is the word actually in use — «variant», «filter»,
+# «standardi», «koordinati», «funktioni», «version», «linje» — and this file
+# has more of those than the other three, because the editor is a developer
+# surface and Greenlandic has no separate register for it.
+#
+# **Number.** `kl` selects **one** and **other**, and both are written where
+# a count is selected on: a counted noun takes the plural ending, so the two
+# branches differ in more than the digit.
+#
+# **Suffixes and placeables.** A Kalaallisut case ending cannot be welded onto
+# a placeable — `{ $element }`, `{ $ref }`, `{ $shortcut }` — whose final
+# sound this catalog never sees. Where English used a preposition, the
+# sentence is built around the argument with separate words. A hyphen onto a
+# *literal* identifier is fine and is used: «DoenetML-ip versionia».
+#
+# **This is the thinnest of the four files, and the context-help panel is
+# where it thins out.** Every message in it is covered, but several are
+# carried by Danish loans rather than by Kalaallisut words — «attributi»,
+# «snippeti», «array», «standardi», «koordinati», «funktioni» — because the
+# language-server concepts behind them have no settled Greenlandic term.
+# «Innersuussut» for *reference* is the one Kalaallisut word this file leans
+# on hardest, and it is the first thing a reviewer should look at.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Utertiguk
+       *[update] Nutarteruk
+    }
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Takutitsissut { $word }
+       *[other] Takutitsissut { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = Filter...
+editor-variant-next = Variant tulleq toqqaruk
+editor-variant-previous = Variant siulia toqqaruk
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA atorsinnaanermut unioqqutitsineq nassaarineqarpoq. Atorsinnaanermut nalunaarusiaq { $action ->
+            [close] matuniarlugu
+           *[open] ammarniarlugu
+        } tooruk.
+        [advisories] Atorsinnaanermut nalunaarusiaq { $action ->
+            [close] matuniarlugu
+           *[open] ammarniarlugu
+        } tooruk. WCAG AA unioqqutitsinernik nassaarineqanngilaq, atorsinnaanermulli siunnersuutit allat pigineqarput.
+       *[clean] Atorsinnaanermut nalunaarusiaq { $action ->
+            [close] matuniarlugu
+           *[open] ammarniarlugu
+        } tooruk. Atorsinnaanermut ajornartorsiutinik nassaarineqanngilaq.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA atorsinnaanermut unioqqutitsineq nassaarineqarpoq. { $count ->
+            [one] WCAG AA unioqqutitsineq { $count }
+           *[other] WCAG AA unioqqutitsinerit { $count }
+        } nassaarineqarput. Atorsinnaanermut nalunaarusiaq { $action ->
+            [close] matuniarlugu
+           *[open] ammarniarlugu
+        } tooruk.
+        [advisories] WCAG AA unioqqutitsinernik nassaarineqanngilaq. Atorsinnaanermut siunnersuutit allat { $count ->
+            [one] { $count }
+           *[other] { $count }
+        } nassaarineqarput. Atorsinnaanermut nalunaarusiaq { $action ->
+            [close] matuniarlugu
+           *[open] ammarniarlugu
+        } tooruk.
+       *[clean] WCAG AA unioqqutitsinernik nassaarineqanngilaq. Atorsinnaanermut nalunaarusiaq { $action ->
+            [close] matuniarlugu
+           *[open] ammarniarlugu
+        } tooruk.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML-ip versionia { $version }
+
+editor-tab-help = Ikiuut sumiiffimmut naleqquttoq
+editor-tab-help-short = Sumiiffik
+editor-tab-errors = Kukkunerit
+editor-tab-warnings = Mianersoqqussutit
+editor-tab-info = Paasissutissat
+editor-tab-accessibility = Atorsinnaaneq
+editor-tab-responses = Akissutit nassiunneqartut
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Periarfissat
+editor-format-as-doenetml = DoenetML-itut ilusilersoruk
+editor-format-as-xml = XML-itut ilusilersoruk
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linje #{ $line }
+
+editor-no-errors = Kukkuneqanngilaq
+editor-no-warnings = Mianersoqqussuteqanngilaq
+editor-no-info = Paasissutissaqanngilaq
+
+editor-show-info-annotations = Paasissutissat allattuiffimmi takutikkit
+editor-show-accessibility-annotations = Atorsinnaanermut paasissutissat allattuiffimmi takutikkit
+
+editor-accessibility-learn-more = Doenet-ip atorsinnaaneq qanoq isigigaa
+editor-accessibility-violations-heading = Atorsinnaanermut unioqqutitsinerit ({ $standard })
+editor-accessibility-other-heading = Atorsinnaanermut ajornartorsiutit allat
+editor-none-found = Nassaarineqanngilaq
+
+
+## Submitted responses
+
+editor-no-responses = Akissutit nassiunneqartut suli peqanngillat
+editor-response-answer-id = Akissutip normua
+editor-response-response = Akissut
+editor-response-credit = Poointit
+editor-response-submitted = Nassiunneqarpoq
+
+
+## The context-help panel
+
+help-placeholder = Nalunaarsuutit pissarsiarilerlugit markøri tag-ip atianut, attributimut imaluunniit { $ref } tungaanut inissikkiuk.
+
+help-unsupported-ref-chain = Innersuussutit ilaqartut soorlu { $example } suli atorneqarsinnaanngillat.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Innersuussutimut referent nassaarineqanngilaq: { $ref }.
+        [multiple] Innersuussutimut referent-it arlallit nassaarineqarput: { $ref }.
+       *[indeterminate] { $ref } tungaanut referent aalajangersarneqarsinnaanngilaq.
+    }
+
+help-learn-about-references = Innersuussutit pillugit ilikkaruk →
+help-reference-page = Nalunaarsuutit quppernerat →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } iluani
+       *[top] Allakkat qaavani
+    }{ $allowed ->
+        [none] { " — maani suussanngilaq." }
+        [text] { " — maani allaguk." }
+        [text-and-components] { " — maani allaguk, imaluunniit misiliguk:" }
+       *[components] { " — misiligassat:" }
+    }
+
+help-suggestions-footer = Komponentit tamaasa { $total } takujumallugit { $shortcut } tooruk.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } tassaavoq innersuussut una tungaanut: { $target }.
+       *[other] { $ref } tassaavoq innersuussut una tungaanut: { $target } (linje { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Aallartitaq: { $owner }, tassanilu { $role }.
+       *[other] Aallartitaq: { $owner }, linjemi { $line }, tassanilu { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } tassaavoq innersuussut una tungaanut: { $element } pigisaa { $property }.
+       *[other] { $ref } tassaavoq innersuussut una tungaanut: { $element } pigisaa { $property } (linje { $line }).
+    }
+
+help-kind-attribute = attribut
+help-kind-snippet = snippet
+help-kind-array-entry = array-ip ilaa
+
+help-default = Standardi:
+help-active-default = Standardi atorneqartoq:
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nalit akuerisat (ataasiakkaanut ataaseq):
+       *[other] Nalit akuerisat:
+    }
+
+help-suggested-values = Siunnersuutit:
+help-inserts = Ilanngunneqartut:
+
+help-coordinates =
+    { $count ->
+        [one] Koordinati:
+       *[other] Koordinatit:
+    }
+
+help-type = Suussusia:
+help-resolved-style = Ilusaa (styleNumber { $styleNumber }):
+help-resolved-function-names = Funktionit aqqi:
+help-reset-list = Input-imi uani utertinneqartut:
+help-added-on-input = Input-imi uani ilanngunneqartut:
+help-removed-on-input = Input-imi uani peerneqartut:
+
+help-reset-overrides = { $reset } { $additional } aamma { $removed } sinnerpai.

--- a/packages/i18n/locales/miq/chrome.ftl
+++ b/packages/i18n/locales/miq/chrome.ftl
@@ -1,0 +1,157 @@
+# Mískito viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography of the Nicaraguan Caribbean
+# coast, the one the Moravian mission established in the nineteenth century and
+# the one the Nicaraguan and Honduran bilingual schools use today:
+# `a b d h i k l m n o p r s t u w y`, with `ng` and the diphthongs `ai` and
+# `aw`. Four notes.
+#
+#   * **`ng` is one sound**, the velar nasal, and is written as the digraph:
+#     «sangni». It is never written `ñ` and never `n` alone.
+#   * **`aw` and `ai` are the two diphthongs** and are written with `w` and `i`
+#     rather than with `u` and `y`: «lawana», «pain», «kaisa». The loans in
+#     these files follow the same rule — «brawn», «bakrawn», «raw».
+#   * **`h` is a consonant that is pronounced** — «pihni», «lalahni» — and not a
+#     silent letter or a length mark, which is where a Spanish-reading eye goes
+#     wrong first.
+#   * `c`, `f`, `g`, `j`, `q`, `v`, `x` and `z` are **not** in the alphabet, and
+#     `k` does the work Spanish gives to `c` and `qu`. Every loan below is
+#     respelled to obey that: Spanish `g` becomes `k` the way «gallina» became
+#     «kalila», `v` becomes `b`, `j` becomes `h`, `z` and `c`-before-`e` become
+#     `s`, and `f` becomes `p`.
+#
+# The language is named «Mískito» in all four of these files, with the accent.
+# The accentless «Miskitu», which is what the Nicaraguan orthography itself
+# increasingly writes, is not mixed into these headers.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `miq`; it falls back to
+# the default locale and reports `one` and `other`, categories Mískito does not
+# select. A Mískito noun after a numeral takes no plural marker — the plural
+# «nani» is not used with a count — so English's `one` and `other` branches are
+# one string here, written as **one unselected form** (`answer-show-responses`).
+# English's explicit `[0]` literal in `attempts-remaining` matches the number
+# itself rather than a category, and is kept.
+#
+# **Loans.** Mískito has no native software register but borrows freely for
+# one, from Spanish on the Nicaraguan coast and from English through the
+# Moravian mission and the Honduran Mosquitia. This file carries, from English,
+# «kredit», «trai», «kliks», «kibord», «baks», «raw», «kolum», «arru», «nut»,
+# «ansa», «dukumint», «rindarar» and «WCAG»; from Spanish, «puntu»,
+# «interbalu», «estadistika», «matematika», «aksesibilidad» and «pista». The
+# frame around them is Mískito: native verbs («kaikaia» to look, «mangkaia» to
+# put, «sakaia» to take out, «kwakaia» to open, «prakaia» to close), the
+# negator «apia» following what it negates, SOV order, and the copulas `sa` and
+# `kaisa`.
+#
+# **Confidence.** Every key in the English catalog is translated. The weakest
+# words are «Saura» for *error* (the ordinary word for *bad*, doing duty for a
+# technical noun), «Aisanka» for *feedback* (a nominalized *saying*), and
+# «Rindarar», a bare English loan for a thing the language has no name for at
+# all. The button texts take the plain imperative — «kaiks», «bliks», «muns» —
+# which is what a Mískito instruction sounds like.
+
+
+## Answer submission
+
+answer-checking = Kaiki sa...
+answer-submitting = Blikisa...
+answer-checking-status = Ansa ba kaiki sa
+answer-submitting-status = Ansa ba blikisa
+answer-correct = Pain
+answer-incorrect = Pain apia
+answer-response-saved = Ansa ba mangkan
+answer-percent-credit = { $percent }% kredit
+answer-percent-correct = { $percent }% pain
+answer-percent-short = { $percent } %
+max-credit-available = Kredit tara briaia sip ba: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] trai kum bara apia
+       *[other] trai { $count } bara
+    }
+validation-correct = (Pain)
+validation-incorrect = (Pain apia)
+validation-partially-correct = (Tila pain)
+answer-show-responses = { $answerId } dukiara ansa { $count } marikaia
+
+
+## Disclosure panels
+
+feedback-heading = Aisanka
+collapsible-click-to-open = (kwakaia dukiara kliks muns)
+collapsible-click-to-close = (prakaia dukiara kliks muns)
+collapsible-initializing = Ta krikisa...
+footnote-show = Nut marikaia
+footnote-hide = Nut bikaia
+description-more-information = tanka kau
+
+
+## Controls
+
+slider-previous = Pas
+slider-next = Wala
+keyboard-open = Kibord Kwakaia
+keyboard-close = Kibord Prakaia
+choice-input-remove-choice = { $choice } sakaia
+matrix-remove-row = Raw sakaia
+matrix-add-row = Raw mangkaia
+matrix-remove-column = Kolum sakaia
+matrix-add-column = Kolum mangkaia
+subset-add-remove-points = Puntu mangkaia/sakaia
+subset-toggle-points-intervals = Puntu wal interbalu nani ba lakaia
+subset-move-points = Puntu nani brih waia
+subset-clear = Sut sakaia
+orbital-add-row = Raw Mangkaia
+orbital-remove-row = Raw Sakaia
+orbital-add-box = Baks Mangkaia
+orbital-remove-box = Baks Sakaia
+orbital-add-up-arrow = Arru pura mangkaia
+orbital-add-down-arrow = Arru munhta mangkaia
+orbital-remove-arrow = Arru sakaia
+orbital-row-label = Raw { $row } nina
+pretzel-answer = Ansa
+summary-statistics-caption = { $column } estadistika tanka
+
+
+## Math input
+
+math-input-preview-region = matematika ulbanka kaikanka
+math-input-preview = Kaikanka
+math-input-invalid-expression = Ulbanka pain apia:
+
+
+## Document status
+
+viewer-initializing = Ta krikisa...
+
+
+## Errors
+
+error-heading = Saura
+error-found-at =
+    { $span ->
+        [line] Lain { $startLine } ra sakan.
+       *[lines] Lain { $startLine }–{ $endLine } ra sakan.
+    }
+document-contains-errors = Naha dukumint ra saura nani bara!
+diagnostic-heading-error = Saura
+diagnostic-heading-warning = Warnin
+diagnostic-heading-information = Tanka
+diagnostic-heading-hint = Pista
+accessibility-heading-level-1 = WCAG AA aksesibilidad saura
+accessibility-heading-level-2 = Aksesibilidad warnin
+something-went-wrong = Diara kum saura takan.
+renderer-load-failed = rindarar kum balras. Wahia ba kli kwaks.
+core-start-failed = Naha dukumint ba ta krikras. Wahia ba kli kwaks.
+core-start-failed-busy = Naha dukumint ba ta krikras. Dukumint manis pyua kumi ra ta krikan, bara masinka sirpi ra baha pyua manis brisa. Dukumint wala nani tnata alkbia taim, wahia ba kli kwakaia ba help munbia.
+core-start-failed-retry = Naha dukumint ba ta krikras.
+core-start-failed-busy-retry = Naha dukumint ba ta krikras. Dukumint manis pyua kumi ra ta krikan, bara masinka sirpi ra baha pyua manis brisa.
+core-start-retry = Kli traiks
+saved-state-unavailable = Man warkkam mangkan ba sakaia sip apia kan.

--- a/packages/i18n/locales/miq/content.ftl
+++ b/packages/i18n/locales/miq/content.ftl
@@ -1,0 +1,291 @@
+# Mískito content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+# English, in `locales/en/content.ftl`, is the source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography of the Nicaraguan Caribbean
+# coast; see `chrome.ftl`'s header for the alphabet, for `ng`, for the `aw` and
+# `ai` diphthongs, and for the pronounced `h`. `c`, `f`, `g`, `j`, `q`, `v`,
+# `x` and `z` are not in the alphabet, so every loan below is respelled: `g`
+# becomes `k` («triánguo» → «trianklu»), `v` becomes `b` («vector» →
+# «bektar»), `j` and Spanish `g`-before-`i` become `h` («ejemplo» → «ehemplu»,
+# «región» → «rehion»), `z` and `c`-before-`e`/`i` become `s` («círculo» →
+# «sirkulu»), and `f` becomes `p` («párrafo» → «parapu»).
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `miq`; it falls back to
+# the default locale and reports `one` and `other`, categories Mískito does not
+# select. Nothing here writes a plural select on a count: a Mískito noun after
+# a numeral takes no plural marker, so one unselected form is what a counted
+# message would say. Numerals **follow** the noun in Mískito — «utla wal», two
+# houses — which is why `noun-regular-polygon` reads «ladu { $numSides }» and
+# why `section-title-prefix` keeps English's order of word and number.
+#
+# **Word order.** The modifier **follows** the noun in Mískito — «utla pihni»,
+# white house — so the composition messages **reverse English's order**:
+# `style-with-noun`, `style-filled-with-noun` and their `-tail` variants put
+# `{ $noun }` first and `{ $description }` after it, and `style-border-clause`
+# puts the head noun «bordi» before the adjectives that describe it. Within a
+# run of modifiers the English order is kept (width, dash pattern, colour). The
+# adjectival colour words carry the `-ni` suffix — «pihni», «pauni»,
+# «lalahni», «sangni» — and «siksa» does not.
+#
+# **Loans.** The geometry and style vocabulary is borrowed, mostly from Spanish
+# (geometry is schooled in Spanish on the Nicaraguan coast): «lain»,
+# «sekmentu», «rayu», «bektar», «kurba», «punsion», «kampu», «parabula»,
+# «polilain», «polikunu», «trianklu», «rektanklu», «sirkulu», «rehion»,
+# «puntu», «kwadradu», «diamanti», «krus», «bordi», «orisontal», «bertikal»,
+# «diakonal», «raya», «kris», «naranha», «siyan», «murada», «blanku», and the
+# sectional words «aktibidad», «kaskada», «tanka marikanka», «ehemplu»,
+# «ehersisiu», «ubhetibu», «parapu», «parti», «problema», «prueba»,
+# «seksion», «solusion», «teorema», «tabla», «estadistika». From English come
+# «blu», «pink», «brawn», «bakrawn», «sait», «nut», «wark» and «ansa». The
+# frame is Mískito throughout: native verbs, the negator «apia» after what it
+# negates, the partitive «wina», and the copula `sa`.
+#
+# **What is kept native.** The five colour words a Mískito speaker already has
+# — «siksa» black, «pihni» white, «pauni» red, «lalahni» yellow, «sangni»
+# green — stand as they are. «sangni» spans what English splits into green and
+# blue, so `.blue` takes the English loan «blu» rather than being folded into
+# «sangni»; that seam is the one `locales/quc` and `locales/kek` also record.
+# `line-width` uses «tara» big and «sirpi» small for *thick* and *thin*,
+# which is how a stroke's weight is said. «lilka», the ordinary word for a
+# picture, names a `<figure>`; «wahia», a leaf, names a page.
+#
+# **What is left out.** `element-name` and `element-anion-name`, the 118
+# chemical elements: chemistry is schooled in Spanish and there is no published
+# Mískito list. Everything else in the English catalog is translated.
+#
+# **Confidence.** `piecewise-condition-if` is the weakest key here. Mískito's
+# conditional marker «kaka» is clause-final, and the renderer places this word
+# *before* the inequality, so «kaka» reads out of position; a speaker should
+# decide whether to leave it, or to accept the mismatch as the price of the
+# renderer's fixed order. «Aisanka» for *feedback* and «Saura» for *error* in
+# `chrome.ftl` have the same weakness. `noun-gender` answers one token,
+# «apu», because Mískito has no grammatical gender and nothing selects on it.
+
+
+## Style vocabulary
+
+color =
+    .black = siksa
+    .white = pihni
+    .gray = kris
+    .red = pauni
+    .orange = naranha
+    .yellow = lalahni
+    .green = sangni
+    .cyan = siyan
+    .blue = blu
+    .purple = murada
+    .pink = pink
+    .brown = brawn
+
+line-width =
+    .thick = tara
+    .thin = sirpi
+
+line-style =
+    .dashed = raya nani
+    .dotted = puntu nani
+
+fill-style =
+    .horizontal = lain nani orisontal
+    .vertical = lain nani bertikal
+    .diagonal = lain nani diakonal
+    .backdiagonal = lain nani diakonal wala
+    .dots = puntu nani
+    .diamonds = diamanti nani
+
+noun =
+    .line = lain
+    .line-segment = lain sekmentu
+    .ray = rayu
+    .vector = bektar
+    .curve = kurba
+    .function = punsion
+    .slope-field = kampu pendienti
+    .vector-field = kampu bektar
+    .parabola = parabula
+    .polyline = polilain
+    .polygon = polikunu
+    .triangle = trianklu
+    .rectangle = rektanklu
+    .circle = sirkulu
+    .region = rehion
+    .point = puntu
+    .square = kwadradu
+    .diamond = diamanti
+    .cross = krus
+    .plus = plus
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] polikunu rekular ladu { $numSides }
+    }
+
+noun-gender = apu
+
+
+## Style composition
+##
+## The noun comes first and its modifiers follow it, which is the reverse of
+## English; see the Word order paragraph in this file's header.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = yenu
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } { $pattern } wal
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } { $pattern } wal
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } { $pattern } wal
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] bordi { $border } wal
+        [and] bara bordi { $border }
+        [and-article] bara bordi { $border }
+       *[with] bordi { $border } wal
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = yenu apia
+
+style-text =
+    { $parts ->
+        [background] { $color }, bakrawn { $background } wal
+       *[plain] { $color }
+    }
+
+style-background-none = apu
+
+
+## Boolean words
+
+boolean-true = kasak
+boolean-false = kasak apia
+
+
+## Answer buttons
+
+answer-submit-label = Wark ba kaiks
+answer-submit-label-no-correctness = Ansa ba bliks
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktibidad
+    .aside = Sait nut
+    .cascade = Kaskada
+    .definition = Tanka marikanka
+    .example = Ehemplu
+    .exercise = Ehersisiu
+    .exercises = Ehersisiu nani
+    .given-answer = Ansa
+    .note = Nut
+    .objectives = Ubhetibu nani
+    .paragraphs = Parapu nani
+    .part = Parti
+    .problem = Problema
+    .problems = Problema nani
+    .proof = Prueba
+    .question = Makabi walanka
+    .section = Seksion
+    .solution = Solusion
+    .task = Wark
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Pista
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Lilka { $enumeration }
+        [numbered-caption] Lilka { $enumeration }{ ": " }
+        [unnumbered-caption] Lilka{ ": " }
+       *[unnumbered] Lilka
+    }
+
+
+## Paginator controls
+
+paginator-previous = Pas
+paginator-next = Wala
+paginator-page = Wahia
+paginator-page-status = { $numPages } wina { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = apia kaka
+piecewise-condition-if = kaka
+piecewise-condition-otherwise = baha apia kaka
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are left out: chemistry is schooled
+## in Spanish and there is no published Mískito list of the 118 elements.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Simbulu kimiku pain apia
+chemistry-invalid-ionic-compound = Kompwestu ioniku pain apia
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blanku
+math-embedded-input-blank-ordinal = { $total } wina blanku { $ordinal }

--- a/packages/i18n/locales/miq/diagnostics.ftl
+++ b/packages/i18n/locales/miq/diagnostics.ftl
@@ -162,7 +162,7 @@ eigen-decomposition-failed = Matris ai awtobalur nani ba kalkulaia sip apia
 matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parametru { $parameters } ba patronka bilara bara apia, bara baha mita ban blanku wal praki kaisa.
 graph-grid-invalid = `<graph>`: grid="{ $grid }" tanka briaia sip apia. none, medium, dense, apia kaka nambar wal, 0 purara, spes kum ni sirpi mangkan, kaia sa, baku: grid="1 0.5". Krid kum ulban apia.
 field-function-wrong-num-outputs =
-    `<{ $component }>` ba punsion kum output wal brih ba want sa, puntu bani ra bektar ba, baku: `(y, -x)`, sakuna punsion yaban ba output { $found } brisa. { $alternative ->
+    `<{ $component }>` ba punsion kum { $expected } output brih ba want sa — kumi, puntu bani ra slope y' ba, baku: `y - x`, apia kaka wal, puntu bani ra bektar ba, baku: `(y, -x)` — sakuna punsion yaban ba output { $found } brisa. { $alternative ->
         [none] Diara kum ulban apia.
        *[other] `<{ $alternative }>` sika baha punsion dukiara kompanenti ba. Diara kum ulban apia.
     }

--- a/packages/i18n/locales/miq/diagnostics.ftl
+++ b/packages/i18n/locales/miq/diagnostics.ftl
@@ -1,0 +1,365 @@
+# Mískito diagnostics: the errors and warnings the core and the parser report
+# about a document. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography of the Nicaraguan Caribbean
+# coast; see `chrome.ftl`'s header for the alphabet, `ng`, the `aw`/`ai`
+# diphthongs and the pronounced `h`. `c`, `f`, `g`, `j`, `q`, `v`, `x` and `z`
+# are not in the alphabet, and that constraint governs every loan here: `k`
+# does the work of `c` and `qu` («kompanenti», «kalkulaia», «kwut»), `p` the
+# work of `f` («pormatka», «paktar», «porsentu»), `b` the work of `v`
+# («balur», «bariabil», «bektar»), `h` the work of `j` and of Spanish `g`
+# before a front vowel («heometria», «marhin»), and `s` the work of `z` and of
+# `c` before `e`/`i` («definision», «interseksion»). DoenetML identifiers —
+# element and attribute names, enumerated values, `mathjs`, `PreFigure`,
+# `styleNumber`, `[deprecation]` — are not Mískito words and keep their own
+# spelling; where English wrote one as bare prose this file puts it in
+# backticks so a reader can see it is a name and not a word.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `miq`; it falls back to
+# the default locale and reports `one` and `other`, categories Mískito does not
+# select. A Mískito noun after a numeral takes no plural marker, so every
+# counted message English splits into `[one]`/`[other]` — the `$attributesCount`,
+# `$valuesCount`, `$parametersCount`, `$intervals`, `$inputs`, `$outputs`,
+# `$found` and `$count` selects — is **one unselected form** here. The selects
+# on `$type`, `$mode`, `$context`, `$reason`, `$suggestion`, `$labelKind`,
+# `$expected`, `$isList`, `$fallback`, `$component`, `$componentType`,
+# `$alternative`, `$span` and `$location` are not plural selects and keep every
+# branch English writes, with English's branch keys.
+#
+# **Loans.** These are sentences, not terminology, so the frame is Mískito
+# throughout — «pain apia» for *invalid*, «sip apia» for *cannot*, «kaia sa»
+# for *must be*, «swisa» for *ignoring*, «sakan apia» for *not found*, «daukan
+# apia sin» for *has not been implemented*, the postposition «ra», the
+# conjunction «bara», the disjunction «apia kaka», and SOV order. The technical
+# nouns inside that frame are loans, mostly through Spanish: «atributu»,
+# «kompanenti», «balur», «nambar», «bektar», «bariabil», «bariant», «lain»,
+# «puntu», «sirkulu», «rehion», «punsion», «ekwasion», «ekspresion»,
+# «parametru», «matris», «awtobalur», «sekwensia», «enteru», «larkuka»,
+# «pormatka», «paktar», «heometria», «interseksion», «anklu»,
+# «parabula», «bertis», «kolorka», «kontrast», «estilu», «propiedad»,
+# «porsentu», «marhin», «lista», «Inglis». From English: «stet bariabilka»,
+# «rindarar», «tak», «raw», «kolum», «wid», «boks», «baks», «kanbas»,
+# «bakrawn», «lait mode», «dark mode», «praim», «kwut mark», «kontena»,
+# «trai», «snipet», «krid», «distraktor».
+#
+# **Confidence.** All 220 messages are translated. Two places lose a
+# distinction English draws, both because the branch keys were `[one]` and
+# `[other]` on something that is not a count Mískito can mark:
+# `field-function-wrong-num-outputs` keeps only the two-output wording of its
+# `$expected` select, and every message that named an input, output, interval,
+# attribute, value or parameter count now says it once rather than twice. The
+# weakest single words are «awtobalur» for *eigenvalue*, «heometria» for
+# *geometry* and «stet bariabilka» for *state variable*; none of the three is
+# said in Mískito outside a sentence like this one, and a speaker should feel
+# free to replace them.
+
+
+line-segment-attributes-ignored-with-endpoints = Tnata puntu wal marikan taim, { $attributes } ba swisa
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Tnata puntu kum wal tila puntu kum marikan taim, { $attributes } ba swisa
+line-segment-midpoint-offset-without-midpoint = midpointOffset ba tila puntu apu kaka warkka daukras
+line-points-undetermined-dimensions = Lain ba puntu nani ai dimensionka sakan apia ba ra luisa.
+line-points-too-few-dimensions = Lain ba puntu nani dimension wal apia kaka kau brisa ba ra luaia sa.
+line-points-depend-on-variables = Lain ba puntu nani bariabil nani ra mangki ba ra luisa: { $variables }.
+line-equation-invalid-format = { $variable1 } wal { $variable2 } bariabil nani wal lain ekwasionka pormatka pain apia.
+ray-overprescribed-through = Rayu ba through, endpoint bara direction ni marikan.  through marikan ba swisa.
+ray-dimension-mismatch = Rayu ra numDimensions ba praki apia.
+vector-overprescribed-head = Bektar ba head, tail bara displacement ni marikan.  head marikan ba swisa.
+vector-dimension-mismatch = Bektar ra numDimensions ba praki apia.
+attract-to-without-nearest-point = `<{ $component }>` ra alkaia sip apia, kan witin nearestPoint stet bariabilka apu.
+constrain-to-without-nearest-point = `<{ $component }>` ra taibaia sip apia, kan witin nearestPoint stet bariabilka apu.
+constrain-to-interior-without-nearest-point = `<{ $component }>` bilara taibaia sip apia, kan witin nearestPoint stet bariabilka apu.
+choice-input-label-position-ignored = labelPosition ba inline apia choiceInput dukiara swisa
+choice-input-indices-count-mismatch = choiceInput dukiara indices marikan ba swisa, kan indices nambarka ba `choice` luhpia nambarka wal praki apia.
+pretzel-indices-count-mismatch = problem dukiara indices marikan ba swisa, kan indices nambarka ba `problem` luhpia nambarka wal praki apia.
+shuffle-indices-count-mismatch = shuffle dukiara indices marikan ba swisa, kan indices nambarka ba kompanenti nambarka wal praki apia.
+indices-ignored-out-of-range = { $component } dukiara indices marikan ba swisa, kan indices kum kum ba tnata luan.
+pretzel-indices-repeated = pretzel dukiara indices marikan ba swisa, kan indices kum kum ba kli ulban.
+pretzel-circuit-first-index = `circuit` mode ra pretzel dukiara indices marikan ba swisa, kan indices pas ba 1 kaia sa.
+string-children-need-type = `<{ $component }>` ba `string` luhpia nani wal warkka daukaia dukiara, `type` atributu kum marikaia sa.
+invalid-type-defaulting-to-math = { $component } kompanenti dukiara { $type } tipka pain apia. math, text, number apia kaka boolean kaia sa. math ra mangkisa.
+string-not-valid-component-to-arrange = String "{ $value }" ba { $component } daukaia dukiara kompanenti pain kum apia sa. Swisa.
+invalid-type-defaulting-to-number = { $type } tipka pain apia, tipka ba number ra mangkisa.
+invalid-variable-value = Bariabil kum balurka pain apia: `{ $value }`
+variant-index-must-be-number = Bariant `index` { $index } ba nambar kum kaia sa
+variant-index-must-be-integer = Bariant `index` { $index } ba enteru kum kaia sa
+side-by-side-absolute-widths = `<{ $component }>` ba absolute paskanka dukiara daukan apia sin. Wid nani ba `relative` ra mangkisa.
+side-by-side-absolute-margins = `<{ $component }>` ba absolute paskanka dukiara daukan apia sin. Marhin nani ba `relative` ra mangkisa.
+side-by-side-no-block-child = `<{ $component }>` pain apia: block luhpia kum kau brih kaia sa.
+label-for-ignored-on-graphical = Krapiku `<label>` ra `for` atributu ba swisa.
+label-for-must-resolve-to-one = `<label>` ra `for` atributu ba kompanenti kumi baman ra praki kaia sa.
+label-for-unresolved = `<label>` ra `for` atributu ba kompanenti kum ra praki sip apia kan.
+label-for-answer-with-authored-inputs = `<label>` ra `for` atributu ba `<answer>` kum ra riparens munisa, bara baha ansa ba input nani ulban brisa; input ba ra sirpi riparens muns.
+label-for-answer-without-input = `<label>` ra `for` atributu ba `<answer>` kum ra riparens munisa, bara baha ansa ba nina mangkaia input kum apu.
+label-for-must-reference-input-or-answer = `<label>` ra `for` atributu ba input kum apia kaka answer kum ra riparens munaia sa.
+accessibility-short-description-or-decorative = Aksesibilidad dukiara, `<{ $component }>` ba tanka kunhka kum brih kaia sa, apia kaka `decorative` baku marikan kaia sa.
+accessibility-video-short-description = Aksesibilidad dukiara, `<video>` ba tanka kunhka kum brih kaia sa.
+accessibility-input-short-description-or-label = Aksesibilidad dukiara, `<{ $component }>` ba tanka kunhka kum apia kaka label kum brih kaia sa.
+accessibility-answer-input-short-description-or-label = Aksesibilidad dukiara, `<answer>` kum input kum paski ba tanka kunhka kum apia kaka label kum brih kaia sa.
+accessibility-short-description-contains-math = Tanka kunhka nani ba `<{ $component }>` baku matematika kompanenti nani briaia apia sa. Matematika ba bila nani ni aisi.
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ba seksion tailka bila dukiara kontrast pain apia brisa (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 kau kaia sa).
+       *[other] { $colorName } ba seksion tailka bila dukiara kontrast pain apia brisa ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 kau kaia sa).
+    }
+circle-through-points-non-numerical = Puntu { $count } ra luan `<circle>` ba daukan apia sin, puntu nani nambar balurka apu kaka.
+circle-too-many-through-points = Puntu 3 purara luan sirkulu kum kalkulaia sip apia.
+circle-overprescribed-radius-center-points = Radius, senter bara luan puntu nani marikan ba wal sirkulu kalkulaia sip apia.
+circle-center-with-multiple-points = Senter marikan wal puntu kumi purara luan sirkulu kalkulaia sip apia.
+circle-radius-too-small = Sirkulu ba kalkulaia sip apia: puntu wal tila ba { $distance } sa kaka, radius marikan { $radius } ba sirpi pali sa.
+circle-radius-with-many-points = Radius marikan wal puntu wal purara luan sirkulu kum paskaia sip apia.
+circle-invalid-center-or-through-points = Sirkulu senterka apia kaka luan puntu nani pain apia.
+circle-radius-center-with-multiple-points = Senter marikan wal puntu kumi purara luan sirkulu radiuska kalkulaia sip apia.
+circle-change-radius-non-numerical = Nambar apia luan puntu nani brisa sirkulu radiuska lakaia sip apia
+circle-radius-with-points-non-numerical = Nambar balurka apu kaka, radius marikan wal puntu kumi purara luan sirkulu paskaia sip apia.
+circle-change-center-non-numerical = Nambar apia balur brisa puntu nani ra luan sirkulu senterka lakaia ba daukan apia sin.
+function-domain-insufficient-dimensions = Punsion domainka dukiara dimension ba kau apu. Domain ba interbalu { $intervals } brisa, sakuna punsion ba input { $inputs } brisa.
+function-domain-invalid-format = Punsion domainka pormatka pain apia.
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Punsion ai maximum nambar apia ba swisa.
+        [minimum] Punsion ai minimum nambar apia ba swisa.
+        [extremum] Punsion ai extremum nambar apia ba swisa.
+        [point] Punsion ai puntu nambar apia ba swisa.
+        [slope] Punsion ai slope nambar apia ba swisa.
+       *[other] Punsion ai { $type } nambar apia ba swisa.
+    }
+function-ignoring-empty =
+    { $type ->
+        [maximum] Punsion ai maximum bila apu ba swisa.
+        [minimum] Punsion ai minimum bila apu ba swisa.
+        [extremum] Punsion ai extremum bila apu ba swisa.
+        [point] Punsion ai puntu bila apu ba swisa.
+       *[other] Punsion ai { $type } bila apu ba swisa.
+    }
+function-points-too-close = Punsion ba puntu wal pat baku kau tila apu brisa. Punsion ba paskaia sip apia.
+function-iterates-input-output-mismatch = Punsion iterates nani ba punsion input nambarka wal output nambarka aikuki kaka baman sip sa. Naha punsion ba input { $inputs } bara output { $outputs } brisa.
+sequence-invalid-length = Sekwensia larkuka pain apia.  Enteru kum, 0 munhta apia, kaia sa.
+sequence-invalid-step = Sekwensia stepka pain apia.  { $type } tipka sekwensia dukiara nambar kum kaia sa.
+sequence-invalid-endpoint-number = Nambar sekwensia dukiara "{ $attribute }" pain apia.  Nambar kum kaia sa.
+sequence-invalid-endpoint-letters = Letra sekwensia dukiara "{ $attribute }" pain apia.  Letra nani asla mangkanka kum kaia sa.
+sequence-invalid-endpoint = Sekwensia dukiara "{ $attribute }" pain apia.
+select-from-sequence-coprime-not-numbers = `coprime` ba swisa, kan nambar nani bakras
+select-from-sequence-coprime-with-exclude-combinations = `coprime` ba swisa, kan excludeCombinations marikan sa
+target-not-found = `<{ $source }>` dukiara target pain apia: target ba sakaia sip apia.
+target-state-variable-not-found = `<{ $source }>` dukiara target pain apia: `<{ $component }>` ra "{ $property }" nina stet bariabilka kum sakaia sip apia.
+ode-system-variables-match-independent = `<odeSystem>` bariabil nani ba independent bariabil wal aikuki kaia apia sa.
+ode-system-duplicate-variable-names = ODE RHS punsion nani ba dependent bariabil nina aikuki nani wal paskaia sip apia.
+ode-system-rhs-function-error = ODE RHS punsion paskaia sip apia.  mathjs punsion paskaia ra saura takan.
+angle-too-many-lines = Lain { $count } tila ra anklu kum paskaia sip apia
+angle-invalid-through-point = `<angle>` ai through ra puntu pain apia
+parabola-vertex-too-many-points = Bertis wal puntu kumi purara luan parabula ba daukan apia sin.
+parabola-too-many-points = Puntu 3 purara luan parabula ba daukan apia sin.
+intersection-too-many-items = Dukia wal purara dukiara interseksion ba daukan apia sin
+ionic-compound-not-two-ions = Ion wal apia ba dukiara kompwestu ioniku ba daukan apia sin.
+ionic-compound-needs-cation-and-anion = Kompwestu ioniku ba katiun kumi bara aniun kumi dukiara baman daukan sa.
+solve-equations-cannot-evaluate = Ekwasion ba wapni daukaia sip apia, kan ekwasion balurka sakaia sip apia: { $equation }
+math-operators-operand-number-required = Math operand kum sakisma taim, operandNumber kum marikaia sa.
+eigen-decomposition-failed = Matris ai awtobalur nani ba kalkulaia sip apia
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parametru { $parameters } ba patronka bilara bara apia, bara baha mita ban blanku wal praki kaisa.
+graph-grid-invalid = `<graph>`: grid="{ $grid }" tanka briaia sip apia. none, medium, dense, apia kaka nambar wal, 0 purara, spes kum ni sirpi mangkan, kaia sa, baku: grid="1 0.5". Krid kum ulban apia.
+field-function-wrong-num-outputs =
+    `<{ $component }>` ba punsion kum output wal brih ba want sa, puntu bani ra bektar ba, baku: `(y, -x)`, sakuna punsion yaban ba output { $found } brisa. { $alternative ->
+        [none] Diara kum ulban apia.
+       *[other] `<{ $alternative }>` sika baha punsion dukiara kompanenti ba. Diara kum ulban apia.
+    }
+field-function-attribute-ignored-with-child = `function` atributu ba swisa, kan punsion ba kompanenti bilara sin yaban; bilara ba yus munisa. Punsion ba wal wina kumi baman ni yabs.
+field-variables-ignored =
+    `<{ $component }>`: `variables` atributu ba kompanenti bilara sirpi ulban ekspresion ai bariabil nani nina makisa. { $reason ->
+        [function-child] Naha ra punsion ba `<function>` luhpia baku yaban, bara witin ai bariabil nani nina makisa, bara baha mita `variables` ba swisa.
+       *[no-expression] Naha ra baku ekspresion kum yaban apia, bara baha mita `variables` ba swisa.
+    }
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ba prefigure rindarar ra daukan apia; right-position laka ni warkisa.
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ba prefigure rindarar ra daukan apia; top-position laka ni warkisa.
+prefigure-invalid-axis-bounds = `<graph>`: prefigure ra lakaia dukiara ehe tnatka nani pain apia; dipalt bbox (-10,-10,10,10) yus munisa.
+prefigure-invalid-width = `<graph>`: prefigure ra lakaia dukiara wid pain apia; dipalt wid 425 yus munisa.
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure ra lakaia dukiara aspectRatio pain apia; dipalt aspect ratio 1 yus munisa.
+prefigure-grid-spacing-too-fine = `<graph>`: krid tila ba sirpi pali sa ehe tnatka nani dukiara; prefigure rindarar ra krid ba swisa.
+prefigure-annotations-not-rendered = `<graph>`: PreFigure rindarar yus munan apia kaka, annotations nani ulban apia kaisa.
+multiple-annotations-children = `<graph>` bilara `<annotations>` luhpia manis sakan; las ba baman brisa, wala nani sut swisa.
+copy-unrecognized-component-type = Kompanenti tipka kaikan apia kum ekstend apia kaka kapi munaia sip apia: { $type }.
+copy-prop-not-found = { $component } tipka kompanenti kum ra { $property } prop ba sakaia sip apia
+collect-no-source = collect dukiara `source` kum sakan apia.
+collect-invalid-component-type = `<{ $component }>` tipka kompanenti nani ba kolekt munaia sip apia, kan kompanenti tipka pain apia sa.
+reference-index-unavailable = `{ $reference }` index ra riparens munaia sip apia
+component-action-unavailable = `{ $reference }` kompanenti ra { $action } paiwaia sip apia
+data-frame-inconsistent-row-lengths = Data ba paskanka pain apia.  Raw nani ba larkuka aikuki apia. componentIdx ra sakan :{ $componentIdx }
+data-frame-duplicate-column-names = Data ba kolum nina aikuki nani brisa.  componentIdx ra sakan :{ $componentIdx }
+data-frame-missing-column-name = Data ba kolum nina kum apu.  componentIdx ra sakan :{ $componentIdx }
+answer-award-depends-on-own-response = Naha ansa dukiara award kum ba answer tak ai ansa blikan purara mangki sa, bara baha mita diara luki apia nani takbia.
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` brisa kontena kum bilara `<answer>` ra `maxNumAttempts` mangkaia ba warkka daukras, kan trai nambarka ba kontena mita mainkisa. `maxNumAttempts` ba kontena ra mangks.
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` brisa kontena wala kum bilara bara `sectionWideCheckWork` brisa kontena kum ra `maxNumAttempts` mangkaia ba warkka daukras, kan trai nambarka ba latara kontena mita mainkisa. `maxNumAttempts` ba latara kontena ra mangks.
+answer-attributes-need-symbolic-equality = symbolicEquality mangkan apia kaka, { $attributes } atributu ba warkka daukbia apia.
+answer-invalid-type = Ansa dukiara tipka pain apia: { $type }
+module-attribute-child-needs-name = `<{ $component }>` kompanenti ba nina apu bak, module atributu kum dukiara yus munaia sip apia
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` kompanenti ba module dukiara atributu baku yus munaia sip apia, kan `<module>` kompanenti tipka ba pat "{ $name }" atributu kum brisa.
+conditional-content-condition-ignored = `condition` atributu ba `case` apia kaka `else` luhpia nani brisa `<conditionalContent>` kompanenti ra swisa.
+slider-markers-type-mismatch = Markers tipka ba slider tipka wal praki apia.
+pretzel-problem-needs-statement-and-answer = `pretzel` pain apia: `<problem>` bani ba `<statement>` kumi bara `<answer>` kumi briaia sa.
+pretzel-circuit-first-problem-distractor = `pretzel` pain apia: mode="circuit" ra, `<problem>` pas ba distraktor kaia sip apia.
+attribute-invalid-values = `{ $attribute }` atributu dukiara balur pain apia { $values }; swisa.
+attribute-must-be-references = `{ $attribute }` atributu dukiara `{ $value }` balur pain apia. Atributu ba `$` wal ta krikan riparens nani wal paskan kaia sa.
+math-input-invalid-function-names = <mathInput>: { $attribute } ra punsion nina pain apia nani ba swisa: { $names }. Nina bani ai marikanka ba letra wal apia kaka kau briaia sa (letra nani apia kaka hyphen nani); `|<mathspeak alternative>` ba ninkara balaia sip sa.
+component-type-invalid = Kompanenti tipka pain apia: `<{ $componentType }>`
+attribute-repeated = { $attribute } atributu ba kli ulbaia sip apia.
+attribute-invalid-for-component = `<{ $componentType }>` tipka kompanenti kum dukiara "{ $attribute }" atributu pain apia.
+style-definition-insufficient-contrast =
+    Estilu paskanka { $styleNumber } ba { $context ->
+        [text-on-background] bila kolorka ba bakrawn kolorka mapara
+        [high-contrast] kontrast tara kolorka ba kanbas mapara
+        [line] lain kolorka ba kanbas mapara
+        [marker] marker kolorka ba kanbas mapara
+       *[text-on-canvas] bila kolorka ba kanbas mapara
+    } kontrast pain apia brisa{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 kau kaia sa).
+style-definition-dark-mode-text-background-contrast =
+    Estilu paskanka { $styleNumber } ba lait mode dukiara kontrast pain marikan sa, sakuna baha balur nani wina sakan dark-mode kolorka nani ba bila kolorka ba bakrawn kolorka mapara kontrast pain apia brisa ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 kau kaia sa). { $suggestion ->
+        [available] Dark mode ra kontrast pain briaia dukiara, lait-mode kontrast ba kau tara daukaia sa (baku: { $lightAttribute }="{ $lightColor }" mangks), apia kaka dark-mode kolorka ba lakaia sa (baku: { $darkAttribute }="{ $darkColor }" mangks).
+       *[none] Dark mode ra kontrast pain briaia dukiara, lait-mode kontrast ba kau tara daukaia sa, apia kaka sakan kolorka nani ba textColorDarkMode bara backgroundColorDarkMode ni lakaia sa.
+    }
+style-definition-dark-mode-text-canvas-contrast =
+    Estilu paskanka { $styleNumber } ba lait mode dukiara kontrast pain brisa bila kolorka kum marikan sa, sakuna baha balur wina sakan dark-mode bila kolorka ba kanbas mapara kontrast pain apia brisa ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; { $threshold }:1 kau kaia sa). { $suggestion ->
+        [available] Dark mode ra kontrast pain briaia dukiara, lait-mode kontrast ba kau tara daukaia sa (baku: textColor="{ $lightColor }" mangks), apia kaka dark-mode kolorka ba lakaia sa (baku: textColorDarkMode="{ $darkColor }" mangks).
+       *[none] Dark mode ra kontrast pain briaia dukiara, lait-mode kontrast ba kau tara daukaia sa, apia kaka sakan kolorka ba textColorDarkMode ni lakaia sa.
+    }
+section-multiple-style-palettes = Seksion kum ba <stylePalette> kumi baman bakaia sip sa; las ba yus munisa.
+variant-num-to-select-not-non-negative-integer = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan numToSelect ba enteru kum, 0 munhta apia, apia sa.
+variant-num-to-select-not-constant-number = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan numToSelect ba nambar lakwan apia kum apia sa.
+variant-with-replacement-not-constant-boolean = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan withReplacement ba boolean lakwan apia kum apia sa.
+variant-select-weight-disables-unique = selectWeight apia kaka selectForVariants marikan option kum bara kaka, select dukiara bariant aikuki apia nani ba takaskan sa
+variant-coprime-undetermined = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan `coprime` ba ban kasak apia sa ba kaikaia sip apia.
+variant-attribute-not-constant = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan { $attribute } ba lakwan apia kum apia sa.
+variant-attribute-not-number = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan { $attribute } ba nambar kum apia sa.
+variant-attribute-wrong-type-for-sequence =
+    { $type } tipka { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan { $attribute } ba { $expected ->
+        [letters-combination] letra nani asla mangkanka kum
+        [math-expression] matematika ekspresion pain kum
+        [integer] enteru kum
+       *[number] nambar kum
+    } apia sa.
+variant-length-not-integer = { $component } dukiara bariant aikuki apia nani ba kaikaia sip apia, kan length ba enteru kum apia sa.
+variant-sort-not-implemented = sort brisa { $component } kum dukiara bariant aikuki apia nani ba daukan apia sin
+variant-exclude-combinations-not-implemented = excludeCombinations brisa { $component } kum dukiara bariant aikuki apia nani ba daukan apia sin
+variant-math-exclude-not-implemented = exclude brisa math tipka { $component } kum dukiara bariant aikuki apia nani ba daukan apia sin
+variant-non-constant-exclude-not-implemented = lakwan apia kum apia exclude brisa { $component } kum dukiara bariant aikuki apia nani ba daukan apia sin
+prefigure-descendant-unsupported = { $subject }: `<graph>` prefigure rindarar ra daukan apia; luhpia ba swisa.
+prefigure-descendant-invalid-geometry = { $subject }: heometria ba tnata apu apia kaka aiska apia; luhpia ba swisa.
+prefigure-curve-label-omitted = { $subject }: kurba elementka lakan nani ra label nani daukan apia; label ba swisa.
+prefigure-curve-unsupported-definition-type = { $subject }: kurba punsion paskanka tipka '{ $definitionType }' ba daukan apia; luhpia ba swisa.
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves ra flipFunctions atributu ba daukan apia; luhpia ba swisa.
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves ra formula tipka luhpia punsion nani baman daukan sa; luhpia ba swisa.
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] lain-taya label
+       *[point] puntu label
+    } dukiara labelPosition '{ $labelPosition }' ba daukan apia; PreFigure dipalt praki laka yus munisa.
+prefigure-fill-style-unsupported = { $subject }: fill estilu '{ $fillStyle }' ba PreFigure ra daukan apia; solid fill kum ra kli mangkisa.
+prefigure-line-style-unknown = { $subject }: lain estilu '{ $lineStyle }' kaikan apia ba PreFigure output wina swisa.
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker estilu '{ $markerStyle }' ba PreFigure estilu 'diamond' ra lakan.
+prefigure-marker-style-unsupported = { $subject }: marker estilu '{ $markerStyle }' ba PreFigure ra daukan apia; dipalt estilu yus munisa.
+annotation-ref-unresolvable = `<annotation>`: `ref` pain apia; target ba sakaia sip apia. Annotation ba swisa.
+annotation-ref-multiple-targets = `<annotation>`: `ref` ba target manis ra praki takan; target pas ba yus munisa.
+annotation-ref-outside-graph = `<annotation>`: `ref` pain apia; target ba `<graph>` latara sa. Annotation ba swisa.
+annotation-ref-unsupported-target = `<annotation>`: `ref` pain apia; target ba prefigure lakanka ra krapiku dukia daukan kum apia sa. Annotation ba swisa.
+annotation-text-missing = `<annotation>`: `text` ba apu apia kaka bila apu; bila apu tekst kum sakisa.
+composite-circular-dependency =
+    { $componentType ->
+        [none] Sirkular dipendensia kum sakan.
+       *[other] `<{ $componentType }>` kompanenti wal sirkular dipendensia kum sakan.
+    }
+reference-no-referent = Naha riparens dukiara diara kum sakan apia: `{ $reference }`
+reference-multiple-referents = Naha riparens dukiara diara manis sakan: `{ $reference }`
+children-invalid-attribute-format = `<{ $componentType }>` ai { $attribute } atributu pormatka pain apia.
+children-invalid = `<{ $componentType }>` dukiara luhpia nani pain apia: Luhpia pain apia nani sakan: { $children }
+attribute-value-invalid-using-default = `{ $attribute }` atributu dukiara `{ $value }` balur pain apia, `{ $default }` balur ba yus munisa
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML bersion { $version } sakan apia.
+       *[other] DoenetML bersion { $version } sakan apia. { $fallback } bersion ra kli mangkisa
+    }
+parse-invalid-doenetml = DoenetML pain apia: { $content }
+parse-tag-missing-close-tag = DoenetML pain apia: `{ $tag }` tak ba prakaia tak apu. Ai wina prakan tak kum apia kaka `</{ $tagName }>` tak kum want kan.
+parse-tag-error = DoenetML pain apia: `<{ $tagName }>` tak ra saura
+parse-attribute-missing-value = DoenetML pain apia: `{ $attribute }` atributu pain apia ba balurka apu baku kaikisa.
+parse-attribute-invalid = DoenetML pain apia: `{ $attribute }` atributu pain apia
+parse-attribute-value-invalid = DoenetML pain apia: `{ $value }` atributu balurka pain apia
+parse-attribute-value-quote-mismatch = DoenetML pain apia: `{ $value }` atributu balurka pain apia. Kwut markka nani ba praki apia. `{ $quote }` kum apu baku kaikisa
+parse-open-tag-name-missing = DoenetML pain apia: Tak kum nina apu sakan, baku: `<`
+parse-tag-not-closed = DoenetML pain apia: `{ $tag }` tak ba prakan apia (`>` kum apu baku kaikisa).
+parse-self-closing-tag-name-missing = DoenetML pain apia: Tak kum nina apu sakan `<{ $content }>`
+parse-self-closing-tag-not-closed = DoenetML pain apia: `{ $tag }` tak ba prakan apia (`/>` ba apu baku kaikisa).
+parse-tag-invalid-attributes = DoenetML pain apia: `{ $tag }` tak ba pain apia. Ai atributu nani ba saura kabia.
+parse-close-tag-name-missing = DoenetML pain apia: Prakaia tak kum nina apu sakan, baku: `</`
+parse-attribute-value-unquoted = Atributu balur nani ba kwut mark nani bilara mangkan kaia sa: `{ $attribute }="{ $value }"`
+parse-close-tag-without-open-tag = DoenetML pain apia: `{ $tag }` prakaia tak sakan, sakuna ai kwakaia tak apu
+parse-close-tag-mismatched = DoenetML pain apia: Prakaia tak ba praki apia. `</{ $expected }>` want kan. `{ $found }` sakan
+parser-node-unconvertible = { $node } node ba Dast node ra lakaia sip apia.
+name-attribute-invalid =
+    name='{ $name }' atributu pain apia. { $reason ->
+        [characters] Nina nani ba letra, nambar, `_` apia kaka `-` baman briaia sip sa.
+       *[start] Nina nani ba letra kum wal ta krikaia sa.
+    }
+component-name-invalid-start = "{ $name }" kompanenti nina pain apia. Nina nani ba letra kum wal ta krikaia sa.
+answer-video-watched-missing-video = videoWatched tipka ansa ba video atributu kum briaia sa
+answer-video-watched-video-not-reference = videoWatched tipka ansa ba riparens kum sa video atributu kum briaia sa
+answer-name-not-single-text = Ansa name atributu ba text luhpia kumi baman briaia sa
+external-doenetml-recursion-limit = Latara DoenetML ba sakaia sip apia, kan ai bilara kli kli dimisa. Sirkular riparens kum bara ki?
+external-doenetml-unavailable = { $attribute }="{ $uri }" wina DoenetML sakaia sip apia
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" wina sakan DoenetML pain apia: "{ $componentType }" kompanenti tipka wal praki apia
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` atributu ba swin sa; `{ $to }` yus muns.
+       *[other] [deprecation] `<{ $component }>` ra `{ $from }` atributu ba swin sa; `{ $to }` yus muns.
+    }
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` atributu ba swin sa bara swisa, kan `{ $to }` sin marikan sa.
+       *[other] [deprecation] `<{ $component }>` ra `{ $from }` atributu ba swin sa bara swisa, kan `{ $to }` sin marikan sa.
+    }
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` ra `{ $attribute }` atributu ba swin sa bara swisa.
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` ra `{ $attribute }` atributu ba swin sa; `<{ $child }>` luhpia kum yus muns.
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` ra `{ $attribute }` atributu ai `{ $value }` balurka ba swin sa; `{ $to }` yus muns.
+pluralize-english-only = `<pluralize>` ba Inglis baman plural ra lakaia sip sa, bara baha mita { $locale } bila ni ulban dukumint kum ra ai tekstka ba lakan apia. Plural pormat ba sirpi ulbs, apia kaka `pluralForm` atributu ni mangks.
+schema-element-unrecognized = `<{ $tag }>` element ba Doenet element kum apia sa.
+schema-element-not-allowed-at-root = `<{ $tag }>` element ba dukumint tunkia ra swin apia.
+schema-element-not-allowed-inside = `<{ $tag }>` element ba `<{ $parent }>` bilara swin apia.
+schema-attribute-unrecognized = `<{ $tag }>` element ba `{ $attribute }` nina atributu kum apu.
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` element ai `{ $attribute }` atributu ba lista kum kaia sa, bara ai dukia bani ba naha nani wina kumi kaia sa: { $allowed }
+       *[other] `<{ $tag }>` element ai `{ $attribute }` atributu ba naha nani wina kumi kaia sa: { $allowed }
+    }
+select-variant-name-option-count-mismatch = select dukiara bariant nina pain apia.  { $variantName } bariant nina ba option { $numOptions } ra takisa, sakuna bakaia nambarka ba { $numToSelect } sa.
+select-variant-name-without-options = select dukiara bariant kum kum marikan sa, sakuna bariant nina takaia sip ba dukiara option kum marikan apia: { $variantName }.
+select-variant-name-not-possible = select dukiara marikan bariant nina { $variantName } ba bariant nina takaia sip kum apia sa.
+select-too-few-options = { $numOptions } baman wina kompanenti { $numToSelect } bakaia sip apia.
+select-from-sequence-too-few-values = Sekwensia larkuka { $length } wina balur { $numToSelect } bakaia sip apia.
+select-from-sequence-indices-count-mismatch = select dukiara marikan indices nambarka ba bakaia nambarka wal praki kaia sa
+select-from-sequence-indices-not-integers = select dukiara marikan indices sut ba enteru kaia sa
+select-from-sequence-index-excluded = selectfromsequence ai index marikan ba sakan swin kan
+select-from-sequence-indices-excluded-combination = selectfromsequence ai indices marikan ba sakan swin asla mangkanka kum kan
+select-from-sequence-coprime-not-positive-integers = `coprime` asla mangkanka nani bakaia sip apia, kan enteru, 0 purara, nani bakras.
+select-from-sequence-coprime-common-factor = `coprime` nambar nani bakaia sip apia. Balur sip sut ba paktar aikuki kum brisa. ("from" apia kaka "to" balur marikan nani ba "step" wal coprime kaia sa.)
+select-from-sequence-coprime-single-number = Nambar kumi, 1 apia, wina `coprime` asla mangkanka nani bakaia sip apia.
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ra asla mangkanka nani wina 70% purara sakan swin
+select-from-sequence-coprime-none-found = `coprime` nambar nani bakaia sip apia kan. Balur sip sut ba paktar aikuki kum brisa.
+select-from-sequence-too-few-unique-values = Sekwensia larkuka { $numPossibleValues } wina balur aikuki apia { $numToSelect } bakaia sip apia
+select-prime-numbers-too-few-values = Praim nambar lista larkuka { $numValues } wina balur { $numToSelect } bakaia sip apia
+select-prime-numbers-values-count-mismatch = select dukiara marikan balur nambarka ba bakaia nambarka wal praki kaia sa
+select-prime-numbers-values-not-prime = select prime number dukiara marikan balur sut ba praim nambar lista ra bara kaia sa
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers ai balur marikan nani ba sakan swin asla mangkanka kum kan
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ra asla mangkanka nani wina 70% purara sakan swin
+select-random-combination-fluke = Diara sip apia baku takan bak, random balur nani asla mangkanka kum bakaia sip apia kan
+select-random-value-fluke = Diara sip apia baku takan bak, random balur kum bakaia sip apia kan
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` ba matematika bilara ulban apia; ekspresion ba input nani bilara dimaia sip kan apia pyua ra baku ulban sa. { $reason ->
+        [not-inline] `inline` choice input baman ekspresion kum bilara dimisa; `inline` apu kaka witin butan nani blakka kum sa.
+        [expanded] `expanded` text input ba lain manis boks kum sa, bara ekspresion bilara dimaia dukiara tara pali sa.
+        [on-graph] `<graph>` purara ekspresion ba lilka kumi baku ulban sa, bara baha ra kontrol kum dukiara pliska apu.
+       *[relative-width] Ai `width` ba `relative` sa (porsentu apia kaka `em`), bara ekspresion bilara baha wal praki diara kum apu. Wid ba absolute paskanka ni yabs, baku: `px`.
+    }

--- a/packages/i18n/locales/miq/diagnostics.ftl
+++ b/packages/i18n/locales/miq/diagnostics.ftl
@@ -46,12 +46,13 @@
 # «bakrawn», «lait mode», «dark mode», «praim», «kwut mark», «kontena»,
 # «trai», «snipet», «krid», «distraktor».
 #
-# **Confidence.** All 220 messages are translated. Two places lose a
-# distinction English draws, both because the branch keys were `[one]` and
-# `[other]` on something that is not a count Mískito can mark:
-# `field-function-wrong-num-outputs` keeps only the two-output wording of its
-# `$expected` select, and every message that named an input, output, interval,
-# attribute, value or parameter count now says it once rather than twice. The
+# **Confidence.** All 220 messages are translated. One place loses a
+# distinction English draws, because the branch keys were `[one]` and
+# `[other]` on something that is not a count Mískito can mark: every message
+# that named an input, output, interval, attribute, value or parameter count
+# says it once rather than twice. `field-function-wrong-num-outputs` is not
+# one of them any more — it names both the slope field and the vector field,
+# so a reader whose function needs one output is told about one output. The
 # weakest single words are «awtobalur» for *eigenvalue*, «heometria» for
 # *geometry* and «stet bariabilka» for *state variable*; none of the three is
 # said in Mískito outside a sentence like this one, and a speaker should feel

--- a/packages/i18n/locales/miq/editor.ftl
+++ b/packages/i18n/locales/miq/editor.ftl
@@ -1,0 +1,227 @@
+# Mískito editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker and the context-help panel. Translated from
+# `locales/en/editor.ftl`, which is the source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Latin orthography of the Nicaraguan Caribbean
+# coast; see `chrome.ftl`'s header for the alphabet, `ng`, the `aw`/`ai`
+# diphthongs and the pronounced `h`. `c`, `f`, `g`, `j`, `q`, `v`, `x` and `z`
+# are not in the alphabet, so `k` does the work of `c` and `qu` («kordenada»),
+# `p` the work of `f` («piltrar», «pormat», «dipalt»), `b` the work of `v`
+# («bersion», «bariant»), and `s` the work of `z` and of `c` before a front
+# vowel («diaknostiku», «suherensia»).
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `miq`; it falls back to
+# the default locale and reports `one` and `other`, categories Mískito does not
+# select. A Mískito noun after a numeral takes no plural marker, so the two
+# counted messages here — `editor-accessibility-label` and `help-coordinates` —
+# are written as **one unselected form** rather than as a `[one]`/`[other]`
+# pair. The `$status`, `$action` and `$shortcut` selects around them are not
+# plural selects and keep all of English's branches.
+#
+# **Loans.** From English: «bariant» (through Spanish), «piltrar», «pormat»,
+# «dipalt», «tekst», «snipet», «arrei», «WCAG», «riparens», «lain», «kredit»,
+# «ansa». From Spanish: «diaknostiku», «bersion», «aksesibilidad»,
+# «kordenada», «propiedad», «suherensia», «estilu», «konteks», «dokumentasion».
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber`, version numbers, element and
+# attribute names and key combinations stay as written. The frame is Mískito:
+# native verbs («kaikaia» to look, «sakaia» to take out, «mangkaia» to put,
+# «marikaia» to show, «ulbaia» to write), the negator «apia» after what it
+# negates, the postposition «ra», and the copula `sa`.
+#
+# **Confidence.** Every key in the English catalog is translated. The panel
+# names things Mískito has never had to name — variant, diagnostic, snippet,
+# array entry, styleNumber — and each of those is a loan in a Mískito sentence
+# rather than a coinage; a reviewer should expect to replace several of them.
+# «Snipet» and «arrei dinkanka» are the two least settled.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Kli mangks
+       *[update] Raiti muns
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Kaikanka { $word }
+       *[other] Kaikanka { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Bariant
+editor-variant-filter = Piltrar...
+editor-variant-next = Bariant wala ba bak
+editor-variant-previous = Bariant pas ba bak
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA aksesibilidad saura kum sakan. Aksesibilidad ripot ba { $action ->
+            [close] prakaia
+           *[open] kwakaia
+        } dukiara kliks muns.
+        [advisories] Aksesibilidad ripot ba { $action ->
+            [close] prakaia
+           *[open] kwakaia
+        } dukiara kliks muns. WCAG AA saura kum sakan apia, sakuna aksesibilidad dukiara smalkanka wala nani bara.
+       *[clean] Aksesibilidad ripot ba { $action ->
+            [close] prakaia
+           *[open] kwakaia
+        } dukiara kliks muns. Aksesibilidad trabil kum sakan apia.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA aksesibilidad saura kum sakan. WCAG AA saura { $count } sakan. Aksesibilidad ripot ba { $action ->
+            [close] prakaia
+           *[open] kwakaia
+        } dukiara kliks muns.
+        [advisories] WCAG AA saura kum sakan apia. Aksesibilidad dukiara smalkanka wala { $count } sakan. Aksesibilidad ripot ba { $action ->
+            [close] prakaia
+           *[open] kwakaia
+        } dukiara kliks muns.
+       *[clean] WCAG AA saura kum sakan apia. Aksesibilidad ripot ba { $action ->
+            [close] prakaia
+           *[open] kwakaia
+        } dukiara kliks muns.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML bersion { $version }
+
+editor-tab-help = Konteks dukiara help
+editor-tab-help-short = Konteks
+editor-tab-errors = Saura nani
+editor-tab-warnings = Warnin nani
+editor-tab-info = Tanka
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Ansa blikan nani
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editor dukia nani
+editor-format-as-doenetml = DoenetML baku pormat muns
+editor-format-as-xml = XML baku pormat muns
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = Saura Apu
+editor-no-warnings = Warnin Apu
+editor-no-info = Tanka diaknostiku apu
+
+editor-show-info-annotations = Tanka diaknostiku nani ba editor ra marikaia
+editor-show-accessibility-annotations = Aksesibilidad diaknostiku nani ba editor ra marikaia
+
+editor-accessibility-learn-more = Doenet ba aksesibilidad dukiara nahki lukisa lan taks
+
+editor-accessibility-violations-heading = Aksesibilidad saura nani ({ $standard })
+
+editor-accessibility-other-heading = Aksesibilidad trabil wala nani
+editor-none-found = Apu
+
+
+## Submitted responses
+
+editor-no-responses = Ansa blikan kum sin apu
+editor-response-answer-id = Ansa Id
+editor-response-response = Ansa
+editor-response-credit = Kredit
+editor-response-submitted = Blikan
+
+
+## The context-help panel
+
+help-placeholder = Dokumentasion briaia dukiara kursur ba tak nina, atributu, apia kaka { $ref } ra mangks.
+
+help-unsupported-ref-chain = { $example } baku riparens tila manis brisa ba dukiara help bara apia sin.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Naha riparens dukiara diara kum sakan apia: { $ref }.
+        [multiple] Naha riparens dukiara diara manis sakan: { $ref }.
+       *[indeterminate] { $ref } dukiara ani diara sa ba kaikaia sip apia.
+    }
+
+help-learn-about-references = Riparens nani tanka lan taks →
+help-reference-page = Riparens wahia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } bilara
+       *[top] Purara ra
+    }{ $allowed ->
+        [none] { " — naha ra diara kum dimbia apia." }
+        [text] { " — naha ra tekst ulbs." }
+        [text-and-components] { " — naha ra tekst ulbs, apia kaka naha nani traiks:" }
+       *[components] { " — naha nani traiks:" }
+    }
+
+help-suggestions-footer = Kompanenti sut { $total } kaikaia dukiara { $shortcut } mangks.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } lika { $target } ra riparens kum sa.
+       *[other] { $ref } lika { $target } ra riparens kum sa (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ba { $role } baku dingkan.
+       *[other] { $owner } ba lain { $line } ra { $role } baku dingkan.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } lika { $element } ai { $property } propiedad ra riparens kum sa.
+       *[other] { $ref } lika { $element } ai { $property } propiedad ra riparens kum sa (lain { $line }).
+    }
+
+help-kind-attribute = atributu
+help-kind-snippet = snipet
+help-kind-array-entry = arrei dinkanka
+
+help-default = Dipalt:
+help-active-default = Dipalt warkka takisa ba:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Balur swin nani (dukia kumi bani dukiara kumi):
+       *[other] Balur swin nani:
+    }
+
+help-suggested-values = Suherensia balur nani:
+
+help-inserts = Dingkisa:
+
+help-coordinates = Kordenada nani:
+
+help-type = Tipka:
+
+help-resolved-style = Estilu sakan (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Punsion nina sakan nani:
+help-reset-list = Naha input ra lista ba kli mangkaia:
+help-added-on-input = Naha input ra mangkan:
+help-removed-on-input = Naha input ra sakan:
+
+help-reset-overrides = { $reset } lika { $additional } bara { $removed } purara sa.

--- a/packages/i18n/locales/pap/chrome.ftl
+++ b/packages/i18n/locales/pap/chrome.ftl
@@ -1,0 +1,187 @@
+# Papiamentu (Kòrsou/Boneiru) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** This catalog is written in the **phonological orthography
+# of Curaçao and Bonaire** — Papiamentu, spelled «kas», «yu», «skol», «bèk»,
+# «buki», «hende». The **etymological orthography of Aruba** — Papiamento,
+# spelled «cas», «hoben», «trece» — is a real and equally official
+# alternative, and it is deliberately **not** mixed into any of these four
+# files. A reviewer from Aruba would **respell** this catalog rather than
+# retranslate it: the words are the same, the spelling system is not.
+#
+# The letters that carry the distinction:
+#
+#   * **`k`** and **`s`** where the etymological system writes `c`, `qu` or
+#     `z` — «kas» / «cas», «kòrekto» / «correcto», «sero» / «cero»,
+#     «kuadro» / «cuadro».
+#   * **`y`** where it writes `j` or `ll` — «yu» / «hijo», «yena» / «llena»,
+#     «ayuda» / «ayuda» beside «mihó» / «mejor».
+#   * **`è`, `ò`, `ù`** for the open and rounded vowels — «bèk», «pòst»,
+#     «dùsh», «fèrf». These are **letters of the alphabet**, not stress
+#     marks, and a reviewer must not strip the diacritic off them.
+#
+# Separately from those three letters, Papiamentu writes an **acute accent**
+# for irregular stress and tone — «kámbia», and the «paña» / «pañá» pattern
+# where the accent is the whole of the difference. This seed marks stress only
+# where the standard orthography requires it, and accent placement is the one
+# thing a reviewer should check key by key.
+#
+# **Number.** `Intl.PluralRules("pap")` resolves to `pap` and reports
+# `['one','other']`. Papiamentu pluralizes with «-nan», but a noun after a
+# numeral is **unmarked** — «dos kas», never «dos kasnan» — so both branches
+# would be word-for-word identical here, and every count message is written as
+# **one unselected form** rather than as two identical branches. English's
+# explicit `[0]` literal in `attempts-remaining` matches the number itself and
+# is kept as a branch.
+#
+# **Loans, named.** Papiamentu freely takes Dutch- and Spanish-mediated
+# technical nouns, and this seed keeps them rather than coining: «funshon»,
+# «matriz», «komponente», «atributo», «diagnóstiko», «seksion», «solushon»,
+# «ehèmpel», «pregunta», «kòrekto», «statístika», «klavier». The grammar
+# around them is Papiamentu throughout: the preverbal markers «ta / a / lo /
+# tabata», «no» for negation, «di» for possession, «pa» for purpose. No
+# sentence in these four files is Dutch or Spanish.
+#
+# **The technical vocabulary here is a lexifier loan set.** Every technical
+# noun in this file is a Dutch- or Spanish-mediated loan — those are the words
+# Papiamentu actually uses, not a substitute for a native term — carried in
+# Papiamentu's own orthography and Papiamentu's own grammar. The sentences
+# around the loans are Papiamentu, not Dutch and not Spanish.
+
+
+## Answer submission — the check-work button and the status it reports.
+
+answer-checking = Ta kontrolá...
+answer-submitting = Ta manda...
+
+answer-checking-status = Ta kontrolá kontesta
+answer-submitting-status = Ta manda kontesta
+
+answer-correct = Kòrekto
+answer-incorrect = Inkòrekto
+
+answer-response-saved = Kontesta Wardá
+
+answer-percent-credit = { $percent }% Krédito
+answer-percent-correct = { $percent }% Kòrekto
+answer-percent-short = { $percent } %
+
+max-credit-available = Máksimo krédito disponibel: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] no tin mas purbamentu
+       *[other] { $count } purbamentu ta sobra
+    }
+
+validation-correct = (Kòrekto)
+validation-incorrect = (Inkòrekto)
+validation-partially-correct = (Parsialmente kòrekto)
+
+answer-show-responses = Mustra { $count } kontesta na { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentario
+
+collapsible-click-to-open = (klek pa habri)
+collapsible-click-to-close = (klek pa sera)
+
+collapsible-initializing = Ta inisiá...
+
+footnote-show = Mustra nota
+footnote-hide = Skonde nota
+
+description-more-information = mas informashon
+
+
+## Controls
+
+slider-previous = Anterior
+slider-next = Siguiente
+
+keyboard-open = Habri Klavier
+keyboard-close = Sera Klavier
+
+choice-input-remove-choice = Kita { $choice }
+
+matrix-remove-row = Kita fila
+matrix-add-row = Agregá fila
+matrix-remove-column = Kita kolumna
+matrix-add-column = Agregá kolumna
+
+subset-add-remove-points = Agregá/Kita punto
+subset-toggle-points-intervals = Kambia entre punto i intervalo
+subset-move-points = Move Punto
+subset-clear = Bòrsa
+
+orbital-add-row = Agregá Fila
+orbital-remove-row = Kita Fila
+orbital-add-box = Agregá Kaha
+orbital-remove-box = Kita Kaha
+orbital-add-up-arrow = Agregá Flecha Ariba
+orbital-add-down-arrow = Agregá Flecha Abou
+orbital-remove-arrow = Kita Flecha
+
+orbital-row-label = Etiketa pa fila { $row }
+
+pretzel-answer = Kontesta
+
+summary-statistics-caption = Statístika resumí di { $column }
+
+
+## Math input
+
+math-input-preview-region = vista previa di ekspreshon matemátiko
+math-input-preview = Vista previa
+math-input-invalid-expression = Ekspreshon inválido:
+
+
+## Document status
+
+viewer-initializing = Ta inisiá...
+
+
+## Errors
+
+error-heading = Eror
+
+error-found-at =
+    { $span ->
+        [line] Hañá na liña { $startLine }.
+       *[lines] Hañá na liña { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = E dokumento aki tin eror!
+
+diagnostic-heading-error = Eror
+diagnostic-heading-warning = Atvertensia
+diagnostic-heading-information = Informashon
+diagnostic-heading-hint = Sugerensia
+
+accessibility-heading-level-1 = Violashon di Aksesibilidat WCAG AA
+accessibility-heading-level-2 = Alerta di aksesibilidat
+
+something-went-wrong = Algu a bai robes.
+
+renderer-load-failed = un renderisadó no a logra karga. Por fabor rekargá e página.
+
+core-start-failed = E dokumento aki no por a kuminsá. Por fabor rekargá e página.
+
+core-start-failed-busy = E dokumento aki no por a kuminsá. Vários dokumento tabata kuminsá na mes momento, i esei por dura mas largu riba un aparato mas lento. Rekargá e página por yuda ora e otro dokumentonan kaba.
+
+core-start-failed-retry = E dokumento aki no por a kuminsá.
+
+core-start-failed-busy-retry = E dokumento aki no por a kuminsá. Vários dokumento tabata kuminsá na mes momento, i esei por dura mas largu riba un aparato mas lento.
+
+core-start-retry = Purba atrobe
+
+saved-state-unavailable = Bo trabou wardá no por a karga.

--- a/packages/i18n/locales/pap/content.ftl
+++ b/packages/i18n/locales/pap/content.ftl
@@ -1,0 +1,298 @@
+# Papiamentu (Kòrsou/Boneiru) content catalog: the prose the core computes
+# into the document. Translated from `locales/en/content.ftl`, which is the
+# source of truth. Selected by `documentLocale` — the language the activity
+# was written in.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** This catalog is written in the **phonological orthography
+# of Curaçao and Bonaire** — Papiamentu, spelled «kas», «yu», «skol», «bèk»,
+# «buki», «hende». The **etymological orthography of Aruba** — Papiamento,
+# «cas», «hoben», «trece» — is a real and equally official alternative and is
+# deliberately **not** mixed into any of these four files. A reviewer from
+# Aruba would **respell** this catalog rather than retranslate it: the words
+# are the same, the spelling system is not. `chrome.ftl`'s header sets out the
+# letters that carry the distinction — `k` and `s` for etymological `c`/`qu`/
+# `z`, `y` for `j`/`ll`, and the vowel letters `è ò ù`. Papiamentu also writes
+# an acute accent for irregular stress and tone («kámbia»; the «paña» /
+# «pañá» pattern); this seed marks stress only where the standard orthography
+# requires it, so accent placement is what a reviewer should check first.
+#
+# **Word order: the modifier FOLLOWS the noun.** A Papiamentu adjective
+# stands after its head — «liña kòrá» is *red line* and «kas grandi» is *big
+# house*, in that order, which is the reverse of English. So the composition
+# messages here **reverse** the English order: `style-with-noun` puts
+# `{ $noun }` before `{ $description }`, and `style-filled-with-noun` does the
+# same, which places «yená» and the colour word after the noun as well.
+# `style-fill` puts the colour after the pattern for the same reason, and
+# `style-border-clause` puts the description after «rant».
+#
+# **No agreement.** Papiamentu has no grammatical gender and no adjective
+# agreement — one form of «kòrá» serves every noun — so no message here forks
+# on `$gender` or `$role`, and `noun-gender` answers a single token that
+# nothing reads.
+#
+# **Number.** `Intl.PluralRules("pap")` resolves to `pap` and reports
+# `['one','other']`. Papiamentu pluralizes with «-nan», but a noun after a
+# numeral is unmarked — «dos kas», never «dos kasnan» — so both branches would
+# be word-for-word identical, which is why one unselected form is written
+# wherever English selects on a count. No count-driven select appears in this
+# file.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# School science on Curaçao and Bonaire is taught in Dutch, from Dutch
+# textbooks; there is no settled Papiamentu periodic table and no published
+# Papiamentu spelling for the hundred and eighteen names. Writing one out
+# would be transliterating the Dutch list and calling the result a Papiamentu
+# nomenclature. `lint:i18n` reports the two keys as missing coverage and that
+# is the correct report. `ion-name-oxidation-state`,
+# `chemistry-invalid-symbol` and `chemistry-invalid-ionic-compound` **are**
+# covered — they are frames, not vocabulary.
+#
+# **Loans kept, rather than coined.** Dutch- and Spanish-mediated: «funshon»,
+# «vektor», «parabola», «poligon», «matriz», «komponente», «seksion»,
+# «solushon», «ehèmpel», «teorema», «definishon», «aktividat», «tabel»,
+# «diagrama». The grammar around them is Papiamentu: «ta / a / lo / tabata»
+# before the verb, «no» for negation, «di» for possession, «pa» for purpose.
+# «sian» for *cyan* is the weakest word in this file — Papiamentu has «blou»
+# and no settled word for cyan, and a speaker may prefer «blou kla».
+#
+# **The technical vocabulary here is a lexifier loan set.** Every technical
+# noun in this file is a Dutch- or Spanish-mediated loan — those are the words
+# Papiamentu actually uses, not a substitute for a native term — carried in
+# Papiamentu's own orthography and Papiamentu's own grammar. The sentences
+# around the loans are Papiamentu, not Dutch and not Spanish.
+
+
+## Style vocabulary
+
+color =
+    .black = pretu
+    .white = blanku
+    .gray = shinishi
+    .red = kòrá
+    .orange = orañe
+    .yellow = geel
+    .green = bèrdè
+    .cyan = sian
+    .blue = blou
+    .purple = lila
+    .pink = ros
+    .brown = brùin
+
+line-width =
+    .thick = diki
+    .thin = fini
+
+line-style =
+    .dashed = di strepi
+    .dotted = di punto
+
+fill-style =
+    .horizontal = liña horizontal
+    .vertical = liña vertikal
+    .diagonal = liña diagonal
+    .backdiagonal = liña diagonal invertí
+    .dots = punto
+    .diamonds = diamante
+
+noun =
+    .line = liña
+    .line-segment = segmento di liña
+    .ray = semirekta
+    .vector = vektor
+    .curve = kurva
+    .function = funshon
+    .slope-field = kampo di pendiente
+    .vector-field = kampo di vektor
+    .parabola = parabola
+    .polyline = polilinia
+    .polygon = poligon
+    .triangle = triángulo
+    .rectangle = rektángulo
+    .circle = sirkulo
+    .region = region
+    .point = punto
+    .square = kuadrado
+    .diamond = diamante
+    .cross = krus
+    .plus = plus
+
+# The side count stays in the head, as it does in English: nothing in Doenet
+# asks for the tail today, and a locale that emptied the head would lose the
+# count. «poligon regular di 5 banda».
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon regular di { $numSides } banda
+    }
+
+noun-gender = neutro
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# Reversed against English: the noun comes first and the description follows
+# it, because a Papiamentu adjective stands after its head.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = yená
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ku { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+# Reversed for the same reason as `style-with-noun`: «sirkulo yená blou ku
+# diamante».
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ku { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ku { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] ku un rant { $border }
+        [and] i rant { $border }
+        [and-article] i un rant { $border }
+       *[with] ku rant { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = sin yena
+
+style-text =
+    { $parts ->
+        [background] { $color } ku un fondo { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = niun
+
+
+## Boolean words
+
+boolean-true = bèrdat
+boolean-false = falsu
+
+
+## Answer buttons
+
+answer-submit-label = Kontrolá Trabou
+answer-submit-label-no-correctness = Manda Kontesta
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktividat
+    .aside = Nota banda
+    .cascade = Kaskada
+    .definition = Definishon
+    .example = Ehèmpel
+    .exercise = Ehersisio
+    .exercises = Ehersisionan
+    .given-answer = Kontesta
+    .note = Nota
+    .objectives = Opjetivonan
+    .paragraphs = Paragrafonan
+    .part = Parti
+    .problem = Problema
+    .problems = Problemanan
+    .proof = Prueba
+    .question = Pregunta
+    .section = Seksion
+    .solution = Solushon
+    .task = Tarea
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Sugerensia
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
+       *[unnumbered] Figura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Anterior
+paginator-next = Siguiente
+paginator-page = Página
+
+paginator-page-status = { $pageLabel } { $currentPage } di { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = of
+
+piecewise-condition-if = si
+
+piecewise-condition-otherwise = den otro kaso
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Símbolo Kímiko Inválido
+chemistry-invalid-ionic-compound = Kompuesto Ióniko Inválido
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blanko
+
+math-embedded-input-blank-ordinal = blanko { $ordinal } di { $total }

--- a/packages/i18n/locales/pap/diagnostics.ftl
+++ b/packages/i18n/locales/pap/diagnostics.ftl
@@ -1,0 +1,685 @@
+# Papiamentu (Kòrsou/Boneiru) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `styleNumber`, `WCAG AA`, `PreFigure`,
+# `[deprecation]` — are part of the language, not prose, and stay in English
+# exactly as written. So does anything quoted back from the author's own
+# source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** This catalog is written in the **phonological orthography
+# of Curaçao and Bonaire** — Papiamentu, spelled «kas», «yu», «skol», «bèk»,
+# «buki», «hende». The **etymological orthography of Aruba** — Papiamento,
+# «cas», «hoben», «trece» — is a real and equally official alternative and is
+# deliberately **not** mixed into any of these four files. A reviewer from
+# Aruba would **respell** this catalog rather than retranslate it: the words
+# are the same, the spelling system is not. `chrome.ftl`'s header sets out the
+# letters that carry the distinction — `k` and `s` for etymological
+# `c`/`qu`/`z`, `y` for `j`/`ll`, and the vowel letters `è ò ù`. Papiamentu
+# also writes an acute accent for irregular stress and tone («kámbia»; the
+# «paña» / «pañá» pattern), and this seed marks stress only where the standard
+# orthography requires it, so a reviewer should check accent placement
+# specifically.
+#
+# **Number.** `Intl.PluralRules("pap")` resolves to `pap` and reports
+# `['one','other']`. A Papiamentu noun after a numeral is unmarked — «dos
+# purbamentu», never «dos purbamentunan» — so English's `one` and `other`
+# branches would be word-for-word identical here, and each such message is
+# written as **one unselected form**. No count-driven select appears in this
+# file. The selects that remain (`$reason`, `$mode`, `$type`, `$expected`,
+# `$isList`, `$suggestion`, `$context`, `$labelKind`, `$componentType`,
+# `$fallback`, `$component`, `$alternative`) are not plural selects and every
+# branch of them is translated.
+#
+# **Register.** Papiamentu takes its technical nouns from Dutch and Spanish
+# and this seed keeps them — «funshon», «vektor», «matriz», «komponente»,
+# «atributo», «sekuensia», «intervalo», «kontraste», «variante» — but the
+# grammar around them is Papiamentu throughout: «ta / a / lo / tabata» before
+# the verb, «no por» for inability, «mester» for obligation, «di» for
+# possession, «pa» for purpose. No sentence here is Dutch or Spanish.
+#
+# **Confidence.** Every key of the English file is covered. The technical
+# noun phrases are the seed's own composition rather than terms attested in a
+# published Papiamentu mathematics register, so a reviewer should read them as
+# proposals: «pendiente» (slope), «semirekta» (ray), «autovalor»
+# (eigenvalue), «koprimo» (coprime) and «kuadrikula» (grid) are the five to
+# check first.
+#
+# **The technical vocabulary here is a lexifier loan set.** Every technical
+# noun in this file is a Dutch- or Spanish-mediated loan — those are the words
+# Papiamentu actually uses, not a substitute for a native term — carried in
+# Papiamentu's own orthography and Papiamentu's own grammar. The sentences
+# around the loans are Papiamentu, not Dutch and not Spanish.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } ta ser ignorá ora dos punto final ta spesifiká
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } ta ser ignorá ora tantu un punto final komo un punto medio ta spesifiká
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset no tin efekto sin un punto medio
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liña pa punto ku dimenshon indeterminá.
+
+line-points-too-few-dimensions = Liña mester pasa pa punto di por lo ménos dos dimenshon.
+
+line-points-depend-on-variables = Liña ta pasa pa punto ku ta dependé di variabel: { $variables }.
+
+line-equation-invalid-format = Fòrmato inválido pa ekuashon di liña den variabel { $variable1 } i { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Semirekta ta spesifiká pa through, endpoint i direction.  Ta ignorá e through spesifiká.
+
+ray-dimension-mismatch = numDimensions no ta kuadra den e semirekta.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ta spesifiká pa head, tail i displacement.  Ta ignorá e head spesifiká.
+
+vector-dimension-mismatch = numDimensions no ta kuadra den e vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = No por atraé na un `<{ $component }>` pasobra e no tin un variabel di estado nearestPoint.
+
+constrain-to-without-nearest-point = No por limitá na un `<{ $component }>` pasobra e no tin un variabel di estado nearestPoint.
+
+constrain-to-interior-without-nearest-point = No por limitá na interior di un `<{ $component }>` pasobra e no tin un variabel di estado nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ta ser ignorá pa un choiceInput ku no ta inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ta ignorá e índisenan spesifiká pa choiceInput pasobra e kantidat di índise no ta kuadra ku e kantidat di yu choice.
+
+pretzel-indices-count-mismatch = Ta ignorá e índisenan spesifiká pa problem pasobra e kantidat di índise no ta kuadra ku e kantidat di yu problem.
+
+shuffle-indices-count-mismatch = Ta ignorá e índisenan spesifiká pa shuffle pasobra e kantidat di índise no ta kuadra ku e kantidat di komponente.
+
+indices-ignored-out-of-range = Ta ignorá e índisenan spesifiká pa { $component } pasobra algun índise ta fuera di rango.
+
+pretzel-indices-repeated = Ta ignorá e índisenan spesifiká pa pretzel pasobra algun índise ta repetí.
+
+pretzel-circuit-first-index = Ta ignorá e índisenan spesifiká pa pretzel den modo circuit pasobra e promé índise mester ta 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Pa `<{ $component }>` funshoná ku yu di tipo string, mester spesifiká un atributo `type`.
+
+invalid-type-defaulting-to-math = Tipo { $type } inválido pa e komponente { $component }. Mester ta math, text, number of boolean. Ta usa math komo balor por defekto.
+
+string-not-valid-component-to-arrange = E string "{ $value }" no ta un komponente válido pa { $component }. Ta ignorá.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipo { $type } inválido, ta pone tipo riba number.
+
+invalid-variable-value = Balor inválido di un variabel: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Índise di variante { $index } mester ta un number
+
+variant-index-must-be-integer = Índise di variante { $index } mester ta un number entero
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` no ta implementá pa midí absoluto. Ta pone e anchonan relativo.
+
+side-by-side-absolute-margins = `<{ $component }>` no ta implementá pa midí absoluto. Ta pone e marchennan relativo.
+
+side-by-side-no-block-child = `<{ $component }>` inválido: e mester tin por lo ménos un yu di tipo block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = E atributo `for` riba un `<label>` gráfiko ta ser ignorá.
+
+label-for-must-resolve-to-one = E atributo `for` riba `<label>` mester resolvé na eksaktamente un komponente.
+
+label-for-unresolved = E atributo `for` riba `<label>` no por a resolvé na un komponente.
+
+label-for-answer-with-authored-inputs = E atributo `for` riba `<label>` ta referí na un `<answer>` ku input skirbí pa e outor; referí direktamente na e input.
+
+label-for-answer-without-input = E atributo `for` riba `<label>` ta referí na un `<answer>` sin un input pa etiketá.
+
+label-for-must-reference-input-or-answer = E atributo `for` riba `<label>` mester referí na un input of na un answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Pa aksesibilidat, `<{ $component }>` mester tin un deskripshon kòrtiku of mester ta spesifiká komo dekorativo.
+
+accessibility-video-short-description = Pa aksesibilidat, `<video>` mester tin un deskripshon kòrtiku.
+
+accessibility-input-short-description-or-label = Pa aksesibilidat, `<{ $component }>` mester tin un deskripshon kòrtiku of un etiketa.
+
+accessibility-answer-input-short-description-or-label = Pa aksesibilidat, un `<answer>` ku ta krea un input mester tin un deskripshon kòrtiku of un etiketa.
+
+accessibility-short-description-contains-math = Deskripshon kòrtiku no mester kontené komponente matemátiko manera `<{ $component }>`. Skirbi tur matemátika ku palabra.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } tin kontraste insufisiente pa e teksto di título di seksion (modo skur) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mester ta por lo ménos { $threshold }:1).
+       *[other] { $colorName } tin kontraste insufisiente pa e teksto di título di seksion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mester ta por lo ménos { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = No a implementá `<circle>` pa { $count } punto den kaso ku e puntonan no tin balor numériko.
+
+circle-too-many-through-points = No por kalkulá un sirkulo pa mas ku 3 punto.
+
+circle-overprescribed-radius-center-points = No por kalkulá un sirkulo ku radio, sentro i punto tur spesifiká.
+
+circle-center-with-multiple-points = No por kalkulá un sirkulo ku sentro spesifiká pa mas ku 1 punto.
+
+circle-radius-too-small = No por kalkulá e sirkulo: siendo ku e distansia entre e dos puntonan ta { $distance }, e radio spesifiká { $radius } ta muchu chikitu.
+
+circle-radius-with-many-points = No por krea un sirkulo pa mas ku dos punto ku un radio spesifiká.
+
+circle-invalid-center-or-through-points = Sentro of punto di paso inválido di e sirkulo.
+
+circle-radius-center-with-multiple-points = No por kalkulá e radio di un sirkulo ku sentro spesifiká pa mas ku 1 punto.
+
+circle-change-radius-non-numerical = No por kambia e radio di un sirkulo ku punto di paso no numériko
+
+circle-radius-with-points-non-numerical = No por krea un sirkulo pa mas ku un punto ku radio spesifiká ora no tin balor numériko.
+
+circle-change-center-non-numerical = No a implementá kambio di sentro di un sirkulo pa punto ku balor no numériko.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Dimenshon insufisiente pa e dominio di e funshon. E dominio tin { $intervals } intervalo pero e funshon tin { $inputs } input.
+
+function-domain-invalid-format = Fòrmato inválido pa e dominio di e funshon.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ta ignorá máksimo no numériko di e funshon.
+        [minimum] Ta ignorá mínimo no numériko di e funshon.
+        [extremum] Ta ignorá ekstremo no numériko di e funshon.
+        [point] Ta ignorá punto no numériko di e funshon.
+        [slope] Ta ignorá pendiente no numériko di e funshon.
+       *[other] Ta ignorá { $type } no numériko di e funshon.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ta ignorá máksimo bashí di e funshon.
+        [minimum] Ta ignorá mínimo bashí di e funshon.
+        [extremum] Ta ignorá ekstremo bashí di e funshon.
+        [point] Ta ignorá punto bashí di e funshon.
+       *[other] Ta ignorá { $type } bashí di e funshon.
+    }
+
+function-points-too-close = E funshon tin dos punto ku ta muchu serka otro. No por definí e funshon.
+
+function-iterates-input-output-mismatch = Iterashon di funshon ta posibel solamente si e kantidat di input di e funshon ta meskos ku e kantidat di output. E funshon aki tin { $inputs } input i { $outputs } output.
+
+## `<sequence>`
+
+sequence-invalid-length = Largura inválido di e sekuensia.  Mester ta un number entero no negativo.
+
+sequence-invalid-step = Paso inválido di e sekuensia.  Mester ta un number pa un sekuensia di tipo { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" inválido di un sekuensia di number.  Mester ta un number.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" inválido di un sekuensia di lèter.  Mester ta un kombinashon di lèter.
+
+sequence-invalid-endpoint = "{ $attribute }" inválido di e sekuensia.
+
+select-from-sequence-coprime-not-numbers = coprime ta ser ignorá pasobra no ta selektá number
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ta ser ignorá pasobra excludeCombinations ta spesifiká
+
+## Resolving a `target`
+
+target-not-found = Target inválido pa `<{ $source }>`: no por hañ'é.
+
+target-state-variable-not-found = Target inválido pa `<{ $source }>`: no por haña un variabel di estado ku nòmber "{ $property }" riba un `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = E variabelnan di `<odeSystem>` mester ta diferente for di e variabel independiente.
+
+ode-system-duplicate-variable-names = No por definí funshon RHS di ODE ku nòmber di variabel dependiente duplicá.
+
+ode-system-rhs-function-error = No por definí e funshon RHS di ODE.  Eror ora di krea e funshon mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = No por definí un angulo entre { $count } liña
+
+angle-invalid-through-point = Punto inválido den e through di `<angle>`
+
+parabola-vertex-too-many-points = No a implementá parabola ku vértise pa mas ku 1 punto.
+
+parabola-too-many-points = No a implementá parabola pa mas ku 3 punto.
+
+intersection-too-many-items = No a implementá interseshon pa mas ku dos elemento
+
+## Other math components
+
+ionic-compound-not-two-ions = No a implementá kompuesto ióniko pa nada otro ku dos ion.
+
+ionic-compound-needs-cation-and-anion = Kompuesto ióniko ta implementá solamente pa un kation i un anion.
+
+solve-equations-cannot-evaluate = No por resolvé e ekuashon pasobra no por a evaluá e ekuashon: { $equation }
+
+math-operators-operand-number-required = Mester spesifiká un operandNumber ora di saka un operando matemátiko.
+
+eigen-decomposition-failed = No por a kalkulá e autovalornan di e matriz
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: e parámetro { $parameters } no ta aparesé den e patronchi, p'esei semper e lo kuadra ku un blanko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: no por interpretá grid="{ $grid }". Mester ta none, medium, dense, of dos number positivo separá pa un spasi, manera grid="1 0.5". No ta dibuhá kuadrikula.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` mester tin un funshon ku { $expected ->
+        [one] un output, e pendiente y' na kada punto, manera `y - x`
+       *[other] dos output, e vektor na kada punto, manera `(y, -x)`
+    }, pero e funshon ku el a haña tin { $found } output. { $alternative ->
+        [none] No ta dibuhá nada.
+       *[other] `<{ $alternative }>` ta e komponente pa e funshon ei. No ta dibuhá nada.
+    }
+
+field-function-attribute-ignored-with-child = E atributo `function` ta ser ignorá pasobra e funshon ta duná tambe paden di e komponente; ta usa esun paden. Duna e funshon di ún di e dos manera so.
+
+field-variables-ignored =
+    `<{ $component }>`: e atributo `variables` ta nombra e variabelnan di un ekspreshon skirbí direktamente paden di e komponente. { $reason ->
+        [function-child] E funshon akinan ta duná komo un yu `<function>`, ku ta nombra su mes variabelnan, p'esei `variables` ta ser ignorá.
+       *[no-expression] No tin tal ekspreshon akinan, p'esei `variables` ta ser ignorá.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" no ta soportá den e renderisadó prefigure; ta usa e komportashon di posishon na drechi.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" no ta soportá den e renderisadó prefigure; ta usa e komportashon di posishon ariba.
+
+prefigure-invalid-axis-bounds = `<graph>`: límite di ehe inválido pa e konvershon prefigure; ta usa e bbox por defekto (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: anchura inválido pa e konvershon prefigure; ta usa e anchura di diagrama por defekto 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio inválido pa e konvershon prefigure; ta usa e proporshon por defekto 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: e spasio di e kuadrikula ta muchu fini pa e límitenan di ehe; e kuadrikula ta ser omití den e renderisadó prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotashon lo no ser renderisá ora no ta usa e renderisadó PreFigure.
+
+multiple-annotations-children = A haña vários yu `<annotations>` den `<graph>`; tur menos e último ta ser ignorá.
+
+## Referring to other components
+
+copy-unrecognized-component-type = No por ekstendé ni kopia un tipo di komponente no rekonosí: { $type }.
+
+copy-prop-not-found = No por a haña e prop { $property } riba un komponente di tipo { $component }
+
+collect-no-source = No a haña fuente pa collect.
+
+collect-invalid-component-type = No por kolektá komponente di tipo `<{ $component }>` pasobra e ta un tipo di komponente inválido.
+
+reference-index-unavailable = No por referí na e índise `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = No por yama { $action } riba e komponente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = E dato tin forma inválido.  E filanan tin largura inkonsistente. Hañá den componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = E dato tin nòmber di kolumna duplicá.  Hañá den componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = E dato ta falta un nòmber di kolumna.  Hañá den componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Un award di e answer aki ta basá riba e mes kontesta mandá di e tag answer, i esei lo hiba na komportashon inesperá.
+
+answer-max-num-attempts-in-section-wide-check-work = Pone `maxNumAttempts` riba un `<answer>` paden di un kontenedor ku `sectionWideCheckWork` no tin efekto, pasobra e kontenedor ta kontrolá e kantidat di purbamentu. Pone `maxNumAttempts` riba e kontenedor mes.
+
+nested-section-wide-check-work-max-num-attempts = Pone `maxNumAttempts` riba un kontenedor ku `sectionWideCheckWork` ku ta paden di un otro kontenedor ku `sectionWideCheckWork` no tin efekto, pasobra e kontenedor di pafó ta kontrolá e kantidat di purbamentu. Pone `maxNumAttempts` riba e kontenedor di pafó.
+
+answer-attributes-need-symbolic-equality = E atributo { $attributes } lo no tin efekto sin symbolicEquality poní.
+
+answer-invalid-type = Tipo inválido pa answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Komo e komponente `<{ $component }>` no tin nòmber, e no por ser usá pa un atributo di module
+
+module-attribute-name-already-defined = E komponente `<{ $component } name="{ $name }">` no por ser usá komo atributo di un module pasobra e tipo di komponente `<module>` ya tin un atributo "{ $name }" definí.
+
+conditional-content-condition-ignored = E atributo `condition` ta ser ignorá riba un komponente `<conditionalContent>` ku yu case of else.
+
+slider-markers-type-mismatch = E tipo di marker no ta kuadra ku e tipo di slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel inválido: kada `<problem>` mester kontené un `<statement>` i un `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel inválido: den mode="circuit", e promé `<problem>` no por ta un distraktor.
+
+## Attribute values
+
+attribute-invalid-values = Balor inválido { $values } pa e atributo `{ $attribute }`; ta ignorá.
+
+attribute-must-be-references = Balor `{ $value }` inválido pa e atributo `{ $attribute }`. E atributo mester ta kompuesto di referensia ku ta kuminsá ku un `$`.
+
+math-input-invalid-function-names = <mathInput>: a ignorá nòmber di funshon inválido den { $attribute }: { $names }. Kada nòmber su segmento di mustra mester tin por lo ménos 2 karakter (lèter of strepi); un sufiho opshonal `|<mathspeak alternative>` por sigui.
+
+## Building components from the source
+
+component-type-invalid = Tipo di komponente inválido: `<{ $componentType }>`
+
+attribute-repeated = No por repetí e atributo { $attribute }.
+
+attribute-invalid-for-component = Atributo "{ $attribute }" inválido pa un komponente di tipo `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    E definishon di estilo { $styleNumber } tin kontraste insufisiente pa { $context ->
+        [text-on-background] koló di teksto kontra koló di fondo
+        [high-contrast] koló di kontraste haltu kontra e kanvas
+        [line] koló di liña kontra e kanvas
+        [marker] koló di marker kontra e kanvas
+       *[text-on-canvas] koló di teksto kontra e kanvas
+    }{ $mode ->
+        [dark] { " (modo skur)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mester ta por lo ménos { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Ounke e definishon di estilo { $styleNumber } tin koló spesifiká ku ta duna kontraste sufisiente pa modo kla, e kolónan di modo skur derivá for di e balornan ei tin kontraste insufisiente pa e koló di teksto kontra e koló di fondo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mester ta por lo ménos { $threshold }:1). { $suggestion ->
+        [available] Pa garantisá kontraste sufisiente den modo skur, of oumentá e kontraste di modo kla (p.e., pone { $lightAttribute }="{ $lightColor }") of kambia e koló di modo skur (p.e., pone { $darkAttribute }="{ $darkColor }").
+       *[none] Pa garantisá kontraste sufisiente den modo skur, oumentá e kontraste di modo kla of kambia e kolónan derivá ku textColorDarkMode i/of backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ounke e definishon di estilo { $styleNumber } tin un koló di teksto spesifiká ku ta duna kontraste sufisiente pa modo kla, e koló di teksto di modo skur derivá for di e balor ei tin kontraste insufisiente kontra e kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mester ta por lo ménos { $threshold }:1). { $suggestion ->
+        [available] Pa garantisá kontraste sufisiente den modo skur, of oumentá e kontraste di modo kla (p.e., pone textColor="{ $lightColor }") of kambia e koló di modo skur (p.e., pone textColorDarkMode="{ $darkColor }").
+       *[none] Pa garantisá kontraste sufisiente den modo skur, oumentá e kontraste di modo kla of kambia e koló derivá ku textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Un seksion por selektá ún <stylePalette> so; ta usa e último.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = no por determiná e variantenan úniko di { $component } pasobra numToSelect no ta un number entero no negativo.
+
+variant-num-to-select-not-constant-number = no por determiná e variantenan úniko di { $component } pasobra numToSelect no ta un number konstante.
+
+variant-with-replacement-not-constant-boolean = no por determiná e variantenan úniko di { $component } pasobra withReplacement no ta un boolean konstante.
+
+variant-select-weight-disables-unique = Variante úniko pa select ta desaktivá si tin un opshon ku selectWeight of selectForVariants spesifiká
+
+variant-coprime-undetermined = no por determiná e variantenan úniko di { $component } pasobra no por determiná ku coprime semper ta falsu.
+
+variant-attribute-not-constant = no por determiná e variantenan úniko di { $component } pasobra { $attribute } no ta un konstante.
+
+variant-attribute-not-number = no por determiná e variantenan úniko di { $component } pasobra { $attribute } no ta un number.
+
+variant-attribute-wrong-type-for-sequence =
+    no por determiná e variantenan úniko di { $component } di tipo { $type } pasobra { $attribute } no ta { $expected ->
+        [letters-combination] un kombinashon di lèter
+        [math-expression] un ekspreshon matemátiko válido
+        [integer] un number entero
+       *[number] un number
+    }.
+
+variant-length-not-integer = no por determiná e variantenan úniko di { $component } pasobra length no ta un number entero.
+
+variant-sort-not-implemented = no a implementá variante úniko di un { $component } ku sort
+
+variant-exclude-combinations-not-implemented = no a implementá variante úniko di un { $component } ku excludeCombinations
+
+variant-math-exclude-not-implemented = no a implementá variante úniko di un { $component } di tipo math ku exclude
+
+variant-non-constant-exclude-not-implemented = no a implementá variante úniko di un { $component } ku exclude no konstante
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: no ta soportá den e renderisadó prefigure di graph; e desendiente ta ser saltá.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometria no finito of inkompleto; e desendiente ta ser saltá.
+
+prefigure-curve-label-omitted = { $subject }: etiketa no ta soportá riba elemento di kurva konvertí; e etiketa ta ser omití.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipo di definishon di funshon di kurva '{ $definitionType }' no ta soportá; e desendiente ta ser saltá.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atributo flipFunctions no ta soportá riba regionBetweenCurves; e desendiente ta ser saltá.
+
+prefigure-region-non-formula-child = { $subject }: solamente funshon yu di tipo formula ta soportá riba regionBetweenCurves; e desendiente ta ser saltá.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' no ta soportá pa { $labelKind ->
+        [line-family] un etiketa di famia di liña
+       *[point] un etiketa di punto
+    }; ta usa e alineashon PreFigure por defekto.
+
+prefigure-fill-style-unsupported = { $subject }: e estilo di yena '{ $fillStyle }' no ta soportá pa PreFigure; ta bolbe na un yena sólido.
+
+prefigure-line-style-unknown = { $subject }: estilo di liña deskonosí '{ $lineStyle }' omití for di e salida PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: estilo di marker '{ $markerStyle }' konvertí na e estilo PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: estilo di marker '{ $markerStyle }' no ta soportá pa PreFigure; ta usa e estilo por defekto.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` inválido; no por resolvé e target. E anotashon ta ser omití.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` a resolvé na vários target; ta usa e promé target.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` inválido; e target ta pafó di e graph ku ta kontené. E anotashon ta ser omití.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` inválido; e target no ta un opheto gráfiko soportá den e konvershon prefigure. E anotashon ta ser omití.
+
+annotation-text-missing = `<annotation>`: `text` ta falta of ta bashí; ta pone teksto bashí.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] A detektá un dependensia sirkular.
+       *[other] A detektá un dependensia sirkular ku ta enbolbé un komponente `<{ $componentType }>`.
+    }
+
+reference-no-referent = No a haña referente pa e referensia: `{ $reference }`
+
+reference-multiple-referents = A haña vários referente pa e referensia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fòrmato inválido pa e atributo { $attribute } di `<{ $componentType }>`.
+
+children-invalid = Yu inválido pa `<{ $componentType }>`: A haña yu inválido: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Balor `{ $value }` inválido pa e atributo `{ $attribute }`, ta usa e balor `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] No a haña e vershon { $version } di DoenetML.
+       *[other] No a haña e vershon { $version } di DoenetML. Ta bolbe na e vershon { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML inválido: { $content }
+
+parse-tag-missing-close-tag = DoenetML inválido: E tag `{ $tag }` no tin tag di sera. Tabata spera un tag ku ta sera su mes of un tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML inválido: Eror den e tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML inválido: Parse ku e atributo inválido `{ $attribute }` ta falta un balor.
+
+parse-attribute-invalid = DoenetML inválido: Atributo inválido `{ $attribute }`
+
+parse-attribute-value-invalid = DoenetML inválido: Balor di atributo inválido `{ $value }`
+
+parse-attribute-value-quote-mismatch = DoenetML inválido: Balor di atributo inválido `{ $value }`. E kòmanan no ta kuadra. Ta parse ku ta falta un `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML inválido: A haña un tag sin nòmber di tag, p.e. `<`
+
+parse-tag-not-closed = DoenetML inválido: E tag `{ $tag }` no a ser será (ta parse ku ta falta un `>`).
+
+parse-self-closing-tag-name-missing = DoenetML inválido: A haña un tag sin nòmber di tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML inválido: E tag `{ $tag }` no a ser será (ta parse ku ta falta un `/>`).
+
+parse-tag-invalid-attributes = DoenetML inválido: E tag `{ $tag }` no ta válido. Podisé e tin atributo robes.
+
+parse-close-tag-name-missing = DoenetML inválido: A haña un tag di sera sin nòmber di tag, p.e. `</`
+
+parse-attribute-value-unquoted = Balor di atributo mester ta entre kòma: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML inválido: A haña e tag di sera `{ $tag }`, pero niun tag di habri korespondiente
+
+parse-close-tag-mismatched = DoenetML inválido: Tag di sera ku no ta kuadra. Tabata spera `</{ $expected }>`. A haña `{ $found }`
+
+parser-node-unconvertible = No por a konvertí e nodo { $node } na un nodo Dast.
+
+## Names
+
+name-attribute-invalid =
+    Nòmber di atributo inválido name='{ $name }'. { $reason ->
+        [characters] Un nòmber por kontené lèter, number, streki abou of strepi so.
+       *[start] Un nòmber mester kuminsá ku un lèter.
+    }
+
+component-name-invalid-start = Nòmber di komponente inválido "{ $name }". Un nòmber mester kuminsá ku un lèter.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Un answer di tipo videoWatched mester tin un atributo video
+
+answer-video-watched-video-not-reference = Un answer di tipo videoWatched mester tin un atributo video ku ta un referensia
+
+answer-name-not-single-text = E atributo name di un answer mester tin un solo yu di tipo text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = No por a haña e DoenetML eksterno pa motibu di muchu nivel di rekurshon. Tin un referensia sirkular?
+
+external-doenetml-unavailable = No por a haña DoenetML for di { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML inválido hañá for di { $attribute }="{ $uri }": e no a kuadra ku e tipo di komponente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] E atributo `{ $from }` ta obsoleto; usa `{ $to }` na su luga.
+       *[other] [deprecation] E atributo `{ $from }` riba `<{ $component }>` ta obsoleto; usa `{ $to }` na su luga.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] E atributo `{ $from }` ta obsoleto i ta ser ignorá pasobra `{ $to }` ta spesifiká tambe.
+       *[other] [deprecation] E atributo `{ $from }` riba `<{ $component }>` ta obsoleto i ta ser ignorá pasobra `{ $to }` ta spesifiká tambe.
+    }
+
+deprecated-attribute-ignored = [deprecation] E atributo `{ $attribute }` riba `<{ $component }>` ta obsoleto i ta ser ignorá.
+
+deprecated-attribute-to-child = [deprecation] E atributo `{ $attribute }` riba `<{ $component }>` ta obsoleto; usa un yu `<{ $child }>` na su luga.
+
+deprecated-attribute-value-renamed = [deprecation] E balor `{ $value }` di e atributo `{ $attribute }` riba `<{ $component }>` ta obsoleto; usa `{ $to }` na su luga.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` por pone solamente ingles den plural, p'esei su teksto ta keda manera e ta den un dokumento skirbí na { $locale }. Skirbi e forma plural direktamente, of pon'é ku e atributo `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = E elemento `<{ $tag }>` no ta un elemento Doenet rekonosí.
+
+schema-element-not-allowed-at-root = E elemento `<{ $tag }>` no ta permití na e rais di e dokumento.
+
+schema-element-not-allowed-inside = E elemento `<{ $tag }>` no ta permití paden di `<{ $parent }>`.
+
+schema-attribute-unrecognized = E elemento `<{ $tag }>` no tin un atributo ku yama `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] E atributo `{ $attribute }` di e elemento `<{ $tag }>` mester ta un lista ku kada elemento ta ún di: { $allowed }
+       *[other] E atributo `{ $attribute }` di e elemento `<{ $tag }>` mester ta ún di: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nòmber di variante inválido pa select.  E nòmber di variante { $variantName } ta aparesé den { $numOptions } opshon pero e kantidat pa selektá ta { $numToSelect }.
+
+select-variant-name-without-options = Tin variante spesifiká pa select pero no tin opshon spesifiká pa e posibel nòmber di variante: { $variantName }.
+
+select-variant-name-not-possible = E nòmber di variante { $variantName } ku ta spesifiká pa select no ta un nòmber di variante posibel.
+
+select-too-few-options = No por selektá { $numToSelect } komponente for di solamente { $numOptions }.
+
+select-from-sequence-too-few-values = No por selektá { $numToSelect } balor for di un sekuensia di largura { $length }.
+
+select-from-sequence-indices-count-mismatch = E kantidat di índise spesifiká pa select mester kuadra ku e kantidat pa selektá
+
+select-from-sequence-indices-not-integers = Tur índise spesifiká pa select mester ta number entero
+
+select-from-sequence-index-excluded = A spesifiká un índise di selectfromsequence ku tabata ekskluí
+
+select-from-sequence-indices-excluded-combination = A spesifiká índise di selectfromsequence ku tabata un kombinashon ekskluí
+
+select-from-sequence-coprime-not-positive-integers = No por selektá kombinashon koprimo pasobra no ta selektá number entero positivo.
+
+select-from-sequence-coprime-common-factor = No por selektá number koprimo. Tur balor posibel ta kompartí un faktor komun. (E balornan spesifiká di "from" of "to" mester ta koprimo ku "step".)
+
+select-from-sequence-coprime-single-number = No por selektá kombinashon koprimo for di un solo number ku no ta 1.
+
+select-from-sequence-excluded-too-many-combinations = A ekskluí mas ku 70% di e kombinashonnan den selectFromSequence
+
+select-from-sequence-coprime-none-found = No por a selektá number koprimo. Tur balor posibel ta kompartí un faktor komun.
+
+select-from-sequence-too-few-unique-values = No por selektá { $numToSelect } balor úniko for di un sekuensia di largura { $numPossibleValues }
+
+select-prime-numbers-too-few-values = No por selektá { $numToSelect } balor for di un lista di number primo di largura { $numValues }
+
+select-prime-numbers-values-count-mismatch = E kantidat di balor spesifiká pa select mester kuadra ku e kantidat pa selektá
+
+select-prime-numbers-values-not-prime = Tur balor spesifiká pa select di number primo mester ta den e lista di number primo
+
+select-prime-numbers-values-excluded-combination = E balornan spesifiká di selectPrimeNumbers tabata un kombinashon ekskluí
+
+select-prime-numbers-excluded-too-many-combinations = A ekskluí mas ku 70% di e kombinashonnan den selectPrimeNumbers
+
+select-random-combination-fluke = Pa un kasualidat masha improbabel, no por a selektá un kombinashon di balor aleatorio
+
+select-random-value-fluke = Pa un kasualidat masha improbabel, no por a selektá un balor aleatorio
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` no ta ser dibuhá paden di e matemátika; e ekspreshon ta ser skirbí manera e tabata promé ku por a pone input paden. { $reason ->
+        [not-inline] Solamente un choice input `inline` ta kaba paden di un ekspreshon; sin `inline` e ta un blòki di bòter.
+        [expanded] Un text input `expanded` ta un kaha di vários liña, ku ta muchu grandi pa kaba paden di un ekspreshon.
+        [on-graph] Riba un graph e ekspreshon ta ser dibuhá komo un solo prenchi, ku no tin espasio pa un kontrol.
+       *[relative-width] Su `width` ta relativo (un porsentahe of `em`), ku no tin nada pa midi kontra dje paden di un ekspreshon. Duna e anchura den unidat absoluto, manera `px`, na su luga.
+    }

--- a/packages/i18n/locales/pap/editor.ftl
+++ b/packages/i18n/locales/pap/editor.ftl
@@ -1,0 +1,240 @@
+# Papiamentu (Kòrsou/Boneiru) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay exactly as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** This catalog is written in the **phonological orthography
+# of Curaçao and Bonaire** — Papiamentu, spelled «kas», «yu», «skol», «bèk»,
+# «buki», «hende». The **etymological orthography of Aruba** — Papiamento,
+# «cas», «hoben», «trece» — is a real and equally official alternative and is
+# deliberately **not** mixed into any of these four files. A reviewer from
+# Aruba would **respell** this catalog rather than retranslate it: the words
+# are the same, the spelling system is not. `chrome.ftl`'s header sets out the
+# letters that carry the distinction — `k` and `s` for etymological
+# `c`/`qu`/`z`, `y` for `j`/`ll`, and the vowel letters `è ò ù`, which are
+# letters of the alphabet rather than stress marks. Papiamentu writes an acute
+# accent separately, for irregular stress and tone («kámbia»; the «paña» /
+# «pañá» pattern); this seed marks stress only where the standard orthography
+# requires it, so accent placement is what a reviewer should check first.
+#
+# **Word order and agreement.** A Papiamentu adjective follows its noun —
+# «liña kòrá», «kas grandi» — the reverse of English; `content.ftl` is where
+# that matters, and its header says how the composition messages reverse.
+# Papiamentu has no grammatical gender and no adjective agreement, so nothing
+# here forks on `$gender` or `$role`.
+#
+# **Number.** `Intl.PluralRules("pap")` resolves to `pap` and reports
+# `['one','other']`. A noun after a numeral is unmarked — «dos violashon»,
+# never «dos violashonnan» — so both branches would be word-for-word identical
+# and every count message is written as **one unselected form**. That covers
+# `editor-accessibility-label` and `help-coordinates`; `help-coordinates` is
+# a heading rather than a counted phrase, and its two English forms differ, so
+# the plural «Koordenadanan» is written there unconditionally.
+#
+# **Coverage.** Every key of the English file is covered. «renderisadó»,
+# «kuadrikula» and «etiketa» are the seed's own choices in a register
+# Papiamentu writes little of; a reviewer should check them.
+#
+# **The technical vocabulary here is a lexifier loan set.** Every technical
+# noun in this file is a Dutch- or Spanish-mediated loan — those are the words
+# Papiamentu actually uses, not a substitute for a native term — carried in
+# Papiamentu's own orthography and Papiamentu's own grammar. The sentences
+# around the loans are Papiamentu, not Dutch and not Spanish.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reinisiá
+       *[update] Aktualisá
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Visor
+       *[other] { $word } Visor { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variante
+
+editor-variant-filter = Filtrá...
+
+editor-variant-next = Selektá e siguiente variante
+
+editor-variant-previous = Selektá e variante anterior
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] A identifiká un violashon di aksesibilidat WCAG AA. Klek pa { $action ->
+            [close] sera
+           *[open] habri
+        } e rapòrt di aksesibilidat.
+        [advisories] Klek pa { $action ->
+            [close] sera
+           *[open] habri
+        } e rapòrt di aksesibilidat. No a haña violashon di WCAG AA, pero tin rekomendashon adishonal di aksesibilidat.
+       *[clean] Klek pa { $action ->
+            [close] sera
+           *[open] habri
+        } e rapòrt di aksesibilidat. No a haña ningun problema di aksesibilidat.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] A identifiká un violashon di aksesibilidat WCAG AA. A haña { $count } violashon di WCAG AA. Klek pa { $action ->
+            [close] sera
+           *[open] habri
+        } e rapòrt di aksesibilidat.
+        [advisories] No a identifiká violashon di WCAG AA. A haña { $count } rekomendashon adishonal di aksesibilidat. Klek pa { $action ->
+            [close] sera
+           *[open] habri
+        } e rapòrt di aksesibilidat.
+       *[clean] No a identifiká violashon di WCAG AA. Klek pa { $action ->
+            [close] sera
+           *[open] habri
+        } e rapòrt di aksesibilidat.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Vershon { $version } di DoenetML
+
+editor-tab-help = Yudansa segun kontèkst
+editor-tab-help-short = Kontèkst
+editor-tab-errors = Eror
+editor-tab-warnings = Atvertensia
+editor-tab-info = Informashon
+editor-tab-accessibility = Aksesibilidat
+editor-tab-responses = Kontesta mandá
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opshon di editor
+editor-format-as-doenetml = Formatiá komo DoenetML
+editor-format-as-xml = Formatiá komo XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liña #{ $line }
+
+editor-no-errors = Sin Eror
+editor-no-warnings = Sin Atvertensia
+editor-no-info = Sin Diagnóstiko Informativo
+
+editor-show-info-annotations = Mustra diagnóstiko informativo den e editor
+editor-show-accessibility-annotations = Mustra diagnóstiko di aksesibilidat den e editor
+
+editor-accessibility-learn-more = Siña kon Doenet ta trata aksesibilidat
+
+editor-accessibility-violations-heading = Violashon di aksesibilidat ({ $standard })
+
+editor-accessibility-other-heading = Otro problema di aksesibilidat
+editor-none-found = No a haña ningun
+
+
+## Submitted responses
+
+editor-no-responses = Ainda no tin kontesta mandá
+editor-response-answer-id = Id di Kontesta
+editor-response-response = Kontesta
+editor-response-credit = Krédito
+editor-response-submitted = Mandá
+
+
+## The context-help panel
+
+help-placeholder = Pone e kursor riba un nòmber di tag, un atributo of { $ref } pa dokumentashon.
+
+help-unsupported-ref-chain = Yudansa pa referensia di vários parti manera { $example } ainda no ta soportá.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] No a haña referente pa e referensia: { $ref }.
+        [multiple] A haña vários referente pa e referensia: { $ref }.
+       *[indeterminate] No por a determiná un referente pa { $ref }.
+    }
+
+help-learn-about-references = Siña tokante referensia →
+help-reference-page = Página di referensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Paden di { $element }
+       *[top] Na e nivel di ariba
+    }{ $allowed ->
+        [none] { " — nada no ta bai akinan." }
+        [text] { " — skirbi teksto akinan." }
+        [text-and-components] { " — skirbi teksto akinan, of purba:" }
+       *[components] { " — kos pa purba:" }
+    }
+
+help-suggestions-footer = Primi { $shortcut } pa mira tur e { $total } komponentenan.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ta un referensia na { $target }.
+       *[other] { $ref } ta un referensia na { $target } (liña { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Introdusí pa { $owner } komo { $role }.
+       *[other] Introdusí pa { $owner } na liña { $line } komo { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ta un referensia na e propiedat { $property } di { $element }.
+       *[other] { $ref } ta un referensia na e propiedat { $property } di { $element } (liña { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = fragmento
+help-kind-array-entry = entrada di array
+
+help-default = Por defekto:
+help-active-default = Por defekto aktivo:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Balor permití (ún pa kada elemento):
+       *[other] Balor permití:
+    }
+
+help-suggested-values = Balor sugerí:
+
+help-inserts = Ta inserta:
+
+help-coordinates = Koordenadanan:
+
+help-type = Tipo:
+
+help-resolved-style = Estilo resolvé (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nòmber di funshon resolvé:
+help-reset-list = Reinisiá lista riba e input aki:
+help-added-on-input = Agregá riba e input aki:
+help-removed-on-input = Kitá riba e input aki:
+
+help-reset-overrides = { $reset } ta prevalesé riba { $additional } i { $removed }.

--- a/packages/i18n/locales/srm/chrome.ftl
+++ b/packages/i18n/locales/srm/chrome.ftl
@@ -1,0 +1,195 @@
+# Saramaccan (Saamáka tongo), the Maroon creole of the upper Suriname River.
+# Viewer chrome, translated from `locales/en/chrome.ftl`, which is the source
+# of truth: `lint:i18n` rejects a key that does not exist there, and reports a
+# key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **standard Saramaccan orthography** of the Rountree /
+# Glock dictionary and of the Saramaccan scriptures. Its points:
+#
+#   * **Seven vowel letters** — `a e ë i o ö u`. `ë` (U+00EB) and `ö`
+#     (U+00F6) are the open-mid vowels and are letters of the alphabet, not
+#     decorations on `e` and `o`.
+#   * **A doubled vowel writes length** — «puu» (*take out*), «hii» (*all*),
+#     «kiin» (*clean*), «gaan» (*big*), «baaka» (*black*), «wooko» (*work*).
+#   * **Nasality is written with an `n` after the vowel** — «an», «en», «in»,
+#     «on», «un» — and that `n` is part of the vowel, not a consonant of its
+#     own.
+#   * **Prenasalized stops are written `mb`, `nd`, `ng`**; `tj` and `dj` are
+#     the palatal affricates.
+#   * **Initial `h`** where the eastern creoles have none: «hopo» (*open*),
+#     «hakisi» (*ask*), «hii», «hën», «hesi». This is one of the clearest
+#     marks that a line is Saramaccan and not Ndyuka.
+#
+# **Tone is NOT written in this catalog, and that is a real loss.** Saramaccan
+# is a tone language: the dictionary and the scriptures mark tone with
+# accents, and tone distinguishes words that are otherwise spelled alike. This
+# seed leaves tone unmarked throughout all four files. A reviewer restoring it
+# is restoring information these files do not carry, not correcting a
+# misspelling. The one accented letter outside `ë` and `ö` is **«á», the
+# preverbal negator** — «wi á sa luku» *we cannot look* — which is written
+# with its accent because that is how the negator is spelled, not as a tone
+# mark this file otherwise omits.
+#
+# **Saramaccan is Portuguese- as well as English-lexified**, and this catalog
+# keeps the Portuguese-derived stratum where the language has it: «manda»
+# (*send*, *mandar*), «kaba» (*finish*, *acabar*), «alanza» (*orange*,
+# *laranja*), «sikifi» (*write*, *escrever*), «pooba» (*try*, *provar*),
+# «buka» (*word*, *boca*), «kuma» (*like*, *como*), «ku» (*and*, *com*),
+# «ezempu» (*example*, *exemplo*). It is not an English creole with Portuguese
+# spellings sprinkled in.
+#
+# **Grammar.** Saramaccan grammar carries every sentence. The preverbal
+# markers are **«ta» (imperfective), «bi» (past), «o» (future), «sa» (able),
+# «musu» (must)** — «ta», not the eastern «e», and «bi», not «be»; the
+# negator «á» stands in front of them; «ku» is *and* and *with*; «u» / «fu» is
+# the purposive; «dee» is the plural and «di» the definite article. Ndyuka, in
+# `locales/djk`, is a different language with a different marker set, and
+# these are not two spellings of one text: an «e» or a «be» in this file is a
+# bug.
+#
+# **Number.** `Intl.PluralRules("srm")` has **no CLDR data for `srm`**: it
+# falls back and answers `['one', 'other']`, which is English's answer and not
+# a fact about Saramaccan. A Saramaccan noun after a numeral is unmarked —
+# «tu pooba», never a pluralized noun; the plural is the preposed «dee», used
+# for definiteness rather than for counting. So the `one` and `other` branches
+# would be word-for-word identical, and where that is so this file writes
+# **one unselected form**. English's explicit `[0]` literal in
+# `attempts-remaining` matches the number itself, not a plural category, and
+# is kept.
+#
+# **Loans.** The computing register is Dutch and English, reshaped to
+# Saramaccan phonology and carried in Saramaccan grammar: «kiibolo»
+# (*keyboard*), «punti» (*point*, and the score word here), «statistika»,
+# «matematika», «ekispesi» (*expression*), «dokumenti», «infoomasi»,
+# «pagina», «masini», «futunota», «vekitoo», «funsi», «renderer» (left as the
+# code's own name), «WCAG» and «aksesibiliteiti».
+#
+# **Confidence.** Saramaccan has a dictionary, a full scripture translation
+# and almost no written technical prose, so the loans above are shapes this
+# seed derived from Saramaccan phonology rather than usage it found. The
+# grammar, the h-initials and the Portuguese stratum are the part to trust.
+# Nothing here was left in English.
+
+
+answer-checking = Ta luku...
+answer-submitting = Ta manda...
+
+answer-checking-status = Ta luku di piki
+answer-submitting-status = Ta manda di piki
+
+answer-correct = Leti
+answer-incorrect = Fowtu
+
+answer-response-saved = Di piki kibi kaba
+
+answer-percent-credit = { $percent }% punti
+answer-percent-correct = { $percent }% leti
+answer-percent-short = { $percent } %
+
+max-credit-available = Di möön hei punti: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] na wan pooba á tan möön
+       *[other] { $count } pooba tan
+    }
+
+validation-correct = (Leti)
+validation-incorrect = (Fowtu)
+validation-partially-correct = (Wan pisi leti)
+
+answer-show-responses = Lei { $count } piki da { $answerId }
+
+
+feedback-heading = Piki u di wooko
+
+collapsible-click-to-open = (kiliki u hopo)
+collapsible-click-to-close = (kiliki u tapa)
+
+collapsible-initializing = Ta bigi...
+
+footnote-show = Lei di futunota
+footnote-hide = Kibi di futunota
+
+description-more-information = möön infoomasi
+
+
+slider-previous = Baka
+slider-next = Fesi
+
+keyboard-open = Hopo di kiibolo
+keyboard-close = Tapa di kiibolo
+
+choice-input-remove-choice = Puu { $choice }
+
+matrix-remove-row = Puu wan lo
+matrix-add-row = Buta wan lo
+matrix-remove-column = Puu wan kolon
+matrix-add-column = Buta wan kolon
+
+subset-add-remove-points = Buta/Puu punti
+subset-toggle-points-intervals = Kambia punti ku intavalu
+subset-move-points = Seke dee punti
+subset-clear = Kiin
+
+orbital-add-row = Buta wan lo
+orbital-remove-row = Puu wan lo
+orbital-add-box = Buta wan bokisi
+orbital-remove-box = Puu wan bokisi
+orbital-add-up-arrow = Buta wan peli di ta go a hei
+orbital-add-down-arrow = Buta wan peli di ta go a basu
+orbital-remove-arrow = Puu di peli
+
+orbital-row-label = Nen da lo { $row }
+
+pretzel-answer = Piki
+
+summary-statistics-caption = Sooto statistika u { $column }
+
+
+math-input-preview-region = luku fosu u di matematika-ekispesi
+math-input-preview = Luku fosu
+math-input-invalid-expression = Di ekispesi á bunu:
+
+
+viewer-initializing = Ta bigi...
+
+
+error-heading = Fowtu
+
+error-found-at =
+    { $span ->
+        [line] Feni a lin { $startLine }.
+       *[lines] Feni a lin { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Di dokumenti aki abi fowtu a dendu!
+
+diagnostic-heading-error = Fowtu
+diagnostic-heading-warning = Wakiman-buka
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Tipi
+
+accessibility-heading-level-1 = WCAG AA aksesibiliteiti-fowtu
+accessibility-heading-level-2 = Aksesibiliteiti-buka
+
+something-went-wrong = Wan soni go fowtu.
+
+renderer-load-failed = wan renderer á sa lai. Gaantangi, lai di pagina baka.
+
+core-start-failed = Di dokumenti aki á sa bigi. Gaantangi, lai di pagina baka.
+
+core-start-failed-busy = Di dokumenti aki á sa bigi. Sömëni dokumenti bi ta bigi a wan pisi ten, nöö a sa tei möön longi a wan safi masini. Te dee woto dokumenti kaba, nöö a sa heepi ee i lai di pagina baka.
+
+core-start-failed-retry = Di dokumenti aki á sa bigi.
+
+core-start-failed-busy-retry = Di dokumenti aki á sa bigi. Sömëni dokumenti bi ta bigi a wan pisi ten, nöö a sa tei möön longi a wan safi masini.
+
+core-start-retry = Pooba baka
+
+saved-state-unavailable = Di wooko di i bi kibi á sa lai.

--- a/packages/i18n/locales/srm/content.ftl
+++ b/packages/i18n/locales/srm/content.ftl
@@ -1,0 +1,276 @@
+# Saramaccan (Saamáka tongo) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. Translated from `locales/en/content.ftl`, which is the source of
+# truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Saramaccan orthography of the Rountree / Glock
+# dictionary and of the Saramaccan scriptures: seven vowel letters `a e ë i o
+# ö u`, with `ë` (U+00EB) and `ö` (U+00F6) as letters in their own right; a
+# **doubled vowel writes length** («puu», «hii», «gaan», «baaka»);
+# **nasality is written with an `n` after the vowel** («an», «en», «in», «on»,
+# «un»), that `n` belonging to the vowel and not being a consonant of its own;
+# prenasalized stops `mb`, `nd`, `ng`; `tj` and `dj` for the palatal
+# affricates; and initial `h` («hopo», «hakisi», «hii», «hën»).
+#
+# **Tone is NOT written in this catalog, and that is a real loss.** Saramaccan
+# is a tone language; the dictionary and the scriptures mark tone with
+# accents, and tone distinguishes words otherwise spelled alike. These four
+# files leave it unmarked throughout. A reviewer restoring it is adding
+# information the files do not carry. The only accented letter outside `ë` and
+# `ö` is **«á», the preverbal negator**, spelled with its accent because that
+# is the negator's spelling, not a tone mark.
+#
+# **Saramaccan is Portuguese- as well as English-lexified**, and the
+# Portuguese stratum is kept where the language has it: «alanza» (*orange*,
+# *laranja*), «ezempu» (*example*, *exemplo*), «kaba», «kuma», «ku» (*and*,
+# *com*), «sikifi», «manda». Ndyuka, in `locales/djk`, is a different language
+# — its preverbal «e» and «be» are not Saramaccan's «ta» and «bi», and the two
+# catalogs are not two spellings of one text.
+#
+# **Word order: the modifier comes before the noun.** Saramaccan puts an
+# attributive adjective in front of its head — «wan dëkë bëë lin» is *a thick
+# red line*, in that order. So every composition message here **keeps the
+# English order**: `style-with-noun` puts the description first and the noun
+# after it, and `style-stroke` runs width, then dash pattern, then colour.
+# `noun-regular-polygon` is the one that moves: Saramaccan counts a side with
+# a following «ku { $numSides } sei», so the count follows the noun instead of
+# preceding it as English's «5-sided» does. It stays in the `head` branch,
+# because it stays beside the noun rather than after the adjectives.
+#
+# **No grammatical gender and no agreement.** Saramaccan adjectives do not
+# inflect for gender, number or case, so no message here forks on `$gender` or
+# on `$role`, and `noun-gender` answers a single token that nothing reads.
+#
+# **Number.** `Intl.PluralRules("srm")` has no CLDR data for `srm` and falls
+# back to English's `['one', 'other']`, which is not a fact about Saramaccan.
+# A noun after a numeral is unmarked — «dii punti»; the plural marker «dee» is
+# preposed and marks definiteness, not counting. So **nothing in this file
+# selects on a count**.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# Science in Suriname is schooled in Dutch, from Dutch textbooks; there is no
+# Saramaccan periodic table in use and no settled Saramaccan spelling for the
+# hundred and eighteen names. Reshaping the Dutch list to Saramaccan phonology
+# would be inventing a nomenclature rather than recording one. `lint:i18n`
+# reports the two keys as missing coverage, and that report is correct: they
+# fall back to English.
+#
+# **Loans.** Dutch and English reshaped to Saramaccan phonology: «vekitoo»,
+# «funsi», «palabola», «poligon», «polilin», «definisi», «teolema», «seksi»,
+# «palagaaf», «kaskade», «nota», «beweisi», «tabel», «figuu», «pagina»,
+# «intavalu», «punti». Saramaccan's own words carry the rest: «lin», «lontu»
+# (*circle*), «diiuku» (*triangle*, three-corner), «fokanti» (*square*,
+# four-corner), «kookotu lin» (*curved line*), «kanti» (*border*), «bakagoon»
+# (*background*), «fuu» (*full*), «tuu» / «falisi». Seven colour names —
+# «asisi kulo», «alanza kulo», «sian», «paasi», «loosu», «buun», «geli» — are
+# the least certain entries here, and «lo» for *row* in `chrome.ftl` is the
+# next; a reviewer should check those first.
+
+
+color =
+    .black = baaka
+    .white = weti
+    .gray = asisi kulo
+    .red = lebi
+    .orange = alanza kulo
+    .yellow = geli
+    .green = guun
+    .cyan = sian
+    .blue = bulu
+    .purple = paasi
+    .pink = loosu
+    .brown = buun
+
+line-width =
+    .thick = dëkë
+    .thin = fini
+
+line-style =
+    .dashed = koti-koti
+    .dotted = punti-punti
+
+fill-style =
+    .horizontal = lin di ta go longilongi
+    .vertical = lin di ta go hei-basu
+    .diagonal = lin di ta go a kanti
+    .backdiagonal = lin di ta go a di woto kanti
+    .dots = punti
+    .diamonds = diamanti
+
+noun =
+    .line = lin
+    .line-segment = pisi lin
+    .ray = sitaali
+    .vector = vekitoo
+    .curve = kookotu lin
+    .function = funsi
+    .slope-field = helin-feeld
+    .vector-field = vekitoo-feeld
+    .parabola = palabola
+    .polyline = polilin
+    .polygon = poligon
+    .triangle = diiuku
+    .rectangle = longi fokanti
+    .circle = lontu
+    .region = pisi peesi
+    .point = punti
+    .square = fokanti
+    .diamond = diamanti
+    .cross = koloisi
+    .plus = pulusi
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] leguleeu poligon ku { $numSides } sei
+    }
+
+noun-gender = neuter
+
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = fuu
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ku { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } ku { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } ku { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] ku wan { $border } kanti
+        [and] ku { $border } kanti
+        [and-article] ku wan { $border } kanti
+       *[with] ku { $border } kanti
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = á fuu
+
+style-text =
+    { $parts ->
+        [background] { $color } ku wan { $background } bakagoon
+       *[plain] { $color }
+    }
+
+style-background-none = na wan
+
+
+boolean-true = tuu
+boolean-false = falisi
+
+
+answer-submit-label = Luku di wooko
+
+answer-submit-label-no-correctness = Manda di piki
+
+
+section-name =
+    .activity = Aktiviteiti
+    .aside = Sei-toli
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Ezempu
+    .exercise = Oefeni
+    .exercises = Dee oefeni
+    .given-answer = Piki
+    .note = Nota
+    .objectives = Dee dulu
+    .paragraphs = Palagaaf
+    .part = Pisi
+    .problem = Pooblema
+    .problems = Dee pooblema
+    .proof = Beweisi
+    .question = Hakisi
+    .section = Seksi
+    .solution = Lusu
+    .task = Opodakiti
+    .theorem = Teolema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Tipi
+
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figuu { $enumeration }
+        [numbered-caption] Figuu { $enumeration }{ ": " }
+        [unnumbered-caption] Figuu{ ": " }
+       *[unnumbered] Figuu
+    }
+
+
+paginator-previous = Baka
+paginator-next = Fesi
+paginator-page = Pagina
+
+paginator-page-status = { $pageLabel } { $currentPage } u { $numPages }
+
+
+piecewise-condition-or = ofu
+
+piecewise-condition-if = ee
+
+piecewise-condition-otherwise = ee á de so
+
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Di kemi-maiki á bunu
+chemistry-invalid-ionic-compound = Di ioniki mokisisoni á bunu
+
+
+math-embedded-input-blank = lëigi peesi
+
+math-embedded-input-blank-ordinal = lëigi peesi { $ordinal } u { $total }

--- a/packages/i18n/locales/srm/diagnostics.ftl
+++ b/packages/i18n/locales/srm/diagnostics.ftl
@@ -1,0 +1,691 @@
+# Saramaccan (Saamáka tongo) diagnostics: the errors and warnings the worker,
+# the parser and the language server put in front of whoever is looking at the
+# screen. Translated from `locales/en/diagnostics.ftl`, which is the source of
+# truth; the ids are reached by diagnostic code and are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Saramaccan orthography of the Rountree /
+# Glock dictionary and of the Saramaccan scriptures: seven vowel letters
+# `a e ë i o ö u` (`ë` U+00EB and `ö` U+00F6 are letters of the alphabet); a
+# doubled vowel writes length; **nasality is written with an `n` after the
+# vowel**, that `n` belonging to the vowel; prenasalized `mb`, `nd`, `ng`;
+# `tj` and `dj` for the palatal affricates; initial `h` («hopo», «hakisi»,
+# «hii»). `chrome.ftl`'s header sets the system out point by point.
+#
+# **Tone is NOT written in this catalog, and that is a real loss.** Saramaccan
+# is a tone language; the dictionary and the scriptures mark tone with
+# accents, and tone distinguishes words otherwise spelled alike. All four
+# files leave it unmarked. The only accented letter outside `ë` and `ö` is
+# **«á», the preverbal negator**, spelled with its accent because that is the
+# negator's spelling and not a tone mark.
+#
+# **Grammar.** The preverbal markers are «ta» (imperfective), «bi» (past),
+# «o» (future), «sa» (able), «musu» (must); «á» negates and precedes them;
+# «ku» is *and* and *with*; «u» / «fu» is the purposive; «dee» is the plural.
+# Ndyuka, in `locales/djk`, is a different language with a different marker
+# set, and these are not two spellings of one text.
+#
+# **DoenetML identifiers stay in English.** Tag names, attribute names and
+# attribute values — `through`, `endpoint`, `midpointOffset`, `numDimensions`,
+# `maxNumAttempts`, `symbolicEquality`, `math`, `text`, `number`, `boolean`,
+# `none`, `medium`, `dense`, `from`, `to`, `step` — are the language, not
+# prose, and are written here exactly as English writes them, as is the
+# `[deprecation]` marker.
+#
+# **Number.** `Intl.PluralRules("srm")` has no CLDR data for `srm` and falls
+# back to English. A Saramaccan noun after a numeral does not inflect, so
+# every message English selects on a count —
+# `line-segment-attributes-ignored-*`,
+# `function-domain-insufficient-dimensions`,
+# `function-iterates-input-output-mismatch`,
+# `matches-pattern-parameter-not-in-pattern`,
+# `answer-attributes-need-symbolic-equality`, `attribute-invalid-values` — is
+# written here as **one unselected form**. The one remaining `[one]` branch,
+# in `field-function-wrong-num-outputs`, is not a plural: it picks between two
+# different sentences about what a slope field and a vector field each need,
+# and dropping it would drop the advice.
+#
+# **Loans.** Dutch and English reshaped to Saramaccan phonology:
+# «komponenti», «atibut», «waalde», «dokumenti», «vesi», «vaaliant»,
+# «indeksi», «palamita», «ekispesi», «funsi», «matiiksi», «sekwensi»,
+# «dimensi», «kontaasi», «anotasi», «sikema», «lefeensi», «fowtu». The
+# Portuguese stratum carries what it carries: «kaba», «kuma», «ku», «sikifi»,
+# «pooba», «manda», «ezempu». Saramaccan's own words carry the sentences:
+# «á sa» (*cannot*), «musu» (*must*), «feni» (*find*), «tei», «buta», «puu»,
+# «lei» (*show*), «tëli» (*count*), «bunu» / «á bunu».
+#
+# **Confidence.** Saramaccan has no written technical prose of this kind, so
+# every loan above is a shape derived by rule rather than one found in use.
+# What a reviewer should read for is the grammar: «ta» / «bi» / «o» / «sa» /
+# «musu», the negator «á» in front of them, and «ku» for *and*. Nothing here
+# was left in English.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } á ta tëli te tu endpoint buta
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } á ta tëli te wan endpoint ku wan midpoint buta hii tu
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset á ta du soni ee na wan midpoint á dë
+
+## `<line>`
+
+line-points-undetermined-dimensions = Di lin ta pasa punti di u á sabi ömëni dimensi de abi.
+
+line-points-too-few-dimensions = Di lin musu pasa punti di abi tu dimensi ofu möön.
+
+line-points-depend-on-variables = Di lin ta pasa punti di ta hanga dee vaaliabel aki: { $variables }.
+
+line-equation-invalid-format = Di foomati u di ekwasi u di lin a dendu dee vaaliabel { $variable1 } ku { $variable2 } á bunu.
+
+## `<ray>`
+
+ray-overprescribed-through = Di sitaali buta ku through, endpoint ku direction.  U á ta tëli di through di buta.
+
+ray-dimension-mismatch = Di numDimensions á ta fiti a dendu di sitaali.
+
+## `<vector>`
+
+vector-overprescribed-head = Di vekitoo buta ku head, tail ku displacement.  U á ta tëli di head di buta.
+
+vector-dimension-mismatch = Di numDimensions á ta fiti a dendu di vekitoo.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = U á sa hali go a wan `<{ $component }>` biga a á abi wan nearestPoint stati-vaaliabel.
+
+constrain-to-without-nearest-point = U á sa tai go a wan `<{ $component }>` biga a á abi wan nearestPoint stati-vaaliabel.
+
+constrain-to-interior-without-nearest-point = U á sa tai go a dendu wan `<{ $component }>` biga a á abi wan nearestPoint stati-vaaliabel.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition á ta tëli a wan choiceInput di á da inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = U á ta tëli dee indices di buta da di choiceInput biga di nömbo u dee indices á ta fiti di nömbo u dee choice mii.
+
+pretzel-indices-count-mismatch = U á ta tëli dee indices di buta da di problem biga di nömbo u dee indices á ta fiti di nömbo u dee problem mii.
+
+shuffle-indices-count-mismatch = U á ta tëli dee indices di buta da di shuffle biga di nömbo u dee indices á ta fiti di nömbo u dee komponenti.
+
+indices-ignored-out-of-range = U á ta tëli dee indices di buta da { $component } biga so u de dë a doo u di peesi.
+
+pretzel-indices-repeated = U á ta tëli dee indices di buta da di pretzel biga so u de dë tu kaba.
+
+pretzel-circuit-first-index = U á ta tëli dee indices di buta da di pretzel a dendu circuit fasi biga di fosu indeksi musu da 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = U `<{ $component }>` sa wooko ku sitingi mii, i musu buta wan `type` atibut.
+
+invalid-type-defaulting-to-math = Di type { $type } á bunu da wan { $component } komponenti. A musu da math, text, number ofu boolean. U o tei math.
+
+string-not-valid-component-to-arrange = Di sitingi "{ $value }" á da wan bunu komponenti u { $component }. U á ta tëli ën.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Di type { $type } á bunu, nöö u ta seti di type a number.
+
+invalid-variable-value = Di waalde u wan vaaliabel á bunu: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Di vaaliant-indeksi { $index } musu da wan nömbo
+
+variant-index-must-be-integer = Di vaaliant-indeksi { $index } musu da wan hii nömbo
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` á mbei da abesoluut maiki. U ta seti dee bëëdë a relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` á mbei da abesoluut maiki. U ta seti dee kanti a relatif.
+
+side-by-side-no-block-child = Di `<{ $component }>` aki á bunu: a musu abi wan blaka mii ofu möön.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Di `for` atibut á ta tëli a wan gaafiki `<label>`.
+
+label-for-must-resolve-to-one = Di `for` atibut a wan `<label>` musu lei wan komponenti nöö.
+
+label-for-unresolved = Di `for` atibut a wan `<label>` á sa feni na wan komponenti.
+
+label-for-answer-with-authored-inputs = Di `for` atibut a wan `<label>` ta lei wan `<answer>` di abi ën eigi inputu sikifi; lei di inputu seei.
+
+label-for-answer-without-input = Di `for` atibut a wan `<label>` ta lei wan `<answer>` di á abi na wan inputu u dëën nen.
+
+label-for-must-reference-input-or-answer = Di `for` atibut a wan `<label>` musu lei wan inputu ofu wan answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = U di aksesibiliteiti, wan `<{ $component }>` musu abi wan sooti deskiipsi ofu a musu buta kuma decorative.
+
+accessibility-video-short-description = U di aksesibiliteiti, wan `<video>` musu abi wan sooti deskiipsi.
+
+accessibility-input-short-description-or-label = U di aksesibiliteiti, wan `<{ $component }>` musu abi wan sooti deskiipsi ofu wan nen.
+
+accessibility-answer-input-short-description-or-label = U di aksesibiliteiti, wan `<answer>` di ta mbei wan inputu musu abi wan sooti deskiipsi ofu wan nen.
+
+accessibility-short-description-contains-math = Sooti deskiipsi á musu abi matematika-komponenti kuma `<{ $component }>` a dendu. Sikifi di matematika ku buka.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } á abi nöfu kontaasi da di seksi-hedi tëkisi (dark fasi) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanöudu { $threshold }:1 ofu möön).
+       *[other] { $colorName } á abi nöfu kontaasi da di seksi-hedi tëkisi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanöudu { $threshold }:1 ofu möön).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = U á mbei wan `<circle>` di ta pasa { $count } punti ete da di situwasi ka dee punti á abi nömbo-waalde.
+
+circle-too-many-through-points = U á sa wooko wan lontu di ta pasa möön kuma 3 punti.
+
+circle-overprescribed-radius-center-points = U á sa wooko wan lontu te radius, center ku through-punti buta hii dii.
+
+circle-center-with-multiple-points = U á sa wooko wan lontu ku wan center di buta di ta pasa möön kuma 1 punti.
+
+circle-radius-too-small = U á sa wooko di lontu: di pasi mindi dee tu punti da { $distance }, nöö di radius { $radius } di buta piki tuutuu.
+
+circle-radius-with-many-points = U á sa mbei wan lontu di ta pasa möön kuma tu punti ku wan radius di buta.
+
+circle-invalid-center-or-through-points = Di center ofu dee through-punti u di lontu á bunu.
+
+circle-radius-center-with-multiple-points = U á sa wooko di radius u wan lontu ku wan center di buta di ta pasa möön kuma 1 punti.
+
+circle-change-radius-non-numerical = U á sa kambia di radius u wan lontu di abi through-punti di á abi nömbo-waalde
+
+circle-radius-with-points-non-numerical = U á sa mbei wan lontu di ta pasa möön kuma wan punti ku wan radius di buta te dee punti á abi nömbo-waalde.
+
+circle-change-center-non-numerical = U á mbei wan fasi ete u kambia di center u wan lontu di ta pasa punti di á abi nömbo-waalde.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Di domein á abi nöfu dimensi da di funsi. Di domein abi { $intervals } intavalu ma di funsi abi { $inputs } inputu.
+
+function-domain-invalid-format = Di foomati u di domein u di funsi á bunu.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] U á ta tëli di möön hei punti u di funsi biga a á da wan nömbo.
+        [minimum] U á ta tëli di möön basu punti u di funsi biga a á da wan nömbo.
+        [extremum] U á ta tëli di ekisteemu u di funsi biga a á da wan nömbo.
+        [point] U á ta tëli di punti u di funsi biga a á da wan nömbo.
+        [slope] U á ta tëli di helin u di funsi biga a á da wan nömbo.
+       *[other] U á ta tëli di { $type } u di funsi biga a á da wan nömbo.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] U á ta tëli di möön hei punti u di funsi biga a lëigi.
+        [minimum] U á ta tëli di möön basu punti u di funsi biga a lëigi.
+        [extremum] U á ta tëli di ekisteemu u di funsi biga a lëigi.
+        [point] U á ta tëli di punti u di funsi biga a lëigi.
+       *[other] U á ta tëli di { $type } u di funsi biga a lëigi.
+    }
+
+function-points-too-close = Di funsi abi tu punti di dë tuutuu kandi u makandi. U á sa mbei di funsi.
+
+function-iterates-input-output-mismatch = Funsi-itelasi sa wooko nöö ee di nömbo u dee inputu da di seei kuma di nömbo u dee outputu. Di funsi aki abi { $inputs } inputu ku { $outputs } outputu.
+
+## `<sequence>`
+
+sequence-invalid-length = Di longi u di sekwensi á bunu.  A musu da wan hii nömbo di á negatif.
+
+sequence-invalid-step = Di step u di sekwensi á bunu.  A musu da wan nömbo da wan sekwensi u type { $type }.
+
+sequence-invalid-endpoint-number = Di "{ $attribute }" u di nömbo-sekwensi á bunu.  A musu da wan nömbo.
+
+sequence-invalid-endpoint-letters = Di "{ $attribute }" u di letu-sekwensi á bunu.  A musu da wan mokisi u letu.
+
+sequence-invalid-endpoint = Di "{ $attribute }" u di sekwensi á bunu.
+
+select-from-sequence-coprime-not-numbers = u á ta tëli coprime biga u á ta tei nömbo
+
+select-from-sequence-coprime-with-exclude-combinations = u á ta tëli coprime biga excludeCombinations buta
+
+## Resolving a `target`
+
+target-not-found = Di target da `<{ $source }>` á bunu: u á sa feni di target.
+
+target-state-variable-not-found = Di target da `<{ $source }>` á bunu: u á sa feni na wan stati-vaaliabel di nen "{ $property }" a wan `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Dee vaaliabel u wan `<odeSystem>` musu da woto fasi kuma di onafanki vaaliabel.
+
+ode-system-duplicate-variable-names = U á sa mbei ODE RHS funsi ku di seei dependenti vaaliabel-nen tu kaba.
+
+ode-system-rhs-function-error = U á sa mbei di ODE RHS funsi.  Fowtu di u bi ta mbei di mathjs funsi.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = U á sa mbei wan uku mindi { $count } lin
+
+angle-invalid-through-point = Di punti a dendu di through u di `<angle>` á bunu
+
+parabola-vertex-too-many-points = U á mbei wan palabola ku wan vertex di ta pasa möön kuma 1 punti ete.
+
+parabola-too-many-points = U á mbei wan palabola di ta pasa möön kuma 3 punti ete.
+
+intersection-too-many-items = U á mbei intaseksi da möön kuma tu soni ete
+
+## Other math components
+
+ionic-compound-not-two-ions = U á mbei na wan ioniki mokisisoni da wan woto soni boiti tu ion ete.
+
+ionic-compound-needs-cation-and-anion = U ta mbei ioniki mokisisoni nöö da wan kation ku wan anion.
+
+solve-equations-cannot-evaluate = U á sa lusu di ekwasi biga u á sa wooko ën: { $equation }
+
+math-operators-operand-number-required = I musu buta wan operandNumber te i ta puu wan matematika-operanti.
+
+eigen-decomposition-failed = U á sa wooko dee eigenwaalde u di matiiksi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: di palamita { $parameters } á dë a dendu di patoon, nöö a o fiti wan lëigi peesi hii yuu.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: u á sa fusutan grid="{ $grid }". A musu da none, medium, dense, ofu tu positif nömbo ku wan peesi mindi de, kuma grid="1 0.5". U á ta tei na wan grid.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` abi fanöudu wan funsi ku { $expected ->
+        [one] wan outputu, di helin y' a hiniwan punti, kuma `y - x`
+       *[other] tu outputu, di vekitoo a hiniwan punti, kuma `(y, -x)`
+    }, ma di funsi di a kisi abi { $found } outputu. { $alternative ->
+        [none] U á ta tei na wan soni.
+       *[other] `<{ $alternative }>` da di komponenti da di funsi dati. U á ta tei na wan soni.
+    }
+
+field-function-attribute-ignored-with-child = U á ta tëli di `function` atibut biga di funsi dë a dendu di komponenti tu; u ta tei di wan di dë a dendu. Da di funsi wan u dee tu fasi nöö.
+
+field-variables-ignored =
+    `<{ $component }>`: di `variables` atibut ta nen dee vaaliabel u wan ekispesi di sikifi a dendu di komponenti seei. { $reason ->
+        [function-child] Di funsi aki da kuma wan `<function>` mii, di ta nen ën eigi vaaliabel, nöö u á ta tëli `variables`.
+       *[no-expression] Na wan söwan ekispesi á dë aki, nöö u á ta tëli `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: di prefigure renderer á ta tei xLabelPosition="left"; u o wooko kuma right.
+
+prefigure-y-label-position-unsupported = `<graph>`: di prefigure renderer á ta tei yLabelPosition="bottom"; u o wooko kuma top.
+
+prefigure-invalid-axis-bounds = `<graph>`: dee asi-maiki á bunu da di prefigure kambia; u o tei di difoolti bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: di bëëdë á bunu da di prefigure kambia; u o tei di difoolti diagram-bëëdë 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: di aspectRatio á bunu da di prefigure kambia; u o tei di difoolti aspek-ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: di grid-peesi fini tuutuu da dee asi-maiki; u ta disa di grid a doo a dendu di prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: u á o tei na wan anotasi ee u á ta wooko ku di PreFigure renderer.
+
+multiple-annotations-children = U feni möön kuma wan `<annotations>` mii a dendu di `<graph>`: u á ta tëli de hii boiti di laasi wan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = U á sa langa ofu kopi wan komponenti-sootu di u á sabi: { $type }.
+
+copy-prop-not-found = U á sa feni di prop { $property } a wan komponenti u sootu { $component }
+
+collect-no-source = U á feni na wan source da di collect.
+
+collect-invalid-component-type = U á sa kolekiti komponenti u sootu `<{ $component }>` biga dati á da wan bunu komponenti-sootu.
+
+reference-index-unavailable = U á sa lei di indeksi `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = U á sa kai { $action } a di komponenti `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Di fomu u di data á bunu.  Dee lo á abi di seei longi. Feni a dendu componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Di data abi di seei kolon-nen tu kaba.  Feni a dendu componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kolon-nen mankei a dendu di data.  Feni a dendu componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award da di piki aki ta hanga di answer tag ën eigi piki di manda, nöö soni o pasa di i á o fusutan.
+
+answer-max-num-attempts-in-section-wide-check-work = Ee i seti `maxNumAttempts` a wan `<answer>` a dendu wan bokisi di abi `sectionWideCheckWork`, a á ta du soni, biga di bokisi ta tii di nömbo u dee pooba. Seti `maxNumAttempts` a di bokisi.
+
+nested-section-wide-check-work-max-num-attempts = Ee i seti `maxNumAttempts` a wan bokisi di abi `sectionWideCheckWork` di dë a dendu wan woto bokisi di abi `sectionWideCheckWork`, a á ta du soni, biga di bokisi a doose ta tii di nömbo u dee pooba. Seti `maxNumAttempts` a di bokisi a doose.
+
+answer-attributes-need-symbolic-equality = Di { $attributes } atibut á o du soni ee symbolicEquality á seti.
+
+answer-invalid-type = Di sootu da di piki á bunu: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Biga di komponenti `<{ $component }>` á abi na wan nen, u á sa wooko ën da wan module atibut
+
+module-attribute-name-already-defined = U á sa wooko di komponenti `<{ $component } name="{ $name }">` kuma wan atibut da wan module biga di `<module>` komponenti-sootu abi wan "{ $name }" atibut kaba.
+
+conditional-content-condition-ignored = Di atibut `condition` á ta tëli a wan `<conditionalContent>` komponenti di abi case ofu else mii.
+
+slider-markers-type-mismatch = Di maiki-sootu á ta fiti di slider-sootu.
+
+pretzel-problem-needs-statement-and-answer = Di pretzel aki á bunu: hiniwan `<problem>` musu abi wan `<statement>` ku wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Di pretzel aki á bunu: a dendu mode="circuit", di fosu `<problem>` á sa da wan distractor.
+
+## Attribute values
+
+attribute-invalid-values = Di waalde { $values } da di atibut `{ $attribute }` á bunu; u á ta tëli ën.
+
+attribute-must-be-references = Di waalde `{ $value }` da di atibut `{ $attribute }` á bunu. Di atibut musu mbei u lefeensi di ta bigi ku wan `$`.
+
+math-input-invalid-function-names = <mathInput>: u á ta tëli funsi-nen di á bunu a dendu { $attribute }: { $names }. Hiniwan nen ën lei-pisi musu abi tu tëkin ofu möön (letu ofu sitëëpi); wan `|<mathspeak alternative>` sa ko a ën baka ee i kë.
+
+## Building components from the source
+
+component-type-invalid = Di komponenti-sootu aki á bunu: `<{ $componentType }>`
+
+attribute-repeated = I á sa buta di atibut { $attribute } tu kaba.
+
+attribute-invalid-for-component = Di atibut "{ $attribute }" á bunu da wan komponenti u sootu `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Sitali-definisi { $styleNumber } á abi nöfu kontaasi da { $context ->
+        [text-on-background] di tëkisi-kulo agensi di bakagoon-kulo
+        [high-contrast] di hei-kontaasi kulo agensi di kanvasi
+        [line] di lin-kulo agensi di kanvasi
+        [marker] di maiki-kulo agensi di kanvasi
+       *[text-on-canvas] di tëkisi-kulo agensi di kanvasi
+    }{ $mode ->
+        [dark] { " (dark fasi)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanöudu { $threshold }:1 ofu möön).
+
+style-definition-dark-mode-text-background-contrast =
+    Aladi sitali-definisi { $styleNumber } buta kulo di abi nöfu kontaasi da light fasi, dee dark-fasi kulo di ko u de á abi nöfu kontaasi da di tëkisi-kulo agensi di bakagoon-kulo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanöudu { $threshold }:1 ofu möön). { $suggestion ->
+        [available] U abi nöfu kontaasi a dendu dark fasi, mbei di light-fasi kontaasi möön gaan (kuma ezempu, seti { $lightAttribute }="{ $lightColor }") ofu kambia di dark-fasi kulo (kuma ezempu, seti { $darkAttribute }="{ $darkColor }").
+       *[none] U abi nöfu kontaasi a dendu dark fasi, mbei di light-fasi kontaasi möön gaan ofu kambia dee kulo di ko u de ku textColorDarkMode ku/ofu backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Aladi sitali-definisi { $styleNumber } buta wan tëkisi-kulo di abi nöfu kontaasi da light fasi, di dark-fasi tëkisi-kulo di ko u ën á abi nöfu kontaasi agensi di kanvasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanöudu { $threshold }:1 ofu möön). { $suggestion ->
+        [available] U abi nöfu kontaasi a dendu dark fasi, mbei di light-fasi kontaasi möön gaan (kuma ezempu, seti textColor="{ $lightColor }") ofu kambia di dark-fasi kulo (kuma ezempu, seti textColorDarkMode="{ $darkColor }").
+       *[none] U abi nöfu kontaasi a dendu dark fasi, mbei di light-fasi kontaasi möön gaan ofu kambia di kulo di ko u ën ku textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan seksi sa tei wan <stylePalette> nöö; u ta tei di laasi wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = u á sa wooko dee apaiti vaaliant u { $component } biga numToSelect á da wan hii nömbo di á negatif.
+
+variant-num-to-select-not-constant-number = u á sa wooko dee apaiti vaaliant u { $component } biga numToSelect á da wan konstanti nömbo.
+
+variant-with-replacement-not-constant-boolean = u á sa wooko dee apaiti vaaliant u { $component } biga withReplacement á da wan konstanti boolean.
+
+variant-select-weight-disables-unique = Dee apaiti vaaliant da select ta tapa ee wan opsi abi selectWeight ofu selectForVariants buta
+
+variant-coprime-undetermined = u á sa wooko dee apaiti vaaliant u { $component } biga u á sa sabi ee coprime da falisi hii yuu.
+
+variant-attribute-not-constant = u á sa wooko dee apaiti vaaliant u { $component } biga { $attribute } á da konstanti.
+
+variant-attribute-not-number = u á sa wooko dee apaiti vaaliant u { $component } biga { $attribute } á da wan nömbo.
+
+variant-attribute-wrong-type-for-sequence =
+    u á sa wooko dee apaiti vaaliant u { $component } u { $type } sootu biga { $attribute } á da { $expected ->
+        [letters-combination] wan mokisi u letu
+        [math-expression] wan bunu matematika-ekispesi
+        [integer] wan hii nömbo
+       *[number] wan nömbo
+    }.
+
+variant-length-not-integer = u á sa wooko dee apaiti vaaliant u { $component } biga di length á da wan hii nömbo.
+
+variant-sort-not-implemented = u á mbei apaiti vaaliant da wan { $component } ku sort ete
+
+variant-exclude-combinations-not-implemented = u á mbei apaiti vaaliant da wan { $component } ku excludeCombinations ete
+
+variant-math-exclude-not-implemented = u á mbei apaiti vaaliant da wan { $component } u sootu math ku exclude ete
+
+variant-non-constant-exclude-not-implemented = u á mbei apaiti vaaliant da wan { $component } ku wan exclude di á konstanti ete
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: di graph prefigure renderer á ta tei disi; u ta pasa di bakamii.
+
+prefigure-descendant-invalid-geometry = { $subject }: di jometi á finiti ofu a á kaba; u ta pasa di bakamii.
+
+prefigure-curve-label-omitted = { $subject }: nen á ta wooko a kookotu lin di kambia; u ta disa di nen a doo.
+
+prefigure-curve-unsupported-definition-type = { $subject }: u á ta tei di kookotu-lin funsi-definisi sootu '{ $definitionType }'; u ta pasa di bakamii.
+
+prefigure-region-flip-functions-unsupported = { $subject }: u á ta tei di flipFunctions atibut a regionBetweenCurves; u ta pasa di bakamii.
+
+prefigure-region-non-formula-child = { $subject }: fomula-sootu mii funsi nöö ta wooko a regionBetweenCurves; u ta pasa di bakamii.
+
+prefigure-label-position-unsupported =
+    { $subject }: u á ta tei labelPosition '{ $labelPosition }' da wan { $labelKind ->
+        [line-family] lin-famii nen
+       *[point] punti-nen
+    }; u ta tei di difoolti PreFigure fasi.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure á ta tei di fuu-sitali '{ $fillStyle }'; u o tei wan sölufu fuu.
+
+prefigure-line-style-unknown = { $subject }: u ta disa di lin-sitali '{ $lineStyle }' di u á sabi a doo u di PreFigure outputu.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: u kambia di maiki-sitali '{ $markerStyle }' go a dendu di PreFigure sitali 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure á ta tei di maiki-sitali '{ $markerStyle }'; u ta tei di difoolti sitali.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: di `ref` á bunu; u á sa feni di target. U ta disa di anotasi a doo.
+
+annotation-ref-multiple-targets = `<annotation>`: di `ref` ta lei möön kuma wan target; u ta tei di fosu wan.
+
+annotation-ref-outside-graph = `<annotation>`: di `ref` á bunu; di target dë a doose u di graph. U ta disa di anotasi a doo.
+
+annotation-ref-unsupported-target = `<annotation>`: di `ref` á bunu; di target á da wan gaafiki soni di di prefigure kambia ta tei. U ta disa di anotasi a doo.
+
+annotation-text-missing = `<annotation>`: di `text` mankei ofu a lëigi; u o puu lëigi tëkisi.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] U feni wan lontu dependensi.
+       *[other] U feni wan lontu dependensi di ta hanga wan `<{ $componentType }>` komponenti.
+    }
+
+reference-no-referent = U á feni na wan soni di di lefeensi aki ta lei: `{ $reference }`
+
+reference-multiple-referents = U feni möön kuma wan soni di di lefeensi aki ta lei: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Di foomati u di atibut { $attribute } u `<{ $componentType }>` á bunu.
+
+children-invalid = Dee mii da `<{ $componentType }>` á bunu: u feni mii di á bunu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Di waalde `{ $value }` da di atibut `{ $attribute }` á bunu, nöö u ta tei di waalde `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] U á feni DoenetML vesi { $version }.
+       *[other] U á feni DoenetML vesi { $version }. U o tei vesi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Di DoenetML aki á bunu: { $content }
+
+parse-tag-missing-close-tag = Di DoenetML aki á bunu: Di tag `{ $tag }` á abi na wan tapa-tag. U bi ta fuuwakiti wan tag di ta tapa ënseei ofu wan `</{ $tagName }>` tag.
+
+parse-tag-error = Di DoenetML aki á bunu: Fowtu a dendu di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Di DoenetML aki á bunu: Di atibut `{ $attribute }` á bunu — a gei taa wan waalde mankei.
+
+parse-attribute-invalid = Di DoenetML aki á bunu: Di atibut `{ $attribute }` á bunu
+
+parse-attribute-value-invalid = Di DoenetML aki á bunu: Di atibut-waalde `{ $value }` á bunu
+
+parse-attribute-value-quote-mismatch = Di DoenetML aki á bunu: Di atibut-waalde `{ $value }` á bunu. Dee koti-maiki á ta fiti makandi. A gei taa wan `{ $quote }` mankei.
+
+parse-open-tag-name-missing = Di DoenetML aki á bunu: U feni wan tag sondee tag-nen, kuma `<`
+
+parse-tag-not-closed = Di DoenetML aki á bunu: Di tag `{ $tag }` á tapa (a gei taa wan `>` mankei).
+
+parse-self-closing-tag-name-missing = Di DoenetML aki á bunu: U feni wan tag sondee tag-nen `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Di DoenetML aki á bunu: Di tag `{ $tag }` á tapa (a gei taa `/>` mankei).
+
+parse-tag-invalid-attributes = Di DoenetML aki á bunu: Di tag `{ $tag }` á bunu. A sa abi fowtu atibut.
+
+parse-close-tag-name-missing = Di DoenetML aki á bunu: U feni wan tapa-tag sondee tag-nen, kuma `</`
+
+parse-attribute-value-unquoted = Atibut-waalde musu dë a dendu koti-maiki: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Di DoenetML aki á bunu: U feni di tapa-tag `{ $tag }`, ma na wan hopo-tag á dë da ën
+
+parse-close-tag-mismatched = Di DoenetML aki á bunu: Di tapa-tag á ta fiti. U bi ta fuuwakiti `</{ $expected }>`. U feni `{ $found }`
+
+parser-node-unconvertible = U á sa kambia di nodu { $node } go a wan Dast nodu.
+
+## Names
+
+name-attribute-invalid =
+    Di atibut name='{ $name }' á bunu. { $reason ->
+        [characters] Nen sa abi letu, nömbo, ondooteki ofu sitëëpi nöö.
+       *[start] Nen musu bigi ku wan letu.
+    }
+
+component-name-invalid-start = Di komponenti-nen "{ $name }" á bunu. Nen musu bigi ku wan letu.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Wan answer u sootu videoWatched musu abi wan video atibut
+
+answer-video-watched-video-not-reference = Wan answer u sootu videoWatched musu abi wan video atibut di da wan lefeensi
+
+answer-name-not-single-text = Di answer name atibut musu abi wan tëkisi-mii nöö
+
+## Referencing another document
+
+external-doenetml-recursion-limit = U á sa kisi di doose DoenetML biga tuutuu sömëni lo u lekursi. Wan lontu lefeensi dë?
+
+external-doenetml-unavailable = U á sa kisi na wan DoenetML u { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Di DoenetML di u kisi u { $attribute }="{ $uri }" á bunu: a á ta fiti di komponenti-sootu "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Di atibut `{ $from }` á ta wooko möön; wooko `{ $to }` a ën peesi.
+       *[other] [deprecation] Di atibut `{ $from }` a `<{ $component }>` á ta wooko möön; wooko `{ $to }` a ën peesi.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Di atibut `{ $from }` á ta wooko möön, nöö u á ta tëli ën, biga `{ $to }` buta tu.
+       *[other] [deprecation] Di atibut `{ $from }` a `<{ $component }>` á ta wooko möön, nöö u á ta tëli ën, biga `{ $to }` buta tu.
+    }
+
+deprecated-attribute-ignored = [deprecation] Di atibut `{ $attribute }` a `<{ $component }>` á ta wooko möön, nöö u á ta tëli ën.
+
+deprecated-attribute-to-child = [deprecation] Di atibut `{ $attribute }` a `<{ $component }>` á ta wooko möön; wooko wan `<{ $child }>` mii a ën peesi.
+
+deprecated-attribute-value-renamed = [deprecation] Di waalde `{ $value }` u di atibut `{ $attribute }` a `<{ $component }>` á ta wooko möön; wooko `{ $to }` a ën peesi.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` sa mbei Ingiisi buka ko sömëni nöö, nöö di tëkisi u ën ta tan di seei a dendu wan dokumenti di sikifi a dendu { $locale }. Sikifi di sömëni-fasi seei, ofu buta ën ku di `pluralForm` atibut.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Di elementi `<{ $tag }>` á da wan Doenet elementi di u sabi.
+
+schema-element-not-allowed-at-root = Di elementi `<{ $tag }>` á sa dë a di lutu u di dokumenti.
+
+schema-element-not-allowed-inside = Di elementi `<{ $tag }>` á sa dë a dendu `<{ $parent }>`.
+
+schema-attribute-unrecognized = Di elementi `<{ $tag }>` á abi na wan atibut di nen `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Di atibut `{ $attribute }` u di elementi `<{ $tag }>` musu da wan lisi ka hiniwan soni da wan u dee aki: { $allowed }
+       *[other] Di atibut `{ $attribute }` u di elementi `<{ $tag }>` musu da wan u dee aki: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Di vaaliant-nen da di select á bunu.  Di vaaliant-nen { $variantName } dë a dendu { $numOptions } opsi ma di nömbo u tei da { $numToSelect }.
+
+select-variant-name-without-options = So vaaliant buta da di select ma na wan opsi á buta da di vaaliant-nen: { $variantName }.
+
+select-variant-name-not-possible = Di vaaliant-nen { $variantName } di buta da di select á da wan vaaliant-nen di sa dë.
+
+select-too-few-options = U á sa tei { $numToSelect } komponenti u { $numOptions } nöö.
+
+select-from-sequence-too-few-values = U á sa tei { $numToSelect } waalde u wan sekwensi di longi { $length }.
+
+select-from-sequence-indices-count-mismatch = Di nömbo u dee indices di buta da di select musu fiti di nömbo u tei
+
+select-from-sequence-indices-not-integers = Hii dee indices di buta da di select musu da hii nömbo
+
+select-from-sequence-index-excluded = Wan indeksi u selectfromsequence buta di bi puu a doo
+
+select-from-sequence-indices-excluded-combination = Dee indices u selectfromsequence di buta bi da wan mokisi di puu a doo
+
+select-from-sequence-coprime-not-positive-integers = U á sa tei koopime mokisi biga u á ta tei positif hii nömbo.
+
+select-from-sequence-coprime-common-factor = U á sa tei koopime nömbo. Hii dee waalde abi di seei fakitoo. (Dee waalde di buta da "from" ofu "to" musu da koopime ku "step".)
+
+select-from-sequence-coprime-single-number = U á sa tei koopime mokisi u wan nömbo nöö di á da 1.
+
+select-from-sequence-excluded-too-many-combinations = Möön kuma 70% u dee mokisi a dendu selectFromSequence bi puu a doo
+
+select-from-sequence-coprime-none-found = U á sa tei koopime nömbo. Hii dee waalde abi di seei fakitoo.
+
+select-from-sequence-too-few-unique-values = U á sa tei { $numToSelect } apaiti waalde u wan sekwensi di longi { $numPossibleValues }
+
+select-prime-numbers-too-few-values = U á sa tei { $numToSelect } waalde u wan lisi u paim nömbo di longi { $numValues }
+
+select-prime-numbers-values-count-mismatch = Di nömbo u dee waalde di buta da di select musu fiti di nömbo u tei
+
+select-prime-numbers-values-not-prime = Hii dee waalde di buta da select paim nömbo musu dë a dendu di lisi u paim nömbo
+
+select-prime-numbers-values-excluded-combination = Dee waalde u selectPrimeNumbers di buta bi da wan mokisi di puu a doo
+
+select-prime-numbers-excluded-too-many-combinations = Möön kuma 70% u dee mokisi a dendu selectPrimeNumbers bi puu a doo
+
+select-random-combination-fluke = Ku wan kansi di haa haa ta pasa, u á sa tei wan mokisi u lukuluku waalde
+
+select-random-value-fluke = Ku wan kansi di haa haa ta pasa, u á sa tei wan lukuluku waalde
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    U á ta tei di `<{ $component }>` a dendu di matematika; u ta seti di ekispesi kuma fa a bi dë fosu inputu bi sa go a dendu. { $reason ->
+        [not-inline] Wan `inline` choice inputu nöö ta fiti a dendu wan ekispesi; sondee `inline` a da wan blaka u kanapu.
+        [expanded] Wan `expanded` tëkisi inputu da wan bokisi ku möön kuma wan lin, nöö a gaan tuutuu u sindo a dendu wan ekispesi.
+        [on-graph] A wan graph, u ta tei di ekispesi kuma wan pentje nöö, nöö na wan peesi á dë da wan kanapu.
+       *[relative-width] Ën `width` da relatif (wan pesenti ofu `em`), nöö na soni á dë u maiki ën agensi a dendu wan ekispesi. Da di bëëdë a dendu abesoluut maiki, kuma `px`.
+    }

--- a/packages/i18n/locales/srm/editor.ftl
+++ b/packages/i18n/locales/srm/editor.ftl
@@ -1,0 +1,224 @@
+# Saramaccan (Saamáka tongo) editor and language-server surfaces: the footer,
+# the diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel. Translated from `locales/en/editor.ftl`, which is the
+# source of truth.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The standard Saramaccan orthography of the Rountree / Glock
+# dictionary and of the Saramaccan scriptures: seven vowel letters `a e ë i o
+# ö u` (`ë` U+00EB and `ö` U+00F6 are letters, not decorated `e` and `o`); a
+# doubled vowel writes length; **nasality is written with an `n` after the
+# vowel**; prenasalized `mb`, `nd`, `ng`; `tj` and `dj`; initial `h`
+# («hopo», «hakisi», «hii»). `chrome.ftl`'s header sets the system out point
+# by point.
+#
+# **Tone is NOT written in this catalog, and that is a real loss.** Saramaccan
+# is tonal, the dictionary and the scriptures mark tone with accents, and
+# these four files leave it unmarked throughout. The only accented letter
+# outside `ë` and `ö` is **«á», the preverbal negator**, spelled with its
+# accent because that is the negator's spelling and not a tone mark.
+#
+# **Grammar.** The preverbal markers are «ta» (imperfective), «bi» (past),
+# «o» (future), «sa» (able), «musu» (must); «á» negates and stands in front of
+# them; «ku» is *and* and *with*; «u» / «fu» is the purposive. Ndyuka's «e»
+# and «be» belong to `locales/djk` and are not Saramaccan.
+#
+# **Number.** `Intl.PluralRules("srm")` has no CLDR data for `srm` and falls
+# back to English. A Saramaccan noun after a numeral does not inflect, so
+# `editor-accessibility-label` and `help-coordinates` — the two messages
+# English selects on a count — are written here as **one unselected form**
+# each, with the count still interpolated. No plural branch appears anywhere
+# in this file.
+#
+# **Loans.** Dutch and English reshaped to Saramaccan phonology: «fowtu»,
+# «wakiman-buka» (*warning*), «info», «aksesibiliteiti», «vaaliant»,
+# «filitee», «komponenti», «atibut», «snipiti», «kolodinaati», «foomati»,
+# «vesi» (*version*), «dokumentasi», «lin», «punti». `WCAG`, `DoenetML`, `XML`
+# and `styleNumber` are names and stay as written, as do the attribute names
+# in `help-reset-overrides`.
+#
+# **Confidence.** This is the file with the least everyday Saramaccan in it —
+# almost every noun is a technical loan reshaped by rule rather than a form
+# this seed found in use. The verbs, the negator «á» and the preverbal markers
+# are Saramaccan throughout, and that is what a reviewer should read for.
+# Nothing was left in English.
+
+
+editor-update-viewer =
+    { $action ->
+        [reset] Seti baka
+       *[update] Njunsu
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } di luku-peesi
+       *[other] { $word } di luku-peesi { $shortcut }
+    }
+
+
+editor-variant = Vaaliant
+
+editor-variant-filter = Filitee...
+
+editor-variant-next = Tei di woto vaaliant di ta ko
+
+editor-variant-previous = Tei di vaaliant di bi pasa
+
+
+editor-accessibility-title =
+    { $status ->
+        [violations] U feni wan WCAG AA aksesibiliteiti-fowtu. Kiliki u { $action ->
+            [close] tapa
+           *[open] hopo
+        } di aksesibiliteiti-lapoti.
+        [advisories] Kiliki u { $action ->
+            [close] tapa
+           *[open] hopo
+        } di aksesibiliteiti-lapoti. U á feni na wan WCAG AA fowtu, ma u abi möön soni u taki u di aksesibiliteiti.
+       *[clean] Kiliki u { $action ->
+            [close] tapa
+           *[open] hopo
+        } di aksesibiliteiti-lapoti. U á feni na wan aksesibiliteiti-pooblema.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] U feni wan WCAG AA aksesibiliteiti-fowtu. U feni { $count } WCAG AA fowtu. Kiliki u { $action ->
+            [close] tapa
+           *[open] hopo
+        } di aksesibiliteiti-lapoti.
+        [advisories] U á feni na wan WCAG AA fowtu. U feni { $count } möön soni u taki u di aksesibiliteiti. Kiliki u { $action ->
+            [close] tapa
+           *[open] hopo
+        } di aksesibiliteiti-lapoti.
+       *[clean] U á feni na wan WCAG AA fowtu. Kiliki u { $action ->
+            [close] tapa
+           *[open] hopo
+        } di aksesibiliteiti-lapoti.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+editor-version-title = DoenetML vesi { $version }
+
+editor-tab-help = Heepi di ta fiti di peesi ka i dë
+editor-tab-help-short = Konteksi
+editor-tab-errors = Fowtu
+editor-tab-warnings = Wakiman-buka
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibiliteiti
+editor-tab-responses = Piki di manda kaba
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editoo-fasi
+editor-format-as-doenetml = Foomati kuma DoenetML
+editor-format-as-xml = Foomati kuma XML
+
+
+editor-diagnostic-line = Lin #{ $line }
+
+editor-no-errors = Na wan fowtu
+editor-no-warnings = Na wan wakiman-buka
+editor-no-info = Na wan info-lapoti
+
+editor-show-info-annotations = Lei dee info-lapoti a dendu di editoo
+editor-show-accessibility-annotations = Lei dee aksesibiliteiti-lapoti a dendu di editoo
+
+editor-accessibility-learn-more = Lei fa Doenet ta wooko ku aksesibiliteiti
+
+editor-accessibility-violations-heading = Aksesibiliteiti-fowtu ({ $standard })
+
+editor-accessibility-other-heading = Woto aksesibiliteiti-pooblema
+editor-none-found = U á feni na wan
+
+
+editor-no-responses = Na wan piki á manda ete
+editor-response-answer-id = Piki Id
+editor-response-response = Piki
+editor-response-credit = Punti
+editor-response-submitted = Manda
+
+
+help-placeholder = Buta di kosoo a wan tag-nen, wan atibut, ofu { $ref } u si di dokumentasi.
+
+help-unsupported-ref-chain = Heepi da wan longi lefeensi kuma { $example } á dë ete.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] U á feni na wan soni di { $ref } ta lei.
+        [multiple] U feni möön kuma wan soni di { $ref } ta lei.
+       *[indeterminate] U á sa sabi andi { $ref } ta lei.
+    }
+
+help-learn-about-references = Lei u dee lefeensi →
+help-reference-page = Lefeensi-pagina →
+
+help-suggestions-header =
+    { $location ->
+        [inside] A dendu { $element }
+       *[top] A hei u hii soni
+    }{ $allowed ->
+        [none] { " — na wan soni á ta go aki." }
+        [text] { " — sikifi tëkisi aki." }
+        [text-and-components] { " — sikifi tëkisi aki, ofu pooba:" }
+       *[components] { " — soni u pooba:" }
+    }
+
+help-suggestions-footer = Buta { $shortcut } u si hii dee { $total } komponenti.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } da wan lefeensi da { $target }.
+       *[other] { $ref } da wan lefeensi da { $target } (lin { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } tja ën ko kuma { $role }.
+       *[other] { $owner } tja ën ko a lin { $line } kuma { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } da wan lefeensi da di { $property } fasi u { $element }.
+       *[other] { $ref } da wan lefeensi da di { $property } fasi u { $element } (lin { $line }).
+    }
+
+help-kind-attribute = atibut
+help-kind-snippet = snipiti
+help-kind-array-entry = aray-soni
+
+help-default = Difoolti:
+help-active-default = Difoolti di ta wooko:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Waalde di i sa wooko (wan da hiniwan soni):
+       *[other] Waalde di i sa wooko:
+    }
+
+help-suggested-values = Waalde di u ta taki i:
+
+help-inserts = Andi a ta buta:
+
+help-coordinates = Kolodinaati:
+
+help-type = Sootu:
+
+help-resolved-style = Di sitali di ko a doo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Dee funsi-nen di ko a doo:
+help-reset-list = Seti di lisi baka a di inputu aki:
+help-added-on-input = Andi buta a di inputu aki:
+help-removed-on-input = Andi puu a di inputu aki:
+
+help-reset-overrides = { $reset } ta wini { $additional } ku { $removed }.

--- a/packages/i18n/locales/srn/chrome.ftl
+++ b/packages/i18n/locales/srn/chrome.ftl
@@ -1,0 +1,185 @@
+# Sranan Tongo (Sranantongo) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** These four files are written in the **1986 official
+# Surinamese orthography** for Sranan Tongo — «taki», «wan», «sma», «tu»,
+# «puru», «sroto», «koloku». The older Dutch-influenced spellings, the
+# pre-1986 conventions that wrote Dutch digraphs and gave the vowels their
+# Dutch values, are **not used anywhere in these four files** and must not be
+# mixed into them. The points where the 1986 system differs from what a
+# Dutch-reading eye expects are these:
+#
+#   * **`u`, never «oe»**, for the /u/ vowel — «puru», «lusu», «musu»,
+#     «kondre-uku». A spelling «poeroe» belongs to the older convention.
+#   * **`y`, never «j»**, for the palatal glide — «yepi», «nyun», «yu». A `j`
+#     does not occur in these files at all.
+#   * **`dy`** for the voiced affricate — «dyamanti», «dyompo» — where the
+#     older spelling wrote «dj».
+#   * **`ky`** and **`gy`** for the palatalized stops, where the older
+#     spelling wrote «tj» and «dj».
+#   * **Vowel length is written with a single letter.** No vowel is doubled
+#     for length; a doubled vowel in the older convention («oso» not «ooso»)
+#     is not reproduced here.
+#
+# The 1986 system is a phonemic Latin orthography with **no diacritics at
+# all**. Any accented character anywhere in these four files is an error.
+#
+# **Number.** `Intl.PluralRules("srn")` reports that there is no CLDR data of
+# its own for `srn`: it resolves to `en-US` and answers `['one', 'other']`.
+# Sranan Tongo marks the plural with the preposed «den» and leaves a noun
+# after a numeral unmarked — «tu pisi», not a pluralized noun — so the `one`
+# and `other` branches would be word-for-word identical here. Where that is
+# so, this file writes **one unselected form** rather than two identical
+# branches. English's explicit `[0]` literal in `attempts-remaining` matches
+# the number itself, not a plural category, and is kept as a branch.
+#
+# **Loans, named.** Sranan Tongo takes its technical vocabulary from Dutch and
+# English, and this seed keeps that rather than coining: «funksi», «vektor»,
+# «komponent», «atribut», «statistik», «matriks», «kibord», «interval»,
+# «krediti», «informasi», «aksesibiliteit». The grammar around them is Sranan:
+# the preverbal «e / ben / sa / musu», «no» for negation, «fu» for possession
+# and purpose, «na» as the copula. «Aksesibiliteit» is the weakest word in the
+# file — it is an English-shaped loan for a concept Suriname discusses in
+# Dutch — and is what a reviewer should look at first. The technical
+# vocabulary in this file is therefore a **lexifier loan set**, Dutch- and
+# English-mediated, carried in Sranan Tongo's own grammar and written in the
+# 1986 orthography: these loans are the words the language actually uses, and
+# the sentences built around them are Sranan, not Dutch.
+
+
+## Answer submission
+
+answer-checking = E kontroleri...
+answer-submitting = E seni...
+
+answer-checking-status = E kontroleri a piki
+answer-submitting-status = E seni a piki
+
+answer-correct = Leti
+answer-incorrect = Fowtu
+
+answer-response-saved = A piki kibri
+
+answer-percent-credit = { $percent }% krediti
+answer-percent-correct = { $percent }% leti
+answer-percent-short = { $percent } %
+
+max-credit-available = A moro hei krediti: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] no wan proberi no tan moro
+       *[other] { $count } proberi tan
+    }
+
+validation-correct = (Leti)
+validation-incorrect = (Fowtu)
+validation-partially-correct = (Haffu leti)
+
+answer-show-responses = Sori { $count } piki gi { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentari
+
+collapsible-click-to-open = (klik fu opo)
+collapsible-click-to-close = (klik fu tapu)
+
+collapsible-initializing = E bigin...
+
+footnote-show = Sori a futnota
+footnote-hide = Kibri a futnota
+
+description-more-information = moro informasi
+
+
+## Controls
+
+slider-previous = Baka
+slider-next = Fesi
+
+keyboard-open = Opo a kibord
+keyboard-close = Tapu a kibord
+
+choice-input-remove-choice = Puru { $choice }
+
+matrix-remove-row = Puru wan rei
+matrix-add-row = Poti wan rei
+matrix-remove-column = Puru wan kolom
+matrix-add-column = Poti wan kolom
+
+subset-add-remove-points = Poti/Puru punt
+subset-toggle-points-intervals = Kenki punt nanga interval
+subset-move-points = Skoifi punt
+subset-clear = Krin
+
+orbital-add-row = Poti wan rei
+orbital-remove-row = Puru wan rei
+orbital-add-box = Poti wan bokisi
+orbital-remove-box = Puru wan bokisi
+orbital-add-up-arrow = Poti wan peiri di e go na tapu
+orbital-add-down-arrow = Poti wan peiri di e go na ondro
+orbital-remove-arrow = Puru a peiri
+
+orbital-row-label = Nen gi rei { $row }
+
+pretzel-answer = Piki
+
+summary-statistics-caption = Kortu statistik fu { $column }
+
+
+## Math input
+
+math-input-preview-region = luku fosi fu a matematika-ekspresi
+math-input-preview = Luku fosi
+math-input-invalid-expression = A ekspresi no bun:
+
+
+## Document status
+
+viewer-initializing = E bigin...
+
+
+## Errors
+
+error-heading = Fowtu
+
+error-found-at =
+    { $span ->
+        [line] Feni na lin { $startLine }.
+       *[lines] Feni na lin { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = A dokumenti disi abi fowtu na ini!
+
+diagnostic-heading-error = Fowtu
+diagnostic-heading-warning = Warskow
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Tipi
+
+accessibility-heading-level-1 = WCAG AA aksesibiliteit-fowtu
+accessibility-heading-level-2 = Aksesibiliteit-warskow
+
+something-went-wrong = Wan sani go fowtu.
+
+renderer-load-failed = wan renderer no ben man lai. Grantangi, lai a blad baka.
+
+core-start-failed = A dokumenti disi no ben man bigin. Grantangi, lai a blad baka.
+
+core-start-failed-busy = A dokumenti disi no ben man bigin. Someni dokumenti ben e bigin na a srefi ten, en dati kan teki moro langa tapu wan moro safri masyin. Te den tra dokumenti kaba, dan a kan yepi fu lai a blad baka.
+
+core-start-failed-retry = A dokumenti disi no ben man bigin.
+
+core-start-failed-busy-retry = A dokumenti disi no ben man bigin. Someni dokumenti ben e bigin na a srefi ten, en dati kan teki moro langa tapu wan moro safri masyin.
+
+core-start-retry = Proberi baka
+
+saved-state-unavailable = A wroko di yu ben kibri no ben man lai.

--- a/packages/i18n/locales/srn/content.ftl
+++ b/packages/i18n/locales/srn/content.ftl
@@ -1,0 +1,289 @@
+# Sranan Tongo (Sranantongo) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. Translated from `locales/en/content.ftl`, which is the source of
+# truth: `lint:i18n` rejects a key that does not exist there, and reports a key
+# that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **1986 official Surinamese orthography** — «taki»,
+# «wan», «sma», «tu», «puru», «sroto», «koloku». `u` for /u/ and never «oe»,
+# `y` for the glide and never «j», `dy` for the voiced affricate, `ky` and `gy`
+# for the palatalized stops, and vowel length written with a single letter
+# rather than a doubled one. The pre-1986 Dutch-influenced spellings are not
+# used anywhere in these four files and must not be mixed into them. The system
+# is phonemic Latin with no diacritics at all, so an accented character here
+# would be an error. `chrome.ftl`'s header sets the differences out point by
+# point.
+#
+# **Word order: the modifier comes before the noun.** A Sranan Tongo adjective
+# normally stands in front of its head, the same order English uses — «bigi
+# oso», «redi lin». So every composition message here **keeps the English
+# order**: `style-stroke`, `style-with-noun`, `style-filled`,
+# `style-filled-with-noun` and `style-fill` put the adjectives first and the
+# noun last, exactly as English does. Nothing is reordered.
+#
+# **No agreement.** Sranan Tongo has no grammatical gender and no adjective
+# agreement: an adjective takes no ending and agrees with nothing. So **no
+# message forks on `$gender` or `$role`**, and `noun-gender` answers a single
+# token that nothing reads.
+#
+# **Number.** `Intl.PluralRules("srn")` has no CLDR data of its own for `srn`:
+# it resolves to `en-US` and answers `['one', 'other']`. Sranan marks the
+# plural with the preposed «den», and a noun after a numeral is unmarked — «tu
+# pisi», not a pluralized noun — so both branches would be word-for-word
+# identical here. That is why **one unselected form** is written wherever
+# English selects on a count, and why no count-driven select appears anywhere
+# in these four files.
+#
+# **The chemistry tables are deliberately absent.** `element-name` and
+# `element-anion-name` are the only English keys this file does not cover.
+# School science in Suriname is taught in Dutch, from Dutch textbooks; there is
+# no Sranan Tongo periodic table in use and no settled Sranan spelling for the
+# hundred and eighteen names. Writing one out would be transliterating the
+# Dutch list and calling the result a Sranan nomenclature. `lint:i18n` reports
+# the two keys as missing coverage and that is the correct report.
+# `ion-name-oxidation-state`, `chemistry-invalid-symbol` and
+# `chemistry-invalid-ionic-compound` **are** covered — they are frames, not
+# vocabulary.
+#
+# **Loans kept, rather than coined.** Sranan takes its technical words from
+# Dutch and English and this seed keeps them, spelled in the 1986 orthography:
+# «funksi», «vektor», «parabola», «poligon», «rektangel», «firkanti»,
+# «diagonal», «horizontal», «vertikal», «interval», «tafra», «prenki»,
+# «definisi», «teorema», «paragraaf», «kaskade», «problema». Sranan words are
+# used where Sranan has one: «lin», «punt», «lontu» (circle), «kroktu lin»
+# (curve), «kroysi» (cross), «kontren» (region), «blaka weti grei redi geri
+# grun blaw brun». The words a reviewer should look at first are «syan» for
+# *cyan*, «rosi» for *pink*, «purper» for *purple* and «dul» for *objective* —
+# each is a loan or a stretch where Sranan has no settled everyday word. The
+# technical vocabulary here is a **lexifier loan set**, Dutch- and
+# English-mediated, carried in Sranan Tongo's own grammar and written in the
+# 1986 orthography: these loans are the words the language actually uses, and
+# the sentences built around them are Sranan, not Dutch.
+
+
+## Style vocabulary
+
+color =
+    .black = blaka
+    .white = weti
+    .gray = grei
+    .red = redi
+    .orange = oranya
+    .yellow = geri
+    .green = grun
+    .cyan = syan
+    .blue = blaw
+    .purple = purper
+    .pink = rosi
+    .brown = brun
+
+line-width =
+    .thick = deki
+    .thin = finyi
+
+line-style =
+    .dashed = strepistrepi
+    .dotted = puntupuntu
+
+fill-style =
+    .horizontal = horizontal lin
+    .vertical = vertikal lin
+    .diagonal = diagonal lin
+    .backdiagonal = diagonal lin na tra sei
+    .dots = puntu
+    .diamonds = dyamanti
+
+noun =
+    .line = lin
+    .line-segment = pisi lin
+    .ray = strali
+    .vector = vektor
+    .curve = kroktu lin
+    .function = funksi
+    .slope-field = helingfeld
+    .vector-field = vektorfeld
+    .parabola = parabola
+    .polyline = polilin
+    .polygon = poligon
+    .triangle = driuku
+    .rectangle = rektangel
+    .circle = lontu
+    .region = kontren
+    .point = punt
+    .square = firkanti
+    .diamond = dyamanti
+    .cross = kroysi
+    .plus = plus
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] regelmati poligon nanga { $numSides } sei
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = furu
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } nanga { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } nanga { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } nanga { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] nanga wan { $border } kanti
+        [and] nanga { $border } kanti
+        [and-article] nanga wan { $border } kanti
+       *[with] nanga { $border } kanti
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = no furu
+
+style-text =
+    { $parts ->
+        [background] { $color } nanga wan { $background } bakagron
+       *[plain] { $color }
+    }
+
+style-background-none = no wan
+
+
+## Boolean words
+
+boolean-true = tru
+boolean-false = falsi
+
+
+## Answer buttons
+
+answer-submit-label = Luku a wroko
+answer-submit-label-no-correctness = Seni a piki
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktiviteit
+    .aside = Seitori
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Eksempre
+    .exercise = Wroko
+    .exercises = Den wroko
+    .given-answer = Piki
+    .note = Nota
+    .objectives = Dul
+    .paragraphs = Paragraaf
+    .part = Pisi
+    .problem = Problema
+    .problems = Den problema
+    .proof = Bewisi
+    .question = Aksi
+    .section = Seksi
+    .solution = Oplosing
+    .task = Opdrakti
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Tipi
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tafra { $enumeration }
+        [numbered-title] Tafra { $enumeration }{ ": " }
+        [unnumbered-title] Tafra{ ": " }
+       *[unnumbered] Tafra
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Prenki { $enumeration }
+        [numbered-caption] Prenki { $enumeration }{ ": " }
+        [unnumbered-caption] Prenki{ ": " }
+       *[unnumbered] Prenki
+    }
+
+
+## Paginator controls
+
+paginator-previous = Baka
+paginator-next = Fesi
+paginator-page = Blad
+
+paginator-page-status = { $pageLabel } { $currentPage } fu { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = noso
+
+piecewise-condition-if = efu
+
+piecewise-condition-otherwise = efu no so
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are omitted; see the header.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = A chemia-marki no bun
+chemistry-invalid-ionic-compound = A ioni-verbinding no bun
+
+## Inputs embedded in math
+
+math-embedded-input-blank = leigi
+
+math-embedded-input-blank-ordinal = leigi { $ordinal } fu { $total }

--- a/packages/i18n/locales/srn/diagnostics.ftl
+++ b/packages/i18n/locales/srn/diagnostics.ftl
@@ -1,0 +1,673 @@
+# Sranan Tongo (Sranantongo) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `[deprecation]`, `PreFigure` — are part of the
+# language, not prose, and stay in English exactly as written. So does anything
+# quoted back from the author's own source, and so do the backticks, angle
+# brackets and quote marks around them.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **1986 official Surinamese orthography** — «taki»,
+# «wan», «sma», «tu», «puru», «sroto», «koloku». `u` for /u/ and never «oe»,
+# `y` for the glide and never «j», `dy` for the voiced affricate, `ky` and `gy`
+# for the palatalized stops, and vowel length written with a single letter
+# rather than a doubled one. The pre-1986 Dutch-influenced spellings appear
+# nowhere in these four files and must not be mixed into them. The system is
+# phonemic Latin with no diacritics at all, so an accented character here would
+# be an error. `chrome.ftl` sets the differences out point by point.
+#
+# **Number.** `Intl.PluralRules("srn")` has no CLDR data of its own for `srn`:
+# it resolves to `en-US` and answers `['one', 'other']`. A Sranan noun after a
+# numeral is unmarked — «tu punt», not a pluralized noun — so English's `one`
+# and `other` branches would be word-for-word identical here, and each is
+# written as **a single unselected form**. No count-driven select appears
+# anywhere in these four files. The selects that remain — `$mode`, `$type`,
+# `$reason`, `$expected`, `$isList`, `$labelKind`, `$suggestion`,
+# `$componentType`, `$fallback`, `$context`, `$component`, `$alternative` — are
+# not plural selects, and every branch of each is translated.
+#
+# **Loans and grammar.** The technical nouns are Dutch- and English-derived,
+# spelled in the 1986 orthography: «funksi», «vektor», «matriks», «komponent»,
+# «atribut», «interval», «variant», «sekwensi», «formaat», «kontras»,
+# «dimensi», «koordinaat», «referensi». The grammar around them is Sranan: the
+# preverbal «e / ben / sa / musu», «no» for negation, «fu» for possession and
+# purpose, «di» and «te» for the subordinate clauses, «na» as the copula. Two
+# renderings recur and a reviewer should judge them once rather than
+# ninety times: «no e teri» for *is ignored*, and «Wi no meki … ete» for
+# *haven't implemented*. The technical vocabulary here is a **lexifier loan
+# set**, Dutch- and English-mediated, carried in Sranan Tongo's own grammar and
+# written in the 1986 orthography: these loans are the words the language
+# actually uses, and the sentences built around them are Sranan, not Dutch.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } no e teri te tu endpoint poti
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } no e teri te wan endpoint nanga wan midpoint poti alatu
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset no abi krakti sondro wan midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = Wan lin di e psa punt di no abi wan sabi dimensi.
+
+line-points-too-few-dimensions = A lin musu psa punt di abi tumusi tu dimensi.
+
+line-points-depend-on-variables = A lin e psa punt di e anga na variabele: { $variables }.
+
+line-equation-invalid-format = A formaat fu a lin-vergelijking nanga variabele { $variable1 } nanga { $variable2 } no bun.
+
+## `<ray>`
+
+ray-overprescribed-through = A strali kisi through, endpoint nanga direction alamala.  A through di poti no e teri.
+
+ray-dimension-mismatch = A numDimensions no e kruderi na ini a strali.
+
+## `<vector>`
+
+vector-overprescribed-head = A vektor kisi head, tail nanga displacement alamala.  A head di poti no e teri.
+
+vector-dimension-mismatch = A numDimensions no e kruderi na ini a vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = No man hari go na wan `<{ $component }>`, bika a no abi wan nearestPoint stat-variabele.
+
+constrain-to-without-nearest-point = No man tai na wan `<{ $component }>`, bika a no abi wan nearestPoint stat-variabele.
+
+constrain-to-interior-without-nearest-point = No man tai na inisei fu wan `<{ $component }>`, bika a no abi wan nearestPoint stat-variabele.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition no e teri gi wan choiceInput di no de inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Den indeks di poti gi choiceInput no e teri, bika a nomru fu indeks no e kruderi nanga a nomru fu choice-pikin.
+
+pretzel-indices-count-mismatch = Den indeks di poti gi problem no e teri, bika a nomru fu indeks no e kruderi nanga a nomru fu problem-pikin.
+
+shuffle-indices-count-mismatch = Den indeks di poti gi shuffle no e teri, bika a nomru fu indeks no e kruderi nanga a nomru fu komponent.
+
+indices-ignored-out-of-range = Den indeks di poti gi { $component } no e teri, bika son indeks de dorosei fu a reiki.
+
+pretzel-indices-repeated = Den indeks di poti gi pretzel no e teri, bika son indeks kon tu leisi.
+
+pretzel-circuit-first-index = Den indeks di poti gi pretzel na ini circuit-modus no e teri, bika a fosi indeks musu de 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Fu `<{ $component }>` man wroko nanga string-pikin, wan `type` atribut musu poti.
+
+invalid-type-defaulting-to-math = A type { $type } no bun gi a komponent { $component }. A musu de wan fu math, text, number noso boolean. Wi e teki math.
+
+string-not-valid-component-to-arrange = A string "{ $value }" na no wan bun komponent fu { $component }. A no e teri.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = A type { $type } no bun, a type e poti tapu number.
+
+invalid-variable-value = A waarde fu wan variabele no bun: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = A variant-indeks { $index } musu de wan nomru
+
+variant-index-must-be-integer = A variant-indeks { $index } musu de wan heri nomru
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` no meki gi absolute marki. Den bradi e poti tapu relatief.
+
+side-by-side-absolute-margins = `<{ $component }>` no meki gi absolute marki. Den kanti e poti tapu relatief.
+
+side-by-side-no-block-child = A `<{ $component }>` no bun: a musu abi tumusi wan blok-pikin.
+
+## `<label>`
+
+label-for-ignored-on-graphical = A `for` atribut tapu wan grafiek `<label>` no e teri.
+
+label-for-must-resolve-to-one = A `for` atribut tapu `<label>` musu sori soifri wan komponent.
+
+label-for-unresolved = A `for` atribut tapu `<label>` no man sori wan komponent.
+
+label-for-answer-with-authored-inputs = A `for` atribut tapu `<label>` e sori wan `<answer>` di abi inputu di a skrifiman srefi skrifi; sori a inputu srefi.
+
+label-for-answer-without-input = A `for` atribut tapu `<label>` e sori wan `<answer>` di no abi wan inputu fu poti wan nen tapu.
+
+label-for-must-reference-input-or-answer = A `for` atribut tapu `<label>` musu sori wan inputu noso wan answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Fu aksesibiliteit ede, `<{ $component }>` musu abi wan syatu tekst noso a musu poti leki decorative.
+
+accessibility-video-short-description = Fu aksesibiliteit ede, `<video>` musu abi wan syatu tekst.
+
+accessibility-input-short-description-or-label = Fu aksesibiliteit ede, `<{ $component }>` musu abi wan syatu tekst noso wan nen.
+
+accessibility-answer-input-short-description-or-label = Fu aksesibiliteit ede, wan `<answer>` di e meki wan inputu musu abi wan syatu tekst noso wan nen.
+
+accessibility-short-description-contains-math = Wan syatu tekst no musu abi matematika-komponent leki `<{ $component }>` na ini. Skrifi a matematika nanga wortu.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } no abi nofo kontras gi a tekst fu a seksi-ede (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu tumusi { $threshold }:1).
+       *[other] { $colorName } no abi nofo kontras gi a tekst fu a seksi-ede ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu tumusi { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wi no meki wan `<circle>` di e psa { $count } punt ete, te den punt no abi nomru-waarde.
+
+circle-too-many-through-points = No man bereken wan lontu di e psa moro leki 3 punt.
+
+circle-overprescribed-radius-center-points = No man bereken wan lontu di abi wan radius, wan mindripunt nanga through-punt alamala.
+
+circle-center-with-multiple-points = No man bereken wan lontu nanga wan mindripunt di e psa moro leki 1 punt.
+
+circle-radius-too-small = No man bereken a lontu: a langa fu tu punt na { $distance }, so a radius { $radius } di poti pikin tumsi.
+
+circle-radius-with-many-points = No man meki wan lontu di e psa moro leki tu punt nanga wan radius di poti.
+
+circle-invalid-center-or-through-points = A mindripunt noso den through-punt fu a lontu no bun.
+
+circle-radius-center-with-multiple-points = No man bereken a radius fu wan lontu nanga wan mindripunt di e psa moro leki 1 punt.
+
+circle-change-radius-non-numerical = No man kenki a radius fu wan lontu di e psa punt di no abi nomru-waarde
+
+circle-radius-with-points-non-numerical = No man meki wan lontu di e psa moro leki wan punt nanga wan radius di poti, te no wan nomru-waarde no de.
+
+circle-change-center-non-numerical = Wi no meki wan fasi ete fu kenki a mindripunt fu wan lontu di e psa punt sondro nomru-waarde.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = A domein no abi nofo dimensi gi a funksi. A domein abi { $intervals } interval ma a funksi abi { $inputs } inputu.
+
+function-domain-invalid-format = A formaat fu a domein fu a funksi no bun.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] A moro hei punt fu a funksi no abi wan nomru-waarde, so a no e teri.
+        [minimum] A moro lagi punt fu a funksi no abi wan nomru-waarde, so a no e teri.
+        [extremum] A extremum fu a funksi no abi wan nomru-waarde, so a no e teri.
+        [point] A punt fu a funksi no abi wan nomru-waarde, so a no e teri.
+        [slope] A heling fu a funksi no abi wan nomru-waarde, so a no e teri.
+       *[other] A { $type } fu a funksi no abi wan nomru-waarde, so a no e teri.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] A moro hei punt fu a funksi leigi, so a no e teri.
+        [minimum] A moro lagi punt fu a funksi leigi, so a no e teri.
+        [extremum] A extremum fu a funksi leigi, so a no e teri.
+        [point] A punt fu a funksi leigi, so a no e teri.
+       *[other] A { $type } fu a funksi leigi, so a no e teri.
+    }
+
+function-points-too-close = A funksi abi tu punt di de tumsi krosbei fu makandra. No man meki a funksi.
+
+function-iterates-input-output-mismatch = Funksi-iterasi de nomo te a nomru fu inputu fu a funksi de a srefi leki a nomru fu outputu. A funksi disi abi { $inputs } inputu nanga { $outputs } outputu.
+
+## `<sequence>`
+
+sequence-invalid-length = A langa fu a sekwensi no bun.  A musu de wan heri nomru di no de ondro nul.
+
+sequence-invalid-step = A step fu a sekwensi no bun.  A musu de wan nomru gi wan sekwensi fu type { $type }.
+
+sequence-invalid-endpoint-number = A "{ $attribute }" fu a nomru-sekwensi no bun.  A musu de wan nomru.
+
+sequence-invalid-endpoint-letters = A "{ $attribute }" fu a letter-sekwensi no bun.  A musu de wan tyapu letter.
+
+sequence-invalid-endpoint = A "{ $attribute }" fu a sekwensi no bun.
+
+select-from-sequence-coprime-not-numbers = coprime no e teri bika no nomru e teki
+
+select-from-sequence-coprime-with-exclude-combinations = coprime no e teri bika excludeCombinations poti
+
+## Resolving a `target`
+
+target-not-found = A target gi `<{ $source }>` no bun: no man feni a target.
+
+target-state-variable-not-found = A target gi `<{ $source }>` no bun: no man feni wan stat-variabele nanga a nen "{ $property }" tapu wan `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Den variabele fu `<odeSystem>` musu de tra fasi leki a onafhankelijk variabele.
+
+ode-system-duplicate-variable-names = No man meki ODE RHS funksi te den afhankelijk variabele abi a srefi nen tu leisi.
+
+ode-system-rhs-function-error = No man meki a ODE RHS funksi.  Wan fowtu psa di a mathjs funksi ben e meki.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = No man meki wan uku na mindri { $count } lin
+
+angle-invalid-through-point = A punt na ini a through fu `<angle>` no bun
+
+parabola-vertex-too-many-points = Wi no meki wan parabola nanga wan tapupunt di e psa moro leki 1 punt ete.
+
+parabola-too-many-points = Wi no meki wan parabola di e psa moro leki 3 punt ete.
+
+intersection-too-many-items = Wi no meki wan krosipasi gi moro leki tu sani ete
+
+## Other math components
+
+ionic-compound-not-two-ions = Wi no meki wan ioni-verbinding gi wan sani di no abi tu ioni ete.
+
+ionic-compound-needs-cation-and-anion = A ioni-verbinding meki gi wan kation nanga wan anion nomo.
+
+solve-equations-cannot-evaluate = No man lusu a vergelijking bika no man rekenu en: { $equation }
+
+math-operators-operand-number-required = Wan operandNumber musu poti te wan matematika-operand e puru.
+
+eigen-decomposition-failed = No man bereken den eigenwaarde fu a matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: a parameter { $parameters } no de na ini a patron, so a sa fiti wan leigi presi ala ten.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: no man frustan grid="{ $grid }". A musu de none, medium, dense, noso tu positief nomru nanga wan spasi na mindri, leki grid="1 0.5". No wan grid no e teken.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` abi fanowdu wan funksi nanga { $expected ->
+        [one] wan outputu, a heling y' na ibri punt, leki `y - x`
+       *[other] tu outputu, a vektor na ibri punt, leki `(y, -x)`
+    }, ma a funksi di a kisi abi { $found } outputu. { $alternative ->
+        [none] No wan sani no e teken.
+       *[other] `<{ $alternative }>` na a komponent gi a funksi dati. No wan sani no e teken.
+    }
+
+field-function-attribute-ignored-with-child = A `function` atribut no e teri bika a funksi de na inisei fu a komponent tu; a wan na inisei e wroko. Gi a funksi na wan fasi nomo.
+
+field-variables-ignored =
+    `<{ $component }>`: a `variables` atribut e kari den variabele fu wan ekspresi di skrifi leti na inisei fu a komponent. { $reason ->
+        [function-child] A funksi dyaso gi leki wan `<function>` pikin, di e kari den variabele fu ensrefi, so `variables` no e teri.
+       *[no-expression] No so wan ekspresi no de dyaso, so `variables` no e teri.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" no e wroko na ini a prefigure renderer; a e wroko leki right.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" no e wroko na ini a prefigure renderer; a e wroko leki top.
+
+prefigure-invalid-axis-bounds = `<graph>`: den grens fu den as no bun gi a prefigure-kenki; a standard bbox (-10,-10,10,10) e teki.
+
+prefigure-invalid-width = `<graph>`: a bradi no bun gi a prefigure-kenki; a standard bradi 425 e teki.
+
+prefigure-invalid-aspect-ratio = `<graph>`: a aspectRatio no bun gi a prefigure-kenki; a standard aspect ratio 1 e teki.
+
+prefigure-grid-spacing-too-fine = `<graph>`: den lin fu a grid de tumsi krosbei fu makandra gi den grens fu den as; a grid e libi na baka na ini a prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: den annotation no sa teken te a PreFigure renderer no e wroko.
+
+multiple-annotations-children = Moro leki wan `<annotations>` pikin feni na ini `<graph>`; ala fu den boiti a lasti wan no e teri.
+
+## Referring to other components
+
+copy-unrecognized-component-type = No man tyari noso kopi wan komponent-type di wi no sabi: { $type }.
+
+copy-prop-not-found = No man feni a prop { $property } tapu wan komponent fu type { $component }
+
+collect-no-source = No wan source no feni gi collect.
+
+collect-invalid-component-type = No man tyari komponent fu type `<{ $component }>` kon makandra, bika a komponent-type no bun.
+
+reference-index-unavailable = No man teki a indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = No man kari { $action } tapu a komponent `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = A data abi wan fasi di no bun.  Den rei no abi a srefi langa. Feni na ini componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = A data abi kolom nanga a srefi nen tu leisi.  Feni na ini componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kolom fu a data no abi wan nen.  Feni na ini componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award fu a piki disi e anga na a piki di a answer-tag srefi seni, en dati sa meki sani psa di yu no ben fruwakti.
+
+answer-max-num-attempts-in-section-wide-check-work = Te yu e poti `maxNumAttempts` tapu wan `<answer>` na ini wan bakisi nanga `sectionWideCheckWork`, dati no abi krakti, bika a bakisi e basi a nomru fu proberi. Poti `maxNumAttempts` tapu a bakisi.
+
+nested-section-wide-check-work-max-num-attempts = Te yu e poti `maxNumAttempts` tapu wan bakisi nanga `sectionWideCheckWork` di de na ini wan tra bakisi nanga `sectionWideCheckWork`, dati no abi krakti, bika a bakisi na dorosei e basi a nomru fu proberi. Poti `maxNumAttempts` tapu a bakisi na dorosei.
+
+answer-attributes-need-symbolic-equality = A { $attributes } atribut no sa abi krakti sondro symbolicEquality.
+
+answer-invalid-type = A type gi a piki no bun: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Bika a komponent `<{ $component }>` no abi wan nen, a no man gebroiki leki wan module-atribut
+
+module-attribute-name-already-defined = A komponent `<{ $component } name="{ $name }">` no man gebroiki leki wan atribut fu wan module, bika a `<module>` komponent-type abi wan "{ $name }" atribut kaba.
+
+conditional-content-condition-ignored = A atribut `condition` no e teri tapu wan `<conditionalContent>` komponent di abi case- noso else-pikin.
+
+slider-markers-type-mismatch = A type fu den marki no e kruderi nanga a type fu a slider.
+
+pretzel-problem-needs-statement-and-answer = A pretzel no bun: ibri `<problem>` musu abi wan `<statement>` nanga wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = A pretzel no bun: na ini mode="circuit", a fosi `<problem>` no man de wan distractor.
+
+## Attribute values
+
+attribute-invalid-values = A waarde { $values } gi a atribut `{ $attribute }` no bun; a no e teri.
+
+attribute-must-be-references = A waarde `{ $value }` gi a atribut `{ $attribute }` no bun. A atribut musu meki fu referensi di e bigin nanga wan `$`.
+
+math-input-invalid-function-names = <mathInput>: den funksi-nen di no bun na ini { $attribute } no e teri: { $names }. A sori-pisi fu ibri nen musu abi tumusi 2 marki (letter noso koto-lin); wan `|<mathspeak alternative>` kan kon na baka efu yu wani.
+
+## Building components from the source
+
+component-type-invalid = A komponent-type no bun: `<{ $componentType }>`
+
+attribute-repeated = No man skrifi a atribut { $attribute } tu leisi.
+
+attribute-invalid-for-component = A atribut "{ $attribute }" no bun gi wan komponent fu type `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    A stail-definisi { $styleNumber } no abi nofo kontras gi { $context ->
+        [text-on-background] a tekst-kloru teige a bakagron-kloru
+        [high-contrast] a hei-kontras kloru teige a kanfasi
+        [line] a lin-kloru teige a kanfasi
+        [marker] a marki-kloru teige a kanfasi
+       *[text-on-canvas] a tekst-kloru teige a kanfasi
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu tumusi { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Aladi a stail-definisi { $styleNumber } abi kloru di e gi nofo kontras gi light mode, den dark-mode kloru di kmoto fu den waarde disi no abi nofo kontras gi a tekst-kloru teige a bakagron-kloru ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu tumusi { $threshold }:1). { $suggestion ->
+        [available] Fu abi nofo kontras na ini dark mode, meki a kontras fu light mode moro bigi (leki, poti { $lightAttribute }="{ $lightColor }") noso kenki a dark-mode kloru srefi (leki, poti { $darkAttribute }="{ $darkColor }").
+       *[none] Fu abi nofo kontras na ini dark mode, meki a kontras fu light mode moro bigi noso kenki den kloru di kmoto fu den, nanga textColorDarkMode noso backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Aladi a stail-definisi { $styleNumber } abi wan tekst-kloru di e gi nofo kontras gi light mode, a dark-mode tekst-kloru di kmoto fu a waarde disi no abi nofo kontras teige a kanfasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a abi fanowdu tumusi { $threshold }:1). { $suggestion ->
+        [available] Fu abi nofo kontras na ini dark mode, meki a kontras fu light mode moro bigi (leki, poti textColor="{ $lightColor }") noso kenki a dark-mode kloru srefi (leki, poti textColorDarkMode="{ $darkColor }").
+       *[none] Fu abi nofo kontras na ini dark mode, meki a kontras fu light mode moro bigi noso kenki a kloru di kmoto fu en, nanga textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan seksi man teki wan <stylePalette> nomo; a lasti wan e wroko.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = no man sabi den aparti variant fu { $component } bika numToSelect no de wan heri nomru di no de ondro nul.
+
+variant-num-to-select-not-constant-number = no man sabi den aparti variant fu { $component } bika numToSelect no de wan fasti nomru.
+
+variant-with-replacement-not-constant-boolean = no man sabi den aparti variant fu { $component } bika withReplacement no de wan fasti boolean.
+
+variant-select-weight-disables-unique = Den aparti variant gi select e tapu te wan option abi selectWeight noso selectForVariants
+
+variant-coprime-undetermined = no man sabi den aparti variant fu { $component } bika no man sabi efu coprime de falsi ala ten.
+
+variant-attribute-not-constant = no man sabi den aparti variant fu { $component } bika { $attribute } no de wan fasti sani.
+
+variant-attribute-not-number = no man sabi den aparti variant fu { $component } bika { $attribute } no de wan nomru.
+
+variant-attribute-wrong-type-for-sequence =
+    no man sabi den aparti variant fu { $component } fu type { $type } bika { $attribute } no de { $expected ->
+        [letters-combination] wan tyapu letter
+        [math-expression] wan bun matematika-ekspresi
+        [integer] wan heri nomru
+       *[number] wan nomru
+    }.
+
+variant-length-not-integer = no man sabi den aparti variant fu { $component } bika length no de wan heri nomru.
+
+variant-sort-not-implemented = wi no meki den aparti variant fu wan { $component } nanga sort ete
+
+variant-exclude-combinations-not-implemented = wi no meki den aparti variant fu wan { $component } nanga excludeCombinations ete
+
+variant-math-exclude-not-implemented = wi no meki den aparti variant fu wan { $component } fu type math nanga exclude ete
+
+variant-non-constant-exclude-not-implemented = wi no meki den aparti variant fu wan { $component } nanga wan exclude di no fasti ete
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: no e wroko na ini a graph prefigure renderer; a pikin e libi na baka.
+
+prefigure-descendant-invalid-geometry = { $subject }: a geometri no de heri noso a no abi wan grens; a pikin e libi na baka.
+
+prefigure-curve-label-omitted = { $subject }: nen no e wroko tapu kroktu lin di kenki; a nen e libi na baka.
+
+prefigure-curve-unsupported-definition-type = { $subject }: a sortu funksi-definisi '{ $definitionType }' gi a kroktu lin no e wroko; a pikin e libi na baka.
+
+prefigure-region-flip-functions-unsupported = { $subject }: a flipFunctions atribut tapu regionBetweenCurves no e wroko; a pikin e libi na baka.
+
+prefigure-region-non-formula-child = { $subject }: soso funksi-pikin fu a formula-type e wroko tapu regionBetweenCurves; a pikin e libi na baka.
+
+prefigure-label-position-unsupported =
+    { $subject }: a labelPosition '{ $labelPosition }' no e wroko gi { $labelKind ->
+        [line-family] wan nen fu a lin-famiri
+       *[point] wan nen fu wan punt
+    }; a standard PreFigure fasi e teki.
+
+prefigure-fill-style-unsupported = { $subject }: a furu-stail '{ $fillStyle }' no e wroko na ini PreFigure; wan heri furu e teki.
+
+prefigure-line-style-unknown = { $subject }: a lin-stail '{ $lineStyle }' no bekenti en a e libi na baka fu a PreFigure outputu.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: a marki-stail '{ $markerStyle }' e kenki go na a PreFigure stail 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: a marki-stail '{ $markerStyle }' no e wroko na ini PreFigure; a standard stail e teki.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: a `ref` no bun; no man feni a target. A annotation e libi na baka.
+
+annotation-ref-multiple-targets = `<annotation>`: a `ref` e sori moro leki wan target; a fosi wan e teki.
+
+annotation-ref-outside-graph = `<annotation>`: a `ref` no bun; a target de dorosei fu a graph. A annotation e libi na baka.
+
+annotation-ref-unsupported-target = `<annotation>`: a `ref` no bun; a target no de wan grafiek sani di e wroko na ini a prefigure-kenki. A annotation e libi na baka.
+
+annotation-text-missing = `<annotation>`: a `text` no de noso a leigi; wan leigi tekst e seni.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wan lontu dependensi feni.
+       *[other] Wan lontu dependensi feni di abi wan `<{ $componentType }>` komponent na ini.
+    }
+
+reference-no-referent = No wan sani no feni gi a referensi: `{ $reference }`
+
+reference-multiple-referents = Moro leki wan sani feni gi a referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = A formaat fu a atribut { $attribute } fu `<{ $componentType }>` no bun.
+
+children-invalid = Den pikin fu `<{ $componentType }>` no bun: den pikin di no bun na: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = A waarde `{ $value }` gi a atribut `{ $attribute }` no bun, a waarde `{ $default }` e teki
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] A DoenetML versi { $version } no feni.
+       *[other] A DoenetML versi { $version } no feni. A versi { $fallback } e teki na en presi
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Invalid DoenetML: { $content }
+
+parse-tag-missing-close-tag = Invalid DoenetML: A tag `{ $tag }` no abi wan tapu-tag. Wan tag di e tapu ensrefi noso wan `</{ $tagName }>` tag ben de fanowdu.
+
+parse-tag-error = Invalid DoenetML: Wan fowtu na ini a tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Invalid DoenetML: A atribut `{ $attribute }` no bun; a gersi leki a no abi wan waarde.
+
+parse-attribute-invalid = Invalid DoenetML: A atribut `{ $attribute }` no bun
+
+parse-attribute-value-invalid = Invalid DoenetML: A atribut-waarde `{ $value }` no bun
+
+parse-attribute-value-quote-mismatch = Invalid DoenetML: A atribut-waarde `{ $value }` no bun. Den kotomarki no e kruderi. A gersi leki wan `{ $quote }` e misi
+
+parse-open-tag-name-missing = Invalid DoenetML: Wan tag sondro wan tag-nen feni, leki `<`
+
+parse-tag-not-closed = Invalid DoenetML: A tag `{ $tag }` no tapu (a gersi leki wan `>` e misi).
+
+parse-self-closing-tag-name-missing = Invalid DoenetML: Wan tag sondro wan tag-nen feni `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Invalid DoenetML: A tag `{ $tag }` no tapu (a gersi leki wan `/>` e misi).
+
+parse-tag-invalid-attributes = Invalid DoenetML: A tag `{ $tag }` no bun. Kande den atribut fu en no bun.
+
+parse-close-tag-name-missing = Invalid DoenetML: Wan tapu-tag sondro wan tag-nen feni, leki `</`
+
+parse-attribute-value-unquoted = Atribut-waarde musu de na ini kotomarki: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Invalid DoenetML: A tapu-tag `{ $tag }` feni, ma no wan opo-tag di e go nanga en no de
+
+parse-close-tag-mismatched = Invalid DoenetML: A tapu-tag no e kruderi. `</{ $expected }>` ben de fanowdu. `{ $found }` feni
+
+parser-node-unconvertible = No man kenki a node { $node } go na wan Dast node.
+
+## Names
+
+name-attribute-invalid =
+    A atribut name='{ $name }' no bun. { $reason ->
+        [characters] Wan nen man abi soso letter, nomru, ondro-lin noso koto-lin.
+       *[start] Wan nen musu bigin nanga wan letter.
+    }
+
+component-name-invalid-start = A komponent-nen "{ $name }" no bun. Wan nen musu bigin nanga wan letter.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Wan answer fu type videoWatched musu abi wan video atribut
+
+answer-video-watched-video-not-reference = Wan answer fu type videoWatched musu abi wan video atribut di na wan referensi
+
+answer-name-not-single-text = A name atribut fu wan answer musu abi wan text-pikin nomo
+
+## Referencing another document
+
+external-doenetml-recursion-limit = No man kisi a DoenetML fu dorosei bika tumsi furu nivo fu rekursi. Kande wan lontu referensi de?
+
+external-doenetml-unavailable = No man kisi a DoenetML fu { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = A DoenetML di kisi fu { $attribute }="{ $uri }" no bun: a no e kruderi nanga a komponent-type "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] A atribut `{ $from }` no e gebroiki moro; gebroiki `{ $to }` na en presi.
+       *[other] [deprecation] A atribut `{ $from }` tapu `<{ $component }>` no e gebroiki moro; gebroiki `{ $to }` na en presi.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] A atribut `{ $from }` no e gebroiki moro en a no e teri bika `{ $to }` poti tu.
+       *[other] [deprecation] A atribut `{ $from }` tapu `<{ $component }>` no e gebroiki moro en a no e teri bika `{ $to }` poti tu.
+    }
+
+deprecated-attribute-ignored = [deprecation] A atribut `{ $attribute }` tapu `<{ $component }>` no e gebroiki moro en a no e teri.
+
+deprecated-attribute-to-child = [deprecation] A atribut `{ $attribute }` tapu `<{ $component }>` no e gebroiki moro; gebroiki wan `<{ $child }>` pikin na en presi.
+
+deprecated-attribute-value-renamed = [deprecation] A waarde `{ $value }` fu a atribut `{ $attribute }` tapu `<{ $component }>` no e gebroiki moro; gebroiki `{ $to }` na en presi.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` man meki soso Ingrisi wortu kon furu, so a tekst fu en e tan a srefi na ini wan dokumenti di skrifi na ini { $locale }. Skrifi a furu-fasi srefi, noso poti en nanga a `pluralForm` atribut.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = A elementi `<{ $tag }>` no de wan Doenet elementi di wi sabi.
+
+schema-element-not-allowed-at-root = A elementi `<{ $tag }>` no mag de na a rutu fu a dokumenti.
+
+schema-element-not-allowed-inside = A elementi `<{ $tag }>` no mag de na ini `<{ $parent }>`.
+
+schema-attribute-unrecognized = A elementi `<{ $tag }>` no abi wan atribut nanga a nen `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] A atribut `{ $attribute }` fu a elementi `<{ $tag }>` musu de wan lisi pe ibri item na wan fu: { $allowed }
+       *[other] A atribut `{ $attribute }` fu a elementi `<{ $tag }>` musu de wan fu: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = A variant-nen gi select no bun.  A variant-nen { $variantName } e kon na ini { $numOptions } option ma a nomru fu teki na { $numToSelect }.
+
+select-variant-name-without-options = Son variant poti gi select ma no wan option no poti gi a variant-nen di kan de: { $variantName }.
+
+select-variant-name-not-possible = A variant-nen { $variantName } di poti gi select no de wan variant-nen di kan de.
+
+select-too-few-options = No man teki { $numToSelect } komponent fu soso { $numOptions }.
+
+select-from-sequence-too-few-values = No man teki { $numToSelect } waarde fu wan sekwensi di langa { $length }.
+
+select-from-sequence-indices-count-mismatch = A nomru fu indeks di poti gi select musu kruderi nanga a nomru fu teki
+
+select-from-sequence-indices-not-integers = Ala indeks di poti gi select musu de heri nomru
+
+select-from-sequence-index-excluded = A indeks di poti gi selectfromsequence ben puru kaba
+
+select-from-sequence-indices-excluded-combination = Den indeks di poti gi selectfromsequence ben meki wan kombinasi di puru kaba
+
+select-from-sequence-coprime-not-positive-integers = No man teki coprime kombinasi bika no positief heri nomru e teki.
+
+select-from-sequence-coprime-common-factor = No man teki coprime nomru. Ala waarde di kan de abi a srefi faktor. (Den waarde di poti gi "from" noso "to" musu de coprime nanga "step".)
+
+select-from-sequence-coprime-single-number = No man teki coprime kombinasi fu wan enkri nomru di no de 1.
+
+select-from-sequence-excluded-too-many-combinations = Moro leki 70% fu den kombinasi na ini selectFromSequence puru
+
+select-from-sequence-coprime-none-found = No man teki coprime nomru. Ala waarde di kan de abi a srefi faktor.
+
+select-from-sequence-too-few-unique-values = No man teki { $numToSelect } aparti waarde fu wan sekwensi di langa { $numPossibleValues }
+
+select-prime-numbers-too-few-values = No man teki { $numToSelect } waarde fu wan lisi fu priem-nomru di langa { $numValues }
+
+select-prime-numbers-values-count-mismatch = A nomru fu waarde di poti gi select musu kruderi nanga a nomru fu teki
+
+select-prime-numbers-values-not-prime = Ala waarde di poti gi select prime number musu de na ini a lisi fu priem-nomru
+
+select-prime-numbers-values-excluded-combination = Den waarde di poti gi selectPrimeNumbers ben meki wan kombinasi di puru kaba
+
+select-prime-numbers-excluded-too-many-combinations = Moro leki 70% fu den kombinasi na ini selectPrimeNumbers puru
+
+select-random-combination-fluke = Fu wan sani di no e psa noiti, no man teki wan kombinasi fu waarde di teki nanga koloku
+
+select-random-value-fluke = Fu wan sani di no e psa noiti, no man teki wan waarde nanga koloku
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    `<{ $component }>` no e teken na ini a matematika; a ekspresi e seti neleki a ben de bifo inputu ben man kon na ini. { $reason ->
+        [not-inline] Soso wan `inline` choice input e fiti na ini wan ekspresi; sondro `inline` a de wan blok fu knopu.
+        [expanded] Wan `expanded` text input de wan bakisi nanga furu lin, di bigi tumsi fu sidon na ini wan ekspresi.
+        [on-graph] Tapu wan graph a ekspresi e teken leki wan enkri prenki, di no abi presi gi wan knopu.
+       *[relative-width] A `width` fu en de relatief (wan prosenti noso `em`), en dati no abi noti fu meti teige na ini wan ekspresi. Gi a bradi na ini absolute marki, leki `px`.
+    }

--- a/packages/i18n/locales/srn/editor.ftl
+++ b/packages/i18n/locales/srn/editor.ftl
@@ -1,0 +1,232 @@
+# Sranan Tongo (Sranantongo) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber`, `prefigure` and every attribute
+# or element name are identifiers, not prose, and stay exactly as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The **1986 official Surinamese orthography** — `u` for /u/
+# and never «oe», `y` for the glide and never «j», `dy` for the voiced
+# affricate, `ky` and `gy` for the palatalized stops, and vowel length written
+# with a single letter. The pre-1986 Dutch-influenced spellings are used
+# nowhere in these four files and must not be mixed into them. The system has
+# no diacritics at all, so an accented character here would be an error.
+# `chrome.ftl` sets the differences out point by point.
+#
+# **Word order and agreement.** Modifiers precede the noun, as in English.
+# Sranan Tongo has no grammatical gender and no adjective agreement, so nothing
+# here agrees with anything.
+#
+# **Number.** The probe reports no CLDR data of its own for `srn`: it resolves
+# to `en-US` and answers `['one', 'other']`. A Sranan noun after a numeral is
+# unmarked, so the two branches would be word-for-word identical and **one
+# unselected form** is written instead. No count-driven select appears in this
+# file.
+#
+# **This is the thinnest of the four files.** The editor is a developer
+# surface, and most of what it names is discussed in Suriname in Dutch or in
+# English rather than in Sranan. «Variant», «filter», «format», «komponent»,
+# «atribut», «snippet», «array», «funksi», «versi», «koordinaat», «kursor» and
+# «diagnostik» are the loans a Sranan speaker working with software would
+# actually use; they are kept, not translated, and are not offered as
+# translations. «Aksesibiliteit» is the word a reviewer should look at first,
+# and «Luku» for *viewer* the second. The technical vocabulary in this file is
+# a **lexifier loan set**, Dutch- and English-mediated, carried in Sranan
+# Tongo's own grammar and written in the 1986 orthography: these loans are the
+# words the language actually uses, and the sentences built around them are
+# Sranan, not Dutch.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reset
+       *[update] Nyun
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } a Luku
+       *[other] { $word } a Luku { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+
+editor-variant-filter = Filter...
+
+editor-variant-next = Teki a variant di e kon baka
+editor-variant-previous = Teki a variant di ben de fosi
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wan WCAG AA aksesibiliteit-fowtu feni. Klik fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteit-rapport.
+        [advisories] Klik fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteit-rapport. No wan WCAG AA fowtu no feni, ma moro aksesibiliteit-rai de.
+       *[clean] Klik fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteit-rapport. No wan aksesibiliteit-problema no feni.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wan WCAG AA aksesibiliteit-fowtu feni. { $count } WCAG AA fowtu feni. Klik fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteit-rapport.
+        [advisories] No wan WCAG AA fowtu no feni. { $count } moro aksesibiliteit-rai feni. Klik fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteit-rapport.
+       *[clean] No wan WCAG AA fowtu no feni. Klik fu { $action ->
+            [close] tapu
+           *[open] opo
+        } a aksesibiliteit-rapport.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Yepi di e fiti a presi
+editor-tab-help-short = Presi
+editor-tab-errors = Fowtu
+editor-tab-warnings = Warskow
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibiliteit
+editor-tab-responses = Piki di seni
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editor-opsi
+editor-format-as-doenetml = Formateri leki DoenetML
+editor-format-as-xml = Formateri leki XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lin #{ $line }
+
+editor-no-errors = No wan fowtu
+editor-no-warnings = No wan warskow
+editor-no-info = No wan info-diagnostik
+
+editor-show-info-annotations = Sori den info-diagnostik na ini a editor
+editor-show-accessibility-annotations = Sori den aksesibiliteit-diagnostik na ini a editor
+
+editor-accessibility-learn-more = Leri fa Doenet e wroko nanga aksesibiliteit
+
+editor-accessibility-violations-heading = Aksesibiliteit-fowtu ({ $standard })
+
+editor-accessibility-other-heading = Tra aksesibiliteit-problema
+editor-none-found = No wan no feni
+
+
+## Submitted responses
+
+editor-no-responses = No wan piki no seni ete
+editor-response-answer-id = Piki-Id
+editor-response-response = Piki
+editor-response-credit = Krediti
+editor-response-submitted = Seni
+
+
+## The context-help panel
+
+help-placeholder = Poti a kursor tapu wan tag-nen, wan atribut, noso { $ref } fu kisi dokumentasi.
+
+help-unsupported-ref-chain = Yepi gi referensi di abi difrenti pisi, leki { $example }, no de ete.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] No wan sani no feni gi a referensi: { $ref }.
+        [multiple] Moro leki wan sani feni gi a referensi: { $ref }.
+       *[indeterminate] Wi no man sabi san { $ref } e sori.
+    }
+
+help-learn-about-references = Leri moro fu referensi →
+help-reference-page = Referensi-blad →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Na ini { $element }
+       *[top] Na a moro hei nivo
+    }{ $allowed ->
+        [none] { " — no wan sani no e go dyaso." }
+        [text] { " — skrifi tekst dyaso." }
+        [text-and-components] { " — skrifi tekst dyaso, noso proberi:" }
+       *[components] { " — sani fu proberi:" }
+    }
+
+help-suggestions-footer = Druk { $shortcut } fu si ala { $total } komponent.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } na wan referensi gi { $target }.
+       *[other] { $ref } na wan referensi gi { $target } (lin { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } tyari en kon leki { $role }.
+       *[other] { $owner } tyari en kon na lin { $line } leki { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } na wan referensi gi a { $property } propaiti fu { $element }.
+       *[other] { $ref } na wan referensi gi a { $property } propaiti fu { $element } (lin { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = snippet
+help-kind-array-entry = array-entri
+
+help-default = Standard:
+help-active-default = Standard di e wroko now:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Waarde di mag (wan gi ibri item):
+       *[other] Waarde di mag:
+    }
+
+help-suggested-values = Waarde di wi e rai:
+
+help-inserts = E poti:
+
+help-coordinates = Koordinaat:
+
+help-type = Sortu:
+
+help-resolved-style = A stail di kon na krin (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Funksi-nen di kon na krin:
+help-reset-list = Reset-lisi tapu a inputu disi:
+help-added-on-input = Poti tapu a inputu disi:
+help-removed-on-input = Puru tapu a inputu disi:
+
+help-reset-overrides = { $reset } e teki presi fu { $additional } nanga { $removed }.

--- a/packages/i18n/locales/yua/chrome.ftl
+++ b/packages/i18n/locales/yua/chrome.ftl
@@ -17,9 +17,14 @@
 #     «maʼalob» — never by an acute accent or a macron.
 #   * **The glottal stop and the ejectives are written with U+02BC MODIFIER
 #     LETTER APOSTROPHE `ʼ`**, not U+2019 RIGHT SINGLE QUOTATION MARK `’` and
-#     not U+0027 APOSTROPHE `'`. Every apostrophe in these four files is
-#     U+02BC. The three characters are homoglyphs in most fonts, so a reviewer
-#     who retypes a word should check the codepoint rather than the shape.
+#     not U+0027 APOSTROPHE `'`. Every apostrophe *inside a Maya word* in
+#     these four files is U+02BC. The three characters are homoglyphs in most
+#     fonts, so a reviewer who retypes a word should check the codepoint
+#     rather than the shape. The straight ASCII `'` does still appear, and is
+#     not a respelling: it is English's own punctuation, carried through
+#     unchanged where a message quotes an enumerated value back to the author
+#     or writes the derivative `y'`. `catalogLint.test.ts` forbids U+2019 here
+#     and deliberately permits U+0027 for that reason.
 #
 # The catalog writes the name of the language as «Maayaʼ tʼàan» in all four
 # files, following the way this batch was commissioned. The tone-marked `à` is

--- a/packages/i18n/locales/yua/chrome.ftl
+++ b/packages/i18n/locales/yua/chrome.ftl
@@ -1,0 +1,186 @@
+# Yucatec Maya (Maayaʼ tʼàan) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The modern unified orthography of the Academia de la Lengua
+# Maya de Yucatán, as INALI publishes it: `a aa b ch chʼ e ee i ii j k kʼ l m n
+# o oo p pʼ r s t tʼ ts tsʼ u uu w x y ʼ`. Two things about it decide how these
+# files look.
+#
+#   * **Length is written by doubling the vowel** — «maayaʼ», «tʼaan»,
+#     «maʼalob» — never by an acute accent or a macron.
+#   * **The glottal stop and the ejectives are written with U+02BC MODIFIER
+#     LETTER APOSTROPHE `ʼ`**, not U+2019 RIGHT SINGLE QUOTATION MARK `’` and
+#     not U+0027 APOSTROPHE `'`. Every apostrophe in these four files is
+#     U+02BC. The three characters are homoglyphs in most fonts, so a reviewer
+#     who retypes a word should check the codepoint rather than the shape.
+#
+# The catalog writes the name of the language as «Maayaʼ tʼàan» in all four
+# files, following the way this batch was commissioned. The tone-marked `à` is
+# not part of the ordinary ALMY spelling, which writes «maayaʼ tʼaan»; the
+# grave here marks the falling tone and is otherwise unwritten in the body of
+# these catalogs.
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `yua`, so it falls back
+# to the default locale and reports `one` and `other` — categories Yucatec does
+# not select. A Yucatec noun after a numeral takes no plural suffix, so the two
+# branches would be the same text, and where that is so this file writes **one
+# unselected form**. English's explicit `[0]` literals match the number itself
+# rather than a category, and `attempts-remaining` keeps that shape.
+#
+# **Loans.** Yucatec has no native software register, and the register it does
+# use for this material in school and in everyday speech is Spanish. The
+# technical nouns here are therefore **Spanish loans written in the ALMY
+# orthography and carried inside an ordinary Yucatec sentence frame** — native
+# verbs, native word order, the native negation «maʼ … -iʼ». The loans this
+# file carries are «teklaado» (keyboard), «renglón» (row), «kolumna» (column),
+# «kaja» (box), «flecha» (arrow), «punto» (point), «intervalo» (interval),
+# «matrís» (matrix), «kréedito» (credit), «ekspresión matemátika» (math
+# expression), «estadístika» (statistics), «dokumento», «páajina» (page),
+# «renderisador» (renderer), «nota» (footnote), «informasión», «aksesibilidad»,
+# «etiketa» (label). Nothing here is a coinage; where the loan is what a
+# speaker would actually say, the loan is written.
+#
+# **Confidence.** All sixty-seven keys in this file are translated. The
+# weakest of them are «Komentario» for *feedback*, which is a loan chosen for
+# want of a settled word rather than an established usage, and the four
+# diagnostic headings, where «Síiʼpil» (fault, mistake) is doing the work of
+# *error* and «Áantaj» (help) that of *hint*. `WCAG AA` is the name of a
+# standard and stays as written, as do `%` and every `{ $variable }`.
+
+
+## Answer submission
+
+answer-checking = Táan u yilaʼal...
+answer-submitting = Táan u túuxtaʼal...
+
+answer-checking-status = Táan u yilaʼal le núukoʼ
+answer-submitting-status = Táan u túuxtaʼal le núukoʼ
+
+answer-correct = Maʼalob
+answer-incorrect = Maʼ maʼalobiʼ
+
+answer-response-saved = Tsʼoʼok u kanáantaʼal le núukoʼ
+
+answer-percent-credit = { $percent }% kréedito
+answer-percent-correct = { $percent }% maʼalob
+answer-percent-short = { $percent } %
+
+max-credit-available = U nojochil kréedito jeʼel u páajtal u kʼaʼamal: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] minaʼan u láakʼ téenel
+       *[other] { $count } téenel pʼaatal
+    }
+
+validation-correct = (Maʼalob)
+validation-incorrect = (Maʼ maʼalobiʼ)
+validation-partially-correct = (Chéen junjaats maʼalob)
+
+answer-show-responses = Eʼes { $count } núuk tiʼ { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentario
+
+collapsible-click-to-open = (kʼop utiaʼal u jeʼebel)
+collapsible-click-to-close = (kʼop utiaʼal u kʼaʼalal)
+
+collapsible-initializing = Táan u káajsaʼal...
+
+footnote-show = Eʼes le notaoʼ
+footnote-hide = Taʼak le notaoʼ
+
+description-more-information = maas informasión
+
+
+## Controls
+
+slider-previous = Paachil
+slider-next = Táanil
+
+keyboard-open = Jeʼe le teklaadooʼ
+keyboard-close = Kʼal le teklaadooʼ
+
+choice-input-remove-choice = Luʼs { $choice }
+
+matrix-remove-row = Luʼs junpʼéel renglón
+matrix-add-row = Tsʼáa junpʼéel renglón
+matrix-remove-column = Luʼs junpʼéel kolumna
+matrix-add-column = Tsʼáa junpʼéel kolumna
+
+subset-add-remove-points = Tsʼáa wa luʼs puntoʼob
+subset-toggle-points-intervals = Kʼex ichil puntoʼob yéetel intervaloʼob
+subset-move-points = Péeks le puntoʼoboʼ
+subset-clear = Luʼs tuláakal
+
+orbital-add-row = Tsʼáa junpʼéel renglón
+orbital-remove-row = Luʼs junpʼéel renglón
+orbital-add-box = Tsʼáa junpʼéel kaja
+orbital-remove-box = Luʼs junpʼéel kaja
+orbital-add-up-arrow = Tsʼáa junpʼéel flecha kaʼanal
+orbital-add-down-arrow = Tsʼáa junpʼéel flecha kabal
+orbital-remove-arrow = Luʼs le flechaoʼ
+
+orbital-row-label = Etiketa tiʼ le renglón { $row }
+
+pretzel-answer = Núuk
+
+summary-statistics-caption = U resumen estadístika tiʼ { $column }
+
+
+## Math input
+
+math-input-preview-region = eʼesajil ekspresión matemátika
+math-input-preview = Eʼesajil
+math-input-invalid-expression = Ekspresión maʼ maʼalobiʼ:
+
+
+## Document status
+
+viewer-initializing = Táan u káajsaʼal...
+
+
+## Errors
+
+error-heading = Síiʼpil
+
+error-found-at =
+    { $span ->
+        [line] Kaxtaʼab tiʼ renglón { $startLine }.
+       *[lines] Kaxtaʼab tiʼ renglonoʼob { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = ¡Le dokumentoaʼ yaan síiʼpiloʼob ichil!
+
+diagnostic-heading-error = Síiʼpil
+diagnostic-heading-warning = Aviso
+diagnostic-heading-information = Informasión
+diagnostic-heading-hint = Áantaj
+
+accessibility-heading-level-1 = U síiʼpilil aksesibilidad tiʼ WCAG AA
+accessibility-heading-level-2 = Aviso tiʼ aksesibilidad
+
+something-went-wrong = Yaan baʼax maʼ bin utsiʼ.
+
+renderer-load-failed = maʼ tu páajtal u káajsaʼal junpʼéel renderisador. Kaʼa káajs le páajinaoʼ.
+
+core-start-failed = Maʼ tu páajtal u káajsaʼal le dokumentoaʼ. Kaʼa káajs le páajinaoʼ.
+
+core-start-failed-busy = Maʼ tu páajtal u káajsaʼal le dokumentoaʼ. Yaʼabach dokumento táan u káajsaʼaloʼob junsúutuk, yéetel jeʼel u xáantal maas tiʼ junpʼéel núukul chan chaambelil. Jeʼel u páajtal u yáantaj a kaʼa káajsik le páajina ken tsʼoʼokok u káajal le uláakʼ dokumentoʼoboʼ.
+
+core-start-failed-retry = Maʼ tu páajtal u káajsaʼal le dokumentoaʼ.
+
+core-start-failed-busy-retry = Maʼ tu páajtal u káajsaʼal le dokumentoaʼ. Yaʼabach dokumento táan u káajsaʼaloʼob junsúutuk, yéetel jeʼel u xáantal maas tiʼ junpʼéel núukul chan chaambelil.
+
+core-start-retry = Kaʼa túuntej
+
+saved-state-unavailable = Maʼ tu páajtal u káajsaʼal a meyaj kanáantaʼanoʼ.

--- a/packages/i18n/locales/yua/content.ftl
+++ b/packages/i18n/locales/yua/content.ftl
@@ -9,10 +9,11 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # **Orthography.** The ALMY/INALI unified orthography; see `chrome.ftl`'s
-# header for the alphabet and the doubled long vowels. Every apostrophe in
-# these files is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
-# and never U+0027 `'`; the three are homoglyphs in most fonts, so check the
-# codepoint rather than the shape. The language is named «Maayaʼ tʼàan», whose
+# header for the alphabet and the doubled long vowels. Every apostrophe inside
+# a Maya word is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`;
+# the two are homoglyphs in most fonts, so check the codepoint rather than the
+# shape. Straight ASCII `'` is English's own punctuation carried through where
+# a message quotes a value, and is not a Maya letter. The language is named «Maayaʼ tʼàan», whose
 # grave marks the falling tone and is not part of ordinary ALMY spelling
 # («maayaʼ tʼaan»).
 #

--- a/packages/i18n/locales/yua/content.ftl
+++ b/packages/i18n/locales/yua/content.ftl
@@ -1,0 +1,290 @@
+# Yucatec Maya (Maayaʼ tʼàan) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. English, in `locales/en/content.ftl`, is the source of truth:
+# `lint:i18n` rejects a key that does not exist there.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The ALMY/INALI unified orthography; see `chrome.ftl`'s
+# header for the alphabet and the doubled long vowels. Every apostrophe in
+# these files is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
+# and never U+0027 `'`; the three are homoglyphs in most fonts, so check the
+# codepoint rather than the shape. The language is named «Maayaʼ tʼàan», whose
+# grave marks the falling tone and is not part of ordinary ALMY spelling
+# («maayaʼ tʼaan»).
+#
+# **Number.** No message here selects on a count. `Intl.PluralRules` has no
+# CLDR data for `yua` and falls back to categories Yucatec does not select, and
+# a Yucatec noun after a numeral takes no plural suffix, so a `[one]`/`[other]`
+# pair would be two copies of one string. Where English writes one, this file
+# writes **one unselected form**. `noun-regular-polygon` prints `{ $numSides }`
+# before an unmarked «tsel» for that reason.
+#
+# **Word order.** The modifier **precedes** the noun in Yucatec — «chak nal»,
+# red maize — which is English's order too. The composition messages
+# (`style-stroke`, `style-with-noun`, `style-filled*`, `style-border-clause`,
+# `style-fill`, `style-text`) therefore keep the order English gives them, and
+# a reviewer should read that as a decision rather than as an untouched string.
+# «yéetel» is the preposition in all of them.
+#
+# **Loans.** Yucatec has no native geometry or software register; the register
+# actually used for this material in Yucatán is Spanish. The shape and style
+# nouns here are therefore **Spanish loans written in the ALMY orthography and
+# carried in a Yucatec frame**: «línea», «segmento», «rayo», «bektor»,
+# «kurba», «funsión», «parábola», «polilínea», «polígono», «triángulo»,
+# «rektángulo», «sírkulo», «rejión», «punto», «kwadrado», «rombo», «kurus»,
+# «borde», «fondo», «patrón», «sekción», «tabla», «figura», «páajina». The
+# words that are not loans are native: «pim» thick, «jaay» thin, «chupaʼan»
+# filled, «jaaj» true, «kʼáatchiʼ» question, «meyaj» activity, «jaats» part,
+# «tsel» side. `rayaʼan` (dashed) and `puntaʼan` (dotted) are Spanish stems
+# taking the native participial `-aʼan`, which is a productive pattern; a
+# reviewer may prefer plain loans there.
+#
+# **What is left out, and why.**
+#
+#   * `element-name` and `element-anion-name` — the 118 chemical elements — are
+#     omitted: chemistry is schooled in Spanish in Yucatán and there is no
+#     published Yucatec list of the elements.
+#   * The colour table is filled in full, but only six of the twelve families
+#     are Yucatec words. «yaʼax» spans green and blue-green and is assigned to
+#     `.green`; `.blue` is «chʼoj», the darker blue. That is a genuine seam and
+#     not a translation of either English word. Gray, orange, cyan, purple,
+#     pink and brown are the Spanish loans a speaker actually says — «gris»,
+#     «naranja», «siyan», «morado», «rosa», «kafé» — written as loans rather
+#     than coined.
+#   * `noun-gender` answers one token, «neutro». Yucatec has no grammatical
+#     gender, so nothing in this catalog selects on it.
+#   * The three piecewise words are the weakest entries here: Yucatec «wa»
+#     covers both *if* and *or*, so `piecewise-condition-if` and
+#     `piecewise-condition-or` are the same word, and a reviewer who knows a
+#     contrast the seed does not should overwrite both.
+
+
+## Style vocabulary
+
+color =
+    .black = box
+    .white = sak
+    .gray = gris
+    .red = chak
+    .orange = naranja
+    .yellow = kʼan
+    .green = yaʼax
+    .cyan = siyan
+    .blue = chʼoj
+    .purple = morado
+    .pink = rosa
+    .brown = kafé
+
+line-width =
+    .thick = pim
+    .thin = jaay
+
+line-style =
+    .dashed = rayaʼan
+    .dotted = puntaʼan
+
+fill-style =
+    .horizontal = líneaʼob orisontal
+    .vertical = líneaʼob bertikal
+    .diagonal = líneaʼob diagonal
+    .backdiagonal = líneaʼob diagonal tu paach
+    .dots = puntoʼob
+    .diamonds = romboʼob
+
+noun =
+    .line = línea
+    .line-segment = segmento
+    .ray = rayo
+    .vector = bektor
+    .curve = kurba
+    .function = funsión
+    .slope-field = kampo tiʼ pendiente
+    .vector-field = kampo bektorial
+    .parabola = parábola
+    .polyline = polilínea
+    .polygon = polígono
+    .triangle = triángulo
+    .rectangle = rektángulo
+    .circle = sírkulo
+    .region = rejión
+    .point = punto
+    .square = kwadrado
+    .diamond = rombo
+    .cross = kurus
+    .plus = signo maas
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } tsel polígono regular
+    }
+
+noun-gender = neutro
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = chupaʼan
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } yéetel { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } yéetel { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } yéetel { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] yéetel junpʼéel { $border } borde
+        [and] yéetel xan { $border } borde
+        [and-article] yéetel xan junpʼéel { $border } borde
+       *[with] yéetel { $border } borde
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = maʼ chupaʼaniʼ
+
+style-text =
+    { $parts ->
+        [background] { $color } yéetel junpʼéel { $background } fondo
+       *[plain] { $color }
+    }
+
+style-background-none = minaʼan
+
+
+## Boolean words
+
+boolean-true = jaaj
+boolean-false = maʼ jaajiʼ
+
+
+## Answer buttons
+
+answer-submit-label = Ils a meyaj
+answer-submit-label-no-correctness = Túuxt a núuk
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Meyaj
+    .aside = Uláakʼ tʼaan
+    .cascade = Kaskada
+    .definition = Definisión
+    .example = Eʼesajil
+    .exercise = Ejersisio
+    .exercises = Ejersisioʼob
+    .given-answer = Núuk
+    .note = Nota
+    .objectives = Objetiboʼob
+    .paragraphs = Párrafoʼob
+    .part = Jaats
+    .problem = Problema
+    .problems = Problemaʼob
+    .proof = Prueba
+    .question = Kʼáatchiʼ
+    .section = Sekción
+    .solution = Solusión
+    .task = Tarea
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Áantaj
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
+       *[unnumbered] Figura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Paachil
+paginator-next = Táanil
+paginator-page = Páajina
+
+paginator-page-status = { $pageLabel } { $currentPage } tiʼ { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = wa
+
+piecewise-condition-if = wa
+
+piecewise-condition-otherwise = wa maʼeʼ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately omitted; see the
+## header. What is here is the prose around them.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Símbolo kímiko maʼ maʼalobiʼ
+chemistry-invalid-ionic-compound = Kompuesto iónico maʼ maʼalobiʼ
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blanko
+
+math-embedded-input-blank-ordinal = blanko { $ordinal } tiʼ { $total }

--- a/packages/i18n/locales/yua/diagnostics.ftl
+++ b/packages/i18n/locales/yua/diagnostics.ftl
@@ -1,0 +1,690 @@
+# Yucatec Maya (Maayaʼ tʼàan) diagnostics: the errors and warnings the core,
+# the parser and the schema checker report about a document, shown to whoever
+# is looking at the screen. Translated from `locales/en/diagnostics.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Element names, attribute names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence`, `WCAG AA` — are part of the language rather than prose
+# and stay in English exactly as written, as does anything quoted back from the
+# author's own source.
+#
+# **Orthography.** The ALMY/INALI unified orthography; see `chrome.ftl`'s
+# header for the alphabet and the doubled long vowels. Every apostrophe in
+# these files is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
+# and never U+0027 `'`. The three are homoglyphs in most fonts, so a reviewer
+# who retypes a word should check the codepoint rather than the shape. The
+# language is named «Maayaʼ tʼàan»; the grave marks the falling tone and is not
+# part of ordinary ALMY spelling («maayaʼ tʼaan»).
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `yua`, so it falls back
+# to the default locale and reports `one` and `other` — categories Yucatec does
+# not select. A Yucatec noun after a numeral takes no plural suffix, so every
+# place English writes a `[one]`/`[other]` pair this file writes **one
+# unselected form**. The selects that remain are on non-numeric variables —
+# `$mode`, `$type`, `$reason`, `$expected`, `$component`, `$suggestion`,
+# `$isList`, `$fallback`, `$labelKind`, `$componentType`, `$context` — and keep
+# every branch English has.
+#
+# **Loans, and the frame around them.** Yucatec has an established written
+# register in school, church and everyday use and no native software or
+# mathematical register at all; the register a speaker actually uses for this
+# material is Spanish. This file therefore writes the technical nouns as
+# **Spanish loans adapted to the ALMY orthography**, inside an ordinary
+# **Yucatec sentence frame**: native verbs, native word order, and the native
+# negation «maʼ … -iʼ». The loans it carries are «atributo», «komponente»,
+# «balor» (value), «referensia», «bariante», «punto», «línea», «bektor»,
+# «sírkulo», «ángulo», «matrís», «funsión», «dominio», «intervalo»,
+# «sekuensia», «índise», «parámetro», «dimensión», «ekuasión», «koordenada»,
+# «kolor», «kontraste», «formato», «tipo», «entero» (integer), «número»,
+# «elemento», «etiketa», «anotasión», «renglón» (row/line), «kolumna»,
+# «bersión», «aksesibilidad». No affix is ever welded onto a `{ $variable }`:
+# where a sentence needs one it falls on a word this catalog wrote, and the
+# author's own word stands untouched inside its quotes.
+#
+# The frame is the honest part; the vocabulary is a loan register recorded as
+# such. This is a usable seed, not yet Yucatec technical prose, and a speaker
+# should overwrite it freely — starting, ideally, from an agreed term list
+# rather than from these sentences.
+#
+# **Confidence.** Every message in the English catalog is translated here.
+# «Síiʼpil» (fault, mistake) carries *error* throughout; «Maʼ beetaʼak» (it has
+# not been made) carries English's "Haven't implemented"; «Maʼ táan u
+# chʼaʼabal» (it is not taken) carries "ignoring". The `[deprecation]` marker
+# is a literal and is left as it stands, as is `Invalid DoenetML: `'s structure
+# — the words in front of the colon are translated, the colon and what follows
+# are not.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = maʼ táan u chʼaʼabal { $attributes } le ken tsʼaʼabak kaʼapʼéel u xuulil puntoʼob
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = maʼ táan u chʼaʼabal { $attributes } le ken tsʼaʼabak junpʼéel u xuulil punto yéetel junpʼéel u chúumukil punto
+
+line-segment-midpoint-offset-without-midpoint = mix baʼal ku beetik midpointOffset wa minaʼan junpʼéel u chúumukil punto
+
+## `<line>`
+
+line-points-undetermined-dimensions = Línea ku máan tiʼ puntoʼob maʼ ojéelaʼan u dimensiónoʼobiʼ.
+
+line-points-too-few-dimensions = Le líneaoʼ yaan u máan tiʼ puntoʼob yéetel kaʼapʼéel dimensión wa maas.
+
+line-points-depend-on-variables = Le líneaoʼ ku máan tiʼ puntoʼob ku bin tu paach bariableʼob: { $variables }.
+
+line-equation-invalid-format = Maʼ maʼalob u formatoil u ekuasiónil le línea tiʼ le bariableʼob { $variable1 } yéetel { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Le rayooʼ tsʼaʼabaltiʼ yéetel through, endpoint yéetel direction.  Maʼ táan u chʼaʼabal le through tsʼaʼabtiʼoʼ.
+
+ray-dimension-mismatch = Maʼ tu núupul numDimensions ichil le rayooʼ.
+
+## `<vector>`
+
+vector-overprescribed-head = Le bektoroʼ tsʼaʼabaltiʼ yéetel head, tail yéetel displacement.  Maʼ táan u chʼaʼabal le head tsʼaʼabtiʼoʼ.
+
+vector-dimension-mismatch = Maʼ tu núupul numDimensions ichil le bektoroʼ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Maʼ tu páajtal u yúuchul atraksión tiʼ junpʼéel `<{ $component }>` tumen minaʼantiʼ u bariable de estado nearestPoint.
+
+constrain-to-without-nearest-point = Maʼ tu páajtal u kʼaʼalal tiʼ junpʼéel `<{ $component }>` tumen minaʼantiʼ u bariable de estado nearestPoint.
+
+constrain-to-interior-without-nearest-point = Maʼ tu páajtal u kʼaʼalal tu taʼakʼanil junpʼéel `<{ $component }>` tumen minaʼantiʼ u bariable de estado nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = maʼ táan u chʼaʼabal labelPosition tiʼ junpʼéel choiceInput maʼ inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Maʼ táan u chʼaʼabal le índiseʼob tsʼaʼaboʼob tiʼ choiceInput tumen maʼ tu núupul u yaʼabil índiseʼob yéetel u yaʼabil paalal choice.
+
+pretzel-indices-count-mismatch = Maʼ táan u chʼaʼabal le índiseʼob tsʼaʼaboʼob tiʼ problem tumen maʼ tu núupul u yaʼabil índiseʼob yéetel u yaʼabil paalal problem.
+
+shuffle-indices-count-mismatch = Maʼ táan u chʼaʼabal le índiseʼob tsʼaʼaboʼob tiʼ shuffle tumen maʼ tu núupul u yaʼabil índiseʼob yéetel u yaʼabil komponenteʼob.
+
+indices-ignored-out-of-range = Maʼ táan u chʼaʼabal le índiseʼob tsʼaʼaboʼob tiʼ { $component } tumen yaan índiseʼob táanxel tiʼ le xúulaʼoʼ.
+
+pretzel-indices-repeated = Maʼ táan u chʼaʼabal le índiseʼob tsʼaʼaboʼob tiʼ pretzel tumen yaan índiseʼob kaʼatéen tsʼíibtaʼan.
+
+pretzel-circuit-first-index = Maʼ táan u chʼaʼabal le índiseʼob tsʼaʼaboʼob tiʼ pretzel tiʼ mode circuit tumen yáax índise yaan u yantal 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Utiaʼal u meyaj `<{ $component }>` yéetel paalal tʼaan, kʼaʼabéet u tsʼaʼabal junpʼéel atributo `type`.
+
+invalid-type-defaulting-to-math = Maʼ maʼalob le tipo { $type } tiʼ le komponente { $component }. Yaan u yantal juntúul tiʼ math, text, number wa boolean. Ku pʼaʼatal bey math.
+
+string-not-valid-component-to-arrange = Le tʼaan "{ $value }" maʼ junpʼéel komponente maʼalob utiaʼal { $component }. Maʼ táan u chʼaʼabaliʼ.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Maʼ maʼalob le tipo { $type }, ku pʼaʼatal bey number.
+
+invalid-variable-value = Maʼ maʼalob u balor junpʼéel bariable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = U índise le bariante { $index } yaan u yantal junpʼéel número
+
+variant-index-must-be-integer = U índise le bariante { $index } yaan u yantal junpʼéel entero
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Maʼ beetaʼak `<{ $component }>` yéetel pʼisibaʼal absoluto. Ku tsʼaʼabal le kóochil bey relatibo.
+
+side-by-side-absolute-margins = Maʼ beetaʼak `<{ $component }>` yéetel pʼisibaʼal absoluto. Ku tsʼaʼabal le márgenoʼob bey relatibo.
+
+side-by-side-no-block-child = Maʼ maʼalob le `<{ $component }>`: yaan u yantaltiʼ maanal junpʼéel paal bloke.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Maʼ táan u chʼaʼabal le atributo `for` tiʼ junpʼéel `<label>` gráfiko.
+
+label-for-must-resolve-to-one = Le atributo `for` tiʼ `<label>` yaan u kʼuchul chéen tiʼ junpʼéel komponente.
+
+label-for-unresolved = Maʼ tu páajtal u kʼuchul le atributo `for` tiʼ `<label>` tiʼ junpʼéel komponente.
+
+label-for-answer-with-authored-inputs = Le atributo `for` tiʼ `<label>` ku yaʼalik junpʼéel `<answer>` yaan u entradaʼob tsʼíibtaʼanoʼob tumen le máax tsʼíibtoʼ; aʼal le entrada toj beyoʼ.
+
+label-for-answer-without-input = Le atributo `for` tiʼ `<label>` ku yaʼalik junpʼéel `<answer>` minaʼan u entrada utiaʼal u yetiketaʼal.
+
+label-for-must-reference-input-or-answer = Le atributo `for` tiʼ `<label>` yaan u yaʼalik junpʼéel entrada wa junpʼéel answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Yóoʼolal aksesibilidad, `<{ $component }>` yaan u yantaltiʼ junpʼéel chan tsolil wa yaan u tsʼaʼabal bey chéen jatsʼutsil.
+
+accessibility-video-short-description = Yóoʼolal aksesibilidad, `<video>` yaan u yantaltiʼ junpʼéel chan tsolil.
+
+accessibility-input-short-description-or-label = Yóoʼolal aksesibilidad, `<{ $component }>` yaan u yantaltiʼ junpʼéel chan tsolil wa junpʼéel etiketa.
+
+accessibility-answer-input-short-description-or-label = Yóoʼolal aksesibilidad, junpʼéel `<answer>` ku beetik junpʼéel entrada yaan u yantaltiʼ junpʼéel chan tsolil wa junpʼéel etiketa.
+
+accessibility-short-description-contains-math = Le chan tsoliloʼob maʼ maʼalob ka yanak tiʼob komponenteʼob matemátiko jeʼex `<{ $component }>`. Tsʼíibt le matemátika yéetel tʼaanoʼob.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Maʼ chuka u kontraste { $colorName } utiaʼal u tʼaanil u pʼóolil le sekción (modo éekʼjochʼeʼen) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʼaʼabéet maanal { $threshold }:1).
+       *[other] Maʼ chuka u kontraste { $colorName } utiaʼal u tʼaanil u pʼóolil le sekción ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʼaʼabéet maanal { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Maʼ beetaʼak `<circle>` ku máan tiʼ { $count } punto ken minaʼan u baloroʼob númeroil le puntoʼoboʼ.
+
+circle-too-many-through-points = Maʼ tu páajtal u chʼaʼabal junpʼéel sírkulo ku máan tiʼ maanal 3 punto.
+
+circle-overprescribed-radius-center-points = Maʼ tu páajtal u chʼaʼabal junpʼéel sírkulo yéetel radio, sentro yéetel puntoʼob ku máan tiʼob.
+
+circle-center-with-multiple-points = Maʼ tu páajtal u chʼaʼabal junpʼéel sírkulo yéetel sentro ku máan tiʼ maanal 1 punto.
+
+circle-radius-too-small = Maʼ tu páajtal u chʼaʼabal le sírkulo: le náachil ichil le kaʼapʼéel punto leti { $distance }, le beetikoʼ jach chichan le radio tsʼaʼab { $radius }.
+
+circle-radius-with-many-points = Maʼ tu páajtal u beetaʼal junpʼéel sírkulo ku máan tiʼ maanal kaʼapʼéel punto yéetel junpʼéel radio tsʼaʼaban.
+
+circle-invalid-center-or-through-points = Maʼ maʼalob u sentro wa u puntoʼob ku máan tiʼob le sírkulooʼ.
+
+circle-radius-center-with-multiple-points = Maʼ tu páajtal u chʼaʼabal u radio junpʼéel sírkulo yéetel sentro ku máan tiʼ maanal 1 punto.
+
+circle-change-radius-non-numerical = Maʼ tu páajtal u kʼeʼexel u radio junpʼéel sírkulo ku máan tiʼ puntoʼob minaʼan u baloroʼob númeroil
+
+circle-radius-with-points-non-numerical = Maʼ tu páajtal u beetaʼal junpʼéel sírkulo ku máan tiʼ maanal junpʼéel punto yéetel junpʼéel radio tsʼaʼaban ken minaʼan u baloroʼob númeroil.
+
+circle-change-center-non-numerical = Maʼ beetaʼak u kʼeʼexel u sentro junpʼéel sírkulo ku máan tiʼ puntoʼob minaʼan u baloroʼob númeroil.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Maʼ chuka u dimensiónoʼob u dominio le funsiónoʼ. Le dominiooʼ yaantiʼ { $intervals } intervalo baʼaleʼ le funsiónoʼ yaantiʼ { $inputs } entrada.
+
+function-domain-invalid-format = Maʼ maʼalob u formatoil u dominio le funsiónoʼ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Maʼ táan u chʼaʼabal u nojochil le funsión maʼ númeroiliʼ.
+        [minimum] Maʼ táan u chʼaʼabal u chichanil le funsión maʼ númeroiliʼ.
+        [extremum] Maʼ táan u chʼaʼabal u xuulil le funsión maʼ númeroiliʼ.
+        [point] Maʼ táan u chʼaʼabal u punto le funsión maʼ númeroiliʼ.
+        [slope] Maʼ táan u chʼaʼabal u pendiente le funsión maʼ númeroiliʼ.
+       *[other] Maʼ táan u chʼaʼabal { $type } le funsión maʼ númeroiliʼ.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Maʼ táan u chʼaʼabal u nojochil le funsión tumen jóoyaʼaniʼ.
+        [minimum] Maʼ táan u chʼaʼabal u chichanil le funsión tumen jóoyaʼaniʼ.
+        [extremum] Maʼ táan u chʼaʼabal u xuulil le funsión tumen jóoyaʼaniʼ.
+        [point] Maʼ táan u chʼaʼabal u punto le funsión tumen jóoyaʼaniʼ.
+       *[other] Maʼ táan u chʼaʼabal { $type } le funsión tumen jóoyaʼaniʼ.
+    }
+
+function-points-too-close = Yaan kaʼapʼéel punto jach naatsʼ ichil le funsiónoʼ. Maʼ tu páajtal u tsʼaʼabal le funsiónoʼ.
+
+function-iterates-input-output-mismatch = Chéen jeʼel u páajtal u yiterartaʼal junpʼéel funsión wa keet u yaʼabil u entradaʼob yéetel u yaʼabil u jóokʼsajiloʼob. Le funsión lelaʼ yaantiʼ { $inputs } entrada yéetel { $outputs } jóokʼsajil.
+
+## `<sequence>`
+
+sequence-invalid-length = Maʼ maʼalob u chowakil le sekuensiaoʼ.  Yaan u yantal junpʼéel entero maʼ chan tiʼ nadaiʼ.
+
+sequence-invalid-step = Maʼ maʼalob u xáak le sekuensiaoʼ.  Yaan u yantal junpʼéel número tiʼ junpʼéel sekuensia tipo { $type }.
+
+sequence-invalid-endpoint-number = Maʼ maʼalob "{ $attribute }" tiʼ junpʼéel sekuensia number.  Yaan u yantal junpʼéel número.
+
+sequence-invalid-endpoint-letters = Maʼ maʼalob "{ $attribute }" tiʼ junpʼéel sekuensia letters.  Yaan u yantal junpʼéel múuchʼ tsʼíiboʼob.
+
+sequence-invalid-endpoint = Maʼ maʼalob "{ $attribute }" tiʼ le sekuensiaoʼ.
+
+select-from-sequence-coprime-not-numbers = maʼ táan u chʼaʼabal coprime tumen maʼ táan u yéeyaʼal númeroʼob
+
+select-from-sequence-coprime-with-exclude-combinations = maʼ táan u chʼaʼabal coprime tumen tsʼaʼab excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Maʼ maʼalob u target `<{ $source }>`: maʼ tu páajtal u kaxtaʼal le target.
+
+target-state-variable-not-found = Maʼ maʼalob u target `<{ $source }>`: maʼ tu páajtal u kaxtaʼal junpʼéel bariable de estado u kʼaabaʼ "{ $property }" tiʼ junpʼéel `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = U bariableʼob `<odeSystem>` yaan u jelaʼantaloʼob tiʼ le bariable independiente.
+
+ode-system-duplicate-variable-names = Maʼ tu páajtal u tsʼaʼabal funsiónoʼob RHS tiʼ ODE yéetel kʼaabaʼob bariable dependiente kaʼatéen tsʼíibtaʼan.
+
+ode-system-rhs-function-error = Maʼ tu páajtal u tsʼaʼabal le funsión RHS tiʼ ODE.  Yaan síiʼpil ku beetaʼal le funsión mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Maʼ tu páajtal u tsʼaʼabal junpʼéel ángulo ichil { $count } línea
+
+angle-invalid-through-point = Maʼ maʼalob le punto tiʼ u through le `<angle>`
+
+parabola-vertex-too-many-points = Maʼ beetaʼak junpʼéel parábola yéetel bértise ku máan tiʼ maanal 1 punto.
+
+parabola-too-many-points = Maʼ beetaʼak junpʼéel parábola ku máan tiʼ maanal 3 punto.
+
+intersection-too-many-items = Maʼ beetaʼak u yúuchul interseksión yéetel maanal kaʼapʼéel baʼal
+
+## Other math components
+
+ionic-compound-not-two-ions = Maʼ beetaʼak junpʼéel kompuesto iónico yéetel uláakʼ baʼal chéen kaʼapʼéel ion.
+
+ionic-compound-needs-cation-and-anion = Chéen beetaʼab le kompuesto iónico yéetel junpʼéel katión yéetel junpʼéel anión.
+
+solve-equations-cannot-evaluate = Maʼ tu páajtal u chʼaʼabal le ekuasión tumen maʼ tu páajtal u yeʼebeʼeltaʼal: { $equation }
+
+math-operators-operand-number-required = Kʼaʼabéet u tsʼaʼabal junpʼéel operandNumber ken jóoʼsaʼak junpʼéel operando matemátiko.
+
+eigen-decomposition-failed = Maʼ tu páajtal u chʼaʼabal u eigenvaloroʼob le matríseʼ
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: le parámetro { $parameters } maʼ ku yúuchul tiʼ le patrón, le beetikoʼ mantatsʼ yaan u núupul yéetel junpʼéel jóoyaʼan.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: maʼ tu páajtal u naʼataʼal grid="{ $grid }". Yaan u yantal none, medium, dense, wa kaʼapʼéel número maas tiʼ nada tsʼíibtaʼan yéetel junpʼéel jóoyaʼan ichiloʼob, jeʼex grid="1 0.5". Maʼ táan u tsʼíibtaʼal mix junpʼéel rejilla.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` kʼaʼabéettiʼ junpʼéel funsión yéetel { $expected ->
+        [one] junpʼéel jóokʼsajil, u pendiente y' tiʼ jujunpʼéel punto, jeʼex `y - x`
+       *[other] kaʼapʼéel jóokʼsajil, u bektor tiʼ jujunpʼéel punto, jeʼex `(y, -x)`
+    }, baʼaleʼ le funsión tsʼaʼabtiʼoʼ yaantiʼ { $found } jóokʼsajil. { $alternative ->
+        [none] Maʼ táan u tsʼíibtaʼal mix baʼal.
+       *[other] `<{ $alternative }>` leti le komponente utiaʼal le funsión lelaʼ. Maʼ táan u tsʼíibtaʼal mix baʼal.
+    }
+
+field-function-attribute-ignored-with-child = Maʼ táan u chʼaʼabal le atributo `function` tumen tsʼaʼab xan le funsión ichil le komponente; leti le yaan ichiloʼ ku meyaj. Tsʼáa le funsión chéen tiʼ junpʼéel tiʼ le kaʼapʼéel bejoʼ.
+
+field-variables-ignored =
+    `<{ $component }>`: le atributo `variables` ku kʼaabaʼtik u bariableʼob junpʼéel ekspresión tsʼíibtaʼan toj ichil le komponente. { $reason ->
+        [function-child] Way tuʼuxaʼ tsʼaʼab le funsión bey junpʼéel paal `<function>`, ku kʼaabaʼtik u bariableʼob tu juunal, le beetikoʼ maʼ táan u chʼaʼabal `variables`.
+       *[no-expression] Minaʼan junpʼéel ekspresión beyoʼ way tuʼuxaʼ, le beetikoʼ maʼ táan u chʼaʼabal `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: maʼ ku chʼaʼabal xLabelPosition="left" tiʼ le renderisador prefigure; ku meyaj bey right.
+
+prefigure-y-label-position-unsupported = `<graph>`: maʼ ku chʼaʼabal yLabelPosition="bottom" tiʼ le renderisador prefigure; ku meyaj bey top.
+
+prefigure-invalid-axis-bounds = `<graph>`: maʼ maʼalob u xuuloʼob le ejeʼob utiaʼal u kʼeʼexel tiʼ prefigure; ku chʼaʼabal le bbox chéen beyoʼ (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: maʼ maʼalob u kóochil utiaʼal u kʼeʼexel tiʼ prefigure; ku chʼaʼabal u kóochil diagrama chéen beyoʼ 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: maʼ maʼalob aspectRatio utiaʼal u kʼeʼexel tiʼ prefigure; ku chʼaʼabal u aspect ratio chéen beyoʼ 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jach chichan u náachil le rejilla utiaʼal u xuuloʼob le ejeʼob; maʼ táan u tsʼíibtaʼal le rejilla tiʼ le renderisador prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: maʼ táan u tsʼíibtaʼal le anotasiónoʼob wa maʼ táan u meyaj le renderisador PreFigure.
+
+multiple-annotations-children = Kaxtaʼab yaʼabkach paalal `<annotations>` ichil `<graph>`; chéen le tsʼook ku chʼaʼabaloʼ.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Maʼ tu páajtal u yaʼalaʼal wa u kopiartaʼal junpʼéel tipo komponente maʼ kʼaj óolaʼaniʼ: { $type }.
+
+copy-prop-not-found = Maʼ tu páajtal u kaxtaʼal le prop { $property } tiʼ junpʼéel komponente tipo { $component }
+
+collect-no-source = Maʼ kaxtaʼab tuʼux u taal collect.
+
+collect-invalid-component-type = Maʼ tu páajtal u muchʼkíinsaʼal komponenteʼob tipo `<{ $component }>` tumen maʼ maʼalob le tipo komponenteoʼ.
+
+reference-index-unavailable = Maʼ tu páajtal u yaʼalaʼal le índise `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Maʼ tu páajtal u tʼaʼanal { $action } tiʼ le komponente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Maʼ maʼalob u boonil le datoʼoboʼ.  Maʼ keet u chowakil le renglónoʼob. Kaxtaʼab tiʼ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Yaan kʼaabaʼob kolumna kaʼatéen tsʼíibtaʼan.  Kaxtaʼab tiʼ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Minaʼan u kʼaabaʼ junpʼéel kolumna.  Kaxtaʼab tiʼ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Junpʼéel award tiʼ le answer lelaʼ ku bin tu paach u núuk tuʼuxaʼ le answer tu juunal, yéetel lelaʼ jeʼel u beetik baʼax maʼ paʼatbil.
+
+answer-max-num-attempts-in-section-wide-check-work = Mix baʼal ku beetik u tsʼaʼabal `maxNumAttempts` tiʼ junpʼéel `<answer>` ichil junpʼéel kontenedor yéetel `sectionWideCheckWork`, tumen le kontenedoroʼ ku kanáantik u yaʼabil téenel. Tsʼáa `maxNumAttempts` tiʼ le kontenedoroʼ.
+
+nested-section-wide-check-work-max-num-attempts = Mix baʼal ku beetik u tsʼaʼabal `maxNumAttempts` tiʼ junpʼéel kontenedor yéetel `sectionWideCheckWork` yaan ichil uláakʼ kontenedor yéetel `sectionWideCheckWork`, tumen le kontenedor yaan tu paachoʼ ku kanáantik u yaʼabil téenel. Tsʼáa `maxNumAttempts` tiʼ le kontenedor yaan tu paachoʼ.
+
+answer-attributes-need-symbolic-equality = Mix baʼal ku beetik le atributo { $attributes } wa maʼ tsʼaʼaban symbolicEquality.
+
+answer-invalid-type = Maʼ maʼalob u tipo le answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Tumen minaʼan u kʼaabaʼ le komponente `<{ $component }>`, maʼ tu páajtal u meyaj bey junpʼéel atributo tiʼ junpʼéel module
+
+module-attribute-name-already-defined = Maʼ tu páajtal u meyaj le komponente `<{ $component } name="{ $name }">` bey junpʼéel atributo tiʼ junpʼéel module tumen le tipo komponente `<module>` yaan tsʼoʼok u yantaltiʼ junpʼéel atributo "{ $name }".
+
+conditional-content-condition-ignored = Maʼ táan u chʼaʼabal le atributo `condition` tiʼ junpʼéel komponente `<conditionalContent>` yaan paalal case wa else.
+
+slider-markers-type-mismatch = Maʼ tu núupul u tipo le markers yéetel u tipo le slider.
+
+pretzel-problem-needs-statement-and-answer = Maʼ maʼalob le pretzel: jujunpʼéel `<problem>` yaan u yantaltiʼ junpʼéel `<statement>` yéetel junpʼéel `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Maʼ maʼalob le pretzel: tiʼ mode="circuit", le yáax `<problem>` maʼ tu páajtal u yantal bey distraktoriʼ.
+
+## Attribute values
+
+attribute-invalid-values = Maʼ maʼalob u balor { $values } tiʼ le atributo `{ $attribute }`; maʼ táan u chʼaʼabaliʼ.
+
+attribute-must-be-references = Maʼ maʼalob u balor `{ $value }` tiʼ le atributo `{ $attribute }`. Le atributooʼ yaan u beetaʼal yéetel referensiaʼob ku káajal yéetel junpʼéel `$`.
+
+math-input-invalid-function-names = <mathInput>: maʼ táan u chʼaʼabal u kʼaabaʼob funsión maʼ maʼalob tiʼ { $attribute }: { $names }. U jaatsil eʼesajil jujunpʼéel kʼaabaʼ yaan u yantaltiʼ maanal 2 tsʼíib (letraʼob wa guiónoʼob); jeʼel u páajtal u taal junpʼéel `|<mathspeak alternative>` tu paach.
+
+## Building components from the source
+
+component-type-invalid = Maʼ maʼalob u tipo le komponente: `<{ $componentType }>`
+
+attribute-repeated = Maʼ tu páajtal u kaʼa tsʼíibtaʼal le atributo { $attribute }.
+
+attribute-invalid-for-component = Maʼ maʼalob le atributo "{ $attribute }" tiʼ junpʼéel komponente tipo `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Maʼ chuka u kontraste u definisión estilo { $styleNumber } tiʼ { $context ->
+        [text-on-background] u kolor le tʼaan yéetel u kolor le fondo
+        [high-contrast] u kolor kontraste kaʼanal yéetel le kanchaoʼ
+        [line] u kolor le línea yéetel le kanchaoʼ
+        [marker] u kolor le markador yéetel le kanchaoʼ
+       *[text-on-canvas] u kolor le tʼaan yéetel le kanchaoʼ
+    }{ $mode ->
+        [dark] { " (modo éekʼjochʼeʼen)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʼaʼabéet maanal { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Kex tsʼaʼaban tiʼ u definisión estilo { $styleNumber } koloroʼob yaan u chuka kontraste tiʼ modo sáasil, le koloroʼob tiʼ modo éekʼjochʼeʼen ku jóokʼloʼob tiʼ le baloroʼob lelaʼ maʼ chuka u kontraste ichil u kolor le tʼaan yéetel u kolor le fondo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʼaʼabéet maanal { $threshold }:1). { $suggestion ->
+        [available] Utiaʼal u yantal chuka kontraste tiʼ modo éekʼjochʼeʼen, nuʼukbes u kontraste modo sáasil (jeʼex, tsʼáa { $lightAttribute }="{ $lightColor }") wa kʼex u kolor modo éekʼjochʼeʼen (jeʼex, tsʼáa { $darkAttribute }="{ $darkColor }").
+       *[none] Utiaʼal u yantal chuka kontraste tiʼ modo éekʼjochʼeʼen, nuʼukbes u kontraste modo sáasil wa kʼex le koloroʼob jóokʼoʼob yéetel textColorDarkMode wa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Kex tsʼaʼaban tiʼ u definisión estilo { $styleNumber } junpʼéel kolor tʼaan yaan u chuka kontraste tiʼ modo sáasil, le kolor tʼaan tiʼ modo éekʼjochʼeʼen ku jóokʼol tiʼ le balor lelaʼ maʼ chuka u kontraste yéetel le kanchaoʼ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʼaʼabéet maanal { $threshold }:1). { $suggestion ->
+        [available] Utiaʼal u yantal chuka kontraste tiʼ modo éekʼjochʼeʼen, nuʼukbes u kontraste modo sáasil (jeʼex, tsʼáa textColor="{ $lightColor }") wa kʼex u kolor modo éekʼjochʼeʼen (jeʼex, tsʼáa textColorDarkMode="{ $darkColor }").
+       *[none] Utiaʼal u yantal chuka kontraste tiʼ modo éekʼjochʼeʼen, nuʼukbes u kontraste modo sáasil wa kʼex le kolor jóokʼoʼ yéetel textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Junpʼéel sekción chéen jeʼel u yéeyik junpʼéel <stylePalette>; ku chʼaʼabal le tsʼookoʼ.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen numToSelect maʼ junpʼéel entero maʼ chan tiʼ nadaiʼ.
+
+variant-num-to-select-not-constant-number = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen numToSelect maʼ junpʼéel número maʼ tu kʼeʼexeliʼ.
+
+variant-with-replacement-not-constant-boolean = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen withReplacement maʼ junpʼéel boolean maʼ tu kʼeʼexeliʼ.
+
+variant-select-weight-disables-unique = Maʼ tu páajtal u bariante juntúulili tiʼ select wa yaan junpʼéel opsión yéetel selectWeight wa selectForVariants tsʼaʼaban
+
+variant-coprime-undetermined = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen maʼ tu páajtal u yojéeltaʼal wa mantatsʼ maʼ jaaj coprime.
+
+variant-attribute-not-constant = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen { $attribute } ku kʼeʼexel.
+
+variant-attribute-not-number = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen maʼ junpʼéel número { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tipo { $type } tumen { $attribute } maʼ { $expected ->
+        [letters-combination] junpʼéel múuchʼ letraʼobiʼ
+        [math-expression] junpʼéel ekspresión matemátika maʼalobiʼ
+        [integer] junpʼéel enteroiʼ
+       *[number] junpʼéel númeroiʼ
+    }.
+
+variant-length-not-integer = maʼ tu páajtal u yojéeltaʼal u bariante juntúulili tiʼ { $component } tumen maʼ junpʼéel entero le chowakiloʼ.
+
+variant-sort-not-implemented = maʼ beetaʼak u bariante juntúulili junpʼéel { $component } yéetel sort
+
+variant-exclude-combinations-not-implemented = maʼ beetaʼak u bariante juntúulili junpʼéel { $component } yéetel excludeCombinations
+
+variant-math-exclude-not-implemented = maʼ beetaʼak u bariante juntúulili junpʼéel { $component } tipo math yéetel exclude
+
+variant-non-constant-exclude-not-implemented = maʼ beetaʼak u bariante juntúulili junpʼéel { $component } yéetel junpʼéel exclude ku kʼeʼexel
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: maʼ ku chʼaʼabal tiʼ le renderisador prefigure tiʼ graph; ku pʼaʼatal tu paach le paaloʼ.
+
+prefigure-descendant-invalid-geometry = { $subject }: u jeometría maʼ chuka wa maʼ xuulaʼaniʼ; ku pʼaʼatal tu paach le paaloʼ.
+
+prefigure-curve-label-omitted = { $subject }: maʼ ku chʼaʼabal etiketaʼob tiʼ elementoʼob kurba kʼeʼexoʼob; maʼ táan u tsʼíibtaʼal le etiketaoʼ.
+
+prefigure-curve-unsupported-definition-type = { $subject }: maʼ ku chʼaʼabal le tipo definisión funsión kurba '{ $definitionType }'; ku pʼaʼatal tu paach le paaloʼ.
+
+prefigure-region-flip-functions-unsupported = { $subject }: maʼ ku chʼaʼabal le atributo flipFunctions tiʼ regionBetweenCurves; ku pʼaʼatal tu paach le paaloʼ.
+
+prefigure-region-non-formula-child = { $subject }: chéen ku chʼaʼabal paalal funsión tipo formula tiʼ regionBetweenCurves; ku pʼaʼatal tu paach le paaloʼ.
+
+prefigure-label-position-unsupported =
+    { $subject }: maʼ ku chʼaʼabal labelPosition '{ $labelPosition }' tiʼ { $labelKind ->
+        [line-family] junpʼéel etiketa tiʼ u chʼiʼibal línea
+       *[point] junpʼéel etiketa punto
+    }; ku chʼaʼabal u nuʼukbesajil PreFigure chéen beyoʼ.
+
+prefigure-fill-style-unsupported = { $subject }: maʼ ku chʼaʼabal u estilo chup '{ $fillStyle }' tumen PreFigure; ku pʼaʼatal yéetel junpʼéel chup chuka.
+
+prefigure-line-style-unknown = { $subject }: maʼ kʼaj óolaʼan u estilo línea '{ $lineStyle }'; maʼ táan u bin tiʼ u jóokʼsajil PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: u estilo markador '{ $markerStyle }' ku kʼeʼexel tiʼ u estilo PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: maʼ ku chʼaʼabal u estilo markador '{ $markerStyle }' tumen PreFigure; ku chʼaʼabal le estilo chéen beyoʼ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: maʼ maʼalob `ref`; maʼ tu páajtal u kaxtaʼal le target. Maʼ táan u tsʼíibtaʼal le anotasiónoʼ.
+
+annotation-ref-multiple-targets = `<annotation>`: yaʼabach target ku kʼuchul tiʼob `ref`; ku chʼaʼabal le yáax targetoʼ.
+
+annotation-ref-outside-graph = `<annotation>`: maʼ maʼalob `ref`; táanxel tiʼ le graph yaan le targetoʼ. Maʼ táan u tsʼíibtaʼal le anotasiónoʼ.
+
+annotation-ref-unsupported-target = `<annotation>`: maʼ maʼalob `ref`; le targetoʼ maʼ junpʼéel baʼal gráfiko ku chʼaʼabal tiʼ u kʼeʼexel prefigure. Maʼ táan u tsʼíibtaʼal le anotasiónoʼ.
+
+annotation-text-missing = `<annotation>`: minaʼan wa jóoyaʼan `text`; ku jóokʼol jóoyaʼan le tʼaanoʼ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kaxtaʼab junpʼéel dependensia sirkular.
+       *[other] Kaxtaʼab junpʼéel dependensia sirkular yéetel junpʼéel komponente `<{ $componentType }>`.
+    }
+
+reference-no-referent = Maʼ kaxtaʼab baʼax ku yaʼalik le referensiaaʼ: `{ $reference }`
+
+reference-multiple-referents = Yaʼabach baʼax ku yaʼalik le referensiaaʼ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Maʼ maʼalob u formatoil le atributo { $attribute } tiʼ `<{ $componentType }>`.
+
+children-invalid = Maʼ maʼalob u paalal `<{ $componentType }>`: Kaxtaʼab paalal maʼ maʼalobiʼ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Maʼ maʼalob u balor `{ $value }` tiʼ le atributo `{ $attribute }`, ku chʼaʼabal u balor `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Maʼ kaxtaʼab u bersión DoenetML { $version }.
+       *[other] Maʼ kaxtaʼab u bersión DoenetML { $version }. Ku pʼaʼatal yéetel u bersión { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Maʼ maʼalob le DoenetML: { $content }
+
+parse-tag-missing-close-tag = Maʼ maʼalob le DoenetML: Minaʼan u etiketa kʼaal le etiketa `{ $tag }`. Kʼaʼabéet junpʼéel etiketa ku kʼaʼalal tu juunal wa junpʼéel etiketa `</{ $tagName }>`.
+
+parse-tag-error = Maʼ maʼalob le DoenetML: Yaan síiʼpil tiʼ le etiketa `<{ $tagName }>`
+
+parse-attribute-missing-value = Maʼ maʼalob le DoenetML: Bey minaʼan u balor le atributo `{ $attribute }`.
+
+parse-attribute-invalid = Maʼ maʼalob le DoenetML: Maʼ maʼalob le atributo `{ $attribute }`
+
+parse-attribute-value-invalid = Maʼ maʼalob le DoenetML: Maʼ maʼalob u balor atributo `{ $value }`
+
+parse-attribute-value-quote-mismatch = Maʼ maʼalob le DoenetML: Maʼ maʼalob u balor atributo `{ $value }`. Maʼ tu núupul le kʼóomoʼob tsʼíib. Bey minaʼan tech junpʼéel `{ $quote }`
+
+parse-open-tag-name-missing = Maʼ maʼalob le DoenetML: Kaxtaʼab junpʼéel etiketa minaʼan u kʼaabaʼ, jeʼex `<`
+
+parse-tag-not-closed = Maʼ maʼalob le DoenetML: Maʼ kʼaʼalab le etiketa `{ $tag }` (bey minaʼan junpʼéel `>`).
+
+parse-self-closing-tag-name-missing = Maʼ maʼalob le DoenetML: Kaxtaʼab junpʼéel etiketa minaʼan u kʼaabaʼ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Maʼ maʼalob le DoenetML: Maʼ kʼaʼalab le etiketa `{ $tag }` (bey minaʼan `/>`).
+
+parse-tag-invalid-attributes = Maʼ maʼalob le DoenetML: Maʼ maʼalob le etiketa `{ $tag }`. Jeʼel u yantaltiʼ atributoʼob maʼ maʼalobiʼ.
+
+parse-close-tag-name-missing = Maʼ maʼalob le DoenetML: Kaxtaʼab junpʼéel etiketa kʼaal minaʼan u kʼaabaʼ, jeʼex `</`
+
+parse-attribute-value-unquoted = U baloroʼob le atributoʼob yaan u yantaloʼob ichil kʼóomoʼob tsʼíib: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Maʼ maʼalob le DoenetML: Kaxtaʼab le etiketa kʼaal `{ $tag }`, baʼaleʼ minaʼan u etiketa jeʼeb
+
+parse-close-tag-mismatched = Maʼ maʼalob le DoenetML: Maʼ tu núupul le etiketa kʼaaloʼ. Kʼaʼabéet `</{ $expected }>`. Kaxtaʼab `{ $found }`
+
+parser-node-unconvertible = Maʼ tu páajtal u kʼeʼexel le nodo { $node } tiʼ junpʼéel nodo Dast.
+
+## Names
+
+name-attribute-invalid =
+    Maʼ maʼalob le atributo name='{ $name }'. { $reason ->
+        [characters] Le kʼaabaʼoboʼ chéen jeʼel u yantaltiʼob letraʼob, númeroʼob, guión bajo wa guión.
+       *[start] Le kʼaabaʼoboʼ yaan u káajaloʼob yéetel junpʼéel letra.
+    }
+
+component-name-invalid-start = Maʼ maʼalob u kʼaabaʼ le komponente "{ $name }". Le kʼaabaʼoboʼ yaan u káajaloʼob yéetel junpʼéel letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Junpʼéel answer tipo videoWatched yaan u yantaltiʼ junpʼéel atributo video
+
+answer-video-watched-video-not-reference = Junpʼéel answer tipo videoWatched yaan u yantaltiʼ junpʼéel atributo video ku yantal bey junpʼéel referensia
+
+answer-name-not-single-text = U atributo name le answer yaan u yantaltiʼ chéen junpʼéel paal text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Maʼ tu páajtal u chʼaʼabal le DoenetML táanxeloʼ tumen jach yaʼab u jaatsil rekursión. ¿Yaan wáaj junpʼéel referensia sirkular?
+
+external-doenetml-unavailable = Maʼ tu páajtal u chʼaʼabal le DoenetML tiʼ { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Maʼ maʼalob le DoenetML chʼaʼab tiʼ { $attribute }="{ $uri }": maʼ tu núupul yéetel u tipo komponente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Tsʼoʼok u xuʼulul u meyaj le atributo `{ $from }`; meyajnaj yéetel `{ $to }`.
+       *[other] [deprecation] Tsʼoʼok u xuʼulul u meyaj le atributo `{ $from }` tiʼ `<{ $component }>`; meyajnaj yéetel `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Tsʼoʼok u xuʼulul u meyaj le atributo `{ $from }` yéetel maʼ táan u chʼaʼabal tumen tsʼaʼab xan `{ $to }`.
+       *[other] [deprecation] Tsʼoʼok u xuʼulul u meyaj le atributo `{ $from }` tiʼ `<{ $component }>` yéetel maʼ táan u chʼaʼabal tumen tsʼaʼab xan `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Tsʼoʼok u xuʼulul u meyaj le atributo `{ $attribute }` tiʼ `<{ $component }>` yéetel maʼ táan u chʼaʼabaliʼ.
+
+deprecated-attribute-to-child = [deprecation] Tsʼoʼok u xuʼulul u meyaj le atributo `{ $attribute }` tiʼ `<{ $component }>`; meyajnaj yéetel junpʼéel paal `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Tsʼoʼok u xuʼulul u meyaj u balor `{ $value }` tiʼ le atributo `{ $attribute }` tiʼ `<{ $component }>`; meyajnaj yéetel `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Chéen jeʼel u páajtal u beetik pluralʼob tiʼ inglés `<pluralize>`, le beetikoʼ maʼ táan u kʼeʼexel u tʼaanil tiʼ junpʼéel dokumento tsʼíibtaʼan tiʼ { $locale }. Tsʼíibt le forma plural toj beyoʼ, wa tsʼáa yéetel le atributo `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Le elemento `<{ $tag }>` maʼ junpʼéel elemento kʼaj óolaʼan tumen Doenetiʼ.
+
+schema-element-not-allowed-at-root = Maʼ tu chaʼabal le elemento `<{ $tag }>` tu motsil le dokumentoiʼ.
+
+schema-element-not-allowed-inside = Maʼ tu chaʼabal le elemento `<{ $tag }>` ichil `<{ $parent }>`.
+
+schema-attribute-unrecognized = Minaʼantiʼ le elemento `<{ $tag }>` junpʼéel atributo u kʼaabaʼ `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Le atributo `{ $attribute }` tiʼ le elemento `<{ $tag }>` yaan u yantal junpʼéel lista tuʼux jujunpʼéel u jaatsil yaan u yantal juntúul tiʼ lelaʼ: { $allowed }
+       *[other] Le atributo `{ $attribute }` tiʼ le elemento `<{ $tag }>` yaan u yantal juntúul tiʼ lelaʼ: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Maʼ maʼalob u kʼaabaʼ bariante tiʼ select.  Le kʼaabaʼ bariante { $variantName } ku yúuchul tiʼ { $numOptions } opsión baʼaleʼ u yaʼabil ken yéeyaʼak leti { $numToSelect }.
+
+select-variant-name-without-options = Tsʼaʼab jujuntúul bariante tiʼ select baʼaleʼ maʼ tsʼaʼab opsiónoʼob tiʼ le kʼaabaʼ bariante: { $variantName }.
+
+select-variant-name-not-possible = Le kʼaabaʼ bariante { $variantName } tsʼaʼab tiʼ select maʼ jeʼel u páajtal u yantaliʼ.
+
+select-too-few-options = Maʼ tu páajtal u yéeyaʼal { $numToSelect } komponente tiʼ chéen { $numOptions }.
+
+select-from-sequence-too-few-values = Maʼ tu páajtal u yéeyaʼal { $numToSelect } balor tiʼ junpʼéel sekuensia u chowakil { $length }.
+
+select-from-sequence-indices-count-mismatch = U yaʼabil índiseʼob tsʼaʼaboʼob tiʼ select yaan u núupul yéetel u yaʼabil ken yéeyaʼak
+
+select-from-sequence-indices-not-integers = Tuláakal le índiseʼob tsʼaʼaboʼob tiʼ select yaan u yantaloʼob bey enteroʼob
+
+select-from-sequence-index-excluded = Tsʼaʼab junpʼéel índise tiʼ selectfromsequence jóoʼsaʼanili
+
+select-from-sequence-indices-excluded-combination = Tsʼaʼab índiseʼob tiʼ selectfromsequence junpʼéel múuchʼ jóoʼsaʼanili
+
+select-from-sequence-coprime-not-positive-integers = Maʼ tu páajtal u yéeyaʼal múuchʼoʼob coprime tumen maʼ táan u yéeyaʼal enteroʼob maas tiʼ nada.
+
+select-from-sequence-coprime-common-factor = Maʼ tu páajtal u yéeyaʼal númeroʼob coprime. Tuláakal le baloroʼob jeʼel u páajtaloʼ yaantiʼob junpʼéel faktor keet. (U baloroʼob "from" wa "to" tsʼaʼaboʼob yaan u yantaloʼob coprime yéetel "step".)
+
+select-from-sequence-coprime-single-number = Maʼ tu páajtal u yéeyaʼal múuchʼoʼob coprime tiʼ junpʼéel número tu juunal maʼ 1.
+
+select-from-sequence-excluded-too-many-combinations = Jóoʼsaʼab maanal 70% tiʼ le múuchʼoʼob tiʼ selectFromSequence
+
+select-from-sequence-coprime-none-found = Maʼ tu páajtal u yéeyaʼal númeroʼob coprime. Tuláakal le baloroʼob jeʼel u páajtaloʼ yaantiʼob junpʼéel faktor keet.
+
+select-from-sequence-too-few-unique-values = Maʼ tu páajtal u yéeyaʼal { $numToSelect } balor juntúulili tiʼ junpʼéel sekuensia u chowakil { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Maʼ tu páajtal u yéeyaʼal { $numToSelect } balor tiʼ junpʼéel lista númeroʼob primo u chowakil { $numValues }
+
+select-prime-numbers-values-count-mismatch = U yaʼabil baloroʼob tsʼaʼaboʼob tiʼ select yaan u núupul yéetel u yaʼabil ken yéeyaʼak
+
+select-prime-numbers-values-not-prime = Tuláakal le baloroʼob tsʼaʼaboʼob tiʼ select prime number yaan u yantaloʼob ichil le lista númeroʼob primo
+
+select-prime-numbers-values-excluded-combination = Le baloroʼob tsʼaʼaboʼob tiʼ selectPrimeNumbers junpʼéel múuchʼ jóoʼsaʼanili
+
+select-prime-numbers-excluded-too-many-combinations = Jóoʼsaʼab maanal 70% tiʼ le múuchʼoʼob tiʼ selectPrimeNumbers
+
+select-random-combination-fluke = Tumen junpʼéel baʼal jach maʼ suuk u yúuchul, maʼ tu páajtal u yéeyaʼal junpʼéel múuchʼ baloroʼob chʼaʼabil
+
+select-random-value-fluke = Tumen junpʼéel baʼal jach maʼ suuk u yúuchul, maʼ tu páajtal u yéeyaʼal junpʼéel balor chʼaʼabil
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    Maʼ táan u tsʼíibtaʼal `<{ $component }>` ichil le matemátikaoʼ; ku tsʼíibtaʼal le ekspresión jeʼex úuchik ka maʼ tu páajtal u tsʼaʼabal entradaʼob ichiloʼ. { $reason ->
+        [not-inline] Chéen junpʼéel choice input `inline` ku kʼuchul ichil junpʼéel ekspresión; wa minaʼan `inline` junpʼéel bloke botónoʼob leti.
+        [expanded] Junpʼéel text input `expanded` junpʼéel kaja yaʼab u renglónoʼob, jach nojoch utiaʼal u kutal ichil junpʼéel ekspresión.
+        [on-graph] Tiʼ junpʼéel graph ku tsʼíibtaʼal le ekspresión bey chéen junpʼéel oochel, minaʼan tuʼux u kutal junpʼéel kontrol.
+       *[relative-width] U `width` relatibo (junpʼéel porsentaje wa `em`), minaʼan baʼax u pʼis ichil junpʼéel ekspresión. Tsʼáa u kóochil yéetel pʼisibaʼal absoluto, jeʼex `px`.
+    }

--- a/packages/i18n/locales/yua/diagnostics.ftl
+++ b/packages/i18n/locales/yua/diagnostics.ftl
@@ -16,10 +16,12 @@
 # author's own source.
 #
 # **Orthography.** The ALMY/INALI unified orthography; see `chrome.ftl`'s
-# header for the alphabet and the doubled long vowels. Every apostrophe in
-# these files is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
-# and never U+0027 `'`. The three are homoglyphs in most fonts, so a reviewer
-# who retypes a word should check the codepoint rather than the shape. The
+# header for the alphabet and the doubled long vowels. Every apostrophe inside
+# a Maya word is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`.
+# The two are homoglyphs in most fonts, so a reviewer who retypes a word
+# should check the codepoint rather than the shape. Straight ASCII `'` is
+# English's own punctuation carried through where a message quotes a value
+# back to the author, and is not a Maya letter. The
 # language is named «Maayaʼ tʼàan»; the grave marks the falling tone and is not
 # part of ordinary ALMY spelling («maayaʼ tʼaan»).
 #

--- a/packages/i18n/locales/yua/editor.ftl
+++ b/packages/i18n/locales/yua/editor.ftl
@@ -10,10 +10,11 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # **Orthography.** The ALMY/INALI unified orthography; see `chrome.ftl`'s
-# header for the alphabet and the doubled long vowels. Every apostrophe in
-# these files is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
-# and never U+0027 `'` — the three are homoglyphs in most fonts, so a reviewer
-# who retypes a word should check the codepoint. The language is named «Maayaʼ
+# header for the alphabet and the doubled long vowels. Every apostrophe inside
+# a Maya word is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
+# — the two are homoglyphs in most fonts, so a reviewer who retypes a word
+# should check the codepoint. Straight ASCII `'` is English's own punctuation
+# carried through where a message quotes a value, and is not a Maya letter. The language is named «Maayaʼ
 # tʼàan», whose grave marks the falling tone and is not part of ordinary ALMY
 # spelling («maayaʼ tʼaan»).
 #

--- a/packages/i18n/locales/yua/editor.ftl
+++ b/packages/i18n/locales/yua/editor.ftl
@@ -1,0 +1,235 @@
+# Yucatec Maya (Maayaʼ tʼàan) editor and language-server surfaces: the footer,
+# the diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel beside them. Translated from `locales/en/editor.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography.** The ALMY/INALI unified orthography; see `chrome.ftl`'s
+# header for the alphabet and the doubled long vowels. Every apostrophe in
+# these files is **U+02BC MODIFIER LETTER APOSTROPHE `ʼ`**, never U+2019 `’`
+# and never U+0027 `'` — the three are homoglyphs in most fonts, so a reviewer
+# who retypes a word should check the codepoint. The language is named «Maayaʼ
+# tʼàan», whose grave marks the falling tone and is not part of ordinary ALMY
+# spelling («maayaʼ tʼaan»).
+#
+# **Number.** `Intl.PluralRules` has no CLDR data for `yua`; it falls back to
+# the default locale and reports categories Yucatec does not select. A Yucatec
+# noun after a numeral takes no plural suffix, so the two counted messages here
+# — `editor-accessibility-label` and `help-coordinates` — are written as **one
+# unselected form** rather than as a `[one]`/`[other]` pair. The selects on
+# `$status`, `$action`, `$shortcut`, `$reason`, `$location`, `$allowed`,
+# `$line` and `$perItem` are not plural selects and keep every branch English
+# has.
+#
+# **Loans.** The technical nouns are **Spanish loans written in the ALMY
+# orthography, carried inside a Yucatec sentence frame** — native verbs, native
+# word order, the native negation «maʼ … -iʼ». This file carries «bariante»
+# (variant), «atributo», «referensia», «komponente», «koordenada», «propiedad»,
+# «balor» (value), «tipo», «elemento», «formato», «kréedito», «etiketa»,
+# «bersión», «aksesibilidad», «rekomendasión», «dokumentasión», «páajina»,
+# «estilo», «snippet» (left as the English term of art the schema uses).
+# Nothing here is a coinage.
+#
+# **Confidence.** All sixty-four keys are translated. `WCAG AA` is the name of
+# a standard and stays as written, as do `DoenetML`, `XML`, `styleNumber`,
+# every element and attribute name, every key shortcut and every version
+# number. The weakest entries are «snippet» and «arreglo» (array), which are
+# terms of art with no Yucatec usage behind them at all, and «Síiʼpil» (fault,
+# mistake) standing for *error* throughout.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Suʼut
+       *[update] Tuʼubs
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } le eʼesajiloʼ
+       *[other] { $word } le eʼesajiloʼ { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Bariante
+
+editor-variant-filter = Xakab...
+
+editor-variant-next = Chʼaʼ u táanil bariante
+
+editor-variant-previous = Chʼaʼ u paachil bariante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Kaxtaʼab junpʼéel síiʼpil aksesibilidad tiʼ WCAG AA. Kʼop utiaʼal a { $action ->
+            [close] kʼalik
+           *[open] jeʼek
+        } le informe tiʼ aksesibilidadoʼ.
+        [advisories] Kʼop utiaʼal a { $action ->
+            [close] kʼalik
+           *[open] jeʼek
+        } le informe tiʼ aksesibilidadoʼ. Maʼ kaxtaʼab síiʼpil tiʼ WCAG AAiʼ, baʼaleʼ yaan uláakʼ rekomendasiónoʼob tiʼ aksesibilidad.
+       *[clean] Kʼop utiaʼal a { $action ->
+            [close] kʼalik
+           *[open] jeʼek
+        } le informe tiʼ aksesibilidadoʼ. Mix junpʼéel talamil tiʼ aksesibilidad kaxtaʼabiʼ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Kaxtaʼab junpʼéel síiʼpil aksesibilidad tiʼ WCAG AA. Kaxtaʼab { $count } síiʼpil tiʼ WCAG AA. Kʼop utiaʼal a { $action ->
+            [close] kʼalik
+           *[open] jeʼek
+        } le informe tiʼ aksesibilidadoʼ.
+        [advisories] Maʼ kaxtaʼab síiʼpil tiʼ WCAG AAiʼ. Kaxtaʼab { $count } uláakʼ rekomendasión tiʼ aksesibilidad. Kʼop utiaʼal a { $action ->
+            [close] kʼalik
+           *[open] jeʼek
+        } le informe tiʼ aksesibilidadoʼ.
+       *[clean] Maʼ kaxtaʼab síiʼpil tiʼ WCAG AAiʼ. Kʼop utiaʼal a { $action ->
+            [close] kʼalik
+           *[open] jeʼek
+        } le informe tiʼ aksesibilidadoʼ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = U bersión DoenetML { $version }
+
+editor-tab-help = Áantaj yóoʼolal baʼax yaan tuʼux yaan le kursoroʼ
+editor-tab-help-short = Áantaj
+editor-tab-errors = Síiʼpiloʼob
+editor-tab-warnings = Avisoʼob
+editor-tab-info = Informasión
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Núukoʼob túuxtaʼanoʼob
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = U opsiónoʼob le editoroʼ
+editor-format-as-doenetml = Utskíint bey DoenetML
+editor-format-as-xml = Utskíint bey XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Renglón #{ $line }
+
+editor-no-errors = Minaʼan síiʼpiloʼob
+editor-no-warnings = Minaʼan avisoʼob
+editor-no-info = Minaʼan diagnóstikoʼob tiʼ informasión
+
+editor-show-info-annotations = Eʼes le diagnóstikoʼob tiʼ informasión ichil le editoroʼ
+editor-show-accessibility-annotations = Eʼes le diagnóstikoʼob tiʼ aksesibilidad ichil le editoroʼ
+
+editor-accessibility-learn-more = Kan bix u meyaj Doenet yéetel aksesibilidad
+
+editor-accessibility-violations-heading = Síiʼpiloʼob tiʼ aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Uláakʼ talamiloʼob tiʼ aksesibilidad
+editor-none-found = Minaʼan
+
+
+## Submitted responses
+
+editor-no-responses = Maʼ túuxtaʼab mix junpʼéel núukiʼ
+editor-response-answer-id = U kʼaabaʼ le núukoʼ
+editor-response-response = Núuk
+editor-response-credit = Kréedito
+editor-response-submitted = Túuxtaʼab
+
+
+## The context-help panel
+
+help-placeholder = Tsʼáa le kursor tiʼ junpʼéel kʼaabaʼ etiketa, atributo, wa { $ref } utiaʼal a wilik le dokumentasiónoʼ.
+
+help-unsupported-ref-chain = Maʼ kʼaʼabéetkunsaʼak áantaj tiʼ referensiaʼob yaʼabkach u jaatsil, jeʼex { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Maʼ kaxtaʼab baʼax ku yaʼalik le referensiaaʼ: { $ref }.
+        [multiple] Yaʼabach baʼax ku yaʼalik le referensiaaʼ: { $ref }.
+       *[indeterminate] Maʼ tu páajtal u yojéeltaʼal baʼax ku yaʼalik { $ref }.
+    }
+
+help-learn-about-references = Kan yóoʼolal referensiaʼob →
+help-reference-page = Páajina tiʼ referensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ichil { $element }
+       *[top] Tu kaʼanalil
+    }{ $allowed ->
+        [none] { " — mix baʼal ku bin wayeʼ." }
+        [text] { " — tsʼíibt tʼaan wayeʼ." }
+        [text-and-components] { " — tsʼíibt tʼaan wayeʼ, wa túunt lelaʼ:" }
+       *[components] { " — baʼaxoʼob jeʼel a túuntikeʼ:" }
+    }
+
+help-suggestions-footer = Pʼuchʼ { $shortcut } utiaʼal a wilik tuláakal le { $total } komponenteʼoboʼ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } leti junpʼéel referensia tiʼ { $target }.
+       *[other] { $ref } leti junpʼéel referensia tiʼ { $target } (renglón { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Tsʼaʼab tumen { $owner } bey { $role }.
+       *[other] Tsʼaʼab tumen { $owner } tiʼ renglón { $line } bey { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } leti junpʼéel referensia tiʼ u propiedad { $property } tiʼ { $element }.
+       *[other] { $ref } leti junpʼéel referensia tiʼ u propiedad { $property } tiʼ { $element } (renglón { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = snippet
+help-kind-array-entry = u jaatsil arreglo
+
+help-default = Baʼax yaan chéen beyoʼ:
+help-active-default = Baʼax yaan chéen beyoʼ bejlaʼe:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Baloroʼob chaʼabal (junpʼéel tiʼ jujunpʼéel):
+       *[other] Baloroʼob chaʼabal:
+    }
+
+help-suggested-values = Baloroʼob kʼubéentaʼan:
+
+help-inserts = Ku tsʼáaik:
+
+help-coordinates = Koordenada:
+
+help-type = Tipo:
+
+help-resolved-style = Estilo tsʼoʼok u yojéeltaʼal (styleNumber { $styleNumber }):
+
+help-resolved-function-names = U kʼaabaʼob funsión tsʼoʼok u yojéeltaʼaloʼob:
+help-reset-list = Listaʼ ku suʼutul tiʼ le entrada lelaʼ:
+help-added-on-input = Ku tsʼaʼabal tiʼ le entrada lelaʼ:
+help-removed-on-input = Ku luʼusaʼal tiʼ le entrada lelaʼ:
+
+help-reset-overrides = { $reset } ku pʼatik tu paach { $additional } yéetel { $removed }.

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -919,9 +919,10 @@ export const LOCALE_NAME_FALLBACKS: Record<
     sgh: { englishName: "Shughni" },
     haz: { englishName: "Hazaragi" },
     // The nine locales of the Americas batch CLDR has no data for, which is
-    // nine of that batch's fifteen — a higher share than any batch before it,
-    // and a fact about which languages get into CLDR rather than about how
-    // many speak these. ICU names `pap`, `srn`, `jam`, `kl` and `iu` and
+    // nine of that batch's fifteen and the largest number any batch here has
+    // needed — the next largest is the seven of the West and Central African
+    // batch above — and a fact about which languages get into CLDR rather
+    // than about how many speak these. ICU names `pap`, `srn`, `jam`, `kl` and `iu` and
     // stops at the nine below. Six of the nine are creoles, and a creole is
     // where the gap concentrates: `pap`, `srn` and `jam` are named only
     // because they are the three with a national or quasi-official standing
@@ -937,10 +938,12 @@ export const LOCALE_NAME_FALLBACKS: Record<
     // Antillean standards write «r» — so a corrector who respells a catalog
     // must respell its roster label with it.
     //
-    // Three of the nine have an endonym that is the English name over again
-    // — Garifuna, Mískito, Saramaccan — and they are written out rather than
-    // omitted, because the accent in «Mískito» and «Saamáka tongo» is part of
-    // the spelling and the label would otherwise lose it.
+    // Two of the nine have an endonym that is the English name over again —
+    // Garifuna and Mískito — and both are written out rather than omitted,
+    // because the accent in «Mískito» is part of the spelling and the label
+    // would otherwise lose it. `srm` is not one of them: "Saramaccan" is the
+    // outside name and «Saamáka tongo» the language's own, so its label reads
+    // "Saramaccan (Saamáka tongo)" like the rest.
     yua: {
         englishName: "Yucatec Maya",
         endonym: "Maaya\u02bc t\u02bc\u00e0an",

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -918,6 +918,53 @@ export const LOCALE_NAME_FALLBACKS: Record<
     dng: { englishName: "Dungan" },
     sgh: { englishName: "Shughni" },
     haz: { englishName: "Hazaragi" },
+    // The nine locales of the Americas batch CLDR has no data for, which is
+    // nine of that batch's fifteen — a higher share than any batch before it,
+    // and a fact about which languages get into CLDR rather than about how
+    // many speak these. ICU names `pap`, `srn`, `jam`, `kl` and `iu` and
+    // stops at the nine below. Six of the nine are creoles, and a creole is
+    // where the gap concentrates: `pap`, `srn` and `jam` are named only
+    // because they are the three with a national or quasi-official standing
+    // ICU already tracks.
+    //
+    // Every one of the nine gets an endonym, which is where this block parts
+    // company with the Silk Road one above: each of these catalogs names its
+    // language exactly one way, in all four of its files, so there is nothing
+    // to choose between and `locales/olo`'s admitted-gap shape is not needed
+    // anywhere here. The spellings are copied letter for letter from the
+    // catalogs' own headers — the U+02BC modifier apostrophe in «Maayaʼ
+    // tʼàan», the grave that marks Yucatec tone, `acf`'s «w» where the
+    // Antillean standards write «r» — so a corrector who respells a catalog
+    // must respell its roster label with it.
+    //
+    // Three of the nine have an endonym that is the English name over again
+    // — Garifuna, Mískito, Saramaccan — and they are written out rather than
+    // omitted, because the accent in «Mískito» and «Saamáka tongo» is part of
+    // the spelling and the label would otherwise lose it.
+    yua: {
+        englishName: "Yucatec Maya",
+        endonym: "Maaya\u02bc t\u02bc\u00e0an",
+    },
+    cab: { englishName: "Garifuna", endonym: "Garifuna" },
+    miq: { englishName: "M\u00edskito", endonym: "M\u00edskito" },
+    gcf: {
+        englishName: "Guadeloupean Creole French",
+        endonym: "kr\u00e9y\u00f2l gwadloup\u00e9yen",
+    },
+    acf: {
+        englishName: "Saint Lucian Creole French",
+        endonym: "Kw\u00e9y\u00f2l",
+    },
+    gcr: {
+        englishName: "Guianese Creole French",
+        endonym: "kriy\u00f2l gwiyan\u00e8",
+    },
+    bzj: { englishName: "Belize Kriol", endonym: "Bileez Kriol" },
+    // ISO 639-3's reference name is "Aukan"; the catalog's own headers lead
+    // with "Aukan / Ndyuka" and the language is as often called the second.
+    // The roster label takes the endonym, which both names agree on.
+    djk: { englishName: "Aukan", endonym: "Okanisi tongo" },
+    srm: { englishName: "Saramaccan", endonym: "Saam\u00e1ka tongo" },
 };
 
 /**

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -922,8 +922,9 @@ export const LOCALE_NAME_FALLBACKS: Record<
     // nine of that batch's fifteen and the largest number any batch here has
     // needed — the next largest is the seven of the West and Central African
     // batch above — and a fact about which languages get into CLDR rather
-    // than about how many speak these. ICU names `pap`, `srn`, `jam`, `kl` and `iu` and
-    // stops at the nine below. Six of the nine are creoles, and a creole is
+    // than about how many speak these. ICU names the other six — `kl`, `iu`,
+    // `kek`, `pap`, `srn` and `jam` — and stops at the nine below. Six of the
+    // nine are creoles, and a creole is
     // where the gap concentrates: `pap`, `srn` and `jam` are named only
     // because they are the three with a national or quasi-official standing
     // ICU already tracks.

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -9,6 +9,7 @@ export type SupportedLocale =
     | "en"
     | "ab"
     | "ace"
+    | "acf"
     | "ady"
     | "af"
     | "ak"
@@ -40,7 +41,9 @@ export type SupportedLocale =
     | "bs"
     | "bua"
     | "bum"
+    | "bzj"
     | "ca"
+    | "cab"
     | "ce"
     | "ceb"
     | "ch"
@@ -57,6 +60,7 @@ export type SupportedLocale =
     | "dar"
     | "de"
     | "dje"
+    | "djk"
     | "dng"
     | "doi"
     | "dsb"
@@ -85,6 +89,8 @@ export type SupportedLocale =
     | "ga"
     | "gaa"
     | "gag"
+    | "gcf"
+    | "gcr"
     | "gd"
     | "gil"
     | "gl"
@@ -110,7 +116,9 @@ export type SupportedLocale =
     | "inh"
     | "is"
     | "it"
+    | "iu"
     | "ja"
+    | "jam"
     | "jv"
     | "ka"
     | "kaa"
@@ -118,10 +126,12 @@ export type SupportedLocale =
     | "kbd"
     | "kbp"
     | "kca"
+    | "kek"
     | "kg"
     | "ki"
     | "kjh"
     | "kk"
+    | "kl"
     | "km"
     | "kmb"
     | "kmr"
@@ -164,6 +174,7 @@ export type SupportedLocale =
     | "mhr"
     | "mi"
     | "min"
+    | "miq"
     | "mk"
     | "ml"
     | "mn"
@@ -198,6 +209,7 @@ export type SupportedLocale =
     | "os"
     | "pa"
     | "pam"
+    | "pap"
     | "pcm"
     | "pl"
     | "pms"
@@ -237,6 +249,8 @@ export type SupportedLocale =
     | "so"
     | "sq"
     | "sr"
+    | "srm"
+    | "srn"
     | "ss"
     | "st"
     | "su"
@@ -287,6 +301,7 @@ export type SupportedLocale =
     | "xh"
     | "yi"
     | "yo"
+    | "yua"
     | "zgh"
     | "zh-Hans"
     | "zh-Hant"
@@ -341,6 +356,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Acehnese",
         endonym: "Acehnese",
         label: "Acehnese",
+    },
+    {
+        locale: "acf",
+        englishName: "Saint Lucian Creole French",
+        endonym: "Kwéyòl",
+        label: "Saint Lucian Creole French (Kwéyòl)",
     },
     {
         locale: "ady",
@@ -494,10 +515,22 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     },
     { locale: "bum", englishName: "Bulu", endonym: "Bulu", label: "Bulu" },
     {
+        locale: "bzj",
+        englishName: "Belize Kriol",
+        endonym: "Bileez Kriol",
+        label: "Belize Kriol (Bileez Kriol)",
+    },
+    {
         locale: "ca",
         englishName: "Catalan",
         endonym: "català",
         label: "Catalan (català)",
+    },
+    {
+        locale: "cab",
+        englishName: "Garifuna",
+        endonym: "Garifuna",
+        label: "Garifuna",
     },
     {
         locale: "ce",
@@ -594,6 +627,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Zarma",
         endonym: "Zarmaciine",
         label: "Zarma (Zarmaciine)",
+    },
+    {
+        locale: "djk",
+        englishName: "Aukan",
+        endonym: "Okanisi tongo",
+        label: "Aukan (Okanisi tongo)",
     },
     {
         locale: "dng",
@@ -734,6 +773,18 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Gagauz",
     },
     {
+        locale: "gcf",
+        englishName: "Guadeloupean Creole French",
+        endonym: "kréyòl gwadloupéyen",
+        label: "Guadeloupean Creole French (kréyòl gwadloupéyen)",
+    },
+    {
+        locale: "gcr",
+        englishName: "Guianese Creole French",
+        endonym: "kriyòl gwiyanè",
+        label: "Guianese Creole French (kriyòl gwiyanè)",
+    },
+    {
         locale: "gd",
         englishName: "Scottish Gaelic",
         endonym: "Gàidhlig",
@@ -869,10 +920,22 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Italian (italiano)",
     },
     {
+        locale: "iu",
+        englishName: "Inuktitut",
+        endonym: "Inuktitut",
+        label: "Inuktitut",
+    },
+    {
         locale: "ja",
         englishName: "Japanese",
         endonym: "日本語",
         label: "Japanese (日本語)",
+    },
+    {
+        locale: "jam",
+        englishName: "Jamaican Creole English",
+        endonym: "Jamaican Creole English",
+        label: "Jamaican Creole English",
     },
     {
         locale: "jv",
@@ -916,6 +979,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "хӑнты ясӑӈ",
         label: "Khanty (хӑнты ясӑӈ)",
     },
+    {
+        locale: "kek",
+        englishName: "Qʼeqchiʼ",
+        endonym: "Qʼeqchiʼ",
+        label: "Qʼeqchiʼ",
+    },
     { locale: "kg", englishName: "Kongo", endonym: "Kongo", label: "Kongo" },
     {
         locale: "ki",
@@ -934,6 +1003,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Kazakh",
         endonym: "қазақ тілі",
         label: "Kazakh (қазақ тілі)",
+    },
+    {
+        locale: "kl",
+        englishName: "Kalaallisut",
+        endonym: "kalaallisut",
+        label: "Kalaallisut (kalaallisut)",
     },
     {
         locale: "km",
@@ -1143,6 +1218,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Minangkabau",
     },
     {
+        locale: "miq",
+        englishName: "Mískito",
+        endonym: "Mískito",
+        label: "Mískito",
+    },
+    {
         locale: "mk",
         englishName: "Macedonian",
         endonym: "македонски",
@@ -1320,6 +1401,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Pampanga",
         endonym: "Pampanga",
         label: "Pampanga",
+    },
+    {
+        locale: "pap",
+        englishName: "Papiamento",
+        endonym: "Papiamento",
+        label: "Papiamento",
     },
     {
         locale: "pcm",
@@ -1539,6 +1626,18 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Serbian",
         endonym: "српски",
         label: "Serbian (српски)",
+    },
+    {
+        locale: "srm",
+        englishName: "Saramaccan",
+        endonym: "Saamáka tongo",
+        label: "Saramaccan (Saamáka tongo)",
+    },
+    {
+        locale: "srn",
+        englishName: "Sranan Tongo",
+        endonym: "Sranan Tongo",
+        label: "Sranan Tongo",
     },
     { locale: "ss", englishName: "Swati", endonym: "Swati", label: "Swati" },
     {
@@ -1779,6 +1878,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Yoruba",
         endonym: "Èdè Yorùbá",
         label: "Yoruba (Èdè Yorùbá)",
+    },
+    {
+        locale: "yua",
+        englishName: "Yucatec Maya",
+        endonym: "Maayaʼ tʼàan",
+        label: "Yucatec Maya (Maayaʼ tʼàan)",
     },
     {
         locale: "zgh",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -375,6 +375,26 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // how close two varieties are rather than a published fact — `kbl` under
     // `kr` and `alq` under `oj` land the same way.
     kmr: ["sdh"],
+    // Inuktitut. `locales/iu` is written in Canadian Aboriginal syllabics, the
+    // script Nunavut legislates and schools in, and ISO 639-3 gives the
+    // macrolanguage exactly two members: `ike` (Eastern Canadian Inuktitut)
+    // and `ikt` (Inuinnaqtun). Only `ike` is listed, and it is listed for the
+    // reason the already-folded codes above are — `Intl.getCanonicalLocales`
+    // rewrites it to `iu` before negotiation is consulted, so naming it keeps
+    // this a statement of membership rather than a list of leftovers.
+    //
+    // **`ikt` is deliberately absent, and the reason is the script rather than
+    // the language.** Inuinnaqtun is written in roman letters, and
+    // `locales/iu` contains no roman-letter Inuktitut word anywhere — so
+    // folding `ikt` here would answer a reader who arrived in one script with
+    // a catalog written wholly in another. That is a worse answer than the
+    // English fallback, which at least uses letters the reader has. It is the
+    // exclusion `kbl` and `alq` illustrate met from a new direction: those two
+    // are excluded because membership does not say they belong, while `ikt`
+    // is a published member excluded because the catalog cannot serve it. The
+    // answer to it is a second catalog in roman letters, which is what
+    // `locales/ha` and `locales/kr` say about their own script asymmetries.
+    iu: ["ike"],
 };
 
 /** Flattened once at module load rather than searched per request. */

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -385,9 +385,10 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     //
     // **`ikt` is deliberately absent, and the reason is the script rather than
     // the language.** Inuinnaqtun is written in roman letters, and
-    // `locales/iu` contains no roman-letter Inuktitut word anywhere — so
-    // folding `ikt` here would answer a reader who arrived in one script with
-    // a catalog written wholly in another. That is a worse answer than the
+    // `locales/iu` contains no roman-letter Inuktitut word anywhere — its
+    // roman is DoenetML identifiers and a few declared English loans, not
+    // prose — so folding `ikt` here would answer a reader who arrived in one
+    // script with a catalog whose every sentence is in another. That is a worse answer than the
     // English fallback, which at least uses letters the reader has. It is the
     // exclusion `kbl` and `alq` illustrate met from a new direction: those two
     // are excluded because membership does not say they belong, while `ikt`

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
     parse,
+    Resource,
+    serialize,
     type Entry,
     type Message,
     type Pattern,
@@ -1262,4 +1264,80 @@ describe("plural categories a locale cannot select", () => {
             ).toEqual(["á", "ë", "ö"]);
         });
     });
+});
+
+/**
+ * Two catalogs can agree without being one catalog, and this batch has both
+ * shapes of that. `jam` and `bzj` are English-lexifier creoles in phonemic
+ * orthographies, so the short everyday words converge — «chruu», «faals»,
+ * «tik dash-dash red lain» — and `gcf` and `gcr` agree word for word on a
+ * styled line. Convergence is the language; a catalog copied to a second tag
+ * is a defect, and the two look alike from a distance.
+ *
+ * What separates them is a *rate*. A copy differs nowhere; these differ in
+ * most of what they both define. The rate over `content.ftl` alone is
+ * asserted in `packages/utils/test/styleDescriptions.test.ts`, beside the
+ * styled-line phrase it is about; what is left here is the whole-catalog
+ * rate, and the French trio, whose agreement is confined to that one phrase.
+ * The floors are floors rather than equalities so that correcting a string
+ * cannot fail the test — only wholesale duplication can.
+ */
+describe("catalogs of one lexifier that are not each other's copy", () => {
+    /** Message id → serialized entry, for every message in one namespace. */
+    const entries = (locale: string, namespace: string) => {
+        const source = readCatalog(locale, namespace);
+        const values = new Map<string, string>();
+        if (source === null) {
+            return values;
+        }
+        for (const entry of parse(source, { withSpans: false }).body) {
+            if (entry.type === "Message") {
+                values.set(entry.id.name, serialize(new Resource([entry]), {}));
+            }
+        }
+        return values;
+    };
+
+    /** How many of the ids both catalogs define carry different text. */
+    const differing = (a: string, b: string, namespaces: readonly string[]) => {
+        let shared = 0;
+        let differ = 0;
+        for (const namespace of namespaces) {
+            const left = entries(a, namespace);
+            const right = entries(b, namespace);
+            for (const [id, value] of left) {
+                const other = right.get(id);
+                if (other === undefined) {
+                    continue;
+                }
+                shared += 1;
+                differ += value === other ? 0 : 1;
+            }
+        }
+        return { shared, differ };
+    };
+
+    it("keeps jam and bzj apart in most of what both define", () => {
+        const all = differing("jam", "bzj", CATALOG_NAMESPACES);
+        expect(all.shared).toBe(389);
+        expect(all.differ).toBeGreaterThanOrEqual(342);
+    });
+
+    /**
+     * The French-lexifier trio, where the styled-line phrase agrees but the
+     * diagnostics do not: `gcr` writes the indefinite «roun» where `gcf`
+     * writes «on», which alone separates most of the file.
+     */
+    it.each([
+        ["gcf", "gcr", 206],
+        ["gcf", "acf", 180],
+        ["acf", "gcr", 205],
+    ] as [string, string, number][])(
+        "keeps %s and %s apart across their diagnostics",
+        (a, b, floor) => {
+            const { shared, differ } = differing(a, b, ["diagnostics"]);
+            expect(shared).toBe(220);
+            expect(differ).toBeGreaterThanOrEqual(floor);
+        },
+    );
 });

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -7,6 +7,7 @@ import {
     type Message,
     type Pattern,
     type SelectExpression,
+    type Variant,
 } from "@fluent/syntax";
 
 import {
@@ -1338,6 +1339,157 @@ describe("catalogs of one lexifier that are not each other's copy", () => {
             const { shared, differ } = differing(a, b, ["diagnostics"]);
             expect(shared).toBe(220);
             expect(differ).toBeGreaterThanOrEqual(floor);
+        },
+    );
+});
+
+/**
+ * A select every branch of which renders the same string is a distinction the
+ * catalog has silently dropped. It parses, it lints, every property above
+ * passes it, and it reads to a skimmer as a locale that carefully wrote out
+ * three forms — but the reader gets one string whatever the count, and the
+ * header claiming the forms differ is now false about its own file.
+ *
+ * The Americas seed shipped five of them and they were the batch's second
+ * semantic defect, after `locales/miq`'s collapsed
+ * `field-function-wrong-num-outputs`. All five were in `kl` and `iu`, which is
+ * where they matter: those two are the batch's catalogs whose plural branches
+ * a runtime can actually select, so a repeated branch is a live branch saying
+ * nothing. They are now written as a single form, which is the honest shape
+ * for a message whose wording does not turn on the count.
+ *
+ * **Identical branches are forbidden; merely non-distinct ones are not.**
+ * `style-border-clause` forks four ways on an article English has and six of
+ * these languages do not, so `[with-article]` and `[with]` land on one string
+ * in `kl`, `cab`, `miq`, `srn`, `djk` and `srm` while `[and]` stays apart.
+ * That is a distinction the target language does not draw, not one the
+ * translation lost, so the floor is *some* branch differing rather than all
+ * of them.
+ */
+describe("selects in the Americas batch that still say something", () => {
+    /** The fifteen tags this batch adds, in the order the README lists them. */
+    const AMERICAS_LOCALES = [
+        "kl",
+        "iu",
+        "yua",
+        "kek",
+        "cab",
+        "miq",
+        "pap",
+        "srn",
+        "jam",
+        "gcf",
+        "acf",
+        "gcr",
+        "bzj",
+        "djk",
+        "srm",
+    ];
+
+    /** A variant's key as written — `[one]`, `[0]` — for a failure message. */
+    const variantKey = (variant: Variant): string =>
+        variant.key.type === "Identifier"
+            ? variant.key.name
+            : variant.key.value;
+
+    /** Every select in one catalog, nested ones included. */
+    const selects = (locale: string, namespace: string) => {
+        const source = readCatalog(locale, namespace);
+        const found: SelectExpression[] = [];
+        if (source === null) {
+            return found;
+        }
+        const walk = (pattern: Pattern) => {
+            for (const element of pattern.elements) {
+                if (
+                    element.type === "Placeable" &&
+                    element.expression.type === "SelectExpression"
+                ) {
+                    found.push(element.expression);
+                    for (const variant of element.expression.variants) {
+                        walk(variant.value);
+                    }
+                }
+            }
+        };
+        for (const entry of parse(source, { withSpans: false }).body) {
+            if (entry.type !== "Message" && entry.type !== "Term") {
+                continue;
+            }
+            for (const pattern of [
+                entry.value,
+                ...entry.attributes.map((attribute) => attribute.value),
+            ]) {
+                if (pattern) {
+                    walk(pattern);
+                }
+            }
+        }
+        return found;
+    };
+
+    /**
+     * A variant's pattern as a comparable string. Written out rather than
+     * handed to `serialize`, which needs a whole `Resource` of real AST nodes
+     * and throws on a synthesized one: text is taken verbatim, and a placeable
+     * is reduced to a canonical token so that two branches differing only in
+     * *which* variable they interpolate still count as different.
+     */
+    const patternText = (pattern: Pattern): string =>
+        pattern.elements
+            .map((element) => {
+                if (element.type === "TextElement") {
+                    return element.value;
+                }
+                const expression = element.expression;
+                if (expression.type === "VariableReference") {
+                    return `{$${expression.id.name}}`;
+                }
+                if (expression.type === "SelectExpression") {
+                    return `{select:${expression.variants
+                        .map(
+                            (variant) =>
+                                `${variantKey(variant)}=${patternText(
+                                    variant.value,
+                                )}`,
+                        )
+                        .join("|")}}`;
+                }
+                if (
+                    expression.type === "StringLiteral" ||
+                    expression.type === "NumberLiteral"
+                ) {
+                    return expression.value;
+                }
+                if (expression.type === "MessageReference") {
+                    return `{${expression.id.name}}`;
+                }
+                if (expression.type === "TermReference") {
+                    return `{-${expression.id.name}}`;
+                }
+                return `{${expression.type}}`;
+            })
+            .join("");
+
+    it.each(AMERICAS_LOCALES)(
+        "leaves no select in %s with every branch the same",
+        (locale) => {
+            const uniform: string[] = [];
+            for (const namespace of CATALOG_NAMESPACES) {
+                for (const select of selects(locale, namespace)) {
+                    const rendered = select.variants.map((variant) =>
+                        patternText(variant.value),
+                    );
+                    if (new Set(rendered).size === 1) {
+                        uniform.push(
+                            `${namespace}: ${select.variants
+                                .map((variant) => variantKey(variant))
+                                .join("/")}`,
+                        );
+                    }
+                }
+            }
+            expect(uniform).toEqual([]);
         },
     );
 });

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1359,12 +1359,14 @@ describe("catalogs of one lexifier that are not each other's copy", () => {
  * for a message whose wording does not turn on the count.
  *
  * **Identical branches are forbidden; merely non-distinct ones are not.**
- * `style-border-clause` forks four ways on an article English has and six of
- * these languages do not, so `[with-article]` and `[with]` land on one string
- * in `kl`, `cab`, `miq`, `srn`, `djk` and `srm` while `[and]` stays apart.
- * That is a distinction the target language does not draw, not one the
- * translation lost, so the floor is *some* branch differing rather than all
- * of them.
+ * `style-border-clause` forks four ways on two distinctions English draws, an
+ * indefinite article and a linker English spells two ways, and six of these
+ * catalogs collapse one of the two: `kl` and `miq` write no article, so
+ * `[with-article]` lands on `[with]`, while `cab`, `srn`, `djk` and `srm` use
+ * one word for both *with* and *and*, so `[with]` lands on `[and]`. Either
+ * way two branches remain. That is a distinction the target language does not
+ * draw, not one the translation lost, so the floor is *some* branch differing
+ * rather than all of them.
  */
 describe("selects in the Americas batch that still say something", () => {
     /** The fifteen tags this batch adds, in the order the README lists them. */

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1172,4 +1172,94 @@ describe("plural categories a locale cannot select", () => {
             },
         );
     });
+
+    /**
+     * The Americas batch's headers make a claim of the same checkable kind the
+     * three Silk Road headers do, but about **one character rather than an
+     * alphabet**: `locales/yua` and `locales/kek` state that the glottal stop
+     * and the ejectives are written with U+02BC MODIFIER LETTER APOSTROPHE
+     * throughout, and never with the typographic U+2019 or the ASCII U+0027.
+     *
+     * That is worth holding for the Silk Road block's reason exactly. The
+     * three characters are near-indistinguishable on screen, a text editor
+     * with smart quotes turns one into another without being asked, and the
+     * result breaks no test and defeats every later search — but «tʼaan» and
+     * «t’aan» are different strings, and in Mayan orthography the ejective is
+     * a letter rather than punctuation.
+     *
+     * `locales/iu` gets the other half of the same idea: its header states
+     * that no Inuktitut word is spelled in roman letters, and the roman that
+     * does appear is either DoenetML source or a declared English loan. The
+     * check that fits that claim is not an inventory — the loans are real
+     * roman words — but the absence of the one syllabics character that would
+     * mean the file had drifted into a neighbouring language's inventory.
+     */
+    describe("the character inventories the Americas headers state exactly", () => {
+        /** The message text of a catalog: comment lines and code spans dropped. */
+        const prose = (locale: string): string =>
+            CATALOG_NAMESPACES.map((namespace) =>
+                readCatalog(locale, namespace),
+            )
+                .filter((source): source is string => source !== null)
+                .join("\n")
+                .split("\n")
+                .filter((line) => !line.trimStart().startsWith("#"))
+                .join("\n")
+                .replace(/`[^`]*`/g, " ");
+
+        it.each(["yua", "kek"])(
+            "writes every apostrophe in %s as U+02BC",
+            (locale) => {
+                const text = prose(locale);
+                expect(text).toContain("\u02bc");
+                // The look-alike, named by codepoint so a failure says which
+                // character crept in rather than printing two identical marks.
+                expect(text).not.toContain("\u2019");
+                // U+0027 is deliberately not forbidden: English's own
+                // messages quote enumerated values with straight quotes and
+                // write the derivative as `y'`, and both come through a
+                // translation unchanged. It is the curly one a smart-quote
+                // editor substitutes, and the curly one that would be a
+                // silent respelling of a Mayan letter.
+            },
+        );
+
+        /**
+         * ᐦ (U+1426) is the Cree final `h`. It is not part of the Nunavut
+         * Inuktitut inventory — `locales/iu` writes ᕼ (U+157C) where it needs
+         * an *h* — and its appearance would mean a syllabics string had been
+         * taken from a Cree source. The batch shipped no Cree catalog, which
+         * is exactly why nothing else would catch this.
+         */
+        it("keeps iu's syllabics out of the Cree finals", () => {
+            // ᕼ itself appears only in the headers — the syllabics words
+            // this catalog happens to use need no *h* — so what is asserted
+            // is the absence, which is the half that could rot.
+            expect(prose("iu")).not.toContain("\u1426");
+        });
+
+        /**
+         * `locales/srm`'s headers state that tone is not written, and that the
+         * one accented letter outside its `ë`/`ö` vowels is «á», the preverbal
+         * negator, whose accent marks the word rather than a tone. Any other
+         * acute would mean tone had been half-restored — worse than the stated
+         * absence, because a reader could not tell which words had been done.
+         */
+        it("keeps srm to the one accented letter its header allows", () => {
+            const accented = new Set(
+                [...prose("srm")].filter((letter) =>
+                    /[\u00c0-\u024f]/.test(letter),
+                ),
+            );
+            // Case-folded: «Ë» opens a sentence in several messages, and a
+            // capital is the same letter.
+            expect(
+                [
+                    ...new Set(
+                        [...accented].map((letter) => letter.toLowerCase()),
+                    ),
+                ].sort(),
+            ).toEqual(["á", "ë", "ö"]);
+        });
+    });
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -874,7 +874,7 @@ describe("the Silk Road batch's plural categories", () => {
 
 /**
  * The Americas, and the batch where three catalogs have CLDR rules and one of
- * the three writes a category the roster had seen only four times before.
+ * the three writes a category the roster had seen only sixteen times before.
  *
  * The blocks above give the other proportions: the Sami block is five
  * catalogs where four have CLDR plural data, the Oceania block eleven where

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -54,6 +54,40 @@ import zzaChrome from "../locales/zza/chrome.ftl?raw";
 import dngChrome from "../locales/dng/chrome.ftl?raw";
 import sghChrome from "../locales/sgh/chrome.ftl?raw";
 import wblChrome from "../locales/wbl/chrome.ftl?raw";
+// The Americas batch, both files for the same reason as the Silk Road's:
+// each catalog's count selects are split between `chrome.ftl` and
+// `diagnostics.ftl`, so where a category branch falls is only checkable
+// across the two together.
+import yuaChrome from "../locales/yua/chrome.ftl?raw";
+import kekChrome from "../locales/kek/chrome.ftl?raw";
+import cabChrome from "../locales/cab/chrome.ftl?raw";
+import miqChrome from "../locales/miq/chrome.ftl?raw";
+import papChrome from "../locales/pap/chrome.ftl?raw";
+import srnChrome from "../locales/srn/chrome.ftl?raw";
+import jamChrome from "../locales/jam/chrome.ftl?raw";
+import gcfChrome from "../locales/gcf/chrome.ftl?raw";
+import acfChrome from "../locales/acf/chrome.ftl?raw";
+import gcrChrome from "../locales/gcr/chrome.ftl?raw";
+import bzjChrome from "../locales/bzj/chrome.ftl?raw";
+import djkChrome from "../locales/djk/chrome.ftl?raw";
+import srmChrome from "../locales/srm/chrome.ftl?raw";
+import klChrome from "../locales/kl/chrome.ftl?raw";
+import iuChrome from "../locales/iu/chrome.ftl?raw";
+import yuaDiagnostics from "../locales/yua/diagnostics.ftl?raw";
+import kekDiagnostics from "../locales/kek/diagnostics.ftl?raw";
+import cabDiagnostics from "../locales/cab/diagnostics.ftl?raw";
+import miqDiagnostics from "../locales/miq/diagnostics.ftl?raw";
+import papDiagnostics from "../locales/pap/diagnostics.ftl?raw";
+import srnDiagnostics from "../locales/srn/diagnostics.ftl?raw";
+import jamDiagnostics from "../locales/jam/diagnostics.ftl?raw";
+import gcfDiagnostics from "../locales/gcf/diagnostics.ftl?raw";
+import acfDiagnostics from "../locales/acf/diagnostics.ftl?raw";
+import gcrDiagnostics from "../locales/gcr/diagnostics.ftl?raw";
+import bzjDiagnostics from "../locales/bzj/diagnostics.ftl?raw";
+import djkDiagnostics from "../locales/djk/diagnostics.ftl?raw";
+import srmDiagnostics from "../locales/srm/diagnostics.ftl?raw";
+import klDiagnostics from "../locales/kl/diagnostics.ftl?raw";
+import iuDiagnostics from "../locales/iu/diagnostics.ftl?raw";
 // The Silk Road batch's `diagnostics.ftl` too: it holds every count select
 // that is not in `chrome.ftl`, so where each catalog's `[one]` falls is only
 // checkable across both files.
@@ -834,6 +868,190 @@ describe("the Silk Road batch's plural categories", () => {
                 t("attempts-remaining", { count: 3 }),
             );
             expect(none).not.toBe(some);
+        },
+    );
+});
+
+/**
+ * The Americas, and the batch where three catalogs have CLDR rules and one of
+ * the three writes a category the roster had seen only four times before.
+ *
+ * The blocks above give the other proportions: the Sami block is five
+ * catalogs where four have CLDR plural data, the Oceania block eleven where
+ * none does, the European regional block fifteen split eight to seven, and
+ * the Silk Road block fifteen where exactly one does. This batch is fifteen
+ * where **three** do — `Intl.PluralRules` resolves `iu`, `kl` and `pap` to
+ * themselves — and the other twelve resolve to the runtime's default locale,
+ * English here, so any category branch they wrote would be chosen by
+ * English's rules on English's terms.
+ *
+ * **`iu` is the reason this block exists.** Inuktitut's CLDR data gives it
+ * `one`, `two` and `other`, and the catalog writes all three with a different
+ * ending in each: the dual is a fact about Inuktitut grammar rather than a
+ * branch copied from English, and it is the only place in the batch where a
+ * count select carries more than the default. Four catalogs on the roster had
+ * a `[two]` before it — `hsb`, `dsb` and the Sami pair — and none of them is
+ * in the Americas.
+ *
+ * That no catalog here carries a `[zero]`, `[few]` or `[many]` branch its own
+ * locale could never select is not asserted in this block: the roster-wide
+ * property in `catalogLint.test.ts` holds it for every catalog, over all four
+ * namespaces and off the syntax tree rather than the text. What is left here
+ * is the half that property cannot state — which tags have CLDR data of their
+ * own, and which categories each resolves — so that a future ICU build losing
+ * Inuktitut's dual, or gaining rules for one of the twelve, fails an
+ * assertion rather than silently changing which branch a reader gets.
+ *
+ * `[one]` is deliberately not in the forbidden list — it is the one category
+ * every runtime default can select — and where it falls in the twelve without
+ * rules is the thing this summary would not have predicted:
+ *
+ *   * **Eleven of the twelve write exactly one `[one]`**, in
+ *     `field-function-wrong-num-outputs`, and it is not a count select at
+ *     all: it forks on how many outputs a component needs — the English says
+ *     "one output"/"two outputs", the slope field against the vector field —
+ *     rather than on how many of anything a reader has.
+ *   * **`kek` and `miq` collapse even that one**, losing the one-output
+ *     wording, which is recorded rather than forbidden and is on the
+ *     reviewer's list.
+ *   * **No catalog in the batch forks a real count.** Every count message in
+ *     the twelve is a single `*[other]`, which is what a creole with a
+ *     preposed plural particle and a Mayan language with an unmarked noun
+ *     after a numeral both want.
+ *
+ * Explicit numeric literals are a different mechanism — matched against the
+ * number rather than against a category — and every catalog in the batch
+ * keeps English's `[0]` branch, which the last block holds.
+ */
+describe("the Americas batch's plural categories", () => {
+    /** Comment lines dropped: several headers discuss `[one]` in prose. */
+    const branches = (catalog: string) =>
+        catalog
+            .split("\n")
+            .filter((line) => !line.trimStart().startsWith("#"))
+            .join("\n");
+
+    type Row = [string, string, string];
+
+    /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
+    const both = ([, chrome, diagnostics]: Row) =>
+        `${branches(chrome)}\n${branches(diagnostics)}`;
+
+    /** The twelve with no CLDR rules of their own. */
+    const NO_RULES: Row[] = [
+        ["yua", yuaChrome, yuaDiagnostics],
+        ["kek", kekChrome, kekDiagnostics],
+        ["cab", cabChrome, cabDiagnostics],
+        ["miq", miqChrome, miqDiagnostics],
+        ["srn", srnChrome, srnDiagnostics],
+        ["jam", jamChrome, jamDiagnostics],
+        ["gcf", gcfChrome, gcfDiagnostics],
+        ["acf", acfChrome, acfDiagnostics],
+        ["gcr", gcrChrome, gcrDiagnostics],
+        ["bzj", bzjChrome, bzjDiagnostics],
+        ["djk", djkChrome, djkDiagnostics],
+        ["srm", srmChrome, srmDiagnostics],
+    ];
+
+    /** The three with them. */
+    const IU: Row = ["iu", iuChrome, iuDiagnostics];
+    const KL: Row = ["kl", klChrome, klDiagnostics];
+    const PAP: Row = ["pap", papChrome, papDiagnostics];
+
+    /** All fifteen, for the assertions that do not care about the split. */
+    const AMERICAS: Row[] = [...NO_RULES, IU, KL, PAP];
+
+    it.each(NO_RULES.map(([locale]) => locale))(
+        "has no CLDR plural rules of its own for %s",
+        (locale) => {
+            expect(Intl.PluralRules.supportedLocalesOf([locale])).toEqual([]);
+        },
+    );
+
+    it.each([
+        ["iu", ["one", "two", "other"]],
+        ["kl", ["one", "other"]],
+        ["pap", ["one", "other"]],
+    ] as [string, string[]][])(
+        "resolves %s against its own rules",
+        (locale, categories) => {
+            expect(Intl.PluralRules.supportedLocalesOf([locale])).toEqual([
+                locale,
+            ]);
+            const resolved = new Intl.PluralRules(locale).resolvedOptions();
+            expect(resolved.locale).toBe(locale);
+            expect([...resolved.pluralCategories].sort()).toEqual(
+                [...categories].sort(),
+            );
+        },
+    );
+
+    /**
+     * The dual, written out. `attempts-remaining` is the one message in the
+     * batch that forks a count three ways, and the three branches have to be
+     * three *different* strings — a dual that repeats the plural is a branch
+     * that renders but says nothing, which is the failure the `[one]`-in-an
+     * -`other`-only-locale rule catches from the other side.
+     */
+    it("writes iu's dual with a distinct form in each branch", () => {
+        const select = /attempts-remaining =\s*\{ \$count ->([\s\S]*?)\n {4}\}/;
+        const body = branches(iuChrome).match(select)?.[1];
+        expect(body).toBeDefined();
+        const forms = ["one", "two", "other"].map(
+            (category) =>
+                body!.match(new RegExp(`\\*?\\[${category}\\]([^\n]*)`))?.[1],
+        );
+        expect(forms.every((form) => form && form.trim().length > 0)).toBe(
+            true,
+        );
+        expect(new Set(forms).size).toBe(3);
+    });
+
+    /**
+     * `[two]` belongs to Inuktitut alone here. The other fourteen would be
+     * writing a branch their own locale can never select — `kl` and `pap`
+     * because their rules have no dual, the twelve because they have no rules
+     * at all.
+     */
+    it.each(AMERICAS.filter(([locale]) => locale !== "iu"))(
+        "leaves %s without a [two] branch",
+        (...row) => {
+            expect(both(row as Row)).not.toMatch(/\[two\]/);
+        },
+    );
+
+    /**
+     * The categories no locale in the batch can select, `iu`'s dual apart.
+     * `[one]` is excluded for the reason the block comment gives.
+     */
+    it.each(AMERICAS)(
+        "leaves %s without a branch its locale cannot select",
+        (...row) => {
+            const catalog = both(row as Row);
+            for (const category of ["zero", "few", "many"]) {
+                expect(catalog).not.toMatch(new RegExp(`\\[${category}\\]`));
+            }
+        },
+    );
+
+    /**
+     * Where the twelve without rules put their one `[one]`, and the two that
+     * put it nowhere. This is a record of the seed rather than a rule: the
+     * message forks the slope-field sentence against the vector-field one, so
+     * a catalog that collapses it loses a distinction English draws.
+     */
+    it.each(NO_RULES)(
+        "keeps %s's [one] out of every count select",
+        (...row) => {
+            const [locale] = row as Row;
+            const catalog = both(row as Row);
+            const ones = [...catalog.matchAll(/\[one\]/g)].length;
+            expect(ones).toBe(locale === "kek" || locale === "miq" ? 0 : 1);
+            if (ones === 1) {
+                expect(catalog).toMatch(
+                    /field-function-wrong-num-outputs =[\s\S]*?\[one\]/,
+                );
+            }
         },
     );
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -1057,15 +1057,32 @@ describe("the Americas batch's plural categories", () => {
                     /field-function-wrong-num-outputs =[\s\S]*?\[one\]/,
                 );
             }
-            // Branch or prose, both fields have to be named. Collapsing to
-            // the vector example alone would state the wrong requirement to
-            // a reader whose function needs one output.
-            const message = catalog.match(
-                /field-function-wrong-num-outputs =[\s\S]*?\n(?=[a-z-]+ =)/,
-            )?.[0];
-            expect(message).toBeDefined();
-            expect(message).toContain("`y - x`");
-            expect(message).toContain("`(y, -x)`");
         },
     );
+
+    /**
+     * Branch or prose, both fields have to be named. Collapsing to the vector
+     * example alone would state the wrong requirement to a reader whose
+     * function needs one output, which is the defect `locales/miq` shipped
+     * with and this assertion exists to keep out of the other fourteen.
+     *
+     * It runs over all fifteen rather than the twelve without CLDR rules: the
+     * three with rules write the same message and could lose the same half of
+     * it. `iu` is the one catalog that leaves the message to English, which is
+     * the 373-of-575 decision its header records, so its absence is asserted
+     * by name rather than skipped silently.
+     */
+    it.each(AMERICAS)("names both fields in %s", (...row) => {
+        const [locale] = row as Row;
+        const message = both(row as Row).match(
+            /field-function-wrong-num-outputs =[\s\S]*?\n(?=[a-z-]+ =)/,
+        )?.[0];
+        if (locale === "iu") {
+            expect(message).toBeUndefined();
+            return;
+        }
+        expect(message).toBeDefined();
+        expect(message).toContain("`y - x`");
+        expect(message).toContain("`(y, -x)`");
+    });
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -889,9 +889,10 @@ describe("the Silk Road batch's plural categories", () => {
  * `one`, `two` and `other`, and the catalog writes all three with a different
  * ending in each: the dual is a fact about Inuktitut grammar rather than a
  * branch copied from English, and it is the only place in the batch where a
- * count select carries more than the default. Four catalogs on the roster had
- * a `[two]` before it — `hsb`, `dsb` and the Sami pair — and none of them is
- * in the Americas.
+ * count select carries more than the default. Sixteen catalogs on the roster
+ * already write a `[two]` their own rules select — Arabic, Hebrew, Maltese,
+ * Slovene, the Celtic four, the Sorbian pair, Santali and the five Sami — and
+ * none of them is in the Americas.
  *
  * That no catalog here carries a `[zero]`, `[few]` or `[many]` branch its own
  * locale could never select is not asserted in this block: the roster-wide
@@ -906,7 +907,7 @@ describe("the Silk Road batch's plural categories", () => {
  * every runtime default can select — and where it falls in the twelve without
  * rules is the thing this summary would not have predicted:
  *
- *   * **Eleven of the twelve write exactly one `[one]`**, in
+ *   * **Ten of the twelve write exactly one `[one]`**, in
  *     `field-function-wrong-num-outputs`, and it is not a count select at
  *     all: it forks on how many outputs a component needs — the English says
  *     "one output"/"two outputs", the slope field against the vector field —

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -911,9 +911,12 @@ describe("the Silk Road batch's plural categories", () => {
  *     all: it forks on how many outputs a component needs — the English says
  *     "one output"/"two outputs", the slope field against the vector field —
  *     rather than on how many of anything a reader has.
- *   * **`kek` and `miq` collapse even that one**, losing the one-output
- *     wording, which is recorded rather than forbidden and is on the
- *     reviewer's list.
+ *   * **`kek` and `miq` write no `[one]` at all**: both spell the fork out
+ *     as prose instead, naming the slope field and the vector field side by
+ *     side and interpolating `{ $expected }` between them, so the
+ *     distinction survives without a category branch. That is recorded
+ *     rather than forbidden — a reviewer may prefer the branch — but neither
+ *     catalog loses the one-output wording.
  *   * **No catalog in the batch forks a real count.** Every count message in
  *     the twelve is a single `*[other]`, which is what a creole with a
  *     preposed plural particle and a Mayan language with an unmarked noun
@@ -1037,8 +1040,10 @@ describe("the Americas batch's plural categories", () => {
     /**
      * Where the twelve without rules put their one `[one]`, and the two that
      * put it nowhere. This is a record of the seed rather than a rule: the
-     * message forks the slope-field sentence against the vector-field one, so
-     * a catalog that collapses it loses a distinction English draws.
+     * message forks the slope-field sentence against the vector-field one,
+     * and `kek` and `miq` keep that fork as prose rather than as a branch —
+     * which is why the second assertion holds every catalog to naming both
+     * fields, branch or no branch.
      */
     it.each(NO_RULES)(
         "keeps %s's [one] out of every count select",
@@ -1052,6 +1057,15 @@ describe("the Americas batch's plural categories", () => {
                     /field-function-wrong-num-outputs =[\s\S]*?\[one\]/,
                 );
             }
+            // Branch or prose, both fields have to be named. Collapsing to
+            // the vector example alone would state the wrong requirement to
+            // a reader whose function needs one output.
+            const message = catalog.match(
+                /field-function-wrong-num-outputs =[\s\S]*?\n(?=[a-z-]+ =)/,
+            )?.[0];
+            expect(message).toBeDefined();
+            expect(message).toContain("`y - x`");
+            expect(message).toContain("`(y, -x)`");
         },
     );
 });

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -2298,6 +2298,148 @@ describe("resolveDocumentLocale", () => {
         expect(resolveDocumentLocale("ES-mx", undefined)).toBe("es-MX");
         expect(resolveDocumentLocale(undefined, "PT-br")).toBe("pt-BR");
     });
+
+    /**
+     * The Americas. Fifteen catalogs between Greenland and the Guianas, and
+     * the batch whose one `MACROLANGUAGE_MEMBERS` entry is there to record an
+     * **exclusion** rather than to rescue a member.
+     *
+     * `iu` (Inuktitut) is the only macrolanguage among the fifteen, and ISO
+     * 639-3 gives it exactly two members: `ike` (Eastern Canadian Inuktitut)
+     * and `ikt` (Inuinnaqtun). ICU folds `ike` on its own, so the entry
+     * `iu: ["ike"]` changes no negotiation result at all — it is the shape
+     * `quz`, `ojg` and `gug` already have, a listed member that would have
+     * arrived anyway, written down so the list is the whole of a group rather
+     * than the leftovers of one.
+     *
+     * **`ikt` is left out, and the reason is the script.** Inuinnaqtun is
+     * written in roman letters; `locales/iu` is written wholly in Canadian
+     * Aboriginal syllabics and contains no roman-letter Inuktitut word
+     * anywhere. Folding `ikt` would hand a reader a catalog in a script they
+     * do not read, which is a worse answer than the English fallback. That is
+     * a third kind of exclusion from this map: `kbl` under `kr` and `alq`
+     * under `oj` are excluded because published membership does not cover
+     * them, `bam` and `dyu` under `mnk` because they have catalogs of their
+     * own, and `ikt` because the catalog cannot serve a member it does cover.
+     * The rows below assert both halves, because they fail differently — an
+     * ICU data change breaks the first, an edit to `src/negotiate.ts` the
+     * second.
+     *
+     * The other fourteen are individual languages that reached English on
+     * their own account before this batch and reach their own catalog now.
+     * Nine of the fifteen are creoles, and a creole tag is exactly the kind
+     * this map cannot help: a creole is not a member of its lexifier, so
+     * nothing folds `gcf` onto `fr` or `jam` onto `en`, and nothing should.
+     */
+    describe("the Americas batch", () => {
+        /** The fifteen tags this batch adds, in the order the README lists them. */
+        const AMERICAS = [
+            "kl",
+            "iu",
+            "yua",
+            "kek",
+            "cab",
+            "miq",
+            "pap",
+            "srn",
+            "jam",
+            "gcf",
+            "acf",
+            "gcr",
+            "bzj",
+            "djk",
+            "srm",
+        ];
+
+        /**
+         * Every one of the fifteen reaches the directory it names when the
+         * whole roster is on offer, and reaches English when only English is —
+         * the second half being what would fail if some entry were quietly
+         * folding one of these tags onto a neighbour instead of letting it
+         * arrive under its own name.
+         */
+        it("gives each of the fifteen its own catalog and nothing else", () => {
+            for (const locale of AMERICAS) {
+                expect(negotiateLocales([locale], ["en"])).toEqual(["en"]);
+                expect(negotiateLocales([locale], available)).toEqual([
+                    locale,
+                    "en",
+                ]);
+            }
+        });
+
+        /**
+         * The half ICU does. `ike` never reaches `MACROLANGUAGE_MEMBERS` at
+         * all: `normalizeLocaleTag` has already rewritten it to `iu` before
+         * negotiation is consulted, so its entry in the map documents a fact
+         * rather than carrying the row.
+         */
+        it("has ICU fold ike onto iu before negotiation sees it", () => {
+            expect(normalizeLocaleTag("ike")).toBe("iu");
+            expect(negotiateLocales([normalizeLocaleTag("ike")], available)) //
+                .toEqual(["iu", "en"]);
+        });
+
+        /**
+         * The exclusion, asserted as a negotiation result rather than as an
+         * absent map entry, so that adding `ikt` to the list fails here
+         * instead of silently changing what an Inuinnaqtun reader is served.
+         * ICU leaves the tag exactly as typed, which is what makes the map the
+         * only thing that could fold it.
+         */
+        it("leaves ikt on English rather than serving it a syllabics catalog", () => {
+            expect(normalizeLocaleTag("ikt")).toBe("ikt");
+            expect(negotiateLocales(["ikt"], available)).toEqual(["en"]);
+        });
+
+        /**
+         * `locales/iu` is syllabics and CLDR agrees: `iu` maximizes to
+         * `iu-Cans-CA`, so a reader arriving under a bare `iu` or under
+         * `iu-Cans` gets a script they can read. `iu-Latn` is the asymmetry
+         * `pa`, `sr` and `ha` already have — a reader in the other script
+         * reaching the catalog written in this one — and the answer to it is a
+         * second catalog rather than a rename of the first.
+         */
+        it("agrees with CLDR that iu is written in syllabics", () => {
+            expect(new Intl.Locale("iu").maximize().script).toBe("Cans");
+            expect(negotiateLocales(["iu-Latn"], available)).toEqual([
+                "iu",
+                "en",
+            ]);
+        });
+
+        /**
+         * The fourteen Latin-script catalogs agree with CLDR about their own
+         * script, so none of them has `iu`'s asymmetry. Asserted as a group
+         * because the interesting case is a future ICU build moving one of
+         * them, not any one row today.
+         */
+        it("has CLDR agree that the other fourteen are written in Latin", () => {
+            for (const locale of AMERICAS.filter((tag) => tag !== "iu")) {
+                expect(new Intl.Locale(locale).maximize().script).toBe("Latn");
+            }
+        });
+
+        /**
+         * A creole is not a member of its lexifier, and nothing here pretends
+         * otherwise: a reader who asks for French is served French even though
+         * three French-lexifier creoles now have catalogs, and the same for
+         * English, Dutch and Spanish. This is what would break if someone
+         * decided a missing lexifier catalog should fall back to a creole, or
+         * the reverse.
+         */
+        it.each([
+            ["fr", "fr"],
+            ["en", "en"],
+            ["nl", "nl"],
+            ["es", "es"],
+        ])(
+            "keeps %s on its own catalog rather than on a creole",
+            (tag, expected) => {
+                expect(negotiateLocales([tag], available)[0]).toBe(expected);
+            },
+        );
+    });
 });
 
 describe("resolveUiLocale", () => {

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -2313,10 +2313,12 @@ describe("resolveDocumentLocale", () => {
      * than the leftovers of one.
      *
      * **`ikt` is left out, and the reason is the script.** Inuinnaqtun is
-     * written in roman letters; `locales/iu` is written wholly in Canadian
-     * Aboriginal syllabics and contains no roman-letter Inuktitut word
-     * anywhere. Folding `ikt` would hand a reader a catalog in a script they
-     * do not read, which is a worse answer than the English fallback. That is
+     * written in roman letters; every Inuktitut word in `locales/iu` is
+     * written in Canadian Aboriginal syllabics, the roman in that catalog
+     * being DoenetML identifiers and a few declared English loans rather than
+     * prose. Folding `ikt` would hand a reader a catalog whose every
+     * translated sentence is in a script they do not read, which is a worse
+     * answer than the English fallback. That is
      * a third kind of exclusion from this map: `kbl` under `kr` and `alq`
      * under `oj` are excluded because published membership does not cover
      * them, `bam` and `dyu` under `mnk` because they have catalogs of their

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65399,6 +65399,10 @@
                             "description": "Acehnese"
                         },
                         {
+                            "value": "acf",
+                            "description": "Saint Lucian Creole French (Kwéyòl)"
+                        },
+                        {
                             "value": "ady",
                             "description": "Adyghe"
                         },
@@ -65523,8 +65527,16 @@
                             "description": "Bulu"
                         },
                         {
+                            "value": "bzj",
+                            "description": "Belize Kriol (Bileez Kriol)"
+                        },
+                        {
                             "value": "ca",
                             "description": "Catalan (català)"
+                        },
+                        {
+                            "value": "cab",
+                            "description": "Garifuna"
                         },
                         {
                             "value": "ce",
@@ -65589,6 +65601,10 @@
                         {
                             "value": "dje",
                             "description": "Zarma (Zarmaciine)"
+                        },
+                        {
+                            "value": "djk",
+                            "description": "Aukan (Okanisi tongo)"
                         },
                         {
                             "value": "dng",
@@ -65703,6 +65719,14 @@
                             "description": "Gagauz"
                         },
                         {
+                            "value": "gcf",
+                            "description": "Guadeloupean Creole French (kréyòl gwadloupéyen)"
+                        },
+                        {
+                            "value": "gcr",
+                            "description": "Guianese Creole French (kriyòl gwiyanè)"
+                        },
+                        {
                             "value": "gd",
                             "description": "Scottish Gaelic (Gàidhlig)"
                         },
@@ -65803,8 +65827,16 @@
                             "description": "Italian (italiano)"
                         },
                         {
+                            "value": "iu",
+                            "description": "Inuktitut"
+                        },
+                        {
                             "value": "ja",
                             "description": "Japanese (日本語)"
+                        },
+                        {
+                            "value": "jam",
+                            "description": "Jamaican Creole English"
                         },
                         {
                             "value": "jv",
@@ -65835,6 +65867,10 @@
                             "description": "Khanty (хӑнты ясӑӈ)"
                         },
                         {
+                            "value": "kek",
+                            "description": "Qʼeqchiʼ"
+                        },
+                        {
                             "value": "kg",
                             "description": "Kongo"
                         },
@@ -65849,6 +65885,10 @@
                         {
                             "value": "kk",
                             "description": "Kazakh (қазақ тілі)"
+                        },
+                        {
+                            "value": "kl",
+                            "description": "Kalaallisut (kalaallisut)"
                         },
                         {
                             "value": "km",
@@ -66019,6 +66059,10 @@
                             "description": "Minangkabau"
                         },
                         {
+                            "value": "miq",
+                            "description": "Mískito"
+                        },
+                        {
                             "value": "mk",
                             "description": "Macedonian (македонски)"
                         },
@@ -66153,6 +66197,10 @@
                         {
                             "value": "pam",
                             "description": "Pampanga"
+                        },
+                        {
+                            "value": "pap",
+                            "description": "Papiamento"
                         },
                         {
                             "value": "pcm",
@@ -66309,6 +66357,14 @@
                         {
                             "value": "sr",
                             "description": "Serbian (српски)"
+                        },
+                        {
+                            "value": "srm",
+                            "description": "Saramaccan (Saamáka tongo)"
+                        },
+                        {
+                            "value": "srn",
+                            "description": "Sranan Tongo"
                         },
                         {
                             "value": "ss",
@@ -66509,6 +66565,10 @@
                         {
                             "value": "yo",
                             "description": "Yoruba (Èdè Yorùbá)"
+                        },
+                        {
+                            "value": "yua",
+                            "description": "Yucatec Maya (Maayaʼ tʼàan)"
                         },
                         {
                             "value": "zgh",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -4890,10 +4890,11 @@ describe("the Americas batch's word order", () => {
      * the same reason.
      *
      * They are not one catalog copied twice, which is the thing worth
-     * catching: two fifths of the values they both define differ, and over all
-     * four namespaces it is four fifths. So what is asserted is not that these
-     * two disagree somewhere — it is that they disagree at a rate a duplicate
-     * could not.
+     * catching: two fifths of the values they both define here differ, and
+     * over all four namespaces, counted off the syntax tree in
+     * `catalogLint.test.ts`, it is 342 of 389. So what is asserted is not that
+     * these two disagree somewhere — it is that they disagree at a rate a
+     * duplicate could not.
      */
     it("has jam and bzj converge on this phrase without being one catalog", () => {
         const jam = prenominal.find(([locale]) => locale === "jam")!;

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -4811,3 +4811,171 @@ describe("the Silk Road batch's word order", () => {
         },
     );
 });
+
+describe("the Americas batch's word order", () => {
+    /**
+     * Fifteen languages of two hemispheres and two orders, and the line
+     * between them is drawn by the **lexifier** rather than by geography or
+     * family: an English- or Dutch-lexifier creole puts its modifiers in front
+     * of the noun and a French-lexifier one puts them behind, because that is
+     * where each lexifier puts them and the creoles kept the order they were
+     * built from. Seven catalogs fall on each side, with `iu` in neither.
+     *
+     * The seven prenominal ones are the English- and Dutch-lexifier creoles —
+     * `jam`, `bzj`, `srn`, and the two Maroon creoles `djk` and `srm` — plus
+     * `yua` and `kek`, which are Mayan and prenominal on their own account.
+     *
+     * The seven postnominal ones split three ways over *why*, and the split is
+     * worth keeping straight because only two of the three are about a
+     * lexifier. The three French-lexifier creoles (`gcf`, `acf`, `gcr`) take
+     * the order from French. `cab` and `miq` take it from Garifuna and Mískito
+     * themselves. `pap` is the one that would have been guessed wrong from its
+     * neighbours: it sits with the French-lexifier creoles rather than with
+     * the English- and Dutch-lexifier ones beside it in Suriname and Curaçao,
+     * because its own vocabulary is Iberian and an Iberian adjective follows
+     * its noun. `kl` is the seventh and is not a lexifier case at all —
+     * Kalaallisut builds the phrase by suffixing, so what comes out is a noun
+     * followed by agreeing participles, «titarneq silissooq
+     * avissaartorsimasoq aappaluttoq», and its header says so.
+     *
+     * The `acf` row is the one to read beside `gcf`: those two differ here by
+     * a single sound, the etymological French /r/ that Saint Lucian writes
+     * «w» — «tiwè» against «tirè» — which is that catalog's central
+     * orthographic commitment, visible in one word.
+     *
+     * `iu` is in neither table, and that is a fact about coverage rather than
+     * about Inuktitut. `locales/iu` omits `noun` and the width and dash words
+     * whole rather than writing roman-letter loans for them, so the phrase it
+     * produces is mostly English fallback with a syllabic colour word at the
+     * end. Asserting an order over a phrase three quarters of which is English
+     * would be asserting English's order.
+     */
+    const prenominal: [string, string, string][] = [
+        ["yua", "pim rayaʼan chak línea", "pim rayaʼan chak"],
+        ["kek", "pim jachbʼil kaq raqal", "pim jachbʼil kaq"],
+        ["srn", "deki strepistrepi redi lin", "deki strepistrepi redi"],
+        ["jam", "tik dash-dash red lain", "tik dash-dash red"],
+        ["bzj", "tik dash-dash red lain", "tik dash-dash red"],
+        ["djk", "deki koti-koti lebi lin", "deki koti-koti lebi"],
+        ["srm", "dëkë koti-koti lebi lin", "dëkë koti-koti lebi"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of prenominal) {
+        it(`puts ${locale}'s adjectives in front of the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            // The noun is appended whole, with nothing of it reaching in among
+            // the adjectives — which is what would break if a catalog started
+            // welding a determiner or a linker onto `{ $noun }`.
+            expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    /**
+     * `jam` and `bzj` produce the same four words here, which is worth seeing
+     * rather than being surprised by later: both are English-lexifier creoles
+     * written in a phonemic orthography, and «tik dash-dash red lain» is what
+     * both spell. Their boolean words coincide too — «chruu», «faals» — for
+     * the same reason.
+     *
+     * They are not one catalog copied twice, which is the thing worth
+     * catching: two fifths of the values they both define differ, and over all
+     * four namespaces it is four fifths. So what is asserted is not that these
+     * two disagree somewhere — it is that they disagree at a rate a duplicate
+     * could not.
+     */
+    it("has jam and bzj converge on this phrase without being one catalog", () => {
+        const jam = prenominal.find(([locale]) => locale === "jam")!;
+        const bzj = prenominal.find(([locale]) => locale === "bzj")!;
+        expect(jam[1]).toBe(bzj[1]);
+
+        /** `id = value` pairs of one catalog, comments and blank lines dropped. */
+        const values = (locale: string): Map<string, string> => {
+            const pairs = new Map<string, string>();
+            for (const line of readCatalog(locale, "content").split("\n")) {
+                if (line.trimStart().startsWith("#")) {
+                    continue;
+                }
+                const match = line.match(/^\s*(\.?[a-z0-9-]+)\s*=\s*(\S.*)$/);
+                if (match) {
+                    pairs.set(match[1], match[2]);
+                }
+            }
+            return pairs;
+        };
+        const jamValues = values("jam");
+        const bzjValues = values("bzj");
+        const shared = [...jamValues.keys()].filter((key) =>
+            bzjValues.has(key),
+        );
+        const differing = shared.filter(
+            (key) => jamValues.get(key) !== bzjValues.get(key),
+        );
+        expect(shared.length).toBeGreaterThan(50);
+        expect(differing.length / shared.length).toBeGreaterThan(1 / 3);
+    });
+
+    const postnominal: [string, string, string][] = [
+        ["pap", "liña diki di strepi kòrá", "diki di strepi kòrá"],
+        ["cab", "línia grúesu rayadu funati", "grúesu rayadu funati"],
+        ["miq", "lain tara raya nani pauni", "tara raya nani pauni"],
+        ["gcf", "liy épé an tirè wouj", "épé an tirè wouj"],
+        ["acf", "liy épé an tiwè wouj", "épé an tiwè wouj"],
+        ["gcr", "liy épé an tirè wouj", "épé an tirè wouj"],
+        [
+            "kl",
+            "titarneq silissooq avissaartorsimasoq aappaluttoq",
+            "silissooq avissaartorsimasoq aappaluttoq",
+        ],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
+        it(`puts ${locale}'s adjectives after the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            // Nothing rides on the noun, so the description is still the tail
+            // of the phrase verbatim. The three French-lexifier creoles all
+            // postpose their definite determiner, and this is what would break
+            // if one of them started attaching it to `{ $noun }` here.
+            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    /**
+     * The two French-lexifier catalogs that differ by the /r/ rule, held
+     * against each other rather than only against their own strings. `gcf` and
+     * `gcr` produce the same phrase here — the two languages agree on all four
+     * of these words — so the assertion that separates them is `acf`'s «w»,
+     * which is that catalog's central orthographic commitment.
+     */
+    it("writes acf's etymological r as w where gcf and gcr keep it", () => {
+        const [, gcfPhrase] = postnominal.find(([l]) => l === "gcf")!;
+        const [, acfPhrase] = postnominal.find(([l]) => l === "acf")!;
+        const [, gcrPhrase] = postnominal.find(([l]) => l === "gcr")!;
+        expect(gcfPhrase).toBe(gcrPhrase);
+        expect(acfPhrase).not.toBe(gcfPhrase);
+        expect(acfPhrase.replace("tiwè", "tirè")).toBe(gcfPhrase);
+    });
+});


### PR DESCRIPTION
Seeds fifteen unreviewed machine-generated catalogs for languages of the
Americas, taking the roster from 286 locales to 301: Kalaallisut (`kl`) and
Inuktitut (`iu`) in the north; Yucatec Maya (`yua`), Qʼeqchiʼ (`kek`),
Garifuna (`cab`) and Mískito (`miq`) in Mesoamerica and on the Caribbean coast
of Central America; and **nine creoles** — Papiamentu (`pap`), Sranan Tongo
(`srn`), Jamaican Creole (`jam`), Guadeloupean Creole French (`gcf`), Saint
Lucian Creole French (`acf`), Guianese Creole French (`gcr`), Belize Kriol
(`bzj`), Aukan (`djk`) and Saramaccan (`srm`).

Nine of fifteen makes this the first batch a *contact* language dominates, and
most of its properties turn out to be about that. A creole is a hard case for
nearly every list in `packages/i18n`: it belongs to no macrolanguage, CLDR
mostly does not name it, its technical vocabulary comes from a language it is
not a variety of, and two creoles of one lexifier can converge on a phrase
without being one catalog. The README carries the full account; the headlines:

- **Six languages were dropped rather than shipped thin, and the reason is a
  rule for future batches.** Navajo (`nv`), Cherokee (`chr`), Lakota (`lkt`),
  Mohawk (`moh`), Plains Cree (`cr`) and Miʼkmaq (`mic`) were seeded for this
  batch and came to **6, 13, 16, 20, 26 and 13 keys of 575**; six creoles
  replaced them. `locales/sgh`'s openly-kept Tajik/Russian loan register does
  **not** transfer to them: there is no Navajo technical register to record —
  a speaker doing mathematics does it in English — so the same move produces
  English respelled, «pálagan» for polygon, which a reviewer must delete before
  they can begin. The rule the batch settled on is *carry a loan register where
  speakers already carry one, and leave the key out where they do not*. #1655
  has been updated with what the attempt measured, and `kl` and `iu` come off
  it as done.
- **Fourteen at 445/575, and one that stops short on purpose.** 445 is the
  whole catalog minus the two chemistry tables, which all fifteen leave to
  English for the school-system reason — Dutch, Danish, Spanish, French or
  English depending on the community, so the fallback *is* the curriculum.
  `iu` is at **373**: it writes the few technical nouns with no settled
  syllabic form in roman letters (the `sgh` move) but **omits the `noun` table
  whole**, twenty geometry names, rather than doing that twenty more times. So
  a style description in Inuktitut renders «line thick dashed ᐊᐅᐸᖅᑐᖅ» — the
  fallback working, not a bug, and why `iu` is in neither word-order table.
- **The lexifier draws the word-order line, and `pap` is the surprise.** Seven
  catalogs are prenominal (`jam`, `bzj`, `srn`, `djk`, `srm`, and `yua`/`kek`
  on their own Mayan account), seven postnominal. `pap` sits with the
  French-lexifier creoles rather than the English- and Dutch-lexifier ones it
  shares a sea with, because its vocabulary is Iberian: «liña diki di strepi
  kòrá», noun first. `kl` is postnominal for no lexifier reason at all —
  Kalaallisut suffixes, so the phrase is a noun plus agreeing participles and
  the description is its *tail*.
- **One `MACROLANGUAGE_MEMBERS` entry, recording an exclusion.** `iu: ["ike"]`
  changes no negotiation result (ICU folds `ike` already); what it documents is
  that **`ikt` is left out over the script** — Inuinnaqtun is roman-letter and
  every Inuktitut word in the catalog is syllabic, so folding it would hand a
  reader a catalog whose every translated sentence is in a script they do not
  read. That is a third kind of exclusion for this map, beside `kbl`/`alq`
  (membership does not cover them) and `bam`/`dyu` (they have catalogs).
  `negotiate.test.ts` also asserts the reverse direction for the creoles:
  French stays on French.
- **Nine `LOCALE_NAME_FALLBACKS` entries**, the largest number a batch here
  has needed — the next largest is the seven of the West and Central African
  batch — six of them creoles. All nine get endonyms — unlike the Silk Road block, no
  catalog here names its language two ways, so `locales/olo`'s admitted-gap
  shape is needed nowhere.
- **The batch's one dual.** `iu` has CLDR `one`/`two`/`other` and writes all
  three of `attempts-remaining` with a different ending — the seventeenth
  catalog on the roster to write a `[two]` its own rules select, and the first
  in the Americas; `kl` and `pap` have rules without a dual; the other twelve have none and write one unselected
  form. The test asserts the three forms *differ*, since a dual repeating the
  plural is the `[one]`-in-an-`other`-only-locale defect from the other side.
- **One character held by CI.** `yua` and `kek` write the glottal stop and
  ejectives with U+02BC throughout — a letter in Mayan orthography, not
  punctuation — and `catalogLint.test.ts` holds them to it the way it holds
  `alt`/`kjh`/`dng` to their Cyrillic inventories. ASCII `'` is deliberately
  *not* forbidden: English's own messages quote values with straight quotes and
  write the derivative `y'`. Also held: `iu` writes no ᐦ (U+1426), the Cree
  final — which matters because this batch ships no Cree catalog it could have
  been copied from — and `srm` allows exactly one accented letter beyond `ë`/`ö`,
  «á», the negator, since Saramaccan is tonal and this seed writes no tone.

Tests: an Americas block in `chrome.test.ts` (which tags have CLDR rules, the
dual written out, no branch a locale cannot select), a batch block in
`negotiate.test.ts` (the fifteen, the `ike`/`ikt` halves separately, the script
asymmetry, and the creole-vs-lexifier direction), the character-inventory block
in `catalogLint.test.ts`, and a word-order block in
`packages/utils/test/styleDescriptions.test.ts` that also holds `jam` and `bzj`
apart by a *rate* — they converge on «tik dash-dash red lain» and on their
boolean words, but more than a third of the values they both define in
`content.ftl` differ. A companion block in `catalogLint.test.ts` takes the
same rate over all four namespaces (342 of their 389 shared values) and over
the French trio's diagnostics, so a catalog copied to a second tag fails
rather than reads as convergence.

Three defects were caught in the seed, and each is a different way for a
machine-written catalog to look right and say something else.

`locales/miq` had collapsed `field-function-wrong-num-outputs` to the
vector-field wording alone, dropping `{ $expected }` entirely, so a Mískito
reader whose function needed **one** output was told it needed two. It now
names both fields the way `locales/kek` does, and `chrome.test.ts` holds all
fifteen to naming both — `iu` by asserting that it leaves the message to
English, which is its 373-of-575 decision, rather than by skipping it.

`locales/gcr` had three Fluent selector keys mangled by a find-and-replace of
the word "on" into the creole's «roun» — `[text-roun-background]`,
`[text-roun-canvas]`, `[roun-graph]` — which parses and lints as prose but
silently selects the default branch forever. `catalogLint.test.ts`'s existing
selector-key property is what found it.

**Five selects had every branch saying the same thing**, all of them in `kl`
and `iu` — the two catalogs here whose plural branches a runtime can actually
select, so a repeated branch is a live branch saying nothing. «interval»,
«input» and «output» are roman-letter loans in `iu` that take no number
ending, and in `kl` the numeral carries the count rather than the verb, so
each select had written one sentence three times. They are now single forms,
and a new property holds every select in the batch to at least two branches
that differ. The floor is *some* branch differing rather than all of them:
`style-border-clause` forks four ways on an indefinite article and a
*with*/*and* linker, and six of these catalogs collapse one of the two — `kl`
and `miq` write no article, so `[with-article]` coincides with `[with]`, while
`cab`, `srn`, `djk` and `srm` use one word for both *with* and *and*, so
`[with]` coincides with `[and]`. Two branches remain either way, and a
distinction the target language does not draw is not one the translation
lost.

Every string is machine-generated and unread by a speaker, and each file says
so at the top. Each header records where it stands: `locales/cab` marks itself
the least certain of the fifteen, `locales/miq` records that its conditional
marker is clause-final while the renderer places it first, and `pap`, `jam` and
`bzj` each commit to one orthography over a live alternative and tell a
reviewer to respell rather than retranslate. Nothing was invented to fill a gap.

Refs #1655

🤖 Generated with [Claude Code](https://claude.com/claude-code)




