### PR TITLE
Seed catalogs for fifteen languages of Southeast Asia

### DIFF
--- a/.changeset/seed-southeast-asia-catalogs.md
+++ b/.changeset/seed-southeast-asia-catalogs.md
@@ -36,8 +36,9 @@ in CLDR and never overrides it.
 
 Malay gains its members, so many readers who reached English before now reach
 a catalog: Brunei Malay (`kxd`), Kedah Malay (`meo`), Pattani Malay (`mfa`),
-Central Malay (`pse`), Sabah Malay (`msi`), North Moluccan (`max`) and Manado
-Malay (`xmm`) and twenty-six other varieties now reach `locales/ms`, which is
+Central Malay (`pse`), Sabah Malay (`msi`), North Moluccan Malay (`max`)
+and Manado Malay (`xmm`) and twenty-six other varieties now reach
+`locales/ms`, which is
 Standard Malay, so a reader served through one of those may meet spellings
 they have to adjust to. A Pattani reader who writes in Jawi is served Rumi.
 Indonesian, Minangkabau and Banjar readers are deliberately left out of that

--- a/.changeset/seed-southeast-asia-catalogs.md
+++ b/.changeset/seed-southeast-asia-catalogs.md
@@ -19,11 +19,14 @@ Twelve are written in the Latin script and three — Shan, Mon and S'gaw Karen �
 in the Myanmar script. All fifteen lay out left to right, so nothing about
 direction changes.
 
-The chemistry element tables are left out of all fifteen and still fall back
-to English, which is what the school systems of these regions teach chemistry
-in — Indonesian, Malay, English or Burmese depending on the community, so the
-fallback is the curriculum rather than a gap. Each catalog's header gives its
-own version of that reason.
+The chemistry element tables are left out of all fifteen, so a document in one
+of these languages still shows the element names in English. None of the
+fifteen is a language chemistry is taught in: secondary science in these
+regions runs in Indonesian, Malay, English or Burmese, so there is no settled
+list of element names in Buginese or Mon to write down, and an invented one
+would be worse than the English. Readers in the English-medium systems get
+their own school vocabulary; the rest get a second language rather than a
+first. Each catalog's header says which case it is in.
 
 `<document lang>` autocompletes all fifteen. Chavacano, Tausug, Maranao, Mon
 and S'gaw Karen are offered from hand-written entries, since CLDR has no name

--- a/.changeset/seed-southeast-asia-catalogs.md
+++ b/.changeset/seed-southeast-asia-catalogs.md
@@ -29,7 +29,10 @@ own version of that reason.
 and S'gaw Karen are offered from hand-written entries, since CLDR has no name
 for those tags in any language; Chavacano is listed as "Chavacano (cbk)"
 because both «Chavacano» and «Chabacano» are in live use for it and the
-catalog does not choose between them.
+catalog does not choose between them. Two of the fifteen are offered under the
+name CLDR gives them rather than the one their catalog writes — "Batak Toba"
+for `bbc` and "Central Dusun" for `dtp` — because the autocomplete fills gaps
+in CLDR and never overrides it.
 
 Malay gains its members, so many readers who reached English before now reach
 a catalog: Brunei Malay (`kxd`), Kedah Malay (`meo`), Pattani Malay (`mfa`),

--- a/.changeset/seed-southeast-asia-catalogs.md
+++ b/.changeset/seed-southeast-asia-catalogs.md
@@ -37,10 +37,11 @@ in CLDR and never overrides it.
 Malay gains its members, so many readers who reached English before now reach
 a catalog: Brunei Malay (`kxd`), Kedah Malay (`meo`), Pattani Malay (`mfa`),
 Central Malay (`pse`), Sabah Malay (`msi`), North Moluccan Malay (`max`)
-and Manado Malay (`xmm`) and twenty-six other varieties now reach
-`locales/ms`, which is
-Standard Malay, so a reader served through one of those may meet spellings
-they have to adjust to. A Pattani reader who writes in Jawi is served Rumi.
+and Manado Malay (`xmm`) and twenty-five other varieties now reach
+`locales/ms`. The list has thirty-three entries; the thirty-third is Standard
+Malay (`zsm`) itself, which already reached that catalog because ICU rewrites
+the tag. `locales/ms` is Standard Malay, so a reader served through one of the
+thirty-two may meet spellings they have to adjust to. A Pattani reader who writes in Jawi is served Rumi.
 Indonesian, Minangkabau and Banjar readers are deliberately left out of that
 list, because each has a catalog of its own. Coastal Kadazan (`kzj`) readers
 reach the new `locales/dtp`. No reader is moved off a catalog they already

--- a/.changeset/seed-southeast-asia-catalogs.md
+++ b/.changeset/seed-southeast-asia-catalogs.md
@@ -42,7 +42,6 @@ list, because each has a catalog of its own. Coastal Kadazan (`kzj`) readers
 reach the new `locales/dtp`. No reader is moved off a catalog they already
 reached.
 
-Numbers written into a message now render in Latin digits in every language,
-including the three written in the Myanmar script. Twelve messages across the
-Mon and S'gaw Karen catalogs were seeded with Myanmar digits, which would have
-put "more than ၃ points" on screen beside a count formatted as "3".
+Numbers written into a message render in Latin digits in every language,
+including the three written in the Myanmar script, so a digit inside a sentence
+matches the count formatted beside it and the mathematics around it.

--- a/.changeset/seed-southeast-asia-catalogs.md
+++ b/.changeset/seed-southeast-asia-catalogs.md
@@ -1,0 +1,48 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for fifteen languages of maritime and
+mainland Southeast Asia: Buginese (`bug`), Makasar (`mak`), Banjar (`bjn`),
+Gorontalo (`gor`), Nias (`nia`), Toba Batak (`bbc`), Iban (`iba`),
+Kadazandusun (`dtp`), Pangasinan (`pag`), Chavacano (`cbk`), Tausug (`tsg`),
+Maranao (`mrw`), Shan (`shn`), Mon (`mnw`) and S'gaw Karen (`ksw`). A document
+declaring one of them now renders its style descriptions, section headings,
+boolean words, answer buttons, editor chrome and diagnostics in that language
+instead of falling back to English.
+
+Twelve are written in the Latin script and three — Shan, Mon and S'gaw Karen —
+in the Myanmar script. All fifteen lay out left to right, so nothing about
+direction changes.
+
+The chemistry element tables are left out of all fifteen and still fall back
+to English, which is what the school systems of these regions teach chemistry
+in — Indonesian, Malay, English or Burmese depending on the community, so the
+fallback is the curriculum rather than a gap. Each catalog's header gives its
+own version of that reason.
+
+`<document lang>` autocompletes all fifteen. Chavacano, Tausug, Maranao, Mon
+and S'gaw Karen are offered from hand-written entries, since CLDR has no name
+for those tags in any language; Chavacano is listed as "Chavacano (cbk)"
+because both «Chavacano» and «Chabacano» are in live use for it and the
+catalog does not choose between them.
+
+Malay gains its members, so many readers who reached English before now reach
+a catalog: Brunei Malay (`kxd`), Kedah Malay (`meo`), Pattani Malay (`mfa`),
+Central Malay (`pse`), Sabah Malay (`msi`), North Moluccan (`max`) and Manado
+Malay (`xmm`) and twenty-six other varieties now reach `locales/ms`, which is
+Standard Malay, so a reader served through one of those may meet spellings
+they have to adjust to. A Pattani reader who writes in Jawi is served Rumi.
+Indonesian, Minangkabau and Banjar readers are deliberately left out of that
+list, because each has a catalog of its own. Coastal Kadazan (`kzj`) readers
+reach the new `locales/dtp`. No reader is moved off a catalog they already
+reached.
+
+Numbers written into a message now render in Latin digits in every language,
+including the three written in the Myanmar script. Twelve messages across the
+Mon and S'gaw Karen catalogs were seeded with Myanmar digits, which would have
+put "more than ၃ points" on screen beside a count formatted as "3".

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2838,10 +2838,12 @@ Two things are worth reading off that list before the split itself. The
 eight Indonesian and Malaysian catalogs **all write «garis»**, and six of the
 eight write «putus-putus» — which is one Indonesian word rather than six
 languages agreeing, and `bug`'s «pettu-pettu» and `mak`'s «tappolo-polo» are
-the two that are not it. Against that, **seven of the eight supply a colour
-word of their own** — macella', eja, habang, meela, rara, mirah, aragang —
-and `locales/nia` is the one that falls back to Indonesian «merah», which its
-own header calls a gap in the seed rather than a claim about Nias.
+the two that are not it. Against that, **seven of the eight supply a red of
+their own** — macella', eja, habang, meela, rara, mirah, aragang — and
+`locales/nia` is the one that falls back to Indonesian «merah», which its own
+header calls a gap in the seed rather than a claim about Nias. Nias does
+supply two colour words of its own, «aitö» and «afusi»; red is simply not one
+of them.
 
 The three Myanmar catalogs invert further than the Indonesian ones do: all
 three fix the description as **colour, then dash pattern, then thickness**,
@@ -2927,7 +2929,7 @@ catalogs, the same two literals in the same two messages, and nothing else.
 `MACROLANGUAGE_MEMBERS` gained exactly one row, and seeding `bjn` forced it:
 Banjar is one of the 36 ISO 639-3 members of Malay. **`ms` lists 33 of them**,
 which makes it the map's second-largest entry — behind only `qu`'s
-forty-three, and ahead of everything else by some distance — and the three
+forty-three, with `nah`'s thirty just behind it — and the three
 that are missing are the point of the row rather than an oversight — `ind`
 (`locales/id`), `min` (`locales/min`) and `bjn` (`locales/bjn`) are members
 this repository answers for itself, which is the `bam`/`dyu` shape under
@@ -2965,7 +2967,8 @@ that could let either reach the S'gaw catalog even if one were wanted.
 
 `LOCALE_NAME_FALLBACKS` gained five entries — `tsg`, `mrw`, `mnw`, `ksw` and
 `cbk` — and the split is geographic rather than about speaker numbers. ICU
-names every Indonesian and Malaysian tag in the batch and the one Myanmar tag
+names all six Indonesian tags in the batch, both Malaysian ones, `pag` — the
+one Philippine tag from Luzon rather than the south — and the one Myanmar tag
 whose language a state is named after, and stops at three languages of the
 southern Philippines and two more of Myanmar.
 
@@ -3082,10 +3085,10 @@ the names in it ever are.
 #### Confidence, and where the batch is thin
 
 Every header grades itself, and two claim to be thinnest — compatibly, since
-`dtp` is not one of the four `mrw` scopes itself against. `locales/dtp` opens
-"THIS IS THE THINNEST CATALOG OF ITS BATCH, AND IT SAYS SO FIRST RATHER THAN
-LAST"; `locales/mrw` opens "This is
-the thinnest of the four Philippine catalogs added with it", which is a claim
+`dtp` is not one of the four `mrw` scopes itself against.
+`locales/dtp/chrome.ftl` says "THIS IS THE THINNEST CATALOG OF ITS BATCH, AND
+IT SAYS SO FIRST RATHER THAN LAST"; `locales/mrw/chrome.ftl` says "This is the
+thinnest of the four Philippine catalogs added with it", which is a claim
 about four files rather than fifteen. Both are scoped, and both are about
 vocabulary rather than coverage: all fifteen sit at the same 445 keys, so
 "thinnest" here never means a catalog that translates less.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -374,15 +374,26 @@ genuinely uses rather than an invented nomenclature.
 sub-Saharan batch and the African and Berber one they split no ways at all:**
 every one of the fifteen is the school-system case, in four mediums. Chemistry
 is taught in Indonesian in Sulawesi, South Kalimantan, Nias and North Sumatra,
-so `bug`, `mak`, `bjn`, `gor`, `nia` and `bbc` meet `locales/id`'s table; in
-Malay in Sabah and Sarawak, so `iba` and `dtp` meet `locales/ms`'s; in English
-across the Philippines from the intermediate grades, which is the `fil` and
-`ceb` case again for `pag`, `cbk`, `tsg` and `mrw`; and in Burmese in Shan and
-Mon States, where Shan- and Mon-medium schooling does not run to the grades
-where the periodic table is taught. `ksw` is the one with no single fallback,
-`locales/wbl`'s shape one batch on: a Karen pupil in Myanmar meets the table in
-Burmese and one in the diaspora in English or Thai, and choosing either would
-hide the split. Four school systems, fifteen catalogs, and not one claim about
+so `bug`, `mak`, `bjn`, `gor`, `nia` and `bbc` meet the table in the language
+`locales/id` carries it in; in Malay in Sabah and Sarawak, so `iba` and `dtp`
+meet the one `locales/ms` does; in English across the Philippines from the
+intermediate grades, which is the `fil` and `ceb` case again for `pag`, `cbk`,
+`tsg` and `mrw`; and in Burmese in Shan and Mon States, where Shan- and
+Mon-medium schooling does not run to the grades where the periodic table is
+taught.
+
+What falls through is English in all fifteen cases, which is the curriculum
+language for the four Philippine catalogs and a *second* language for the ten
+taught in Indonesian, Malay or Burmese. Those ten are not reached by
+`locales/id` or `locales/ms` either: nothing folds `bjn` onto Indonesian or
+`iba` onto Malay, and this batch's `ms` entry in `MACROLANGUAGE_MEMBERS` leaves
+`bjn` out deliberately. So the reason these keys are omitted is that there is no
+settled Buginese or Mon list to write down — not that English is what those
+readers use.
+
+`ksw` is the one with no single fallback, `locales/wbl`'s shape one batch on: a
+Karen pupil in Myanmar meets the table in Burmese and one in the diaspora in
+English or Thai, and choosing either would hide the split. Four school systems, fifteen catalogs, and not one claim about
 a language among them; see [Fifteen languages of Southeast
 Asia](#fifteen-languages-of-southeast-asia-and-the-batch-whose-word-order-follows-a-border)
 for what does divide the batch.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -67,43 +67,47 @@ locales/<locale>/
 ```
 
 English is the source of truth. Every translation —
-`ab`, `ace`, `ady`, `af`, `ak`, `alt`, `am`, `ar`, `arn`, `as`, `ast`,
-`av`, `ay`, `az`, `ba`, `bal`, `ban`, `bci`, `be`, `bem`, `bg`, `bho`,
-`bi`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`, `brx`, `bs`, `bua`, `bum`,
-`ca`, `ce`, `ceb`, `ch`, `chk`, `ckb`, `co`, `crh`, `cs`, `csb`, `cv`,
-`cy`, `da`, `dag`, `dar`, `de`, `dje`, `dng`, `doi`, `dsb`, `dv`, `dyo`,
+`ab`, `ace`, `ady`, `af`, `ak`, `alt`, `am`, `ar`, `arn`, `as`,
+`ast`, `av`, `ay`, `az`, `ba`, `bal`, `ban`, `bbc`, `bci`, `be`,
+`bem`, `bg`, `bho`, `bi`, `bik`, `bin`, `bjn`, `bm`, `bn`, `bo`,
+`br`, `brx`, `bs`, `bua`, `bug`, `bum`, `ca`, `cbk`, `ce`, `ceb`,
+`ch`, `chk`, `ckb`, `co`, `crh`, `cs`, `csb`, `cv`, `cy`, `da`,
+`dag`, `dar`, `de`, `dje`, `dng`, `doi`, `dsb`, `dtp`, `dv`, `dyo`,
 `dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`,
-`fi`, `fil`, `fit`, `fj`, `fo`, `fon`, `fr`, `fur`, `fy`, `ga`, `gaa`,
-`gag`, `gd`, `gil`, `gl`, `glk`, `gn`, `gsw`, `gu`, `ha`, `haw`, `haz`,
-`he`, `hi`, `hil`, `hnj`, `hr`, `hsb`, `ht`, `hu`, `hy`, `id`, `ig`,
-`ilo`, `inh`, `is`, `it`, `ja`, `jv`, `ka`, `kaa`, `kab`, `kbd`, `kbp`,
-`kca`, `kg`, `ki`, `kjh`, `kk`, `km`, `kmb`, `kmr`, `kn`, `ko`, `koi`,
-`kok`, `kos`, `kpe`, `kpv`, `kr`, `krc`, `kri`, `krl`, `ks`, `ksh`,
-`ktu`, `kum`, `ky`, `lb`, `lbe`, `lez`, `lg`, `li`, `lij`, `ln`, `lo`,
-`lom`, `lrc`, `lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `mdf`, `men`,
-`mg`, `mh`, `mhr`, `mi`, `min`, `mk`, `ml`, `mn`, `mni`, `mnk`, `mns`,
-`mos`, `mr`, `mrj`, `ms`, `mt`, `my`, `myv`, `mzn`, `nah`, `nap`, `nb`,
-`nds`, `ne`, `niu`, `nl`, `nn`, `nog`, `nso`, `ny`, `nyn`, `oc`, `oj`,
-`olo`, `om`, `or`, `os`, `pa`, `pam`, `pcm`, `pl`, `pms`, `pon`, `ps`,
-`pt`, `qu`, `quc`, `rar`, `rm`, `rn`, `ro`, `ru`, `rue`, `rw`, `sa`,
-`sah`, `sat`, `sc`, `scn`, `sco`, `sd`, `se`, `sg`, `sgh`, `shi`, `si`,
-`sjd`, `sk`, `sl`, `sm`, `sma`, `smj`, `smn`, `sms`, `sn`, `so`, `sq`,
-`sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`, `szl`, `ta`, `tab`, `te`,
-`tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`, `tly`, `tn`,
-`to`, `tpi`, `tr`, `ts`, `tt`, `ttt`, `tvl`, `ty`, `tyv`, `udm`, `ug`,
-`uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vec`, `vep`, `vi`, `vro`, `war`,
-`wbl`, `wls`, `wo`, `xal`, `xh`, `yi`, `yo`, `zgh`, `zh-Hans`, `zh-
-Hant`, `zu`, `zza`
+`fi`, `fil`, `fit`, `fj`, `fo`, `fon`, `fr`, `fur`, `fy`, `ga`,
+`gaa`, `gag`, `gd`, `gil`, `gl`, `glk`, `gn`, `gor`, `gsw`, `gu`,
+`ha`, `haw`, `haz`, `he`, `hi`, `hil`, `hnj`, `hr`, `hsb`, `ht`,
+`hu`, `hy`, `iba`, `id`, `ig`, `ilo`, `inh`, `is`, `it`, `ja`, `jv`,
+`ka`, `kaa`, `kab`, `kbd`, `kbp`, `kca`, `kg`, `ki`, `kjh`, `kk`,
+`km`, `kmb`, `kmr`, `kn`, `ko`, `koi`, `kok`, `kos`, `kpe`, `kpv`,
+`kr`, `krc`, `kri`, `krl`, `ks`, `ksh`, `ksw`, `ktu`, `kum`, `ky`,
+`lb`, `lbe`, `lez`, `lg`, `li`, `lij`, `ln`, `lo`, `lom`, `lrc`,
+`lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `mak`, `mdf`, `men`, `mg`,
+`mh`, `mhr`, `mi`, `min`, `mk`, `ml`, `mn`, `mni`, `mnk`, `mns`,
+`mnw`, `mos`, `mr`, `mrj`, `mrw`, `ms`, `mt`, `my`, `myv`, `mzn`,
+`nah`, `nap`, `nb`, `nds`, `ne`, `nia`, `niu`, `nl`, `nn`, `nog`,
+`nso`, `ny`, `nyn`, `oc`, `oj`, `olo`, `om`, `or`, `os`, `pa`,
+`pag`, `pam`, `pcm`, `pl`, `pms`, `pon`, `ps`, `pt`, `qu`, `quc`,
+`rar`, `rm`, `rn`, `ro`, `ru`, `rue`, `rw`, `sa`, `sah`, `sat`,
+`sc`, `scn`, `sco`, `sd`, `se`, `sg`, `sgh`, `shi`, `shn`, `si`,
+`sjd`, `sk`, `sl`, `sm`, `sma`, `smj`, `smn`, `sms`, `sn`, `so`,
+`sq`, `sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`, `szl`, `ta`, `tab`,
+`te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`,
+`tly`, `tn`, `to`, `tpi`, `tr`, `ts`, `tsg`, `tt`, `ttt`, `tvl`,
+`ty`, `tyv`, `udm`, `ug`, `uk`, `umb`, `ur`, `urh`, `uz`, `ve`,
+`vec`, `vep`, `vi`, `vro`, `war`, `wbl`, `wls`, `wo`, `xal`, `xh`,
+`yi`, `yo`, `zgh`, `zh-Hans`, `zh-Hant`, `zu`, `zza`
 — is an **unreviewed machine-generated seed**, which each file's own
 header says at the top, and which is what #1521's translation platform is for.
 None has been read by a speaker. Correcting one needs no permission and no
 coordination: a wrong string is just wrong, and the English is one key away.
 
-Two hundred and eight of them are deliberately partial. Two hundred and
-seven are partial in the same place — the two chemistry tables — while
+Two hundred and twenty-three of them are deliberately partial. Two hundred and
+twenty-two are partial in the same place — the two chemistry tables — while
 Klingon is partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The two
-hundred and seven are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
+hundred and twenty-two are: Somali, Hmong Njua, Amharic, Assamese, Nepali,
+Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -129,7 +133,9 @@ Tuvaluan, Rarotongan, Wallisian, Bislama, Scots, Swiss German, Colognian,
 Limburgish, Friulian, Venetian, Ligurian, Piedmontese, Neapolitan, Upper
 Sorbian, Lower Sorbian, Kashubian, Silesian, Rusyn, Crimean Tatar, Gagauz,
 Karakalpak, Khakas, Southern Altai, Balochi, Hazaragi, Muslim Tat, Zazaki,
-Shughni, Dungan and Wakhi
+Shughni, Dungan, Wakhi, Buginese, Makasar, Banjar, Gorontalo, Nias, Batak
+Toba, Iban, Central Dusun, Pangasinan, Chavacano, Tausug, Maranao, Shan, Mon
+and S'gaw Karen
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -358,6 +364,21 @@ them are `mzn`, `glk` and `lrc`: see [Fifteen catalogs along the Silk
 Road](#fifteen-catalogs-along-the-silk-road-and-three-element-tables-borrowed-whole)
 for why a Persian table in a Mazanderani catalog is a loan the language
 genuinely uses rather than an invented nomenclature.
+
+**All fifteen of the Southeast Asian batch are partial, and like the second
+sub-Saharan batch and the African and Berber one they split no ways at all:**
+every one of the fifteen is the school-system case, in four mediums. Chemistry
+is taught in Indonesian in Sulawesi, South Kalimantan, Nias and North Sumatra,
+so `bug`, `mak`, `bjn`, `gor`, `nia` and `bbc` meet `locales/id`'s table; in
+Malay in Sabah and Sarawak, so `iba` and `dtp` meet `locales/ms`'s; in English
+across the Philippines from the intermediate grades, which is the `fil` and
+`ceb` case again for `pag`, `cbk`, `tsg` and `mrw`; and in Burmese in Shan and
+Mon States, where Shan- and Mon-medium schooling does not run to the grades
+where the periodic table is taught. `ksw` is the one with no single fallback,
+`locales/wbl`'s shape one batch on: a Karen pupil in Myanmar meets the table in
+Burmese and one in the diaspora in English or Thai, and choosing either would
+hide the split. Four school systems, fifteen catalogs, and not one claim about
+a language among them.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -2770,6 +2791,384 @@ Persianate words current across the region.
 
 **`locales/ttt` marks itself the least certain of the batch and asks a
 reviewer to assume every line needs work.**
+
+Every string in all fifteen is machine-generated and unread by a speaker, and
+each file says so at the top. Correcting any of it needs no permission.
+
+### Fifteen languages of Southeast Asia, and the batch whose word order follows a border
+
+The roster goes from 286 locales to 301: Buginese (`bug`), Makasar (`mak`),
+Banjar (`bjn`), Gorontalo (`gor`), Nias (`nia`) and Toba Batak (`bbc`) — six
+languages of Indonesia; Iban (`iba`) and Kadazandusun (`dtp`) — Malaysian
+Borneo; Pangasinan (`pag`), Chavacano (`cbk`), Tausug (`tsg`) and Maranao
+(`mrw`) — the Philippines, three of them from Mindanao and Sulu; and Shan
+(`shn`), Mon (`mnw`) and S'gaw Karen (`ksw`) — Myanmar, all three in the
+Myanmar script.
+
+It is assembled around a **region** rather than a family: eleven of the
+fifteen are Austronesian, one is Tai-Kadai, one Austroasiatic, one
+Sino-Tibetan and one a Spanish-lexifier creole. Every one of the fifteen sits
+at **445/575 keys** — the whole catalog minus the two chemistry tables — and
+that uniformity is the batch's least interesting property. What splits inside
+it is word order, and the line it splits on is a national border.
+
+#### Word order splits eleven against four, and the line is a country
+
+Eleven catalogs put the noun first and four put the description first. The
+four are **exactly the four Philippine ones**, and no other property in this
+file divides the batch that way: not family, not script, not script direction,
+not the register the technical vocabulary is borrowed from.
+
+Postnominal, rendered for "thick dashed red line":
+
+- `bug` «garis tebal pettu-pettu macella'», `mak` «garis kapala'
+  tappolo-polo eja», `bjn` «garis kandal putus-putus habang», `gor` «garis
+  tebal putus-putus meela», `nia` «garis tebal putus-putus merah», `bbc`
+  «garis na hapal putus-putus rara», `iba` «garis tebal putus-putus mirah»,
+  `dtp` «garis tebal putus-putus aragang»;
+- `shn` «သဵၼ်ႈ သီလႅင် ၶၢတ်ႇ ၼႃ», `mnw` «မျဉ်း အနီ အပြတ် ထူ», `ksw`
+  «မျဉ်း ဂီၤ အပြတ် ဖးထီၣ်».
+
+Prenominal: `tsg` «makapal nga pinutu'-putu' nga pula nga linya», `pag`
+«makapal a putol-putol a ambalanga a linya», `cbk` «grueso cortao rojo linea»,
+`mrw` «makapal a dashed a mariga a linya».
+
+Two things are worth reading off that list before the split itself. The
+eight Indonesian and Malaysian catalogs **all write «garis»**, and six of the
+eight write «putus-putus» — which is one Indonesian word rather than six
+languages agreeing, and `bug`'s «pettu-pettu» and `mak`'s «tappolo-polo» are
+the two that are not it. Against that, **seven of the eight supply a colour
+word of their own** — macella', eja, habang, meela, rara, mirah, aragang —
+and `locales/nia` is the one that falls back to Indonesian «merah», which its
+own header calls a gap in the seed rather than a claim about Nias.
+
+The three Myanmar catalogs invert further than the Indonesian ones do: all
+three fix the description as **colour, then dash pattern, then thickness**,
+where every other catalog in the batch keeps English's internal sequence of
+the three adjectives. Only the head moved in eight files; in three the whole
+run reversed.
+
+**`locales/cbk` is the sharp case, and its header says which "correction" to
+expect.** Zamboangueño's lexicon is Spanish and its syntax is Philippine, so
+the modifier goes in *front* — «rojo linea», not «linea roja» — which is the
+opposite of Spanish's own order. A reviewer who reads the vocabulary as
+Spanish will read the word order as an error, and `content.ftl`'s header names
+that as the single thing about these files most likely to be corrected
+wrongly.
+
+#### One question, five answers: what joins a noun to its modifiers
+
+The batch asks the linker question harder than any before it, because the
+languages in it answer it five different ways and three of the answers are in
+one country.
+
+- **A free linker, written out.** `tsg` writes «nga» and `pag` and `mrw` write
+  «a», in every position. `locales/tsg`'s header argues the point the Bisayan
+  catalogs already made: «nga» never contracts onto the word before it, so it
+  can stand next to a placeable without the catalog knowing what lands there
+  — the escape from [A ligature is an affix too](#a-ligature-is-an-affix-too).
+  `locales/mrw` makes the same claim about «a» and adds the observation that
+  this is the one place a thin catalog is on firmer ground than the fuller
+  ones beside it.
+- **No linker at all.** `cbk` juxtaposes. Its header states why in one line:
+  the Spanish lexicon came without a ligature and the creole did not build
+  one, so nothing in that file is at risk from the ligature problem — the
+  only Philippine catalog in the roster that can say so.
+- **A postnominal relator.** `bbc` writes «na» between the noun and the
+  description, once in front of the run rather than before each adjective.
+  Its header names that as the one place a reader can tell the file from
+  `locales/ban` at a glance: same word order, different linker.
+- **Nothing, by juxtaposition.** The other Indonesian catalogs put the
+  modifier straight behind the noun.
+- **A prefix on the modifier the catalog cannot supply.** `locales/nia` is
+  the honest failure. A Nias property word takes an attributive form in `s-`
+  — «ebua» becomes «sebua» — and there is no «stebal» to build on an
+  Indonesian loan, so every loan adjective in that file stands bare in its
+  citation form. Its header sets the three side by side: Toba Batak needs a
+  relator, Gorontalo needs nothing, and Nias wants morphology this seed
+  cannot write.
+
+**`locales/pag` is the one where the free linker is knowingly wrong part of
+the time.** Pangasinan's linker has two shapes and the *preceding* word picks
+them — «a» after a consonant, enclitic «-n» after a vowel — so the catalog
+does what `locales/pam` and `locales/bik` did, writes the free «a»
+everywhere, and names the exact entries in its own tables where it misfires:
+«ambalanga», «lila», «kape», «diamante», «tuldek-tuldek». It also misfires
+after an author's own `lineColorWord`, which the catalog cannot see, and the
+header says the fix is a change to what the composition messages are handed
+rather than to the tables.
+
+`locales/dtp` states its rule rather than its exception: «dot» is written
+where it introduces a relative clause and omitted between a noun and a bare
+describing word. Its header calls that the file's largest open question and
+says correcting the split corrects every message at once.
+
+#### Not one of the fifteen has CLDR plural data
+
+`new Intl.PluralRules(tag).resolvedOptions().locale` is the runtime's own
+default for every one of the fifteen. So a `zero`, `two`, `few`, `many` or
+`one` branch anywhere in the batch would be text selected by somebody else's
+rules, and **no such branch is written anywhere**: sixty files, zero plural
+categories. That is the Oceania batch's finding arriving a second time, and
+here the grammar agrees with the constraint without exception — none of these
+fifteen languages marks a noun for number after a numeral, and `shn`, `mnw`
+and `ksw` count with a classifier the frame has no place for in any case.
+
+What all fifteen keep is English's numeric literals, which Fluent matches
+against the number itself before consulting any plural rule. Each catalog
+writes exactly **one `[0]`** — `attempts-remaining` — and exactly **one
+`[1]`** — `field-function-wrong-num-outputs`, which forks on how many outputs
+a component *needs* rather than on a count the reader is looking at. Fifteen
+catalogs, the same two literals in the same two messages, and nothing else.
+
+#### Negotiation: one entry, and it is the largest in the map
+
+`MACROLANGUAGE_MEMBERS` gained exactly one row, and seeding `bjn` forced it:
+Banjar is one of the 36 ISO 639-3 members of Malay. **`ms` lists 33 of them**,
+which makes it the biggest entry in the map by some distance, and the three
+that are missing are the point of the row rather than an oversight — `ind`
+(`locales/id`), `min` (`locales/min`) and `bjn` (`locales/bjn`) are members
+this repository answers for itself, which is the `bam`/`dyu` shape under
+`mnk`. Listing `min` or `bjn` would take a Minangkabau or Banjar reader off
+the catalog written for them and put them on Standard Malay; `ind` would be
+inert either way, since ICU rewrites it before negotiation is consulted.
+
+Two costs are named in the comment rather than left to be discovered. **`mfa`
+(Pattani Malay) maximizes to `mfa-Arab-TH`**, so a reader most likely arriving
+in Jawi is served Rumi — `locales/kr`'s asymmetry with `kby` again, and the
+answer to it is a second catalog rather than a change to the map. And **`max`
+(North Moluccan Malay) and `xmm` (Manado Malay) are Malay-lexifier trade
+creoles** rather than varieties of Malay, listed all the same because unlike
+`ktu` under `kg` ISO 639-3 puts them *inside* the macrolanguage; the map
+follows membership rather than second-guessing it.
+
+Nothing else moved. `LANGUAGE_ALIASES` is unchanged, and **`kzj` (Coastal
+Kadazan) needs no row at all**: `Intl.getCanonicalLocales("kzj")` already
+returns `dtp`, so ICU folds it before this file is reached, while `dtb` and
+`drg` — Coastal Kadazan's and Rungus's own codes — miss and fall to English,
+which `locales/dtp`'s header records as the cost of one tag per catalog.
+
+The near misses this batch does **not** fold are mostly siblings inside one
+island group rather than the far-flung relatives the Silk Road block listed:
+`btd`, `bts`, `btx` and `btz` beside `bbc`, which ISO 639-3 makes four
+separate languages rather than members of anything; `mdr` (Mandar) beside
+`bug` and `mak`; `mdh` (Maguindanaon) beside `mrw`; `krj` and `akl` beside
+`tsg`; and `nij` (Ngaju), which is `bjn`'s Bornean neighbour and, being Barito
+rather than Malayic, not in `msa` either. **`blk` (Pa'o) and `kjp` (Eastern
+Pwo) beside `ksw` are the sharpest**, because `kar` is an ISO 639-5
+*collection* code rather than a macrolanguage: there is no membership fact
+that could let either reach the S'gaw catalog even if one were wanted.
+
+#### Naming: five gaps, and two labels that disagree with their catalogs
+
+`LOCALE_NAME_FALLBACKS` gained five entries — `tsg`, `mrw`, `mnw`, `ksw` and
+`cbk` — and the split is geographic rather than about speaker numbers. ICU
+names every Indonesian and Malaysian tag in the batch and the one Myanmar tag
+whose language a state is named after, and stops at three languages of the
+southern Philippines and two more of Myanmar.
+
+Four of the five get endonyms, because each names its language exactly one way
+wherever its headers name it: «Bahasa Sūg», «Basa a Mëranaw», «ဘာသာမန်»,
+«ကညီကျိာ်». **`cbk` takes `locales/olo`'s admitted-gap shape**, because its
+header names the language two ways — «Chavacano» beside «Chabacano de
+Zamboanga» — and picking one here would settle in the roster what the catalog
+deliberately leaves open; the label reads "Chavacano (cbk)". **`shn` needs no
+row in either column**: CLDR already gives it «တႆး», which is the spelling
+`locales/shn` writes.
+
+**Two of the ten CLDR does name, it names differently from the catalog, and
+both stand** — the `ny`-reads-Nyanja rule, twice in one batch. The roster
+renders `bbc` as **Batak Toba** where every header in those files writes Toba
+Batak, and `dtp` as **Central Dusun** where the catalog writes Kadazandusun
+throughout and treats "Central Dusun" as the ISO label rather than the name.
+The table fills gaps and never overrides ICU, so each catalog's own header
+says which language it is and the label stays as CLDR writes it.
+
+Nothing else in negotiation had to move for scripts, either: all fifteen tags
+maximize the way their catalogs are written — `-Latn-ID` for the six
+Indonesian ones, `-Latn-MY` for `iba` and `dtp`, `-Latn-PH` for the four
+Philippine ones, `-Mymr-MM` for the three from Myanmar — so this batch adds
+none of the `ha`/`kr` asymmetries the Silk Road batch collected.
+
+#### Scripts, and four catalogs that argued their way to Latin
+
+Twelve catalogs are Latin and three are Myanmar-script, and four of the twelve
+had a script of their own to decline. None of the four declines it by default;
+each gives a reason.
+
+- **`bug` and `mak` against Lontara** (and, for Makasar, the older Ukiri'
+  Jangang-jangang as well). Both headers give the same two reasons: Latin is
+  what the language is printed in today, and Lontara writes neither the final
+  glottal stop, nor the geminates, nor the syllable-final nasal — the three
+  things these spellings turn on — so a Lontara catalog would spell «de'» and
+  «dé», «kebo'» and «kebo» identically and a reviewer could not tell a
+  correction from a typo. Both call a conversion a *conversion* rather than a
+  transliteration, because the dropped distinctions would have to be restored
+  by someone who knows the words.
+- **`bbc` against Surat Batak**, on a different ground: the script is taught,
+  printed and carved, and it is simply not what Toba Batak is *written* in —
+  every newspaper, hymnal, dictionary and schoolbook since the nineteenth
+  century is Latin. Its header adds that a Surat Batak seed would also have to
+  settle a dozen questions no current practice settles, starting with where to
+  put the pangolat.
+- **`tsg` against Sulat Sūg**, and this is the one argued from the software
+  rather than from the language. Tausug's Jawi-derived tradition is older and
+  still written, but these strings sit beside DoenetML source, attribute names
+  and mathematics that are Latin and left to right, and a right-to-left
+  catalog would put a bidi boundary in the middle of nearly every message. The
+  header's conclusion is the roster's standing one: a reader who wants Sulat
+  Sūg should have a catalog of its own rather than a mixture.
+
+All four say the same thing about how to change their minds — **all four files
+at once, never a mixture inside one catalog** — as do `pag` (modernised
+against Spanish-influenced spelling), `cbk` (traditional Spanish-based against
+the phonemic orthography promoted in Zamboanga City), `bjn` (Banjar Hulu's
+three vowels), `iba`, `dtp`, `nia` (the northern standard) and `mrw` (the
+schwa written «ë»).
+
+**The three Myanmar-script catalogs write their own language's letters, and a
+homoglyph audit during seeding caught two headers claiming letters their text
+did not contain.** `locales/shn` uses the Shan consonants ၵ ၶ ၸ ၺ ၼ ၽ ၾ ႁ ဢ
+with the Shan vowels and tone marks, and warns against folding any of them
+into their Burmese look-alikes. `locales/mnw` uses Mon ၚ and ၜ and the medials
+ၞ ၟ ၠ. `locales/ksw` uses the S'gaw signs ၢ ၣ ၤ. Two claims did not survive
+checking: `mnw` had listed ဿ and ၝ and `ksw` had listed ဢ and ၡ as letters in
+use, and none of the four appears in either catalog's text. **The headers were
+corrected to match the files rather than the other way round** — each now says
+the letters are real parts of the orthography that no word this catalog
+happens to use needs — which is what a checkable claim is for. `ksw` also
+records that ၦ and ၯ are **Pwo** letters, deliberately absent, and that a Pwo
+letter inside an S'gaw file is a mistake rather than a variant.
+
+One letter is shared and is the batch's own homoglyph trap: **`ၢ` U+1062 is
+named MYANMAR VOWEL SIGN SGAW KAREN EU and Shan writes it too**, for /aa/
+before a final consonant. `locales/shn/chrome.ftl` says so beside the letter,
+so nobody "corrects" it out of the Shan files as a Karen leak.
+
+The two Myanmar-script catalogs also disagree about **spacing**, and both say
+so. Shan publishing separates words with spaces; Mon follows the Burmese
+convention of running a clause together with a space at the phrase boundary;
+S'gaw Karen spaces phrases but not words. Each header states its practice
+because it decides where the messages may wrap in a narrow panel, and
+`locales/mnw`'s adds that the difference from `locales/shn` is real rather
+than an inconsistency between two files of one batch.
+
+#### The chemistry gap does not split at all
+
+All fifteen leave `element-name` and `element-anion-name` out, and all fifteen
+are the school-system case. The mediums are the batch's one geographic fact:
+**Indonesian** for the six Indonesian catalogs, **Malay** for `iba` and `dtp`
+— out of textbooks printing the Dewan Bahasa dan Pustaka names `locales/ms`
+already carries — **English** for the four Philippine ones, which is the `fil`
+and `ceb` case those catalogs already record, and **Burmese** for `shn` and
+`mnw`, whose Shan- and Mon-medium schooling does not run to the grades where
+the periodic table is taught.
+
+**`locales/ksw` is the one with two fallbacks rather than one**, and it is the
+`locales/wbl` shape from the batch before. In Myanmar a Karen pupil meets the
+table in Burmese; in the diaspora, in English or in Thai. Its header says that
+coining 118 names would invent a nomenclature no reader has met *and* hide
+that split, and that English falls through because it is at least what part
+of the readership's schooling uses.
+
+None of the fifteen is the Kannada case of having two lists, and none is the
+Khmer case of having the names but no convention to reproduce. Every one of
+the fifteen translates the three messages that are *frames* rather than names,
+on the standing ground that a frame is the catalog's business whether or not
+the names in it ever are.
+
+#### Confidence, and where the batch is thin
+
+Every header grades itself, and two claim to be thinnest — compatibly, which is
+why neither was edited. `locales/dtp` opens "THIS IS THE THINNEST CATALOG OF
+ITS BATCH, AND IT SAYS SO FIRST RATHER THAN LAST"; `locales/mrw` opens "This is
+the thinnest of the three Philippine catalogs added with it", which is a claim
+about three files rather than fifteen. Both are scoped, and both are about
+vocabulary rather than coverage: all fifteen sit at the same 445 keys, so
+"thinnest" here never means a catalog that translates less.
+
+**`bjn` and `iba` are the strongest**, and for the same reason: both are
+Malayic, and the risk in a Malayic catalog is that it becomes Indonesian or
+Malay with a few words changed. Both are written around that risk and both
+name the check. Banjar keeps an everyday layer apart from the Indonesian
+technical register — «kada», «kadada», «kawa», «nang», «gasan», «matan»,
+«lawan», «amun», «tagal», «lantaran» — and says a message where «tidak»,
+«yang» or «untuk» has crept back is a defect rather than a variant. Iban says
+the same of «yang», «ada», «tidak», «dengan» and «atau», and calls it the
+defect this seed is most likely to have made.
+
+**`gor`, `nia`, `dtp` and the three Myanmar catalogs are frames around
+declared loans**, and each says which words are the frame. That is the tier
+`locales/sgh` reached for two whole namespaces one batch earlier, arriving
+here for six catalogs at once.
+
+**`locales/mnw` supplies no native colour word at all.** All twelve are
+Burmese loans in Burmese spelling, and its header says plainly that Mon
+certainly has its own words for at least black, white and red, that they are
+absent because the seed does not know them rather than because they do not
+exist, and that correcting the twelve is a bigger improvement to the catalog
+than correcting anything else in it. The rest of the batch's colour lines
+grade themselves the same way and land in different places: `bbc` and `mrw`
+five native words, `ksw` five, `shn` six, `gor` five *attempted and
+unverified*, `nia` two, `bug` five, `mak` four, and `iba` and `dtp` each
+naming the same five Malay loans — gray, orange, purple, pink and brown —
+among their twelve, which is as close as this batch comes to two catalogs
+agreeing about anything.
+
+**Several catalogs declare a paraphrase where they had no word, and use it
+everywhere so that one search replaces it.** `locales/gor` writes «diila
+pohutuwolo» — literally *is not acted on* — for English's *is ignored*;
+`locales/nia` writes «lö tefaigi», *is not looked at*; `locales/pag` writes
+«Ag-uusaren», *is not used*; `locales/mrw` writes two, *is not used* for
+*ignored* and *is not seen* for *not found*. Each header names its own and
+says it is the first thing to replace. `locales/bbc` records the milder
+version: it is not sure «diparrohahon» is the right word for *ignored* in a
+warning a beginner sees fifty times, and picked one and used it everywhere so
+that changing it is one search.
+
+#### Things the batch records rather than fixes
+
+**`locales/mnw` marks a conditional clause-finally.** Mon writes မ္ဂး after
+the condition where English writes "if" in front of it, and
+`piecewise-condition-if` is placed by the renderer *before* the mathematics it
+introduces, so the word cannot be moved from inside the catalog. It is written
+in the position the core gives it and the limit is recorded beside the key —
+the `locales/dv` shape, reached for the first time by an Austroasiatic
+catalog. It is the only one of the fifteen on that side of the line: the other
+fourteen conditionals are clause-initial and land correctly, «rékko»,
+«punna», «amun», «wonu», «na», «molo», «enti», «nung», «no», «si», «bang»,
+«amay ka», «သင်ဝႃႈ» and «မ့ၢ်».
+
+**`locales/nia` applies no initial mutation anywhere.** A Nias noun changes
+its initial consonant in certain syntactic positions — the property the
+language is best known for — and the seed cannot apply it reliably. Applying
+it in some places and not others would be worse than not applying it, so every
+noun is in its citation form and the header tells a reviewer to expect to
+**mutate rather than to correct**: the words are meant to be right and the
+morphology is simply missing.
+
+**`locales/dtp` cannot write Kadazandusun verbal aspect**, so `answer-checking`
+and `answer-submitting` are a bare verb with an ellipsis — «Periksa…»,
+«Hantar…» — rather than "is being checked". Its header calls that a hole
+rather than a style and the first thing to fix.
+
+**`locales/bug` never writes the definite suffix `-é`.** Buginese marks a
+definite noun with it, its shape depends on the last sound of the word it
+attaches to, and several of these messages end in a placeable the catalog
+never sees — so every noun is written bare. That is [An affix cannot be
+welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable) reached from
+a new direction, and the cost is named: the file reads as indefinite
+throughout.
+
+**`locales/iba` and `locales/dtp` have near-identical `noun` tables**, and
+that is a fact about one education ministry rather than about two languages.
+Sabah, Sarawak and the peninsula teach mathematics out of the same Malay
+textbooks, so both tables are the Dewan Bahasa terms and they differ in four
+entries out of thirty-two — «kawasan» against «pomogunan» for the region,
+«tanda silang» against «tanda pangkah» for the cross, and two spellings that
+follow from Iban's `be-` where Malay writes `ber-`. `locales/dtp`'s header
+says where to look instead: what differs between the three catalogs is
+everything around the table.
 
 Every string in all fifteen is machine-generated and unread by a speaker, and
 each file says so at the top. Correcting any of it needs no permission.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2841,9 +2841,9 @@ languages agreeing, and `bug`'s «pettu-pettu» and `mak`'s «tappolo-polo» are
 the two that are not it. Against that, **seven of the eight supply a red of
 their own** — macella', eja, habang, meela, rara, mirah, aragang — and
 `locales/nia` is the one that falls back to Indonesian «merah», which its own
-header calls a gap in the seed rather than a claim about Nias. Nias does
-supply two colour words of its own, «aitö» and «afusi»; red is simply not one
-of them.
+header calls a gap in the seed rather than a claim about Nias. That file
+attempts two colour words in Nias, «aitö» and «afusi», and marks even those as
+unverified; red is one the seed could not supply, not one the language lacks.
 
 The three Myanmar catalogs invert further than the Indonesian ones do: all
 three fix the description as **colour, then dash pattern, then thickness**,
@@ -2948,8 +2948,8 @@ follows membership rather than second-guessing it.
 
 Nothing else moved. `LANGUAGE_ALIASES` is unchanged, and **`kzj` (Coastal
 Kadazan) needs no row at all**: `Intl.getCanonicalLocales("kzj")` already
-returns `dtp`, so ICU folds it before this file is reached, while `dtb` and
-`drg` — Coastal Kadazan's and Rungus's own codes — miss and fall to English,
+returns `dtp`, so ICU folds it before this file is reached, while `dtb`
+(Labuk-Kinabatangan Kadazan) and `drg` (Rungus) miss and fall to English,
 which `locales/dtp`'s header records as the cost of one tag per catalog.
 
 The near misses this batch does **not** fold are mostly siblings inside one

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -2922,11 +2922,12 @@ writes exactly **one `[0]`** — `attempts-remaining` — and exactly **one
 a component *needs* rather than on a count the reader is looking at. Fifteen
 catalogs, the same two literals in the same two messages, and nothing else.
 
-#### Negotiation: one entry, and it is the largest in the map
+#### Negotiation: one entry, and it is the second-largest in the map
 
 `MACROLANGUAGE_MEMBERS` gained exactly one row, and seeding `bjn` forced it:
 Banjar is one of the 36 ISO 639-3 members of Malay. **`ms` lists 33 of them**,
-which makes it the biggest entry in the map by some distance, and the three
+which makes it the map's second-largest entry — behind only `qu`'s
+forty-three, and ahead of everything else by some distance — and the three
 that are missing are the point of the row rather than an oversight — `ind`
 (`locales/id`), `min` (`locales/min`) and `bjn` (`locales/bjn`) are members
 this repository answers for itself, which is the `bam`/`dyu` shape under
@@ -3154,22 +3155,29 @@ and `answer-submitting` are a bare verb with an ellipsis — «Periksa…»,
 «Hantar…» — rather than "is being checked". Its header calls that a hole
 rather than a style and the first thing to fix.
 
-**`locales/bug` never writes the definite suffix `-é`.** Buginese marks a
-definite noun with it, its shape depends on the last sound of the word it
+**`locales/bug` writes no noun with the definite suffix `-é`.** Buginese marks
+a definite noun with it, its shape depends on the last sound of the word it
 attaches to, and several of these messages end in a placeable the catalog
-never sees — so every noun is written bare. That is [An affix cannot be
-welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable) reached from
-a new direction, and the cost is named: the file reads as indefinite
-throughout.
+never sees — so every noun is written bare, the `noun` table included. That is
+[An affix cannot be welded to a
+placeable](#an-affix-cannot-be-welded-to-a-placeable) reached from a new
+direction, and the cost is named: the nouns read as indefinite throughout. The
+same enclitic still closes the relative clauses the catalog writes out in full
+— «iya riruntu'é», «iya weddingngé» — where there is no placeable for it to
+land on, and its header distinguishes the two.
 
 **`locales/iba` and `locales/dtp` have near-identical `noun` tables**, and
 that is a fact about one education ministry rather than about two languages.
 Sabah, Sarawak and the peninsula teach mathematics out of the same Malay
 textbooks, so both tables are the Dewan Bahasa terms and they differ in four
 entries out of twenty — «kawasan» against «pomogunan» for the region,
-«tanda silang» against «tanda pangkah» for the cross, and two spellings that
-follow from Iban's `be-` where Malay writes `ber-`. `locales/dtp`'s header
-says where to look instead: what differs between the three catalogs is
+«tanda silang» against «tanda pangkah» for the cross, «bebilang» against
+«berbilang» for the polyline, which is Iban's `be-` where Malay writes `ber-`,
+and «kecherunan» against «kecerunan» for the slope field, Iban keeping the
+digraph «ch» that Malay respelled to «c». The `be-`/`ber-` difference runs on
+into `noun-regular-polygon`'s «besisi» against «bersisi», outside the table.
+`locales/dtp`'s header says where to look instead: what differs between those
+two catalogs and `locales/ms`, whose table is nearly the same again, is
 everything around the table.
 
 Every string in all fifteen is machine-generated and unread by a speaker, and

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -107,11 +107,10 @@ twenty-two are partial in the same place — the two chemistry tables — while
 Klingon is partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The two
 hundred and twenty-two are: Somali, Hmong Njua, Amharic, Assamese, Nepali,
-Burmese,
-Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
-Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
-Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
-Southern Sotho, Setswana, Tigrinya, Ganda, Luxembourgish, Western Frisian, Low
+Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu,
+Xhosa, Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala,
+Cebuano, Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala,
+Shona, Southern Sotho, Setswana, Tigrinya, Ganda, Luxembourgish, Western Frisian, Low
 German, Romansh, Occitan, Asturian, Sardinian, Sicilian, Corsican, Northern
 Sami, Yiddish, Haitian Creole, Quechua, Guarani, Aymara, Nahuatl, Kʼicheʼ,
 Mapudungun, Ojibwe, Ilocano, Waray, Hiligaynon, Kapampangan, Bikol, Balinese,
@@ -378,7 +377,9 @@ where the periodic table is taught. `ksw` is the one with no single fallback,
 `locales/wbl`'s shape one batch on: a Karen pupil in Myanmar meets the table in
 Burmese and one in the diaspora in English or Thai, and choosing either would
 hide the split. Four school systems, fifteen catalogs, and not one claim about
-a language among them.
+a language among them; see [Fifteen languages of Southeast
+Asia](#fifteen-languages-of-southeast-asia-and-the-batch-whose-word-order-follows-a-border)
+for what does divide the batch.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -3079,11 +3080,12 @@ the names in it ever are.
 
 #### Confidence, and where the batch is thin
 
-Every header grades itself, and two claim to be thinnest — compatibly, which is
-why neither was edited. `locales/dtp` opens "THIS IS THE THINNEST CATALOG OF
-ITS BATCH, AND IT SAYS SO FIRST RATHER THAN LAST"; `locales/mrw` opens "This is
-the thinnest of the three Philippine catalogs added with it", which is a claim
-about three files rather than fifteen. Both are scoped, and both are about
+Every header grades itself, and two claim to be thinnest — compatibly, since
+`dtp` is not one of the four `mrw` scopes itself against. `locales/dtp` opens
+"THIS IS THE THINNEST CATALOG OF ITS BATCH, AND IT SAYS SO FIRST RATHER THAN
+LAST"; `locales/mrw` opens "This is
+the thinnest of the four Philippine catalogs added with it", which is a claim
+about four files rather than fifteen. Both are scoped, and both are about
 vocabulary rather than coverage: all fifteen sit at the same 445 keys, so
 "thinnest" here never means a catalog that translates less.
 
@@ -3164,7 +3166,7 @@ throughout.
 that is a fact about one education ministry rather than about two languages.
 Sabah, Sarawak and the peninsula teach mathematics out of the same Malay
 textbooks, so both tables are the Dewan Bahasa terms and they differ in four
-entries out of thirty-two — «kawasan» against «pomogunan» for the region,
+entries out of twenty — «kawasan» against «pomogunan» for the region,
 «tanda silang» against «tanda pangkah» for the cross, and two spellings that
 follow from Iban's `be-` where Malay writes `ber-`. `locales/dtp`'s header
 says where to look instead: what differs between the three catalogs is

--- a/packages/i18n/locales/bbc/chrome.ftl
+++ b/packages/i18n/locales/bbc/chrome.ftl
@@ -1,0 +1,190 @@
+# Toba Batak (Hata Batak Toba) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, and that is an argument rather than an oversight.** Toba
+# Batak has a script of its own, Surat Batak, and it is taught, printed and
+# carved; Unicode encodes it at U+1BC0–U+1BFF. It is not what Toba Batak is
+# *written* in. Every newspaper, hymnal, dictionary and schoolbook in the
+# language since the nineteenth century is in the Latin alphabet, and a reader
+# who meets Toba Batak prose meets it in Latin. A seed written in Surat Batak
+# would be a display of the script rather than a catalog anybody reads, and it
+# would also have to decide a dozen things — how to write the loanwords, where
+# to put the pangolat — that no current practice settles. So: **Latin**, in the
+# conventional spelling of the Batak Bible and of Warneck's dictionary. A
+# corrector who wants Surat Batak must convert **all four files at once** and
+# must never mix two scripts inside one catalog.
+#
+# The letters used are `a b d e g h i j k l m n o p r s t u` plus the digraph
+# `ng`, and, in loanwords only, `c f v w y z`. `e` is written for both /e/ and
+# /ə/, as the standard spelling does; this catalog does not mark the schwa.
+#
+# **The technical register is Indonesian, and it is declared as such.** Batak
+# speakers are schooled in Indonesian, and the words for a line, a circle, a
+# polygon, an attribute and a version are the Indonesian ones in a Toba Batak
+# classroom as much as in an Indonesian one. This catalog uses them —
+# `garis`, `lingkaran`, `poligon`, `atribut`, `versi`, `dokumen`, `format`,
+# `label`, `kolom`, `baris` — rather than coining Batak equivalents that no
+# teacher would recognize. What is Toba Batak here is everything around them:
+# the verbs, the negator `ndang`, the modal `boi`, the attributive linker `na`,
+# the conjunctions `dohot`, `alai`, `jala`, `manang`, `molo` and `ala`, and the
+# derivational prefixes `mar-`, `mang-`/`mam-`, `pa-` and `di-`.
+#
+# **Words this catalog uses that are Toba Batak and not Indonesian**, so that a
+# reviewer can see the seam: «sintong» (correct), «sala» (wrong), «hasalaan»
+# (error), «alus» (answer), «pasahat» (submit, hand over), «pareso» (check),
+# «patuduhon» (show), «tabunihon» (hide), «pahobas» (make ready), «buhai»
+# (open), «sesa» (erase), «pahehe» (start up, raise), «jumpang» (found),
+# «balosan» (reply — used here for *feedback*, in preference to Indonesian
+# «umpan balik», which reads as a translation rather than as speech),
+# «sipaingot» (warning), «panuturi» (advice), «ginjang» (up), «toru» (down),
+# «ulahi» (do again).
+#
+# **What this catalog does not know.** Toba Batak has a rich set of politeness
+# and register distinctions, and a viewer's buttons are exactly the place where
+# getting one wrong is noticeable. The seed writes plain unmarked forms
+# throughout and makes no attempt at the deferential register; a speaker should
+# expect to adjust the imperatives. It also does not know whether «hasalaan» or
+# a phrase with «sala» reads better as a heading, and has picked one.
+#
+# Toba Batak has a single plural category — a noun after a numeral is
+# unmarked — so `attempts-remaining` and `answer-show-responses` collapse to a
+# single `*[other]` branch. The `[0]` branch stays: Fluent matches a numeric
+# literal against the number itself, before any plural rule.
+
+
+## Answer submission
+
+answer-checking = Dipareso...
+answer-submitting = Dipasahat...
+
+answer-checking-status = Dipareso alus i
+answer-submitting-status = Dipasahat alus i
+
+answer-correct = Sintong
+answer-incorrect = Sala
+
+answer-response-saved = Nunga tarsimpan alus i
+
+answer-percent-credit = Nilai { $percent }%
+answer-percent-correct = { $percent }% sintong
+answer-percent-short = { $percent } %
+
+max-credit-available = Nilai na gumodang na boi dapot: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] ndang adong be usaha na tading
+       *[other] { $count } usaha na tading
+    }
+
+validation-correct = (Sintong)
+validation-incorrect = (Sala)
+validation-partially-correct = (Sintong sabagian)
+
+answer-show-responses = Patuduhon { $count } alus tu { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Balosan
+
+collapsible-click-to-open = (klik laho mambuhai)
+collapsible-click-to-close = (klik laho manutup)
+
+collapsible-initializing = Dipahobas...
+
+footnote-show = Patuduhon catatan di toru
+footnote-hide = Tabunihon catatan di toru
+
+description-more-information = keterangan tamba
+
+
+## Controls
+
+slider-previous = Na jolo
+slider-next = Na pudi
+
+keyboard-open = Buhai papan ketik
+keyboard-close = Tutup papan ketik
+
+choice-input-remove-choice = Buang { $choice }
+
+matrix-remove-row = Buang baris
+matrix-add-row = Tamba baris
+matrix-remove-column = Buang kolom
+matrix-add-column = Tamba kolom
+
+subset-add-remove-points = Tamba/Buang titik
+subset-toggle-points-intervals = Gantihon titik dohot selang
+subset-move-points = Pindahon titik
+subset-clear = Sesa
+
+orbital-add-row = Tamba baris
+orbital-remove-row = Buang baris
+orbital-add-box = Tamba kotak
+orbital-remove-box = Buang kotak
+orbital-add-up-arrow = Tamba panah tu ginjang
+orbital-add-down-arrow = Tamba panah tu toru
+orbital-remove-arrow = Buang panah
+
+orbital-row-label = Label tu baris { $row }
+
+pretzel-answer = Alus
+
+summary-statistics-caption = Statistik ringkas ni { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ni ekspresi matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ekspresi na sala:
+
+
+## Document status
+
+viewer-initializing = Dipahobas...
+
+
+## Errors
+
+error-heading = Hasalaan
+
+error-found-at =
+    { $span ->
+        [line] Jumpang di baris { $startLine }.
+       *[lines] Jumpang di baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Adong hasalaan di bagasan dokumen on!
+
+diagnostic-heading-error = Hasalaan
+diagnostic-heading-warning = Sipaingot
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Panuturi
+
+accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Sipaingot aksesibilitas
+
+something-went-wrong = Adong na sala.
+
+renderer-load-failed = sada perender ndang boi dimuat. Ulahi ma mamuka halaman on.
+
+core-start-failed = Ndang boi dipahehe dokumen on. Ulahi ma mamuka halaman on.
+
+core-start-failed-busy = Ndang boi dipahehe dokumen on. Torop dokumen na pungka rap tingki, jala i boi lam leleng di alat na lambat. Ulahi mamuka halaman on molo nunga sidung dokumen na asing i.
+
+core-start-failed-retry = Ndang boi dipahehe dokumen on.
+
+core-start-failed-busy-retry = Ndang boi dipahehe dokumen on. Torop dokumen na pungka rap tingki, jala i boi lam leleng di alat na lambat.
+
+core-start-retry = Ulahi
+
+saved-state-unavailable = Ndang boi dibuat ulaonmu na tarsimpan.

--- a/packages/i18n/locales/bbc/content.ftl
+++ b/packages/i18n/locales/bbc/content.ftl
@@ -1,0 +1,289 @@
+# Toba Batak (Hata Batak Toba) content catalog: the prose the core computes
+# into the document. Selected by `documentLocale` — the language the activity
+# was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin**, in the conventional spelling of the Batak Bible and of
+# Warneck's dictionary; `chrome.ftl`'s header argues the choice against Surat
+# Batak at length. No Batak script anywhere in this file, and a corrector who
+# wants it must convert all four files at once.
+#
+# ## Word order, and the linker
+#
+# **The noun comes first and its modifiers follow it**, joined by the
+# attributive relator «na»: «garis na hapal rara» is *thick red line*. So every
+# composition message here inverts English's order, and `style-with-noun` puts
+# «na» between the noun and the description. Within the description the
+# adjectives keep English's own sequence — width, dash pattern, colour — and
+# «na» is written once, in front of the run, rather than before each adjective;
+# writing it three times is grammatical but is not how the phrase is said.
+#
+# That order is shared with the other Indonesian catalogs in the roster
+# (`locales/id`, `locales/ban`, `locales/jv`) and the *linker* is not: Balinese
+# puts the adjective straight behind the noun with nothing between them, and
+# Toba Batak needs «na». It is the one place a reader can tell this file from
+# `locales/ban` at a glance.
+#
+# `style-stroke` and `style-fill` are rendered on their own as well as inside a
+# noun phrase, so they carry no «na» of their own — the message that embeds
+# them supplies it.
+#
+# **`[noun-tail]` is unused.** The side count of a regular polygon binds to the
+# noun rather than to the adjectives, so it folds into the head exactly as
+# English's does and the tail stays empty.
+#
+# ## Gender and role
+#
+# Toba Batak has no grammatical gender and does not inflect a modifier for the
+# position its phrase sits in, so `noun-gender` answers one token for every
+# noun and nothing here selects on `$gender` or on `$role`.
+#
+# ## Vocabulary, and where the seam is
+#
+# **The geometry is Indonesian and is declared as a loan register**, not
+# translated into invented Batak. Toba Batak pupils learn mathematics out of
+# Indonesian-language textbooks, so «garis», «lingkaran», «poligon», «vektor»,
+# «kurva», «fungsi», «titik», «persegi» and the rest are the words that are
+# actually used, and coining Batak replacements would report a wish rather than
+# a fact. The same goes for the two dash patterns, «putus-putus» and
+# «titik-titik».
+#
+# **Five colours are Toba Batak's own** — «birong» (black), «bontar» (white),
+# «rara» (red), «gorsing» (yellow) and «rata» (green, and also *unripe*). The
+# other seven have no Batak basic term and are written with the Indonesian
+# words. That is the honest shape of a basic colour inventory and not a gap in
+# the seed: no language has a native word for *cyan*.
+#
+# The widths «hapal» and «nipis», the fill word «gok» (full), «jongjong»
+# (standing, for a vertical line) and «malintang» (crosswise, for a horizontal
+# one) are Toba Batak. So are the section words «Ulaon» (activity), «Umpama»
+# (example), «Alus» (answer), «Sungkun-sungkun» (question) and «Pasal»
+# (section — the word the Batak Bible uses for a chapter), and the boolean pair
+# «tutu» / «so tutu».
+#
+# ## Chemistry
+#
+# **The 118 element names and the 12 anion names are deliberately absent**, and
+# fall back to English. Chemistry is taught in North Sumatra out of
+# Indonesian-language textbooks, so the periodic table a Batak pupil meets is
+# `locales/id`'s. Copying the Indonesian table wholesale into this file would
+# record a fact about a textbook rather than about Toba Batak, and inventing a
+# Batak table would record nothing at all. The three messages that are *frames*
+# rather than names are translated, because a frame is this catalog's business
+# whether or not the names in it ever are.
+
+
+## Style vocabulary
+
+color =
+    .black = birong
+    .white = bontar
+    .gray = abu-abu
+    .red = rara
+    .orange = oranye
+    .yellow = gorsing
+    .green = rata
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = merah muda
+    .brown = cokelat
+line-width =
+    .thick = hapal
+    .thin = nipis
+line-style =
+    .dashed = putus-putus
+    .dotted = titik-titik
+# Noun phrases, not adjectives: they follow «dohot» and modify nothing.
+fill-style =
+    .horizontal = garis malintang
+    .vertical = garis jongjong
+    .diagonal = garis diagonal
+    .backdiagonal = garis diagonal na balik
+    .dots = titik
+    .diamonds = belah ketupat
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = kurva
+    .function = fungsi
+    .slope-field = medan kemiringan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis patah
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = persegi panjang
+    .circle = lingkaran
+    .region = daerah
+    .point = titik
+    .square = persegi
+    .diamond = belah ketupat
+    .cross = silang
+    .plus = tanda tambah
+# «marsisi { $numSides }» binds to the noun, so it folds into the head and
+# there is no tail — putting it after the adjectives would read as though the
+# colour had the sides.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon biasa marsisi { $numSides }
+    }
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun leads and «na» introduces the run of modifiers behind it:
+# «garis na hapal putus-putus rara».
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } na { $description }
+       *[noun] { $noun } na { $description }
+    }
+style-filled-word = gok
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } dohot { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } na { $filled } { $color } dohot { $pattern }
+        [plain-tail] { $noun } { $nounTail } na { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } na { $filled } { $color } dohot { $pattern }
+       *[plain] { $noun } na { $filled } { $color }
+    }
+# Toba Batak has no article, so the two `-article` branches read the same as
+# the ones without. «jala» is the sentence-linking *and*.
+style-border-clause =
+    { $parts ->
+        [with-article] dohot batas na { $border }
+        [and] jala batas na { $border }
+        [and-article] jala batas na { $border }
+       *[with] dohot batas na { $border }
+    }
+# The pattern is a noun and the colour is its modifier, so «na» comes back.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } na { $color }
+       *[plain] { $color }
+    }
+style-unfilled = so gok
+style-text =
+    { $parts ->
+        [background] { $color } dohot latar na { $background }
+       *[plain] { $color }
+    }
+style-background-none = ndang adong
+
+
+## Boolean words
+
+boolean-true = tutu
+boolean-false = so tutu
+
+
+## Answer buttons
+
+answer-submit-label = Pareso
+answer-submit-label-no-correctness = Pasahat alus
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Ulaon
+    .aside = Sisipan
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Umpama
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Alus
+    .note = Catatan
+    .objectives = Tujuan
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Sungkun-sungkun
+    .section = Pasal
+    .solution = Penyelesaian
+    .task = Tugas
+    .theorem = Teorema
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Panuturi
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = Na jolo
+paginator-next = Na pudi
+paginator-page = Halaman
+paginator-page-status = { $pageLabel } { $currentPage } sian { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = manang
+piecewise-condition-if = molo
+piecewise-condition-otherwise = na asing i
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header. These three are frames rather than vocabulary, so they are
+## translated whether or not the names ever are.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Simbol kimia na sala
+chemistry-invalid-ionic-compound = Senyawa ionik na sala
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = lowong
+math-embedded-input-blank-ordinal = lowong paha-{ $ordinal } sian { $total }

--- a/packages/i18n/locales/bbc/diagnostics.ftl
+++ b/packages/i18n/locales/bbc/diagnostics.ftl
@@ -1,0 +1,679 @@
+# Toba Batak (Hata Batak Toba) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin**, in the spelling `chrome.ftl`'s header sets out. No Surat
+# Batak anywhere in this file.
+#
+# **The frames.** This file is 220 sentences built out of a dozen recurring
+# frames, and reading the frames is the fastest way to review it:
+#
+#     ndang diparrohahon      is ignored
+#     Ndang boi …             cannot …
+#     ingkon …                must …
+#     … na sala               invalid …
+#     Ndang dope dibahen …    has not been implemented …
+#     ndang jumpang           not found
+#     ndang tudos             does not match
+#     ala …                   because …
+#     ndang marguna           has no effect
+#     Ndang adong …           there is no …
+#
+# Correcting one frame corrects a fifth of the file, which is why they are
+# named here.
+#
+# **Register.** Indonesian for the technical nouns — `atribut`, `komponen`,
+# `nilai`, `variabel`, `titik`, `garis`, `lingkaran`, `fungsi`, `dimensi`,
+# `indeks`, `referensi`, `versi`, `format`, `dokumen` — declared as a loan
+# register in `chrome.ftl`'s header, with a Toba Batak frame around them.
+# Nothing here is a coinage.
+#
+# **Plural.** Toba Batak leaves a noun unmarked after a numeral, so every
+# `[one]`/`[other]` fork in the English collapses to a single `*[other]`
+# branch. Two messages keep an explicit `[1]` literal, because English forks
+# there on *one output* against *two outputs* and the distinction is about the
+# shape of the function rather than about agreement; Fluent matches a numeric
+# literal against the number itself, before any plural rule, so those stay
+# selectable.
+#
+# **What this catalog does not know.** Whether «diparrohahon» or a shorter verb
+# reads better for *ignored* in a warning a beginner sees fifty times; the seed
+# picked one and used it everywhere so that changing it is one search.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } ndang diparrohahon molo dua titik ujung ditontuhon
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } ndang diparrohahon molo titik ujung dohot titik tonga rap ditontuhon
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ndang marguna molo ndang adong titik tonga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis mamolus titik na so boi ditontuhon dimensina.
+
+line-points-too-few-dimensions = Garis ingkon mamolus titik na marbahen dua dimensi paling otik.
+
+line-points-depend-on-variables = Garis mamolus titik na marhite variabel: { $variables }.
+
+line-equation-invalid-format = Format ni persamaan garis di variabel { $variable1 } dohot { $variable2 } sala.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar ditontuhon rap marhite through, endpoint dohot direction. Ndang diparrohahon through na ditontuhon i.
+
+ray-dimension-mismatch = numDimensions ni sinar ndang tudos.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ditontuhon rap marhite head, tail dohot displacement. Ndang diparrohahon head na ditontuhon i.
+
+vector-dimension-mismatch = numDimensions ni vektor ndang tudos.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ndang boi marsihol tu `<{ $component }>` ala ndang adong variabel keadaan nearestPoint disi.
+
+constrain-to-without-nearest-point = Ndang boi mangkatai tu `<{ $component }>` ala ndang adong variabel keadaan nearestPoint disi.
+
+constrain-to-interior-without-nearest-point = Ndang boi mangkatai tu bagasan `<{ $component }>` ala ndang adong variabel keadaan nearestPoint disi.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ndang diparrohahon di choiceInput na so inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ndang diparrohahon indices na ditontuhon di choiceInput ala godang ni indices ndang tudos tu godang ni anak choice.
+
+pretzel-indices-count-mismatch = Ndang diparrohahon indices na ditontuhon di problem ala godang ni indices ndang tudos tu godang ni anak problem.
+
+shuffle-indices-count-mismatch = Ndang diparrohahon indices na ditontuhon di shuffle ala godang ni indices ndang tudos tu godang ni komponen.
+
+indices-ignored-out-of-range = Ndang diparrohahon indices na ditontuhon di { $component } ala adong indeks na di balian ni jangkauan.
+
+pretzel-indices-repeated = Ndang diparrohahon indices na ditontuhon di pretzel ala adong indeks na diulang.
+
+pretzel-circuit-first-index = Ndang diparrohahon indices na ditontuhon di pretzel mode circuit ala indeks parjolo ingkon 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Asa mardalan `<{ $component }>` dohot anak na string, atribut `type` ingkon ditontuhon.
+
+invalid-type-defaulting-to-math = Tipe { $type } sala di komponen { $component }. Ingkon sada sian math, text, number, manang boolean. Dipangke math.
+
+string-not-valid-component-to-arrange = String "{ $value }" ndang komponen na denggan di { $component }. Ndang diparrohahon.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipe { $type } sala, tipe dibahen gabe number.
+
+invalid-variable-value = Nilai ni variabel sala: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } ingkon bilangan
+
+variant-index-must-be-integer = Indeks varian { $index } ingkon bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ndang dope dibahen tu ukuran absolut. Lebar digantihon gabe relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` ndang dope dibahen tu ukuran absolut. Margin digantihon gabe relatif.
+
+side-by-side-no-block-child = `<{ $component }>` sala: ingkon adong sada anak na blok paling otik.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` di `<label>` grafis ndang diparrohahon.
+
+label-for-must-resolve-to-one = Atribut `for` di `<label>` ingkon manudu tu sada komponen sambing.
+
+label-for-unresolved = Atribut `for` di `<label>` ndang boi manudu tu sada komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` di `<label>` manudu tu `<answer>` na masukanna disurathon sandiri; tudu ma masukan i tigor.
+
+label-for-answer-without-input = Atribut `for` di `<label>` manudu tu `<answer>` na so adong masukanna na boi dilabeli.
+
+label-for-must-reference-input-or-answer = Atribut `for` di `<label>` ingkon manudu tu sada masukan manang sada jawaban.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ala ni aksesibilitas, `<{ $component }>` ingkon marbahen deskripsi na jempek manang ditandai gabe hiasan.
+
+accessibility-video-short-description = Ala ni aksesibilitas, `<video>` ingkon marbahen deskripsi na jempek.
+
+accessibility-input-short-description-or-label = Ala ni aksesibilitas, `<{ $component }>` ingkon marbahen deskripsi na jempek manang label.
+
+accessibility-answer-input-short-description-or-label = Ala ni aksesibilitas, `<answer>` na mambahen masukan ingkon marbahen deskripsi na jempek manang label.
+
+accessibility-short-description-contains-math = Deskripsi na jempek ndang denggan marisi komponen matematika songon `<{ $component }>`. Surathon ma isi matematikana marhite hata.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } hurang kontrasna di teks judul bagian (mode na birong) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; porlu paling otik { $threshold }:1).
+       *[other] { $colorName } hurang kontrasna di teks judul bagian ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; porlu paling otik { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Ndang dope dibahen `<circle>` mamolus { $count } titik molo titik i ndang marnilai numerik.
+
+circle-too-many-through-points = Ndang boi dihira lingkaran na mamolus lobi sian 3 titik.
+
+circle-overprescribed-radius-center-points = Ndang boi dihira lingkaran molo jari-jari, pusat dohot titik na dipolus rap ditontuhon.
+
+circle-center-with-multiple-points = Ndang boi dihira lingkaran na martontu pusat mamolus lobi sian 1 titik.
+
+circle-radius-too-small = Ndang boi dihira lingkaran: ala jarak ni dua titik i { $distance }, jari-jari { $radius } na ditontuhon i metmet situtu.
+
+circle-radius-with-many-points = Ndang boi dibahen lingkaran na mamolus lobi sian dua titik molo jari-jari ditontuhon.
+
+circle-invalid-center-or-through-points = Pusat manang titik na dipolus ni lingkaran sala.
+
+circle-radius-center-with-multiple-points = Ndang boi dihira jari-jari ni lingkaran na martontu pusat mamolus lobi sian 1 titik.
+
+circle-change-radius-non-numerical = Ndang boi digantihon jari-jari ni lingkaran na titik dipolusna ndang numerik
+
+circle-radius-with-points-non-numerical = Ndang boi dibahen lingkaran na mamolus lobi sian sada titik dohot jari-jari na ditontuhon molo ndang adong nilai numerik.
+
+circle-change-center-non-numerical = Ndang dope dibahen panggantion ni pusat ni lingkaran na mamolus titik na so numerik.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Hurang dimensi ni domain ni fungsi. Domain marisi { $intervals } selang alai fungsi i marisi { $inputs } masukan.
+
+function-domain-invalid-format = Format ni domain ni fungsi sala.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ndang diparrohahon maximum ni fungsi na so numerik.
+        [minimum] Ndang diparrohahon minimum ni fungsi na so numerik.
+        [extremum] Ndang diparrohahon extremum ni fungsi na so numerik.
+        [point] Ndang diparrohahon titik ni fungsi na so numerik.
+        [slope] Ndang diparrohahon kemiringan ni fungsi na so numerik.
+       *[other] Ndang diparrohahon { $type } ni fungsi na so numerik.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ndang diparrohahon maximum ni fungsi na lowong.
+        [minimum] Ndang diparrohahon minimum ni fungsi na lowong.
+        [extremum] Ndang diparrohahon extremum ni fungsi na lowong.
+        [point] Ndang diparrohahon titik ni fungsi na lowong.
+       *[other] Ndang diparrohahon { $type } ni fungsi na lowong.
+    }
+
+function-points-too-close = Fungsi marisi dua titik na jonok situtu. Ndang boi dibahen fungsi.
+
+function-iterates-input-output-mismatch = Iterasi ni fungsi holan boi molo godang ni masukan tudos tu godang ni luaran. Fungsi on marisi { $inputs } masukan dohot { $outputs } luaran.
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang ni sequence sala.  Ingkon bilangan bulat na so negatif.
+
+sequence-invalid-step = Step ni sequence sala.  Ingkon bilangan di sequence tipe { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ni sequence bilangan sala.  Ingkon bilangan.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ni sequence surat sala.  Ingkon rangkaian surat.
+
+sequence-invalid-endpoint = "{ $attribute }" ni sequence sala.
+
+select-from-sequence-coprime-not-numbers = coprime ndang diparrohahon ala na dipillit i ndang bilangan
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ndang diparrohahon ala excludeCombinations ditontuhon
+
+## Resolving a `target`
+
+target-not-found = Target ni `<{ $source }>` sala: ndang jumpang targetna.
+
+target-state-variable-not-found = Target ni `<{ $source }>` sala: ndang jumpang variabel keadaan na margoar "{ $property }" di sada `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel ni `<odeSystem>` ingkon asing sian variabel bebas.
+
+ode-system-duplicate-variable-names = Ndang boi dibahen fungsi RHS ODE na marisi goar variabel na dua hali.
+
+ode-system-rhs-function-error = Ndang boi dibahen fungsi RHS ODE.  Hasalaan di pambahenan fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ndang boi dibahen sudut di holang-holang ni { $count } garis
+
+angle-invalid-through-point = Titik di through ni `<angle>` sala
+
+parabola-vertex-too-many-points = Ndang dope dibahen parabola na marpuncak mamolus lobi sian 1 titik.
+
+parabola-too-many-points = Ndang dope dibahen parabola na mamolus lobi sian 3 titik.
+
+intersection-too-many-items = Ndang dope dibahen perpotongan tu lobi sian dua barang
+
+## Other math components
+
+ionic-compound-not-two-ions = Ndang dope dibahen senyawa ionik tu na asing sian dua ion.
+
+ionic-compound-needs-cation-and-anion = Senyawa ionik holan dibahen tu sada kation dohot sada anion.
+
+solve-equations-cannot-evaluate = Ndang boi disolusihon persamaan on ala ndang boi dihira persamaanna: { $equation }
+
+math-operators-operand-number-required = Ingkon ditontuhon operandNumber molo mambuat operand matematika.
+
+eigen-decomposition-failed = Ndang boi dihira nilai eigen ni matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } ndang adong di pola i, gabe tongtong do i tudos tu na lowong.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ndang boi diantusi grid="{ $grid }". Ingkon none, medium, dense, manang dua bilangan positif na dipisat spasi, songon grid="1 0.5". Ndang adong kisi na digambar.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` porlu fungsi na marisi { $expected ->
+        [1] sada luaran, i ma kemiringan y' di ganup titik, songon `y - x`
+       *[other] dua luaran, i ma vektor di ganup titik, songon `(y, -x)`
+    }, alai fungsi na dilehon i marisi { $found } luaran. { $alternative ->
+        [none] Ndang adong na digambar.
+       *[other] `<{ $alternative }>` do komponen tu fungsi songon i. Ndang adong na digambar.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` ndang diparrohahon ala fungsi i dilehon huhut di bagasan komponen; na di bagasan i do dipangke. Lehon ma fungsi i holan sada dalan.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` mangaraphon variabel ni ekspresi na disurat tigor di bagasan komponen. { $reason ->
+        [function-child] Fungsi dison dilehon songon anak `<function>`, na mangaraphon variabelna sandiri, gabe `variables` ndang diparrohahon.
+       *[no-expression] Ndang adong ekspresi songon i dison, gabe `variables` ndang diparrohahon.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ndang didukung di perender prefigure; dipangke parange posisi siamun.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ndang didukung di perender prefigure; dipangke parange posisi ginjang.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbu sala tu konversi prefigure; dipangke bbox bawaan (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lebar sala tu konversi prefigure; dipangke lebar diagram bawaan 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio sala tu konversi prefigure; dipangke rasio aspek bawaan 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: holang-holang ni kisi i lumat situtu tu batas sumbu; kisi i ndang dibahen di perender prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi ndang digambar molo ndang dipangke perender PreFigure.
+
+multiple-annotations-children = Torop anak `<annotations>` jumpang di `<graph>`; sude na so parpudi ndang diparrohahon.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ndang boi ditamba manang dicopy tipe komponen na so tarboto: { $type }.
+
+copy-prop-not-found = Ndang jumpang prop { $property } di komponen tipe { $component }
+
+collect-no-source = Ndang jumpang sumber tu collect.
+
+collect-invalid-component-type = Ndang boi dipapungu komponen tipe `<{ $component }>` ala tipe komponen i sala.
+
+reference-index-unavailable = Ndang boi ditudu indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ndang boi dipangido { $action } di komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk ni data sala.  Panjang ni baris ndang rap. Jumpang di componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data marisi goar kolom na dua hali.  Jumpang di componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data hurang sada goar kolom.  Jumpang di componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award ni jawaban on marhite alus na pinasahat ni tag jawaban i sandiri, jala i mambahen parange na so dihalomohon.
+
+answer-max-num-attempts-in-section-wide-check-work = Pambahenan `maxNumAttempts` di `<answer>` na di bagasan wadah na marbahen `sectionWideCheckWork` ndang marguna, ala godang ni usaha diatur wadah i. Bahen ma `maxNumAttempts` di wadah i.
+
+nested-section-wide-check-work-max-num-attempts = Pambahenan `maxNumAttempts` di wadah na marbahen `sectionWideCheckWork` na di bagasan wadah na marbahen `sectionWideCheckWork` muse ndang marguna, ala godang ni usaha diatur wadah na di balian. Bahen ma `maxNumAttempts` di wadah na di balian i.
+
+answer-attributes-need-symbolic-equality = Atribut { $attributes } ndang marguna molo symbolicEquality ndang ditontuhon.
+
+answer-invalid-type = Tipe ni jawaban sala: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ala ndang margoar komponen `<{ $component }>`, ndang boi i dipangke gabe atribut ni module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` ndang boi dipangke gabe atribut ni module ala tipe komponen `<module>` nunga marbahen atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` ndang diparrohahon di komponen `<conditionalContent>` na marbahen anak case manang else.
+
+slider-markers-type-mismatch = Tipe ni marker ndang tudos tu tipe ni slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel sala: ganup `<problem>` ingkon marisi sada `<statement>` dohot sada `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel sala: di mode="circuit", `<problem>` parjolo ndang boi gabe distraktor.
+
+## Attribute values
+
+attribute-invalid-values = Nilai { $values } sala tu atribut `{ $attribute }`; ndang diparrohahon.
+
+attribute-must-be-references = Nilai `{ $value }` sala tu atribut `{ $attribute }`. Atribut ingkon dibahen sian referensi na mamungka dohot `$`.
+
+math-input-invalid-function-names = <mathInput>: ndang diparrohahon goar fungsi na sala di { $attribute }: { $names }. Ganup goar ingkon marisi paling otik 2 karakter (surat manang garis pisat); boi ditamba akhiran `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Tipe komponen sala: `<{ $componentType }>`
+
+attribute-repeated = Ndang boi diulang atribut { $attribute }.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" sala tu komponen tipe `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definisi gaya { $styleNumber } hurang kontrasna tu { $context ->
+        [text-on-background] warna teks tu warna latar
+        [high-contrast] warna kontras na timbo tu kanvas
+        [line] warna garis tu kanvas
+        [marker] warna marker tu kanvas
+       *[text-on-canvas] warna teks tu kanvas
+    }{ $mode ->
+        [dark] { " (mode na birong)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; porlu paling otik { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Nang pe definisi gaya { $styleNumber } marbahen warna na sae kontrasna tu mode na tiur, warna mode na birong na ro sian nilai i hurang kontrasna tu warna teks tu warna latar ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; porlu paling otik { $threshold }:1). { $suggestion ->
+        [available] Asa sae kontrasna di mode na birong, patimbo ma kontras mode na tiur (umpamana bahen { $lightAttribute }="{ $lightColor }") manang gantihon warna mode na birong (umpamana bahen { $darkAttribute }="{ $darkColor }").
+       *[none] Asa sae kontrasna di mode na birong, patimbo ma kontras mode na tiur manang gantihon warna na ro i marhite textColorDarkMode dohot/manang backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Nang pe definisi gaya { $styleNumber } marbahen warna teks na sae kontrasna tu mode na tiur, warna teks mode na birong na ro sian nilai i hurang kontrasna tu kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; porlu paling otik { $threshold }:1). { $suggestion ->
+        [available] Asa sae kontrasna di mode na birong, patimbo ma kontras mode na tiur (umpamana bahen textColor="{ $lightColor }") manang gantihon warna mode na birong (umpamana bahen textColorDarkMode="{ $darkColor }").
+       *[none] Asa sae kontrasna di mode na birong, patimbo ma kontras mode na tiur manang gantihon warna na ro i marhite textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Sada bagian holan boi mamillit sada <stylePalette>; na parpudi do dipangke.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ndang boi ditontuhon varian na unik ni { $component } ala numToSelect ndang bilangan bulat na so negatif.
+
+variant-num-to-select-not-constant-number = ndang boi ditontuhon varian na unik ni { $component } ala numToSelect ndang bilangan na hot.
+
+variant-with-replacement-not-constant-boolean = ndang boi ditontuhon varian na unik ni { $component } ala withReplacement ndang boolean na hot.
+
+variant-select-weight-disables-unique = Varian na unik tu select ndang mardalan molo adong option na marbahen selectWeight manang selectForVariants
+
+variant-coprime-undetermined = ndang boi ditontuhon varian na unik ni { $component } ala ndang boi ditontuhon coprime tongtong salah.
+
+variant-attribute-not-constant = ndang boi ditontuhon varian na unik ni { $component } ala { $attribute } ndang hot.
+
+variant-attribute-not-number = ndang boi ditontuhon varian na unik ni { $component } ala { $attribute } ndang bilangan.
+
+variant-attribute-wrong-type-for-sequence =
+    ndang boi ditontuhon varian na unik ni { $component } tipe { $type } ala { $attribute } ndang { $expected ->
+        [letters-combination] rangkaian surat
+        [math-expression] ekspresi matematika na denggan
+        [integer] bilangan bulat
+       *[number] bilangan
+    }.
+
+variant-length-not-integer = ndang boi ditontuhon varian na unik ni { $component } ala length ndang bilangan bulat.
+
+variant-sort-not-implemented = ndang dope dibahen varian na unik ni { $component } na marbahen sort
+
+variant-exclude-combinations-not-implemented = ndang dope dibahen varian na unik ni { $component } na marbahen excludeCombinations
+
+variant-math-exclude-not-implemented = ndang dope dibahen varian na unik ni { $component } tipe math na marbahen exclude
+
+variant-non-constant-exclude-not-implemented = ndang dope dibahen varian na unik ni { $component } na marbahen exclude na so hot
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ndang didukung di perender prefigure ni graph; pinompar dilaosi.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri na so hot manang na hurang; pinompar dilaosi.
+
+prefigure-curve-label-omitted = { $subject }: label ndang didukung di elemen kurva na dikonversi; label dilaosi.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipe definisi fungsi kurva '{ $definitionType }' ndang didukung; pinompar dilaosi.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions di regionBetweenCurves ndang didukung; pinompar dilaosi.
+
+prefigure-region-non-formula-child = { $subject }: holan anak fungsi tipe formula na didukung di regionBetweenCurves; pinompar dilaosi.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ndang didukung tu { $labelKind ->
+        [line-family] label ni kelompok garis
+       *[point] label ni titik
+    }; dipangke perataan PreFigure bawaan.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' ndang didukung PreFigure; mulak tu isi na solid.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' na so tarboto dilaosi sian luaran PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' dibahen gabe gaya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' ndang didukung PreFigure; dipangke gaya bawaan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` sala; ndang boi ditontuhon targetna. Anotasi dilaosi.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` manudu tu torop target; na parjolo do dipangke.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` sala; target i di balian ni graph na mangompol i. Anotasi dilaosi.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` sala; target i ndang objek grafis na didukung di konversi prefigure. Anotasi dilaosi.
+
+annotation-text-missing = `<annotation>`: `text` hurang manang lowong; teks na lowong do dibahen.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Jumpang katergantungan na marputar.
+       *[other] Jumpang katergantungan na marputar na maniop komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Ndang jumpang na ditudu referensi: `{ $reference }`
+
+reference-multiple-referents = Torop na ditudu referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format ni atribut { $attribute } ni `<{ $componentType }>` sala.
+
+children-invalid = Anak ni `<{ $componentType }>` sala: Jumpang anak na sala: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` sala tu atribut `{ $attribute }`, dipangke nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ndang jumpang versi DoenetML { $version }.
+       *[other] Ndang jumpang versi DoenetML { $version }. Mulak tu versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML sala: { $content }
+
+parse-tag-missing-close-tag = DoenetML sala: Tag `{ $tag }` ndang marbahen tag panutup. Ingkon tag na manutup dirina manang tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML sala: Hasalaan di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML sala: Atribut `{ $attribute }` na sala on rupana hurang nilai.
+
+parse-attribute-invalid = DoenetML sala: Atribut `{ $attribute }` sala
+
+parse-attribute-value-invalid = DoenetML sala: Nilai atribut `{ $value }` sala
+
+parse-attribute-value-quote-mismatch = DoenetML sala: Nilai atribut `{ $value }` sala. Tanda kutip ndang tudos. Rupana hurang sada `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML sala: Jumpang tag na so margoar tag, songon `<`
+
+parse-tag-not-closed = DoenetML sala: Tag `{ $tag }` ndang ditutup (rupana hurang `>`).
+
+parse-self-closing-tag-name-missing = DoenetML sala: Jumpang tag na so margoar tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML sala: Tag `{ $tag }` ndang ditutup (rupana hurang `/>`).
+
+parse-tag-invalid-attributes = DoenetML sala: Tag `{ $tag }` sala. Boi jadi atributna sala.
+
+parse-close-tag-name-missing = DoenetML sala: Jumpang tag panutup na so margoar tag, songon `</`
+
+parse-attribute-value-unquoted = Nilai atribut ingkon dilehon di bagasan tanda kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML sala: Jumpang tag panutup `{ $tag }`, alai ndang adong tag pambungka na hombar
+
+parse-close-tag-mismatched = DoenetML sala: Tag panutup ndang tudos. Na diharaphon `</{ $expected }>`. Na jumpang `{ $found }`
+
+parser-node-unconvertible = Ndang boi dikonversi node { $node } gabe node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Goar atribut name='{ $name }' sala. { $reason ->
+        [characters] Goar holan boi marisi surat, angka, garis di toru manang garis pisat.
+       *[start] Goar ingkon mamungka dohot sada surat.
+    }
+
+component-name-invalid-start = Goar komponen "{ $name }" sala. Goar ingkon mamungka dohot sada surat.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Jawaban tipe videoWatched ingkon marbahen atribut video
+
+answer-video-watched-video-not-reference = Jawaban tipe videoWatched ingkon marbahen atribut video na sada referensi
+
+answer-name-not-single-text = Atribut name ni jawaban ingkon marbahen sada anak text sambing
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ndang boi dibuat DoenetML sian luar ala lam bagas rekursina. Adong do referensi na marputar?
+
+external-doenetml-unavailable = Ndang boi dibuat DoenetML sian { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML na dibuat sian { $attribute }="{ $uri }" sala: ndang tudos tu tipe komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` nunga ditadingkon; pangke ma `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` di `<{ $component }>` nunga ditadingkon; pangke ma `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` nunga ditadingkon jala ndang diparrohahon ala `{ $to }` ditontuhon huhut.
+       *[other] [deprecation] Atribut `{ $from }` di `<{ $component }>` nunga ditadingkon jala ndang diparrohahon ala `{ $to }` ditontuhon huhut.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` di `<{ $component }>` nunga ditadingkon jala ndang diparrohahon.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` di `<{ $component }>` nunga ditadingkon; pangke ma anak `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` ni atribut `{ $attribute }` di `<{ $component }>` nunga ditadingkon; pangke ma `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` holan boi mambahen bentuk jamak ni hata Inggris, gabe teksna ndang digantihon di dokumen na sinurat marhite { $locale }. Surathon ma bentuk jamakna tigor, manang bahen marhite atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` ndang elemen Doenet na tarboto.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` ndang boi di bona ni dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` ndang boi di bagasan `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` ndang marbahen atribut na margoar `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` ni elemen `<{ $tag }>` ingkon sada daftar na ganup itemna sada sian: { $allowed }
+       *[other] Atribut `{ $attribute }` ni elemen `<{ $tag }>` ingkon sada sian: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Goar varian ni select sala.  Goar varian { $variantName } adong di { $numOptions } option alai godang na dipillit { $numToSelect }.
+
+select-variant-name-without-options = Adong varian na ditontuhon di select alai ndang adong option tu goar varian na boi: { $variantName }.
+
+select-variant-name-not-possible = Goar varian { $variantName } na ditontuhon di select ndang goar varian na boi.
+
+select-too-few-options = Ndang boi dipillit { $numToSelect } komponen sian holan { $numOptions }.
+
+select-from-sequence-too-few-values = Ndang boi dipillit { $numToSelect } nilai sian sequence na marpanjang { $length }.
+
+select-from-sequence-indices-count-mismatch = Godang ni indices na ditontuhon di select ingkon tudos tu godang na dipillit
+
+select-from-sequence-indices-not-integers = Sude indices na ditontuhon di select ingkon bilangan bulat
+
+select-from-sequence-index-excluded = Indeks selectfromsequence na ditontuhon i nunga dipabali
+
+select-from-sequence-indices-excluded-combination = Indices selectfromsequence na ditontuhon i sada kombinasi na dipabali
+
+select-from-sequence-coprime-not-positive-integers = Ndang boi dipillit kombinasi coprime ala na dipillit i ndang bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Ndang boi dipillit bilangan coprime. Sude nilai na boi marbahen faktor na rap. (Nilai "from" manang "to" na ditontuhon ingkon coprime dohot "step".)
+
+select-from-sequence-coprime-single-number = Ndang boi dipillit kombinasi coprime sian sada bilangan na so 1.
+
+select-from-sequence-excluded-too-many-combinations = Lobi sian 70% kombinasi dipabali di selectFromSequence
+
+select-from-sequence-coprime-none-found = Ndang boi dipillit bilangan coprime. Sude nilai na boi marbahen faktor na rap.
+
+select-from-sequence-too-few-unique-values = Ndang boi dipillit { $numToSelect } nilai na unik sian sequence na marpanjang { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ndang boi dipillit { $numToSelect } nilai sian daftar bilangan prima na marpanjang { $numValues }
+
+select-prime-numbers-values-count-mismatch = Godang ni nilai na ditontuhon di select ingkon tudos tu godang na dipillit
+
+select-prime-numbers-values-not-prime = Sude nilai na ditontuhon di select bilangan prima ingkon adong di daftar bilangan prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers na ditontuhon i sada kombinasi na dipabali
+
+select-prime-numbers-excluded-too-many-combinations = Lobi sian 70% kombinasi dipabali di selectPrimeNumbers
+
+select-random-combination-fluke = Ala hasompatan na jarang situtu, ndang boi dipillit kombinasi ni nilai acak
+
+select-random-value-fluke = Ala hasompatan na jarang situtu, ndang boi dipillit nilai acak
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` on ndang dipatuduhon ala di bagasan matematika jala ndang `inline`. Tamba ma `inline` asa gabe daftar na turun, na muat di bagasan sada ekspresi.
+        [expanded] `<{ $component }>` on ndang dipatuduhon ala di bagasan matematika jala `expanded`. Buang ma `expanded`; kotak na godang barisna ndang muat di bagasan sada ekspresi.
+        [on-graph] `<{ $component }>` on ndang dipatuduhon ala di bagasan matematika na digambar di graph, na so maringanan tu masukan.
+       *[relative-width] `<{ $component }>` on ndang dipatuduhon ala di bagasan matematika jala marlebar relatif. Lehon ma lebarna marhite satuan absolut, songon `px`.
+    }

--- a/packages/i18n/locales/bbc/editor.ftl
+++ b/packages/i18n/locales/bbc/editor.ftl
@@ -1,0 +1,229 @@
+# Toba Batak (Hata Batak Toba) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin**, in the spelling `chrome.ftl`'s header sets out, and no
+# Surat Batak anywhere in this file.
+#
+# **This is the file where the Indonesian loan register is heaviest**, and it
+# should be read as such rather than as a failure to translate. An editor's
+# nouns — «editor», «penampil», «varian», «saringan», «komponen», «atribut»,
+# «referensi», «properti», «cuplikan», «larik», «nilai», «tipe», «gaya»,
+# «koordinat», «fungsi», «baris», «tag», «dokumentasi», «aksesibilitas»,
+# «laporan», «versi», «format», «konteks», «diagnostik» — are Indonesian in a
+# Batak speaker's computing vocabulary, and there is no Batak word for any of
+# them that a reviewer would recognize. What is Toba Batak here is the frame:
+# the negator «ndang», the modal «boi», the linker «na», the possessive «ni»,
+# the prepositions «di», «tu» and «sian», and the verbs «patuduhon» (show),
+# «tabunihon» (hide), «mambuhai» (open), «manutup» (close), «pillit» (choose),
+# «jumpang» (found), «pasahat» (submit) and «guruhon» (learn).
+#
+# **`editor-coordinates` and the count selects.** Toba Batak leaves a noun
+# unmarked after a numeral, so «koordinat» is the same word for one and for
+# many; `help-coordinates` and the two counts inside
+# `editor-accessibility-label` collapse to a single `*[other]` branch. That is
+# also what the plural rule requires — `bbc` has no CLDR plural data, so an
+# `[one]` branch here would be selected by English's rules — but it would be
+# the right form even if it did.
+#
+# **What this catalog does not know.** Whether «penampil» or a Batak phrase
+# reads better for *viewer*, and whether an imperative like «Buhai» is polite
+# enough for a button. Both are speaker questions, and both are one edit away.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ulang
+       *[update] Perbarui
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } penampil
+       *[other] { $word } penampil { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+
+editor-variant-filter = Saring...
+
+editor-variant-next = Pillit varian na pudi
+editor-variant-previous = Pillit varian na jolo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Jumpang pelanggaran aksesibilitas WCAG AA. Klik laho { $action ->
+            [close] manutup
+           *[open] mambuhai
+        } laporan aksesibilitas.
+        [advisories] Klik laho { $action ->
+            [close] manutup
+           *[open] mambuhai
+        } laporan aksesibilitas. Ndang adong pelanggaran WCAG AA na jumpang, alai adong dope panuturi aksesibilitas na asing.
+       *[clean] Klik laho { $action ->
+            [close] manutup
+           *[open] mambuhai
+        } laporan aksesibilitas. Ndang adong parsoalan aksesibilitas na jumpang.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Jumpang pelanggaran aksesibilitas WCAG AA. Jumpang { $count } pelanggaran WCAG AA. Klik laho { $action ->
+            [close] manutup
+           *[open] mambuhai
+        } laporan aksesibilitas.
+        [advisories] Ndang adong pelanggaran WCAG AA na jumpang. Jumpang { $count } panuturi aksesibilitas na asing. Klik laho { $action ->
+            [close] manutup
+           *[open] mambuhai
+        } laporan aksesibilitas.
+       *[clean] Ndang adong pelanggaran WCAG AA na jumpang. Klik laho { $action ->
+            [close] manutup
+           *[open] mambuhai
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Panorangi na hombar tu konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Hasalaan
+editor-tab-warnings = Sipaingot
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Alus na pinasahat
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Format songon DoenetML
+editor-format-as-xml = Format songon XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Ndang adong hasalaan
+editor-no-warnings = Ndang adong sipaingot
+editor-no-info = Ndang adong diagnostik info
+
+editor-show-info-annotations = Patuduhon diagnostik info di editor
+editor-show-accessibility-annotations = Patuduhon diagnostik aksesibilitas di editor
+
+editor-accessibility-learn-more = Guruhon songon dia Doenet mangaradoti aksesibilitas
+
+editor-accessibility-violations-heading = Pelanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Parsoalan aksesibilitas na asing
+editor-none-found = Ndang adong na jumpang
+
+
+## Submitted responses
+
+editor-no-responses = Ndang adong dope alus na pinasahat
+editor-response-answer-id = Id ni alus
+editor-response-response = Alus
+editor-response-credit = Nilai
+editor-response-submitted = Pinasahat
+
+
+## The context-help panel
+
+help-placeholder = Bahen kursor tu goar ni tag, atribut, manang { $ref } laho mangida dokumentasi.
+
+help-unsupported-ref-chain = Panorangi tu referensi na marlapis-lapis songon { $example } ndang dope adong.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ndang jumpang na ditudu referensi on: { $ref }.
+        [multiple] Torop na ditudu referensi on: { $ref }.
+       *[indeterminate] Ndang boi ditontuhon aha na ditudu { $ref }.
+    }
+
+help-learn-about-references = Guruhon taringot referensi →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Di bagasan { $element }
+       *[top] Di tingkat na tumimbo
+    }{ $allowed ->
+        [none] { " — ndang adong na boi dibahen dison." }
+        [text] { " — surathon teks dison." }
+        [text-and-components] { " — surathon teks dison, manang coba:" }
+       *[components] { " — na boi dicoba:" }
+    }
+
+help-suggestions-footer = Tostos { $shortcut } laho mangida sude { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } i ma referensi tu { $target }.
+       *[other] { $ref } i ma referensi tu { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Dipabotohon { $owner } songon { $role }.
+       *[other] Dipabotohon { $owner } di baris { $line } songon { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } i ma referensi tu properti { $property } ni { $element }.
+       *[other] { $ref } i ma referensi tu properti { $property } ni { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = cuplikan
+help-kind-array-entry = entri larik
+
+help-default = Bawaan:
+help-active-default = Bawaan na mardalan:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai na boi (sada ganup item):
+       *[other] Nilai na boi:
+    }
+
+help-suggested-values = Nilai na tinuturhon:
+
+help-inserts = Na dibahen masuk:
+
+help-coordinates = Koordinat:
+
+help-type = Tipe:
+
+help-resolved-style = Gaya na dapot (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Goar ni fungsi na dapot:
+help-reset-list = Daftar na diulang di masukan on:
+help-added-on-input = Na tinamba di masukan on:
+help-removed-on-input = Na binuang di masukan on:
+
+help-reset-overrides = { $reset } manggantihon { $additional } dohot { $removed }.

--- a/packages/i18n/locales/bjn/chrome.ftl
+++ b/packages/i18n/locales/bjn/chrome.ftl
@@ -1,0 +1,178 @@
+# Banjar (Bahasa Banjar) viewer chrome. Translated from `locales/en/chrome.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and orthography.** Banjar is a Malayic language of South Kalimantan
+# with two dialect groups, Banjar Hulu and Banjar Kuala. This catalog writes
+# the **Banjar Hulu** vowel system, which is the one Banjar writing normally
+# uses: three vowels, `a i u`, so Indonesian's `e` and `o` are written `a`, `i`
+# and `u` — «barasih» for *bersih*, «cuklat» for *coklat*, «kandal» for
+# *tebal*. A Banjar Kuala reader will recognize the words and may prefer to
+# respell some of them; that is a spelling change and not a translation change.
+# The orthography is the ordinary Indonesian Latin one, with no diacritics.
+#
+# **The technical register is Indonesian, and that is not a shortcut.** Banjar
+# speakers are schooled in Indonesian, and the words for a component, an
+# attribute, a matrix or a percentage are the Indonesian ones because those are
+# the words the community actually uses. They are written here as Indonesian
+# rather than respelled into a Banjar shape the language does not give them.
+#
+# **What is Banjar, and what a reviewer should check first.** The risk in a
+# Malayic catalog is that it becomes Indonesian with a few words changed. What
+# holds this one apart from `locales/id` is the everyday layer, and it is used
+# consistently: «kada» for *tidak* and «kadada» for *tidak ada*, «kawa» for
+# *bisa/dapat* (so *cannot* is «kada kawa»), «nang» for *yang*, «gasan» for
+# *untuk*, «matan» for *dari*, «lawan» for *dengan*, «wan» for *dan*, «atawa»
+# for *atau*, «amun» for *jika*, «tagal» for *tetapi*, «lantaran» for *karena*,
+# «barataan» for *semua*, «ganal» and «halus» for *besar* and *kecil*, «bujur»
+# for *benar*, «katamu» for *ditemukan*, «pulang» for *lagi*, «jua» for *juga*,
+# «balum» for *belum*, and «pian» as the polite second person. A message where
+# «tidak», «yang», «untuk», «dari», «dengan» or «jika» has crept back in is a
+# mistake, not a variant.
+#
+# **The reader is addressed as «pian»**, the polite second person, and only
+# `saved-state-unavailable` and `core-start-failed*` address them at all. The
+# rest are labels and headings with no addressee.
+#
+# **Counts.** CLDR has no plural data for `bjn`, so `Intl.PluralRules` would
+# resolve it against the runtime's own locale and any `[one]` branch would be
+# selected by English's rules rather than by Banjar's. The two counted messages
+# here collapse to a single `*[other]`, keeping only `attempts-remaining`'s
+# explicit `[0]`, which Fluent matches against the number itself. A Banjar noun
+# is unmarked after a numeral anyway, so one form is correct.
+
+
+## Answer submission — the check-work button and the status it reports.
+
+answer-checking = Mamariksa...
+answer-submitting = Mangirim...
+
+answer-checking-status = Mamariksa jawaban
+answer-submitting-status = Mangirim jawaban
+
+answer-correct = Bujur
+answer-incorrect = Salah
+
+answer-response-saved = Jawaban sudah disimpan
+
+answer-percent-credit = Nilai { $percent }%
+answer-percent-correct = { $percent }% bujur
+answer-percent-short = { $percent } %
+
+max-credit-available = Nilai paling ganal nang kawa didapat: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] kadada lagi cuba nang tasisa
+       *[other] tasisa { $count } kali cuba
+    }
+
+validation-correct = (Bujur)
+validation-incorrect = (Salah)
+validation-partially-correct = (Sabagian bujur)
+
+answer-show-responses = Tunjukakan { $count } jawaban gasan { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Umpan balik
+
+collapsible-click-to-open = (klik gasan mambuka)
+collapsible-click-to-close = (klik gasan manutup)
+
+collapsible-initializing = Lagi disiapakan...
+
+footnote-show = Tunjukakan catatan bawah
+footnote-hide = Sumbunyiakan catatan bawah
+
+description-more-information = katarangan labih lanjut
+
+
+## Controls
+
+slider-previous = Sabalumnya
+slider-next = Barikutnya
+
+keyboard-open = Buka papan katik
+keyboard-close = Tutup papan katik
+
+choice-input-remove-choice = Hapus { $choice }
+
+matrix-remove-row = Hapus baris
+matrix-add-row = Tambah baris
+matrix-remove-column = Hapus kolom
+matrix-add-column = Tambah kolom
+
+subset-add-remove-points = Tambah/Hapus titik
+subset-toggle-points-intervals = Alihakan titik lawan salang
+subset-move-points = Pindahakan titik
+subset-clear = Barasihakan
+
+orbital-add-row = Tambah baris
+orbital-remove-row = Hapus baris
+orbital-add-box = Tambah kutak
+orbital-remove-box = Hapus kutak
+orbital-add-up-arrow = Tambah anak panah ka atas
+orbital-add-down-arrow = Tambah anak panah ka bawah
+orbital-remove-arrow = Hapus anak panah
+
+orbital-row-label = Label gasan baris { $row }
+
+pretzel-answer = Jawaban
+
+summary-statistics-caption = Ringkasan statistik matan { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ungkapan matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ungkapan kada sah:
+
+
+## Document status
+
+viewer-initializing = Lagi disiapakan...
+
+
+## Errors
+
+error-heading = Kasalahan
+
+error-found-at =
+    { $span ->
+        [line] Katamu di baris { $startLine }.
+       *[lines] Katamu di baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen ini bakasalahan!
+
+diagnostic-heading-error = Kasalahan
+diagnostic-heading-warning = Paringatan
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Patunjuk
+
+accessibility-heading-level-1 = Palanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Paringatan aksesibilitas
+
+something-went-wrong = Ada nang salah.
+
+renderer-load-failed = sabuting perender kada kawa dimuat. Muat ulang halaman ni.
+
+core-start-failed = Dokumen ini kada kawa dijalanakan. Muat ulang halaman ni.
+
+core-start-failed-busy = Dokumen ini kada kawa dijalanakan. Ada babarapa dokumen nang bamula sabarataan, nang kawa jadi labih lawas di alat nang lambat. Muat ulang halaman ni mungkin manulungi imbah dokumen nang lain tuntung.
+
+core-start-failed-retry = Dokumen ini kada kawa dijalanakan.
+
+core-start-failed-busy-retry = Dokumen ini kada kawa dijalanakan. Ada babarapa dokumen nang bamula sabarataan, nang kawa jadi labih lawas di alat nang lambat.
+
+core-start-retry = Cuba pulang
+
+saved-state-unavailable = Gawian pian nang tasimpan kada kawa dimuat.

--- a/packages/i18n/locales/bjn/content.ftl
+++ b/packages/i18n/locales/bjn/content.ftl
@@ -1,0 +1,279 @@
+# Banjar (Bahasa Banjar) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: Banjar Hulu in the ordinary Indonesian Latin alphabet**, as
+# `chrome.ftl`'s header sets out — three vowels, so *bersih* is «barasih» and
+# *tebal* is «kandal». No diacritics anywhere.
+#
+# ## Word order
+#
+# **The noun comes first and every modifier follows it**, in the order width,
+# dash pattern, colour: «garis kandal putus-putus habang» is *thick dashed red
+# line*. So `style-with-noun` and `style-filled-with-noun` put `{ $noun }`
+# before `{ $description }`, which is the reverse of English's sequence of
+# placeables and is a fact about Banjar rather than a failure to translate.
+# `style-stroke` keeps English's internal order of the three adjectives,
+# because that is also Banjar's.
+#
+# **`[noun-tail]` carries the side count.** `noun-regular-polygon` fills `head`
+# with «poligon baraturan basisi { $numSides }» and leaves `tail` empty, as
+# English does: the count follows the noun here too, so nothing has to be
+# split around the adjectives.
+#
+# ## Gender, role and number
+#
+# **No `$gender` fork and no `$role` fork.** Banjar is Malayic and has neither
+# grammatical gender nor case, so `noun-gender` answers the single token
+# `neuter` and no adjective below selects on anything. That is a claim about
+# the language rather than a limit of the seed.
+#
+# **Nothing selects on a count.** A Banjar noun is unmarked after a numeral —
+# «lima titik», not a plural form — so no message here needs a plural branch,
+# and CLDR has no plural data for `bjn` to write one against in any case.
+#
+# ## Vocabulary
+#
+# The colour, shape and section words below are the ones a Banjar speaker
+# uses in ordinary speech where Banjar has its own — «hirang», «habang»,
+# «kandal», «nipis», «pasagi», «balah katupat», «patakunan», «gawian» — and
+# the Indonesian ones where the term is school vocabulary, because that is the
+# register Banjar-speaking schools teach mathematics in. **Two are guesses a
+# reviewer should look at first**: `.cyan` is written «sian», the Indonesian
+# loan, and `.pink` is written «habang anum» — «anum» is Banjar for *muda*,
+# so this is a calque on Indonesian *merah muda* rather than an attested
+# Banjar colour term. Neither was invented as a word; both are compounds of
+# words Banjar has, and either may simply be wrong.
+
+
+## Style vocabulary
+
+color =
+    .black = hirang
+    .white = putih
+    .gray = kulabu
+    .red = habang
+    .orange = jingga
+    .yellow = kuning
+    .green = hijau
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = habang anum
+    .brown = cuklat
+
+line-width =
+    .thick = kandal
+    .thin = nipis
+
+line-style =
+    .dashed = putus-putus
+    .dotted = titik-titik
+
+fill-style =
+    .horizontal = garis mandatar
+    .vertical = garis tagak
+    .diagonal = garis miring
+    .backdiagonal = garis miring tabalik
+    .dots = titik
+    .diamonds = balah katupat
+
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = kurva
+    .function = fungsi
+    .slope-field = medan kamiringan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis patah
+    .polygon = poligon
+    .triangle = sagitiga
+    .rectangle = pasagi panjang
+    .circle = lingkaran
+    .region = daerah
+    .point = titik
+    .square = pasagi
+    .diamond = balah katupat
+    .cross = tanda silang
+    .plus = tanda tambah
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon baraturan basisi { $numSides }
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = tarisi
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } lawan { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } lawan { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } lawan { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] lawan batas { $border }
+        [and] wan batas { $border }
+        [and-article] wan batas { $border }
+       *[with] lawan batas { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = kada tarisi
+
+style-text =
+    { $parts ->
+        [background] { $color } lawan latar { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = kadada
+
+
+## Boolean words
+
+boolean-true = bujur
+boolean-false = salah
+
+
+## Answer buttons
+
+answer-submit-label = Pariksa
+answer-submit-label-no-correctness = Kirim jawaban
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Gawian
+    .aside = Sisipan
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Contoh
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Jawaban
+    .note = Catatan
+    .objectives = Tujuan
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Patakunan
+    .section = Bab
+    .solution = Panyalasaian
+    .task = Tugas
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Patunjuk
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = Sabalumnya
+paginator-next = Barikutnya
+paginator-page = Halaman
+
+paginator-page-status = { $pageLabel } { $currentPage } matan { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = atawa
+
+piecewise-condition-if = amun
+
+piecewise-condition-otherwise = amun kada bagitu
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so those
+## 130 keys fall back to English. South Kalimantan teaches secondary chemistry
+## in Indonesian, out of Indonesian textbooks, so a Banjar table would be the
+## Indonesian one in Banjar spelling — a claim about spelling rather than about
+## the language, and one no Banjar reader meets in a classroom.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Lambang kimia kada sah
+chemistry-invalid-ionic-compound = Sanyawa ion kada sah
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = kosong
+
+math-embedded-input-blank-ordinal = kosong { $ordinal } matan { $total }

--- a/packages/i18n/locales/bjn/content.ftl
+++ b/packages/i18n/locales/bjn/content.ftl
@@ -19,7 +19,7 @@
 # `style-stroke` keeps English's internal order of the three adjectives,
 # because that is also Banjar's.
 #
-# **`[noun-tail]` carries the side count.** `noun-regular-polygon` fills `head`
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head`
 # with «poligon baraturan basisi { $numSides }» and leaves `tail` empty, as
 # English does: the count follows the noun here too, so nothing has to be
 # split around the adjectives.

--- a/packages/i18n/locales/bjn/diagnostics.ftl
+++ b/packages/i18n/locales/bjn/diagnostics.ftl
@@ -1,0 +1,670 @@
+# Banjar (Bahasa Banjar) diagnostics: the warnings and errors the worker
+# raises and the reader is shown. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth. Selected by `uiLocale`, not by the language the
+# document was written in.
+#
+# Message ids are never translated — only the text to the right of `=`. Neither
+# are the DoenetML identifiers quoted inside these sentences: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence` and every tag and attribute name like them are part of
+# the language an author writes, not prose, and stay in English exactly as
+# written. So does the `[deprecation]` marker, which is a label rather than a
+# word.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography and register** are `chrome.ftl`'s: Banjar Hulu in the ordinary
+# Indonesian Latin alphabet, three vowels, no diacritics. The technical
+# vocabulary — komponen, atribut, variabel, dimensi, matriks, referensi — is
+# Indonesian and is declared as such: Banjar-speaking schools teach mathematics
+# and computing in Indonesian, and inventing Banjar equivalents would put words
+# in front of a reader that no Banjar reader has met.
+#
+# **What holds this apart from `locales/id`** is the grammatical layer, used
+# without exception: «kada» for *tidak*, «kada kawa» for *tidak dapat*,
+# «kadada» for *tidak ada*, «nang» for *yang*, «gasan» for *untuk*, «matan»
+# for *dari*, «lawan» for *dengan*, «wan» for *dan*, «atawa» for *atau*,
+# «amun» for *jika*, «tagal» for *tetapi*, «lantaran» for *karena*, «katamu»
+# for *ditemukan*, «barataan» for *semua*, «balum» for *belum*, «sabuting» for
+# *sebuah*. A sentence that has slipped back into «tidak», «yang» or «untuk»
+# is a mistake to fix, not a stylistic choice.
+#
+# **No plural branches.** CLDR has no plural data for `bjn`, so every
+# `[one]`/`[other]` fork English writes over a count is collapsed here: most
+# become a plain message, since a Banjar noun is unmarked after a numeral and
+# one form is correct. The one exception is
+# `field-function-wrong-num-outputs`, where English is not counting but
+# distinguishing a one-output field from a two-output one; that fork is kept
+# as the numeric literal `[1]`, which Fluent matches against the number itself
+# rather than against a plural category.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } kada dihiraukan amun dua titik ujung ditantuakan
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } kada dihiraukan amun titik ujung wan titik tangah sama-sama ditantuakan
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset kadada pangaruhnya amun kadada titik tangah
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis malalui titik-titik nang dimensinya kada kawa ditantuakan.
+
+line-points-too-few-dimensions = Garis harus malalui titik-titik nang dimensinya kada kurang matan dua.
+
+line-points-depend-on-variables = Garis malalui titik-titik nang bagantung wan variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis dalam variabel { $variable1 } wan { $variable2 } kada sah.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar ditantuakan sakaligus ulih through, endpoint, wan direction. Through nang ditantuakan kada dihiraukan.
+
+ray-dimension-mismatch = numDimensions di sinar kada cucuk.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ditantuakan sakaligus ulih head, tail, wan displacement. Head nang ditantuakan kada dihiraukan.
+
+vector-dimension-mismatch = numDimensions di vektor kada cucuk.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Kada kawa manarik ka `<{ $component }>` lantaran inya kadada variabel kaadaan nearestPoint.
+
+constrain-to-without-nearest-point = Kada kawa mambatasi ka `<{ $component }>` lantaran inya kadada variabel kaadaan nearestPoint.
+
+constrain-to-interior-without-nearest-point = Kada kawa mambatasi ka bagian dalam `<{ $component }>` lantaran inya kadada variabel kaadaan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition kada dihiraukan gasan choiceInput nang bukan inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indices nang ditantuakan gasan choiceInput kada dihiraukan lantaran jumlah indices kada cucuk lawan jumlah anak choice.
+
+pretzel-indices-count-mismatch = Indices nang ditantuakan gasan problem kada dihiraukan lantaran jumlah indices kada cucuk lawan jumlah anak problem.
+
+shuffle-indices-count-mismatch = Indices nang ditantuakan gasan shuffle kada dihiraukan lantaran jumlah indices kada cucuk lawan jumlah komponen.
+
+indices-ignored-out-of-range = Indices nang ditantuakan gasan { $component } kada dihiraukan lantaran ada indeks nang di luar jangkauan.
+
+pretzel-indices-repeated = Indices nang ditantuakan gasan pretzel kada dihiraukan lantaran ada indeks nang baulang.
+
+pretzel-circuit-first-index = Indices nang ditantuakan gasan pretzel di mode circuit kada dihiraukan lantaran indeks nang partama harus 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Supaya `<{ $component }>` bajalan lawan anak barupa string, atribut `type` harus ditantuakan.
+
+invalid-type-defaulting-to-math = Tipe { $type } kada sah gasan komponen { $component }. Harus salah satu matan math, text, number, atawa boolean. Mamakai math.
+
+string-not-valid-component-to-arrange = String "{ $value }" bukan komponen nang sah gasan { $component }. Kada dihiraukan.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipe { $type } kada sah, tipe disatel ka number.
+
+invalid-variable-value = Nilai variabel kada sah: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } harus barupa bilangan
+
+variant-index-must-be-integer = Indeks varian { $index } harus barupa bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` balum diadaakan gasan ukuran absolut. Lebar diubah jadi relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` balum diadaakan gasan ukuran absolut. Margin diubah jadi relatif.
+
+side-by-side-no-block-child = `<{ $component }>` kada sah: inya harus bapunya paling kada satu anak barupa blok.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` di `<label>` grafis kada dihiraukan.
+
+label-for-must-resolve-to-one = Atribut `for` di `<label>` harus mangarah pas ka satu komponen.
+
+label-for-unresolved = Atribut `for` di `<label>` kada kawa diarahakan ka sabuting komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` di `<label>` marujuk ka `<answer>` nang masukannya ditulis surang; rujuk masukan itu langsung.
+
+label-for-answer-without-input = Atribut `for` di `<label>` marujuk ka `<answer>` nang kadada masukan gasan dilabeli.
+
+label-for-must-reference-input-or-answer = Atribut `for` di `<label>` harus marujuk ka sabuting masukan atawa sabuting jawaban.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Gasan aksesibilitas, `<{ $component }>` harus bapunya katarangan singkat atawa ditandai sabagai dekoratif.
+
+accessibility-video-short-description = Gasan aksesibilitas, `<video>` harus bapunya katarangan singkat.
+
+accessibility-input-short-description-or-label = Gasan aksesibilitas, `<{ $component }>` harus bapunya katarangan singkat atawa label.
+
+accessibility-answer-input-short-description-or-label = Gasan aksesibilitas, sabuting `<answer>` nang maulah masukan harus bapunya katarangan singkat atawa label.
+
+accessibility-short-description-contains-math = Katarangan singkat kada baik mamuat komponen matematika kaya `<{ $component }>`. Tulisakan isi matematikanya lawan kata-kata.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kontrasnya kada cukup gasan teks judul bagian (mode kalam) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mamarluakan paling kada { $threshold }:1).
+       *[other] { $colorName } kontrasnya kada cukup gasan teks judul bagian ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mamarluakan paling kada { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Balum diadaakan `<circle>` malalui { $count } titik amun titik-titiknya kadada nilai numerik.
+
+circle-too-many-through-points = Kada kawa manghitung lingkaran malalui labih matan 3 titik.
+
+circle-overprescribed-radius-center-points = Kada kawa manghitung lingkaran nang jari-jari, pusat, wan titik lintasannya ditantuakan sakaligus.
+
+circle-center-with-multiple-points = Kada kawa manghitung lingkaran lawan pusat tartantu nang malalui labih matan 1 titik.
+
+circle-radius-too-small = Kada kawa manghitung lingkaran: lantaran jarak antara dua titik itu { $distance }, jari-jari { $radius } nang ditantuakan talalu halus.
+
+circle-radius-with-many-points = Kada kawa maulah lingkaran malalui labih matan dua titik lawan jari-jari tartantu.
+
+circle-invalid-center-or-through-points = Pusat atawa titik lintasan lingkaran kada sah.
+
+circle-radius-center-with-multiple-points = Kada kawa manghitung jari-jari lingkaran lawan pusat tartantu nang malalui labih matan 1 titik.
+
+circle-change-radius-non-numerical = Kada kawa maubah jari-jari lingkaran nang titik lintasannya kada numerik
+
+circle-radius-with-points-non-numerical = Kada kawa maulah lingkaran malalui labih matan satu titik lawan jari-jari tartantu amun kadada nilai numerik.
+
+circle-change-center-non-numerical = Balum diadaakan pangubahan pusat lingkaran nang malalui titik-titik kada numerik.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Dimensi domain fungsi kada cukup. Domain bapunya { $intervals } salang tagal fungsi bapunya { $inputs } masukan.
+
+function-domain-invalid-format = Format domain fungsi kada sah.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Maksimum fungsi nang kada numerik kada dihiraukan.
+        [minimum] Minimum fungsi nang kada numerik kada dihiraukan.
+        [extremum] Ekstremum fungsi nang kada numerik kada dihiraukan.
+        [point] Titik fungsi nang kada numerik kada dihiraukan.
+        [slope] Kamiringan fungsi nang kada numerik kada dihiraukan.
+       *[other] { $type } fungsi nang kada numerik kada dihiraukan.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Maksimum fungsi nang kosong kada dihiraukan.
+        [minimum] Minimum fungsi nang kosong kada dihiraukan.
+        [extremum] Ekstremum fungsi nang kosong kada dihiraukan.
+        [point] Titik fungsi nang kosong kada dihiraukan.
+       *[other] { $type } fungsi nang kosong kada dihiraukan.
+    }
+
+function-points-too-close = Fungsi mamuat dua titik nang talalu rapat lataknya. Fungsi kada kawa didefinisiakan.
+
+function-iterates-input-output-mismatch = Iterasi fungsi hanya kawa amun jumlah masukan sama lawan jumlah kaluaran. Fungsi ini bapunya { $inputs } masukan wan { $outputs } kaluaran.
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang barisan kada sah. Harus barupa bilangan bulat kada negatif.
+
+sequence-invalid-step = Langkah barisan kada sah. Harus barupa bilangan gasan barisan batipe { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" di barisan bilangan kada sah. Harus barupa bilangan.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" di barisan huruf kada sah. Harus barupa kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" di barisan kada sah.
+
+select-from-sequence-coprime-not-numbers = coprime kada dihiraukan lantaran nang dipilih bukan bilangan
+
+select-from-sequence-coprime-with-exclude-combinations = coprime kada dihiraukan lantaran excludeCombinations ditantuakan
+
+## Resolving a `target`
+
+target-not-found = Target gasan `<{ $source }>` kada sah: target kada katamu.
+
+target-state-variable-not-found = Target gasan `<{ $source }>` kada sah: kada katamu variabel kaadaan banama "{ $property }" di `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel `<odeSystem>` harus balain matan variabel babas.
+
+ode-system-duplicate-variable-names = Kada kawa mandefinisiakan fungsi ruas kanan ODE lawan nama variabel tarikat nang baulang.
+
+ode-system-rhs-function-error = Kada kawa mandefinisiakan fungsi ruas kanan ODE. Ada kasalahan waktu maulah fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Kada kawa mandefinisiakan sudut antara { $count } garis
+
+angle-invalid-through-point = Ada titik kada sah di through milik `<angle>`
+
+parabola-vertex-too-many-points = Balum diadaakan parabola lawan titik puncak tartantu nang malalui labih matan 1 titik.
+
+parabola-too-many-points = Balum diadaakan parabola malalui labih matan 3 titik.
+
+intersection-too-many-items = Balum diadaakan irisan gasan labih matan dua objek
+
+## Other math components
+
+ionic-compound-not-two-ions = Balum diadaakan sanyawa ion salain gasan dua ion.
+
+ionic-compound-needs-cation-and-anion = Sanyawa ion hanya diadaakan gasan satu kation wan satu anion.
+
+solve-equations-cannot-evaluate = Kada kawa manyalasaiakan persamaan lantaran persamaannya kada kawa dievaluasi: { $equation }
+
+math-operators-operand-number-required = operandNumber harus ditantuakan amun handak maambil sabuting operan matematika.
+
+eigen-decomposition-failed = Kada kawa manghitung nilai eigen matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } kada muncul dalam pola, jadi inya akan salalu cucuk lawan kakosongan.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: kada kawa manafsirakan grid="{ $grid }". Nilainya harus none, medium, dense, atawa dua bilangan positif nang dipisah spasi, misalnya grid="1 0.5". Kisi kada digambar.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` mamarluakan fungsi lawan { $expected ->
+        [1] satu kaluaran, yaitu kamiringan y' di tiap titik, misalnya `y - x`
+       *[other] dua kaluaran, yaitu vektor di tiap titik, misalnya `(y, -x)`
+    }, tagal fungsi nang dibari bapunya { $found ->
+       *[other] { $found } kaluaran
+    }. { $alternative ->
+        [none] Kadada nang digambar.
+       *[other] `<{ $alternative }>` marupakan komponen gasan fungsi macam itu. Kadada nang digambar.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` kada dihiraukan lantaran fungsinya dibari jua di dalam komponen; nang di dalam itu nang dipakai. Bari fungsinya lawan salah satu cara haja.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` manyambat variabel matan ungkapan nang ditulis langsung di dalam komponen. { $reason ->
+        [function-child] Fungsi di sini dibari sabagai anak `<function>`, nang manyambat variabelnya surang, jadi `variables` kada dihiraukan.
+       *[no-expression] Kadada ungkapan macam itu di sini, jadi `variables` kada dihiraukan.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" kada didukung di perender prefigure; mamakai parilaku posisi kanan.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" kada didukung di perender prefigure; mamakai parilaku posisi atas.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbu kada sah gasan konversi prefigure; mamakai bbox bawaan (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lebar kada sah gasan konversi prefigure; mamakai lebar diagram bawaan 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio kada sah gasan konversi prefigure; mamakai rasio aspek bawaan 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jarak kisi talalu rapat gasan batas sumbunya; kisi dihilangakan di perender prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi kada akan digambar amun perender PreFigure kada dipakai.
+
+multiple-annotations-children = Katamu babarapa anak `<annotations>` di dalam `<graph>`; barataan kada dihiraukan kacuali nang pahabisan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Kada kawa mamperluas atawa manyalin tipe komponen nang kada takanal: { $type }.
+
+copy-prop-not-found = Kada katamu prop { $property } di komponen batipe { $component }
+
+collect-no-source = Kadada sumber nang katamu gasan collect.
+
+collect-invalid-component-type = Kada kawa mangumpulakan komponen batipe `<{ $component }>` lantaran itu bukan tipe komponen nang sah.
+
+reference-index-unavailable = Kada kawa marujuk indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Kada kawa mamanggil { $action } di komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bantuk data kada sah. Panjang baris kada sama. Katamu di componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data bapunya nama kolom nang baulang. Katamu di componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data kahilangan sabuting nama kolom. Katamu di componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Sabuting award gasan jawaban ini badasar di jawaban nang dikirim ulih tag answer itu surang, nang akan maulah parilaku nang kada disangka.
+
+answer-max-num-attempts-in-section-wide-check-work = Manyatel `maxNumAttempts` di `<answer>` nang ada di dalam wadah nang bapunya `sectionWideCheckWork` kadada pangaruhnya, lantaran jumlah cuba dikandalikan ulih wadah itu. Satel `maxNumAttempts` di wadahnya.
+
+nested-section-wide-check-work-max-num-attempts = Manyatel `maxNumAttempts` di wadah nang bapunya `sectionWideCheckWork` nang ada di dalam wadah lain nang bapunya `sectionWideCheckWork` kadada pangaruhnya, lantaran jumlah cuba dikandalikan ulih wadah nang paling luar. Satel `maxNumAttempts` di wadah nang paling luar.
+
+answer-attributes-need-symbolic-equality = Atribut { $attributes } kadada pangaruhnya amun symbolicEquality kada disatel.
+
+answer-invalid-type = Tipe gasan answer kada sah: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Lantaran komponen `<{ $component }>` kadada nama, inya kada kawa dipakai sabagai atribut modul
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` kada kawa dipakai sabagai atribut sabuting modul lantaran tipe komponen `<module>` sudah bapunya atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` kada dihiraukan di komponen `<conditionalContent>` nang bapunya anak case atawa else.
+
+slider-markers-type-mismatch = Tipe pananda kada cucuk lawan tipe panggeser.
+
+pretzel-problem-needs-statement-and-answer = Pretzel kada sah: satiap `<problem>` harus mamuat satu `<statement>` wan satu `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel kada sah: di mode="circuit", `<problem>` nang partama kada bulih barupa pangicuh.
+
+## Attribute values
+
+attribute-invalid-values = Nilai { $values } gasan atribut `{ $attribute }` kada sah; kada dihiraukan.
+
+attribute-must-be-references = Nilai `{ $value }` gasan atribut `{ $attribute }` kada sah. Atribut harus tasusun matan referensi nang diawali `$`.
+
+math-input-invalid-function-names = <mathInput>: nama fungsi nang kada sah di { $attribute } kada dihiraukan: { $names }. Bagian tampilan tiap nama harus paling kada 2 karakter (huruf atawa tanda hubung); kawa diikuti akhiran pilihan `|<alternatif mathspeak>`.
+
+## Building components from the source
+
+component-type-invalid = Tipe komponen kada sah: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } kada kawa diulang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" kada sah gasan komponen batipe `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definisi gaya { $styleNumber } kontrasnya kada cukup gasan { $context ->
+        [text-on-background] warna teks tarhadap warna latar
+        [high-contrast] warna kontras tinggi tarhadap kanvas
+        [line] warna garis tarhadap kanvas
+        [marker] warna pananda tarhadap kanvas
+       *[text-on-canvas] warna teks tarhadap kanvas
+    }{ $mode ->
+        [dark] { " (mode kalam)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mamarluakan paling kada { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Walaupun definisi gaya { $styleNumber } manantuakan warna nang kontrasnya cukup gasan mode tarang, warna mode kalam nang diturunakan matan nilai-nilai itu kontrasnya kada cukup antara warna teks wan warna latar ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mamarluakan paling kada { $threshold }:1). { $suggestion ->
+        [available] Supaya kontrasnya cukup di mode kalam, tinggiakan kontras mode tarang (misalnya satel { $lightAttribute }="{ $lightColor }") atawa timpa warna mode kalam (misalnya satel { $darkAttribute }="{ $darkColor }").
+       *[none] Supaya kontrasnya cukup di mode kalam, tinggiakan kontras mode tarang atawa timpa warna turunannya lawan textColorDarkMode wan/atawa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Walaupun definisi gaya { $styleNumber } manantuakan warna teks nang kontrasnya cukup gasan mode tarang, warna teks mode kalam nang diturunakan matan nilai itu kontrasnya kada cukup tarhadap kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mamarluakan paling kada { $threshold }:1). { $suggestion ->
+        [available] Supaya kontrasnya cukup di mode kalam, tinggiakan kontras mode tarang (misalnya satel textColor="{ $lightColor }") atawa timpa warna mode kalam (misalnya satel textColorDarkMode="{ $darkColor }").
+       *[none] Supaya kontrasnya cukup di mode kalam, tinggiakan kontras mode tarang atawa timpa warna turunannya lawan textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Sabuting bagian hanya kawa mamilih satu <stylePalette>; mamakai nang pahabisan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = kada kawa manantuakan varian unik matan { $component } lantaran numToSelect bukan bilangan bulat kada negatif.
+
+variant-num-to-select-not-constant-number = kada kawa manantuakan varian unik matan { $component } lantaran numToSelect bukan bilangan nang tatap.
+
+variant-with-replacement-not-constant-boolean = kada kawa manantuakan varian unik matan { $component } lantaran withReplacement bukan boolean nang tatap.
+
+variant-select-weight-disables-unique = Varian unik gasan select dimatiakan amun ada opsi nang manantuakan selectWeight atawa selectForVariants
+
+variant-coprime-undetermined = kada kawa manantuakan varian unik matan { $component } lantaran kada kawa dipastiakan coprime salalu salah.
+
+variant-attribute-not-constant = kada kawa manantuakan varian unik matan { $component } lantaran { $attribute } bukan nilai nang tatap.
+
+variant-attribute-not-number = kada kawa manantuakan varian unik matan { $component } lantaran { $attribute } bukan bilangan.
+
+variant-attribute-wrong-type-for-sequence =
+    kada kawa manantuakan varian unik matan { $component } batipe { $type } lantaran { $attribute } bukan { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ungkapan matematika nang sah
+        [integer] bilangan bulat
+       *[number] bilangan
+    }.
+
+variant-length-not-integer = kada kawa manantuakan varian unik matan { $component } lantaran length bukan bilangan bulat.
+
+variant-sort-not-implemented = balum diadaakan varian unik matan { $component } lawan sort
+
+variant-exclude-combinations-not-implemented = balum diadaakan varian unik matan { $component } lawan excludeCombinations
+
+variant-math-exclude-not-implemented = balum diadaakan varian unik matan { $component } batipe math lawan exclude
+
+variant-non-constant-exclude-not-implemented = balum diadaakan varian unik matan { $component } lawan exclude nang kada tatap
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: kada didukung di perender prefigure grafik; turunan dilewati.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri kada hingga atawa kada langkap; turunan dilewati.
+
+prefigure-curve-label-omitted = { $subject }: label kada didukung di elemen kurva hasil konversi; label dihilangakan.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipe definisi fungsi kurva '{ $definitionType }' kada didukung; turunan dilewati.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions di regionBetweenCurves kada didukung; turunan dilewati.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves hanya mandukung fungsi anak batipe formula; turunan dilewati.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' kada didukung gasan { $labelKind ->
+        [line-family] label kaluarga garis
+       *[point] label titik
+    }; mamakai parataan bawaan PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isian '{ $fillStyle }' kada didukung ulih PreFigure; baalih ka isian padat.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' kada takanal wan dihilangakan matan kaluaran PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya pananda '{ $markerStyle }' dipetaakan ka gaya 'diamond' milik PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya pananda '{ $markerStyle }' kada didukung ulih PreFigure; mamakai gaya bawaan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` kada sah; target kada kawa diarahakan. Anotasi dihilangakan.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` mangarah ka babarapa target; mamakai target nang partama.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` kada sah; target ada di luar grafik nang mamuatnya. Anotasi dihilangakan.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` kada sah; target bukan objek grafis nang didukung dalam konversi prefigure. Anotasi dihilangakan.
+
+annotation-text-missing = `<annotation>`: `text` hilang atawa kosong; maulah teks kosong.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Katamu katagantungan malingkar.
+       *[other] Katamu katagantungan malingkar nang malibatakan komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Kadada acuan nang katamu gasan referensi: `{ $reference }`
+
+reference-multiple-referents = Katamu babarapa acuan gasan referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } di `<{ $componentType }>` kada sah.
+
+children-invalid = Anak `<{ $componentType }>` kada sah: katamu anak nang kada sah: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` gasan atribut `{ $attribute }` kada sah, mamakai nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML versi { $version } kada katamu.
+       *[other] DoenetML versi { $version } kada katamu. Baulih ka versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML kada sah: { $content }
+
+parse-tag-missing-close-tag = DoenetML kada sah: Tag `{ $tag }` kadada tag panutup. Diharap ada tag nang manutup surang atawa tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML kada sah: Ada kasalahan di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML kada sah: Atribut `{ $attribute }` kaya kahilangan nilai.
+
+parse-attribute-invalid = DoenetML kada sah: Atribut `{ $attribute }` kada sah
+
+parse-attribute-value-invalid = DoenetML kada sah: Nilai atribut `{ $value }` kada sah
+
+parse-attribute-value-quote-mismatch = DoenetML kada sah: Nilai atribut `{ $value }` kada sah. Tanda kutipnya kada cucuk. Pian kaya kahilangan sabuting `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML kada sah: Katamu tag nang kadada nama tag, misalnya `<`
+
+parse-tag-not-closed = DoenetML kada sah: Tag `{ $tag }` balum ditutup (kaya `>` nang hilang).
+
+parse-self-closing-tag-name-missing = DoenetML kada sah: Katamu tag nang kadada nama tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML kada sah: Tag `{ $tag }` balum ditutup (kaya `/>` nang hilang).
+
+parse-tag-invalid-attributes = DoenetML kada sah: Tag `{ $tag }` kada sah. Atributnya mungkin salah.
+
+parse-close-tag-name-missing = DoenetML kada sah: Katamu tag panutup nang kadada nama tag, misalnya `</`
+
+parse-attribute-value-unquoted = Nilai atribut harus diapit tanda kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML kada sah: Katamu tag panutup `{ $tag }`, tagal kadada tag pambuka nang cucuk
+
+parse-close-tag-mismatched = DoenetML kada sah: Tag panutup kada cucuk. Diharap `</{ $expected }>`. Katamu `{ $found }`
+
+parser-node-unconvertible = Kada kawa maubah simpul { $node } jadi simpul Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' kada sah. { $reason ->
+        [characters] Nama hanya kawa mamuat huruf, angka, garis bawah, atawa tanda hubung.
+       *[start] Nama harus diawali lawan huruf.
+    }
+
+component-name-invalid-start = Nama komponen "{ $name }" kada sah. Nama harus diawali lawan huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer batipe videoWatched harus bapunya atribut video
+
+answer-video-watched-video-not-reference = Answer batipe videoWatched harus bapunya atribut video nang barupa referensi
+
+answer-name-not-single-text = Atribut name di answer harus bapunya pas satu anak barupa teks
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Kada kawa maambil DoenetML luar lantaran talalu banyak tingkat rekursi. Adakah referensi nang malingkar?
+
+external-doenetml-unavailable = Kada kawa maambil DoenetML matan { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML nang diambil matan { $attribute }="{ $uri }" kada sah: inya kada cucuk lawan tipe komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` sudah usang; pakai `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` di `<{ $component }>` sudah usang; pakai `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` sudah usang wan kada dihiraukan lantaran `{ $to }` ditantuakan jua.
+       *[other] [deprecation] Atribut `{ $from }` di `<{ $component }>` sudah usang wan kada dihiraukan lantaran `{ $to }` ditantuakan jua.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` di `<{ $component }>` sudah usang wan kada dihiraukan.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` di `<{ $component }>` sudah usang; pakai anak `<{ $child }>` haja.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` matan atribut `{ $attribute }` di `<{ $component }>` sudah usang; pakai `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` hanya kawa manjamakakan bahasa Inggris, jadi teksnya dibiarakan apa adanya di dokumen nang ditulis dalam { $locale }. Tulisakan bantuk jamaknya langsung, atawa satel lawan atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` bukan elemen Doenet nang takanal.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` kada dibulihakan di akar dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` kada dibulihakan di dalam `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` kadada atribut banama `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` di elemen `<{ $tag }>` harus barupa daftar nang tiap isiannya salah satu matan: { $allowed }
+       *[other] Atribut `{ $attribute }` di elemen `<{ $tag }>` harus salah satu matan: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nama varian gasan select kada sah. Nama varian { $variantName } muncul di { $numOptions } opsi tagal jumlah nang dipilih { $numToSelect }.
+
+select-variant-name-without-options = Ada varian nang ditantuakan gasan select tagal kadada opsi gasan nama varian nang mungkin: { $variantName }.
+
+select-variant-name-not-possible = Nama varian { $variantName } nang ditantuakan gasan select bukan nama varian nang mungkin.
+
+select-too-few-options = Kada kawa mamilih { $numToSelect } komponen matan hanya { $numOptions }.
+
+select-from-sequence-too-few-values = Kada kawa mamilih { $numToSelect } nilai matan barisan sapanjang { $length }.
+
+select-from-sequence-indices-count-mismatch = Jumlah indeks nang ditantuakan gasan select harus sama lawan jumlah nang dipilih
+
+select-from-sequence-indices-not-integers = Barataan indeks nang ditantuakan gasan select harus barupa bilangan bulat
+
+select-from-sequence-index-excluded = Indeks nang ditantuakan gasan selectfromsequence tamasuk nang dikacualiakan
+
+select-from-sequence-indices-excluded-combination = Indeks nang ditantuakan gasan selectfromsequence maulah kombinasi nang dikacualiakan
+
+select-from-sequence-coprime-not-positive-integers = Kada kawa mamilih kombinasi saling prima lantaran nang dipilih bukan bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Kada kawa mamilih bilangan nang saling prima. Barataan nilai nang mungkin bapunya faktor pasakutuan. (Nilai "from" atawa "to" nang ditantuakan harus saling prima lawan "step".)
+
+select-from-sequence-coprime-single-number = Kada kawa mamilih kombinasi saling prima matan sabuting bilangan tunggal nang bukan 1.
+
+select-from-sequence-excluded-too-many-combinations = Labih matan 70% kombinasi dikacualiakan di selectFromSequence
+
+select-from-sequence-coprime-none-found = Kada baisi mamilih bilangan nang saling prima. Barataan nilai nang mungkin bapunya faktor pasakutuan.
+
+select-from-sequence-too-few-unique-values = Kada kawa mamilih { $numToSelect } nilai nang balain matan barisan sapanjang { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Kada kawa mamilih { $numToSelect } nilai matan daftar bilangan prima sapanjang { $numValues }
+
+select-prime-numbers-values-count-mismatch = Jumlah nilai nang ditantuakan gasan select harus sama lawan jumlah nang dipilih
+
+select-prime-numbers-values-not-prime = Barataan nilai nang ditantuakan gasan select prime number harus ada di daftar bilangan prima
+
+select-prime-numbers-values-excluded-combination = Nilai nang ditantuakan gasan selectPrimeNumbers maulah kombinasi nang dikacualiakan
+
+select-prime-numbers-excluded-too-many-combinations = Labih matan 70% kombinasi dikacualiakan di selectPrimeNumbers
+
+select-random-combination-fluke = Lantaran kabatulan nang amat langka, kombinasi nilai acak kada baisi dipilih
+
+select-random-value-fluke = Lantaran kabatulan nang amat langka, nilai acak kada baisi dipilih
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` ini kada ditampaiakan lantaran inya ada di dalam matematika tagal kada `inline`. Tambahakan `inline` supaya inya jadi daftar turun, nang muat di dalam ungkapan.
+        [expanded] `<{ $component }>` ini kada ditampaiakan lantaran inya ada di dalam matematika wan `expanded`. Hapus `expanded`; kutak babaris banyak kada muat di dalam ungkapan.
+        [on-graph] `<{ $component }>` ini kada ditampaiakan lantaran inya ada di dalam matematika nang digambar di grafik, nang kadada ruang gasan masukan.
+       *[relative-width] `<{ $component }>` ini kada ditampaiakan lantaran inya ada di dalam matematika wan lebarnya relatif. Bari lebarnya dalam satuan absolut, misalnya `px`.
+    }

--- a/packages/i18n/locales/bjn/editor.ftl
+++ b/packages/i18n/locales/bjn/editor.ftl
@@ -1,0 +1,226 @@
+# Banjar (Bahasa Banjar) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography and register** are `chrome.ftl`'s: Banjar Hulu in the ordinary
+# Indonesian Latin alphabet, with an Indonesian technical vocabulary declared
+# as such and a Banjar everyday layer — «kada», «kada kawa», «nang», «gasan»,
+# «matan», «lawan», «amun», «katamu», «barataan» — that is what makes this
+# catalog Banjar rather than Indonesian.
+#
+# **`WCAG`, `DoenetML`, `styleNumber` and every attribute and element name
+# stay in English**, as they do in every catalog: they are identifiers an
+# author types, not words.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `bjn`, so an English-selected
+# branch would be worse than none, and Banjar leaves the noun unmarked after a
+# numeral in any case.
+#
+# **`help-name-summary` is punctuation.** It is rendered with `{ $name }`
+# empty for a suggestion the panel has already named, so the em dash and its
+# spaces have to read on their own; that is why it is not rewritten as a
+# sentence.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Balikakan
+       *[update] Barui
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Panampil
+       *[other] { $word } Panampil { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+
+editor-variant-filter = Saring...
+
+editor-variant-next = Pilih varian barikutnya
+
+editor-variant-previous = Pilih varian sabalumnya
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Katamu palanggaran aksesibilitas WCAG AA. Klik gasan { $action ->
+            [close] manutup
+           *[open] mambuka
+        } laporan aksesibilitas.
+        [advisories] Klik gasan { $action ->
+            [close] manutup
+           *[open] mambuka
+        } laporan aksesibilitas. Kadada palanggaran WCAG AA nang katamu, tagal ada saran aksesibilitas nang lain.
+       *[clean] Klik gasan { $action ->
+            [close] manutup
+           *[open] mambuka
+        } laporan aksesibilitas. Kadada masalah aksesibilitas nang katamu.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Katamu palanggaran aksesibilitas WCAG AA. Katamu { $count ->
+           *[other] { $count } palanggaran WCAG AA
+        }. Klik gasan { $action ->
+            [close] manutup
+           *[open] mambuka
+        } laporan aksesibilitas.
+        [advisories] Kadada palanggaran WCAG AA nang katamu. Katamu { $count ->
+           *[other] { $count } saran aksesibilitas tambahan
+        }. Klik gasan { $action ->
+            [close] manutup
+           *[open] mambuka
+        } laporan aksesibilitas.
+       *[clean] Kadada palanggaran WCAG AA nang katamu. Klik gasan { $action ->
+            [close] manutup
+           *[open] mambuka
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Batuan sasuai kunteks
+editor-tab-help-short = Kunteks
+editor-tab-errors = Kasalahan
+editor-tab-warnings = Paringatan
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Jawaban nang tapadi
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan panyunting
+editor-format-as-doenetml = Ator sabagai DoenetML
+editor-format-as-xml = Ator sabagai XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Kadada kasalahan
+editor-no-warnings = Kadada paringatan
+editor-no-info = Kadada diagnostik info
+
+editor-show-info-annotations = Tampaiakan diagnostik info di panyunting
+editor-show-accessibility-annotations = Tampaiakan diagnostik aksesibilitas di panyunting
+
+editor-accessibility-learn-more = Pelajari kayapa Doenet manggarap aksesibilitas
+
+editor-accessibility-violations-heading = Palanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masalah aksesibilitas nang lain
+editor-none-found = Kadada nang katamu
+
+
+## Submitted responses
+
+editor-no-responses = Balum ada jawaban nang tapadi
+editor-response-answer-id = Id jawaban
+editor-response-response = Jawaban
+editor-response-credit = Nilai
+editor-response-submitted = Tapadi
+
+
+## The context-help panel
+
+help-placeholder = Andakakan kursor di nama tag, atribut, atawa { $ref } gasan dokumentasi.
+
+help-unsupported-ref-chain = Batuan gasan referensi babagian kaya { $example } balum didukung.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Kadada acuan nang katamu gasan referensi: { $ref }.
+        [multiple] Katamu babarapa acuan gasan referensi: { $ref }.
+       *[indeterminate] Acuan gasan { $ref } kada kawa ditantuakan.
+    }
+
+help-learn-about-references = Pelajari pasal referensi →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Di dalam { $element }
+       *[top] Di tingkat paling luar
+    }{ $allowed ->
+        [none] { " — kadada nang muat di sini." }
+        [text] { " — tulis teks di sini." }
+        [text-and-components] { " — tulis teks di sini, atawa cuba:" }
+       *[components] { " — nang kawa dicuba:" }
+    }
+
+help-suggestions-footer = Tikan { $shortcut } gasan malihat barataan { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } marupakan referensi ka { $target }.
+       *[other] { $ref } marupakan referensi ka { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Diadaakan ulih { $owner } sabagai { $role }.
+       *[other] Diadaakan ulih { $owner } di baris { $line } sabagai { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } marupakan referensi ka properti { $property } milik { $element }.
+       *[other] { $ref } marupakan referensi ka properti { $property } milik { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = potongan
+help-kind-array-entry = isian larik
+
+help-default = Bawaan:
+help-active-default = Bawaan nang bajalan:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai nang dibulihakan (satu gasan tiap item):
+       *[other] Nilai nang dibulihakan:
+    }
+
+help-suggested-values = Nilai nang disaranakan:
+
+help-inserts = Manyisipakan:
+
+help-coordinates =
+    { $count ->
+       *[other] Kuurdinat:
+    }
+
+help-type = Tipe:
+
+help-resolved-style = Gaya nang tatantu (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nama fungsi nang tatantu:
+help-reset-list = Daftar nang diulang di masukan ini:
+help-added-on-input = Ditambah di masukan ini:
+help-removed-on-input = Dihapus di masukan ini:
+
+help-reset-overrides = { $reset } manimpa { $additional } wan { $removed }.

--- a/packages/i18n/locales/bug/chrome.ftl
+++ b/packages/i18n/locales/bug/chrome.ftl
@@ -1,0 +1,194 @@
+# Buginese (Basa Ugi) viewer chrome. Translated from `locales/en/chrome.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, not Lontara.** Buginese has its own historic script,
+# Lontara (ᨒᨚᨊᨈᨑ), and a reviewer may reasonably have expected it. This catalog
+# writes **Latin**, for two reasons and neither of them a judgement about which
+# script is the language's own. The first is that Latin is what Buginese is
+# actually written in today in print, in newspapers, in schoolbooks and online,
+# so it is the form a Buginese reader will read fastest. The second is
+# structural: Lontara does not write the final glottal stop, the geminate
+# consonants or the syllable-final nasal, so a Lontara catalog would spell
+# «de'» and «dé», «wedding» and «weding» identically, and a reviewer could not
+# tell a correction from a typo. Converting this catalog to Lontara means
+# converting **all four files at once**, and it is a conversion rather than a
+# transliteration, because the missing distinctions have to be supplied by
+# someone who knows the words.
+#
+# **The glottal stop is written with the ASCII apostrophe `'` (U+0027)**,
+# everywhere in all four files — «de'», «macella'», «tetti'», «soala'». The
+# typographic apostrophe U+2019 is not used anywhere, so a search for `'` finds
+# every one of them. `é` is written with an acute accent where the seed is
+# confident of the vowel and left as plain `e` where it is not; that
+# inconsistency is a limit of the seed rather than a spelling rule, and a
+# speaker should regularize it in one pass.
+#
+# **The technical register is Indonesian, and it is declared rather than
+# disguised.** Buginese speakers are schooled in Indonesian, and the words for
+# a component, an attribute, a matrix, a percentage or a keyboard are the
+# Indonesian ones because those are the words the community uses. They are
+# written here as Indonesian, not respelled into a Buginese shape the language
+# does not give them.
+#
+# **What is Buginese here is the frame**, and it is used consistently: «de'»
+# for *tidak* and «de'gaga» for *tidak ada*, «wedding» for *dapat* (so *cannot*
+# is «de' nawedding»), «sibawa» for *dengan*, «na» for *dan*, «iyaré'ga» for
+# *atau*, «nasaba» for *karena*, «rékko» for *jika*, «naé» for *tetapi*,
+# «pole ri» for *dari*, «untu'» for *untuk*, «ri» for *di*, «maneng» for
+# *semua*, «tungke'» for *tiap*, «de'pa» for *belum*, «pura» for *sudah*,
+# «riruntu'» for *ditemukan*, «paimeng» for *lagi*, and «idi'» as the polite
+# second person. Content words that are Buginese rather than Indonesian —
+# «tongeng», «sala», «pappébali», «pakkutana», «tetti'», «tanrang»,
+# «gambara'», «jama-jamang», «riolo», «rimonri» — are used wherever the seed
+# is confident of them.
+#
+# **The definite suffix `-é` is not written.** Buginese marks a definite noun
+# with `-é`, whose shape depends on the last sound of the word it attaches to,
+# and several of these messages end in a placeable the catalog never sees. So
+# the seed writes every noun bare rather than welding a suffix onto a value.
+# That reads as indefinite throughout, which is a real cost; a speaker adding
+# the suffix should add it only where the word is one the catalog writes out.
+#
+# **Counts.** CLDR has no plural data for `bug`, so `Intl.PluralRules` would
+# resolve it against the runtime's own locale and any `[one]` branch would be
+# selected by English's rules. The two counted messages here collapse to a
+# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
+# Fluent matches against the number itself. A Buginese noun is unmarked after a
+# numeral anyway, so one form is correct.
+
+
+## Answer submission — the check-work button and the status it reports.
+
+answer-checking = Riparessa...
+answer-submitting = Rikiring...
+
+answer-checking-status = Paressa pappébali
+answer-submitting-status = Kiring pappébali
+
+answer-correct = Tongeng
+answer-incorrect = Sala
+
+answer-response-saved = Pappébali pura ritaro
+
+answer-percent-credit = Nilai { $percent }%
+answer-percent-correct = { $percent }% tongeng
+answer-percent-short = { $percent } %
+
+max-credit-available = Nilai kaminang battoa iya weddingngé riala: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] de'gaga na cobana iya masesaé
+       *[other] masesa { $count } cobana
+    }
+
+validation-correct = (Tongeng)
+validation-incorrect = (Sala)
+validation-partially-correct = (Sibagéang tongeng)
+
+answer-show-responses = Paitangngi { $count } pappébali untu' { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Pappébali balé
+
+collapsible-click-to-open = (klik untu' timpa')
+collapsible-click-to-close = (klik untu' tutu')
+
+collapsible-initializing = Rispakkang...
+
+footnote-show = Paitangngi catatang yawa
+footnote-hide = Subbui catatang yawa
+
+description-more-information = keterangan lebbi maéga
+
+
+## Controls
+
+slider-previous = Riolo
+slider-next = Rimonri
+
+keyboard-open = Timpa' papan tikkeng
+keyboard-close = Tutu' papan tikkeng
+
+choice-input-remove-choice = Abbéangngi { $choice }
+
+matrix-remove-row = Abbéangngi baris
+matrix-add-row = Tambai baris
+matrix-remove-column = Abbéangngi kolom
+matrix-add-column = Tambai kolom
+
+subset-add-remove-points = Tamba/Abbéang tetti'
+subset-toggle-points-intervals = Sélléi tetti' sibawa selang
+subset-move-points = Léttéi tetti'
+subset-clear = Paccingngi
+
+orbital-add-row = Tambai baris
+orbital-remove-row = Abbéangngi baris
+orbital-add-box = Tambai kotak
+orbital-remove-box = Abbéangngi kotak
+orbital-add-up-arrow = Tambai pana liyasé
+orbital-add-down-arrow = Tambai pana liyawa
+orbital-remove-arrow = Abbéangngi pana
+
+orbital-row-label = Label untu' baris { $row }
+
+pretzel-answer = Pappébali
+
+summary-statistics-caption = Ringkasan statistik pole ri { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ungkapan matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ungkapan de' nasah:
+
+
+## Document status
+
+viewer-initializing = Rispakkang...
+
+
+## Errors
+
+error-heading = Asalang
+
+error-found-at =
+    { $span ->
+        [line] Riruntu' ri baris { $startLine }.
+       *[lines] Riruntu' ri baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen iyaé engka asalanna!
+
+diagnostic-heading-error = Asalang
+diagnostic-heading-warning = Papparingerrang
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Petunju'
+
+accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Papparingerrang aksesibilitas
+
+something-went-wrong = Engka iya salaé.
+
+renderer-load-failed = séddi perender de' nawedding riala. Taassuroi paimeng halaman iyaé.
+
+core-start-failed = Dokumen iyaé de' nawedding ripaompo. Taassuroi paimeng halaman iyaé.
+
+core-start-failed-busy = Dokumen iyaé de' nawedding ripaompo. Engka maéga dokumen iya mappammulaé massidi, iya weddingngé lebbi maitta ri alat malamma. Taassuroi paimeng halaman iyaé rékko pura maneng dokumen laingngé.
+
+core-start-failed-retry = Dokumen iyaé de' nawedding ripaompo.
+
+core-start-failed-busy-retry = Dokumen iyaé de' nawedding ripaompo. Engka maéga dokumen iya mappammulaé massidi, iya weddingngé lebbi maitta ri alat malamma.
+
+core-start-retry = Coba paimeng
+
+saved-state-unavailable = Jama-jamang idi' iya puraé ritaro de' nawedding riala.

--- a/packages/i18n/locales/bug/chrome.ftl
+++ b/packages/i18n/locales/bug/chrome.ftl
@@ -48,12 +48,16 @@
 # «gambara'», «jama-jamang», «riolo», «rimonri» — are used wherever the seed
 # is confident of them.
 #
-# **The definite suffix `-é` is not written.** Buginese marks a definite noun
-# with `-é`, whose shape depends on the last sound of the word it attaches to,
-# and several of these messages end in a placeable the catalog never sees. So
-# the seed writes every noun bare rather than welding a suffix onto a value.
-# That reads as indefinite throughout, which is a real cost; a speaker adding
-# the suffix should add it only where the word is one the catalog writes out.
+# **The definite suffix `-é` is not written on the nouns these messages name.**
+# Buginese marks a definite noun with `-é`, whose shape depends on the last
+# sound of the word it attaches to, and several of these messages end in a
+# placeable the catalog never sees. So the seed leaves the nouns bare —
+# `content.ftl`'s whole `noun` table is citation forms — rather than welding a
+# suffix onto a value. The enclitic does appear where it closes a relative
+# clause the catalog writes out in full («iya riruntu'é», «iya weddingngé»),
+# which is a different job and carries no placeable. The nouns themselves read
+# as indefinite throughout, which is a real cost; a speaker adding the suffix
+# should add it only where the word is one the catalog writes out.
 #
 # **Counts.** CLDR has no plural data for `bug`, so `Intl.PluralRules` would
 # resolve it against the runtime's own locale and any `[one]` branch would be

--- a/packages/i18n/locales/bug/content.ftl
+++ b/packages/i18n/locales/bug/content.ftl
@@ -1,0 +1,290 @@
+# Buginese (Basa Ugi) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, not Lontara**, for the reasons `chrome.ftl`'s header sets
+# out in full — Latin is what Buginese is printed in today, and Lontara does
+# not write the final glottal stop, the geminates or the syllable-final nasal,
+# so a Lontara seed could not be checked word against word. The final glottal
+# stop is the **ASCII apostrophe `'` (U+0027)** here as in every other file of
+# this catalog; U+2019 appears nowhere.
+#
+# ## Word order
+#
+# **The noun comes first and every modifier follows it**, in the order width,
+# dash pattern, colour: «garis tebal pettu-pettu macella'» is *thick dashed red
+# line*. So `style-with-noun` and `style-filled-with-noun` put `{ $noun }`
+# before `{ $description }` — the reverse of English's sequence of placeables,
+# and a fact about Buginese rather than a failure to translate. `style-stroke`
+# keeps English's internal order of the three adjectives, because that is
+# Buginese's order too.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «poligon biasa iya { $numSides } sisina» and leaves `tail` empty, as English
+# does: the side count follows the noun here as well, so nothing has to be
+# split around the adjectives.
+#
+# ## Gender, role and number
+#
+# **No `$gender` fork and no `$role` fork.** Buginese has no grammatical
+# gender, so `noun-gender` answers the single token `neuter` and no adjective
+# selects on it. Nor does it inflect a modifier for the position its phrase is
+# going into, so the three clause positions are written identically. Both are
+# claims about the language rather than gaps in the seed.
+#
+# **Nothing selects on a count.** A Buginese noun is unmarked after a numeral,
+# and CLDR has no plural data for `bug` in any case.
+#
+# ## Vocabulary, and what this file does not know
+#
+# The geometry words are **Indonesian, declared as such**: Buginese-speaking
+# schools teach mathematics in Indonesian, and «segitiga», «persegi panjang»,
+# «lingkaran», «poligon», «vektor» and «fungsi» are the words a Buginese
+# student has met. Where Buginese has its own word the seed is confident of,
+# it is used: «tetti'» for a point or a dot, «tanrang» for a mark, «katupa'»
+# for the rhombus, «gambara'» for a figure, «tongeng» and «sala» for true and
+# false, «pakkutana» for a question, «pappébali» for an answer, «jama-jamang»
+# for a task, «butti» for a proof, «akkatta» for an aim, «rékko» for *if*,
+# «iyaré'ga» for *or*.
+#
+# **The colours are the weakest part of this file and a reviewer should start
+# there.** Five are Buginese — «malotong», «mapute», «macella'», «maridi»,
+# «makudara» — and the other seven are written as plain Indonesian loans
+# («abu-abu», «oranye», «sian», «biru», «ungu», «merah muda», «coklat»)
+# because the seed has no Buginese term for them that it trusts. Nothing was
+# invented to fill the gap. The same is true of `line-width`: «tebal» and
+# «tipis» are Indonesian, written as loans rather than as a guess at a
+# Buginese adjective.
+
+
+## Style vocabulary
+
+color =
+    .black = malotong
+    .white = mapute
+    .gray = abu-abu
+    .red = macella'
+    .orange = oranye
+    .yellow = maridi
+    .green = makudara
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = merah muda
+    .brown = coklat
+
+line-width =
+    .thick = tebal
+    .thin = tipis
+
+line-style =
+    .dashed = pettu-pettu
+    .dotted = tetti'-tetti'
+
+fill-style =
+    .horizontal = garis maléwa
+    .vertical = garis tettong
+    .diagonal = garis miring
+    .backdiagonal = garis miring tabbalé'
+    .dots = tetti'
+    .diamonds = katupa'
+
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = kurva
+    .function = fungsi
+    .slope-field = medan kemiringan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis pettu
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = persegi panjang
+    .circle = lingkaran
+    .region = daéra
+    .point = tetti'
+    .square = persegi
+    .diamond = katupa'
+    .cross = tanrang silang
+    .plus = tanrang tamba
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon biasa iya { $numSides } sisina
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = malise'
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } sibawa { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } sibawa { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } sibawa { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] sibawa batas { $border }
+        [and] na batas { $border }
+        [and-article] na batas { $border }
+       *[with] sibawa batas { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = de' namalise'
+
+style-text =
+    { $parts ->
+        [background] { $color } sibawa latar { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = de'gaga
+
+
+## Boolean words
+
+boolean-true = tongeng
+boolean-false = sala
+
+
+## Answer buttons
+
+answer-submit-label = Paressai
+answer-submit-label-no-correctness = Kiringngi pappébali
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kegiatan
+    .aside = Sisipan
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Conto
+    .exercise = Latihang
+    .exercises = Latihang
+    .given-answer = Pappébali
+    .note = Catatang
+    .objectives = Akkatta
+    .paragraphs = Paragraf
+    .part = Bagiang
+    .problem = Soala'
+    .problems = Soala'
+    .proof = Butti
+    .question = Pakkutana
+    .section = Bab
+    .solution = Solusi
+    .task = Jama-jamang
+    .theorem = Teoréma
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Petunju'
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gambara' { $enumeration }
+        [numbered-caption] Gambara' { $enumeration }{ ": " }
+        [unnumbered-caption] Gambara'{ ": " }
+       *[unnumbered] Gambara'
+    }
+
+
+## Paginator controls
+
+paginator-previous = Riolo
+paginator-next = Rimonri
+paginator-page = Halaman
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = iyaré'ga
+
+piecewise-condition-if = rékko
+
+piecewise-condition-otherwise = rékko de' nakkuwa
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so those
+## 130 keys fall back to English. South Sulawesi teaches secondary chemistry in
+## Indonesian, out of Indonesian textbooks, so the element names a Buginese
+## student meets are the Indonesian ones and a Buginese table would be a claim
+## about spelling rather than about the language.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Lambang kimia de' nasah
+chemistry-invalid-ionic-compound = Senyawa ion de' nasah
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = lobang
+
+math-embedded-input-blank-ordinal = lobang { $ordinal } pole ri { $total }

--- a/packages/i18n/locales/bug/diagnostics.ftl
+++ b/packages/i18n/locales/bug/diagnostics.ftl
@@ -1,0 +1,687 @@
+# Buginese (Basa Ugi) diagnostics: the warnings and errors the worker raises
+# and the reader is shown. Translated from `locales/en/diagnostics.ftl`, which
+# is the source of truth. Selected by `uiLocale`, not by the language the
+# document was written in.
+#
+# Message ids are never translated — only the text to the right of `=`. Neither
+# are the DoenetML identifiers quoted inside these sentences: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence` and every tag and attribute name like them are part of
+# the language an author writes, not prose, and stay in English exactly as
+# written. So does the `[deprecation]` marker, which is a label rather than a
+# word.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and apostrophe** are `chrome.ftl`'s: Latin rather than Lontara, and
+# the final glottal stop written with the ASCII apostrophe `'` (U+0027)
+# everywhere.
+#
+# **The technical vocabulary is Indonesian and is declared as such** —
+# komponen, atribut, variabel, dimensi, matriks, referensi, fungsi, persamaan.
+# Buginese speakers are schooled in Indonesian, and these are the words the
+# community uses; inventing Buginese equivalents would put words in front of a
+# reader that no Buginese reader has met.
+#
+# **What is Buginese is the frame**, and it carries the whole file:
+#
+#   «de'»              *tidak*, the plain negator
+#   «de' nawedding»    *tidak dapat* — «wedding» is *dapat*
+#   «de'gaga»          *tidak ada*
+#   «de'pa»            *belum*; «de'pa nariébbu» is *belum diterapkan*
+#   «tenripaduli»      *diabaikan* — the passive negative of «paduli»
+#   «riruntu'»         *ditemukan*; «de' nariruntu'» is *tidak ditemukan*
+#   «harusu'»          *harus*
+#   «nasaba»           *karena*
+#   «rékko»            *jika*
+#   «naé»              *tetapi*
+#   «sibawa» / «na»    *dengan* / *dan*
+#   «iyaré'ga»         *atau*
+#   «pole ri»          *dari*; «untu'» *untuk*; «ri» *di*
+#   «maneng»           *semua*; «tungke'» *tiap*; «lebbi pole ri» *lebih dari*
+#   «mappunnai»        *memiliki*; «de' nappunnai» *tidak memiliki*
+#
+# A sentence that has slipped back into «tidak», «yang», «karena» or «dari» is
+# a mistake to fix rather than a stylistic choice. This is a **framed**
+# catalog: the sentences are Buginese, the nouns inside them are declared
+# Indonesian, and a speaker should expect to correct the sentences as often as
+# the words.
+#
+# **No plural branches.** CLDR has no plural data for `bug`, so every
+# `[one]`/`[other]` fork English writes over a count is collapsed here; most
+# become a plain message, since a Buginese noun is unmarked after a numeral.
+# The one exception is `field-function-wrong-num-outputs`, where English is
+# not counting but distinguishing a one-output field from a two-output one;
+# that fork is kept as the numeric literal `[1]`, which Fluent matches against
+# the number itself rather than against a plural category.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } tenripaduli rékko dua tetti' ujung ripattentu
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } tenripaduli rékko tetti' ujung na tetti' tengnga ripattentu maneng
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset de'gaga akkegunanna rékko de'gaga tetti' tengnga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis molai tetti'-tetti' iya dimensinna de' nawedding ripattentu.
+
+line-points-too-few-dimensions = Garis harusu' molai tetti'-tetti' iya dimensinna kurang-kurangna duwa.
+
+line-points-depend-on-variables = Garis molai tetti'-tetti' iya maccoé ri variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis ri variabel { $variable1 } na { $variable2 } de' nasah.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar ripattentu massidi ri through, endpoint, na direction. Through iya ripattentué tenripaduli.
+
+ray-dimension-mismatch = numDimensions ri sinar de' nasitinaja.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ripattentu massidi ri head, tail, na displacement. Head iya ripattentué tenripaduli.
+
+vector-dimension-mismatch = numDimensions ri vektor de' nasitinaja.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = De' nawedding rigettengngi lao ri `<{ $component }>` nasaba de' nappunnai variabel keadaan nearestPoint.
+
+constrain-to-without-nearest-point = De' nawedding ribatasi lao ri `<{ $component }>` nasaba de' nappunnai variabel keadaan nearestPoint.
+
+constrain-to-interior-without-nearest-point = De' nawedding ribatasi lao ri laleng `<{ $component }>` nasaba de' nappunnai variabel keadaan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition tenripaduli untu' choiceInput iya tanniyaé inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indices iya ripattentué untu' choiceInput tenripaduli nasaba jumla indices de' nasitinaja sibawa jumla ana' choice.
+
+pretzel-indices-count-mismatch = Indices iya ripattentué untu' problem tenripaduli nasaba jumla indices de' nasitinaja sibawa jumla ana' problem.
+
+shuffle-indices-count-mismatch = Indices iya ripattentué untu' shuffle tenripaduli nasaba jumla indices de' nasitinaja sibawa jumla komponen.
+
+indices-ignored-out-of-range = Indices iya ripattentué untu' { $component } tenripaduli nasaba engka indeks iya massué pole ri jangkauan.
+
+pretzel-indices-repeated = Indices iya ripattentué untu' pretzel tenripaduli nasaba engka indeks iya makkolik.
+
+pretzel-circuit-first-index = Indices iya ripattentué untu' pretzel ri mode circuit tenripaduli nasaba indeks mammulangngé harusu' 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Kuammengngi `<{ $component }>` majjama sibawa ana' rupa string, atribut `type` harusu' ripattentu.
+
+invalid-type-defaulting-to-math = Tipe { $type } de' nasah untu' komponen { $component }. Harusu' séddi pole ri math, text, number, iyaré'ga boolean. Napaké math.
+
+string-not-valid-component-to-arrange = String "{ $value }" tenniya komponen iya sahé untu' { $component }. Tenripaduli.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipe { $type } de' nasah, tipe ripattentu ri number.
+
+invalid-variable-value = Nilai variabel de' nasah: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } harusu' rupa bilangan
+
+variant-index-must-be-integer = Indeks varian { $index } harusu' rupa bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` de'pa nariébbu untu' ukuran absolut. Lebbara' ripinra mancaji relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` de'pa nariébbu untu' ukuran absolut. Margin ripinra mancaji relatif.
+
+side-by-side-no-block-child = `<{ $component }>` de' nasah: harusu' mappunnai kurang-kurangna séddi ana' rupa blok.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` ri `<label>` grafis tenripaduli.
+
+label-for-must-resolve-to-one = Atribut `for` ri `<label>` harusu' mattuju tepa' ri séddi komponen.
+
+label-for-unresolved = Atribut `for` ri `<label>` de' nawedding rituju lao ri séddi komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` ri `<label>` mattuju ri `<answer>` iya masukanna riokii alena; tujuiwi masukan iyaro matteru.
+
+label-for-answer-without-input = Atribut `for` ri `<label>` mattuju ri `<answer>` iya de'gaga masukanna untu' rilabeli.
+
+label-for-must-reference-input-or-answer = Atribut `for` ri `<label>` harusu' mattuju ri séddi masukan iyaré'ga séddi pappébali.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Untu' aksesibilitas, `<{ $component }>` harusu' mappunnai keterangan ponco' iyaré'ga ripattentu selaku dekoratif.
+
+accessibility-video-short-description = Untu' aksesibilitas, `<video>` harusu' mappunnai keterangan ponco'.
+
+accessibility-input-short-description-or-label = Untu' aksesibilitas, `<{ $component }>` harusu' mappunnai keterangan ponco' iyaré'ga label.
+
+accessibility-answer-input-short-description-or-label = Untu' aksesibilitas, séddi `<answer>` iya ébbu'é masukan harusu' mappunnai keterangan ponco' iyaré'ga label.
+
+accessibility-short-description-contains-math = Keterangan ponco' de' nasitinaja mappunnai komponen matematika pada-pada `<{ $component }>`. Okii isi matematikana sibawa ada-ada.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kontrasna de' nagenne' untu' teks judul bagiang (mode malotong) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; napparelluang kurang-kurangna { $threshold }:1).
+       *[other] { $colorName } kontrasna de' nagenne' untu' teks judul bagiang ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; napparelluang kurang-kurangna { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = De'pa nariébbu `<circle>` molai { $count } tetti' rékko tetti'-tetti'na de'gaga nilai numerikna.
+
+circle-too-many-through-points = De' nawedding ribilang lingkaran iya molaé lebbi pole ri 3 tetti'.
+
+circle-overprescribed-radius-center-points = De' nawedding ribilang lingkaran iya jari-jarina, posina na tetti' laloanna ripattentu maneng.
+
+circle-center-with-multiple-points = De' nawedding ribilang lingkaran sibawa posi tertentu iya molaé lebbi pole ri 1 tetti'.
+
+circle-radius-too-small = De' nawedding ribilang lingkaran: nasaba éllé' duwa tetti'é iyanaritu { $distance }, jari-jari { $radius } iya ripattentué lalo baiccu'.
+
+circle-radius-with-many-points = De' nawedding riébbu lingkaran iya molaé lebbi pole ri duwa tetti' sibawa jari-jari tertentu.
+
+circle-invalid-center-or-through-points = Posi iyaré'ga tetti' laloanna lingkaran de' nasah.
+
+circle-radius-center-with-multiple-points = De' nawedding ribilang jari-jarina lingkaran sibawa posi tertentu iya molaé lebbi pole ri 1 tetti'.
+
+circle-change-radius-non-numerical = De' nawedding ripinra jari-jarina lingkaran iya tetti' laloanna de' namanumerik
+
+circle-radius-with-points-non-numerical = De' nawedding riébbu lingkaran iya molaé lebbi pole ri séddi tetti' sibawa jari-jari tertentu rékko de'gaga nilai numerik.
+
+circle-change-center-non-numerical = De'pa nariébbu pappinra posina lingkaran iya molaé tetti'-tetti' de' namanumerik.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Dimensi domainna fungsi de' nagenne'. Domain mappunnai { $intervals } selang naé fungsi mappunnai { $inputs } masukan.
+
+function-domain-invalid-format = Format domainna fungsi de' nasah.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Maksimum fungsi iya de'é namanumerik tenripaduli.
+        [minimum] Minimum fungsi iya de'é namanumerik tenripaduli.
+        [extremum] Ekstremum fungsi iya de'é namanumerik tenripaduli.
+        [point] Tetti' fungsi iya de'é namanumerik tenripaduli.
+        [slope] Kemiringan fungsi iya de'é namanumerik tenripaduli.
+       *[other] { $type } fungsi iya de'é namanumerik tenripaduli.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Maksimum fungsi iya lobbangngé tenripaduli.
+        [minimum] Minimum fungsi iya lobbangngé tenripaduli.
+        [extremum] Ekstremum fungsi iya lobbangngé tenripaduli.
+        [point] Tetti' fungsi iya lobbangngé tenripaduli.
+       *[other] { $type } fungsi iya lobbangngé tenripaduli.
+    }
+
+function-points-too-close = Fungsi mappunnai duwa tetti' iya lalo maddeppé onronna. Fungsi de' nawedding ripattentu.
+
+function-iterates-input-output-mismatch = Iterasi fungsi wedding bawang rékko jumla masukanna pada sibawa jumla assuna. Fungsi iyaé mappunnai { $inputs } masukan na { $outputs } assu.
+
+## `<sequence>`
+
+sequence-invalid-length = Lampéna barisan de' nasah. Harusu' rupa bilangan bulat iya tenniyaé negatif.
+
+sequence-invalid-step = Langkana barisan de' nasah. Harusu' rupa bilangan untu' barisan tipe { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ri barisan bilangan de' nasah. Harusu' rupa bilangan.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ri barisan huruf de' nasah. Harusu' rupa kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" ri barisan de' nasah.
+
+select-from-sequence-coprime-not-numbers = coprime tenripaduli nasaba iya ripilé'é tenniya bilangan
+
+select-from-sequence-coprime-with-exclude-combinations = coprime tenripaduli nasaba excludeCombinations ripattentu
+
+## Resolving a `target`
+
+target-not-found = Target untu' `<{ $source }>` de' nasah: target de' nariruntu'.
+
+target-state-variable-not-found = Target untu' `<{ $source }>` de' nasah: de' nariruntu' variabel keadaan iya riasengngé "{ $property }" ri `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabelna `<odeSystem>` harusu' laingngé pole ri variabel bebas.
+
+ode-system-duplicate-variable-names = De' nawedding ripattentu fungsi ruas atau ODE sibawa aseng variabel terikat iya makkolik.
+
+ode-system-rhs-function-error = De' nawedding ripattentu fungsi ruas atau ODE. Engka asalang wettunna riébbu fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = De' nawedding ripattentu sudu' ri pallawangenna { $count } garis
+
+angle-invalid-through-point = Engka tetti' de' nasah ri through appunnangenna `<angle>`
+
+parabola-vertex-too-many-points = De'pa nariébbu parabola sibawa tetti' puncak tertentu iya molaé lebbi pole ri 1 tetti'.
+
+parabola-too-many-points = De'pa nariébbu parabola iya molaé lebbi pole ri 3 tetti'.
+
+intersection-too-many-items = De'pa nariébbu irisan untu' lebbi pole ri duwa objek
+
+## Other math components
+
+ionic-compound-not-two-ions = De'pa nariébbu senyawa ion sangadinna untu' duwa ion.
+
+ionic-compound-needs-cation-and-anion = Senyawa ion riébbu bawang untu' séddi kation na séddi anion.
+
+solve-equations-cannot-evaluate = De' nawedding ripettu persamaan nasaba persamaanna de' nawedding rievaluasi: { $equation }
+
+math-operators-operand-number-required = operandNumber harusu' ripattentu rékko maéloki mala séddi operan matematika.
+
+eigen-decomposition-failed = De' nawedding ribilang nilai eigenna matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } de' nakompoi ri laleng pola, jaji tuli sitinaja sibawa alobbangeng.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: de' nawedding ripahang grid="{ $grid }". Nilaina harusu' none, medium, dense, iyaré'ga duwa bilangan positif iya ripasarangngé spasi, contona grid="1 0.5". Kisi de' nariébbu.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` napparelluang fungsi sibawa { $expected ->
+        [1] séddi assu, iyanaritu kemiringan y' ri tungke' tetti', contona `y - x`
+       *[other] duwa assu, iyanaritu vektor ri tungke' tetti', contona `(y, -x)`
+    }, naé fungsi iya riwéréngngé mappunnai { $found ->
+       *[other] { $found } assu
+    }. { $alternative ->
+        [none] De'gaga iya riébbué.
+       *[other] `<{ $alternative }>` iyanaritu komponen untu' fungsi makkuwaéro. De'gaga iya riébbué.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` tenripaduli nasaba fungsina riwéréng towi ri laleng komponen; iya ri lalengngé iya ripaké. Wéréngngi fungsina séddi bawang pole ri duwa carana.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` masengngi variabelna ungkapan iya riokié matteru ri laleng komponen. { $reason ->
+        [function-child] Fungsi kuae riwéréng selaku ana' `<function>`, iya masengngé variabelna alena, jaji `variables` tenripaduli.
+       *[no-expression] De'gaga ungkapan makkuwaéro kuae, jaji `variables` tenripaduli.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" de' naridukung ri perender prefigure; napaké kelakuan posisi atau.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" de' naridukung ri perender prefigure; napaké kelakuan posisi liyasé.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbu de' nasah untu' konversi prefigure; napaké bbox bawaan (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lebbara' de' nasah untu' konversi prefigure; napaké lebbara' diagram bawaan 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio de' nasah untu' konversi prefigure; napaké rasio aspek bawaan 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: éllé' kisina lalo maddeppé untu' batas sumbuna; kisi ripallennye' ri perender prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi de' nariébbu rékko perender PreFigure de' naripaké.
+
+multiple-annotations-children = Riruntu' maéga ana' `<annotations>` ri laleng `<graph>`; maneng tenripaduli sangadinna iya paccappurengngé.
+
+## Referring to other components
+
+copy-unrecognized-component-type = De' nawedding ripaluwa iyaré'ga ricopy tipe komponen iya de'é naissengngi: { $type }.
+
+copy-prop-not-found = De' nariruntu' prop { $property } ri komponen tipe { $component }
+
+collect-no-source = De'gaga sumber iya riruntu'é untu' collect.
+
+collect-invalid-component-type = De' nawedding ripaddeppungeng komponen tipe `<{ $component }>` nasaba iyaro tenniya tipe komponen iya sahé.
+
+reference-index-unavailable = De' nawedding rituju indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = De' nawedding riobbi { $action } ri komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Rupanna data de' nasah. Lampéna baris de' napada. Riruntu' ri componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data mappunnai aseng kolom iya makkolik. Riruntu' ri componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data ateddéngeng séddi aseng kolom. Riruntu' ri componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Séddi award untu' pappébali iyaé mappallaiseng ri pappébali iya nakiringngé tag answer alena, iya mébbué kelakuan iya de'é narisenna.
+
+answer-max-num-attempts-in-section-wide-check-work = Pattentu `maxNumAttempts` ri `<answer>` iya engkaé ri laleng wadah sibawa `sectionWideCheckWork` de'gaga akkegunanna, nasaba jumla cobana nakuasai wadah iyaro. Pattentui `maxNumAttempts` ri wadahna.
+
+nested-section-wide-check-work-max-num-attempts = Pattentu `maxNumAttempts` ri wadah sibawa `sectionWideCheckWork` iya engkaé ri laleng wadah laingngé sibawa `sectionWideCheckWork` de'gaga akkegunanna, nasaba jumla cobana nakuasai wadah kaminang saliweng. Pattentui `maxNumAttempts` ri wadah kaminang saliweng.
+
+answer-attributes-need-symbolic-equality = Atribut { $attributes } de'gaga akkegunanna rékko symbolicEquality de' naripattentu.
+
+answer-invalid-type = Tipe untu' answer de' nasah: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Nasaba komponen `<{ $component }>` de' nappunnai aseng, de' nawedding ripaké selaku atribut modul
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` de' nawedding ripaké selaku atribut séddi modul nasaba tipe komponen `<module>` purani mappunnai atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` tenripaduli ri komponen `<conditionalContent>` iya mappunnaié ana' case iyaré'ga else.
+
+slider-markers-type-mismatch = Tipe tanrang de' nasitinaja sibawa tipe panggeser.
+
+pretzel-problem-needs-statement-and-answer = Pretzel de' nasah: tungke' `<problem>` harusu' mappunnai séddi `<statement>` na séddi `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel de' nasah: ri mode="circuit", `<problem>` mammulangngé de' nawedding mancaji pabbelléang.
+
+## Attribute values
+
+attribute-invalid-values = Nilai { $values } untu' atribut `{ $attribute }` de' nasah; tenripaduli.
+
+attribute-must-be-references = Nilai `{ $value }` untu' atribut `{ $attribute }` de' nasah. Atribut harusu' ripatettong pole ri referensi iya mammulaé sibawa `$`.
+
+math-input-invalid-function-names = <mathInput>: aseng fungsi iya de'é nasah ri { $attribute } tenripaduli: { $names }. Bagiang tampilanna tungke' aseng harusu' kurang-kurangna 2 karakter (huruf iyaré'ga tanrang sambung); wedding naccoé akhiran pilihan `|<alternatif mathspeak>`.
+
+## Building components from the source
+
+component-type-invalid = Tipe komponen de' nasah: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } de' nawedding rikolik.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" de' nasah untu' komponen tipe `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definisi gaya { $styleNumber } kontrasna de' nagenne' untu' { $context ->
+        [text-on-background] warna teks lao ri warna latar
+        [high-contrast] warna kontras matanré lao ri kanvas
+        [line] warna garis lao ri kanvas
+        [marker] warna tanrang lao ri kanvas
+       *[text-on-canvas] warna teks lao ri kanvas
+    }{ $mode ->
+        [dark] { " (mode malotong)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; napparelluang kurang-kurangna { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Namuni definisi gaya { $styleNumber } pattentui warna iya kontrasna genne' untu' mode macakka, warna mode malotong iya ripaompoé pole ri nilai-nilaéro kontrasna de' nagenne' ri pallawangenna warna teks na warna latar ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; napparelluang kurang-kurangna { $threshold }:1). { $suggestion ->
+        [available] Kuammengngi kontrasna genne' ri mode malotong, pattanréi kontras mode macakka (contona pattentui { $lightAttribute }="{ $lightColor }") iyaré'ga timpai warna mode malotong (contona pattentui { $darkAttribute }="{ $darkColor }").
+       *[none] Kuammengngi kontrasna genne' ri mode malotong, pattanréi kontras mode macakka iyaré'ga timpai warna ripaompoé sibawa textColorDarkMode na/iyaré'ga backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Namuni definisi gaya { $styleNumber } pattentui warna teks iya kontrasna genne' untu' mode macakka, warna teks mode malotong iya ripaompoé pole ri nilaéro kontrasna de' nagenne' lao ri kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; napparelluang kurang-kurangna { $threshold }:1). { $suggestion ->
+        [available] Kuammengngi kontrasna genne' ri mode malotong, pattanréi kontras mode macakka (contona pattentui textColor="{ $lightColor }") iyaré'ga timpai warna mode malotong (contona pattentui textColorDarkMode="{ $darkColor }").
+       *[none] Kuammengngi kontrasna genne' ri mode malotong, pattanréi kontras mode macakka iyaré'ga timpai warna ripaompoé sibawa textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Séddi bagiang wedding bawang mamilé séddi <stylePalette>; napaké iya paccappurengngé.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = de' nawedding ripattentu varian unik pole ri { $component } nasaba numToSelect tenniya bilangan bulat iya tenniyaé negatif.
+
+variant-num-to-select-not-constant-number = de' nawedding ripattentu varian unik pole ri { $component } nasaba numToSelect tenniya bilangan tetteng.
+
+variant-with-replacement-not-constant-boolean = de' nawedding ripattentu varian unik pole ri { $component } nasaba withReplacement tenniya boolean tetteng.
+
+variant-select-weight-disables-unique = Varian unik untu' select ripeddé rékko engka opsi iya pattentué selectWeight iyaré'ga selectForVariants
+
+variant-coprime-undetermined = de' nawedding ripattentu varian unik pole ri { $component } nasaba de' nawedding ripattentu makkedaé coprime tuli sala.
+
+variant-attribute-not-constant = de' nawedding ripattentu varian unik pole ri { $component } nasaba { $attribute } tenniya nilai tetteng.
+
+variant-attribute-not-number = de' nawedding ripattentu varian unik pole ri { $component } nasaba { $attribute } tenniya bilangan.
+
+variant-attribute-wrong-type-for-sequence =
+    de' nawedding ripattentu varian unik pole ri { $component } tipe { $type } nasaba { $attribute } tenniya { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ungkapan matematika iya sahé
+        [integer] bilangan bulat
+       *[number] bilangan
+    }.
+
+variant-length-not-integer = de' nawedding ripattentu varian unik pole ri { $component } nasaba length tenniya bilangan bulat.
+
+variant-sort-not-implemented = de'pa nariébbu varian unik pole ri { $component } sibawa sort
+
+variant-exclude-combinations-not-implemented = de'pa nariébbu varian unik pole ri { $component } sibawa excludeCombinations
+
+variant-math-exclude-not-implemented = de'pa nariébbu varian unik pole ri { $component } tipe math sibawa exclude
+
+variant-non-constant-exclude-not-implemented = de'pa nariébbu varian unik pole ri { $component } sibawa exclude iya tenniyaé tetteng
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: de' naridukung ri perender prefigure grafik; turunanna rilalo.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri de' namattentu iyaré'ga de' nasukku'; turunanna rilalo.
+
+prefigure-curve-label-omitted = { $subject }: label de' naridukung ri elemen kurva assalenna konversi; label ripallennye'.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipe definisi fungsi kurva '{ $definitionType }' de' naridukung; turunanna rilalo.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions ri regionBetweenCurves de' naridukung; turunanna rilalo.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves nadukung bawang fungsi ana' tipe formula; turunanna rilalo.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' de' naridukung untu' { $labelKind ->
+        [line-family] label rumpunna garis
+       *[point] label tetti'
+    }; napaké perataan bawaan PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' de' naridukung ri PreFigure; palisu lao ri isi padat.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' de' naissengngi na ripallennye' pole ri assuna PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya tanrang '{ $markerStyle }' ripalétté lao ri gaya 'diamond' appunnangenna PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya tanrang '{ $markerStyle }' de' naridukung ri PreFigure; napaké gaya bawaan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` de' nasah; target de' nawedding rituju. Anotasi ripallennye'.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` mattuju ri maéga target; napaké target mammulangngé.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` de' nasah; target engka ri saliwenna grafik iya mattampu'é. Anotasi ripallennye'.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` de' nasah; target tenniya objek grafis iya naridukungngé ri konversi prefigure. Anotasi ripallennye'.
+
+annotation-text-missing = `<annotation>`: `text` teddéng iyaré'ga lobbang; mébbu teks lobbang.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Riruntu' appallaisengeng mattulili.
+       *[other] Riruntu' appallaisengeng mattulili iya maccampuru'é komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = De'gaga acuan iya riruntu'é untu' referensi: `{ $reference }`
+
+reference-multiple-referents = Riruntu' maéga acuan untu' referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } ri `<{ $componentType }>` de' nasah.
+
+children-invalid = Ana' `<{ $componentType }>` de' nasah: riruntu' ana' iya de'é nasah: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` untu' atribut `{ $attribute }` de' nasah, napaké nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML versi { $version } de' nariruntu'.
+       *[other] DoenetML versi { $version } de' nariruntu'. Palisu lao ri versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML de' nasah: { $content }
+
+parse-tag-missing-close-tag = DoenetML de' nasah: Tag `{ $tag }` de' nappunnai tag pattutu'. Nasenna' engka tag iya mattutu' alena iyaré'ga tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML de' nasah: Engka asalang ri tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML de' nasah: Atribut `{ $attribute }` pada-pada ateddéngeng nilai.
+
+parse-attribute-invalid = DoenetML de' nasah: Atribut `{ $attribute }` de' nasah
+
+parse-attribute-value-invalid = DoenetML de' nasah: Nilai atribut `{ $value }` de' nasah
+
+parse-attribute-value-quote-mismatch = DoenetML de' nasah: Nilai atribut `{ $value }` de' nasah. Tanrang kutipna de' nasitinaja. Pada-pada ateddéngengki séddi `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML de' nasah: Riruntu' tag iya de'é nappunnai aseng tag, contona `<`
+
+parse-tag-not-closed = DoenetML de' nasah: Tag `{ $tag }` de'pa naritutu' (pada-pada ateddéngeng `>`).
+
+parse-self-closing-tag-name-missing = DoenetML de' nasah: Riruntu' tag iya de'é nappunnai aseng tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML de' nasah: Tag `{ $tag }` de'pa naritutu' (pada-pada ateddéngeng `/>`).
+
+parse-tag-invalid-attributes = DoenetML de' nasah: Tag `{ $tag }` de' nasah. Atributna wedding sala.
+
+parse-close-tag-name-missing = DoenetML de' nasah: Riruntu' tag pattutu' iya de'é nappunnai aseng tag, contona `</`
+
+parse-attribute-value-unquoted = Nilai atribut harusu' riala sibawa tanrang kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML de' nasah: Riruntu' tag pattutu' `{ $tag }`, naé de'gaga tag pattimpa' iya sitinajaé
+
+parse-close-tag-mismatched = DoenetML de' nasah: Tag pattutu' de' nasitinaja. Nasenna' `</{ $expected }>`. Riruntu' `{ $found }`
+
+parser-node-unconvertible = De' nawedding ripinra simpul { $node } mancaji simpul Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' de' nasah. { $reason ->
+        [characters] Aseng wedding bawang mappunnai huruf, angka, garis yawa, iyaré'ga tanrang sambung.
+       *[start] Aseng harusu' mammula sibawa huruf.
+    }
+
+component-name-invalid-start = Aseng komponen "{ $name }" de' nasah. Aseng harusu' mammula sibawa huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer tipe videoWatched harusu' mappunnai atribut video
+
+answer-video-watched-video-not-reference = Answer tipe videoWatched harusu' mappunnai atribut video iya rupa referensi
+
+answer-name-not-single-text = Atribut name ri answer harusu' mappunnai tepa' séddi ana' rupa teks
+
+## Referencing another document
+
+external-doenetml-recursion-limit = De' nawedding riala DoenetML saliweng nasaba lalo maéga tingkat rekursi. Engkaga referensi mattulili?
+
+external-doenetml-unavailable = De' nawedding riala DoenetML pole ri { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML iya rialaé pole ri { $attribute }="{ $uri }" de' nasah: de' nasitinaja sibawa tipe komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` purani teddéng; paké `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` ri `<{ $component }>` purani teddéng; paké `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` purani teddéng na tenripaduli nasaba `{ $to }` ripattentu towi.
+       *[other] [deprecation] Atribut `{ $from }` ri `<{ $component }>` purani teddéng na tenripaduli nasaba `{ $to }` ripattentu towi.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` ri `<{ $component }>` purani teddéng na tenripaduli.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` ri `<{ $component }>` purani teddéng; paké ana' `<{ $child }>` bawang.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` pole ri atribut `{ $attribute }` ri `<{ $component }>` purani teddéng; paké `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` wedding bawang mébbu jama'na basa Inggris, jaji teksna ritaro pada-padanna ri dokumen iya riokié ri { $locale }. Okii bentu' jama'na matteru, iyaré'ga pattentui sibawa atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` tenniya elemen Doenet iya riissengngé.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` de' nariwéréng ri ure'na dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` de' nariwéréng ri laleng `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` de' nappunnai atribut iya riasengngé `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` ri elemen `<{ $tag }>` harusu' rupa daftar iya tungke' isinna séddi pole ri: { $allowed }
+       *[other] Atribut `{ $attribute }` ri elemen `<{ $tag }>` harusu' séddi pole ri: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Aseng varian untu' select de' nasah. Aseng varian { $variantName } kompoi ri { $numOptions } opsi naé jumla iya ripilé'é { $numToSelect }.
+
+select-variant-name-without-options = Engka varian iya ripattentué untu' select naé de'gaga opsi untu' aseng varian iya weddingngé: { $variantName }.
+
+select-variant-name-not-possible = Aseng varian { $variantName } iya ripattentué untu' select tenniya aseng varian iya weddingngé.
+
+select-too-few-options = De' nawedding ripilé { $numToSelect } komponen pole ri { $numOptions } bawang.
+
+select-from-sequence-too-few-values = De' nawedding ripilé { $numToSelect } nilai pole ri barisan iya lampéna { $length }.
+
+select-from-sequence-indices-count-mismatch = Jumla indeks iya ripattentué untu' select harusu' pada sibawa jumla iya ripilé'é
+
+select-from-sequence-indices-not-integers = Maneng indeks iya ripattentué untu' select harusu' rupa bilangan bulat
+
+select-from-sequence-index-excluded = Indeks iya ripattentué untu' selectfromsequence maccowé ri iya ripasalaié
+
+select-from-sequence-indices-excluded-combination = Indeks iya ripattentué untu' selectfromsequence mébbu kombinasi iya ripasalaié
+
+select-from-sequence-coprime-not-positive-integers = De' nawedding ripilé kombinasi sipprima nasaba iya ripilé'é tenniya bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = De' nawedding ripilé bilangan iya sipprima. Maneng nilai iya weddingngé mappunnai faktor sisumpung. (Nilai "from" iyaré'ga "to" iya ripattentué harusu' sipprima sibawa "step".)
+
+select-from-sequence-coprime-single-number = De' nawedding ripilé kombinasi sipprima pole ri séddi bilangan alena iya tenniyaé 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebbi pole ri 70% kombinasi ripasalai ri selectFromSequence
+
+select-from-sequence-coprime-none-found = De' naulléi ripilé bilangan iya sipprima. Maneng nilai iya weddingngé mappunnai faktor sisumpung.
+
+select-from-sequence-too-few-unique-values = De' nawedding ripilé { $numToSelect } nilai iya laingngé pole ri barisan iya lampéna { $numPossibleValues }
+
+select-prime-numbers-too-few-values = De' nawedding ripilé { $numToSelect } nilai pole ri daftar bilangan prima iya lampéna { $numValues }
+
+select-prime-numbers-values-count-mismatch = Jumla nilai iya ripattentué untu' select harusu' pada sibawa jumla iya ripilé'é
+
+select-prime-numbers-values-not-prime = Maneng nilai iya ripattentué untu' select prime number harusu' engka ri daftar bilangan prima
+
+select-prime-numbers-values-excluded-combination = Nilai iya ripattentué untu' selectPrimeNumbers mébbu kombinasi iya ripasalaié
+
+select-prime-numbers-excluded-too-many-combinations = Lebbi pole ri 70% kombinasi ripasalai ri selectPrimeNumbers
+
+select-random-combination-fluke = Nasaba appakkennang iya majarangngé senna', kombinasi nilai acak de' naulléi ripilé
+
+select-random-value-fluke = Nasaba appakkennang iya majarangngé senna', nilai acak de' naulléi ripilé
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` iyaé de' naripaita nasaba engkai ri laleng matematika naé tenniya `inline`. Tambai `inline` kuammengngi mancaji daftar nonno', iya muttamana ri laleng ungkapan.
+        [expanded] `<{ $component }>` iyaé de' naripaita nasaba engkai ri laleng matematika na `expanded`. Abbéangngi `expanded`; kotak maéga barisna de' namuttama ri laleng ungkapan.
+        [on-graph] `<{ $component }>` iyaé de' naripaita nasaba engkai ri laleng matematika iya riébbué ri grafik, iya de'é nappunnai onrong untu' masukan.
+       *[relative-width] `<{ $component }>` iyaé de' naripaita nasaba engkai ri laleng matematika na lebbara'na relatif. Wéréngngi lebbara'na ri satuan absolut, contona `px`.
+    }

--- a/packages/i18n/locales/bug/editor.ftl
+++ b/packages/i18n/locales/bug/editor.ftl
@@ -1,0 +1,225 @@
+# Buginese (Basa Ugi) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script, apostrophe and register** are `chrome.ftl`'s: Latin rather than
+# Lontara, the final glottal stop written with the ASCII apostrophe `'`
+# (U+0027), and an Indonesian technical vocabulary declared as a loan register
+# around a Buginese frame — «de'», «de' nawedding», «de'gaga», «sibawa», «na»,
+# «iyaré'ga», «nasaba», «rékko», «pole ri», «untu'», «ri», «maneng»,
+# «tungke'», «riruntu'».
+#
+# **`WCAG`, `DoenetML`, `styleNumber` and every element and attribute name
+# stay in English.** They are identifiers an author types, not words.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `bug`, so an English-selected
+# branch would be worse than none, and a Buginese noun is unmarked after a
+# numeral in any case.
+#
+# **`help-name-summary` is punctuation.** It renders with `{ $name }` empty
+# for a suggestion the panel has already named, so the em dash and its spaces
+# have to read on their own.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Palisu
+       *[update] Baruwi
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Panampi'
+       *[other] { $word } Panampi' { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+
+editor-variant-filter = Saring...
+
+editor-variant-next = Piléi varian rimonri
+
+editor-variant-previous = Piléi varian riolo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Riruntu' pelanggaran aksesibilitas WCAG AA. Klik untu' { $action ->
+            [close] tutu'
+           *[open] timpa'
+        } laporan aksesibilitas.
+        [advisories] Klik untu' { $action ->
+            [close] tutu'
+           *[open] timpa'
+        } laporan aksesibilitas. De'gaga pelanggaran WCAG AA iya riruntu'é, naé engka saran aksesibilitas laingngé.
+       *[clean] Klik untu' { $action ->
+            [close] tutu'
+           *[open] timpa'
+        } laporan aksesibilitas. De'gaga masala aksesibilitas iya riruntu'é.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Riruntu' pelanggaran aksesibilitas WCAG AA. Riruntu' { $count ->
+           *[other] { $count } pelanggaran WCAG AA
+        }. Klik untu' { $action ->
+            [close] tutu'
+           *[open] timpa'
+        } laporan aksesibilitas.
+        [advisories] De'gaga pelanggaran WCAG AA iya riruntu'é. Riruntu' { $count ->
+           *[other] { $count } saran aksesibilitas tamba
+        }. Klik untu' { $action ->
+            [close] tutu'
+           *[open] timpa'
+        } laporan aksesibilitas.
+       *[clean] De'gaga pelanggaran WCAG AA iya riruntu'é. Klik untu' { $action ->
+            [close] tutu'
+           *[open] timpa'
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Bantuan situru' konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Asalang
+editor-tab-warnings = Papparingerrang
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Pappébali iya purae rikiring
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan panyunting
+editor-format-as-doenetml = Atoro' selaku DoenetML
+editor-format-as-xml = Atoro' selaku XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = De'gaga asalang
+editor-no-warnings = De'gaga papparingerrang
+editor-no-info = De'gaga diagnostik info
+
+editor-show-info-annotations = Paitangngi diagnostik info ri panyunting
+editor-show-accessibility-annotations = Paitangngi diagnostik aksesibilitas ri panyunting
+
+editor-accessibility-learn-more = Pelajari pékkugi Doenet majjama aksesibilitas
+
+editor-accessibility-violations-heading = Pelanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masala aksesibilitas laingngé
+editor-none-found = De'gaga iya riruntu'é
+
+
+## Submitted responses
+
+editor-no-responses = De'pa engka pappébali iya rikiringngé
+editor-response-answer-id = Id pappébali
+editor-response-response = Pappébali
+editor-response-credit = Nilai
+editor-response-submitted = Purani rikiring
+
+
+## The context-help panel
+
+help-placeholder = Taroi kursor ri aseng tag, atribut, iyaré'ga { $ref } untu' dokumentasi.
+
+help-unsupported-ref-chain = Bantuan untu' referensi maéga bagiang pada-pada { $example } de'pa nariébbu.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] De'gaga acuan iya riruntu'é untu' referensi: { $ref }.
+        [multiple] Riruntu' maéga acuan untu' referensi: { $ref }.
+       *[indeterminate] Acuan untu' { $ref } de' nawedding ripattentu.
+    }
+
+help-learn-about-references = Pelajari passalenna referensi →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ri laleng { $element }
+       *[top] Ri tingkat kaminang liyasé
+    }{ $allowed ->
+        [none] { " — de'gaga iya wedding ritaro kuae." }
+        [text] { " — okii teks kuae." }
+        [text-and-components] { " — okii teks kuae, iyaré'ga coba:" }
+       *[components] { " — iya wedding ricoba:" }
+    }
+
+help-suggestions-footer = Tikkeng { $shortcut } untu' mitai maneng { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } iyanaritu referensi lao ri { $target }.
+       *[other] { $ref } iyanaritu referensi lao ri { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ripaompo ri { $owner } selaku { $role }.
+       *[other] Ripaompo ri { $owner } ri baris { $line } selaku { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } iyanaritu referensi lao ri properti { $property } appunnangenna { $element }.
+       *[other] { $ref } iyanaritu referensi lao ri properti { $property } appunnangenna { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = pettuang
+help-kind-array-entry = isi larik
+
+help-default = Bawaan:
+help-active-default = Bawaan iya majjamaé:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai iya riwéréngngé (séddi untu' tungke' item):
+       *[other] Nilai iya riwéréngngé:
+    }
+
+help-suggested-values = Nilai iya risaranangngé:
+
+help-inserts = Nasisip:
+
+help-coordinates =
+    { $count ->
+       *[other] Koordinat:
+    }
+
+help-type = Tipe:
+
+help-resolved-style = Gaya iya pura ripattentu (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Aseng fungsi iya pura ripattentu:
+help-reset-list = Daftar iya ripalisué ri masukan iyaé:
+help-added-on-input = Ritamba ri masukan iyaé:
+help-removed-on-input = Riabbéang ri masukan iyaé:
+
+help-reset-overrides = { $reset } natimpai { $additional } na { $removed }.

--- a/packages/i18n/locales/cbk/chrome.ftl
+++ b/packages/i18n/locales/cbk/chrome.ftl
@@ -1,0 +1,174 @@
+# Chavacano (Chabacano de Zamboanga) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **This is Zamboangueño, and it is a creole, not a variety of Spanish.**
+# `cbk` covers several Chabacano varieties, and they are not interchangeable:
+# Zamboangueño, of Zamboanga City and Basilan, is much the largest and the one
+# still acquired by children, and it is what this catalog is written in.
+# A **Caviteño** or **Ternateño** reader will differ from these files in
+# vocabulary, in some of the particles, and in the shape of the pronouns —
+# those are different Chabacano, not corrections to this one, and a reviewer
+# who speaks them should say which variety they are correcting from.
+#
+# The lexicon below is Spanish and the grammar is Philippine. Nothing here is
+# Spanish that has been left half-translated:
+#
+#   - Aspect is carried by **preverbal particles**, not by conjugation: «ya»
+#     for a completed action, «ta» for an ongoing or habitual one, «ay» for
+#     one still to come. The verb itself never inflects — it is Spanish's bare
+#     stem, «ta manda», «ya principia».
+#   - Negation is **«hende»** before a non-past or an adjective, **«no hay»**
+#     for 'there is none', and **«nunca»** for a refused future. Spanish's «no»
+#     is not the general negator here.
+#   - **«el»** is the article, **«maga»** the plural word (from Tagalog «mga»),
+#     **«con»** the object marker and **«na»** the general locative — 'in',
+#     'on', 'at' and 'to' all at once, which no Spanish preposition does.
+#   - **The describing word comes before the noun**, as in every Philippine
+#     language and unlike Spanish: «rojo linea», not «linea roja». That is the
+#     single thing about these files most likely to look like an error to a
+#     reader who reads the vocabulary as Spanish, and `content.ftl` holds to it
+#     everywhere.
+#
+# **Orthography: the traditional Spanish-based spelling**, which is what most
+# printed Chavacano uses — «que», «ciudad», «poligono», «circulo». The
+# competing system is the **phonemic orthography promoted in Zamboanga City**,
+# which writes «ke», «siudad», «poligono», «sirkulo» on Filipino letter values.
+# A reviewer who prefers it should **respell rather than retranslate**: the two
+# differ by a letter-for-letter mapping and no word choice below depends on
+# which is used. Respell all four files at once or none.
+#
+# **Accents are not written.** Spanish's «á é í ó ú» are dropped throughout —
+# «mas», «poligono», «region» — which is ordinary Chavacano practice and a
+# checkable claim: there should be no acute accent anywhere in these four
+# files.
+#
+# **The technical register.** Zamboangueño speakers are schooled in English
+# and Filipino, and the classroom vocabulary for mathematics is English on top
+# of the Spanish the language already carries. Where a Spanish-lexifier word
+# is the one in use — «linea», «punto», «circulo», «poligono», «cuadrado»,
+# «fila», «columna», «estadistica» — it is used. Where it is not, the English
+# word is kept outright (`WCAG`, `renderer`, `reload`, `teclado`'s neighbours
+# in `editor.ftl`) rather than coined.
+
+answer-checking = Ta revisa...
+answer-submitting = Ta manda...
+
+answer-checking-status = Ta revisa el respuesta
+answer-submitting-status = Ta manda el respuesta
+
+answer-correct = Correcto
+answer-incorrect = Incorrecto
+
+answer-response-saved = Guardao el Respuesta
+
+answer-percent-credit = { $percent }% Credito
+answer-percent-correct = { $percent }% Correcto
+answer-percent-short = { $percent } %
+
+max-credit-available = Maximo credito puede consigui: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] no hay ya intento que sobra
+       *[other] { $count } intento pa el sobra
+    }
+
+validation-correct = (Correcto)
+validation-incorrect = (Incorrecto)
+validation-partially-correct = (Parcialmente correcto)
+
+answer-show-responses =
+    { $count ->
+       *[other] Mostra el { $count } respuesta con { $answerId }
+    }
+
+feedback-heading = Comentario
+
+collapsible-click-to-open = (click para abri)
+collapsible-click-to-close = (click para cerra)
+
+collapsible-initializing = Ta principia...
+
+footnote-show = Mostra el nota na pie
+footnote-hide = Esconde el nota na pie
+
+description-more-information = mas informacion
+
+slider-previous = Antes
+slider-next = Siguiente
+
+keyboard-open = Abri el Teclado
+keyboard-close = Cerra el Teclado
+
+choice-input-remove-choice = Quita el { $choice }
+
+matrix-remove-row = Quita el fila
+matrix-add-row = Agrega un fila
+matrix-remove-column = Quita el columna
+matrix-add-column = Agrega un columna
+
+subset-add-remove-points = Agrega/Quita maga punto
+subset-toggle-points-intervals = Cambia entre maga punto y maga intervalo
+subset-move-points = Mueve el maga punto
+subset-clear = Limpia
+
+orbital-add-row = Agrega un fila
+orbital-remove-row = Quita el fila
+orbital-add-box = Agrega un caja
+orbital-remove-box = Quita el caja
+orbital-add-up-arrow = Agrega un flecha para arriba
+orbital-add-down-arrow = Agrega un flecha para abajo
+orbital-remove-arrow = Quita el flecha
+
+orbital-row-label = Letrero para na fila { $row }
+
+pretzel-answer = Respuesta
+
+summary-statistics-caption = Resumen de estadistica de { $column }
+
+math-input-preview-region = vista previa del matematico expresion
+math-input-preview = Vista previa
+math-input-invalid-expression = Invalido expresion:
+
+viewer-initializing = Ta principia...
+
+error-heading = Error
+
+error-found-at =
+    { $span ->
+        [line] Encontrao na linea { $startLine }.
+       *[lines] Encontrao na maga linea { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Tiene error este documento!
+
+diagnostic-heading-error = Error
+diagnostic-heading-warning = Aviso
+diagnostic-heading-information = Informacion
+diagnostic-heading-hint = Consejo
+
+accessibility-heading-level-1 = Violacion na Accesibilidad WCAG AA
+accessibility-heading-level-2 = Aviso de accesibilidad
+
+something-went-wrong = Tiene cosa ya sale mal.
+
+renderer-load-failed = hende ya puede carga un renderer. Favor recarga el pagina.
+
+core-start-failed = Hende puede principia este documento. Favor recarga el pagina.
+
+core-start-failed-busy = Hende puede principia este documento. Muchos documento ya principia junto, y mas largo ese si mas lento el aparato. Puede ayuda el recarga del pagina si acaba ya el otro maga documento.
+
+core-start-failed-retry = Hende puede principia este documento.
+
+core-start-failed-busy-retry = Hende puede principia este documento. Muchos documento ya principia junto, y mas largo ese si mas lento el aparato.
+
+core-start-retry = Intenta otra vez
+
+saved-state-unavailable = Hende puede carga el guardao de tuyo trabajo.

--- a/packages/i18n/locales/cbk/content.ftl
+++ b/packages/i18n/locales/cbk/content.ftl
@@ -59,7 +59,7 @@
 #
 # **The two chemistry tables — `element-name` and `element-anion-name` — are
 # omitted.** Secondary science in Zamboanga is taught in English, so the
-# English fallback is the language of the classroom, and filling those 132 keys
+# English fallback is the language of the classroom, and filling those 130 keys
 # would claim a translation that had not happened. `ion-name-oxidation-state`
 # and the two `chemistry-invalid-` messages are prose and are translated.
 

--- a/packages/i18n/locales/cbk/content.ftl
+++ b/packages/i18n/locales/cbk/content.ftl
@@ -1,0 +1,296 @@
+# Chavacano (Chabacano de Zamboanga) content catalog: the prose the core
+# computes into the document. Selected by `documentLocale` — the language the
+# activity was written in. `locales/en/content.ftl` is the source of truth, and
+# message ids, placeables and variant keys are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Zamboangueño, and a creole rather than a variety of Spanish.**
+# `chrome.ftl`'s header sets out the grammar in full: preverbal «ya», «ta» and
+# «ay» for aspect, «hende» and «no hay» for negation, «el», «maga», «con» and
+# «na» for the noun phrase. Caviteño and Ternateño readers will differ from
+# these files, and that is a difference between varieties rather than an error
+# in this one.
+#
+# **Orthography: the traditional Spanish-based spelling, with no accent
+# marks.** The phonemic orthography promoted in Zamboanga City is the
+# competing one; respell rather than retranslate, and respell all four files
+# at once.
+#
+# ## Word order — the thing this file is most likely to be "corrected" wrongly
+#
+# **The describing word comes first and the noun after it**: «grueso rojo
+# linea» is *thick red line*, and «lleno azul circulo» is *filled blue
+# circle*. A reader who takes the vocabulary for Spanish will expect «linea
+# roja» and be wrong: Zamboangueño puts the modifier in front, as Cebuano and
+# Tagalog do, and this catalog holds to that everywhere. So `style-stroke`,
+# `style-with-noun` and `style-filled-with-noun` keep English's sequence of
+# placeables — which is a fact about Zamboangueño's syntax and not a failure
+# to translate.
+#
+# **There is no linker.** This is where these files diverge sharply from the
+# other Philippine catalogs in the roster: Tagalog's «na»/«-ng», Cebuano's
+# «nga», Ilocano's «a»/«nga» and Pangasinan's «a»/«-n» all have to be placed
+# and all have two shapes, and Zamboangueño simply juxtaposes — the Spanish
+# lexicon came without a ligature and the creole did not build one. Nothing in
+# this file is at risk from the problem
+# [A ligature is an affix too](../../README.md#a-ligature-is-an-affix-too)
+# describes.
+#
+# **Number.** The noun is unmarked; «maga» is the plural word and is written
+# only where the sense is genuinely plural — the four `fill-style` patterns,
+# which are patterns of many marks — and left off elsewhere, so «linea» covers
+# one line and many alike.
+#
+# ## Vocabulary
+#
+# Everything below is Spanish-lexifier because the language is. The
+# derivational shape worth naming is **«-ao»**, Chavacano's reflex of Spanish
+# «-ado»: «lleno» has no need of it but «cortao» (cut) and «puntiao» (dotted)
+# do, and a reviewer should read those as ordinary Chavacano rather than as
+# clipped Spanish. `.slope-field` and `.vector-field` are written «campo de
+# pendiente» and «campo de vector»; if the classroom in Zamboanga says
+# "slope field" in English, that is what should replace them.
+#
+# Chavacano has no grammatical gender agreement of the Spanish kind — the
+# adjective does not move for a feminine noun — so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or `$role`.
+#
+# **The two chemistry tables — `element-name` and `element-anion-name` — are
+# omitted.** Secondary science in Zamboanga is taught in English, so the
+# English fallback is the language of the classroom, and filling those 132 keys
+# would claim a translation that had not happened. `ion-name-oxidation-state`
+# and the two `chemistry-invalid-` messages are prose and are translated.
+
+
+## Style vocabulary
+
+color =
+    .black = negro
+    .white = blanco
+    .gray = gris
+    .red = rojo
+    .orange = anaranjado
+    .yellow = amarillo
+    .green = verde
+    .cyan = cian
+    .blue = azul
+    .purple = morado
+    .pink = rosado
+    .brown = marron
+
+line-width =
+    .thick = grueso
+    .thin = delgado
+
+# «-ao» is Chavacano's form of Spanish «-ado»; these are not clipped Spanish.
+line-style =
+    .dashed = cortao
+    .dotted = puntiao
+
+# The one place «maga» is written: a fill pattern is genuinely many marks.
+fill-style =
+    .horizontal = maga horizontal linea
+    .vertical = maga vertical linea
+    .diagonal = maga diagonal linea
+    .backdiagonal = maga contrario diagonal linea
+    .dots = maga punto
+    .diamonds = maga diamante
+
+noun =
+    .line = linea
+    .line-segment = segmento de linea
+    .ray = rayo
+    .vector = vector
+    .curve = curva
+    .function = funcion
+    .slope-field = campo de pendiente
+    .vector-field = campo de vector
+    .parabola = parabola
+    .polyline = polilinea
+    .polygon = poligono
+    .triangle = triangulo
+    .rectangle = rectangulo
+    .circle = circulo
+    .region = region
+    .point = punto
+    .square = cuadrado
+    .diamond = diamante
+    .cross = cruz
+    .plus = mas
+
+# The side count follows the adjectives as a complement, so that they stay in
+# front of the noun where Zamboangueño wants them.
+noun-regular-polygon =
+    { $part ->
+        [tail] que tiene { $numSides } lado
+       *[head] regular poligono
+    }
+
+# One answer for every noun: Chavacano's adjectives do not agree, so nothing
+# downstream has anything to agree with.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = lleno
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } con { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } con { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } con { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# «un» is Chavacano's indefinite article, so the two `-article` branches carry
+# it and the other two do not — the same distinction English makes. What
+# separates a first clause from a further one is «con» against «y».
+style-border-clause =
+    { $parts ->
+        [with-article] con un { $border } orilla
+        [and] y { $border } orilla
+        [and-article] y un { $border } orilla
+       *[with] con { $border } orilla
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = hende lleno
+
+style-text =
+    { $parts ->
+        [background] { $color } con un { $background } fondo
+       *[plain] { $color }
+    }
+
+style-background-none = no hay
+
+
+## Boolean words
+
+boolean-true = verdad
+boolean-false = falso
+
+
+## Answer buttons
+
+answer-submit-label = Revisa el Trabajo
+answer-submit-label-no-correctness = Manda el Respuesta
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Actividad
+    .aside = Aparte
+    .cascade = Cascada
+    .definition = Definicion
+    .example = Ejemplo
+    .exercise = Ejercicio
+    .exercises = Maga Ejercicio
+    .given-answer = Respuesta
+    .note = Nota
+    .objectives = Maga Objetivo
+    .paragraphs = Maga Parrafo
+    .part = Parte
+    .problem = Problema
+    .problems = Maga Problema
+    .proof = Prueba
+    .question = Pregunta
+    .section = Seccion
+    .solution = Solucion
+    .task = Tarea
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Consejo
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
+       *[unnumbered] Figura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Antes
+paginator-next = Siguiente
+paginator-page = Pagina
+
+paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = o
+
+piecewise-condition-if = si
+
+piecewise-condition-otherwise = si hende
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Invalido Simbolo Quimico
+chemistry-invalid-ionic-compound = Invalido Compuesto Ionico
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blanco
+
+math-embedded-input-blank-ordinal = blanco { $ordinal } de { $total }

--- a/packages/i18n/locales/cbk/diagnostics.ftl
+++ b/packages/i18n/locales/cbk/diagnostics.ftl
@@ -1,0 +1,707 @@
+# Chavacano (Chabacano de Zamboanga) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Zamboangueño**, in the traditional Spanish-based spelling and with no
+# accent marks. `chrome.ftl`'s header sets out the variety, the grammar and
+# the orthography, and names what a Caviteño or Ternateño reader should expect
+# to differ. Respell all four files at once or none.
+#
+# **The frames.** This file is some 220 sentences built out of a dozen
+# recurring frames, and reading the frames is the fastest way to review it:
+#
+#     Ta ignora el …           … is ignored
+#     Hende puede …            cannot / is not possible
+#     Debe …                   must / is required
+#     Invalido …               invalid …
+#     No hay encontrao …       not found
+#     No hay …                 there is no …
+#     Tiene …                  there is …
+#     No hay efecto …          has no effect
+#     Hende pa implementao …   has not been implemented
+#     porque …                 because …
+#     … que ya especifica      … that was specified
+#     Ta usa el …              … is used
+#
+# The aspect particles are doing real work in these: «ya especifica» is a
+# completed act by the author, «ta ignora» an ongoing state of the system, and
+# «hende puede» a present incapacity. A reviewer replacing a frame should
+# replace the particle with it.
+#
+# **Loans, declared.** The technical nouns are Spanish-lexifier where
+# Chavacano has them — «componente», «atributo», «valor», «tipo», «version»,
+# «indice», «matriz», «expresion», «dimension», «funcion», «region», «color»,
+# «linea», «punto», «fila», «columna» — and English outright where it does not:
+# `renderer`, `input`, `output`, `slope`, `grid`, `default`, `mode`, `list`,
+# `state variable`. Nothing was coined.
+#
+# **No plural-category branches.** CLDR has no plural data for `cbk`, so a
+# `[one]` branch would be text selected by English's rules; and the noun after
+# a numeral is unmarked in Chavacano, so one form is correct anyway. Every
+# `$…Count` and `$count` select is collapsed to a single `*[other]`. The
+# explicit numeric literals English forks on are kept where the branch is a
+# real distinction rather than a plural rule.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] ta ignora el { $attributes } si dos endpoint el ya especifica
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] ta ignora el { $attributes } si un endpoint y un midpoint ambos el ya especifica
+    }
+
+line-segment-midpoint-offset-without-midpoint = no hay efecto el midpointOffset si no hay midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linea que ta pasa na maga punto que hende determinao el dimension.
+
+line-points-too-few-dimensions = Debe pasa el linea na maga punto que dos dimension al menos.
+
+line-points-depend-on-variables = Ta pasa el linea na maga punto que ta depende na maga variable: { $variables }.
+
+line-equation-invalid-format = Invalido formato del ecuacion del linea na maga variable { $variable1 } y { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = El rayo ya especifica con through, endpoint, y direction.  Ta ignora el through que ya especifica.
+
+ray-dimension-mismatch = Hende ta cuadra el numDimensions na rayo.
+
+## `<vector>`
+
+vector-overprescribed-head = El vector ya especifica con head, tail, y displacement.  Ta ignora el head que ya especifica.
+
+vector-dimension-mismatch = Hende ta cuadra el numDimensions na vector.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Hende puede atrae na un `<{ $component }>` porque no hay ese nearestPoint state variable.
+
+constrain-to-without-nearest-point = Hende puede limita na un `<{ $component }>` porque no hay ese nearestPoint state variable.
+
+constrain-to-interior-without-nearest-point = Hende puede limita na adentro de un `<{ $component }>` porque no hay ese nearestPoint state variable.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ta ignora el labelPosition para na choiceInput que hende inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ta ignora el maga indice que ya especifica para na choiceInput porque hende ta cuadra el numero de indice con el numero del maga hijo choice.
+
+pretzel-indices-count-mismatch = Ta ignora el maga indice que ya especifica para na problem porque hende ta cuadra el numero de indice con el numero del maga hijo problem.
+
+shuffle-indices-count-mismatch = Ta ignora el maga indice que ya especifica para na shuffle porque hende ta cuadra el numero de indice con el numero del maga componente.
+
+indices-ignored-out-of-range = Ta ignora el maga indice que ya especifica para na { $component } porque tiene indice que fuera del rango.
+
+pretzel-indices-repeated = Ta ignora el maga indice que ya especifica para na pretzel porque tiene indice que ya repiti.
+
+pretzel-circuit-first-index = Ta ignora el maga indice que ya especifica para na pretzel na circuit mode porque debe 1 el primer indice.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Para funciona el `<{ $component }>` con maga hijo string, debe especifica un atributo `type`.
+
+invalid-type-defaulting-to-math = Invalido tipo { $type } para na componente { $component }. Debe uno entre math, text, number, o boolean. Ta usa el math.
+
+string-not-valid-component-to-arrange = El string "{ $value }" hende valido componente para { $component }. Ta ignora.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Invalido tipo { $type }, ta pone el tipo na number.
+
+invalid-variable-value = Invalido valor de un variable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = El indice de variante { $index } debe numero
+
+variant-index-must-be-integer = El indice de variante { $index } debe entero
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Hende pa implementao el `<{ $component }>` para na maga medida absoluto. Ta pone el maga ancho na relativo.
+
+side-by-side-absolute-margins = Hende pa implementao el `<{ $component }>` para na maga medida absoluto. Ta pone el maga margen na relativo.
+
+side-by-side-no-block-child = Invalido `<{ $component }>`: debe tiene al menos un hijo que block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ta ignora el atributo `for` na un `<label>` que grafico.
+
+label-for-must-resolve-to-one = El atributo `for` na `<label>` debe apunta na un componente lang.
+
+label-for-unresolved = Hende puede apunta na un componente el atributo `for` na `<label>`.
+
+label-for-answer-with-authored-inputs = El atributo `for` na `<label>` ta apunta na un `<answer>` que tiene maga input ya escribi del autor; apunta na el mismo input.
+
+label-for-answer-without-input = El atributo `for` na `<label>` ta apunta na un `<answer>` que no hay input para pone letrero.
+
+label-for-must-reference-input-or-answer = El atributo `for` na `<label>` debe apunta na un input o na un answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para na accesibilidad, el `<{ $component }>` debe tiene corto descripcion o debe especifica como decorativo.
+
+accessibility-video-short-description = Para na accesibilidad, el `<video>` debe tiene corto descripcion.
+
+accessibility-input-short-description-or-label = Para na accesibilidad, el `<{ $component }>` debe tiene corto descripcion o letrero.
+
+accessibility-answer-input-short-description-or-label = Para na accesibilidad, un `<answer>` que ta hace un input debe tiene corto descripcion o letrero.
+
+accessibility-short-description-contains-math = Hende debe tiene componente matematico como el `<{ $component }>` na maga corto descripcion. Escribi con palabra el matematica.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Hende bastante el contraste del { $colorName } para na texto del titulo de seccion (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; necesita al menos { $threshold }:1).
+       *[other] Hende bastante el contraste del { $colorName } para na texto del titulo de seccion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; necesita al menos { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Hende pa implementao el `<circle>` que ta pasa na { $count } punto si no hay numerico valor el maga punto.
+
+circle-too-many-through-points = Hende puede calcula el circulo que ta pasa na mas de 3 punto.
+
+circle-overprescribed-radius-center-points = Hende puede calcula el circulo que tiene ya especificao radius, centro, y maga punto para pasa.
+
+circle-center-with-multiple-points = Hende puede calcula el circulo que tiene ya especificao centro y ta pasa na mas de 1 punto.
+
+circle-radius-too-small = Hende puede calcula el circulo: cay el distancia entre el dos punto { $distance }, muy chiquito el radius { $radius } que ya especifica.
+
+circle-radius-with-many-points = Hende puede hace circulo que ta pasa na mas de dos punto con un radius que ya especifica.
+
+circle-invalid-center-or-through-points = Invalido centro o maga punto para pasa del circulo.
+
+circle-radius-center-with-multiple-points = Hende puede calcula el radius del circulo que tiene ya especificao centro y ta pasa na mas de 1 punto.
+
+circle-change-radius-non-numerical = Hende puede cambia el radius del circulo si hende numerico el maga punto para pasa
+
+circle-radius-with-points-non-numerical = Hende puede hace circulo que ta pasa na mas de un punto con un radius que ya especifica si no hay numerico valor.
+
+circle-change-center-non-numerical = Hende pa implementao el cambia del centro de un circulo que ta pasa na maga punto que hende numerico.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Hende bastante el dimension del domain para na funcion. El domain tiene { $intervals } intervalo pero el funcion tiene { $inputs ->
+           *[other] { $inputs } input
+        }.
+    }
+
+function-domain-invalid-format = Invalido formato del domain para na funcion.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ta ignora el maximum del funcion que hende numerico.
+        [minimum] Ta ignora el minimum del funcion que hende numerico.
+        [extremum] Ta ignora el extremum del funcion que hende numerico.
+        [point] Ta ignora el punto del funcion que hende numerico.
+        [slope] Ta ignora el slope del funcion que hende numerico.
+       *[other] Ta ignora el { $type } del funcion que hende numerico.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ta ignora el maximum del funcion que vacio.
+        [minimum] Ta ignora el minimum del funcion que vacio.
+        [extremum] Ta ignora el extremum del funcion que vacio.
+        [point] Ta ignora el punto del funcion que vacio.
+       *[other] Ta ignora el { $type } del funcion que vacio.
+    }
+
+function-points-too-close = Tiene dos punto el funcion que muy cerca el lugar. Hende puede determina el funcion.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] Puede lang hace maga iterate del funcion si igual el numero de input y el numero de output. Este funcion tiene { $inputs } input y { $outputs ->
+           *[other] { $outputs } output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Invalido largo del sequence.  Debe entero que hende negativo.
+
+sequence-invalid-step = Invalido step del sequence.  Debe numero para na sequence que tipo { $type }.
+
+sequence-invalid-endpoint-number = Invalido "{ $attribute }" del sequence de numero.  Debe numero.
+
+sequence-invalid-endpoint-letters = Invalido "{ $attribute }" del sequence de letra.  Debe combinacion de letra.
+
+sequence-invalid-endpoint = Invalido "{ $attribute }" del sequence.
+
+select-from-sequence-coprime-not-numbers = ta ignora el coprime porque hende maga numero el ta escoge
+
+select-from-sequence-coprime-with-exclude-combinations = ta ignora el coprime porque ya especifica el excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Invalido target para na `<{ $source }>`: hende puede encontra el target.
+
+target-state-variable-not-found = Invalido target para na `<{ $source }>`: hende puede encontra un state variable que nombre "{ $property }" na un `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = El maga variable del `<odeSystem>` debe diferente del independent variable.
+
+ode-system-duplicate-variable-names = Hende puede determina maga funcion ODE RHS que igual el nombre del dependent variable.
+
+ode-system-rhs-function-error = Hende puede determina el funcion ODE RHS.  Tiene error na hacer del funcion mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Hende puede determina un angulo entre { $count } linea
+
+angle-invalid-through-point = Invalido punto na through del `<angle>`
+
+parabola-vertex-too-many-points = Hende pa implementao el parabola que tiene vertex y ta pasa na mas de 1 punto.
+
+parabola-too-many-points = Hende pa implementao el parabola que ta pasa na mas de 3 punto.
+
+intersection-too-many-items = Hende pa implementao el intersection para na mas de dos cosa
+
+## Other math components
+
+ionic-compound-not-two-ions = Hende pa implementao el compuesto ionico si hende dos ion.
+
+ionic-compound-needs-cation-and-anion = Implementao lang el compuesto ionico para na un cation y un anion.
+
+solve-equations-cannot-evaluate = Hende puede resolve el ecuacion porque hende puede evalua: { $equation }
+
+math-operators-operand-number-required = Debe especifica un operandNumber si ta saca un operando matematico.
+
+eigen-decomposition-failed = Hende puede calcula el maga eigenvalue del matriz
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: el parametro { $parameters } no hay na pattern, asi que siempre un blanco el ay cuadra con ese.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: hende puede entende el grid="{ $grid }". Debe none, medium, dense, o dos numero positivo que separao con un espacio, como el grid="1 0.5". No hay grid ya dibuja.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    El `<{ $component }>` necesita un funcion que tiene { $expected ->
+        [1] un output, el slope y' na cada punto, como el `y - x`
+       *[other] dos output, el vector na cada punto, como el `(y, -x)`
+    }, pero el funcion que ya dale tiene { $found ->
+       *[other] { $found } output
+    }. { $alternative ->
+        [none] No hay ya dibuja.
+       *[other] El `<{ $alternative }>` el componente para na ese funcion. No hay ya dibuja.
+    }
+
+field-function-attribute-ignored-with-child = Ta ignora el atributo `function` porque ya dale tambien el funcion adentro del componente; el adentro el ta usa. Dale el funcion na uno lang entre el dos.
+
+field-variables-ignored =
+    `<{ $component }>`: el atributo `variables` ta nombra el maga variable de un expresion que ya escribi mismo adentro del componente. { $reason ->
+        [function-child] El funcion aqui ya dale como un hijo `<function>`, que ta nombra el de suyo maga variable, asi que ta ignora el `variables`.
+       *[no-expression] No hay tal expresion aqui, asi que ta ignora el `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: hende suportao el xLabelPosition="left" na prefigure renderer; ta usa el comportamiento del right-position.
+
+prefigure-y-label-position-unsupported = `<graph>`: hende suportao el yLabelPosition="bottom" na prefigure renderer; ta usa el comportamiento del top-position.
+
+prefigure-invalid-axis-bounds = `<graph>`: invalido maga limite del axis para na conversion na prefigure; ta usa el default bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: invalido ancho para na conversion na prefigure; ta usa el default ancho de diagrama 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: invalido aspectRatio para na conversion na prefigure; ta usa el default aspect ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: muy junto el espacio del cuadricula para na maga limite del axis; ta quita el cuadricula na prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: hende ay dibuja el maga annotation si hende PreFigure renderer el ta usa.
+
+multiple-annotations-children = Muchos hijo `<annotations>` ya encontra na `<graph>`; ta ignora todo menos el ultimo.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Hende puede extende o copia un tipo de componente que hende reconocido: { $type }.
+
+copy-prop-not-found = Hende puede encontra el prop { $property } na un componente que tipo { $component }
+
+collect-no-source = No hay encontrao source para na collect.
+
+collect-invalid-component-type = Hende puede recogi maga componente que tipo `<{ $component }>` porque invalido tipo de componente ese.
+
+reference-index-unavailable = Hende puede apunta na indice `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Hende puede llama el { $action } na componente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Invalido forma del data.  Hende igual el largo del maga fila. Ya encontra na componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Tiene igual nombre de columna el data.  Ya encontra na componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Falta un nombre de columna na data.  Ya encontra na componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Un award para na este answer ta basa na el mismo respuesta que ya manda del answer tag, y ay resulta ese na comportamiento que hende esperao.
+
+answer-max-num-attempts-in-section-wide-check-work = No hay efecto el pone `maxNumAttempts` na un `<answer>` que adentro de un contenedor que tiene `sectionWideCheckWork`, porque el contenedor el ta controla el numero de intento. Pone el `maxNumAttempts` na el contenedor.
+
+nested-section-wide-check-work-max-num-attempts = No hay efecto el pone `maxNumAttempts` na un contenedor que tiene `sectionWideCheckWork` y que adentro de otro contenedor que tiene `sectionWideCheckWork`, porque el contenedor de fuera el ta controla el numero de intento. Pone el `maxNumAttempts` na el contenedor de fuera.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] No hay efecto el atributo { $attributes } si hende ya pone el symbolicEquality.
+    }
+
+answer-invalid-type = Invalido tipo para na answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Como no hay nombre el componente `<{ $component }>`, hende puede usa ese para atributo de un module
+
+module-attribute-name-already-defined = Hende puede usa el componente `<{ $component } name="{ $name }">` para atributo de un module porque tiene ya el tipo `<module>` un atributo "{ $name }".
+
+conditional-content-condition-ignored = Ta ignora el atributo `condition` na un componente `<conditionalContent>` que tiene hijo case o else.
+
+slider-markers-type-mismatch = Hende ta cuadra el tipo del maga marker con el tipo del slider.
+
+pretzel-problem-needs-statement-and-answer = Invalido pretzel: cada `<problem>` debe tiene un `<statement>` y un `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Invalido pretzel: na mode="circuit", hende puede distractor el primer `<problem>`.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Invalido valor { $values } para na atributo `{ $attribute }`; ta ignora.
+    }
+
+attribute-must-be-references = Invalido valor `{ $value }` para na atributo `{ $attribute }`. Debe hecho el atributo de maga reference que ta principia con un `$`.
+
+math-input-invalid-function-names = <mathInput>: ta ignora el maga invalido nombre de funcion na { $attribute }: { $names }. El parte que ta sale de cada nombre debe dos caracter al menos (letra o guion); puede sigui un `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Invalido tipo de componente: `<{ $componentType }>`
+
+attribute-repeated = Hende puede repiti el atributo { $attribute }.
+
+attribute-invalid-for-component = Invalido atributo "{ $attribute }" para na un componente que tipo `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    El style definition { $styleNumber } hende bastante el contraste para na { $context ->
+        [text-on-background] color del texto contra el color del fondo
+        [high-contrast] color de alto contraste contra el canvas
+        [line] color del linea contra el canvas
+        [marker] color del marker contra el canvas
+       *[text-on-canvas] color del texto contra el canvas
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; necesita al menos { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Maskin tiene el style definition { $styleNumber } maga color que bastante el contraste para na light mode, el maga color de dark mode que ya sale de estos hende bastante el contraste del color del texto contra el color del fondo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; necesita al menos { $threshold }:1). { $suggestion ->
+        [available] Para bastante el contraste na dark mode, o aumenta el contraste na light mode (ejemplo, pone { $lightAttribute }="{ $lightColor }") o cambia el color de dark mode (ejemplo, pone { $darkAttribute }="{ $darkColor }").
+       *[none] Para bastante el contraste na dark mode, aumenta el contraste na light mode o cambia el maga color que ya sale con textColorDarkMode y/o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Maskin tiene el style definition { $styleNumber } un color de texto que bastante el contraste para na light mode, el color de texto na dark mode que ya sale de ese hende bastante el contraste contra el canvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; necesita al menos { $threshold }:1). { $suggestion ->
+        [available] Para bastante el contraste na dark mode, o aumenta el contraste na light mode (ejemplo, pone textColor="{ $lightColor }") o cambia el color de dark mode (ejemplo, pone textColorDarkMode="{ $darkColor }").
+       *[none] Para bastante el contraste na dark mode, aumenta el contraste na light mode o cambia el color que ya sale con textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Puede escoge un <stylePalette> lang el un seccion; ta usa el ultimo.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = hende puede determina el maga unique variant del { $component } porque hende entero que hende negativo el numToSelect.
+
+variant-num-to-select-not-constant-number = hende puede determina el maga unique variant del { $component } porque hende constante numero el numToSelect.
+
+variant-with-replacement-not-constant-boolean = hende puede determina el maga unique variant del { $component } porque hende constante boolean el withReplacement.
+
+variant-select-weight-disables-unique = Ta apaga el maga unique variant para na select si tiene un opcion que ya especifica el selectWeight o el selectForVariants
+
+variant-coprime-undetermined = hende puede determina el maga unique variant del { $component } porque hende puede determina si siempre false el coprime.
+
+variant-attribute-not-constant = hende puede determina el maga unique variant del { $component } porque hende constante el { $attribute }.
+
+variant-attribute-not-number = hende puede determina el maga unique variant del { $component } porque hende numero el { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    hende puede determina el maga unique variant del { $component } que tipo { $type } porque hende { $expected ->
+        [letters-combination] un combinacion de letra
+        [math-expression] un valido expresion matematico
+        [integer] un entero
+       *[number] un numero
+    } el { $attribute }.
+
+variant-length-not-integer = hende puede determina el maga unique variant del { $component } porque hende entero el length.
+
+variant-sort-not-implemented = hende pa implementao el maga unique variant de un { $component } que tiene sort
+
+variant-exclude-combinations-not-implemented = hende pa implementao el maga unique variant de un { $component } que tiene excludeCombinations
+
+variant-math-exclude-not-implemented = hende pa implementao el maga unique variant de un { $component } que tipo math y que tiene exclude
+
+variant-non-constant-exclude-not-implemented = hende pa implementao el maga unique variant de un { $component } que hende constante el exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: hende suportao na graph prefigure renderer; ya salta el descendiente.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometria que hende finito o hende completo; ya salta el descendiente.
+
+prefigure-curve-label-omitted = { $subject }: hende suportao el maga letrero na maga elemento curve que ya converti; ya quita el letrero.
+
+prefigure-curve-unsupported-definition-type = { $subject }: hende suportao el tipo de definition de curve '{ $definitionType }'; ya salta el descendiente.
+
+prefigure-region-flip-functions-unsupported = { $subject }: hende suportao el atributo flipFunctions na regionBetweenCurves; ya salta el descendiente.
+
+prefigure-region-non-formula-child = { $subject }: maga hijo funcion que tipo formula lang el suportao na regionBetweenCurves; ya salta el descendiente.
+
+prefigure-label-position-unsupported =
+    { $subject }: hende suportao el labelPosition '{ $labelPosition }' para na { $labelKind ->
+        [line-family] letrero del familia de linea
+       *[point] letrero de punto
+    }; ta usa el default alineacion del PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: hende suportao del PreFigure el fill style '{ $fillStyle }'; ta usa un solido relleno.
+
+prefigure-line-style-unknown = { $subject }: hende conocido el line style '{ $lineStyle }'; ya quita na output del PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: el marker style '{ $markerStyle }' ya converti na style 'diamond' del PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: hende suportao del PreFigure el marker style '{ $markerStyle }'; ta usa el default style.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: invalido `ref`; hende puede encontra el target. Ya quita el annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: muchos target el ya sale del `ref`; ta usa el primer target.
+
+annotation-ref-outside-graph = `<annotation>`: invalido `ref`; fuera el target del graph que ta contiene con ese. Ya quita el annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: invalido `ref`; hende suportao objeto grafico el target na conversion na prefigure. Ya quita el annotation.
+
+annotation-text-missing = `<annotation>`: falta o vacio el `text`; ta sale vacio texto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Ya detecta un circular dependency.
+       *[other] Ya detecta un circular dependency que ta envolve el componente `<{ $componentType }>`.
+    }
+
+reference-no-referent = No hay encontrao referente para na reference: `{ $reference }`
+
+reference-multiple-referents = Muchos referente ya encontra para na reference: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Invalido formato del atributo { $attribute } del `<{ $componentType }>`.
+
+children-invalid = Invalido maga hijo para na `<{ $componentType }>`: Ya encontra maga invalido hijo: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Invalido valor `{ $value }` para na atributo `{ $attribute }`, ta usa el valor `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] No hay encontrao el version { $version } del DoenetML.
+       *[other] No hay encontrao el version { $version } del DoenetML. Ta usa el version { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Invalido DoenetML: { $content }
+
+parse-tag-missing-close-tag = Invalido DoenetML: No hay closing tag el tag `{ $tag }`. Debe un self-closing tag o un `</{ $tagName }>` tag.
+
+parse-tag-error = Invalido DoenetML: Tiene error na tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Invalido DoenetML: Parece falta el valor del invalido atributo `{ $attribute }`.
+
+parse-attribute-invalid = Invalido DoenetML: Invalido atributo `{ $attribute }`
+
+parse-attribute-value-invalid = Invalido DoenetML: Invalido valor de atributo `{ $value }`
+
+parse-attribute-value-quote-mismatch = Invalido DoenetML: Invalido valor de atributo `{ $value }`. Hende ta cuadra el maga comilla. Parece falta un `{ $quote }`
+
+parse-open-tag-name-missing = Invalido DoenetML: Ya encontra un tag que no hay nombre, ejemplo `<`
+
+parse-tag-not-closed = Invalido DoenetML: Hende ya cerra el tag `{ $tag }` (parece falta un `>`).
+
+parse-self-closing-tag-name-missing = Invalido DoenetML: Ya encontra un tag que no hay nombre `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Invalido DoenetML: Hende ya cerra el tag `{ $tag }` (parece falta un `/>`).
+
+parse-tag-invalid-attributes = Invalido DoenetML: Hende valido el tag `{ $tag }`. Puede incorrecto el maga atributo.
+
+parse-close-tag-name-missing = Invalido DoenetML: Ya encontra un closing tag que no hay nombre, ejemplo `</`
+
+parse-attribute-value-unquoted = Debe pone adentro de comilla el maga valor de atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Invalido DoenetML: Ya encontra el closing tag `{ $tag }`, pero no hay correspondiente opening tag
+
+parse-close-tag-mismatched = Invalido DoenetML: Hende ta cuadra el closing tag. Ta espera `</{ $expected }>`. Ya encontra `{ $found }`
+
+parser-node-unconvertible = Hende puede converti el node { $node } na Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Invalido atributo name='{ $name }'. { $reason ->
+        [characters] Puede tiene lang letra, numero, underscore o guion el maga nombre.
+       *[start] Debe principia na un letra el maga nombre.
+    }
+
+component-name-invalid-start = Invalido nombre de componente "{ $name }". Debe principia na un letra el maga nombre.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = El answer que tipo videoWatched debe tiene un atributo video
+
+answer-video-watched-video-not-reference = El answer que tipo videoWatched debe tiene un atributo video que un reference
+
+answer-name-not-single-text = El atributo name del answer debe tiene un hijo text lang
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Hende puede saca el DoenetML de fuera cay muchos el nivel de recursion. Tiene ba circular reference?
+
+external-doenetml-unavailable = Hende puede saca el DoenetML de { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Invalido DoenetML el ya saca de { $attribute }="{ $uri }": hende ya cuadra con el tipo de componente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Deprecated ya el atributo `{ $from }`; usa el `{ $to }`.
+       *[other] [deprecation] Deprecated ya el atributo `{ $from }` na `<{ $component }>`; usa el `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Deprecated ya el atributo `{ $from }` y ta ignora porque ya especifica tambien el `{ $to }`.
+       *[other] [deprecation] Deprecated ya el atributo `{ $from }` na `<{ $component }>` y ta ignora porque ya especifica tambien el `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Deprecated ya el atributo `{ $attribute }` na `<{ $component }>` y ta ignora.
+
+deprecated-attribute-to-child = [deprecation] Deprecated ya el atributo `{ $attribute }` na `<{ $component }>`; usa un hijo `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Deprecated ya el valor `{ $value }` del atributo `{ $attribute }` na `<{ $component }>`; usa el `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Puede lang hace plural el `<pluralize>` na Ingles, asi que hende ta cambia el de suyo texto na un documento que ya escribi na { $locale }. Escribi mismo el forma plural, o pone ese con el atributo `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = El elemento `<{ $tag }>` hende reconocido elemento del Doenet.
+
+schema-element-not-allowed-at-root = Hende permitido el elemento `<{ $tag }>` na raiz del documento.
+
+schema-element-not-allowed-inside = Hende permitido el elemento `<{ $tag }>` adentro del `<{ $parent }>`.
+
+schema-attribute-unrecognized = No hay atributo que nombre `{ $attribute }` el elemento `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] El atributo `{ $attribute }` del elemento `<{ $tag }>` debe un lista que cada item uno entre: { $allowed }
+       *[other] El atributo `{ $attribute }` del elemento `<{ $tag }>` debe uno entre: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Invalido nombre de variante para na select.  El nombre de variante { $variantName } ta sale na { $numOptions } opcion pero { $numToSelect } el numero para escoge.
+
+select-variant-name-without-options = Tiene maga variante que ya especifica para na select pero no hay opcion que ya especifica para na posible nombre de variante: { $variantName }.
+
+select-variant-name-not-possible = El nombre de variante { $variantName } que ya especifica para na select hende posible nombre de variante.
+
+select-too-few-options = Hende puede escoge { $numToSelect } componente de { $numOptions } lang.
+
+select-from-sequence-too-few-values = Hende puede escoge { $numToSelect } valor de un sequence que { $length } el largo.
+
+select-from-sequence-indices-count-mismatch = Debe cuadra el numero de indice que ya especifica para na select con el numero para escoge
+
+select-from-sequence-indices-not-integers = Debe entero todo el maga indice que ya especifica para na select
+
+select-from-sequence-index-excluded = Ya especifica un indice del selectfromsequence que ya excluyi
+
+select-from-sequence-indices-excluded-combination = Ya especifica maga indice del selectfromsequence que un combinacion que ya excluyi
+
+select-from-sequence-coprime-not-positive-integers = Hende puede escoge maga combinacion coprime porque hende maga positivo entero el ta escoge.
+
+select-from-sequence-coprime-common-factor = Hende puede escoge maga numero coprime. Todo el posible valor tiene igual factor. (Debe coprime con el "step" el maga valor que ya especifica na "from" o "to".)
+
+select-from-sequence-coprime-single-number = Hende puede escoge maga combinacion coprime de un solo numero que hende 1.
+
+select-from-sequence-excluded-too-many-combinations = Ya excluyi mas del 70% del maga combinacion na selectFromSequence
+
+select-from-sequence-coprime-none-found = Hende puede escoge maga numero coprime. Todo el posible valor tiene igual factor.
+
+select-from-sequence-too-few-unique-values = Hende puede escoge { $numToSelect } unico valor de un sequence que { $numPossibleValues } el largo
+
+select-prime-numbers-too-few-values = Hende puede escoge { $numToSelect } valor de un lista de primo que { $numValues } el largo
+
+select-prime-numbers-values-count-mismatch = Debe cuadra el numero de valor que ya especifica para na select con el numero para escoge
+
+select-prime-numbers-values-not-prime = Debe na lista del maga primo todo el valor que ya especifica para na select prime number
+
+select-prime-numbers-values-excluded-combination = Ya especifica maga valor del selectPrimeNumbers que un combinacion que ya excluyi
+
+select-prime-numbers-excluded-too-many-combinations = Ya excluyi mas del 70% del maga combinacion na selectPrimeNumbers
+
+select-random-combination-fluke = Por un casualidad bien raro, hende ya puede escoge combinacion de maga random valor
+
+select-random-value-fluke = Por un casualidad bien raro, hende ya puede escoge random valor
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Hende ta sale este `<{ $component }>` porque adentro ese del matematica y hende `inline`. Pone el `inline` para queda un drop-down list, que ta cabe adentro de un expresion.
+        [expanded] Hende ta sale este `<{ $component }>` porque adentro ese del matematica y `expanded`. Quita el `expanded`; hende ta cabe adentro de un expresion un caja que muchos linea.
+        [on-graph] Hende ta sale este `<{ $component }>` porque adentro ese del matematica que ya dibuja na un graph, y no hay lugar alli para un input.
+       *[relative-width] Hende ta sale este `<{ $component }>` porque adentro ese del matematica y relativo el ancho. Dale el ancho na absoluto unidad, como el `px`.
+    }

--- a/packages/i18n/locales/cbk/editor.ftl
+++ b/packages/i18n/locales/cbk/editor.ftl
@@ -1,0 +1,236 @@
+# Chavacano (Chabacano de Zamboanga) editor and language-server surfaces.
+# Translated from `locales/en/editor.ftl`, which is the source of truth:
+# `lint:i18n` rejects a key that does not exist there, and reports a key that
+# exists there but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber`, `Answer Id` and every attribute
+# or element name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Zamboangueño**, in the traditional Spanish-based spelling and with no
+# accent marks — `chrome.ftl`'s header sets out the variety, the grammar and
+# the orthography, and says what a Caviteño or Ternateño reader should expect
+# to differ. Respell all four files at once or none.
+#
+# **This is the file where the English is heaviest.** The editor's own nouns
+# have no Chavacano currency at all and are kept as they stand — `editor`,
+# `viewer`, `filter`, `snippet`, `array entry`, `default`, `cursor`, `tag`,
+# `property`, `reference`, `WCAG` — **around a Chavacano frame**. What is
+# Chavacano here is the preverbal aspect («ta mira», «ya principia»), the
+# negation («hende», «no hay»), the object marker «con», the locative «na»,
+# the article «el» and the plural «maga», and the modifier-before-noun order.
+# The words that do have Spanish-lexifier currency are used in it: «variante»,
+# «componente», «atributo», «valor», «linea», «pagina», «informacion»,
+# «accesibilidad», «documentacion», «credito», «coordenada», «funcion».
+#
+# `editor-update-viewer`'s two words are **«Actualiza»** and **«Reinicia»**,
+# both of which fit a toolbar button. If either is too long in practice, the
+# English «Update» and «Reset» are the fallback a corrector should reach for
+# rather than a coinage.
+#
+# **No plural-category branches.** CLDR has no plural data for `cbk`, so a
+# `[one]` branch would be text selected by English's rules; and Chavacano
+# leaves the noun unmarked after a numeral — «{ $count } violacion» is right
+# for one and for many — so one form is correct anyway. Every count select is
+# collapsed to a single `*[other]`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reinicia
+       *[update] Actualiza
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } el Viewer
+       *[other] { $word } el Viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variante
+
+editor-variant-filter = Filtra...
+
+editor-variant-next = Escoge el siguiente variante
+
+editor-variant-previous = Escoge el variante antes
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Tiene encontrao violacion na accesibilidad WCAG AA. Click para { $action ->
+            [close] cerra
+           *[open] abri
+        } el reporte de accesibilidad.
+        [advisories] Click para { $action ->
+            [close] cerra
+           *[open] abri
+        } el reporte de accesibilidad. No hay encontrao violacion na WCAG AA, pero tiene otro maga recomendacion de accesibilidad.
+       *[clean] Click para { $action ->
+            [close] cerra
+           *[open] abri
+        } el reporte de accesibilidad. No hay encontrao problema de accesibilidad.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Tiene encontrao violacion na accesibilidad WCAG AA. Ya encontra { $count ->
+           *[other] { $count } violacion na WCAG AA
+        }. Click para { $action ->
+            [close] cerra
+           *[open] abri
+        } el reporte de accesibilidad.
+        [advisories] No hay encontrao violacion na WCAG AA. Ya encontra { $count ->
+           *[other] { $count } otro recomendacion de accesibilidad
+        }. Click para { $action ->
+            [close] cerra
+           *[open] abri
+        } el reporte de accesibilidad.
+       *[clean] No hay encontrao violacion na WCAG AA. Click para { $action ->
+            [close] cerra
+           *[open] abri
+        } el reporte de accesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Version de DoenetML { $version }
+
+editor-tab-help = Ayuda segun el contexto
+editor-tab-help-short = Contexto
+editor-tab-errors = Maga Error
+editor-tab-warnings = Maga Aviso
+editor-tab-info = Informacion
+editor-tab-accessibility = Accesibilidad
+editor-tab-responses = Maga respuesta ya manda
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Maga opcion del editor
+editor-format-as-doenetml = Formatea como DoenetML
+editor-format-as-xml = Formatea como XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linea #{ $line }
+
+editor-no-errors = No Hay Error
+editor-no-warnings = No Hay Aviso
+editor-no-info = No Hay Informacion
+
+editor-show-info-annotations = Mostra na editor el maga diagnostico de informacion
+editor-show-accessibility-annotations = Mostra na editor el maga diagnostico de accesibilidad
+
+editor-accessibility-learn-more = Aprende paquemodo ta atende el Doenet con el accesibilidad
+
+editor-accessibility-violations-heading = Maga violacion na accesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Otro maga problema de accesibilidad
+editor-none-found = No hay encontrao
+
+
+## Submitted responses
+
+editor-no-responses = No hay pa respuesta ya manda
+editor-response-answer-id = Answer Id
+editor-response-response = Respuesta
+editor-response-credit = Credito
+editor-response-submitted = Ya manda
+
+
+## The context-help panel
+
+help-placeholder = Pone el cursor na un nombre de tag, atributo, o { $ref } para na documentacion.
+
+help-unsupported-ref-chain = Hende pa suportao el ayuda para na maga reference que muchos el parte, como el { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] No hay encontrao referente para na reference: { $ref }.
+        [multiple] Muchos referente ya encontra para na reference: { $ref }.
+       *[indeterminate] Hende puede determina el referente de { $ref }.
+    }
+
+help-learn-about-references = Aprende acerca del maga reference →
+help-reference-page = Pagina de reference →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Adentro del { $element }
+       *[top] Na mas alto nivel
+    }{ $allowed ->
+        [none] { " — no hay cosa puede pone aqui." }
+        [text] { " — escribi texto aqui." }
+        [text-and-components] { " — escribi texto aqui, o intenta:" }
+       *[components] { " — maga cosa puede intenta:" }
+    }
+
+help-suggestions-footer = Aprita el { $shortcut } para mira todo el { $total } componente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] El { $ref } un reference con { $target }.
+       *[other] El { $ref } un reference con { $target } (linea { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ya introduci del { $owner } como { $role }.
+       *[other] Ya introduci del { $owner } na linea { $line } como { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] El { $ref } un reference con el property { $property } del { $element }.
+       *[other] El { $ref } un reference con el property { $property } del { $element } (linea { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = Default:
+help-active-default = Activo default:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Maga valor permitido (uno cada item):
+       *[other] Maga valor permitido:
+    }
+
+help-suggested-values = Maga valor sugerido:
+
+help-inserts = Ta pone:
+
+help-coordinates =
+    { $count ->
+       *[other] Coordenada:
+    }
+
+help-type = Tipo:
+
+help-resolved-style = Style ya determina (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Maga nombre de funcion ya determina:
+help-reset-list = Reinicia el lista na este input:
+help-added-on-input = Ya agrega na este input:
+help-removed-on-input = Ya quita na este input:
+
+help-reset-overrides = El { $reset } ta manda sobre el { $additional } y el { $removed }.

--- a/packages/i18n/locales/dtp/chrome.ftl
+++ b/packages/i18n/locales/dtp/chrome.ftl
@@ -15,11 +15,17 @@
 # the **standardised Kadazandusun taught in Sabah's schools** — the written
 # standard built on **Bundu-Liwan** Dusun and used in the state's
 # Kadazandusun-language curriculum and dictionaries. `dtp` is one member of a
-# cluster: **Coastal Kadazan is `dtb`** and **Rungus is `drg`**, and a reader
-# of either will find words here that are not theirs. «opurak» for white is
-# the clearest of them — Coastal Kadazan says «oputi'» — and a `dtb` or `drg`
-# reader should expect to respell rather than to find their own variety
-# served. That is the cost of one tag per catalog, not an oversight.
+# cluster: **Coastal Kadazan is `kzj`**, **Labuk-Kinabatangan Kadazan is
+# `dtb`** and **Rungus is `drg`**, and a reader of any of the three will find
+# words here that are not theirs. «opurak» for white is the clearest of them —
+# Coastal Kadazan says «oputi'» — and such a reader should expect to respell
+# rather than to find their own variety served. That is the cost of one tag
+# per catalog, not an oversight.
+#
+# `kzj` alone arrives here without anything in this repository arranging it:
+# ICU canonicalizes the tag onto `dtp`, so a Coastal Kadazan request is served
+# this file. `dtb` and `drg` fall to English, because `dtp` is not an ISO
+# 639-3 macrolanguage and there is no published membership to fold them on.
 #
 # ORTHOGRAPHY. The standard Kadazandusun spelling: `v` is a letter of the
 # alphabet and not a stand-in for `w` («vagu», «avasi»), the glottal stop is

--- a/packages/i18n/locales/dtp/chrome.ftl
+++ b/packages/i18n/locales/dtp/chrome.ftl
@@ -1,0 +1,168 @@
+# Central Dusun / Kadazandusun viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Kadazandusun** (Boros Dusun), the Dusunic language of the interior and
+# west coast of Sabah, Malaysia.
+#
+# **WHICH VARIETY.** `dtp` is Central Dusun, and this catalog is written in
+# the **standardised Kadazandusun taught in Sabah's schools** — the written
+# standard built on **Bundu-Liwan** Dusun and used in the state's
+# Kadazandusun-language curriculum and dictionaries. `dtp` is one member of a
+# cluster: **Coastal Kadazan is `dtb`** and **Rungus is `drg`**, and a reader
+# of either will find words here that are not theirs. «opurak» for white is
+# the clearest of them — Coastal Kadazan says «oputi'» — and a `dtb` or `drg`
+# reader should expect to respell rather than to find their own variety
+# served. That is the cost of one tag per catalog, not an oversight.
+#
+# ORTHOGRAPHY. The standard Kadazandusun spelling: `v` is a letter of the
+# alphabet and not a stand-in for `w` («vagu», «avasi»), the glottal stop is
+# written with an apostrophe («amu'»), and `ng` is one letter. A corrector who
+# prefers an older mission spelling should convert **all four files at once**.
+#
+# **THIS IS THE THINNEST CATALOG OF ITS BATCH, AND IT SAYS SO FIRST RATHER
+# THAN LAST.** What is Kadazandusun here is the **frame**: the function words,
+# the negators, the existentials, the colour terms and a short list of nouns.
+# Most of the verbs and nearly all of the technical vocabulary are **declared
+# Malay loans, written in Malay spelling and not adapted**. A Kadazandusun
+# pupil in Sabah is schooled in Malay and meets these ideas in Malay, so a
+# loan is what they actually use; what this seed refuses to do is invent a
+# Kadazandusun word by hanging a Kadazandusun prefix on a Malay root, which
+# would look like the language and be nothing of the sort. A speaker should
+# expect to **rewrite sentences** here rather than to correct words inside
+# them.
+#
+# THE KADAZANDUSUN A REVIEWER CAN CHECK IN A SECOND:
+#
+#   - **«waro»** for "there is" and **«aiso»** for "there is none" — the pair
+#     this file leans on hardest;
+#   - **«amu'»** for "not", **«om»** for "and", **«toi»** for "or",
+#     **«nga»** for "but", **«nung»** for "if", **«montok»** for "for",
+#     **«id»** for "at, in", **«mantad»** for "from", **«obuli»** for "can";
+#   - **«diti»** "this", **«dilo'»** "that", **«nu»** "your", **«nogi»**
+#     "still, more", **«vagu»** "again, new";
+#   - the nouns it does have: «simbar» (answer), «ngaran» (name), «otopot»
+#     (correct, true), «avasi» (good), «koilaan» (knowledge).
+#
+# **WHAT THIS CATALOG DOES NOT KNOW.** It cannot write Kadazandusun's verbal
+# aspect, so the two progressive strings — `answer-checking` and
+# `answer-submitting` — are written as a **bare verb with an ellipsis**
+# instead of "is being checked". That is a hole, not a style, and it is the
+# first thing to fix. It also has no confident word for "feedback", "hide" or
+# "renderer", and writes the Malay «Maklum Balas», «Sorok» and the English
+# `renderer` for the three.
+#
+# PLURALS. `Intl.PluralRules` has no data for `dtp`, so a `[one]` branch would
+# be selected by the runtime's default locale rather than by Kadazandusun —
+# and Kadazandusun would not want one, since a noun after a numeral is
+# unmarked. Every count select is collapsed to a single `*[other]`. An
+# explicit `[0]` is matched against the number itself rather than against a
+# plural category, so it stays.
+
+
+## Answer submission
+
+answer-checking = Periksa…
+answer-submitting = Hantar…
+answer-checking-status = Periksa simbar
+answer-submitting-status = Hantar simbar
+answer-correct = Otopot
+answer-incorrect = Amu' otopot
+answer-response-saved = Simbar disimpan
+answer-percent-credit = { $percent }% markah
+answer-percent-correct = { $percent }% otopot
+answer-percent-short = { $percent } %
+max-credit-available = Markah paling tinggi dot obuli: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] aiso no peluang
+       *[other] { $count } peluang nogi
+    }
+validation-correct = (Otopot)
+validation-incorrect = (Amu' otopot)
+validation-partially-correct = (Otopot sebahagian)
+answer-show-responses =
+    { $count ->
+       *[other] Tunjuk { $count } simbar montok { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Maklum Balas
+collapsible-click-to-open = (tekan montok buka)
+collapsible-click-to-close = (tekan montok tutup)
+collapsible-initializing = Sedia…
+footnote-show = Tunjuk nota kaki
+footnote-hide = Sorok nota kaki
+description-more-information = keterangan tambahan
+
+
+## Controls
+
+slider-previous = Sebelum
+slider-next = Seterusnya
+keyboard-open = Buka Papan Kekunci
+keyboard-close = Tutup Papan Kekunci
+choice-input-remove-choice = Buang { $choice }
+matrix-remove-row = Buang baris
+matrix-add-row = Tambah baris
+matrix-remove-column = Buang lajur
+matrix-add-column = Tambah lajur
+subset-add-remove-points = Tambah/Buang titik
+subset-toggle-points-intervals = Tukar antara titik om selang
+subset-move-points = Alih Titik
+subset-clear = Kosongkan
+orbital-add-row = Tambah Baris
+orbital-remove-row = Buang Baris
+orbital-add-box = Tambah Kotak
+orbital-remove-box = Buang Kotak
+orbital-add-up-arrow = Tambah Anak Panah Ke Atas
+orbital-add-down-arrow = Tambah Anak Panah Ke Bawah
+orbital-remove-arrow = Buang Anak Panah
+orbital-row-label = Label montok baris { $row }
+pretzel-answer = Simbar
+summary-statistics-caption = Ringkasan statistik { $column }
+
+
+## Math input
+
+math-input-preview-region = pratonton ungkapan matematik
+math-input-preview = Pratonton
+math-input-invalid-expression = Ungkapan amu' otopot:
+
+
+## Document status
+
+viewer-initializing = Sedia…
+
+
+## Errors
+
+error-heading = Ralat
+error-found-at =
+    { $span ->
+        [line] Nokito id baris { $startLine }.
+       *[lines] Nokito id baris { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Waro ralat id dokumen diti!
+diagnostic-heading-error = Ralat
+diagnostic-heading-warning = Amaran
+diagnostic-heading-information = Maklumat
+diagnostic-heading-hint = Petunjuk
+accessibility-heading-level-1 = Pelanggaran akses WCAG AA
+accessibility-heading-level-2 = Amaran akses
+something-went-wrong = Waro masalah nokojadi.
+renderer-load-failed = iso renderer amu' obuli dimuat. Muat semula halaman diti.
+core-start-failed = Dokumen diti amu' obuli dimulakan. Muat semula halaman diti.
+core-start-failed-busy = Dokumen diti amu' obuli dimulakan. Beberapa dokumen dimulakan serentak, om diti obuli mengambil masa lebih lama id peranti dot perlahan. Muat semula halaman diti obuli menolong nung dokumen lain siap.
+core-start-failed-retry = Dokumen diti amu' obuli dimulakan.
+core-start-failed-busy-retry = Dokumen diti amu' obuli dimulakan. Beberapa dokumen dimulakan serentak, om diti obuli mengambil masa lebih lama id peranti dot perlahan.
+core-start-retry = Cuba Vagu
+saved-state-unavailable = Kerja nu dot disimpan amu' obuli dimuat.

--- a/packages/i18n/locales/dtp/content.ftl
+++ b/packages/i18n/locales/dtp/content.ftl
@@ -55,7 +55,7 @@
 # is also why «biru otomou» for cyan is a reach rather than a term.
 #
 # CHEMISTRY. `element-name` and `element-anion-name` are deliberately **left
-# out**, so their ~130 keys fall back to English. Chemistry in Sabah is taught
+# out**, so their 130 keys fall back to English. Chemistry in Sabah is taught
 # in Malay, out of textbooks printing the Dewan Bahasa dan Pustaka names,
 # which `locales/ms` already carries; there is no separate Kadazandusun list,
 # and copying the Malay one under this tag would report a language fact that

--- a/packages/i18n/locales/dtp/content.ftl
+++ b/packages/i18n/locales/dtp/content.ftl
@@ -1,0 +1,288 @@
+# Kadazandusun content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Kadazandusun** (Boros Dusun) of Sabah, written in the **standardised
+# Bundu-Liwan-based orthography** taught in Sabah's schools. `dtp` is Central
+# Dusun; **Coastal Kadazan is `dtb`** and **Rungus is `drg`**, and a reader of
+# either variety will need to respell some of what is here. See
+# `locales/dtp/chrome.ftl` for the whole of that note.
+#
+# WORD ORDER. The head noun comes first and its describing word follows, so
+# "thick dashed red line" is «garis tebal putus-putus merah» — noun, width,
+# dash pattern, colour, keeping English's order among the adjectives
+# themselves. `style-with-noun` and `style-filled-with-noun` put `{ $noun }`
+# first, and every message in this file agrees with them.
+#
+# **THE LINKER, WHICH IS THIS FILE'S LARGEST OPEN QUESTION.** Kadazandusun
+# joins a modifier to a head with **«do»/«dot»**, and where it is obligatory
+# is not something this seed can get right message by message. So the rule it
+# follows is stated once and applied everywhere: **«dot» is written where it
+# introduces a relative clause** («markah paling tinggi dot obuli»), and
+# **omitted between a noun and a bare describing word** («garis tebal»). A
+# speaker should check that split before anything else in this file; it is one
+# decision, and correcting it corrects every message at once.
+#
+# GENDER AND NUMBER. Kadazandusun has no grammatical gender and does not
+# inflect a describing word to agree with its noun, so `$gender` and `$role`
+# are received and ignored, as in English. It has no article, so the two
+# `-article` branches read exactly like the ones without. A noun after a
+# numeral is unmarked.
+#
+# **THE NOUN TABLE IS MALAY, AND THAT IS DELIBERATE.** «poligon», «fungsi»,
+# «vektor», «parabola», «segi tiga», «segi empat tepat», «bulatan», «rombus»
+# and the rest are the Malay school terms, written unchanged. They are nearly
+# the same words `locales/ms` and `locales/iba` carry, because Sabah, Sarawak
+# and the peninsula teach mathematics out of the same Malay textbooks — a fact
+# about one education ministry rather than about three languages. **What
+# differs between the three catalogs is everything around the table**, and
+# that is where a reviewer should look to see whether this one is
+# Kadazandusun.
+#
+# WHAT IS KADAZANDUSUN HERE. The colour terms «oitom», «opurak», «aragang»,
+# «osilou» and «otomou»; «waro» and «aiso»; «amu'», «om», «toi», «nung»,
+# «miampai», «montok», «mantad», «obuli»; «simbar» for the answer, «otopot»
+# for true.
+#
+# CONFIDENCE. The colour list is the thinnest part of the file. Five of the
+# twelve — «kelabu» (gray), «jingga» (orange), «ungu» (purple), «merah jambu»
+# (pink) and «perang» (brown) — are the **Malay words**, written because
+# Kadazandusun's everyday colour vocabulary does not settle these five and a
+# coinage would be worse than a loan a speaker already uses. «otomou» is
+# written for green; it covers a green-to-blue range for many speakers, which
+# is also why «biru otomou» for cyan is a reach rather than a term.
+#
+# CHEMISTRY. `element-name` and `element-anion-name` are deliberately **left
+# out**, so their ~130 keys fall back to English. Chemistry in Sabah is taught
+# in Malay, out of textbooks printing the Dewan Bahasa dan Pustaka names,
+# which `locales/ms` already carries; there is no separate Kadazandusun list,
+# and copying the Malay one under this tag would report a language fact that
+# is not true. The frames around the names are translated, because they are
+# frames rather than vocabulary.
+
+
+## Style vocabulary
+
+color =
+    .black = oitom
+    .white = opurak
+    .gray = kelabu
+    .red = aragang
+    .orange = jingga
+    .yellow = osilou
+    .green = otomou
+    .cyan = biru otomou
+    .blue = biru
+    .purple = ungu
+    .pink = merah jambu
+    .brown = perang
+line-width =
+    .thick = tebal
+    .thin = nipis
+line-style =
+    .dashed = putus-putus
+    .dotted = bertitik
+# Noun phrases: they follow «miampai» and modify nothing themselves. The
+# reduplication is the plural.
+fill-style =
+    .horizontal = garis-garis mendatar
+    .vertical = garis-garis menegak
+    .diagonal = garis-garis serong
+    .backdiagonal = garis-garis serong terbalik
+    .dots = titik-titik
+    .diamonds = rombus
+noun =
+    .line = garis
+    .line-segment = tembereng garis
+    .ray = sinar
+    .vector = vektor
+    .curve = lengkung
+    .function = fungsi
+    .slope-field = medan kecerunan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis berbilang
+    .polygon = poligon
+    .triangle = segi tiga
+    .rectangle = segi empat tepat
+    .circle = bulatan
+    .region = pomogunan
+    .point = titik
+    .square = segi empat sama
+    .diamond = rombus
+    .cross = tanda pangkah
+    .plus = tanda tambah
+# «bersisi» has to stay beside the number that counts the sides, so the count
+# folds into the head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon sekata bersisi { $numSides }
+    }
+# Kadazandusun has no grammatical gender, so every noun answers the same and
+# the answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun leads and its describing words follow: «garis tebal putus-putus
+# aragang».
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = berisi
+# «miampai» — "together with" — is the Kadazandusun word carrying English's
+# "with"; «om» is the one that chains a further clause on.
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } miampai { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } miampai { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } miampai { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+# Kadazandusun has no article, so the `-article` branches read like the ones
+# without.
+style-border-clause =
+    { $parts ->
+        [with-article] miampai sempadan { $border }
+        [and] om sempadan { $border }
+        [and-article] om sempadan { $border }
+       *[with] miampai sempadan { $border }
+    }
+# The pattern is a noun and the colour follows it, as everywhere else.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = amu' berisi
+style-text =
+    { $parts ->
+        [background] { $color } miampai latar belakang { $background }
+       *[plain] { $color }
+    }
+# «aiso» is the Kadazandusun "there is none", the negative counterpart of
+# «waro».
+style-background-none = aiso
+
+
+## Boolean words
+
+boolean-true = otopot
+boolean-false = amu' otopot
+
+
+## Answer buttons
+
+answer-submit-label = Periksa Kerja
+answer-submit-label-no-correctness = Hantar Simbar
+
+
+## Sectional blocks
+##
+## Kadazandusun does not mark number on a noun, so `.exercise` and
+## `.exercises`, and `.problem` and `.problems`, are the same word. These are
+## the Malay school words but for `.given-answer`, which is Kadazandusun
+## «Simbar»; see the header for why the rest are loans rather than coinages.
+
+section-name =
+    .activity = Aktiviti
+    .aside = Nota Tepi
+    .cascade = Kaskad
+    .definition = Takrif
+    .example = Contoh
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Simbar
+    .note = Nota
+    .objectives = Tujuan
+    .paragraphs = Perenggan
+    .part = Bahagian
+    .problem = Masalah
+    .problems = Masalah
+    .proof = Bukti
+    .question = Soalan
+    .section = Seksyen
+    .solution = Penyelesaian
+    .task = Tugasan
+    .theorem = Teorem
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Petunjuk
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Jadual { $enumeration }
+        [numbered-title] Jadual { $enumeration }{ ": " }
+        [unnumbered-title] Jadual{ ": " }
+       *[unnumbered] Jadual
+    }
+figure-name =
+    { $parts ->
+        [numbered] Rajah { $enumeration }
+        [numbered-caption] Rajah { $enumeration }{ ": " }
+        [unnumbered-caption] Rajah{ ": " }
+       *[unnumbered] Rajah
+    }
+
+
+## Paginator controls
+
+paginator-previous = Sebelum
+paginator-next = Seterusnya
+paginator-page = Halaman
+paginator-page-status = { $pageLabel } { $currentPage } mantad { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = toi
+piecewise-condition-if = nung
+piecewise-condition-otherwise = nung amu'
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header for why. These three are frames rather than vocabulary, so they are
+## translated whether or not the names ever are.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Simbol Kimia Amu' Otopot
+chemistry-invalid-ionic-compound = Sebatian Ionik Amu' Otopot
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = kosong
+math-embedded-input-blank-ordinal = kosong { $ordinal } mantad { $total }

--- a/packages/i18n/locales/dtp/content.ftl
+++ b/packages/i18n/locales/dtp/content.ftl
@@ -6,8 +6,9 @@
 #
 # **Kadazandusun** (Boros Dusun) of Sabah, written in the **standardised
 # Bundu-Liwan-based orthography** taught in Sabah's schools. `dtp` is Central
-# Dusun; **Coastal Kadazan is `dtb`** and **Rungus is `drg`**, and a reader of
-# either variety will need to respell some of what is here. See
+# Dusun; **Coastal Kadazan is `kzj`**, **Labuk-Kinabatangan Kadazan is `dtb`**
+# and **Rungus is `drg`**, and a reader of any of those varieties will need to
+# respell some of what is here. See
 # `locales/dtp/chrome.ftl` for the whole of that note.
 #
 # WORD ORDER. The head noun comes first and its describing word follows, so

--- a/packages/i18n/locales/dtp/diagnostics.ftl
+++ b/packages/i18n/locales/dtp/diagnostics.ftl
@@ -1,0 +1,695 @@
+# Kadazandusun diagnostics. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the standardised Bundu-Liwan-based Kadazandusun orthography used
+# by the other three files of this locale; see `locales/dtp/chrome.ftl` for
+# the whole note, and for why the technical vocabulary below is a declared
+# Malay loan rather than a Kadazandusun coinage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source, and so do `PreFigure`, `DoenetML` and `Dast`.
+#
+# **THIS IS THE FILE WHERE THE CATALOG IS THINNEST**, because a diagnostic is
+# a whole sentence and a sentence needs more of a language than a button
+# label does. The sentences here are Malay; what is Kadazandusun is the frame
+# they are hung on, and the frame is small enough to list:
+#
+#   - **«waro»** "there is" and **«aiso»** "there is none";
+#   - **«amu'»** "not", **«amu' obuli»** "cannot", **«amu' nogi»** "not yet";
+#   - **«om»** "and", **«toi»** "or", **«nga»** "but", **«nung»** "if";
+#   - **«id»** "at, in", **«mantad»** "from", **«montok»** "for";
+#   - **«dot»** the relative linker, **«diti»** "this", **«dilo'»** "that".
+#
+# Two phrases carry most of the file, and naming them here means a corrector
+# can change all of them at once: "is ignored" is **«diabaikan»** and "have
+# not implemented" is **«amu' nogi dilaksanakan»**. A speaker should expect to
+# rewrite these sentences rather than to correct words inside them.
+#
+# Every count selection is a single `*[other]`: Kadazandusun does not mark
+# number on a noun after a numeral, and `Intl.PluralRules` has no data for
+# `dtp` to select a `[one]` branch with. The one `[1]` below is a numeric
+# literal matched against the number itself, which stays legal.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] { $attributes } diabaikan nung dua hujung ditetapkan
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] { $attributes } diabaikan nung satu hujung om titik tengah ditetapkan serentak
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset aiso kesan nung aiso titik tengah
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis melalui titik dot amu' ditentukan dimensinya.
+
+line-points-too-few-dimensions = Garis mesti melalui titik dot sekurang-kurangnya dua dimensi.
+
+line-points-depend-on-variables = Garis melalui titik dot bergantung id pemboleh ubah: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis id pemboleh ubah { $variable1 } om { $variable2 } amu' otopot.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar ditetapkan mantad through, endpoint om direction.  through dot ditetapkan diabaikan.
+
+ray-dimension-mismatch = numDimensions amu' sepadan id sinar.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ditetapkan mantad head, tail om displacement.  head dot ditetapkan diabaikan.
+
+vector-dimension-mismatch = numDimensions amu' sepadan id vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Amu' obuli ditarik id `<{ $component }>` sebab aiso pemboleh ubah keadaan nearestPoint.
+
+constrain-to-without-nearest-point = Amu' obuli dikekang id `<{ $component }>` sebab aiso pemboleh ubah keadaan nearestPoint.
+
+constrain-to-interior-without-nearest-point = Amu' obuli dikekang id dalam `<{ $component }>` sebab aiso pemboleh ubah keadaan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition diabaikan montok choiceInput dot bukan inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indeks dot ditetapkan montok choiceInput diabaikan sebab bilangan indeks amu' sepadan om bilangan anak pilihan.
+
+pretzel-indices-count-mismatch = Indeks dot ditetapkan montok problem diabaikan sebab bilangan indeks amu' sepadan om bilangan anak problem.
+
+shuffle-indices-count-mismatch = Indeks dot ditetapkan montok shuffle diabaikan sebab bilangan indeks amu' sepadan om bilangan komponen.
+
+indices-ignored-out-of-range = Indeks dot ditetapkan montok { $component } diabaikan sebab waro indeks di luar julat.
+
+pretzel-indices-repeated = Indeks dot ditetapkan montok pretzel diabaikan sebab waro indeks dot berulang.
+
+pretzel-circuit-first-index = Indeks dot ditetapkan montok pretzel id mode circuit diabaikan sebab indeks pertama mesti 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Supaya `<{ $component }>` berfungsi om anak string, atribut `type` mesti ditetapkan.
+
+invalid-type-defaulting-to-math = Type { $type } amu' otopot montok komponen { $component }. Mesti salah satu mantad math, text, number toi boolean. Ditetapkan semula id math.
+
+string-not-valid-component-to-arrange = String "{ $value }" bukan komponen dot obuli di{ $component }. Diabaikan.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } amu' otopot, type ditukar id number.
+
+invalid-variable-value = Nilai pemboleh ubah amu' otopot: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } mesti nombor
+
+variant-index-must-be-integer = Indeks varian { $index } mesti integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` amu' nogi dilaksanakan montok ukuran mutlak. Lebar ditukar id relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` amu' nogi dilaksanakan montok ukuran mutlak. Jidar ditukar id relatif.
+
+side-by-side-no-block-child = `<{ $component }>` amu' otopot: mesti waro sekurang-kurangnya satu anak blok.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` id `<label>` grafik diabaikan.
+
+label-for-must-resolve-to-one = Atribut `for` id `<label>` mesti menunjuk id satu komponen sahaja.
+
+label-for-unresolved = Atribut `for` id `<label>` amu' obuli ditentukan id satu komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` id `<label>` merujuk `<answer>` dot waro input ditulis penulis; rujuk terus input dilo'.
+
+label-for-answer-without-input = Atribut `for` id `<label>` merujuk `<answer>` dot aiso input montok dilabel.
+
+label-for-must-reference-input-or-answer = Atribut `for` id `<label>` mesti merujuk input toi answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Montok akses, `<{ $component }>` mesti waro keterangan ringkas toi ditetapkan sebagai hiasan.
+
+accessibility-video-short-description = Montok akses, `<video>` mesti waro keterangan ringkas.
+
+accessibility-input-short-description-or-label = Montok akses, `<{ $component }>` mesti waro keterangan ringkas toi label.
+
+accessibility-answer-input-short-description-or-label = Montok akses, `<answer>` dot membina input mesti waro keterangan ringkas toi label.
+
+accessibility-short-description-contains-math = Keterangan ringkas amu' patut waro komponen matematik macam `<{ $component }>`. Tulis matematik dilo' om perkataan.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } aiso kontras dot cukup montok teks tajuk seksyen (mod gelap) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; perlu sekurang-kurangnya { $threshold }:1).
+       *[other] { $colorName } aiso kontras dot cukup montok teks tajuk seksyen ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; perlu sekurang-kurangnya { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` melalui { $count } titik amu' nogi dilaksanakan nung titik dilo' aiso nilai nombor.
+
+circle-too-many-through-points = Amu' obuli mengira bulatan melalui lebih mantad 3 titik.
+
+circle-overprescribed-radius-center-points = Amu' obuli mengira bulatan om jejari, pusat om titik dot ditetapkan serentak.
+
+circle-center-with-multiple-points = Amu' obuli mengira bulatan om pusat dot ditetapkan melalui lebih mantad 1 titik.
+
+circle-radius-too-small = Amu' obuli mengira bulatan: sebab jarak antara dua titik dilo' { $distance }, jejari { $radius } dot ditetapkan terlalu kecil.
+
+circle-radius-with-many-points = Amu' obuli membina bulatan melalui lebih mantad dua titik om jejari dot ditetapkan.
+
+circle-invalid-center-or-through-points = Pusat toi titik dot dilalui bulatan amu' otopot.
+
+circle-radius-center-with-multiple-points = Amu' obuli mengira jejari bulatan om pusat dot ditetapkan melalui lebih mantad 1 titik.
+
+circle-change-radius-non-numerical = Amu' obuli menukar jejari bulatan melalui titik dot aiso nilai nombor
+
+circle-radius-with-points-non-numerical = Amu' obuli membina bulatan melalui lebih mantad satu titik om jejari dot ditetapkan nung aiso nilai nombor.
+
+circle-change-center-non-numerical = Menukar pusat bulatan melalui titik dot aiso nilai nombor amu' nogi dilaksanakan.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Dimensi domain fungsi amu' cukup. Domain waro { $intervals } selang nga fungsi waro { $inputs ->
+           *[other] { $inputs } input
+        }.
+    }
+
+function-domain-invalid-format = Format domain fungsi amu' otopot.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nilai maksimum fungsi dot bukan nombor diabaikan.
+        [minimum] Nilai minimum fungsi dot bukan nombor diabaikan.
+        [extremum] Nilai ekstremum fungsi dot bukan nombor diabaikan.
+        [point] Titik fungsi dot bukan nombor diabaikan.
+        [slope] Kecerunan fungsi dot bukan nombor diabaikan.
+       *[other] { $type } fungsi dot bukan nombor diabaikan.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nilai maksimum fungsi dot kosong diabaikan.
+        [minimum] Nilai minimum fungsi dot kosong diabaikan.
+        [extremum] Nilai ekstremum fungsi dot kosong diabaikan.
+        [point] Titik fungsi dot kosong diabaikan.
+       *[other] { $type } fungsi dot kosong diabaikan.
+    }
+
+function-points-too-close = Fungsi waro dua titik dot terlalu rapat. Fungsi amu' obuli ditakrifkan.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] Lelaran fungsi obuli sahaja nung bilangan input fungsi sepadan om bilangan output. Fungsi diti waro { $inputs } input om { $outputs ->
+           *[other] { $outputs } output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang jujukan amu' otopot.  Mesti integer dot bukan negatif.
+
+sequence-invalid-step = Langkah jujukan amu' otopot.  Mesti nombor montok jujukan jenis { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" jujukan nombor amu' otopot.  Mesti nombor.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" jujukan huruf amu' otopot.  Mesti gabungan huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" jujukan amu' otopot.
+
+select-from-sequence-coprime-not-numbers = coprime diabaikan sebab bukan nombor dot dipilih
+
+select-from-sequence-coprime-with-exclude-combinations = coprime diabaikan sebab excludeCombinations ditetapkan
+
+## Resolving a `target`
+
+target-not-found = Target montok `<{ $source }>` amu' otopot: target amu' dijumpai.
+
+target-state-variable-not-found = Target montok `<{ $source }>` amu' otopot: pemboleh ubah keadaan dot bernama "{ $property }" amu' dijumpai id `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Pemboleh ubah `<odeSystem>` mesti berbeza mantad pemboleh ubah bebas.
+
+ode-system-duplicate-variable-names = Amu' obuli menakrif fungsi RHS ODE om nama pemboleh ubah dot sama.
+
+ode-system-rhs-function-error = Amu' obuli menakrif fungsi RHS ODE.  Ralat membina fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Amu' obuli menakrif sudut antara { $count } garis
+
+angle-invalid-through-point = Titik id through `<angle>` amu' otopot
+
+parabola-vertex-too-many-points = Parabola om bucu melalui lebih mantad 1 titik amu' nogi dilaksanakan.
+
+parabola-too-many-points = Parabola melalui lebih mantad 3 titik amu' nogi dilaksanakan.
+
+intersection-too-many-items = Persilangan montok lebih mantad dua item amu' nogi dilaksanakan
+
+## Other math components
+
+ionic-compound-not-two-ions = Sebatian ionik montok selain dua ion amu' nogi dilaksanakan.
+
+ionic-compound-needs-cation-and-anion = Sebatian ionik dilaksanakan sahaja montok satu kation om satu anion.
+
+solve-equations-cannot-evaluate = Amu' obuli menyelesaikan persamaan sebab persamaan amu' obuli dinilai: { $equation }
+
+math-operators-operand-number-required = operandNumber mesti ditetapkan nung mengambil operand matematik.
+
+eigen-decomposition-failed = Amu' obuli mengira nilai eigen matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: parameter { $parameters } aiso id dalam pola, jadi sentiasa sepadan om ruang kosong.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" amu' obuli ditafsirkan. Mesti none, medium, dense toi dua nombor positif dipisahkan om ruang, macam grid="1 0.5". Aiso grid dilukis.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` perlu fungsi dot waro { $expected ->
+        [1] satu output, iaitu kecerunan y' id setiap titik, macam `y - x`
+       *[other] dua output, iaitu vektor id setiap titik, macam `(y, -x)`
+    }, nga fungsi dot diberi waro { $found ->
+       *[other] { $found } output
+    }. { $alternative ->
+        [none] Aiso dilukis.
+       *[other] `<{ $alternative }>` komponen dot sesuai montok fungsi dilo'. Aiso dilukis.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` diabaikan sebab fungsi juga diberi id dalam komponen; dot id dalam digunakan. Beri fungsi dilo' satu cara sahaja.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` menamakan pemboleh ubah ungkapan dot ditulis terus id dalam komponen. { $reason ->
+        [function-child] Fungsi diti diberi sebagai anak `<function>`, dot menamakan pemboleh ubahnya sendiri, jadi `variables` diabaikan.
+       *[no-expression] Aiso ungkapan macam dilo' diti, jadi `variables` diabaikan.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" amu' disokong id renderer prefigure; cara kedudukan kanan digunakan.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" amu' disokong id renderer prefigure; cara kedudukan atas digunakan.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas paksi amu' otopot montok penukaran prefigure; bbox asal (-10,-10,10,10) digunakan.
+
+prefigure-invalid-width = `<graph>`: lebar amu' otopot montok penukaran prefigure; lebar rajah asal 425 digunakan.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio amu' otopot montok penukaran prefigure; nisbah asal 1 digunakan.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jarak grid terlalu halus montok batas paksi; grid amu' dilukis id renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi amu' dilukis nung renderer PreFigure amu' digunakan.
+
+multiple-annotations-children = Waro beberapa anak `<annotations>` id `<graph>`; semua kecuali dot terakhir diabaikan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Amu' obuli melanjutkan toi menyalin jenis komponen dot amu' dikenali: { $type }.
+
+copy-prop-not-found = Prop { $property } amu' dijumpai id komponen jenis { $component }
+
+collect-no-source = Aiso source dijumpai montok collect.
+
+collect-invalid-component-type = Amu' obuli mengumpul komponen jenis `<{ $component }>` sebab jenis komponen dilo' amu' otopot.
+
+reference-index-unavailable = Amu' obuli merujuk indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Amu' obuli memanggil { $action } id komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk data amu' otopot.  Baris waro panjang dot berbeza. Dijumpai id componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data waro nama lajur dot sama.  Dijumpai id componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data kurang satu nama lajur.  Dijumpai id componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Satu award montok simbar diti bergantung id simbar dot dihantar answer diti sendiri, om dilo' akan membawa kelakuan dot amu' dijangka.
+
+answer-max-num-attempts-in-section-wide-check-work = Menetapkan `maxNumAttempts` id `<answer>` dot id dalam bekas dot waro `sectionWideCheckWork` aiso kesan, sebab bilangan percubaan dikawal bekas dilo'. Tetapkan `maxNumAttempts` id bekas dilo'.
+
+nested-section-wide-check-work-max-num-attempts = Menetapkan `maxNumAttempts` id bekas dot waro `sectionWideCheckWork` dot id dalam bekas lain dot juga waro `sectionWideCheckWork` aiso kesan, sebab bilangan percubaan dikawal bekas di luar. Tetapkan `maxNumAttempts` id bekas di luar.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] Atribut { $attributes } aiso kesan nung symbolicEquality amu' ditetapkan.
+    }
+
+answer-invalid-type = Jenis answer amu' otopot: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sebab komponen `<{ $component }>` aiso nama, amu' obuli digunakan montok atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` amu' obuli digunakan sebagai atribut module sebab jenis komponen `<module>` sudah waro atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` diabaikan id komponen `<conditionalContent>` dot waro anak case toi else.
+
+slider-markers-type-mismatch = Jenis markers amu' sepadan om jenis slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel amu' otopot: setiap `<problem>` mesti waro satu `<statement>` om satu `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel amu' otopot: id mode="circuit", `<problem>` pertama amu' obuli jadi distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Nilai { $values } amu' otopot montok atribut `{ $attribute }`; diabaikan.
+    }
+
+attribute-must-be-references = Nilai `{ $value }` amu' otopot montok atribut `{ $attribute }`. Atribut mesti terdiri mantad rujukan dot bermula om `$`.
+
+math-input-invalid-function-names = <mathInput>: nama fungsi dot amu' otopot id { $attribute } diabaikan: { $names }. Setiap nama mesti waro sekurang-kurangnya 2 aksara id bahagian paparan (huruf toi sengkang); akhiran `|<mathspeak alternative>` obuli menyusul.
+
+## Building components from the source
+
+component-type-invalid = Jenis komponen amu' otopot: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } amu' obuli diulang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" amu' otopot montok komponen jenis `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Takrif gaya { $styleNumber } aiso kontras dot cukup montok { $context ->
+        [text-on-background] warna teks lawan warna latar belakang
+        [high-contrast] warna kontras tinggi lawan kanvas
+        [line] warna garis lawan kanvas
+        [marker] warna penanda lawan kanvas
+       *[text-on-canvas] warna teks lawan kanvas
+    }{ $mode ->
+        [dark] { " (mod gelap)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; perlu sekurang-kurangnya { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Walaupun takrif gaya { $styleNumber } menetapkan warna dot cukup kontras montok mod terang, warna mod gelap dot diperoleh mantad nilai dilo' aiso kontras dot cukup antara warna teks om warna latar belakang ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; perlu sekurang-kurangnya { $threshold }:1). { $suggestion ->
+        [available] Supaya kontras cukup id mod gelap, tambah kontras mod terang (contoh, tetapkan { $lightAttribute }="{ $lightColor }") toi tukar warna mod gelap (contoh, tetapkan { $darkAttribute }="{ $darkColor }").
+       *[none] Supaya kontras cukup id mod gelap, tambah kontras mod terang toi tukar warna dot diperoleh dilo' om textColorDarkMode toi backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Walaupun takrif gaya { $styleNumber } menetapkan warna teks dot cukup kontras montok mod terang, warna teks mod gelap dot diperoleh mantad nilai dilo' aiso kontras dot cukup lawan kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; perlu sekurang-kurangnya { $threshold }:1). { $suggestion ->
+        [available] Supaya kontras cukup id mod gelap, tambah kontras mod terang (contoh, tetapkan textColor="{ $lightColor }") toi tukar warna mod gelap (contoh, tetapkan textColorDarkMode="{ $darkColor }").
+       *[none] Supaya kontras cukup id mod gelap, tambah kontras mod terang toi tukar warna dot diperoleh dilo' om textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Satu seksyen obuli memilih satu <stylePalette> sahaja; dot terakhir digunakan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = varian unik { $component } amu' obuli ditentukan sebab numToSelect bukan integer dot bukan negatif.
+
+variant-num-to-select-not-constant-number = varian unik { $component } amu' obuli ditentukan sebab numToSelect bukan nombor tetap.
+
+variant-with-replacement-not-constant-boolean = varian unik { $component } amu' obuli ditentukan sebab withReplacement bukan boolean tetap.
+
+variant-select-weight-disables-unique = Varian unik montok select dimatikan nung waro option dot waro selectWeight toi selectForVariants
+
+variant-coprime-undetermined = varian unik { $component } amu' obuli ditentukan sebab amu' obuli ditentukan coprime sentiasa false.
+
+variant-attribute-not-constant = varian unik { $component } amu' obuli ditentukan sebab { $attribute } bukan nilai tetap.
+
+variant-attribute-not-number = varian unik { $component } amu' obuli ditentukan sebab { $attribute } bukan nombor.
+
+variant-attribute-wrong-type-for-sequence =
+    varian unik { $component } jenis { $type } amu' obuli ditentukan sebab { $attribute } bukan { $expected ->
+        [letters-combination] gabungan huruf
+        [math-expression] ungkapan matematik dot otopot
+        [integer] integer
+       *[number] nombor
+    }.
+
+variant-length-not-integer = varian unik { $component } amu' obuli ditentukan sebab length bukan integer.
+
+variant-sort-not-implemented = varian unik { $component } dot waro sort amu' nogi dilaksanakan
+
+variant-exclude-combinations-not-implemented = varian unik { $component } dot waro excludeCombinations amu' nogi dilaksanakan
+
+variant-math-exclude-not-implemented = varian unik { $component } jenis math dot waro exclude amu' nogi dilaksanakan
+
+variant-non-constant-exclude-not-implemented = varian unik { $component } dot waro exclude dot bukan tetap amu' nogi dilaksanakan
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: amu' disokong id renderer prefigure graph; keturunan dilangkau.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri amu' terhingga toi amu' lengkap; keturunan dilangkau.
+
+prefigure-curve-label-omitted = { $subject }: label amu' disokong id elemen lengkung dot ditukar; label dibuang.
+
+prefigure-curve-unsupported-definition-type = { $subject }: jenis takrif fungsi lengkung '{ $definitionType }' amu' disokong; keturunan dilangkau.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions id regionBetweenCurves amu' disokong; keturunan dilangkau.
+
+prefigure-region-non-formula-child = { $subject }: hanya anak fungsi jenis formula disokong id regionBetweenCurves; keturunan dilangkau.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' amu' disokong montok { $labelKind ->
+        [line-family] label keluarga garis
+       *[point] label titik
+    }; jajaran PreFigure asal digunakan.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isian '{ $fillStyle }' amu' disokong PreFigure; isian pejal digunakan.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' amu' dikenali om dibuang mantad output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya penanda '{ $markerStyle }' dipetakan id gaya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: gaya penanda '{ $markerStyle }' amu' disokong PreFigure; gaya asal digunakan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` amu' otopot; target amu' obuli ditentukan. Anotasi dibuang.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` menunjuk id beberapa target; target pertama digunakan.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` amu' otopot; target id luar graph dot mengandunginya. Anotasi dibuang.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` amu' otopot; target bukan objek grafik dot disokong id penukaran prefigure. Anotasi dibuang.
+
+annotation-text-missing = `<annotation>`: `text` kurang toi kosong; teks kosong dikeluarkan.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kebergantungan berpusing dikesan.
+       *[other] Kebergantungan berpusing dikesan id komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Aiso rujukan dijumpai montok: `{ $reference }`
+
+reference-multiple-referents = Waro beberapa rujukan dijumpai montok: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } id `<{ $componentType }>` amu' otopot.
+
+children-invalid = Anak `<{ $componentType }>` amu' otopot: waro anak dot amu' otopot: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` amu' otopot montok atribut `{ $attribute }`, nilai `{ $default }` digunakan
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } amu' dijumpai.
+       *[other] Versi DoenetML { $version } amu' dijumpai. Versi { $fallback } digunakan
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML amu' otopot: { $content }
+
+parse-tag-missing-close-tag = DoenetML amu' otopot: Tag `{ $tag }` aiso tag penutup. Tag dot menutup sendiri toi tag `</{ $tagName }>` dijangka.
+
+parse-tag-error = DoenetML amu' otopot: Ralat id tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML amu' otopot: Atribut `{ $attribute }` dot amu' otopot nampaknya kurang nilai.
+
+parse-attribute-invalid = DoenetML amu' otopot: Atribut `{ $attribute }` amu' otopot
+
+parse-attribute-value-invalid = DoenetML amu' otopot: Nilai atribut `{ $value }` amu' otopot
+
+parse-attribute-value-quote-mismatch = DoenetML amu' otopot: Nilai atribut `{ $value }` amu' otopot. Tanda petik amu' sepadan. Nampaknya kurang satu `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML amu' otopot: Waro tag dot aiso nama, macam `<`
+
+parse-tag-not-closed = DoenetML amu' otopot: Tag `{ $tag }` amu' ditutup (nampaknya kurang satu `>`).
+
+parse-self-closing-tag-name-missing = DoenetML amu' otopot: Waro tag dot aiso nama `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML amu' otopot: Tag `{ $tag }` amu' ditutup (nampaknya kurang `/>`).
+
+parse-tag-invalid-attributes = DoenetML amu' otopot: Tag `{ $tag }` amu' otopot. Mungkin atributnya salah.
+
+parse-close-tag-name-missing = DoenetML amu' otopot: Waro tag penutup dot aiso nama, macam `</`
+
+parse-attribute-value-unquoted = Nilai atribut mesti diletak id dalam tanda petik: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML amu' otopot: Waro tag penutup `{ $tag }`, nga aiso tag pembuka dot sepadan
+
+parse-close-tag-mismatched = DoenetML amu' otopot: Tag penutup amu' sepadan. `</{ $expected }>` dijangka. `{ $found }` dijumpai
+
+parser-node-unconvertible = Node { $node } amu' obuli ditukar id node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Nama atribut name='{ $name }' amu' otopot. { $reason ->
+        [characters] Nama obuli waro huruf, nombor, garis bawah toi sengkang sahaja.
+       *[start] Nama mesti bermula om huruf.
+    }
+
+component-name-invalid-start = Nama komponen "{ $name }" amu' otopot. Nama mesti bermula om huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer jenis videoWatched mesti waro atribut video
+
+answer-video-watched-video-not-reference = Answer jenis videoWatched mesti waro atribut video dot jadi rujukan
+
+answer-name-not-single-text = Atribut name id answer mesti waro satu anak text sahaja
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Amu' obuli mengambil DoenetML luaran sebab rekursi terlalu dalam. Waro rujukan berpusing?
+
+external-doenetml-unavailable = Amu' obuli mengambil DoenetML mantad { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML dot diambil mantad { $attribute }="{ $uri }" amu' otopot: amu' sepadan om jenis komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` sudah lapuk; guna `{ $to }` ganti dilo'.
+       *[other] [deprecation] Atribut `{ $from }` id `<{ $component }>` sudah lapuk; guna `{ $to }` ganti dilo'.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` sudah lapuk om diabaikan sebab `{ $to }` juga ditetapkan.
+       *[other] [deprecation] Atribut `{ $from }` id `<{ $component }>` sudah lapuk om diabaikan sebab `{ $to }` juga ditetapkan.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` id `<{ $component }>` sudah lapuk om diabaikan.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` id `<{ $component }>` sudah lapuk; guna anak `<{ $child }>` ganti dilo'.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` atribut `{ $attribute }` id `<{ $component }>` sudah lapuk; guna `{ $to }` ganti dilo'.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` obuli menjamakkan teks Inggeris sahaja, jadi teksnya amu' diubah id dokumen dot ditulis om { $locale }. Tulis terus bentuk jamak dilo', toi tetapkan om atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` bukan elemen Doenet dot dikenali.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` amu' dibenarkan id akar dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` amu' dibenarkan id dalam `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` aiso atribut bernama `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` elemen `<{ $tag }>` mesti senarai dot setiap itemnya salah satu mantad: { $allowed }
+       *[other] Atribut `{ $attribute }` elemen `<{ $tag }>` mesti salah satu mantad: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nama varian montok select amu' otopot.  Nama varian { $variantName } muncul id { $numOptions } option nga bilangan dot dipilih { $numToSelect }.
+
+select-variant-name-without-options = Waro varian ditetapkan montok select nga aiso option ditetapkan montok nama varian: { $variantName }.
+
+select-variant-name-not-possible = Nama varian { $variantName } dot ditetapkan montok select bukan nama varian dot mungkin.
+
+select-too-few-options = Amu' obuli memilih { $numToSelect } komponen mantad { $numOptions } sahaja.
+
+select-from-sequence-too-few-values = Amu' obuli memilih { $numToSelect } nilai mantad jujukan dot panjangnya { $length }.
+
+select-from-sequence-indices-count-mismatch = Bilangan indeks dot ditetapkan montok select mesti sepadan om bilangan dot dipilih
+
+select-from-sequence-indices-not-integers = Semua indeks dot ditetapkan montok select mesti integer
+
+select-from-sequence-index-excluded = Indeks selectfromsequence dot ditetapkan dilo' sudah dikecualikan
+
+select-from-sequence-indices-excluded-combination = Indeks selectfromsequence dot ditetapkan dilo' gabungan dot dikecualikan
+
+select-from-sequence-coprime-not-positive-integers = Amu' obuli memilih gabungan coprime sebab bukan integer positif dot dipilih.
+
+select-from-sequence-coprime-common-factor = Amu' obuli memilih nombor coprime. Semua nilai dot mungkin waro faktor sepunya. (Nilai "from" toi "to" dot ditetapkan mesti coprime om "step".)
+
+select-from-sequence-coprime-single-number = Amu' obuli memilih gabungan coprime mantad satu nombor dot bukan 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebih 70% gabungan dikecualikan id selectFromSequence
+
+select-from-sequence-coprime-none-found = Amu' obuli memilih nombor coprime. Semua nilai dot mungkin waro faktor sepunya.
+
+select-from-sequence-too-few-unique-values = Amu' obuli memilih { $numToSelect } nilai unik mantad jujukan dot panjangnya { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Amu' obuli memilih { $numToSelect } nilai mantad senarai nombor perdana dot panjangnya { $numValues }
+
+select-prime-numbers-values-count-mismatch = Bilangan nilai dot ditetapkan montok select mesti sepadan om bilangan dot dipilih
+
+select-prime-numbers-values-not-prime = Semua nilai dot ditetapkan montok select nombor perdana mesti waro id senarai nombor perdana
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers dot ditetapkan dilo' gabungan dot dikecualikan
+
+select-prime-numbers-excluded-too-many-combinations = Lebih 70% gabungan dikecualikan id selectPrimeNumbers
+
+select-random-combination-fluke = Sebab nasib dot amat jarang, gabungan nilai rawak amu' obuli dipilih
+
+select-random-value-fluke = Sebab nasib dot amat jarang, nilai rawak amu' obuli dipilih
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` diti amu' dipaparkan sebab id dalam matematik om bukan `inline`. Tambah `inline` supaya jadi senarai turun, dot muat id dalam ungkapan.
+        [expanded] `<{ $component }>` diti amu' dipaparkan sebab id dalam matematik om `expanded`. Buang `expanded`; kotak berbilang baris amu' muat id dalam ungkapan.
+        [on-graph] `<{ $component }>` diti amu' dipaparkan sebab id dalam matematik dot dilukis id graph, dot aiso ruang montok input.
+       *[relative-width] `<{ $component }>` diti amu' dipaparkan sebab id dalam matematik om waro lebar relatif. Beri lebar dilo' id unit mutlak, macam `px`.
+    }

--- a/packages/i18n/locales/dtp/editor.ftl
+++ b/packages/i18n/locales/dtp/editor.ftl
@@ -1,0 +1,222 @@
+# Kadazandusun editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the standardised Bundu-Liwan-based Kadazandusun orthography used
+# by the other three files of this locale; see `locales/dtp/chrome.ftl` for
+# the whole note, including why most of the vocabulary below is a declared
+# Malay loan rather than a Kadazandusun coinage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay in English exactly as written.
+#
+# The Kadazandusun in this file is its frame — «waro», «aiso», «amu'», «om»,
+# «toi», «nung», «montok», «id», «mantad», «obuli», «diti», «dot» — around
+# Malay technical nouns. A reviewer who wants to know whether the file is
+# Kadazandusun should read those words rather than the nouns between them.
+#
+# Kadazandusun does not mark number on a noun after a numeral, and
+# `Intl.PluralRules` has no data for `dtp` in any case, so every count
+# selection here is collapsed to a single `*[other]`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Set Semula
+       *[update] Kemas Kini
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Pemapar
+       *[other] { $word } Pemapar { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+editor-variant-filter = Tapis…
+editor-variant-next = Pilih varian dot seterusnya
+editor-variant-previous = Pilih varian dot sebelum
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Waro pelanggaran akses WCAG AA. Tekan montok { $action ->
+            [close] tutup
+           *[open] buka
+        } laporan akses.
+        [advisories] Tekan montok { $action ->
+            [close] tutup
+           *[open] buka
+        } laporan akses. Aiso pelanggaran WCAG AA, nga waro cadangan akses tambahan.
+       *[clean] Tekan montok { $action ->
+            [close] tutup
+           *[open] buka
+        } laporan akses. Aiso masalah akses.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Waro pelanggaran akses WCAG AA. Waro { $count ->
+           *[other] { $count } pelanggaran WCAG AA
+        }. Tekan montok { $action ->
+            [close] tutup
+           *[open] buka
+        } laporan akses.
+        [advisories] Aiso pelanggaran WCAG AA. Waro { $count ->
+           *[other] { $count } cadangan akses tambahan
+        }. Tekan montok { $action ->
+            [close] tutup
+           *[open] buka
+        } laporan akses.
+       *[clean] Aiso pelanggaran WCAG AA. Tekan montok { $action ->
+            [close] tutup
+           *[open] buka
+        } laporan akses.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versi DoenetML { $version }
+
+editor-tab-help = Bantuan mengikut konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Ralat
+editor-tab-warnings = Amaran
+editor-tab-info = Maklumat
+editor-tab-accessibility = Akses
+editor-tab-responses = Simbar dot dihantar
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Format sebagai DoenetML
+editor-format-as-xml = Format sebagai XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Aiso Ralat
+editor-no-warnings = Aiso Amaran
+editor-no-info = Aiso Maklumat
+
+editor-show-info-annotations = Tunjuk maklumat id editor
+editor-show-accessibility-annotations = Tunjuk pesanan akses id editor
+
+editor-accessibility-learn-more = Belajar pasal cara Doenet menjaga akses
+
+editor-accessibility-violations-heading = Pelanggaran akses ({ $standard })
+
+editor-accessibility-other-heading = Masalah akses lain
+editor-none-found = Aiso
+
+
+## Submitted responses
+
+editor-no-responses = Aiso nogi simbar dot dihantar
+editor-response-answer-id = Id Simbar
+editor-response-response = Simbar
+editor-response-credit = Markah
+editor-response-submitted = Dihantar
+
+
+## The context-help panel
+
+help-placeholder = Letak kursor id nama tag, atribut toi { $ref } montok melihat dokumentasi.
+
+help-unsupported-ref-chain = Bantuan montok rujukan berbilang bahagian macam { $example } amu' nogi disokong.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Aiso rujukan dijumpai montok: { $ref }.
+        [multiple] Waro beberapa rujukan dijumpai montok: { $ref }.
+       *[indeterminate] Rujukan montok { $ref } amu' obuli ditentukan.
+    }
+
+help-learn-about-references = Belajar pasal rujukan →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Id dalam { $element }
+       *[top] Id aras atas
+    }{ $allowed ->
+        [none] { " — aiso dot boleh masuk diti." }
+        [text] { " — taip teks diti." }
+        [text-and-components] { " — taip teks diti, toi cuba diti:" }
+       *[components] { " — dot boleh dicuba:" }
+    }
+
+help-suggestions-footer = Tekan { $shortcut } montok melihat semua { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } nopo rujukan montok { $target }.
+       *[other] { $ref } nopo rujukan montok { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Diperkenalkan { $owner } sebagai { $role }.
+       *[other] Diperkenalkan { $owner } id baris { $line } sebagai { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } nopo rujukan montok sifat { $property } id { $element }.
+       *[other] { $ref } nopo rujukan montok sifat { $property } id { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = cebisan kod
+help-kind-array-entry = isi array
+
+help-default = Nilai asal:
+help-active-default = Nilai asal dot aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai dot dibenarkan (satu montok setiap item):
+       *[other] Nilai dot dibenarkan:
+    }
+
+help-suggested-values = Nilai dot dicadangkan:
+
+help-inserts = Menyisip:
+
+help-coordinates =
+    { $count ->
+       *[other] Koordinat:
+    }
+
+help-type = Jenis:
+
+help-resolved-style = Gaya dot ditentukan (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nama fungsi dot ditentukan:
+help-reset-list = Senarai set semula id input diti:
+help-added-on-input = Ditambah id input diti:
+help-removed-on-input = Dibuang mantad input diti:
+
+help-reset-overrides = { $reset } mengatasi { $additional } om { $removed }.

--- a/packages/i18n/locales/gor/chrome.ftl
+++ b/packages/i18n/locales/gor/chrome.ftl
@@ -1,0 +1,187 @@
+# Gorontalo (Bahasa Hulontalo) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **This catalog is a Gorontalo frame around declared Indonesian loans, and it
+# says so first rather than last.** Gorontalo is spoken in Gorontalo province
+# on the northern peninsula of Sulawesi; it has published lexical material, but
+# less of it than Toba Batak or Nias, and a seed can reach very little of it.
+# What is Gorontalo here is the **frame** — the negator «diila», the modal
+# «mowali», the nominalizing relator «u», the existential «woluwo», the
+# conjunctions «wawu», «meyalo», «wonu» and «sababu», the prepositions «to» and
+# «lonto», the genitive «lo», the verb «mohutu» and the causative prefix
+# «mopo-». Almost every content noun is an Indonesian loan, written as
+# Indonesian writes it. A speaker should expect to rewrite the sentences rather
+# than to correct words inside them.
+#
+# The one place native content vocabulary is attempted is the colour table in
+# `content.ftl`, and that header says exactly which five words are attempted
+# and how confident the seed is in them.
+#
+# **Orthography: the Latin practice in current use**, the alphabet Gorontalo is
+# written with in local publishing and in the province's schools: `a b d e f g
+# h i j k l m n o p r s t u w y` plus the digraph `ng` and the apostrophe `'`
+# for the glottal stop. No diacritics. Gorontalo has no competing script, so
+# the choice a corrector might disagree with is not the alphabet but the
+# spelling of the glottal stop and of the long vowels, which local practice
+# writes inconsistently; this catalog writes the glottal stop only where a word
+# would otherwise be ambiguous, and does not double a long vowel. A corrector
+# who wants either convention applied throughout should apply it to **all four
+# files at once**.
+#
+# **The technical register is Indonesian, and it is declared as a loan
+# register rather than dressed up.** Gorontalo speakers are schooled in
+# Indonesian; the words for a line, a circle, an attribute, a version and a
+# document are the Indonesian ones in a Gorontalo classroom. This catalog uses
+# them as they stand — «garis», «lingkaran», «atribut», «versi», «dokumen»,
+# «komponen», «nilai», «baris», «kolom» — and does not respell them into an
+# invented Gorontalo phonology. Writing «atributu» or «garisi» would look like
+# a loan Gorontalo had actually made, and the seed does not know that it has.
+#
+# **What this catalog does not know.** Gorontalo distinguishes inclusive from
+# exclusive first person and marks its verbs for a set of aspectual and modal
+# prefixes the seed cannot use reliably; every verb here is written in a plain
+# unmarked form, which will read as flat rather than as wrong. It also does not
+# know the polite register a button ought to be in.
+#
+# Gorontalo has a single plural category — a noun after a numeral is
+# unmarked — so `attempts-remaining` and `answer-show-responses` collapse to a
+# single `*[other]` branch. The `[0]` branch stays: Fluent matches a numeric
+# literal against the number itself, before any plural rule.
+
+
+## Answer submission
+
+answer-checking = Hemapareksa...
+answer-submitting = Hemodelo...
+
+answer-checking-status = Hemapareksa jawaban
+answer-submitting-status = Hemodelo jawaban
+
+answer-correct = Banari
+answer-incorrect = Diila banari
+
+answer-response-saved = Jawaban ma tuwoto
+
+answer-percent-credit = Nilai { $percent }%
+answer-percent-correct = { $percent }% banari
+answer-percent-short = { $percent } %
+
+max-credit-available = Nilai u palingu daata woluwo: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] diila woluwo poli usaha
+       *[other] { $count } usaha u ontonga poli
+    }
+
+validation-correct = (Banari)
+validation-incorrect = (Diila banari)
+validation-partially-correct = (Banari ngointa)
+
+answer-show-responses = Popobiloheyi { $count } jawaban ode { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Tanggapan
+
+collapsible-click-to-open = (klik u mohuo)
+collapsible-click-to-close = (klik u molautu)
+
+collapsible-initializing = Hemopo'olopu...
+
+footnote-show = Popobiloheyi catatan to walungo
+footnote-hide = Potuowa catatan to walungo
+
+description-more-information = keterangan poli
+
+
+## Controls
+
+slider-previous = U lomayi
+slider-next = U ma monao
+
+keyboard-open = Huo papan ketik
+keyboard-close = Lautu papan ketik
+
+choice-input-remove-choice = Luluta { $choice }
+
+matrix-remove-row = Luluta baris
+matrix-add-row = Tambahi baris
+matrix-remove-column = Luluta kolom
+matrix-add-column = Tambahi kolom
+
+subset-add-remove-points = Tambahi/Luluta titik
+subset-toggle-points-intervals = Bulita titik wawu selang
+subset-move-points = Deloa titik
+subset-clear = Bersihi
+
+orbital-add-row = Tambahi baris
+orbital-remove-row = Luluta baris
+orbital-add-box = Tambahi kotak
+orbital-remove-box = Luluta kotak
+orbital-add-up-arrow = Tambahi panah ode yitato
+orbital-add-down-arrow = Tambahi panah ode walungo
+orbital-remove-arrow = Luluta panah
+
+orbital-row-label = Label ode baris { $row }
+
+pretzel-answer = Jawaban
+
+summary-statistics-caption = Statistik ringkas lo { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau lo ekspresi matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ekspresi u diila banari:
+
+
+## Document status
+
+viewer-initializing = Hemopo'olopu...
+
+
+## Errors
+
+error-heading = Ututala
+
+error-found-at =
+    { $span ->
+        [line] Iloontonga to baris { $startLine }.
+       *[lines] Iloontonga to baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen botie o ututala!
+
+diagnostic-heading-error = Ututala
+diagnostic-heading-warning = Poti'ingoti
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Petunjuk
+
+accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Poti'ingoti aksesibilitas
+
+something-went-wrong = Woluwo u tala.
+
+renderer-load-failed = ngotalu perender diila mowali dimuat. Poluli mohuo halaman botie.
+
+core-start-failed = Dokumen botie diila mowali pomulaalo. Poluli mohuo halaman botie.
+
+core-start-failed-busy = Dokumen botie diila mowali pomulaalo. Daata dokumen lomula to wakutu tuwawu, wawu uito mowali lebe hiheo to alat u molambatu. Poluli mohuo halaman botie wonu dokumen wuwewo ma yilapato.
+
+core-start-failed-retry = Dokumen botie diila mowali pomulaalo.
+
+core-start-failed-busy-retry = Dokumen botie diila mowali pomulaalo. Daata dokumen lomula to wakutu tuwawu, wawu uito mowali lebe hiheo to alat u molambatu.
+
+core-start-retry = Poluli
+
+saved-state-unavailable = Karajamu u tuwoto diila mowali biluohu.

--- a/packages/i18n/locales/gor/content.ftl
+++ b/packages/i18n/locales/gor/content.ftl
@@ -1,0 +1,283 @@
+# Gorontalo (Bahasa Hulontalo) content catalog: the prose the core computes
+# into the document. Selected by `documentLocale` — the language the activity
+# was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **This catalog is a Gorontalo frame around declared Indonesian loans**, in
+# the sense `chrome.ftl`'s header sets out in full. Read that first: it names
+# what is Gorontalo here (the negator «diila», the modal «mowali», the relator
+# «u», the existential «woluwo», «wawu», «meyalo», «wonu», «sababu», «to»,
+# «lonto», «lo», «mohutu», «mopo-») and what is Indonesian (everything else).
+#
+# **Orthography: the Latin practice in current use**, no diacritics, the
+# glottal stop written `'` only where a word would otherwise be ambiguous.
+#
+# ## Word order, and the absence of a linker
+#
+# **The noun comes first and its modifiers follow it, with nothing between
+# them**: «garis meela» is *red line*. So every composition message here
+# inverts English's order, and none of them writes a linker. That is the
+# single fact that most cleanly separates this file from `locales/bbc` beside
+# it in the same batch: Toba Batak needs the relator «na» between the noun and
+# its modifiers and Gorontalo needs nothing at all, which is why the two files
+# do not have the same shape even where they have the same order. Within the
+# description the adjectives keep English's own sequence — width, dash
+# pattern, colour.
+#
+# **`[noun-tail]` is unused.** The side count of a regular polygon binds to the
+# noun rather than to the adjectives, so it folds into the head exactly as
+# English's does and the tail stays empty.
+#
+# ## Gender and role
+#
+# Gorontalo has no grammatical gender and does not inflect a modifier for the
+# position its phrase sits in, so `noun-gender` answers one token for every
+# noun and nothing here selects on `$gender` or on `$role`.
+#
+# ## The colour table is the one place native vocabulary is attempted
+#
+# Five of the twelve are written with what the seed reads as the Gorontalo
+# basic colour terms — «moitomo» (black), «moputio» (white), «meela» (red),
+# «molalahu» (yellow) and «moidu» (green, and in some descriptions blue as
+# well). They are written in the `mo-` stative shape a Gorontalo property word
+# takes, which is why the seed believes them to be the right *form* even where
+# it is less sure of the root. **They are unverified against a dictionary, and
+# a reviewer should check all five before trusting any of them.** «moidu» is
+# the one most likely to be wrong in this use: a green/blue term that has not
+# split is exactly the kind of word a colour picker's twelve-way table
+# mistranslates, and this catalog uses the Indonesian «biru» for blue rather
+# than stretching it.
+#
+# The other seven have no Gorontalo basic term the seed can reach and are
+# written with the Indonesian words. That is the honest shape of a basic colour
+# inventory and not a gap: no language has a native word for *cyan*.
+#
+# Everything else in this file — the geometry, the dash patterns, the section
+# words, the table and figure words — is Indonesian, because that is the
+# register a Gorontalo pupil learns mathematics in. Coining Gorontalo
+# replacements would report a wish rather than a fact.
+#
+# ## Chemistry
+#
+# **The 118 element names and the 12 anion names are deliberately absent**, and
+# fall back to English. Chemistry is taught in Gorontalo province out of
+# Indonesian-language textbooks, so the periodic table a Gorontalo pupil meets
+# is `locales/id`'s. Copying the Indonesian table wholesale into this file
+# would record a fact about a textbook rather than about Gorontalo. The three
+# messages that are *frames* rather than names are translated, because a frame
+# is this catalog's business whether or not the names in it ever are.
+
+
+## Style vocabulary
+
+color =
+    .black = moitomo
+    .white = moputio
+    .gray = abu-abu
+    .red = meela
+    .orange = oranye
+    .yellow = molalahu
+    .green = moidu
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = merah muda
+    .brown = cokelat
+line-width =
+    .thick = tebal
+    .thin = tipis
+line-style =
+    .dashed = putus-putus
+    .dotted = titik-titik
+# Noun phrases, not adjectives: they follow «wolo» and modify nothing.
+fill-style =
+    .horizontal = garis melintang
+    .vertical = garis tihu-tihulo
+    .diagonal = garis diagonal
+    .backdiagonal = garis diagonal u lobalika
+    .dots = titik
+    .diamonds = belah ketupat
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = kurva
+    .function = fungsi
+    .slope-field = medan kemiringan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis patah
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = persegi panjang
+    .circle = lingkaran
+    .region = daerah
+    .point = titik
+    .square = persegi
+    .diamond = belah ketupat
+    .cross = silang
+    .plus = tanda tambah
+# The side count binds to the noun, so it folds into the head and there is no
+# tail — putting it after the adjectives would read as though the colour had
+# the sides.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon beraturan u o sisi { $numSides }
+    }
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun leads and its modifiers follow it directly, with no linker:
+# «garis tebal putus-putus meela».
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = polu
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } wolo { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } wolo { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } wolo { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+# Gorontalo has no article, so the two `-article` branches read the same as the
+# ones without. «wawu» is the linking *and*.
+style-border-clause =
+    { $parts ->
+        [with-article] wolo batas { $border }
+        [and] wawu batas { $border }
+        [and-article] wawu batas { $border }
+       *[with] wolo batas { $border }
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = diila polu
+style-text =
+    { $parts ->
+        [background] { $color } wolo latar { $background }
+       *[plain] { $color }
+    }
+style-background-none = diila woluwo
+
+
+## Boolean words
+
+boolean-true = banari
+boolean-false = diila banari
+
+
+## Answer buttons
+
+answer-submit-label = Pareksa
+answer-submit-label-no-correctness = Delo jawaban
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Karaja
+    .aside = Sisipan
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Misalu
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Jawaban
+    .note = Catatan
+    .objectives = Tujuan
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Pertanyaan
+    .section = Pasal
+    .solution = Penyelesaian
+    .task = Tugas
+    .theorem = Teorema
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Petunjuk
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = U lomayi
+paginator-next = U ma monao
+paginator-page = Halaman
+paginator-page-status = { $pageLabel } { $currentPage } lonto { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = meyalo
+piecewise-condition-if = wonu
+piecewise-condition-otherwise = wonu diila
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header. These three are frames rather than vocabulary, so they are
+## translated whether or not the names ever are.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Simbol kimia u diila banari
+chemistry-invalid-ionic-compound = Senyawa ionik u diila banari
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = lowong
+math-embedded-input-blank-ordinal = lowong { $ordinal } lonto { $total }

--- a/packages/i18n/locales/gor/diagnostics.ftl
+++ b/packages/i18n/locales/gor/diagnostics.ftl
@@ -1,0 +1,685 @@
+# Gorontalo (Bahasa Hulontalo) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: the Latin practice in current use**, no diacritics, the
+# glottal stop written `'` only where a word would otherwise be ambiguous;
+# `chrome.ftl`'s header sets it out in full.
+#
+# **This file is a Gorontalo frame around Indonesian nouns**, and the frames
+# are worth reading before the sentences, because a dozen of them carry the
+# whole file:
+#
+#     … diila pohutuwolo      … is not acted on   (see below)
+#     Diila mowali …          cannot …
+#     … musi …                must …
+#     … u diila banari        invalid …
+#     Dipo pilohutu …         has not yet been done …
+#     diila iloontonga        not found / not seen
+#     diila motu'ude          does not match
+#     sababu …                because …
+#     diila o pengaruh        has no effect
+#     Diila woluwo …          there is no …
+#     … ma woluwo             … is specified / is already there
+#
+# **Two of those are paraphrases and are declared as such**, because Gorontalo
+# words for them are not something this seed can reach. «diila pohutuwolo» is
+# literally *is not acted on*, built from «mohutu» (to do); it stands
+# throughout for English's *is ignored*, and it is used everywhere rather than
+# varied, so that a speaker who has a better word changes one string and finds
+# every site. «… ma woluwo» is literally *is already there*, and stands for
+# English's *is specified*. Neither is a coinage; both are ordinary Gorontalo
+# saying something slightly wider than the English does.
+#
+# **Register.** Indonesian for the technical nouns — `atribut`, `komponen`,
+# `nilai`, `variabel`, `titik`, `garis`, `lingkaran`, `fungsi`, `dimensi`,
+# `indeks`, `referensi`, `versi`, `format`, `dokumen` — declared as a loan
+# register in `chrome.ftl`'s header, with a Gorontalo frame around them.
+# Nothing here is a coinage, and no Indonesian word here has been respelled to
+# look like a Gorontalo loan.
+#
+# **Plural.** Gorontalo leaves a noun unmarked after a numeral, so every
+# `[one]`/`[other]` fork in the English collapses to a single `*[other]`
+# branch. One message keeps an explicit `[1]` literal, because English forks
+# there on *one output* against *two outputs* and the distinction is about the
+# shape of the function rather than about agreement; Fluent matches a numeric
+# literal against the number itself, before any plural rule, so it stays
+# selectable.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } diila pohutuwolo wonu dulota titik ujung ma woluwo
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } diila pohutuwolo wonu titik ujung wawu titik tengah ma woluwo pe'enta
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset diila o pengaruh wonu diila woluwo titik tengah
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis mo'otalu titik u dimensina diila mowali otawa.
+
+line-points-too-few-dimensions = Garis musi mo'otalu titik u o dimensi palingu ngoidi dulo.
+
+line-points-depend-on-variables = Garis mo'otalu titik u modepitayi variabel: { $variables }.
+
+line-equation-invalid-format = Format lo persamaan garis to variabel { $variable1 } wawu { $variable2 } diila banari.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar ma woluwo pe'enta lonto through, endpoint wawu direction. through u ma woluwo boito diila pohutuwolo.
+
+ray-dimension-mismatch = numDimensions lo sinar diila motu'ude.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ma woluwo pe'enta lonto head, tail wawu displacement. head u ma woluwo boito diila pohutuwolo.
+
+vector-dimension-mismatch = numDimensions lo vektor diila motu'ude.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Diila mowali motarika ode `<{ $component }>` sababu diila woluwo variabel keadaan nearestPoint teto.
+
+constrain-to-without-nearest-point = Diila mowali mopobatasi ode `<{ $component }>` sababu diila woluwo variabel keadaan nearestPoint teto.
+
+constrain-to-interior-without-nearest-point = Diila mowali mopobatasi ode delomo `<{ $component }>` sababu diila woluwo variabel keadaan nearestPoint teto.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition diila pohutuwolo to choiceInput u diila inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices u ma woluwo to choiceInput diila pohutuwolo sababu jumlah lo indices diila motu'ude wolo jumlah lo walao choice.
+
+pretzel-indices-count-mismatch = indices u ma woluwo to problem diila pohutuwolo sababu jumlah lo indices diila motu'ude wolo jumlah lo walao problem.
+
+shuffle-indices-count-mismatch = indices u ma woluwo to shuffle diila pohutuwolo sababu jumlah lo indices diila motu'ude wolo jumlah lo komponen.
+
+indices-ignored-out-of-range = indices u ma woluwo to { $component } diila pohutuwolo sababu woluwo indeks to bulemengo jangkauan.
+
+pretzel-indices-repeated = indices u ma woluwo to pretzel diila pohutuwolo sababu woluwo indeks u tilulude poluli.
+
+pretzel-circuit-first-index = indices u ma woluwo to pretzel to mode circuit diila pohutuwolo sababu indeks bohulio musi 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Alihu `<{ $component }>` mokaraja wolo walao u string, atribut `type` musi woluwo.
+
+invalid-type-defaulting-to-math = Tipe { $type } diila banari ode komponen { $component }. Musi tuwawu lonto math, text, number, meyalo boolean. math u pilake.
+
+string-not-valid-component-to-arrange = String "{ $value }" diila komponen u banari ode { $component }. Diila pohutuwolo.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipe { $type } diila banari, tipe pilotaalo number.
+
+invalid-variable-value = Nilai lo variabel diila banari: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } musi bilangan
+
+variant-index-must-be-integer = Indeks varian { $index } musi bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` dipo pilohutu ode ukuran absolut. Lebar pilotaalo relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` dipo pilohutu ode ukuran absolut. Margin pilotaalo relatif.
+
+side-by-side-no-block-child = `<{ $component }>` diila banari: musi o walao u blok palingu ngoidi tuwawu.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` to `<label>` grafis diila pohutuwolo.
+
+label-for-must-resolve-to-one = Atribut `for` to `<label>` musi motunu ode tuwawu komponen bo.
+
+label-for-unresolved = Atribut `for` to `<label>` diila mowali motunu ode ngotalu komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` to `<label>` motunu ode `<answer>` u masukanilio tiluladu lohihilao; tunu masukan boito tulusu.
+
+label-for-answer-without-input = Atribut `for` to `<label>` motunu ode `<answer>` u diila o masukan u mowali labelilo.
+
+label-for-must-reference-input-or-answer = Atribut `for` to `<label>` musi motunu ode ngotalu masukan meyalo ngotalu jawaban.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Alihu aksesibilitas, `<{ $component }>` musi o deskripsi u limbu'u meyalo tilandai debo hiasan.
+
+accessibility-video-short-description = Alihu aksesibilitas, `<video>` musi o deskripsi u limbu'u.
+
+accessibility-input-short-description-or-label = Alihu aksesibilitas, `<{ $component }>` musi o deskripsi u limbu'u meyalo label.
+
+accessibility-answer-input-short-description-or-label = Alihu aksesibilitas, `<answer>` u mohutu masukan musi o deskripsi u limbu'u meyalo label.
+
+accessibility-short-description-contains-math = Deskripsi u limbu'u diila mopiyohu o komponen matematika debo `<{ $component }>`. Tulade isi matematikalio wolo huruf.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kurang kontrasilio ode teks judul bagian (mode moitomo) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; palingu ngoidi musi { $threshold }:1).
+       *[other] { $colorName } kurang kontrasilio ode teks judul bagian ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; palingu ngoidi musi { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Dipo pilohutu `<circle>` mo'otalu { $count } titik wonu titik boito diila o nilai numerik.
+
+circle-too-many-through-points = Diila mowali hitungolo lingkaran u mo'otalu lebe lonto 3 titik.
+
+circle-overprescribed-radius-center-points = Diila mowali hitungolo lingkaran wonu jari-jari, pusat wawu titik u otalu ma woluwo pe'enta.
+
+circle-center-with-multiple-points = Diila mowali hitungolo lingkaran u o pusat mo'otalu lebe lonto 1 titik.
+
+circle-radius-too-small = Diila mowali hitungolo lingkaran: sababu jarak lo dulota titik boito { $distance }, jari-jari { $radius } u ma woluwo boito lebe kecil.
+
+circle-radius-with-many-points = Diila mowali pohutuwolo lingkaran u mo'otalu lebe lonto dulota titik wonu jari-jari ma woluwo.
+
+circle-invalid-center-or-through-points = Pusat meyalo titik u otalu lo lingkaran diila banari.
+
+circle-radius-center-with-multiple-points = Diila mowali hitungolo jari-jari lo lingkaran u o pusat mo'otalu lebe lonto 1 titik.
+
+circle-change-radius-non-numerical = Diila mowali bulitolo jari-jari lo lingkaran u titik otalulio diila numerik
+
+circle-radius-with-points-non-numerical = Diila mowali pohutuwolo lingkaran u mo'otalu lebe lonto tuwawu titik wolo jari-jari u ma woluwo wonu diila woluwo nilai numerik.
+
+circle-change-center-non-numerical = Dipo pilohutu pobulita lo pusat lo lingkaran u mo'otalu titik u diila numerik.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Kurang dimensi lo domain lo fungsi. Domain o { $intervals } selang bo fungsi boito o { $inputs } masukan.
+
+function-domain-invalid-format = Format lo domain lo fungsi diila banari.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] maximum lo fungsi u diila numerik diila pohutuwolo.
+        [minimum] minimum lo fungsi u diila numerik diila pohutuwolo.
+        [extremum] extremum lo fungsi u diila numerik diila pohutuwolo.
+        [point] titik lo fungsi u diila numerik diila pohutuwolo.
+        [slope] kemiringan lo fungsi u diila numerik diila pohutuwolo.
+       *[other] { $type } lo fungsi u diila numerik diila pohutuwolo.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] maximum lo fungsi u lowong diila pohutuwolo.
+        [minimum] minimum lo fungsi u lowong diila pohutuwolo.
+        [extremum] extremum lo fungsi u lowong diila pohutuwolo.
+        [point] titik lo fungsi u lowong diila pohutuwolo.
+       *[other] { $type } lo fungsi u lowong diila pohutuwolo.
+    }
+
+function-points-too-close = Fungsi o dulota titik u lebe membide. Diila mowali pohutuwolo fungsi.
+
+function-iterates-input-output-mismatch = Iterasi lo fungsi bo mowali wonu jumlah lo masukan motu'ude wolo jumlah lo luaran. Fungsi botie o { $inputs } masukan wawu { $outputs } luaran.
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang lo sequence diila banari.  Musi bilangan bulat u diila negatif.
+
+sequence-invalid-step = Step lo sequence diila banari.  Musi bilangan ode sequence tipe { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" lo sequence bilangan diila banari.  Musi bilangan.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" lo sequence huruf diila banari.  Musi rangkaian huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" lo sequence diila banari.
+
+select-from-sequence-coprime-not-numbers = coprime diila pohutuwolo sababu u tilulawoto diila bilangan
+
+select-from-sequence-coprime-with-exclude-combinations = coprime diila pohutuwolo sababu excludeCombinations ma woluwo
+
+## Resolving a `target`
+
+target-not-found = Target lo `<{ $source }>` diila banari: target diila iloontonga.
+
+target-state-variable-not-found = Target lo `<{ $source }>` diila banari: variabel keadaan u o tanggulo "{ $property }" to `<{ $component }>` diila iloontonga.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel lo `<odeSystem>` musi wuwewo lonto variabel bebas.
+
+ode-system-duplicate-variable-names = Diila mowali pohutuwolo fungsi RHS ODE u o tanggulo variabel u tilulude poluli.
+
+ode-system-rhs-function-error = Diila mowali pohutuwolo fungsi RHS ODE.  Ututala to pohutu lo fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Diila mowali pohutuwolo sudut to wolota lo { $count } garis
+
+angle-invalid-through-point = Titik to through lo `<angle>` diila banari
+
+parabola-vertex-too-many-points = Dipo pilohutu parabola u o puncak mo'otalu lebe lonto 1 titik.
+
+parabola-too-many-points = Dipo pilohutu parabola u mo'otalu lebe lonto 3 titik.
+
+intersection-too-many-items = Dipo pilohutu perpotongan ode lebe lonto dulota barang
+
+## Other math components
+
+ionic-compound-not-two-ions = Dipo pilohutu senyawa ionik ode u wuwewo lonto dulota ion.
+
+ionic-compound-needs-cation-and-anion = Senyawa ionik bo pilohutu ode tuwawu kation wawu tuwawu anion.
+
+solve-equations-cannot-evaluate = Diila mowali tulusiyolo persamaan botie sababu persamaanilio diila mowali hitungolo: { $equation }
+
+math-operators-operand-number-required = operandNumber musi woluwo wonu mohama operand matematika.
+
+eigen-decomposition-failed = Diila mowali hitungolo nilai eigen lo matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } diila woluwo to pola boito, so'o layito motu'ude wolo u lowong.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" diila mowali otawa. Musi none, medium, dense, meyalo dulota bilangan positif u pilotayade lo spasi, debo grid="1 0.5". Diila woluwo kisi u tiluladu.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` mo'ohuna fungsi u o { $expected ->
+        [1] tuwawu luaran, deuito kemiringan y' to tuwa-tuwawu titik, debo `y - x`
+       *[other] dulota luaran, deuito vektor to tuwa-tuwawu titik, debo `(y, -x)`
+    }, bo fungsi u yiluhu boito o { $found } luaran. { $alternative ->
+        [none] Diila woluwo u tiluladu.
+       *[other] `<{ $alternative }>` komponen ode fungsi u odito. Diila woluwo u tiluladu.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` diila pohutuwolo sababu fungsi boito yiluhu olo to delomo komponen; u to delomo boito u pilake. Wohi fungsi boito bo lonto tuwawu dalalo.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` motanggulo variabel lo ekspresi u tiluladu tulusu to delomo komponen. { $reason ->
+        [function-child] Fungsi teya yiluhu debo walao `<function>`, u motanggulo variabelilio lohihilao, so'o `variables` diila pohutuwolo.
+       *[no-expression] Diila woluwo ekspresi u odito teya, so'o `variables` diila pohutuwolo.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" diila dukungolo to perender prefigure; u pilake parangi posisi olowala.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" diila dukungolo to perender prefigure; u pilake parangi posisi yitato.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbu diila banari ode konversi prefigure; u pilake bbox bawaan (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lebar diila banari ode konversi prefigure; u pilake lebar diagram bawaan 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio diila banari ode konversi prefigure; u pilake rasio aspek bawaan 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: wolota lo kisi boito lebe limbu'u ode batas sumbu; kisi boito diila pohutuwolo to perender prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi diila tuladulo wonu diila pilake perender PreFigure.
+
+multiple-annotations-children = Daata walao `<annotations>` iloontonga to `<graph>`; ngoa'amila u diila pulitio diila pohutuwolo.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Diila mowali tambahilo meyalo salinolo tipe komponen u diila otawa: { $type }.
+
+copy-prop-not-found = prop { $property } to komponen tipe { $component } diila iloontonga
+
+collect-no-source = Sumber ode collect diila iloontonga.
+
+collect-invalid-component-type = Diila mowali himoa'a komponen tipe `<{ $component }>` sababu tipe komponen boito diila banari.
+
+reference-index-unavailable = Diila mowali tunuwolo indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Diila mowali pohutuwolo { $action } to komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk lo data diila banari.  Panjang lo baris diila motu'ude. Iloontonga to componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data o tanggulo kolom u tilulude poluli.  Iloontonga to componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data kurang tuwawu tanggulo kolom.  Iloontonga to componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award lo jawaban botie modepitayi jawaban u diludelo lo tag jawaban boito lohihilao, wawu uito mo'owali parangi u diila harapulo.
+
+answer-max-num-attempts-in-section-wide-check-work = Pohutu lo `maxNumAttempts` to `<answer>` u to delomo wadah u o `sectionWideCheckWork` diila o pengaruh, sababu jumlah lo usaha yilaturu lo wadah boito. Pohutu `maxNumAttempts` to wadah boito.
+
+nested-section-wide-check-work-max-num-attempts = Pohutu lo `maxNumAttempts` to wadah u o `sectionWideCheckWork` u to delomo wadah wuwewo u o `sectionWideCheckWork` diila o pengaruh, sababu jumlah lo usaha yilaturu lo wadah u to bulemengo. Pohutu `maxNumAttempts` to wadah u to bulemengo boito.
+
+answer-attributes-need-symbolic-equality = Atribut { $attributes } diila o pengaruh wonu symbolicEquality diila woluwo.
+
+answer-invalid-type = Tipe lo jawaban diila banari: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sababu komponen `<{ $component }>` diila o tanggulo, boito diila mowali pilake debo atribut lo module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` diila mowali pilake debo atribut lo module sababu tipe komponen `<module>` ma o atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` diila pohutuwolo to komponen `<conditionalContent>` u o walao case meyalo else.
+
+slider-markers-type-mismatch = Tipe lo marker diila motu'ude wolo tipe lo slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel diila banari: tuwa-tuwawu `<problem>` musi o tuwawu `<statement>` wawu tuwawu `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel diila banari: to mode="circuit", `<problem>` bohulio diila mowali mowali distraktor.
+
+## Attribute values
+
+attribute-invalid-values = Nilai { $values } diila banari ode atribut `{ $attribute }`; diila pohutuwolo.
+
+attribute-must-be-references = Nilai `{ $value }` diila banari ode atribut `{ $attribute }`. Atribut musi pohutuwolo lonto referensi u momula wolo `$`.
+
+math-input-invalid-function-names = <mathInput>: tanggulo fungsi u diila banari to { $attribute } diila pohutuwolo: { $names }. Tuwa-tuwawu tanggulo musi o palingu ngoidi 2 karakter (huruf meyalo garis tayade); mowali tambahilo akhiran `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Tipe komponen diila banari: `<{ $componentType }>`
+
+attribute-repeated = Diila mowali tulude poluli atribut { $attribute }.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" diila banari ode komponen tipe `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definisi gaya { $styleNumber } kurang kontrasilio ode { $context ->
+        [text-on-background] warna teks ode warna latar
+        [high-contrast] warna kontras u molanggato ode kanvas
+        [line] warna garis ode kanvas
+        [marker] warna marker ode kanvas
+       *[text-on-canvas] warna teks ode kanvas
+    }{ $mode ->
+        [dark] { " (mode moitomo)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; palingu ngoidi musi { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Openu definisi gaya { $styleNumber } ma o warna u sae kontrasilio ode mode mobango, warna mode moitomo u lonto nilai boito kurang kontrasilio ode warna teks wolo warna latar ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; palingu ngoidi musi { $threshold }:1). { $suggestion ->
+        [available] Alihu sae kontrasilio to mode moitomo, popolanggato kontras mode mobango (misalu pohutu { $lightAttribute }="{ $lightColor }") meyalo bulita warna mode moitomo (misalu pohutu { $darkAttribute }="{ $darkColor }").
+       *[none] Alihu sae kontrasilio to mode moitomo, popolanggato kontras mode mobango meyalo bulita warna u lonto boito wolo textColorDarkMode wawu/meyalo backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Openu definisi gaya { $styleNumber } ma o warna teks u sae kontrasilio ode mode mobango, warna teks mode moitomo u lonto nilai boito kurang kontrasilio ode kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; palingu ngoidi musi { $threshold }:1). { $suggestion ->
+        [available] Alihu sae kontrasilio to mode moitomo, popolanggato kontras mode mobango (misalu pohutu textColor="{ $lightColor }") meyalo bulita warna mode moitomo (misalu pohutu textColorDarkMode="{ $darkColor }").
+       *[none] Alihu sae kontrasilio to mode moitomo, popolanggato kontras mode mobango meyalo bulita warna u lonto boito wolo textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Ngotalu bagian bo mowali motulawoto tuwawu <stylePalette>; u pulitio u pilake.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = varian u unik lo { $component } diila mowali otawa sababu numToSelect diila bilangan bulat u diila negatif.
+
+variant-num-to-select-not-constant-number = varian u unik lo { $component } diila mowali otawa sababu numToSelect diila bilangan u tatapu.
+
+variant-with-replacement-not-constant-boolean = varian u unik lo { $component } diila mowali otawa sababu withReplacement diila boolean u tatapu.
+
+variant-select-weight-disables-unique = Varian u unik ode select diila mokaraja wonu woluwo option u o selectWeight meyalo selectForVariants
+
+variant-coprime-undetermined = varian u unik lo { $component } diila mowali otawa sababu coprime layito salah diila mowali otawa.
+
+variant-attribute-not-constant = varian u unik lo { $component } diila mowali otawa sababu { $attribute } diila tatapu.
+
+variant-attribute-not-number = varian u unik lo { $component } diila mowali otawa sababu { $attribute } diila bilangan.
+
+variant-attribute-wrong-type-for-sequence =
+    varian u unik lo { $component } tipe { $type } diila mowali otawa sababu { $attribute } diila { $expected ->
+        [letters-combination] rangkaian huruf
+        [math-expression] ekspresi matematika u banari
+        [integer] bilangan bulat
+       *[number] bilangan
+    }.
+
+variant-length-not-integer = varian u unik lo { $component } diila mowali otawa sababu length diila bilangan bulat.
+
+variant-sort-not-implemented = dipo pilohutu varian u unik lo { $component } u o sort
+
+variant-exclude-combinations-not-implemented = dipo pilohutu varian u unik lo { $component } u o excludeCombinations
+
+variant-math-exclude-not-implemented = dipo pilohutu varian u unik lo { $component } tipe math u o exclude
+
+variant-non-constant-exclude-not-implemented = dipo pilohutu varian u unik lo { $component } u o exclude u diila tatapu
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: diila dukungolo to perender prefigure lo graph; walao dilalowa.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri u diila tatapu meyalo u kurang; walao dilalowa.
+
+prefigure-curve-label-omitted = { $subject }: label diila dukungolo to elemen kurva u yiluli; label dilalowa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipe definisi fungsi kurva '{ $definitionType }' diila dukungolo; walao dilalowa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions to regionBetweenCurves diila dukungolo; walao dilalowa.
+
+prefigure-region-non-formula-child = { $subject }: bo walao fungsi tipe formula u dukungolo to regionBetweenCurves; walao dilalowa.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' diila dukungolo ode { $labelKind ->
+        [line-family] label lo kelompok garis
+       *[point] label lo titik
+    }; u pilake perataan PreFigure bawaan.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' diila dukungolo lo PreFigure; muli ode isi u solid.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' u diila otawa dilalowa lonto luaran PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' pilotaalo gaya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' diila dukungolo lo PreFigure; u pilake gaya bawaan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` diila banari; target diila mowali otawa. Anotasi dilalowa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` motunu ode daata target; u bohulio u pilake.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` diila banari; target boito to bulemengo graph u modu'olo. Anotasi dilalowa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` diila banari; target boito diila objek grafis u dukungolo to konversi prefigure. Anotasi dilalowa.
+
+annotation-text-missing = `<annotation>`: `text` kurang meyalo lowong; teks u lowong u pilohutu.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Iloontonga katergantungan u molihu.
+       *[other] Iloontonga katergantungan u molihu u o komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = U tilunuhu lo referensi diila iloontonga: `{ $reference }`
+
+reference-multiple-referents = Daata u tilunuhu lo referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format lo atribut { $attribute } lo `<{ $componentType }>` diila banari.
+
+children-invalid = Walao lo `<{ $componentType }>` diila banari: Iloontonga walao u diila banari: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` diila banari ode atribut `{ $attribute }`, nilai `{ $default }` u pilake
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } diila iloontonga.
+       *[other] Versi DoenetML { $version } diila iloontonga. Muli ode versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML diila banari: { $content }
+
+parse-tag-missing-close-tag = DoenetML diila banari: Tag `{ $tag }` diila o tag palautu. Musi tag u molautu batangalio meyalo tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML diila banari: Ututala to tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML diila banari: Atribut `{ $attribute }` u diila banari botie tanu kurang nilai.
+
+parse-attribute-invalid = DoenetML diila banari: Atribut `{ $attribute }` diila banari
+
+parse-attribute-value-invalid = DoenetML diila banari: Nilai atribut `{ $value }` diila banari
+
+parse-attribute-value-quote-mismatch = DoenetML diila banari: Nilai atribut `{ $value }` diila banari. Tanda kutip diila motu'ude. Tanu kurang tuwawu `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML diila banari: Iloontonga tag u diila o tanggulo tag, debo `<`
+
+parse-tag-not-closed = DoenetML diila banari: Tag `{ $tag }` diila lilautu (tanu kurang `>`).
+
+parse-self-closing-tag-name-missing = DoenetML diila banari: Iloontonga tag u diila o tanggulo tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML diila banari: Tag `{ $tag }` diila lilautu (tanu kurang `/>`).
+
+parse-tag-invalid-attributes = DoenetML diila banari: Tag `{ $tag }` diila banari. Tanu atributilio diila banari.
+
+parse-close-tag-name-missing = DoenetML diila banari: Iloontonga tag palautu u diila o tanggulo tag, debo `</`
+
+parse-attribute-value-unquoted = Nilai atribut musi to delomo tanda kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML diila banari: Iloontonga tag palautu `{ $tag }`, bo diila woluwo tag pamula u motu'ude
+
+parse-close-tag-mismatched = DoenetML diila banari: Tag palautu diila motu'ude. U harapulo `</{ $expected }>`. U iloontonga `{ $found }`
+
+parser-node-unconvertible = Node { $node } diila mowali uliyolo ode node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Tanggulo atribut name='{ $name }' diila banari. { $reason ->
+        [characters] Tanggulo bo mowali o huruf, angka, garis to walungo meyalo garis tayade.
+       *[start] Tanggulo musi momula wolo tuwawu huruf.
+    }
+
+component-name-invalid-start = Tanggulo komponen "{ $name }" diila banari. Tanggulo musi momula wolo tuwawu huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Jawaban tipe videoWatched musi o atribut video
+
+answer-video-watched-video-not-reference = Jawaban tipe videoWatched musi o atribut video u ngotalu referensi
+
+answer-name-not-single-text = Atribut name lo jawaban musi o tuwawu walao text bo
+
+## Referencing another document
+
+external-doenetml-recursion-limit = DoenetML lonto bulemengo diila mowali hamawa sababu rekursilio lebe daata lapisilio. Woluwo referensi u molihu?
+
+external-doenetml-unavailable = DoenetML lonto { $attribute }="{ $uri }" diila mowali hamawa
+
+external-doenetml-type-mismatch = DoenetML u yilohama lonto { $attribute }="{ $uri }" diila banari: diila motu'ude wolo tipe komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` ma tilolaalo; pake `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` to `<{ $component }>` ma tilolaalo; pake `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` ma tilolaalo wawu diila pohutuwolo sababu `{ $to }` ma woluwo olo.
+       *[other] [deprecation] Atribut `{ $from }` to `<{ $component }>` ma tilolaalo wawu diila pohutuwolo sababu `{ $to }` ma woluwo olo.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` to `<{ $component }>` ma tilolaalo wawu diila pohutuwolo.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` to `<{ $component }>` ma tilolaalo; pake walao `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` lo atribut `{ $attribute }` to `<{ $component }>` ma tilolaalo; pake `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` bo mowali mopobentuk jamak lo bahasa Inggris, so'o teksilio diila bulitolo to dokumen u tiluladu wolo { $locale }. Tulade bentuk jamakilio tulusu, meyalo pohutu wolo atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` diila elemen Doenet u otawa.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` diila mowali to wumbuto lo dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` diila mowali to delomo `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` diila o atribut u o tanggulo `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` lo elemen `<{ $tag }>` musi ngotalu daftar u tuwa-tuwawu itemilio tuwawu lonto: { $allowed }
+       *[other] Atribut `{ $attribute }` lo elemen `<{ $tag }>` musi tuwawu lonto: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Tanggulo varian lo select diila banari.  Tanggulo varian { $variantName } woluwo to { $numOptions } option bo jumlah u tulawoto { $numToSelect }.
+
+select-variant-name-without-options = Woluwo varian u ma woluwo to select bo diila woluwo option ode tanggulo varian u mowali: { $variantName }.
+
+select-variant-name-not-possible = Tanggulo varian { $variantName } u ma woluwo to select diila tanggulo varian u mowali.
+
+select-too-few-options = Diila mowali tulawoto { $numToSelect } komponen lonto bo { $numOptions }.
+
+select-from-sequence-too-few-values = Diila mowali tulawoto { $numToSelect } nilai lonto sequence u o panjang { $length }.
+
+select-from-sequence-indices-count-mismatch = Jumlah lo indices u ma woluwo to select musi motu'ude wolo jumlah u tulawoto
+
+select-from-sequence-indices-not-integers = Ngoa'amila indices u ma woluwo to select musi bilangan bulat
+
+select-from-sequence-index-excluded = Indeks selectfromsequence u ma woluwo boito ma yilulutalo
+
+select-from-sequence-indices-excluded-combination = indices selectfromsequence u ma woluwo boito ngotalu kombinasi u yilulutalo
+
+select-from-sequence-coprime-not-positive-integers = Diila mowali tulawoto kombinasi coprime sababu u tilulawoto diila bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Diila mowali tulawoto bilangan coprime. Ngoa'amila nilai u mowali o faktor u tuwawu. (Nilai "from" meyalo "to" u ma woluwo musi coprime wolo "step".)
+
+select-from-sequence-coprime-single-number = Diila mowali tulawoto kombinasi coprime lonto tuwawu bilangan u diila 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebe lonto 70% kombinasi yilulutalo to selectFromSequence
+
+select-from-sequence-coprime-none-found = Diila mowali tulawoto bilangan coprime. Ngoa'amila nilai u mowali o faktor u tuwawu.
+
+select-from-sequence-too-few-unique-values = Diila mowali tulawoto { $numToSelect } nilai u unik lonto sequence u o panjang { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Diila mowali tulawoto { $numToSelect } nilai lonto daftar bilangan prima u o panjang { $numValues }
+
+select-prime-numbers-values-count-mismatch = Jumlah lo nilai u ma woluwo to select musi motu'ude wolo jumlah u tulawoto
+
+select-prime-numbers-values-not-prime = Ngoa'amila nilai u ma woluwo to select bilangan prima musi woluwo to daftar bilangan prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers u ma woluwo boito ngotalu kombinasi u yilulutalo
+
+select-prime-numbers-excluded-too-many-combinations = Lebe lonto 70% kombinasi yilulutalo to selectPrimeNumbers
+
+select-random-combination-fluke = Sababu kabatula u jarang da'a, kombinasi lo nilai acak diila mowali tulawoto
+
+select-random-value-fluke = Sababu kabatula u jarang da'a, nilai acak diila mowali tulawoto
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` botie diila biluohu sababu to delomo matematika wawu diila `inline`. Tambahi `inline` alihu mowali daftar u motuhuto, u motu'ude to delomo ngotalu ekspresi.
+        [expanded] `<{ $component }>` botie diila biluohu sababu to delomo matematika wawu `expanded`. Luluta `expanded`; kotak u daata barisilio diila motu'ude to delomo ngotalu ekspresi.
+        [on-graph] `<{ $component }>` botie diila biluohu sababu to delomo matematika u tiluladu to graph, u diila o tambati ode masukan.
+       *[relative-width] `<{ $component }>` botie diila biluohu sababu to delomo matematika wawu o lebar relatif. Wohi lebarilio wolo satuan absolut, debo `px`.
+    }

--- a/packages/i18n/locales/gor/editor.ftl
+++ b/packages/i18n/locales/gor/editor.ftl
@@ -1,0 +1,228 @@
+# Gorontalo (Bahasa Hulontalo) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: the Latin practice in current use**, no diacritics, the
+# glottal stop written `'` only where a word would otherwise be ambiguous;
+# `chrome.ftl`'s header sets it out in full.
+#
+# **This is the file where the loan register is heaviest**, and it should be
+# read as such rather than as a failure to translate. An editor's nouns —
+# «editor», «penampil», «varian», «saringan», «komponen», «atribut»,
+# «referensi», «properti», «cuplikan», «larik», «nilai», «tipe», «gaya»,
+# «koordinat», «fungsi», «baris», «tag», «dokumentasi», «aksesibilitas»,
+# «laporan», «versi», «format», «konteks», «diagnostik» — are Indonesian in a
+# Gorontalo speaker's computing vocabulary, and there is no Gorontalo word for
+# any of them the seed can reach. What is Gorontalo here is the frame: «diila»,
+# «mowali», «woluwo», «u», «to», «lonto», «lo», «wawu», «meyalo», «wonu», the
+# verbs «mohuo» (open), «molautu» (close), «mohutu» (do), «momilohu» (see) and
+# the causative «mopo-».
+#
+# **The count selects.** Gorontalo leaves a noun unmarked after a numeral, so
+# «koordinat» is the same word for one and for many; `help-coordinates` and the
+# two counts inside `editor-accessibility-label` collapse to a single
+# `*[other]` branch. That is also what the plural rule requires — `gor` has no
+# CLDR plural data, so an `[one]` branch here would be selected by English's
+# rules — but it would be the right form even if it did.
+#
+# **What this catalog does not know.** Whether «penampil» or a Gorontalo phrase
+# reads better for *viewer*, and what register an imperative on a button should
+# be in. Both are speaker questions.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Poluli
+       *[update] Perbarui
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } penampil
+       *[other] { $word } penampil { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+
+editor-variant-filter = Saring...
+
+editor-variant-next = Tulawota varian u ma monao
+editor-variant-previous = Tulawota varian u lomayi
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Iloontonga pelanggaran aksesibilitas WCAG AA. Klik u { $action ->
+            [close] molautu
+           *[open] mohuo
+        } laporan aksesibilitas.
+        [advisories] Klik u { $action ->
+            [close] molautu
+           *[open] mohuo
+        } laporan aksesibilitas. Diila woluwo pelanggaran WCAG AA u iloontonga, bo woluwo poli saran aksesibilitas wuwewo.
+       *[clean] Klik u { $action ->
+            [close] molautu
+           *[open] mohuo
+        } laporan aksesibilitas. Diila woluwo masalah aksesibilitas u iloontonga.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Iloontonga pelanggaran aksesibilitas WCAG AA. Iloontonga { $count } pelanggaran WCAG AA. Klik u { $action ->
+            [close] molautu
+           *[open] mohuo
+        } laporan aksesibilitas.
+        [advisories] Diila woluwo pelanggaran WCAG AA u iloontonga. Iloontonga { $count } saran aksesibilitas wuwewo. Klik u { $action ->
+            [close] molautu
+           *[open] mohuo
+        } laporan aksesibilitas.
+       *[clean] Diila woluwo pelanggaran WCAG AA u iloontonga. Klik u { $action ->
+            [close] molautu
+           *[open] mohuo
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Bantuan u motu'ude wolo konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Ututala
+editor-tab-warnings = Poti'ingoti
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Jawaban u ma diludelo
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Format debo DoenetML
+editor-format-as-xml = Format debo XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Diila woluwo ututala
+editor-no-warnings = Diila woluwo poti'ingoti
+editor-no-info = Diila woluwo diagnostik info
+
+editor-show-info-annotations = Popobiloheyi diagnostik info to editor
+editor-show-accessibility-annotations = Popobiloheyi diagnostik aksesibilitas to editor
+
+editor-accessibility-learn-more = Pelajari wololo Doenet momarakisa aksesibilitas
+
+editor-accessibility-violations-heading = Pelanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masalah aksesibilitas wuwewo
+editor-none-found = Diila woluwo u iloontonga
+
+
+## Submitted responses
+
+editor-no-responses = Dipo woluwo jawaban u ma diludelo
+editor-response-answer-id = Id lo jawaban
+editor-response-response = Jawaban
+editor-response-credit = Nilai
+editor-response-submitted = Diludelo
+
+
+## The context-help panel
+
+help-placeholder = Pomao kursor to tanggulo tag, atribut, meyalo { $ref } u momilohu dokumentasi.
+
+help-unsupported-ref-chain = Bantuan ode referensi u o'oduluwo debo { $example } dipo woluwo.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Diila woluwo u tilunuhu lo referensi: { $ref }.
+        [multiple] Daata u tilunuhu lo referensi: { $ref }.
+       *[indeterminate] U tilunuhu lo { $ref } diila mowali otawa.
+    }
+
+help-learn-about-references = Pelajari tomimbihu referensi →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] To delomo { $element }
+       *[top] To tingkat u palingu yitato
+    }{ $allowed ->
+        [none] { " — diila woluwo u mowali potaowa teya." }
+        [text] { " — tulade teks teya." }
+        [text-and-components] { " — tulade teks teya, meyalo coba:" }
+       *[components] { " — u mowali cobalo:" }
+    }
+
+help-suggestions-footer = Tomo'o { $shortcut } u momilohu ngoa'amila { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } yito referensi ode { $target }.
+       *[other] { $ref } yito referensi ode { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Pilomulaalo li { $owner } debo { $role }.
+       *[other] Pilomulaalo li { $owner } to baris { $line } debo { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } yito referensi ode properti { $property } lo { $element }.
+       *[other] { $ref } yito referensi ode properti { $property } lo { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = cuplikan
+help-kind-array-entry = entri larik
+
+help-default = Bawaan:
+help-active-default = Bawaan u hemokaraja:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai u mowali (tuwawu ngota-ngota item):
+       *[other] Nilai u mowali:
+    }
+
+help-suggested-values = Nilai u sinaranilo:
+
+help-inserts = U potuwoto:
+
+help-coordinates = Koordinat:
+
+help-type = Tipe:
+
+help-resolved-style = Gaya u iloontonga (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Tanggulo fungsi u iloontonga:
+help-reset-list = Daftar u poluliyolo to masukan botie:
+help-added-on-input = U tilambahu to masukan botie:
+help-removed-on-input = U lilulutalo to masukan botie:
+
+help-reset-overrides = { $reset } momuli { $additional } wawu { $removed }.

--- a/packages/i18n/locales/iba/chrome.ftl
+++ b/packages/i18n/locales/iba/chrome.ftl
@@ -1,0 +1,162 @@
+# Iban viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Iban** (Jaku Iban), the Malayic language of Sarawak and of the upper Kapuas
+# in West Kalimantan. It is close to Malay and this catalog is written by
+# somebody who can read Malay, which is the whole of its risk: see below.
+#
+# ORTHOGRAPHY. The standard Sarawak spelling used in Iban schooling, in the
+# Iban press and in the Bup Kudus. Its two visible breaks with Malay are kept
+# throughout and are not typos: **`ch`** where Malay writes `c` («chukup»,
+# «chunto»), and **`nya`/`ny`** as in Malay. Verbal and nominal prefixes are
+# written Iban rather than Malay: **`be-`** for Malay `ber-` («besisi»,
+# «bejalai»), **`te-`** for Malay `ter-` («tebalik»), **`pe-`/`peN-`** for
+# Malay `per-`/`peN-` («penerang», «pengawa», «penyalah»). A corrector who
+# prefers the older mission spellings should convert **all four files at
+# once** and should not leave one file in one system.
+#
+# **THE RISK THIS FILE IS WRITTEN AROUND.** Iban's technical register really
+# is Malay — an Iban speaker is schooled in Malay and meets «poligon»,
+# «fungsi» and «vektor» in a Malay textbook — so the honest catalog uses those
+# words and says it is using them. What must not happen is the other thing:
+# Malay sentences with a few Iban words dropped in. So the *grammar* of this
+# file is Iban and is checkable in a second:
+#
+#   - the three negators are kept apart — **«enda»** before a verb, **«ukai»**
+#     before a noun or an identification, **«nadai»** for "there is none";
+#   - **«bisi»** for "there is", **«udah»** for the perfect, **«benung»** for
+#     the progressive, **«agi»** for "still, any more";
+#   - **«enggau»** for "and/with", **«tauka»** for "or", **«ba»** for "at",
+#     **«ngagai»** for "to", **«ti»** as the relativizer, **«nuan»** for "you";
+#   - everyday words that are Iban and not Malay: «utai», «mayuh», «besai»,
+#     «pemadu», «bukai», «kutak», «lambar», «jaku», «tulung», «lubah», «tembu».
+#
+# A reviewer who finds a Malay function word in here — «yang», «ada»,
+# «tidak», «dengan», «atau» — has found a defect, and it is the defect this
+# seed is most likely to have made.
+#
+# DECLARED LOANS. `WCAG`, `DoenetML`, `renderer`, `statistik`, `matematik`,
+# `markah`, `label`, `baris`, `lajur`, `papan kekunci`, `komponen`, `akses`
+# and `amaran` are written as they stand. The first four are English; the rest
+# are the Malay school words, kept because that is what an Iban reader has met
+# them as, and named here rather than replaced with a coinage.
+#
+# WHAT THIS CATALOG DOES NOT KNOW. It has no Iban word for "to hide", so
+# `footnote-hide` says "close" («Tutup») instead — the word that can be
+# written without guessing. It has no Iban word for "renderer" and keeps the
+# English. Both are the first places to look.
+#
+# PLURALS. `Intl.PluralRules` has no data for `iba`, so a `[one]` branch would
+# be selected by whatever the runtime's default locale is rather than by Iban
+# — and Iban would not want one anyway, since a noun after a numeral is not
+# marked («dua kutak», not «dua kutak-kutak»). Every count select is collapsed
+# to a single `*[other]`. An explicit `[0]` is matched against the number
+# itself rather than against a plural category, so it stays.
+
+
+## Answer submission
+
+answer-checking = Benung nguji…
+answer-submitting = Benung ngirum…
+answer-checking-status = Benung nguji saut
+answer-submitting-status = Benung ngirum saut
+answer-correct = Amat
+answer-incorrect = Salah
+answer-response-saved = Saut udah disimpan
+answer-percent-credit = { $percent }% markah
+answer-percent-correct = { $percent }% amat
+answer-percent-short = { $percent } %
+max-credit-available = Markah pemadu besai ti ulih diambi: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] nadai peluang agi
+       *[other] { $count } peluang agi
+    }
+validation-correct = (Amat)
+validation-incorrect = (Salah)
+validation-partially-correct = (Amat sekeda)
+answer-show-responses =
+    { $count ->
+       *[other] Ayanka { $count } saut ngagai { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Jaku Balas
+collapsible-click-to-open = (tekan kena muka)
+collapsible-click-to-close = (tekan kena nutup)
+collapsible-initializing = Benung nyedia…
+footnote-show = Ayanka nota kaki
+footnote-hide = Tutup nota kaki
+description-more-information = penerang tambah
+
+
+## Controls
+
+slider-previous = Ka Belakang
+slider-next = Ka Mua
+keyboard-open = Muka Papan Kekunci
+keyboard-close = Tutup Papan Kekunci
+choice-input-remove-choice = Buai { $choice }
+matrix-remove-row = Buai baris
+matrix-add-row = Tambah baris
+matrix-remove-column = Buai lajur
+matrix-add-column = Tambah lajur
+subset-add-remove-points = Tambah/Buai titik
+subset-toggle-points-intervals = Tukar entara titik enggau selang
+subset-move-points = Pindahka Titik
+subset-clear = Kosongka
+orbital-add-row = Tambah Baris
+orbital-remove-row = Buai Baris
+orbital-add-box = Tambah Kutak
+orbital-remove-box = Buai Kutak
+orbital-add-up-arrow = Tambah Anak Panah Ka Atas
+orbital-add-down-arrow = Tambah Anak Panah Ka Baruh
+orbital-remove-arrow = Buai Anak Panah
+orbital-row-label = Nama ke baris { $row }
+pretzel-answer = Saut
+summary-statistics-caption = Ringkas statistik { $column }
+
+
+## Math input
+
+math-input-preview-region = peda dulu ungkapan matematik
+math-input-preview = Peda Dulu
+math-input-invalid-expression = Ungkapan enda betul:
+
+
+## Document status
+
+viewer-initializing = Benung nyedia…
+
+
+## Errors
+
+error-heading = Penyalah
+error-found-at =
+    { $span ->
+        [line] Ditemu ba baris { $startLine }.
+       *[lines] Ditemu ba baris { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Dokumen tu bisi penyalah!
+diagnostic-heading-error = Penyalah
+diagnostic-heading-warning = Amaran
+diagnostic-heading-information = Penerang
+diagnostic-heading-hint = Tunjuk Jalai
+accessibility-heading-level-1 = Pelanggar akses WCAG AA
+accessibility-heading-level-2 = Amaran pasal akses
+something-went-wrong = Bisi utai ti salah nyadi.
+renderer-load-failed = siti renderer enda ulih dimuat. Tulung muat baru lambar tu.
+core-start-failed = Dokumen tu enda ulih dimulaka. Tulung muat baru lambar tu.
+core-start-failed-busy = Dokumen tu enda ulih dimulaka. Mayuh dokumen benung dimulaka sama-sama, lalu tu majak lama agi ba alat ti lubah. Muat baru lambar tu ulih nulung lebuh dokumen bukai udah tembu.
+core-start-failed-retry = Dokumen tu enda ulih dimulaka.
+core-start-failed-busy-retry = Dokumen tu enda ulih dimulaka. Mayuh dokumen benung dimulaka sama-sama, lalu tu majak lama agi ba alat ti lubah.
+core-start-retry = Uji Baru
+saved-state-unavailable = Pengawa nuan ti udah disimpan enda ulih dimuat.

--- a/packages/i18n/locales/iba/content.ftl
+++ b/packages/i18n/locales/iba/content.ftl
@@ -50,7 +50,7 @@
 # reach for cyan.
 #
 # CHEMISTRY. `element-name` and `element-anion-name` are deliberately **left
-# out**, so their ~130 keys fall back to English. Chemistry in Sarawak is
+# out**, so their 130 keys fall back to English. Chemistry in Sarawak is
 # taught in Malay, out of textbooks printing the Dewan Bahasa dan Pustaka
 # names, which `locales/ms` already carries; there is no separate Iban list,
 # and copying the Malay one under an Iban tag would report a language fact

--- a/packages/i18n/locales/iba/content.ftl
+++ b/packages/i18n/locales/iba/content.ftl
@@ -1,0 +1,280 @@
+# Iban content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Iban** (Jaku Iban), a Malayic language of Sarawak and of West Kalimantan,
+# written in the standard Sarawak orthography: `ch` where Malay writes `c`,
+# and the Iban prefixes `be-`, `te-`, `pe-`/`peN-` where Malay has `ber-`,
+# `ter-`, `per-`/`peN-`. See `locales/iba/chrome.ftl` for the whole of that
+# note and for the list of Iban function words a reviewer can check this file
+# against in a second.
+#
+# WORD ORDER. Iban is head-initial and its adjectives **follow** the noun, so
+# "thick dashed red line" is «garis tebal putus-putus mirah» — noun, then
+# width, then dash pattern, then colour, keeping English's order among the
+# adjectives themselves. `style-with-noun` and `style-filled-with-noun`
+# therefore put `{ $noun }` first, and every message in this file agrees with
+# them. That order is the one thing here that a test pins, so a corrector who
+# moves it has to move it in both messages at once.
+#
+# The side count folds into the head — «poligon rata besisi 5» — because
+# «besisi» has to stay beside the number counting it. So `[tail]` is empty.
+#
+# GENDER AND NUMBER. Iban has no grammatical gender and does not inflect an
+# attributive adjective, so `$gender` and `$role` are received and ignored, as
+# in English. It has no article either, so the two `-article` branches read
+# exactly like the ones without. A noun after a numeral is unmarked.
+#
+# THE TECHNICAL REGISTER IS MALAY, AND IS DECLARED AS SUCH. An Iban pupil is
+# schooled in Malay and meets «poligon», «fungsi», «vektor», «parabola»,
+# «rombus» and «statistik» in a Malay textbook. Those are written here as they
+# stand rather than replaced with coinages — including the shape names «segi
+# tiga», «segi empat tepat», «segi empat sama» and the field terms «medan
+# kecherunan», «medan vektor». What is Iban in this file is everything around
+# them.
+#
+# WHERE IBAN HAS ITS OWN WORD IT IS USED: «mirah» rather than Malay «merah»,
+# «itam» rather than «hitam», «burak» rather than «putih», «gadung» for green,
+# «bulatan» for the circle, «titik» for the point, «kawasan» for the region,
+# «beisi»/«nadai isi» for filled and unfilled, «tauka» for "or", «enti» for
+# "if", «lalu» for the "and" that chains one clause onto another.
+#
+# CONFIDENCE. The colour list is the thinnest part of the file. «kelabu»
+# (gray), «jingga» (orange), «ungu» (purple), «mirah jambu» (pink) and
+# «perang» (brown) are the Malay words, written because Iban's own everyday
+# colour vocabulary does not settle these five and a coinage would be worse
+# than a loan a speaker actually uses. «gadung» is written for green; a
+# speaker may prefer «ijau», and may not agree that «biru gadung» is the right
+# reach for cyan.
+#
+# CHEMISTRY. `element-name` and `element-anion-name` are deliberately **left
+# out**, so their ~130 keys fall back to English. Chemistry in Sarawak is
+# taught in Malay, out of textbooks printing the Dewan Bahasa dan Pustaka
+# names, which `locales/ms` already carries; there is no separate Iban list,
+# and copying the Malay one under an Iban tag would report a language fact
+# that is not true. The frames around the names — `ion-name-oxidation-state`
+# and the two invalid-input messages — are translated, because they are frames
+# rather than vocabulary.
+
+
+## Style vocabulary
+
+color =
+    .black = itam
+    .white = burak
+    .gray = kelabu
+    .red = mirah
+    .orange = jingga
+    .yellow = kuning
+    .green = gadung
+    .cyan = biru gadung
+    .blue = biru
+    .purple = ungu
+    .pink = mirah jambu
+    .brown = perang
+line-width =
+    .thick = tebal
+    .thin = nipis
+line-style =
+    .dashed = putus-putus
+    .dotted = betitik
+# Noun phrases: they follow «enggau» and modify nothing themselves. «te-» is
+# the Iban prefix, not a misspelling of Malay «ter-».
+fill-style =
+    .horizontal = garis melintang
+    .vertical = garis bediri
+    .diagonal = garis serong
+    .backdiagonal = garis serong tebalik
+    .dots = titik
+    .diamonds = rombus
+noun =
+    .line = garis
+    .line-segment = tembereng garis
+    .ray = sinar
+    .vector = vektor
+    .curve = lengkung
+    .function = fungsi
+    .slope-field = medan kecherunan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis bebilang
+    .polygon = poligon
+    .triangle = segi tiga
+    .rectangle = segi empat tepat
+    .circle = bulatan
+    .region = kawasan
+    .point = titik
+    .square = segi empat sama
+    .diamond = rombus
+    .cross = tanda silang
+    .plus = tanda tambah
+# «besisi» has to stay beside the number that counts the sides, so the count
+# folds into the head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon rata besisi { $numSides }
+    }
+# Iban has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun leads and its adjectives follow: «garis tebal putus-putus mirah».
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = beisi
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } enggau { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } enggau { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } enggau { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+# «sempadan» leads its own adjectives, as every noun here does. Iban has no
+# article, so the `-article` branches read like the ones without; «lalu» is
+# the Iban word that chains one clause onto the next.
+style-border-clause =
+    { $parts ->
+        [with-article] enggau sempadan { $border }
+        [and] lalu sempadan { $border }
+        [and-article] lalu sempadan { $border }
+       *[with] enggau sempadan { $border }
+    }
+# The pattern is a noun and the colour follows it, as everywhere else.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+# «nadai» is the existential negator: "has no filling", not "not filled".
+style-unfilled = nadai isi
+style-text =
+    { $parts ->
+        [background] { $color } enggau latar belakang { $background }
+       *[plain] { $color }
+    }
+style-background-none = nadai
+
+
+## Boolean words
+
+boolean-true = amat
+boolean-false = ukai amat
+
+
+## Answer buttons
+
+answer-submit-label = Uji Pengawa
+answer-submit-label-no-correctness = Kirum Saut
+
+
+## Sectional blocks
+##
+## Iban does not mark number on a noun, so `.exercise` and `.exercises`, and
+## `.problem` and `.problems`, are the same word. That is the language rather
+## than an omission.
+
+section-name =
+    .activity = Pengawa
+    .aside = Nota Tepi
+    .cascade = Kaskad
+    .definition = Reti
+    .example = Chunto
+    .exercise = Latih
+    .exercises = Latih
+    .given-answer = Saut
+    .note = Nota
+    .objectives = Tuju
+    .paragraphs = Perenggan
+    .part = Bagi
+    .problem = Pekara
+    .problems = Pekara
+    .proof = Bukti
+    .question = Tanya
+    .section = Seksyen
+    .solution = Penyelesaian
+    .task = Tugas
+    .theorem = Teorem
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Tunjuk Jalai
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Jadual { $enumeration }
+        [numbered-title] Jadual { $enumeration }{ ": " }
+        [unnumbered-title] Jadual{ ": " }
+       *[unnumbered] Jadual
+    }
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ka Belakang
+paginator-next = Ka Mua
+paginator-page = Lambar
+paginator-page-status = { $pageLabel } { $currentPage } ari { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = tauka
+piecewise-condition-if = enti
+piecewise-condition-otherwise = enti ukai
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header for why. These three are frames rather than vocabulary, so they are
+## translated whether or not the names ever are.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Simbol Kimia Enda Betul
+chemistry-invalid-ionic-compound = Sebatian Ionik Enda Betul
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = kosong
+math-embedded-input-blank-ordinal = kosong { $ordinal } ari { $total }

--- a/packages/i18n/locales/iba/diagnostics.ftl
+++ b/packages/i18n/locales/iba/diagnostics.ftl
@@ -1,0 +1,691 @@
+# Iban diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the standard Sarawak Iban orthography used by the other three
+# files of this locale; see `locales/iba/chrome.ftl` for the whole note on the
+# spelling and on the Iban function words this file can be checked against.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source, and so do `PreFigure`, `DoenetML` and `Dast`.
+#
+# TWO PHRASES CARRY MOST OF THIS FILE, and naming them here means a corrector
+# can change all of them at once. "is ignored" is **«enda dititihka»** —
+# literally "is not followed" — and "have not implemented" is **«apin
+# digaga»**, using «apin», the Iban "not yet". «enda» negates a verb, «ukai» a
+# noun, and «nadai» an existence; a Malay «tidak» or «bukan» anywhere in this
+# file is a defect.
+#
+# DECLARED LOANS. The technical nouns are the Malay school words — `komponen`,
+# `atribut`, `indeks`, `matriks`, `parameter`, `format`, `versi`, `rekursi`,
+# `dimensyen`, `fungsi`, `vektor`, `nilai eigen`, `grid`, `label`, `input` —
+# because that is what an Iban reader has met them as, and a coinage would be
+# worse than a loan already in use.
+#
+# Every count selection is a single `*[other]`: Iban does not mark number on a
+# noun after a numeral, and `Intl.PluralRules` has no data for `iba` to select
+# a `[one]` branch with. The one `[1]` below is a numeric literal matched
+# against the number itself, which stays legal.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] { $attributes } enda dititihka lebuh dua ujung disebut
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] { $attributes } enda dititihka lebuh siti ujung enggau titik tengah disebut sama-sama
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset nadai guna enti titik tengah enda disebut
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis ti nengah titik ti enda dikelala dimensyen iya.
+
+line-points-too-few-dimensions = Garis patut nengah titik ti bisi sekurang-kurang dua dimensyen.
+
+line-points-depend-on-variables = Garis nengah titik ti begantung ba pemubah: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis dalam pemubah { $variable1 } enggau { $variable2 } enda betul.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar disebut ngena through, endpoint enggau direction.  through ti disebut enda dititihka.
+
+ray-dimension-mismatch = numDimensions enda sebaka dalam sinar.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor disebut ngena head, tail enggau displacement.  head ti disebut enda dititihka.
+
+vector-dimension-mismatch = numDimensions enda sebaka dalam vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Enda ulih ditarit ngagai `<{ $component }>` laban iya nadai pemubah nearestPoint.
+
+constrain-to-without-nearest-point = Enda ulih dikangkang ngagai `<{ $component }>` laban iya nadai pemubah nearestPoint.
+
+constrain-to-interior-without-nearest-point = Enda ulih dikangkang ngagai dalam `<{ $component }>` laban iya nadai pemubah nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition enda dititihka ba choiceInput ti ukai inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indeks ti disebut ke choiceInput enda dititihka laban penyampau indeks enda sebaka enggau penyampau anak pilih.
+
+pretzel-indices-count-mismatch = Indeks ti disebut ke problem enda dititihka laban penyampau indeks enda sebaka enggau penyampau anak problem.
+
+shuffle-indices-count-mismatch = Indeks ti disebut ke shuffle enda dititihka laban penyampau indeks enda sebaka enggau penyampau komponen.
+
+indices-ignored-out-of-range = Indeks ti disebut ke { $component } enda dititihka laban sekeda indeks luar ari julat.
+
+pretzel-indices-repeated = Indeks ti disebut ke pretzel enda dititihka laban sekeda indeks diulang.
+
+pretzel-circuit-first-index = Indeks ti disebut ke pretzel dalam mode circuit enda dititihka laban indeks ti keterubah patut 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ngambika `<{ $component }>` bejalai enggau anak string, atribut `type` patut disebut.
+
+invalid-type-defaulting-to-math = Type { $type } enda betul ke komponen { $component }. Patut siti ari math, text, number tauka boolean. Dipulaika ngagai math.
+
+string-not-valid-component-to-arrange = String "{ $value }" ukai komponen ti ulih di{ $component }. Enda dititihka.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } enda betul, type ditukar ngagai number.
+
+invalid-variable-value = Nilai pemubah enda betul: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } patut nambar
+
+variant-index-must-be-integer = Indeks varian { $index } patut nambar bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` apin digaga ke ukur mutlak. Lebar ditukar ngagai relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` apin digaga ke ukur mutlak. Birai ditukar ngagai relatif.
+
+side-by-side-no-block-child = `<{ $component }>` enda betul: iya patut bisi sekurang-kurang siti anak blok.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` ba `<label>` grafik enda dititihka.
+
+label-for-must-resolve-to-one = Atribut `for` ba `<label>` patut nunjuk ngagai siti komponen aja.
+
+label-for-unresolved = Atribut `for` ba `<label>` enda ulih dipetara ngagai komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` ba `<label>` nunjuk ngagai `<answer>` ti udah bisi input ditulis penulis; tunjuk terus ngagai input nya.
+
+label-for-answer-without-input = Atribut `for` ba `<label>` nunjuk ngagai `<answer>` ti nadai input ke dilabel.
+
+label-for-must-reference-input-or-answer = Atribut `for` ba `<label>` patut nunjuk ngagai input tauka answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ke akses, `<{ $component }>` patut bisi penerang pandak tauka disebut baka perengka perias.
+
+accessibility-video-short-description = Ke akses, `<video>` patut bisi penerang pandak.
+
+accessibility-input-short-description-or-label = Ke akses, `<{ $component }>` patut bisi penerang pandak tauka label.
+
+accessibility-answer-input-short-description-or-label = Ke akses, `<answer>` ti ngaga input patut bisi penerang pandak tauka label.
+
+accessibility-short-description-contains-math = Penerang pandak enda patut bisi komponen matematik baka `<{ $component }>`. Tulis matematik nya ngena jaku.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } nadai kontras ti chukup ke teks pala seksyen (mode chelum) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; patut sekurang-kurang { $threshold }:1).
+       *[other] { $colorName } nadai kontras ti chukup ke teks pala seksyen ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; patut sekurang-kurang { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` ti nengah { $count } titik apin digaga lebuh titik nya nadai nilai nambar.
+
+circle-too-many-through-points = Enda ulih ngira bulatan ti nengah lebih ari 3 titik.
+
+circle-overprescribed-radius-center-points = Enda ulih ngira bulatan enggau jejari, pun enggau titik ti disebut sama-sama.
+
+circle-center-with-multiple-points = Enda ulih ngira bulatan enggau pun ti disebut nengah lebih ari 1 titik.
+
+circle-radius-too-small = Enda ulih ngira bulatan: laban jarak entara dua titik nya { $distance }, jejari { $radius } ti disebut mimit agi ari patut.
+
+circle-radius-with-many-points = Enda ulih ngaga bulatan nengah lebih ari dua titik enggau jejari ti disebut.
+
+circle-invalid-center-or-through-points = Pun tauka titik ti dilalui bulatan enda betul.
+
+circle-radius-center-with-multiple-points = Enda ulih ngira jejari bulatan enggau pun ti disebut nengah lebih ari 1 titik.
+
+circle-change-radius-non-numerical = Enda ulih nukar jejari bulatan ti nengah titik ti nadai nilai nambar
+
+circle-radius-with-points-non-numerical = Enda ulih ngaga bulatan nengah lebih ari siti titik enggau jejari ti disebut lebuh nadai nilai nambar.
+
+circle-change-center-non-numerical = Nukar pun bulatan ti nengah titik ti nadai nilai nambar apin digaga.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Dimensyen domain fungsi enda chukup. Domain bisi { $intervals } selang tang fungsi bisi { $inputs ->
+           *[other] { $inputs } input
+        }.
+    }
+
+function-domain-invalid-format = Format domain fungsi enda betul.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nilai pemadu besai fungsi ti ukai nambar enda dititihka.
+        [minimum] Nilai pemadu mit fungsi ti ukai nambar enda dititihka.
+        [extremum] Nilai ujung fungsi ti ukai nambar enda dititihka.
+        [point] Titik fungsi ti ukai nambar enda dititihka.
+        [slope] Cherun fungsi ti ukai nambar enda dititihka.
+       *[other] { $type } fungsi ti ukai nambar enda dititihka.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nilai pemadu besai fungsi ti kosong enda dititihka.
+        [minimum] Nilai pemadu mit fungsi ti kosong enda dititihka.
+        [extremum] Nilai ujung fungsi ti kosong enda dititihka.
+        [point] Titik fungsi ti kosong enda dititihka.
+       *[other] { $type } fungsi ti kosong enda dititihka.
+    }
+
+function-points-too-close = Fungsi bisi dua titik ti semak amat siti enggau siti. Fungsi enda ulih ditusun.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] Ulang fungsi ulih dikira semina enti penyampau input fungsi sebaka enggau penyampau output. Fungsi tu bisi { $inputs } input enggau { $outputs ->
+           *[other] { $outputs } output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Panjai jujut enda betul.  Patut nambar bulat ti ukai negatif.
+
+sequence-invalid-step = Langkah jujut enda betul.  Patut nambar ke jujut jenis { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" jujut nambar enda betul.  Patut nambar.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" jujut huruf enda betul.  Patut gabung huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" jujut enda betul.
+
+select-from-sequence-coprime-not-numbers = coprime enda dititihka laban ukai nambar ti dipilih
+
+select-from-sequence-coprime-with-exclude-combinations = coprime enda dititihka laban excludeCombinations disebut
+
+## Resolving a `target`
+
+target-not-found = Target ke `<{ $source }>` enda betul: target enda ditemu.
+
+target-state-variable-not-found = Target ke `<{ $source }>` enda betul: pemubah keadaan ti benama "{ $property }" enda ditemu ba `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Pemubah `<odeSystem>` patut belain ari pemubah ti bediri kediri.
+
+ode-system-duplicate-variable-names = Enda ulih nusun fungsi RHS ODE enggau nama pemubah ti sama.
+
+ode-system-rhs-function-error = Enda ulih nusun fungsi RHS ODE.  Penyalah ba mensia ngaga fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Enda ulih nusun sudut entara { $count } garis
+
+angle-invalid-through-point = Titik dalam through `<angle>` enda betul
+
+parabola-vertex-too-many-points = Parabola enggau puncha ti nengah lebih ari 1 titik apin digaga.
+
+parabola-too-many-points = Parabola ti nengah lebih ari 3 titik apin digaga.
+
+intersection-too-many-items = Temu simpang ke lebih ari dua utai apin digaga
+
+## Other math components
+
+ionic-compound-not-two-ions = Sebatian ionik ke utai bukai ari dua ion apin digaga.
+
+ionic-compound-needs-cation-and-anion = Sebatian ionik semina digaga ke siti kation enggau siti anion.
+
+solve-equations-cannot-evaluate = Enda ulih ngungkai persamaan laban persamaan enda ulih dinilai: { $equation }
+
+math-operators-operand-number-required = operandNumber patut disebut lebuh ngambi operand matematik.
+
+eigen-decomposition-failed = Enda ulih ngira nilai eigen matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: parameter { $parameters } nadai dalam pola nya, nya alai iya seruran nemu ruang kosong.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" enda ulih dikelala. Iya patut none, medium, dense tauka dua nambar positif ti dipisah enggau ruang, baka grid="1 0.5". Nadai grid dilukis.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` minta fungsi ti bisi { $expected ->
+        [1] siti output, iya nya cherun y' ba tiap titik, baka `y - x`
+       *[other] dua output, iya nya vektor ba tiap titik, baka `(y, -x)`
+    }, tang fungsi ti diberi bisi { $found ->
+       *[other] { $found } output
+    }. { $alternative ->
+        [none] Nadai utai dilukis.
+       *[other] `<{ $alternative }>` komponen ti ngena ke fungsi nya. Nadai utai dilukis.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` enda dititihka laban fungsi mega diberi dalam komponen; ti dalam nya dipakai. Beri fungsi nya siti chara aja.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` nyebut pemubah ungkapan ti ditulis terus dalam komponen. { $reason ->
+        [function-child] Fungsi ditu diberi baka anak `<function>`, ti nyebut pemubah iya empu, nya alai `variables` enda dititihka.
+       *[no-expression] Nadai ungkapan baka nya ditu, nya alai `variables` enda dititihka.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" enda disukung dalam renderer prefigure; chara sipak kanan dipakai.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" enda disukung dalam renderer prefigure; chara sipak atas dipakai.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas paksi enda betul ke tukar prefigure; bbox asal (-10,-10,10,10) dipakai.
+
+prefigure-invalid-width = `<graph>`: lebar enda betul ke tukar prefigure; lebar rajah asal 425 dipakai.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio enda betul ke tukar prefigure; nisbah asal 1 dipakai.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jarak entara garis grid mimit amat ke batas paksi; grid enda dilukis dalam renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi enda dilukis enti renderer PreFigure enda dipakai.
+
+multiple-annotations-children = Mayuh anak `<annotations>` ditemu dalam `<graph>`; semua kelia ari ti penudi enda dititihka.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Enda ulih manjangka tauka nyalin jenis komponen ti enda dikelala: { $type }.
+
+copy-prop-not-found = Prop { $property } enda ditemu ba komponen jenis { $component }
+
+collect-no-source = Nadai source ditemu ke collect.
+
+collect-invalid-component-type = Enda ulih ngempul komponen jenis `<{ $component }>` laban jenis komponen nya enda betul.
+
+reference-index-unavailable = Enda ulih nunjuk ngagai indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Enda ulih ngangau { $action } ba komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk data enda betul.  Baris bisi panjai ti belain-lain. Ditemu ba componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data bisi nama lajur ti sama.  Ditemu ba componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data kurang siti nama lajur.  Ditemu ba componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Siti award ke saut tu begantung ba saut ti dikirum answer tu empu, lalu tu ulih ngasuh iya bejalai enda baka ti dikinsika.
+
+answer-max-num-attempts-in-section-wide-check-work = Nyetel `maxNumAttempts` ba `<answer>` ti dalam bekas ti bisi `sectionWideCheckWork` nadai guna, laban penyampau peluang dikemudi bekas nya. Setel `maxNumAttempts` ba bekas nya.
+
+nested-section-wide-check-work-max-num-attempts = Nyetel `maxNumAttempts` ba bekas ti bisi `sectionWideCheckWork` ti dalam bekas bukai ti mega bisi `sectionWideCheckWork` nadai guna, laban penyampau peluang dikemudi bekas ti di luar. Setel `maxNumAttempts` ba bekas ti di luar.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] Atribut { $attributes } nadai guna enti symbolicEquality enda disetel.
+    }
+
+answer-invalid-type = Jenis answer enda betul: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Laban komponen `<{ $component }>` nadai nama, iya enda ulih dipakai ke atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` enda ulih dipakai ke atribut module laban jenis komponen `<module>` udah bisi atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` enda dititihka ba komponen `<conditionalContent>` ti bisi anak case tauka else.
+
+slider-markers-type-mismatch = Jenis markers enda sebaka enggau jenis slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel enda betul: tiap `<problem>` patut bisi siti `<statement>` enggau siti `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel enda betul: dalam mode="circuit", `<problem>` ti keterubah enda ulih nyadi distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Nilai { $values } enda betul ke atribut `{ $attribute }`; enda dititihka.
+    }
+
+attribute-must-be-references = Nilai `{ $value }` enda betul ke atribut `{ $attribute }`. Atribut patut ditusun ari rujuk ti berengkah enggau `$`.
+
+math-input-invalid-function-names = <mathInput>: nama fungsi ti enda betul dalam { $attribute } enda dititihka: { $names }. Tiap nama patut bisi sekurang-kurang 2 aksara ba bagi ti dipandang (huruf tauka sengkang); ekur `|<mathspeak alternative>` ulih ditambah enti dikedeka.
+
+## Building components from the source
+
+component-type-invalid = Jenis komponen enda betul: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } enda ulih diulang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" enda betul ke komponen jenis `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Takrif gaya { $styleNumber } nadai kontras ti chukup ke { $context ->
+        [text-on-background] warna teks ngelaban warna latar belakang
+        [high-contrast] warna kontras tinggi ngelaban kanvas
+        [line] warna garis ngelaban kanvas
+        [marker] warna penanda ngelaban kanvas
+       *[text-on-canvas] warna teks ngelaban kanvas
+    }{ $mode ->
+        [dark] { " (mode chelum)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; patut sekurang-kurang { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Taja pan takrif gaya { $styleNumber } nyebut warna ti chukup kontras ke mode terang, warna mode chelum ti diambi ari nilai nya nadai kontras ti chukup entara warna teks enggau warna latar belakang ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; patut sekurang-kurang { $threshold }:1). { $suggestion ->
+        [available] Ngambika kontras chukup dalam mode chelum, tambah kontras mode terang (chunto, setel { $lightAttribute }="{ $lightColor }") tauka tukar warna mode chelum (chunto, setel { $darkAttribute }="{ $darkColor }").
+       *[none] Ngambika kontras chukup dalam mode chelum, tambah kontras mode terang tauka tukar warna ti diambi nya ngena textColorDarkMode tauka backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Taja pan takrif gaya { $styleNumber } nyebut warna teks ti chukup kontras ke mode terang, warna teks mode chelum ti diambi ari nilai nya nadai kontras ti chukup ngelaban kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; patut sekurang-kurang { $threshold }:1). { $suggestion ->
+        [available] Ngambika kontras chukup dalam mode chelum, tambah kontras mode terang (chunto, setel textColor="{ $lightColor }") tauka tukar warna mode chelum (chunto, setel textColorDarkMode="{ $darkColor }").
+       *[none] Ngambika kontras chukup dalam mode chelum, tambah kontras mode terang tauka tukar warna ti diambi nya ngena textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Siti seksyen ulih milih siti <stylePalette> aja; ti penudi dipakai.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = varian tunggal { $component } enda ulih dipastika laban numToSelect ukai nambar bulat ti ukai negatif.
+
+variant-num-to-select-not-constant-number = varian tunggal { $component } enda ulih dipastika laban numToSelect ukai nambar ti tetap.
+
+variant-with-replacement-not-constant-boolean = varian tunggal { $component } enda ulih dipastika laban withReplacement ukai boolean ti tetap.
+
+variant-select-weight-disables-unique = Varian tunggal ke select dipedika enti bisi option ti bisi selectWeight tauka selectForVariants
+
+variant-coprime-undetermined = varian tunggal { $component } enda ulih dipastika laban enda ulih dipastika coprime seruran false.
+
+variant-attribute-not-constant = varian tunggal { $component } enda ulih dipastika laban { $attribute } ukai nilai ti tetap.
+
+variant-attribute-not-number = varian tunggal { $component } enda ulih dipastika laban { $attribute } ukai nambar.
+
+variant-attribute-wrong-type-for-sequence =
+    varian tunggal { $component } jenis { $type } enda ulih dipastika laban { $attribute } ukai { $expected ->
+        [letters-combination] gabung huruf
+        [math-expression] ungkapan matematik ti betul
+        [integer] nambar bulat
+       *[number] nambar
+    }.
+
+variant-length-not-integer = varian tunggal { $component } enda ulih dipastika laban length ukai nambar bulat.
+
+variant-sort-not-implemented = varian tunggal { $component } ti bisi sort apin digaga
+
+variant-exclude-combinations-not-implemented = varian tunggal { $component } ti bisi excludeCombinations apin digaga
+
+variant-math-exclude-not-implemented = varian tunggal { $component } jenis math ti bisi exclude apin digaga
+
+variant-non-constant-exclude-not-implemented = varian tunggal { $component } ti bisi exclude ti ukai tetap apin digaga
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: enda disukung dalam renderer prefigure graph; anak iya dilangkau.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri ti enda tembu tauka enda terelak; anak iya dilangkau.
+
+prefigure-curve-label-omitted = { $subject }: label enda disukung ba elemen lengkung ti udah ditukar; label dibuai.
+
+prefigure-curve-unsupported-definition-type = { $subject }: jenis takrif fungsi lengkung '{ $definitionType }' enda disukung; anak iya dilangkau.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions ba regionBetweenCurves enda disukung; anak iya dilangkau.
+
+prefigure-region-non-formula-child = { $subject }: semina anak fungsi jenis formula disukung ba regionBetweenCurves; anak iya dilangkau.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' enda disukung ke { $labelKind ->
+        [line-family] label bala garis
+       *[point] label titik
+    }; jajar PreFigure asal dipakai.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' enda disukung PreFigure; isi pejal dipakai.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' enda dikelala lalu dibuai ari pengeluar PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya penanda '{ $markerStyle }' ditukar ngagai gaya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: gaya penanda '{ $markerStyle }' enda disukung PreFigure; gaya asal dipakai.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` enda betul; target enda ulih dipetara. Anotasi dibuai.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` nunjuk ngagai mayuh target; target ti keterubah dipakai.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` enda betul; target di luar graph ti ngandung iya. Anotasi dibuai.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` enda betul; target ukai utai grafik ti disukung dalam tukar prefigure. Anotasi dibuai.
+
+annotation-text-missing = `<annotation>`: `text` kurang tauka kosong; teks kosong dikeluarka.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Pengantung ti bepusing ditemu.
+       *[other] Pengantung ti bepusing ditemu ba komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Nadai utai ditemu ke rujuk: `{ $reference }`
+
+reference-multiple-referents = Mayuh utai ditemu ke rujuk: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } ba `<{ $componentType }>` enda betul.
+
+children-invalid = Anak `<{ $componentType }>` enda betul: anak ti enda betul ditemu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` enda betul ke atribut `{ $attribute }`, nilai `{ $default }` dipakai
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } enda ditemu.
+       *[other] Versi DoenetML { $version } enda ditemu. Versi { $fallback } dipakai
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML enda betul: { $content }
+
+parse-tag-missing-close-tag = DoenetML enda betul: Tag `{ $tag }` nadai tag penutup. Tag ti nutup diri empu tauka tag `</{ $tagName }>` dikinsika.
+
+parse-tag-error = DoenetML enda betul: Penyalah ba tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML enda betul: Atribut `{ $attribute }` ti enda betul baka ke kurang nilai.
+
+parse-attribute-invalid = DoenetML enda betul: Atribut `{ $attribute }` enda betul
+
+parse-attribute-value-invalid = DoenetML enda betul: Nilai atribut `{ $value }` enda betul
+
+parse-attribute-value-quote-mismatch = DoenetML enda betul: Nilai atribut `{ $value }` enda betul. Tanda petik enda sebaka. Nuan baka ke kurang siti `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML enda betul: Tag ti nadai nama ditemu, baka `<`
+
+parse-tag-not-closed = DoenetML enda betul: Tag `{ $tag }` enda ditutup (baka ke kurang siti `>`).
+
+parse-self-closing-tag-name-missing = DoenetML enda betul: Tag ti nadai nama ditemu `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML enda betul: Tag `{ $tag }` enda ditutup (baka ke kurang `/>`).
+
+parse-tag-invalid-attributes = DoenetML enda betul: Tag `{ $tag }` enda betul. Engka atribut iya enda kena.
+
+parse-close-tag-name-missing = DoenetML enda betul: Tag penutup ti nadai nama ditemu, baka `</`
+
+parse-attribute-value-unquoted = Nilai atribut patut ditaruh dalam tanda petik: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML enda betul: Tag penutup `{ $tag }` ditemu, tang nadai tag pemuka ti kena enggau iya
+
+parse-close-tag-mismatched = DoenetML enda betul: Tag penutup enda sebaka. `</{ $expected }>` dikinsika. `{ $found }` ditemu
+
+parser-node-unconvertible = Node { $node } enda ulih ditukar ngagai node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Nama atribut name='{ $name }' enda betul. { $reason ->
+        [characters] Nama semina ulih bisi huruf, nambar, garis bah tauka sengkang.
+       *[start] Nama patut berengkah enggau huruf.
+    }
+
+component-name-invalid-start = Nama komponen "{ $name }" enda betul. Nama patut berengkah enggau huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer jenis videoWatched patut bisi atribut video
+
+answer-video-watched-video-not-reference = Answer jenis videoWatched patut bisi atribut video ti nyadi rujuk
+
+answer-name-not-single-text = Atribut name ba answer patut bisi siti anak text aja
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Enda ulih ngambi DoenetML ari luar laban rekursi kelalu dalam. Kati bisi rujuk ti bepusing?
+
+external-doenetml-unavailable = Enda ulih ngambi DoenetML ari { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ti diambi ari { $attribute }="{ $uri }" enda betul: iya enda sebaka enggau jenis komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` udah lama; pakai `{ $to }` ganti iya.
+       *[other] [deprecation] Atribut `{ $from }` ba `<{ $component }>` udah lama; pakai `{ $to }` ganti iya.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` udah lama lalu enda dititihka laban `{ $to }` mega disebut.
+       *[other] [deprecation] Atribut `{ $from }` ba `<{ $component }>` udah lama lalu enda dititihka laban `{ $to }` mega disebut.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` ba `<{ $component }>` udah lama lalu enda dititihka.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` ba `<{ $component }>` udah lama; pakai anak `<{ $child }>` ganti iya.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` atribut `{ $attribute }` ba `<{ $component }>` udah lama; pakai `{ $to }` ganti iya.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` semina ulih ngaga jamak jaku Inggeris, nya alai teks iya enda diubah dalam dokumen ti ditulis ngena { $locale }. Tulis terus bentuk jamak nya, tauka setel iya ngena atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` ukai elemen Doenet ti dikelala.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` enda ulih ba pun dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` enda ulih dalam `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` nadai atribut ti benama `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` elemen `<{ $tag }>` patut nyadi senarai ti tiap isi iya siti ari: { $allowed }
+       *[other] Atribut `{ $attribute }` elemen `<{ $tag }>` patut siti ari: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nama varian ke select enda betul.  Nama varian { $variantName } pegari dalam { $numOptions } option tang penyampau ti dipilih { $numToSelect }.
+
+select-variant-name-without-options = Sekeda varian disebut ke select tang nadai option disebut ke nama varian: { $variantName }.
+
+select-variant-name-not-possible = Nama varian { $variantName } ti disebut ke select ukai nama varian ti ulih dipakai.
+
+select-too-few-options = Enda ulih milih { $numToSelect } komponen ari { $numOptions } aja.
+
+select-from-sequence-too-few-values = Enda ulih milih { $numToSelect } nilai ari jujut ti panjai iya { $length }.
+
+select-from-sequence-indices-count-mismatch = Penyampau indeks ti disebut ke select patut sebaka enggau penyampau ti dipilih
+
+select-from-sequence-indices-not-integers = Semua indeks ti disebut ke select patut nambar bulat
+
+select-from-sequence-index-excluded = Indeks selectfromsequence ti disebut nya udah dibuai
+
+select-from-sequence-indices-excluded-combination = Indeks selectfromsequence ti disebut nya gabung ti udah dibuai
+
+select-from-sequence-coprime-not-positive-integers = Enda ulih milih gabung coprime laban ukai nambar bulat positif ti dipilih.
+
+select-from-sequence-coprime-common-factor = Enda ulih milih nambar coprime. Semua nilai ti ulih dipakai bisi faktor ti sama. (Nilai "from" tauka "to" ti disebut patut coprime enggau "step".)
+
+select-from-sequence-coprime-single-number = Enda ulih milih gabung coprime ari siti nambar ti ukai 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebih ari 70% gabung dibuai dalam selectFromSequence
+
+select-from-sequence-coprime-none-found = Enda ulih milih nambar coprime. Semua nilai ti ulih dipakai bisi faktor ti sama.
+
+select-from-sequence-too-few-unique-values = Enda ulih milih { $numToSelect } nilai tunggal ari jujut ti panjai iya { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Enda ulih milih { $numToSelect } nilai ari senarai nambar perdana ti panjai iya { $numValues }
+
+select-prime-numbers-values-count-mismatch = Penyampau nilai ti disebut ke select patut sebaka enggau penyampau ti dipilih
+
+select-prime-numbers-values-not-prime = Semua nilai ti disebut ke select nambar perdana patut bisi dalam senarai nambar perdana
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers ti disebut nya gabung ti udah dibuai
+
+select-prime-numbers-excluded-too-many-combinations = Lebih ari 70% gabung dibuai dalam selectPrimeNumbers
+
+select-random-combination-fluke = Ngambika enda ngasoh kaban, gabung nilai chabut enda ulih dipilih
+
+select-random-value-fluke = Ngambika enda ngasoh kaban, nilai chabut enda ulih dipilih
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` tu enda dipandang laban iya dalam matematik lalu ukai `inline`. Tambah `inline` ngambika iya nyadi senarai turun, ti muat dalam ungkapan.
+        [expanded] `<{ $component }>` tu enda dipandang laban iya dalam matematik lalu `expanded`. Buai `expanded`; kutak mayuh baris enda muat dalam ungkapan.
+        [on-graph] `<{ $component }>` tu enda dipandang laban iya dalam matematik ti dilukis ba graph, ti nadai ruang ke input.
+       *[relative-width] `<{ $component }>` tu enda dipandang laban iya dalam matematik lalu bisi lebar relatif. Beri lebar nya dalam ukur mutlak, baka `px`.
+    }

--- a/packages/i18n/locales/iba/editor.ftl
+++ b/packages/i18n/locales/iba/editor.ftl
@@ -1,0 +1,225 @@
+# Iban editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the standard Sarawak Iban orthography used by the other three
+# files of this locale — `ch` for Malay `c`, and the Iban prefixes `be-`,
+# `te-`, `pe-`/`peN-`. See `locales/iba/chrome.ftl` for the whole note.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay in English exactly as written.
+#
+# DECLARED LOANS. `editor`, `input`, `array`, `kod`, `kursor`, `tag`,
+# `atribut`, `koordinat`, `varian`, `versi` and `konteks` are written as they
+# stand: they are the words an Iban reader has met these ideas under, in Malay
+# or in English, and a coinage would be worse than a loan that is already in
+# use. `Papan Peda` for "viewer" is a description rather than a loan —
+# literally "viewing panel" — and is the phrase in this file a reviewer is
+# most likely to want to replace.
+#
+# Iban does not mark number on a noun after a numeral, and `Intl.PluralRules`
+# has no data for `iba` in any case, so every count selection here is
+# collapsed to a single `*[other]` rather than carrying two branches that
+# would read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Pulaika
+       *[update] Baruka
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Papan Peda
+       *[other] { $word } Papan Peda { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+editor-variant-filter = Tapis…
+editor-variant-next = Pilih varian ti ka mua
+editor-variant-previous = Pilih varian ti ka belakang
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Pelanggar akses WCAG AA udah ditemu. Tekan kena { $action ->
+            [close] nutup
+           *[open] muka
+        } laporan akses.
+        [advisories] Tekan kena { $action ->
+            [close] nutup
+           *[open] muka
+        } laporan akses. Nadai pelanggar WCAG AA ditemu, tang bisi saran akses tambah.
+       *[clean] Tekan kena { $action ->
+            [close] nutup
+           *[open] muka
+        } laporan akses. Nadai penyalah akses ditemu.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Pelanggar akses WCAG AA udah ditemu. { $count ->
+           *[other] { $count } pelanggar WCAG AA
+        } ditemu. Tekan kena { $action ->
+            [close] nutup
+           *[open] muka
+        } laporan akses.
+        [advisories] Nadai pelanggar WCAG AA ditemu. { $count ->
+           *[other] { $count } saran akses tambah
+        } ditemu. Tekan kena { $action ->
+            [close] nutup
+           *[open] muka
+        } laporan akses.
+       *[clean] Nadai pelanggar WCAG AA ditemu. Tekan kena { $action ->
+            [close] nutup
+           *[open] muka
+        } laporan akses.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versi DoenetML { $version }
+
+editor-tab-help = Tulung nitihka konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Penyalah
+editor-tab-warnings = Amaran
+editor-tab-info = Penerang
+editor-tab-accessibility = Akses
+editor-tab-responses = Saut ti udah dikirum
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Susun baka DoenetML
+editor-format-as-xml = Susun baka XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Nadai Penyalah
+editor-no-warnings = Nadai Amaran
+editor-no-info = Nadai Penerang
+
+editor-show-info-annotations = Ayanka penerang dalam editor
+editor-show-accessibility-annotations = Ayanka pesan akses dalam editor
+
+editor-accessibility-learn-more = Belajar pasal chara Doenet ngintu akses
+
+editor-accessibility-violations-heading = Pelanggar akses ({ $standard })
+
+editor-accessibility-other-heading = Penyalah akses bukai
+editor-none-found = Nadai ditemu
+
+
+## Submitted responses
+
+editor-no-responses = Apin bisi saut dikirum
+editor-response-answer-id = Id Saut
+editor-response-response = Saut
+editor-response-credit = Markah
+editor-response-submitted = Udah dikirum
+
+
+## The context-help panel
+
+help-placeholder = Taruh kursor ba nama tag, atribut tauka { $ref } kena meda dokumentasi.
+
+help-unsupported-ref-chain = Tulung ke rujuk mayuh bagi baka { $example } apin disukung.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Nadai utai ditemu ke rujuk: { $ref }.
+        [multiple] Mayuh utai ditemu ke rujuk: { $ref }.
+       *[indeterminate] Utai ti ditunjuk { $ref } enda ulih dipastika.
+    }
+
+help-learn-about-references = Belajar pasal rujuk →
+help-reference-page = Lambar rujuk →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Dalam { $element }
+       *[top] Ba tingkat atas
+    }{ $allowed ->
+        [none] { " — nadai utai tama ditu." }
+        [text] { " — tulis teks ditu." }
+        [text-and-components] { " — tulis teks ditu, tauka uji tu:" }
+       *[components] { " — utai ti ulih diuji:" }
+    }
+
+help-suggestions-footer = Tekan { $shortcut } kena meda semua { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } nya rujuk ngagai { $target }.
+       *[other] { $ref } nya rujuk ngagai { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ditaruh { $owner } baka { $role }.
+       *[other] Ditaruh { $owner } ba baris { $line } baka { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } nya rujuk ngagai sipat { $property } ba { $element }.
+       *[other] { $ref } nya rujuk ngagai sipat { $property } ba { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = keping kod
+help-kind-array-entry = isi array
+
+help-default = Nilai asal:
+help-active-default = Nilai asal ti bejalai:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai ti ulih dipakai (siti ke tiap iti):
+       *[other] Nilai ti ulih dipakai:
+    }
+
+help-suggested-values = Nilai ti disaran:
+
+help-inserts = Nyelit:
+
+help-coordinates =
+    { $count ->
+       *[other] Koordinat:
+    }
+
+help-type = Jenis:
+
+help-resolved-style = Gaya ti udah dipastika (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nama fungsi ti udah dipastika:
+help-reset-list = Senarai pulai ba input tu:
+help-added-on-input = Ditambah ba input tu:
+help-removed-on-input = Dibuai ari input tu:
+
+help-reset-overrides = { $reset } ngatasi { $additional } enggau { $removed }.

--- a/packages/i18n/locales/ksw/chrome.ftl
+++ b/packages/i18n/locales/ksw/chrome.ftl
@@ -1,0 +1,213 @@
+# S'gaw Karen (ကညီကျိာ်) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and script.** S'gaw Karen (ကညီကျိာ်) of Kayin State and of the
+# Karen diaspora in Thailand, the United States, Australia and elsewhere,
+# written in the Burmese-derived S'gaw Karen script — the orthography of the
+# Karen Baptist mission tradition, which is what Karen literacy, hymnals,
+# newspapers and Unicode publishing all use. The letters this catalog uses
+# that Burmese does not are the S'gaw vowel and tone signs **ၢ** (U+1062),
+# **ၣ** (U+1063) and **ၤ** (U+1064), which carry most of what makes a Karen
+# word look like one. A corrector must not fold ၢ into Burmese ာ or ၣ into န:
+# they look nearly alike at small sizes, the substitution is invisible on
+# screen, and it breaks every search for a Karen word. **ၢ is shared with
+# Shan**, which writes it for /aa/ before a final consonant, so its presence
+# in `locales/shn` is not a Karen letter leaking in.
+#
+# Two further S'gaw letters — **ဢ** (U+1022) and **ၡ** (U+1061) — are part of
+# the orthography and appear nowhere in this catalog, because no word it
+# happens to use needs them. That is a fact about this vocabulary, not about
+# the alphabet, and a corrector who needs either should write it.
+#
+# **ၦ and ၯ are not used here, and that is deliberate.** They are Pwo Karen
+# letters. Pwo is a different language written in a related orthography, and a
+# Pwo letter inside an S'gaw file is a mistake rather than a variant. If Pwo
+# is ever seeded it is a catalog of its own beside this one.
+#
+# **Tone.** S'gaw writes its tones with the syllable-final signs ်, ၢ်, ၣ်,
+# ံ, ဲ and ့, so a tone is part of the spelling of a word rather than an
+# optional diacritic — a wrong tone sign is a different word. Where the seed
+# could not place one with confidence it chose a word it could rather than
+# guessing, which is why some sentences below are blunter than a speaker would
+# write them. **This is the likeliest place for an error in this catalog to
+# be**, and it is the first thing a reviewer should check.
+#
+# **Spacing.** S'gaw Karen publishing separates phrases with spaces rather
+# than running a whole clause together as Burmese does, and this catalog
+# follows that practice: a space between the parts of a phrase, none inside a
+# word. That decides where these messages may wrap in a narrow panel.
+#
+# **Register, and what is a loan.** Karen speakers in Myanmar are schooled in
+# Burmese; in the diaspora they are schooled in English or Thai. This catalog
+# is an **S'gaw Karen frame around two declared loan vocabularies**, and
+# neither is respelled into invented Karen syllables:
+#
+#   * **Burmese, in its own Burmese spelling**, for the school register:
+#     အမှတ် (point), မြား (arrow), ဇယား (table), အောက်ခြေမှတ်စု (footnote),
+#     စက်ဝိုင်း (circle), တြိဂံ (triangle), သက်သေပြချက် (proof), and — see
+#     `content.ftl` — seven of the twelve colours.
+#   * **English, in the Latin alphabet**, for computing and the DoenetML
+#     vocabulary: `keyboard`, `row`, `column`, `box`, `credit`, `preview`,
+#     `math expression`, `interval`, `document`, `renderer`, `load`,
+#     `summary statistics`, `WCAG AA`, `accessibility`. Karen technical
+#     writing leaves such terms in Latin letters, and writing them out in
+#     Karen syllables would invent a spelling no reader has seen.
+#
+# The Karen is the frame, and it is a real one: the **negative circumfix
+# တ…ဘၣ်** (တသ့ဘၣ် 'cannot', တအိၣ်ဘၣ် 'there is none', တထံၣ်ဘၣ် 'not
+# found'), the nominalizing prefix **တၢ်**, the declarative sentence-final
+# **လီၤ**, the postposed **အဃိ** ('because of that'), **အဂီၢ်** ('for'),
+# **အပူၤ** ('inside'), **လၢ** (relative and locative), **ဒီး** ('and'),
+# **မ့တမ့ၢ်** ('or'), **န့ၣ်** ('that'), **အံၤ** ('this'), and the verbs
+# သမံသမိး (check), ဆှၢ (send), ပာ် (keep), အိးထီၣ် (open), ကးတံာ် (close),
+# ပာ်ဖှိၣ် (add), ထုးထီၣ်ကွံာ် (remove), သုး (move), တြူာ်ကွံာ် (clear),
+# ဒုးနဲၣ် (show), ဆီၣ် (press), ကဒီး (again), ထံၣ် (find), ကဘၣ် (must).
+#
+# **Counting.** CLDR has no plural data for `ksw`, so `Intl.PluralRules`
+# resolves it against the runtime's default locale and a category branch here
+# would be text chosen by English's rules. Karen leaves a noun unmarked after
+# a numeral and counts with a classifier instead, so one form is correct
+# anyway: every count select below collapses to a single `*[other]`.
+# English's explicit `[0]` is kept, because Fluent matches it against the
+# number itself before consulting any plural rule. No `[zero]`, `[one]`,
+# `[two]`, `[few]` or `[many]` branch appears in any of these four files.
+
+
+## Answer submission
+
+answer-checking = သမံသမိးဝဲဒၣ်…
+answer-submitting = ဆှၢထီၣ်ဝဲဒၣ်…
+
+answer-checking-status = သမံသမိး တၢ်စံးဆၢ
+answer-submitting-status = ဆှၢထီၣ် တၢ်စံးဆၢ
+
+answer-correct = ဘၣ်
+answer-incorrect = တဘၣ်ဘၣ်
+
+answer-response-saved = တၢ်စံးဆၢ ပာ်ဃာ်ဝဲလံ
+
+answer-percent-credit = { $percent }% credit
+answer-percent-correct = { $percent }% ဘၣ်
+answer-percent-short = { $percent } %
+
+max-credit-available = credit အါကတၢၢ်: { $percent }%
+
+# Single `*[other]`: Karen does not mark a noun for number after a numeral,
+# and `ksw` has no CLDR plural data. `[0]` is matched against the number.
+attempts-remaining =
+    { $count ->
+        [0] တၢ်ဂဲၤလိာ်အခွဲး တအိၣ်လၢၤဘၣ်
+       *[other] အိၣ်ဒံး { $count } ဘျီ
+    }
+
+validation-correct = (ဘၣ်)
+validation-incorrect = (တဘၣ်ဘၣ်)
+validation-partially-correct = (ဘၣ် တနီၤ)
+
+answer-show-responses = ဒုးနဲၣ် { $answerId } အဂီၢ် တၢ်စံးဆၢ { $count } ခါ
+
+
+## Disclosure panels
+
+feedback-heading = တၢ်စံးဆၢက့ၤ
+
+collapsible-click-to-open = (ဆီၣ် ဒ်သိး ကအိးထီၣ်)
+collapsible-click-to-close = (ဆီၣ် ဒ်သိး ကကးတံာ်)
+
+collapsible-initializing = စးထီၣ်ဝဲဒၣ်…
+
+footnote-show = ဒုးနဲၣ် အောက်ခြေမှတ်စု
+footnote-hide = ပာ်ခူသူၣ် အောက်ခြေမှတ်စု
+
+description-more-information = တၢ်ဂ့ၢ်တၢ်ကျိၤ အါထီၣ်
+
+
+## Controls
+
+slider-previous = လၢညါ
+slider-next = လၢခံ
+
+keyboard-open = အိးထီၣ် keyboard
+keyboard-close = ကးတံာ် keyboard
+
+choice-input-remove-choice = ထုးထီၣ်ကွံာ် { $choice }
+
+matrix-remove-row = ထုးထီၣ်ကွံာ် row
+matrix-add-row = ပာ်ဖှိၣ် row
+matrix-remove-column = ထုးထီၣ်ကွံာ် column
+matrix-add-column = ပာ်ဖှိၣ် column
+
+subset-add-remove-points = ပာ်ဖှိၣ်/ထုးထီၣ်ကွံာ် အမှတ်
+subset-toggle-points-intervals = ဆီတလဲ အမှတ် ဒီး interval
+subset-move-points = သုး အမှတ်
+subset-clear = တြူာ်ကွံာ်
+
+orbital-add-row = ပာ်ဖှိၣ် row
+orbital-remove-row = ထုးထီၣ်ကွံာ် row
+orbital-add-box = ပာ်ဖှိၣ် box
+orbital-remove-box = ထုးထီၣ်ကွံာ် box
+orbital-add-up-arrow = ပာ်ဖှိၣ် မြား ဆူထး
+orbital-add-down-arrow = ပာ်ဖှိၣ် မြား ဆူဖီလာ်
+orbital-remove-arrow = ထုးထီၣ်ကွံာ် မြား
+
+orbital-row-label = row { $row } အဂီၢ် အမံၤ
+
+pretzel-answer = တၢ်စံးဆၢ
+
+summary-statistics-caption = { $column } အဂီၢ် summary statistics
+
+
+## Math input
+
+math-input-preview-region = math expression အ preview
+math-input-preview = preview
+math-input-invalid-expression = expression တဘၣ်ဘၣ်:
+
+
+## Document status
+
+viewer-initializing = စးထီၣ်ဝဲဒၣ်…
+
+
+## Errors
+
+error-heading = တၢ်ကမၣ်
+
+error-found-at =
+    { $span ->
+        [line] ထံၣ်န့ၢ်လၢ line { $startLine } အပူၤ လီၤ။
+       *[lines] ထံၣ်န့ၢ်လၢ line { $startLine }–{ $endLine } အပူၤ လီၤ။
+    }
+
+document-contains-errors = document အံၤ အပူၤ တၢ်ကမၣ် အိၣ်ဝဲ လီၤ!
+
+diagnostic-heading-error = တၢ်ကမၣ်
+diagnostic-heading-warning = တၢ်ဟ့ၣ်ပလီၢ်
+diagnostic-heading-information = တၢ်ဂ့ၢ်တၢ်ကျိၤ
+diagnostic-heading-hint = တၢ်ဟ့ၣ်ကူၣ်
+
+accessibility-heading-level-1 = WCAG AA accessibility တၢ်ကမၣ်
+accessibility-heading-level-2 = accessibility တၢ်ဟ့ၣ်ပလီၢ်
+
+something-went-wrong = တၢ်တခါခါ ကမၣ်ဝဲ လီၤ။
+
+renderer-load-failed = renderer တခါ load တန့ၢ်ဘၣ်။ ဝံသးစူၤ load ကဘျံးပၤ ကဒီးတဘျီ။
+
+core-start-failed = document အံၤ စးထီၣ် တန့ၢ်ဘၣ်။ ဝံသးစူၤ load ကဘျံးပၤ ကဒီးတဘျီ။
+
+core-start-failed-busy = document အံၤ စးထီၣ် တန့ၢ်ဘၣ်။ document အါခါ စးထီၣ်တဘျီဃီ အဃိ စဲးဖီကဟၣ် လၢအဃၢ်န့ၣ် ဆၢကတီၢ်ယံာ်ဝဲ လီၤ။ document အဂၤ ဝံၤဝံၤ load ကဘျံးပၤ ကဒီးတဘျီ န့ၣ် ဘၣ်သ့ၣ်သ့ၣ် ကမၤစၢၤဝဲ လီၤ။
+
+core-start-failed-retry = document အံၤ စးထီၣ် တန့ၢ်ဘၣ်။
+
+core-start-failed-busy-retry = document အံၤ စးထီၣ် တန့ၢ်ဘၣ်။ document အါခါ စးထီၣ်တဘျီဃီ အဃိ စဲးဖီကဟၣ် လၢအဃၢ်န့ၣ် ဆၢကတီၢ်ယံာ်ဝဲ လီၤ။
+
+core-start-retry = မၤကွၢ် ကဒီးတဘျီ
+
+saved-state-unavailable = နတၢ်မၤ လၢပာ်ဃာ်ဝဲန့ၣ် load တန့ၢ်ဘၣ်။

--- a/packages/i18n/locales/ksw/content.ftl
+++ b/packages/i18n/locales/ksw/content.ftl
@@ -1,0 +1,302 @@
+# S'gaw Karen (ကညီကျိာ်) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. `locales/en/content.ftl` is the source of truth, and message ids
+# and attribute names are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# S'gaw Karen of Kayin State and the diaspora, in the S'gaw Karen script with
+# the S'gaw signs ၢ ၣ ၤ — never Burmese ာ for ၢ or န for ၣ — and spaces
+# between phrases. ဢ and ၡ are S'gaw letters no word in this catalog needs. The Pwo letters ၦ and ၯ
+# are not used anywhere in this catalog.
+#
+# ## Word order: the noun comes first
+#
+# **Karen puts the head noun first and every modifier after it.** So
+# `style-with-noun` places `{ $noun }` in front of `{ $description }`, and
+# inside the description the order is fixed as **colour, then dash pattern,
+# then thickness** — "line red dashed thick" rather than English's "thick
+# dashed red line". That order is consistent across every message in this file
+# and it is what the style-description tests pin.
+#
+# **`[noun-tail]` is unused.** Modifiers follow the head, so a regular
+# polygon's side count sits after the noun without splitting it, and
+# `noun-regular-polygon` fills `head` and leaves `tail` empty as English does.
+#
+# ## No gender fork and no `$role` fork
+#
+# Karen has no grammatical gender and no case inflection on a modifier, so
+# `noun-gender` answers the single token `neuter` and nothing forks on
+# `$gender` or `$role`. What Karen would want and this frame cannot give it is
+# a **classifier** between a numeral and a noun; no message here counts a
+# noun, so nothing is lost.
+#
+# ## What this catalog does not know, stated plainly
+#
+# **Five of the twelve colours are Karen and seven are Burmese loans**, and
+# the seven are named so nobody mistakes them for Karen: မီးခိုး (gray),
+# လိမ္မော် (orange), စိမ်းပြာ (cyan), အပြာ (blue), ခရမ်း (purple), ပန်း
+# (pink), အညို (brown). The five that are Karen are ဝါ (white), သူ (black),
+# ဂီၤ (red), ဘီ (yellow) and လါ (green). Karen very likely has words for more
+# of the seven — blue especially — and they are absent because this seed does
+# not know them, not because they do not exist. **This is the first place a
+# speaker should look.**
+#
+# The geometric nouns are the same case one step further out: `<circle>` and
+# `<triangle>` are written with the Burmese school words စက်ဝိုင်း and
+# တြိဂံ, which is what a Karen pupil meets in a Burmese maths lesson, and
+# everything from `line segment` outwards is left in English in Latin letters.
+# What is Karen here is the frame around them — the noun-first order, the
+# nominalizing တၢ်, and the negative circumfix တ…ဘၣ်.
+#
+# ## Chemistry: both element tables are deliberately absent
+#
+# `element-name` and `element-anion-name` are the **only English keys this
+# file does not cover**, 130 of them, and the reason is two school systems
+# rather than a fact about Karen. In Myanmar, secondary science in Kayin State
+# is taught in **Burmese** out of the national curriculum's textbooks; the
+# Karen Education Department schools and the refugee-camp schools teach in
+# Karen but stop below, or teach science out of English-language materials. In
+# the diaspora a Karen pupil meets the table in **English** or in **Thai**. So
+# there is no settled, checkable Karen list of the 118 elements to seed from
+# and no single fallback either, and coining 118 names would invent a
+# nomenclature no reader has met while hiding that split. The 130 keys fall
+# back to English, which is at least what part of the readership's schooling
+# uses. `ion-name-oxidation-state` and the two invalid-symbol messages are
+# frames rather than vocabulary and are covered below.
+
+
+## Style vocabulary
+
+# Five Karen colour words and seven Burmese loans; see the header.
+color =
+    .black = သူ
+    .white = ဝါ
+    .gray = မီးခိုး
+    .red = ဂီၤ
+    .orange = လိမ္မော်
+    .yellow = ဘီ
+    .green = လါ
+    .cyan = စိမ်းပြာ
+    .blue = အပြာ
+    .purple = ခရမ်း
+    .pink = ပန်း
+    .brown = အညို
+
+line-width =
+    .thick = ဖးထီၣ်
+    .thin = ဘၢၣ်
+
+line-style =
+    .dashed = အပြတ်
+    .dotted = အစက်
+
+fill-style =
+    .horizontal = မျဉ်း အလျားလိုက်
+    .vertical = မျဉ်း ဒေါင်လိုက်
+    .diagonal = မျဉ်း ထောင့်ဖြတ်
+    .backdiagonal = မျဉ်း ထောင့်ဖြတ် ပြောင်းပြန်
+    .dots = အစက်
+    .diamonds = စိန်ပုံ
+
+noun =
+    .line = မျဉ်း
+    .line-segment = line segment
+    .ray = ray
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = တြိဂံ
+    .rectangle = rectangle
+    .circle = စက်ဝိုင်း
+    .region = လီၢ်ကဝီၤ
+    .point = အမှတ်
+    .square = square
+    .diamond = စိန်ပုံ
+    .cross = ကြက်ခြေခတ်
+    .plus = အပေါင်း
+
+# Modifiers follow the head noun in Karen, so the side count sits after the
+# noun and `tail` stays empty, as it does in English.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] regular polygon လၢအအိၣ်ဒီး { $numSides } ထောင့်
+    }
+
+# One token for everything: Karen has no grammatical gender, so nothing below
+# forks on `$gender`.
+noun-gender = neuter
+
+
+## Style composition
+
+# Colour, then dash pattern, then thickness — the reverse of English's order.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $color } { $lineStyle } { $width }
+        [width-color] { $color } { $width }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $lineStyle } { $width }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun comes first and the description follows it.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = ပှဲၤ
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } ဒီး { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } ဒီး { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } ဒီး { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+# Karen has no article, so the two `-article` branches say what the two
+# without them say. What survives is အိၣ်ဒီး ('having') against ဒီးစ့ၢ်ကီး
+# ('and also') — a first clause against a further one.
+style-border-clause =
+    { $parts ->
+        [with-article] အိၣ်ဒီး border { $border }
+        [and] ဒီးစ့ၢ်ကီး border { $border }
+        [and-article] ဒီးစ့ၢ်ကီး border { $border }
+       *[with] အိၣ်ဒီး border { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = တပှဲၤဘၣ်
+
+style-text =
+    { $parts ->
+        [background] { $color } အိၣ်ဒီး background { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = တအိၣ်ဘၣ်
+
+
+## Boolean words
+
+boolean-true = မ့ၢ်
+boolean-false = တမ့ၢ်ဘၣ်
+
+
+## Answer buttons
+
+answer-submit-label = သမံသမိး တၢ်မၤ
+answer-submit-label-no-correctness = ဆှၢထီၣ် တၢ်စံးဆၢ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = တၢ်ဖံးတၢ်မၤ
+    .aside = aside
+    .cascade = cascade
+    .definition = တၢ်အခီပညီ
+    .example = တၢ်ဒိ
+    .exercise = တၢ်မၤလိ
+    .exercises = တၢ်မၤလိ
+    .given-answer = တၢ်စံးဆၢ
+    .note = တၢ်မၤနီၣ်
+    .objectives = တၢ်ပညိၣ်
+    .paragraphs = paragraph
+    .part = တၢ်တကူာ်
+    .problem = တၢ်ဂ့ၢ်ကီ
+    .problems = တၢ်ဂ့ၢ်ကီ
+    .proof = သက်သေပြချက်
+    .question = တၢ်သံကွၢ်
+    .section = တၢ်ကူာ်
+    .solution = တၢ်ဒုးန့ၢ်တၢ်စံးဆၢ
+    .task = တၢ်ဖံးတၢ်မၤအမူ
+    .theorem = theorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = တၢ်ဟ့ၣ်ကူၣ်
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] ဇယား { $enumeration }
+        [numbered-title] ဇယား { $enumeration }{ ": " }
+        [unnumbered-title] ဇယား{ ": " }
+       *[unnumbered] ဇယား
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] တၢ်ဂီၤ { $enumeration }
+        [numbered-caption] တၢ်ဂီၤ { $enumeration }{ ": " }
+        [unnumbered-caption] တၢ်ဂီၤ{ ": " }
+       *[unnumbered] တၢ်ဂီၤ
+    }
+
+
+## Paginator controls
+
+paginator-previous = လၢညါ
+paginator-next = လၢခံ
+paginator-page = ကဘျံးပၤ
+
+paginator-page-status = { $pageLabel } { $currentPage } လၢ { $numPages } အကျါ
+
+
+## Piecewise functions
+
+piecewise-condition-or = မ့တမ့ၢ်
+piecewise-condition-if = မ့ၢ်
+piecewise-condition-otherwise = မ့တမ့ၢ်ဘၣ်န့ၣ်
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are absent on purpose; the header
+## says why. What is here is the frames, which are not vocabulary.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = symbol တဘၣ်ဘၣ်
+chemistry-invalid-ionic-compound = ionic compound တဘၣ်ဘၣ်
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = လီၢ်အိၣ်ကလီ
+math-embedded-input-blank-ordinal = လီၢ်အိၣ်ကလီ { $ordinal } လၢ { $total } အကျါ

--- a/packages/i18n/locales/ksw/content.ftl
+++ b/packages/i18n/locales/ksw/content.ftl
@@ -44,10 +44,14 @@
 # not know them, not because they do not exist. **This is the first place a
 # speaker should look.**
 #
-# The geometric nouns are the same case one step further out: `<circle>` and
-# `<triangle>` are written with the Burmese school words စက်ဝိုင်း and
-# တြိဂံ, which is what a Karen pupil meets in a Burmese maths lesson, and
-# everything from `line segment` outwards is left in English in Latin letters.
+# The geometric nouns are the same case one step further out. Eight entries of
+# the `noun` table are written in the script: `circle` စက်ဝိုင်း, `triangle`
+# တြိဂံ, `line` မျဉ်း, `point` အမှတ်, `diamond` စိန်ပုံ, `cross` ကြက်ခြေခတ်
+# and `plus` အပေါင်း are the Burmese school words a Karen pupil meets in a
+# Burmese maths lesson, and `region` လီၢ်ကဝီၤ is the one that is Karen. **The
+# other twelve entries — `line segment`, `ray`, `vector`, `curve`, `function`,
+# `slope field`, `vector field`, `parabola`, `polyline`, `polygon`,
+# `rectangle` and `square` — are left in English in Latin letters.**
 # What is Karen here is the frame around them — the noun-first order, the
 # nominalizing တၢ်, and the negative circumfix တ…ဘၣ်.
 #

--- a/packages/i18n/locales/ksw/diagnostics.ftl
+++ b/packages/i18n/locales/ksw/diagnostics.ftl
@@ -186,11 +186,11 @@ accessibility-section-title-insufficient-contrast =
 
 circle-through-points-non-numerical = အမှတ် တအိၣ်ဒီး နီၣ်ဂံၢ်တၢ်လုၢ်ပှ့ၤဘၣ်အခါ အမှတ် { $count } ခါ လဲၤခီဖျိသော `<circle>` န့ၣ် တမၤဒံးဘၣ်။
 
-circle-too-many-through-points = အမှတ် အါန့ၢ် ၃ ခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+circle-too-many-through-points = အမှတ် အါန့ၢ် 3 ခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
 
 circle-overprescribed-radius-center-points = radius, center ဒီး through point သၢခါလိာ် ပာ်ပနီၣ်ဝဲသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
 
-circle-center-with-multiple-points = center ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် ၁ ခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+circle-center-with-multiple-points = center ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် 1 ခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
 
 circle-radius-too-small = စက်ဝိုင်း ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်: အမှတ် ခံခါအဘၢၣ်စၢၤ အယံၤ မ့ၢ် { $distance } အဃိ radius လၢပာ်ပနီၣ်ဝဲ { $radius } န့ၣ် ဆံးကဲၣ်ဆိး လီၤ။
 
@@ -198,7 +198,7 @@ circle-radius-with-many-points = radius ပာ်ပနီၣ်ဝဲဒီး 
 
 circle-invalid-center-or-through-points = စက်ဝိုင်း အ center မ့တမ့ၢ် through point တဘၣ်ဘၣ်။
 
-circle-radius-center-with-multiple-points = center ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် ၁ ခါ လဲၤခီဖျိသော စက်ဝိုင်း အ radius န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+circle-radius-center-with-multiple-points = center ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် 1 ခါ လဲၤခီဖျိသော စက်ဝိုင်း အ radius န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
 
 circle-change-radius-non-numerical = through point တအိၣ်ဒီး နီၣ်ဂံၢ်တၢ်လုၢ်ပှ့ၤဘၣ်သော စက်ဝိုင်း အ radius န့ၣ် ဆီတလဲ တန့ၢ်ဘၣ်
 
@@ -277,9 +277,9 @@ angle-too-many-lines = မျဉ်း { $count } ဘိ အဘၢၣ်စၢ�
 
 angle-invalid-through-point = `<angle>` အ through အပူၤ အမှတ် တဘၣ်ဘၣ်
 
-parabola-vertex-too-many-points = vertex အိၣ်ဒီး အမှတ် အါန့ၢ် ၁ ခါ လဲၤခီဖျိသော parabola န့ၣ် တမၤဒံးဘၣ်။
+parabola-vertex-too-many-points = vertex အိၣ်ဒီး အမှတ် အါန့ၢ် 1 ခါ လဲၤခီဖျိသော parabola န့ၣ် တမၤဒံးဘၣ်။
 
-parabola-too-many-points = အမှတ် အါန့ၢ် ၃ ခါ လဲၤခီဖျိသော parabola န့ၣ် တမၤဒံးဘၣ်။
+parabola-too-many-points = အမှတ် အါန့ၢ် 3 ခါ လဲၤခီဖျိသော parabola န့ၣ် တမၤဒံးဘၣ်။
 
 intersection-too-many-items = တၢ်ဂ့ၢ် အါန့ၢ် ခံခါ အဂီၢ် intersection န့ၣ် တမၤဒံးဘၣ်
 
@@ -405,7 +405,7 @@ attribute-invalid-values =
 
 attribute-must-be-references = attribute `{ $attribute }` အဂီၢ် တၢ်လုၢ်ပှ့ၤ `{ $value }` တဘၣ်ဘၣ်။ attribute န့ၣ် `$` ဒီးစးထီၣ်သော reference တဖၣ် ကဘၣ်မ့ၢ် လီၤ။
 
-math-input-invalid-function-names = <mathInput>: { $attribute } အပူၤ function အမံၤ လၢအတဘၣ်ဘၣ်န့ၣ် တစူးကါဘၣ်: { $names }။ မံၤကိးခါ အဒုးနဲၣ်အကူာ် န့ၣ် အစှၤကတၢၢ် ၂ ဖျၢၣ် (လံာ်မဲာ်ဖျၢၣ် မ့တမ့ၢ် ဘီၣ်ထူၣ်) ကဘၣ်အိၣ်; လၢခံ `|<mathspeak alternative>` န့ၣ် ပာ်ဂ့ၤ တပာ်ဂ့ၤ လီၤ။
+math-input-invalid-function-names = <mathInput>: { $attribute } အပူၤ function အမံၤ လၢအတဘၣ်ဘၣ်န့ၣ် တစူးကါဘၣ်: { $names }။ မံၤကိးခါ အဒုးနဲၣ်အကူာ် န့ၣ် အစှၤကတၢၢ် 2 ဖျၢၣ် (လံာ်မဲာ်ဖျၢၣ် မ့တမ့ၢ် ဘီၣ်ထူၣ်) ကဘၣ်အိၣ်; လၢခံ `|<mathspeak alternative>` န့ၣ် ပာ်ဂ့ၤ တပာ်ဂ့ၤ လီၤ။
 
 ## Building components from the source
 

--- a/packages/i18n/locales/ksw/diagnostics.ftl
+++ b/packages/i18n/locales/ksw/diagnostics.ftl
@@ -1,0 +1,709 @@
+# S'gaw Karen (ကညီကျိာ်) warnings and errors. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# S'gaw Karen in the S'gaw Karen script with the S'gaw signs ၢ ၣ ၤ, spaces between
+# phrases, and no Pwo letters (ၦ, ၯ) anywhere in the file. ဢ and ၡ are S'gaw
+# letters no word in this catalog needs.
+#
+# **Every DoenetML name stays in English exactly as written**: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `selectFromSequence`, every
+# tag and every attribute. They are part of the language rather than prose.
+#
+# **This file is a Karen frame around English technical nouns**, and it is the
+# most heavily loaned of the four. A diagnostic names DoenetML objects almost
+# every time it opens its mouth — component, attribute, function, sequence,
+# variant, reference, index — and Karen has no established word for any of
+# them, so they stay in Latin letters as the classroom leaves them. What is
+# Karen is the sentence, built from a small fixed set of patterns used the
+# same way throughout so that a corrector can fix one pattern in one place:
+#
+#   * «X တဘၣ်ဘၣ်» — X is invalid
+#   * «တစူးကါဘၣ်» — ignored
+#   * «တန့ၢ်ဘၣ်» — cannot
+#   * «ကဘၣ်» — must
+#   * «တမၤဒံးဘၣ်» — has not been implemented yet
+#   * «တထံၣ်ဘၣ်» — cannot find
+#   * «အဃိ» — because (postposed, after the reason)
+#   * «ပာ်ပနီၣ်» — to specify; «လၢပာ်ပနီၣ်ဝဲ» — specified
+#   * «လီၤ» — the declarative sentence-final particle
+#
+# The negative circumfix **တ…ဘၣ်** is the frame's most visible feature and the
+# one a corrector must not break: the တ goes in front of the verb and the ဘၣ်
+# at the end of the clause, and dropping either half leaves an affirmative
+# sentence that reads as its own opposite.
+#
+# The Burmese loans, in Burmese spelling, are အမှတ် (point), စက်ဝိုင်း
+# (circle), မျဉ်း (line), ဇယား (table) and သတိပေးချက်'s Karen counterpart
+# တၢ်ဟ့ၣ်ပလီၢ်, which is Karen; everything else non-Karen is English in Latin
+# letters.
+#
+# **What this catalog does not know.** Karen has no settled terminology for
+# software diagnostics or for the higher-mathematics vocabulary these messages
+# use, and this seed did not invent one. Where English says "prescribed",
+# "overprescribed", "coprime", "eigenvalue" or "circular dependency", the
+# Karen around the English term is a paraphrase of what the sentence means
+# rather than a translation of the term. Those are the places a speaker with
+# the mathematical register will want to rewrite, and they are marked by the
+# English word standing bare in the sentence.
+#
+# **Counting.** CLDR has no plural data for `ksw`. Every count select English
+# writes is collapsed to a single `*[other]`, because Karen leaves a noun
+# unmarked after a numeral and a category branch here would be text chosen by
+# English's rules. No `[zero]`, `[one]`, `[two]`, `[few]` or `[many]` branch
+# appears anywhere in these four files.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] endpoint ခံခါ ပာ်ပနီၣ်ဝဲအခါ { $attributes } တစူးကါဘၣ်
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] endpoint ဒီး midpoint ခံခါလိာ် ပာ်ပနီၣ်ဝဲအခါ { $attributes } တစူးကါဘၣ်
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpoint တအိၣ်ဘၣ်န့ၣ် midpointOffset တမၤတၢ်နီတမံၤဘၣ်
+
+## `<line>`
+
+line-points-undetermined-dimensions = မျဉ်း လဲၤခီဖျိ အမှတ် လၢအ dimension တပာ်ပနီၣ်ဘၣ်ဝဲ လီၤ။
+
+line-points-too-few-dimensions = မျဉ်း ကဘၣ်လဲၤခီဖျိ အမှတ် လၢအအိၣ်ဒီး dimension အစှၤကတၢၢ် ခံခါ လီၤ။
+
+line-points-depend-on-variables = မျဉ်း လဲၤခီဖျိ အမှတ် လၢအဘၣ်ထွဲဒီး variable: { $variables }။
+
+line-equation-invalid-format = variable { $variable1 } ဒီး { $variable2 } အပူၤ မျဉ်း အ equation အကျဲ တဘၣ်ဘၣ်။
+
+## `<ray>`
+
+ray-overprescribed-through = ray န့ၣ် through, endpoint ဒီး direction သၢခါလိာ် ပာ်ပနီၣ်ဝဲ လီၤ။ through လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+ray-dimension-mismatch = ray အပူၤ numDimensions တဘၣ်လိာ်ဘၣ်။
+
+## `<vector>`
+
+vector-overprescribed-head = vector န့ၣ် head, tail ဒီး displacement သၢခါလိာ် ပာ်ပနီၣ်ဝဲ လီၤ။ head လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+vector-dimension-mismatch = vector အပူၤ numDimensions တဘၣ်လိာ်ဘၣ်။
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` န့ၣ် state variable nearestPoint တအိၣ်ဘၣ်အဃိ attract တန့ၢ်ဘၣ်။
+
+constrain-to-without-nearest-point = `<{ $component }>` န့ၣ် state variable nearestPoint တအိၣ်ဘၣ်အဃိ constrain တန့ၢ်ဘၣ်။
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` န့ၣ် state variable nearestPoint တအိၣ်ဘၣ်အဃိ အပူၤ ဆူ constrain တန့ၢ်ဘၣ်။
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline တမ့ၢ်ဘၣ်သော choiceInput အဂီၢ် labelPosition တစူးကါဘၣ်
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices အနီၣ်ဂံၢ် ဒီး choice ဖိ အနီၣ်ဂံၢ် တဘၣ်လိာ်ဘၣ်အဃိ choiceInput အဂီၢ် indices လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+pretzel-indices-count-mismatch = indices အနီၣ်ဂံၢ် ဒီး problem ဖိ အနီၣ်ဂံၢ် တဘၣ်လိာ်ဘၣ်အဃိ problem အဂီၢ် indices လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+shuffle-indices-count-mismatch = indices အနီၣ်ဂံၢ် ဒီး component အနီၣ်ဂံၢ် တဘၣ်လိာ်ဘၣ်အဃိ shuffle အဂီၢ် indices လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+indices-ignored-out-of-range = index တနီၤ လဲၤကပာ်ကွံာ်အဆူၣ်အဃိ { $component } အဂီၢ် indices လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+pretzel-indices-repeated = index တနီၤ ဟဲက့ၤအါဘျီအဃိ pretzel အဂီၢ် indices လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+pretzel-circuit-first-index = index အခီၣ်ထံး ကဘၣ်မ့ၢ် 1 အဃိ circuit mode အပူၤ pretzel အဂီၢ် indices လၢပာ်ပနီၣ်ဝဲန့ၣ် တစူးကါဘၣ်။
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` န့ၣ် string ဖိ ဒီး မၤတၢ်ကန့ၢ်အဂီၢ် attribute `type` ကဘၣ်ပာ်ပနီၣ်ဝဲ လီၤ။
+
+invalid-type-defaulting-to-math = component { $component } အဂီၢ် type { $type } တဘၣ်ဘၣ်။ ကဘၣ်မ့ၢ် math, text, number မ့တမ့ၢ် boolean လီၤ။ math န့ၣ် default ဒ်အသိး စူးကါဝဲ လီၤ။
+
+string-not-valid-component-to-arrange = string "{ $value }" န့ၣ် { $component } မၤအဂီၢ် component လၢအဘၣ် တမ့ၢ်ဘၣ်။ တစူးကါဘၣ်။
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } တဘၣ်ဘၣ်၊ type န့ၣ် number ပာ်ဝဲ လီၤ။
+
+invalid-variable-value = variable အတၢ်လုၢ်ပှ့ၤ တဘၣ်ဘၣ်: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = variant index { $index } ကဘၣ်မ့ၢ် number
+
+variant-index-must-be-integer = variant index { $index } ကဘၣ်မ့ၢ် integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` န့ၣ် တၢ်ထိၣ်လၢအလီၢ်ဂၢၢ် အဂီၢ် တမၤဒံးဘၣ်။ width န့ၣ် relative ပာ်ဝဲ လီၤ။
+
+side-by-side-absolute-margins = `<{ $component }>` န့ၣ် တၢ်ထိၣ်လၢအလီၢ်ဂၢၢ် အဂီၢ် တမၤဒံးဘၣ်။ margin န့ၣ် relative ပာ်ဝဲ လီၤ။
+
+side-by-side-no-block-child = `<{ $component }>` တဘၣ်ဘၣ်: block ဖိ အစှၤကတၢၢ် တခါ ကဘၣ်အိၣ် လီၤ။
+
+## `<label>`
+
+label-for-ignored-on-graphical = တၢ်ဂီၤ `<label>` အလိၤ attribute `for` န့ၣ် တစူးကါဘၣ်။
+
+label-for-must-resolve-to-one = `<label>` အလိၤ attribute `for` န့ၣ် component တခါဧိၤ ကဘၣ်ဒုးနဲၣ် လီၤ။
+
+label-for-unresolved = `<label>` အလိၤ attribute `for` န့ၣ် component တဒုးနဲၣ်န့ၢ်ဘၣ်။
+
+label-for-answer-with-authored-inputs = `<label>` အလိၤ attribute `for` န့ၣ် input လၢပှၤကွဲးတၢ်ပာ်ဝဲအိၣ်သော `<answer>` ဆူညါ ဒုးနဲၣ်ဝဲ လီၤ; input န့ၣ် လိၤလိၤ ဒုးနဲၣ်တက့ၢ်။
+
+label-for-answer-without-input = `<label>` အလိၤ attribute `for` န့ၣ် label အဂီၢ် input တအိၣ်ဘၣ်သော `<answer>` ဆူညါ ဒုးနဲၣ်ဝဲ လီၤ။
+
+label-for-must-reference-input-or-answer = `<label>` အလိၤ attribute `for` န့ၣ် input မ့တမ့ၢ် answer ကဘၣ်ဒုးနဲၣ် လီၤ။
+
+## Accessibility
+
+accessibility-short-description-or-decorative = accessibility အဂီၢ် `<{ $component }>` န့ၣ် တၢ်ကတိၤဖုၣ်ကိာ်တခါ ကဘၣ်အိၣ် မ့တမ့ၢ် decorative ကဘၣ်ပာ်ပနီၣ် လီၤ။
+
+accessibility-video-short-description = accessibility အဂီၢ် `<video>` န့ၣ် တၢ်ကတိၤဖုၣ်ကိာ်တခါ ကဘၣ်အိၣ် လီၤ။
+
+accessibility-input-short-description-or-label = accessibility အဂီၢ် `<{ $component }>` န့ၣ် တၢ်ကတိၤဖုၣ်ကိာ် မ့တမ့ၢ် label ကဘၣ်အိၣ် လီၤ။
+
+accessibility-answer-input-short-description-or-label = accessibility အဂီၢ် input ဒုးအိၣ်ထီၣ်သော `<answer>` န့ၣ် တၢ်ကတိၤဖုၣ်ကိာ် မ့တမ့ၢ် label ကဘၣ်အိၣ် လီၤ။
+
+accessibility-short-description-contains-math = တၢ်ကတိၤဖုၣ်ကိာ် အပူၤ `<{ $component }>` ဒ်သိးသော math component တဘၣ်အိၣ်ဘၣ်။ math န့ၣ် တၢ်ကတိၤ လၢကွဲးဖျါထီၣ်တက့ၢ်။
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } န့ၣ် တၢ်ကူာ် ခိၣ်တီ text အဂီၢ် contrast တလၢဘၣ် (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; အစှၤကတၢၢ် { $threshold }:1 ကဘၣ်အိၣ်)။
+       *[other] { $colorName } န့ၣ် တၢ်ကူာ် ခိၣ်တီ text အဂီၢ် contrast တလၢဘၣ် ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; အစှၤကတၢၢ် { $threshold }:1 ကဘၣ်အိၣ်)။
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = အမှတ် တအိၣ်ဒီး နီၣ်ဂံၢ်တၢ်လုၢ်ပှ့ၤဘၣ်အခါ အမှတ် { $count } ခါ လဲၤခီဖျိသော `<circle>` န့ၣ် တမၤဒံးဘၣ်။
+
+circle-too-many-through-points = အမှတ် အါန့ၢ် ၃ ခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+
+circle-overprescribed-radius-center-points = radius, center ဒီး through point သၢခါလိာ် ပာ်ပနီၣ်ဝဲသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+
+circle-center-with-multiple-points = center ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် ၁ ခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+
+circle-radius-too-small = စက်ဝိုင်း ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်: အမှတ် ခံခါအဘၢၣ်စၢၤ အယံၤ မ့ၢ် { $distance } အဃိ radius လၢပာ်ပနီၣ်ဝဲ { $radius } န့ၣ် ဆံးကဲၣ်ဆိး လီၤ။
+
+circle-radius-with-many-points = radius ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် ခံခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဒုးအိၣ်ထီၣ် တန့ၢ်ဘၣ်။
+
+circle-invalid-center-or-through-points = စက်ဝိုင်း အ center မ့တမ့ၢ် through point တဘၣ်ဘၣ်။
+
+circle-radius-center-with-multiple-points = center ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် ၁ ခါ လဲၤခီဖျိသော စက်ဝိုင်း အ radius န့ၣ် ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်။
+
+circle-change-radius-non-numerical = through point တအိၣ်ဒီး နီၣ်ဂံၢ်တၢ်လုၢ်ပှ့ၤဘၣ်သော စက်ဝိုင်း အ radius န့ၣ် ဆီတလဲ တန့ၢ်ဘၣ်
+
+circle-radius-with-points-non-numerical = နီၣ်ဂံၢ်တၢ်လုၢ်ပှ့ၤ တအိၣ်ဘၣ်အခါ radius ပာ်ပနီၣ်ဝဲဒီး အမှတ် အါန့ၢ် တခါ လဲၤခီဖျိသော စက်ဝိုင်း န့ၣ် ဒုးအိၣ်ထီၣ် တန့ၢ်ဘၣ်။
+
+circle-change-center-non-numerical = နီၣ်ဂံၢ်တၢ်လုၢ်ပှ့ၤ တအိၣ်ဘၣ်သော အမှတ် လဲၤခီဖျိသော စက်ဝိုင်း အ center ဆီတလဲ န့ၣ် တမၤဒံးဘၣ်။
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] function အဂီၢ် domain အ dimension တလၢဘၣ်။ domain န့ၣ် interval { $intervals } ခါ အိၣ်ဘၣ်ဆၣ် function န့ၣ် input { $inputs } ခါ အိၣ်ဝဲ လီၤ။
+    }
+
+function-domain-invalid-format = function အဂီၢ် domain အကျဲ တဘၣ်ဘၣ်။
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] function အ maximum လၢအတမ့ၢ်နီၣ်ဂံၢ်န့ၣ် တစူးကါဘၣ်။
+        [minimum] function အ minimum လၢအတမ့ၢ်နီၣ်ဂံၢ်န့ၣ် တစူးကါဘၣ်။
+        [extremum] function အ extremum လၢအတမ့ၢ်နီၣ်ဂံၢ်န့ၣ် တစူးကါဘၣ်။
+        [point] function အ အမှတ် လၢအတမ့ၢ်နီၣ်ဂံၢ်န့ၣ် တစူးကါဘၣ်။
+        [slope] function အ slope လၢအတမ့ၢ်နီၣ်ဂံၢ်န့ၣ် တစူးကါဘၣ်။
+       *[other] function အ { $type } လၢအတမ့ၢ်နီၣ်ဂံၢ်န့ၣ် တစူးကါဘၣ်။
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] function အ maximum လၢအအိၣ်ကလီန့ၣ် တစူးကါဘၣ်။
+        [minimum] function အ minimum လၢအအိၣ်ကလီန့ၣ် တစူးကါဘၣ်။
+        [extremum] function အ extremum လၢအအိၣ်ကလီန့ၣ် တစူးကါဘၣ်။
+        [point] function အ အမှတ် လၢအအိၣ်ကလီန့ၣ် တစူးကါဘၣ်။
+       *[other] function အ { $type } လၢအအိၣ်ကလီန့ၣ် တစူးကါဘၣ်။
+    }
+
+function-points-too-close = function အပူၤ အမှတ် ခံခါ အလီၢ် ဘူးကဲၣ်ဆိး လီၤ။ function ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] function iterate န့ၣ် function အ input အနီၣ်ဂံၢ် ဒီး output အနီၣ်ဂံၢ် ဘၣ်လိာ်မှ ကဲထီၣ်သ့ လီၤ။ function အံၤ န့ၣ် input { $inputs } ခါ ဒီး output { $outputs } ခါ အိၣ်ဝဲ လီၤ။
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = sequence အ length တဘၣ်ဘၣ်။ ကဘၣ်မ့ၢ် integer လၢအတဆံးန့ၢ် သုည လီၤ။
+
+sequence-invalid-step = sequence အ step တဘၣ်ဘၣ်။ sequence type { $type } အဂီၢ် ကဘၣ်မ့ၢ် number လီၤ။
+
+sequence-invalid-endpoint-number = number sequence အ "{ $attribute }" တဘၣ်ဘၣ်။ ကဘၣ်မ့ၢ် number လီၤ။
+
+sequence-invalid-endpoint-letters = letters sequence အ "{ $attribute }" တဘၣ်ဘၣ်။ ကဘၣ်မ့ၢ် လံာ်မဲာ်ဖျၢၣ် လၢအဘၣ်ဟူးဘၣ်ဂဲၤ လီၤ။
+
+sequence-invalid-endpoint = sequence အ "{ $attribute }" တဘၣ်ဘၣ်။
+
+select-from-sequence-coprime-not-numbers = number တဃုထၢဘၣ်အဃိ coprime တစူးကါဘၣ်
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations ပာ်ပနီၣ်ဝဲအဃိ coprime တစူးကါဘၣ်
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` အဂီၢ် target တဘၣ်ဘၣ်: target တထံၣ်ဘၣ်။
+
+target-state-variable-not-found = `<{ $source }>` အဂီၢ် target တဘၣ်ဘၣ်: `<{ $component }>` အလိၤ state variable အမံၤ "{ $property }" တထံၣ်ဘၣ်။
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` အ variable န့ၣ် independent variable ဒီး ကဘၣ်လီၤဆီ လီၤ။
+
+ode-system-duplicate-variable-names = dependent variable အမံၤ ဒ်သိးသိး အိၣ်ဝဲန့ၣ် ODE RHS function ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+ode-system-rhs-function-error = ODE RHS function ပာ်ပနီၣ် တန့ၢ်ဘၣ်။ mathjs function ဒုးအိၣ်ထီၣ်အခါ တၢ်ကမၣ် အိၣ်ထီၣ်ဝဲ လီၤ။
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = မျဉ်း { $count } ဘိ အဘၢၣ်စၢၤ ထောင့် ပာ်ပနီၣ် တန့ၢ်ဘၣ်
+
+angle-invalid-through-point = `<angle>` အ through အပူၤ အမှတ် တဘၣ်ဘၣ်
+
+parabola-vertex-too-many-points = vertex အိၣ်ဒီး အမှတ် အါန့ၢ် ၁ ခါ လဲၤခီဖျိသော parabola န့ၣ် တမၤဒံးဘၣ်။
+
+parabola-too-many-points = အမှတ် အါန့ၢ် ၃ ခါ လဲၤခီဖျိသော parabola န့ၣ် တမၤဒံးဘၣ်။
+
+intersection-too-many-items = တၢ်ဂ့ၢ် အါန့ၢ် ခံခါ အဂီၢ် intersection န့ၣ် တမၤဒံးဘၣ်
+
+## Other math components
+
+ionic-compound-not-two-ions = ion ခံခါ အဂၤ အဂီၢ် ionic compound န့ၣ် တမၤဒံးဘၣ်။
+
+ionic-compound-needs-cation-and-anion = ionic compound န့ၣ် cation တခါ ဒီး anion တခါ အဂီၢ်ဧိၤ မၤဝဲ လီၤ။
+
+solve-equations-cannot-evaluate = equation ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်အဃိ equation ဖးဆၢ တန့ၢ်ဘၣ်: { $equation }
+
+math-operators-operand-number-required = math operand ထုးထီၣ်အခါ operandNumber ကဘၣ်ပာ်ပနီၣ် လီၤ။
+
+eigen-decomposition-failed = matrix အ eigenvalue ဂံၢ်ထုးထီၣ် တန့ၢ်ဘၣ်
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: parameter { $parameters } န့ၣ် pattern အပူၤ တအိၣ်ဘၣ်အဃိ လီၢ်အိၣ်ကလီ ဒီး ထီဘိ ဘၣ်လိာ်ကွာ်ဒီး လီၤ။
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" န့ၣ် နၢ်ပၢၢ် တန့ၢ်ဘၣ်။ ကဘၣ်မ့ၢ် none, medium, dense မ့တမ့ၢ် number လၢအအါန့ၢ်သုည ခံခါ လၢအိၣ်ဒီးလီၢ်လၢအကျါ ဒ်သိး grid="1 0.5" လီၤ။ grid တဒုးအိၣ်ထီၣ်ဘၣ်။
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` န့ၣ် { $expected ->
+        [1] output တခါ, အမှတ် ကိးခါ အလိၤ slope y', ဒ်သိး `y - x`
+       *[other] output ခံခါ, အမှတ် ကိးခါ အလိၤ vector, ဒ်သိး `(y, -x)`
+    } အိၣ်သော function လိၣ်ဘၣ်ဝဲ, ဘၣ်ဆၣ် function လၢဟ့ၣ်လီၤဝဲန့ၣ် output { $found } ခါ အိၣ်ဝဲ လီၤ။ { $alternative ->
+        [none] တၢ်နီတမံၤ တဒုးအိၣ်ထီၣ်ဘၣ်။
+       *[other] function န့ၣ်အဂီၢ် `<{ $alternative }>` မ့ၢ် component လီၤ။ တၢ်နီတမံၤ တဒုးအိၣ်ထီၣ်ဘၣ်။
+    }
+
+field-function-attribute-ignored-with-child = function န့ၣ် component အပူၤစ့ၢ်ကီး ဟ့ၣ်လီၤဝဲအဃိ attribute `function` တစူးကါဘၣ်; အပူၤအဝဲန့ၣ် စူးကါဝဲ လီၤ။ function န့ၣ် ကျဲတဘိဧိၤ ဟ့ၣ်လီၤတက့ၢ်။
+
+field-variables-ignored =
+    `<{ $component }>`: attribute `variables` န့ၣ် component အပူၤ လိၤလိၤ ကွဲးဝဲသော expression အ variable ဒုးနဲၣ်ဝဲ လီၤ။ { $reason ->
+        [function-child] လၢအံၤ function န့ၣ် `<function>` ဖိ ဒ်အသိး ဟ့ၣ်လီၤဝဲ ဒီး အဝဲန့ၣ် အ variable ဒၣ်ဝဲ ဒုးနဲၣ်ဝဲအဃိ `variables` တစူးကါဘၣ်။
+       *[no-expression] လၢအံၤ expression ဒ်သိးအံၤ တအိၣ်ဘၣ်အဃိ `variables` တစူးကါဘၣ်။
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure renderer အပူၤ xLabelPosition="left" စူးကါ တန့ၢ်ဘၣ်; right-position အကျဲ စူးကါဝဲ လီၤ။
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure renderer အပူၤ yLabelPosition="bottom" စူးကါ တန့ၢ်ဘၣ်; top-position အကျဲ စူးကါဝဲ လီၤ။
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure အဂီၢ် axis bound တဘၣ်ဘၣ်; default bbox (-10,-10,10,10) စူးကါဝဲ လီၤ။
+
+prefigure-invalid-width = `<graph>`: prefigure အဂီၢ် width တဘၣ်ဘၣ်; default width 425 စူးကါဝဲ လီၤ။
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure အဂီၢ် aspectRatio တဘၣ်ဘၣ်; default aspect ratio 1 စူးကါဝဲ လီၤ။
+
+prefigure-grid-spacing-too-fine = `<graph>`: axis အဆၢ အဂီၢ် grid အဘၢၣ်စၢၤ ဆံးကဲၣ်ဆိး; prefigure renderer အပူၤ grid တဒုးအိၣ်ထီၣ်ဘၣ်။
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure renderer တစူးကါဘၣ်အခါ annotation တဒုးအိၣ်ထီၣ်ဘၣ်။
+
+multiple-annotations-children = `<graph>` အပူၤ `<annotations>` ဖိ အါခါ ထံၣ်န့ၢ်ဝဲ; လၢခံကတၢၢ်တခါဧိၤ စူးကါဝဲ လီၤ။
+
+## Referring to other components
+
+copy-unrecognized-component-type = component type လၢတသ့ၣ်ညါဘၣ်န့ၣ် extend မ့တမ့ၢ် copy တန့ၢ်ဘၣ်: { $type }။
+
+copy-prop-not-found = component type { $component } အလိၤ prop { $property } တထံၣ်ဘၣ်
+
+collect-no-source = collect အဂီၢ် source တထံၣ်ဘၣ်။
+
+collect-invalid-component-type = component type `<{ $component }>` န့ၣ် တဘၣ်ဘၣ်အဃိ collect တန့ၢ်ဘၣ်။
+
+reference-index-unavailable = index `{ $reference }` ဒုးနဲၣ် တန့ၢ်ဘၣ်
+
+## `<callAction>`
+
+component-action-unavailable = component `{ $reference }` အလိၤ { $action } ကိး တန့ၢ်ဘၣ်
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = data အကျဲ တဘၣ်ဘၣ်။ row အထီ တဒ်သိးလိာ်ဘၣ်။ componentIdx :{ $componentIdx } အပူၤ ထံၣ်န့ၢ်ဝဲ
+
+data-frame-duplicate-column-names = data အပူၤ column အမံၤ ဒ်သိးသိး အိၣ်ဝဲ။ componentIdx :{ $componentIdx } အပူၤ ထံၣ်န့ၢ်ဝဲ
+
+data-frame-missing-column-name = data အပူၤ column အမံၤ တခါ တအိၣ်ဘၣ်။ componentIdx :{ $componentIdx } အပူၤ ထံၣ်န့ၢ်ဝဲ
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = answer အံၤအ award န့ၣ် answer tag ဒၣ်ဝဲ အတၢ်စံးဆၢ လၢဆှၢထီၣ်ဝဲအလိၤ ဒိးသန့ၤထီၣ်အသးအဃိ တၢ်လၢတမုၢ်လၢ်ဘၣ် ကကဲထီၣ် လီၤ။
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` အိၣ်သော container အပူၤ `<answer>` အလိၤ `maxNumAttempts` ပာ်ဝဲန့ၣ် တမၤတၢ်နီတမံၤဘၣ်၊ ဘျီအနီၣ်ဂံၢ်န့ၣ် container ဟံးဃာ်ဝဲအဃိ လီၤ။ `maxNumAttempts` န့ၣ် container အလိၤ ပာ်တက့ၢ်။
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` အိၣ်သော container အဂၤအပူၤ အိၣ်သော `sectionWideCheckWork` container အလိၤ `maxNumAttempts` ပာ်ဝဲန့ၣ် တမၤတၢ်နီတမံၤဘၣ်၊ ဘျီအနီၣ်ဂံၢ်န့ၣ် ချၢတခီ container ဟံးဃာ်ဝဲအဃိ လီၤ။ `maxNumAttempts` န့ၣ် ချၢတခီ container အလိၤ ပာ်တက့ၢ်။
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality တပာ်ဘၣ်န့ၣ် attribute { $attributes } တမၤတၢ်နီတမံၤဘၣ်။
+    }
+
+answer-invalid-type = answer အဂီၢ် type တဘၣ်ဘၣ်: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = component `<{ $component }>` န့ၣ် အမံၤ တအိၣ်ဘၣ်အဃိ module အ attribute ဒ်အသိး စူးကါ တန့ၢ်ဘၣ်
+
+module-attribute-name-already-defined = component type `<module>` န့ၣ် attribute "{ $name }" ပာ်ပနီၣ်ဝဲလံအဃိ component `<{ $component } name="{ $name }">` န့ၣ် module အ attribute ဒ်အသိး စူးကါ တန့ၢ်ဘၣ်။
+
+conditional-content-condition-ignored = case မ့တမ့ၢ် else ဖိ အိၣ်သော `<conditionalContent>` အလိၤ attribute `condition` တစူးကါဘၣ်။
+
+slider-markers-type-mismatch = marker အ type ဒီး slider အ type တဘၣ်လိာ်ဘၣ်။
+
+pretzel-problem-needs-statement-and-answer = pretzel တဘၣ်ဘၣ်: `<problem>` ကိးခါ န့ၣ် `<statement>` တခါ ဒီး `<answer>` တခါ ကဘၣ်အိၣ် လီၤ။
+
+pretzel-circuit-first-problem-distractor = pretzel တဘၣ်ဘၣ်: mode="circuit" အပူၤ `<problem>` အခီၣ်ထံး န့ၣ် distractor ကဲ တန့ၢ်ဘၣ်။
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] attribute `{ $attribute }` အဂီၢ် တၢ်လုၢ်ပှ့ၤ { $values } တဘၣ်ဘၣ်; တစူးကါဘၣ်။
+    }
+
+attribute-must-be-references = attribute `{ $attribute }` အဂီၢ် တၢ်လုၢ်ပှ့ၤ `{ $value }` တဘၣ်ဘၣ်။ attribute န့ၣ် `$` ဒီးစးထီၣ်သော reference တဖၣ် ကဘၣ်မ့ၢ် လီၤ။
+
+math-input-invalid-function-names = <mathInput>: { $attribute } အပူၤ function အမံၤ လၢအတဘၣ်ဘၣ်န့ၣ် တစူးကါဘၣ်: { $names }။ မံၤကိးခါ အဒုးနဲၣ်အကူာ် န့ၣ် အစှၤကတၢၢ် ၂ ဖျၢၣ် (လံာ်မဲာ်ဖျၢၣ် မ့တမ့ၢ် ဘီၣ်ထူၣ်) ကဘၣ်အိၣ်; လၢခံ `|<mathspeak alternative>` န့ၣ် ပာ်ဂ့ၤ တပာ်ဂ့ၤ လီၤ။
+
+## Building components from the source
+
+component-type-invalid = component type တဘၣ်ဘၣ်: `<{ $componentType }>`
+
+attribute-repeated = attribute { $attribute } ကွဲးကဒီးတဘျီ တန့ၢ်ဘၣ်။
+
+attribute-invalid-for-component = component type `<{ $componentType }>` အဂီၢ် attribute "{ $attribute }" တဘၣ်ဘၣ်။
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    style definition { $styleNumber } န့ၣ် { $context ->
+        [text-on-background] background အလွဲၢ် ဒီး text အလွဲၢ်
+        [high-contrast] canvas ဒီး high-contrast အလွဲၢ်
+        [line] canvas ဒီး မျဉ်း အလွဲၢ်
+        [marker] canvas ဒီး marker အလွဲၢ်
+       *[text-on-canvas] canvas ဒီး text အလွဲၢ်
+    } အဂီၢ် contrast တလၢဘၣ်{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; အစှၤကတၢၢ် { $threshold }:1 ကဘၣ်အိၣ်)။
+
+style-definition-dark-mode-text-background-contrast =
+    style definition { $styleNumber } န့ၣ် light mode အဂီၢ် contrast လၢဝဲသော အလွဲၢ် ပာ်ပနီၣ်ဝဲဘၣ်ဆၣ်, အဝဲန့ၣ်အပူၤ ဟဲထီၣ်သော dark mode အလွဲၢ် န့ၣ် background အလွဲၢ် ဒီး text အလွဲၢ် အဂီၢ် contrast တလၢဘၣ် ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; အစှၤကတၢၢ် { $threshold }:1 ကဘၣ်အိၣ်)။ { $suggestion ->
+        [available] dark mode အပူၤ contrast လၢဝဲအဂီၢ် light mode အ contrast အါထီၣ်တက့ၢ် (ဒ်သိး { $lightAttribute }="{ $lightColor }" ပာ်) မ့တမ့ၢ် dark mode အလွဲၢ် ဆီတလဲပာ်တက့ၢ် (ဒ်သိး { $darkAttribute }="{ $darkColor }" ပာ်)။
+       *[none] dark mode အပူၤ contrast လၢဝဲအဂီၢ် light mode အ contrast အါထီၣ်တက့ၢ် မ့တမ့ၢ် ဟဲထီၣ်သော အလွဲၢ် န့ၣ် textColorDarkMode ဒီး/မ့တမ့ၢ် backgroundColorDarkMode ဒီး ဆီတလဲပာ်တက့ၢ်။
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    style definition { $styleNumber } န့ၣ် light mode အဂီၢ် contrast လၢဝဲသော text အလွဲၢ် ပာ်ပနီၣ်ဝဲဘၣ်ဆၣ်, အဝဲန့ၣ်အပူၤ ဟဲထီၣ်သော dark mode text အလွဲၢ် န့ၣ် canvas ဒီး contrast တလၢဘၣ် ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; အစှၤကတၢၢ် { $threshold }:1 ကဘၣ်အိၣ်)။ { $suggestion ->
+        [available] dark mode အပူၤ contrast လၢဝဲအဂီၢ် light mode အ contrast အါထီၣ်တက့ၢ် (ဒ်သိး textColor="{ $lightColor }" ပာ်) မ့တမ့ၢ် dark mode အလွဲၢ် ဆီတလဲပာ်တက့ၢ် (ဒ်သိး textColorDarkMode="{ $darkColor }" ပာ်)။
+       *[none] dark mode အပူၤ contrast လၢဝဲအဂီၢ် light mode အ contrast အါထီၣ်တက့ၢ် မ့တမ့ၢ် ဟဲထီၣ်သော အလွဲၢ် န့ၣ် textColorDarkMode ဒီး ဆီတလဲပာ်တက့ၢ်။
+    }
+
+section-multiple-style-palettes = တၢ်ကူာ်တခါ န့ၣ် <stylePalette> တခါဧိၤ ဃုထၢသ့; လၢခံကတၢၢ်တခါ စူးကါဝဲ လီၤ။
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect န့ၣ် integer လၢအတဆံးန့ၢ်သုည တမ့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-num-to-select-not-constant-number = numToSelect န့ၣ် number လၢအလီၢ်ဂၢၢ် တမ့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-with-replacement-not-constant-boolean = withReplacement န့ၣ် boolean လၢအလီၢ်ဂၢၢ် တမ့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-select-weight-disables-unique = selectWeight မ့တမ့ၢ် selectForVariants ပာ်ပနီၣ်ဝဲသော option အိၣ်န့ၣ် select အဂီၢ် unique variant တဖၣ် ကးတံာ်ဃာ်ဝဲ လီၤ
+
+variant-coprime-undetermined = coprime န့ၣ် ထီဘိ တမ့ၢ်ဘၣ် လၢပာ်ပနီၣ် တန့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-attribute-not-constant = { $attribute } န့ၣ် အလီၢ်ဂၢၢ် တမ့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-attribute-not-number = { $attribute } န့ၣ် number တမ့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } န့ၣ် { $expected ->
+        [letters-combination] လံာ်မဲာ်ဖျၢၣ် လၢအဘၣ်ဟူးဘၣ်ဂဲၤ
+        [math-expression] math expression လၢအဘၣ်
+        [integer] integer
+       *[number] number
+    } တမ့ၢ်ဘၣ်အဃိ type { $type } အိၣ်သော { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-length-not-integer = length န့ၣ် integer တမ့ၢ်ဘၣ်အဃိ { $component } အ unique variant ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+
+variant-sort-not-implemented = sort အိၣ်သော { $component } အ unique variant န့ၣ် တမၤဒံးဘၣ်
+
+variant-exclude-combinations-not-implemented = excludeCombinations အိၣ်သော { $component } အ unique variant န့ၣ် တမၤဒံးဘၣ်
+
+variant-math-exclude-not-implemented = exclude အိၣ်သော type math { $component } အ unique variant န့ၣ် တမၤဒံးဘၣ်
+
+variant-non-constant-exclude-not-implemented = အလီၢ်ဂၢၢ်တမ့ၢ်ဘၣ်သော exclude အိၣ်သော { $component } အ unique variant န့ၣ် တမၤဒံးဘၣ်
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure renderer အပူၤ စူးကါ တန့ၢ်ဘၣ်; အစၢၤ ကပာ်ကွံာ်ဝဲ လီၤ။
+
+prefigure-descendant-invalid-geometry = { $subject }: တၢ်ဒိအကျဲ တလၢဘၣ် မ့တမ့ၢ် တဘၣ်ဘၣ်; အစၢၤ ကပာ်ကွံာ်ဝဲ လီၤ။
+
+prefigure-curve-label-omitted = { $subject }: လဲလိာ်ဝဲသော curve အလိၤ label စူးကါ တန့ၢ်ဘၣ်; label ကပာ်ကွံာ်ဝဲ လီၤ။
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve function definition type '{ $definitionType }' စူးကါ တန့ၢ်ဘၣ်; အစၢၤ ကပာ်ကွံာ်ဝဲ လီၤ။
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves အလိၤ attribute flipFunctions စူးကါ တန့ၢ်ဘၣ်; အစၢၤ ကပာ်ကွံာ်ဝဲ လီၤ။
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves အလိၤ formula type function ဖိဧိၤ စူးကါသ့; အစၢၤ ကပာ်ကွံာ်ဝဲ လီၤ။
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] line family အ label
+       *[point] အမှတ် အ label
+    } အဂီၢ် labelPosition '{ $labelPosition }' စူးကါ တန့ၢ်ဘၣ်; default PreFigure alignment စူးကါဝဲ လီၤ။
+
+prefigure-fill-style-unsupported = { $subject }: fill style '{ $fillStyle }' န့ၣ် PreFigure စူးကါ တန့ၢ်ဘၣ်; fill လၢအပှဲၤ ဆူ က့ၤစူးကါဝဲ လီၤ။
+
+prefigure-line-style-unknown = { $subject }: တသ့ၣ်ညါဘၣ်သော line style '{ $lineStyle }' န့ၣ် PreFigure output အပူၤ တပာ်ဃုာ်ဘၣ်။
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }' န့ၣ် PreFigure style 'diamond' ဆူ လဲလိာ်ဝဲ လီၤ။
+
+prefigure-marker-style-unsupported = { $subject }: marker style '{ $markerStyle }' န့ၣ် PreFigure စူးကါ တန့ၢ်ဘၣ်; default style စူးကါဝဲ လီၤ။
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` တဘၣ်ဘၣ်; target ဒုးနဲၣ် တန့ၢ်ဘၣ်။ annotation ကပာ်ကွံာ်ဝဲ လီၤ။
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` န့ၣ် target အါခါ ဒုးနဲၣ်ဝဲ; target အခီၣ်ထံး စူးကါဝဲ လီၤ။
+
+annotation-ref-outside-graph = `<annotation>`: `ref` တဘၣ်ဘၣ်; target န့ၣ် graph အချၢ အိၣ်ဝဲ လီၤ။ annotation ကပာ်ကွံာ်ဝဲ လီၤ။
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` တဘၣ်ဘၣ်; target န့ၣ် prefigure အပူၤ စူးကါသ့သော တၢ်ဂီၤ တမ့ၢ်ဘၣ်။ annotation ကပာ်ကွံာ်ဝဲ လီၤ။
+
+annotation-text-missing = `<annotation>`: `text` တအိၣ်ဘၣ် မ့တမ့ၢ် အိၣ်ကလီ; text အိၣ်ကလီ ထုးထီၣ်ဝဲ လီၤ။
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] circular dependency ထံၣ်န့ၢ်ဝဲ လီၤ။
+       *[other] component `<{ $componentType }>` ဒီး ဘၣ်ထွဲသော circular dependency ထံၣ်န့ၢ်ဝဲ လီၤ။
+    }
+
+reference-no-referent = reference အဂီၢ် တၢ်လၢအဘၣ်ထွဲ တထံၣ်ဘၣ်: `{ $reference }`
+
+reference-multiple-referents = reference အဂီၢ် တၢ်လၢအဘၣ်ထွဲ အါခါ ထံၣ်န့ၢ်ဝဲ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` အ attribute { $attribute } အကျဲ တဘၣ်ဘၣ်။
+
+children-invalid = `<{ $componentType }>` အဂီၢ် ဖိ တဘၣ်ဘၣ်: ဖိ လၢအတဘၣ်ဘၣ် ထံၣ်န့ၢ်ဝဲ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = attribute `{ $attribute }` အဂီၢ် တၢ်လုၢ်ပှ့ၤ `{ $value }` တဘၣ်ဘၣ်၊ တၢ်လုၢ်ပှ့ၤ `{ $default }` စူးကါဝဲ လီၤ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML version { $version } တထံၣ်ဘၣ်။
+       *[other] DoenetML version { $version } တထံၣ်ဘၣ်။ version { $fallback } ဆူ က့ၤစူးကါဝဲ လီၤ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML တဘၣ်ဘၣ်: { $content }
+
+parse-tag-missing-close-tag = DoenetML တဘၣ်ဘၣ်: tag `{ $tag }` န့ၣ် ကးတံာ် tag တအိၣ်ဘၣ်။ ကဘၣ်မ့ၢ် tag လၢအကးတံာ်လီၤအသး မ့တမ့ၢ် `</{ $tagName }>` tag လီၤ။
+
+parse-tag-error = DoenetML တဘၣ်ဘၣ်: tag `<{ $tagName }>` အပူၤ တၢ်ကမၣ်
+
+parse-attribute-missing-value = DoenetML တဘၣ်ဘၣ်: attribute `{ $attribute }` လၢအတဘၣ်ဘၣ်န့ၣ် တၢ်လုၢ်ပှ့ၤ တအိၣ်ဘၣ် လီၤ။
+
+parse-attribute-invalid = DoenetML တဘၣ်ဘၣ်: attribute `{ $attribute }` တဘၣ်ဘၣ်
+
+parse-attribute-value-invalid = DoenetML တဘၣ်ဘၣ်: attribute အတၢ်လုၢ်ပှ့ၤ `{ $value }` တဘၣ်ဘၣ်
+
+parse-attribute-value-quote-mismatch = DoenetML တဘၣ်ဘၣ်: attribute အတၢ်လုၢ်ပှ့ၤ `{ $value }` တဘၣ်ဘၣ်။ တၢ်ကတိၤပနီၣ် တဘၣ်လိာ်ဘၣ်။ `{ $quote }` တအိၣ်ဘၣ် လီၤ
+
+parse-open-tag-name-missing = DoenetML တဘၣ်ဘၣ်: tag အမံၤ တအိၣ်ဘၣ်သော tag ထံၣ်န့ၢ်ဝဲ, ဒ်သိး `<`
+
+parse-tag-not-closed = DoenetML တဘၣ်ဘၣ်: tag `{ $tag }` တကးတံာ်ဘၣ် (`>` တအိၣ်ဘၣ်)။
+
+parse-self-closing-tag-name-missing = DoenetML တဘၣ်ဘၣ်: tag အမံၤ တအိၣ်ဘၣ်သော tag ထံၣ်န့ၢ်ဝဲ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML တဘၣ်ဘၣ်: tag `{ $tag }` တကးတံာ်ဘၣ် (`/>` တအိၣ်ဘၣ်)။
+
+parse-tag-invalid-attributes = DoenetML တဘၣ်ဘၣ်: tag `{ $tag }` တဘၣ်ဘၣ်။ attribute ကမၣ်ဝဲ ဘၣ်သ့ၣ်သ့ၣ် လီၤ။
+
+parse-close-tag-name-missing = DoenetML တဘၣ်ဘၣ်: tag အမံၤ တအိၣ်ဘၣ်သော ကးတံာ် tag ထံၣ်န့ၢ်ဝဲ, ဒ်သိး `</`
+
+parse-attribute-value-unquoted = attribute အတၢ်လုၢ်ပှ့ၤ န့ၣ် တၢ်ကတိၤပနီၣ် အပူၤ ကဘၣ်ပာ်: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML တဘၣ်ဘၣ်: ကးတံာ် tag `{ $tag }` ထံၣ်န့ၢ်ဝဲဘၣ်ဆၣ် အိးထီၣ် tag လၢအဘၣ်ထွဲ တအိၣ်ဘၣ်
+
+parse-close-tag-mismatched = DoenetML တဘၣ်ဘၣ်: ကးတံာ် tag တဘၣ်လိာ်ဘၣ်။ ကဘၣ်မ့ၢ် `</{ $expected }>` လီၤ။ `{ $found }` ထံၣ်န့ၢ်ဝဲ
+
+parser-node-unconvertible = node { $node } န့ၣ် Dast node ဆူ လဲလိာ် တန့ၢ်ဘၣ်။
+
+## Names
+
+name-attribute-invalid =
+    attribute name='{ $name }' တဘၣ်ဘၣ်။ { $reason ->
+        [characters] မံၤ န့ၣ် လံာ်မဲာ်ဖျၢၣ်, နီၣ်ဂံၢ်, ဘီၣ်ထူၣ်ဖီလာ် မ့တမ့ၢ် ဘီၣ်ထူၣ်ဧိၤ ပာ်ဃုာ်သ့ လီၤ။
+       *[start] မံၤ န့ၣ် လံာ်မဲာ်ဖျၢၣ် ဒီး ကဘၣ်စးထီၣ် လီၤ။
+    }
+
+component-name-invalid-start = component အမံၤ "{ $name }" တဘၣ်ဘၣ်။ မံၤ န့ၣ် လံာ်မဲာ်ဖျၢၣ် ဒီး ကဘၣ်စးထီၣ် လီၤ။
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = type videoWatched အိၣ်သော answer န့ၣ် attribute video ကဘၣ်အိၣ်
+
+answer-video-watched-video-not-reference = type videoWatched အိၣ်သော answer န့ၣ် reference မ့ၢ်သော attribute video ကဘၣ်အိၣ်
+
+answer-name-not-single-text = answer အ attribute name န့ၣ် text ဖိ တခါဧိၤ ကဘၣ်အိၣ်
+
+## Referencing another document
+
+external-doenetml-recursion-limit = recursion အတီၤ အါကဲၣ်ဆိးအဃိ ချၢတခီ DoenetML ဟံးန့ၢ် တန့ၢ်ဘၣ်။ circular reference အိၣ်ဧါ။
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" အပူၤ DoenetML ဟံးန့ၢ် တန့ၢ်ဘၣ်
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" အပူၤ ဟံးန့ၢ်ဝဲသော DoenetML တဘၣ်ဘၣ်: component type "{ $componentType }" ဒီး တဘၣ်လိာ်ဘၣ်
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] attribute `{ $from }` န့ၣ် တစူးကါလၢၤဘၣ်; `{ $to }` စူးကါတက့ၢ်။
+       *[other] [deprecation] `<{ $component }>` အလိၤ attribute `{ $from }` န့ၣ် တစူးကါလၢၤဘၣ်; `{ $to }` စူးကါတက့ၢ်။
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }` စ့ၢ်ကီး ပာ်ပနီၣ်ဝဲအဃိ attribute `{ $from }` န့ၣ် တစူးကါလၢၤဘၣ် ဒီး တစူးကါဘၣ်။
+       *[other] [deprecation] `{ $to }` စ့ၢ်ကီး ပာ်ပနီၣ်ဝဲအဃိ `<{ $component }>` အလိၤ attribute `{ $from }` န့ၣ် တစူးကါလၢၤဘၣ် ဒီး တစူးကါဘၣ်။
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` အလိၤ attribute `{ $attribute }` န့ၣ် တစူးကါလၢၤဘၣ် ဒီး တစူးကါဘၣ်။
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` အလိၤ attribute `{ $attribute }` န့ၣ် တစူးကါလၢၤဘၣ်; `<{ $child }>` ဖိ စူးကါတက့ၢ်။
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` အလိၤ attribute `{ $attribute }` အ တၢ်လုၢ်ပှ့ၤ `{ $value }` န့ၣ် တစူးကါလၢၤဘၣ်; `{ $to }` စူးကါတက့ၢ်။
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` န့ၣ် အဲကလံးကျိာ်ဧိၤ နီၣ်ဂံၢ်အါ မၤသ့အဃိ { $locale } ဒီး ကွဲးဝဲသော document အပူၤ အ text န့ၣ် ဒ်အအိၣ်အသိး အိၣ်တ့ၢ်ဝဲ လီၤ။ နီၣ်ဂံၢ်အါအကျဲ လိၤလိၤ ကွဲးတက့ၢ်, မ့တမ့ၢ် attribute `pluralForm` ဒီး ပာ်တက့ၢ်။
+
+
+## Checking against the schema
+
+schema-element-unrecognized = element `<{ $tag }>` န့ၣ် Doenet element လၢအသ့ၣ်ညါဝဲ တမ့ၢ်ဘၣ်။
+
+schema-element-not-allowed-at-root = element `<{ $tag }>` န့ၣ် document အ root အလိၤ ပာ် တန့ၢ်ဘၣ်။
+
+schema-element-not-allowed-inside = element `<{ $tag }>` န့ၣ် `<{ $parent }>` အပူၤ ပာ် တန့ၢ်ဘၣ်။
+
+schema-attribute-unrecognized = element `<{ $tag }>` န့ၣ် `{ $attribute }` အမံၤ အိၣ်သော attribute တအိၣ်ဘၣ်။
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] element `<{ $tag }>` အ attribute `{ $attribute }` န့ၣ် အကူာ်ကိးခါ အံၤအကျါ တခါ မ့ၢ်သော list ကဘၣ်မ့ၢ်: { $allowed }
+       *[other] element `<{ $tag }>` အ attribute `{ $attribute }` န့ၣ် အံၤအကျါ တခါ ကဘၣ်မ့ၢ်: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select အဂီၢ် variant name တဘၣ်ဘၣ်။ variant name { $variantName } န့ၣ် option { $numOptions } ခါအပူၤ အိၣ်ဘၣ်ဆၣ် ဃုထၢအနီၣ်ဂံၢ် န့ၣ် { $numToSelect } လီၤ။
+
+select-variant-name-without-options = select အဂီၢ် variant တနီၤ ပာ်ပနီၣ်ဝဲဘၣ်ဆၣ် ကဲထီၣ်သ့သော variant name အဂီၢ် option တအိၣ်ဘၣ်: { $variantName }။
+
+select-variant-name-not-possible = select အဂီၢ် ပာ်ပနီၣ်ဝဲသော variant name { $variantName } န့ၣ် ကဲထီၣ်သ့သော variant name တမ့ၢ်ဘၣ်။
+
+select-too-few-options = { $numOptions } ဧိၤအကျါ component { $numToSelect } ခါ ဃုထၢ တန့ၢ်ဘၣ်။
+
+select-from-sequence-too-few-values = အထီ { $length } အိၣ်သော sequence အကျါ တၢ်လုၢ်ပှ့ၤ { $numToSelect } ခါ ဃုထၢ တန့ၢ်ဘၣ်။
+
+select-from-sequence-indices-count-mismatch = select အဂီၢ် ပာ်ပနီၣ်ဝဲသော indices အနီၣ်ဂံၢ် န့ၣ် ဃုထၢအနီၣ်ဂံၢ် ဒီး ကဘၣ်ဘၣ်လိာ်
+
+select-from-sequence-indices-not-integers = select အဂီၢ် ပာ်ပနီၣ်ဝဲသော indices ခဲလၢာ် ကဘၣ်မ့ၢ် integer
+
+select-from-sequence-index-excluded = selectfromsequence အ ပာ်ပနီၣ်ဝဲသော index န့ၣ် ထုးထီၣ်ကွံာ်ဃာ်ဝဲ လီၤ
+
+select-from-sequence-indices-excluded-combination = selectfromsequence အ ပာ်ပနီၣ်ဝဲသော indices န့ၣ် ထုးထီၣ်ကွံာ်ဃာ်ဝဲသော combination လီၤ
+
+select-from-sequence-coprime-not-positive-integers = သုညအါန့ၢ်သော integer တဃုထၢဘၣ်အဃိ coprime combination ဃုထၢ တန့ၢ်ဘၣ်။
+
+select-from-sequence-coprime-common-factor = coprime number ဃုထၢ တန့ၢ်ဘၣ်။ ကဲထီၣ်သ့သော တၢ်လုၢ်ပှ့ၤ ခဲလၢာ် န့ၣ် factor ဒ်သိးသိး အိၣ်ဝဲ လီၤ။ ("from" မ့တမ့ၢ် "to" လၢပာ်ပနီၣ်ဝဲန့ၣ် "step" ဒီး coprime ကဘၣ်မ့ၢ်။)
+
+select-from-sequence-coprime-single-number = 1 တမ့ၢ်ဘၣ်သော number တခါဧိၤအကျါ coprime combination ဃုထၢ တန့ၢ်ဘၣ်။
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence အပူၤ combination 70% အါန့ၢ် ထုးထီၣ်ကွံာ်ဃာ်ဝဲ လီၤ
+
+select-from-sequence-coprime-none-found = coprime number ဃုထၢ တန့ၢ်ဘၣ်။ ကဲထီၣ်သ့သော တၢ်လုၢ်ပှ့ၤ ခဲလၢာ် န့ၣ် factor ဒ်သိးသိး အိၣ်ဝဲ လီၤ။
+
+select-from-sequence-too-few-unique-values = အထီ { $numPossibleValues } အိၣ်သော sequence အကျါ unique တၢ်လုၢ်ပှ့ၤ { $numToSelect } ခါ ဃုထၢ တန့ၢ်ဘၣ်
+
+select-prime-numbers-too-few-values = အထီ { $numValues } အိၣ်သော prime စရီ အကျါ တၢ်လုၢ်ပှ့ၤ { $numToSelect } ခါ ဃုထၢ တန့ၢ်ဘၣ်
+
+select-prime-numbers-values-count-mismatch = select အဂီၢ် ပာ်ပနီၣ်ဝဲသော တၢ်လုၢ်ပှ့ၤ အနီၣ်ဂံၢ် န့ၣ် ဃုထၢအနီၣ်ဂံၢ် ဒီး ကဘၣ်ဘၣ်လိာ်
+
+select-prime-numbers-values-not-prime = select prime number အဂီၢ် ပာ်ပနီၣ်ဝဲသော တၢ်လုၢ်ပှ့ၤ ခဲလၢာ် န့ၣ် prime စရီ အပူၤ ကဘၣ်အိၣ်
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers အ ပာ်ပနီၣ်ဝဲသော တၢ်လုၢ်ပှ့ၤ န့ၣ် ထုးထီၣ်ကွံာ်ဃာ်ဝဲသော combination လီၤ
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers အပူၤ combination 70% အါန့ၢ် ထုးထီၣ်ကွံာ်ဃာ်ဝဲ လီၤ
+
+select-random-combination-fluke = ကဲထီၣ်တသ့သးဖှံသးညီ random တၢ်လုၢ်ပှ့ၤ အ combination ဃုထၢ တန့ၢ်ဘၣ်
+
+select-random-value-fluke = ကဲထီၣ်တသ့သးဖှံသးညီ random တၢ်လုၢ်ပှ့ၤ ဃုထၢ တန့ၢ်ဘၣ်
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` အံၤ တဒုးနဲၣ်ဘၣ်, math အပူၤ အိၣ်ဘၣ်ဆၣ် `inline` တမ့ၢ်ဘၣ်အဃိ လီၤ။ `inline` ပာ်ဖှိၣ်တက့ၢ်, စံးအသိး expression အပူၤ လုၢ်သ့သော drop-down list ကကဲထီၣ် လီၤ။
+        [expanded] `<{ $component }>` အံၤ တဒုးနဲၣ်ဘၣ်, math အပူၤ အိၣ်ဒီး `expanded` မ့ၢ်ဝဲအဃိ လီၤ။ `expanded` ထုးထီၣ်ကွံာ်တက့ၢ်; ကျိၤအါဘိအိၣ်သော တလါ န့ၣ် expression အပူၤ တလုၢ်ဘၣ်။
+        [on-graph] `<{ $component }>` အံၤ တဒုးနဲၣ်ဘၣ်, graph အလိၤ ဒုးအိၣ်ထီၣ်ဝဲသော math အပူၤ အိၣ်ဒီး input အဂီၢ် လီၢ် တအိၣ်ဘၣ်အဃိ လီၤ။
+       *[relative-width] `<{ $component }>` အံၤ တဒုးနဲၣ်ဘၣ်, math အပူၤ အိၣ်ဒီး relative width အိၣ်ဝဲအဃိ လီၤ။ width န့ၣ် `px` ဒ်သိးသော တၢ်ထိၣ်လၢအလီၢ်ဂၢၢ် ဒီး ဟ့ၣ်လီၤတက့ၢ်။
+    }

--- a/packages/i18n/locales/ksw/editor.ftl
+++ b/packages/i18n/locales/ksw/editor.ftl
@@ -1,0 +1,234 @@
+# S'gaw Karen (ကညီကျိာ်) editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# S'gaw Karen in the S'gaw Karen script with the S'gaw signs ၢ ၣ ၤ, spaces between
+# phrases, and no Pwo letters (ၦ, ၯ) anywhere. ဢ and ၡ are S'gaw letters no
+# word in this catalog needs.
+#
+# **This is the file where the loans are heaviest, and it should be read as
+# such.** The editor's own nouns are English almost without exception —
+# `editor`, `viewer`, `variant`, `filter`, `component`, `attribute`,
+# `reference`, `property`, `snippet`, `array entry`, `type`, `style`,
+# `default`, `coordinate`, `function`, `line`, `tag`, `report`, `credit`,
+# `accessibility`, `Answer Id` — **around a Karen frame**. What is Karen here
+# is the word order (verb before object, modifier after head noun), the
+# negative circumfix တ…ဘၣ်, the nominalizing prefix တၢ်, the declarative
+# final လီၤ, and the ordinary verbs ဒုးနဲၣ် (show), ဃုထၢ (choose), ထံၣ်
+# (find), အိၣ် (there is), မ့ၢ် (be), ဆီၣ် (press).
+#
+# **`editor-update-viewer`'s two words are Karen**: မၤသီထီၣ် ('make new')
+# for Update and ပာ်က့ၤအလီၢ် ('put back in place') for Reset. Both sit on a
+# narrow toolbar button and both are longer than the English; if they do not
+# fit, that is a layout problem to report rather than a reason to shorten
+# them wrongly.
+#
+# **What this catalog does not know.** The context-help panel's register —
+# what a Karen-speaking mathematics teacher calls a reference, a property or a
+# default — is not something this seed could establish, so those sentences are
+# a Karen frame around the English words and read as such. The panel is the
+# first place a speaker's rewriting will show.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ပာ်က့ၤအလီၢ်
+       *[update] မၤသီထီၣ်
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } viewer
+       *[other] { $word } viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = variant
+
+editor-variant-filter = filter…
+
+editor-variant-next = ဃုထၢ variant လၢခံ
+
+editor-variant-previous = ဃုထၢ variant လၢညါ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] ထံၣ်န့ၢ် WCAG AA accessibility တၢ်ကမၣ် လီၤ။ ဆီၣ် ဒ်သိး က{ $action ->
+            [close] ကးတံာ်
+           *[open] အိးထီၣ်
+        } accessibility report။
+        [advisories] ဆီၣ် ဒ်သိး က{ $action ->
+            [close] ကးတံာ်
+           *[open] အိးထီၣ်
+        } accessibility report။ WCAG AA တၢ်ကမၣ် တထံၣ်ဘၣ်ဆၣ် accessibility အဂ့ၢ် တၢ်ဟ့ၣ်ကူၣ် အဂၤ အိၣ်ဒံး လီၤ။
+       *[clean] ဆီၣ် ဒ်သိး က{ $action ->
+            [close] ကးတံာ်
+           *[open] အိးထီၣ်
+        } accessibility report။ accessibility အဂ့ၢ်ကီ တအိၣ်ဘၣ်။
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] ထံၣ်န့ၢ် WCAG AA accessibility တၢ်ကမၣ် လီၤ။ WCAG AA တၢ်ကမၣ် { $count } ခါ ထံၣ်န့ၢ်ဝဲ လီၤ။ ဆီၣ် ဒ်သိး က{ $action ->
+            [close] ကးတံာ်
+           *[open] အိးထီၣ်
+        } accessibility report။
+        [advisories] WCAG AA တၢ်ကမၣ် တထံၣ်ဘၣ်။ accessibility အဂ့ၢ် တၢ်ဟ့ၣ်ကူၣ် အဂၤ { $count } ခါ ထံၣ်န့ၢ်ဝဲ လီၤ။ ဆီၣ် ဒ်သိး က{ $action ->
+            [close] ကးတံာ်
+           *[open] အိးထီၣ်
+        } accessibility report။
+       *[clean] WCAG AA တၢ်ကမၣ် တထံၣ်ဘၣ်။ ဆီၣ် ဒ်သိး က{ $action ->
+            [close] ကးတံာ်
+           *[open] အိးထီၣ်
+        } accessibility report။
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = တၢ်မၤစၢၤ လၢအလီၢ်အိၣ်ဝဲအသိး
+editor-tab-help-short = တၢ်မၤစၢၤ
+editor-tab-errors = တၢ်ကမၣ်
+editor-tab-warnings = တၢ်ဟ့ၣ်ပလီၢ်
+editor-tab-info = တၢ်ဂ့ၢ်တၢ်ကျိၤ
+editor-tab-accessibility = accessibility
+editor-tab-responses = တၢ်စံးဆၢ လၢဆှၢထီၣ်ဝဲ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = editor အတၢ်ဃုထၢ
+editor-format-as-doenetml = ကွဲးကျဲၤ ဒ် DoenetML
+editor-format-as-xml = ကွဲးကျဲၤ ဒ် XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = line #{ $line }
+
+editor-no-errors = တၢ်ကမၣ် တအိၣ်ဘၣ်
+editor-no-warnings = တၢ်ဟ့ၣ်ပလီၢ် တအိၣ်ဘၣ်
+editor-no-info = info diagnostic တအိၣ်ဘၣ်
+
+editor-show-info-annotations = ဒုးနဲၣ် info diagnostic လၢ editor အပူၤ
+editor-show-accessibility-annotations = ဒုးနဲၣ် accessibility diagnostic လၢ editor အပူၤ
+
+editor-accessibility-learn-more = မၤလိကွၢ် Doenet မၤ accessibility ဒ်လဲၣ်
+
+editor-accessibility-violations-heading = accessibility တၢ်ကမၣ် ({ $standard })
+
+editor-accessibility-other-heading = accessibility အဂ့ၢ်ကီ အဂၤ
+editor-none-found = တထံၣ်ဘၣ်နီတခါ
+
+
+## Submitted responses
+
+editor-no-responses = တၢ်စံးဆၢ လၢဆှၢထီၣ်ဝဲ တအိၣ်ဒံးဘၣ်
+editor-response-answer-id = Answer Id
+editor-response-response = တၢ်စံးဆၢ
+editor-response-credit = credit
+editor-response-submitted = ဆှၢထီၣ်ဝဲလံ
+
+
+## The context-help panel
+
+help-placeholder = documentation အဂီၢ် ပာ် cursor လၢ tag, attribute မ့တမ့ၢ် { $ref } အလိၤ တက့ၢ်။
+
+help-unsupported-ref-chain = { $example } ဒ်သိးအံၤ reference လၢအအိၣ်ဒီးအကူာ်အါခါ အဂီၢ် တၢ်မၤစၢၤ တအိၣ်ဒံးဘၣ်။
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] reference အဂီၢ် တၢ်လၢအဘၣ်ထွဲ တထံၣ်ဘၣ်: { $ref }။
+        [multiple] reference အဂီၢ် တၢ်လၢအဘၣ်ထွဲ အါခါ ထံၣ်န့ၢ်ဝဲ: { $ref }။
+       *[indeterminate] { $ref } အဂီၢ် တၢ်လၢအဘၣ်ထွဲ ပာ်ပနီၣ် တန့ၢ်ဘၣ်။
+    }
+
+help-learn-about-references = မၤလိကွၢ် reference အဂ့ၢ် →
+help-reference-page = reference ကဘျံးပၤ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } အပူၤ
+       *[top] top level အလိၤ
+    }{ $allowed ->
+        [none] { " — တၢ်နီတမံၤ ပာ်ဖှိၣ် တန့ၢ်ဘၣ်။" }
+        [text] { " — ကွဲး text လၢအံၤ တက့ၢ်။" }
+        [text-and-components] { " — ကွဲး text လၢအံၤ မ့တမ့ၢ် မၤကွၢ်:" }
+       *[components] { " — တၢ်လၢမၤကွၢ်သ့:" }
+    }
+
+help-suggestions-footer = component ခဲလၢာ် { $total } ခါ ကွၢ်အဂီၢ် ဆီၣ် { $shortcut } တက့ၢ်။
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } မ့ၢ် { $target } အဂီၢ် reference လီၤ။
+       *[other] { $ref } မ့ၢ် { $target } အဂီၢ် reference လီၤ (line { $line })။
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ပာ်ဖှိၣ်ဝဲ ဒ် { $role } လီၤ။
+       *[other] { $owner } ပာ်ဖှိၣ်ဝဲ လၢ line { $line } အပူၤ ဒ် { $role } လီၤ။
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } မ့ၢ် { $element } အ property { $property } အဂီၢ် reference လီၤ။
+       *[other] { $ref } မ့ၢ် { $element } အ property { $property } အဂီၢ် reference လီၤ (line { $line })။
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = default:
+help-active-default = default လၢအမၤတၢ်ဒံး:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] တၢ်လုၢ်ပှ့ၤ လၢပာ်ဖှိၣ်သ့ (တခါစုာ်စုာ်):
+       *[other] တၢ်လုၢ်ပှ့ၤ လၢပာ်ဖှိၣ်သ့:
+    }
+
+help-suggested-values = တၢ်လုၢ်ပှ့ၤ လၢဟ့ၣ်ကူၣ်ဝဲ:
+
+help-inserts = ပာ်နုာ်လီၤ:
+
+help-coordinates =
+    { $count ->
+       *[other] coordinate:
+    }
+
+help-type = type:
+
+help-resolved-style = style လၢထုးထီၣ်န့ၢ်ဝဲ (styleNumber { $styleNumber }):
+
+help-resolved-function-names = function အမံၤ လၢထုးထီၣ်န့ၢ်ဝဲ:
+help-reset-list = input အံၤအလိၤ reset list:
+help-added-on-input = input အံၤအလိၤ ပာ်ဖှိၣ်ဝဲ:
+help-removed-on-input = input အံၤအလိၤ ထုးထီၣ်ကွံာ်ဝဲ:
+
+help-reset-overrides = { $reset } မၤဂၢၤန့ၢ် { $additional } ဒီး { $removed } လီၤ။

--- a/packages/i18n/locales/mak/chrome.ftl
+++ b/packages/i18n/locales/mak/chrome.ftl
@@ -1,0 +1,190 @@
+# Makasar (Basa Mangkasara') viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, not Lontara.** Makasar has two historic scripts of its own,
+# Lontara and the older Makasar script (Ukiri' Jangang-jangang), and a reviewer
+# may reasonably have expected one of them. This catalog writes **Latin**,
+# because Latin is what Makasar is written in today in print, in schoolbooks
+# and online, and because Lontara does not write the final glottal stop, the
+# geminates or the syllable-final nasal — the three things this language's
+# spelling turns on. In Lontara «kebo'» and «kebo», «ca'di» and «cadi» would
+# look the same, and a reviewer could not tell a correction from a typo.
+# Converting to Lontara means converting **all four files at once**, and it is
+# a conversion rather than a transliteration, because the distinctions the
+# script drops would have to be restored by someone who knows the words.
+#
+# **The final glottal stop is written with the ASCII apostrophe `'`
+# (U+0027)**, everywhere in all four files — «kebo'», «ca'di», «tena nia'»,
+# «tanra». The typographic apostrophe U+2019 appears nowhere, so a search for
+# `'` finds every one of them. This is the convention Makasar print uses and
+# the one a reviewer can type without a special keyboard.
+#
+# **The technical register is Indonesian, and it is declared rather than
+# disguised.** Makasar speakers are schooled in Indonesian, and the words for a
+# component, an attribute, a matrix, a percentage or a keyboard are the
+# Indonesian ones because those are the words the community uses. They are
+# written here as Indonesian, not respelled into a Makasar shape the language
+# does not give them.
+#
+# **What is Makasar here is the frame**, and it is used consistently: «tena»
+# for *tidak* and «tena nia'» for *tidak ada*, «akkulle» for *bisa* (so
+# *cannot* is «tena nakkulle»), «siagang» for *dengan* and *dan*, «yareka» for
+# *atau*, «lanri» for *karena*, «punna» for *jika*, «mingka» for *tetapi*,
+# «battu ri» for *dari*, «untu'» for *untuk*, «ri» for *di*, «ngaseng» for
+# *semua*, «tunggala'» for *tiap*, «tenapa» for *belum*, «le'ba'» for *sudah*,
+# «nigappa» for *ditemukan*, «pole» for *lagi*, «dudu» after an adjective for
+# *terlalu*, «anne» and «anjo» for *ini* and *itu*, and «katte» as the polite
+# second person.
+#
+# **This is not the Buginese catalog with different spellings.** `locales/bug`
+# is the neighbouring language and the two are typologically alike, but the
+# function words are different words and are kept apart deliberately: Buginese
+# «de'», «wedding», «sibawa», «iyaré'ga», «nasaba», «rékko», «naé», «pole ri»,
+# «maneng» against Makasar «tena», «akkulle», «siagang», «yareka», «lanri»,
+# «punna», «mingka», «battu ri», «ngaseng». A message here written with a
+# Buginese function word is a mistake, not a variant.
+#
+# **Counts.** CLDR has no plural data for `mak`, so `Intl.PluralRules` would
+# resolve it against the runtime's own locale and any `[one]` branch would be
+# selected by English's rules. The two counted messages here collapse to a
+# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
+# Fluent matches against the number itself. A Makasar noun is unmarked after a
+# numeral anyway, so one form is correct.
+
+
+## Answer submission — the check-work button and the status it reports.
+
+answer-checking = Niparessa...
+answer-submitting = Nikiring...
+
+answer-checking-status = Paressa jawaban
+answer-submitting-status = Kiring jawaban
+
+answer-correct = Tojeng
+answer-incorrect = Sala
+
+answer-response-saved = Jawaban le'ba' niboli'
+
+answer-percent-credit = Nilai { $percent }%
+answer-percent-correct = { $percent }% tojeng
+answer-percent-short = { $percent } %
+
+max-credit-available = Nilai kaminang lompo akkullea nigappa: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] tena nia' pole percobaan tassisa
+       *[other] tassisa { $count } percobaan
+    }
+
+validation-correct = (Tojeng)
+validation-incorrect = (Sala)
+validation-partially-correct = (Sipa'gang tojeng)
+
+answer-show-responses = Paccinikangi { $count } jawaban untu' { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Pappiali balasa'
+
+collapsible-click-to-open = (klik untu' sungke)
+collapsible-click-to-close = (klik untu' tongko')
+
+collapsible-initializing = Nipasadia...
+
+footnote-show = Paccinikangi catatang rawa
+footnote-hide = Cokkoi catatang rawa
+
+description-more-information = katarangang la'biangngang
+
+
+## Controls
+
+slider-previous = Riolo
+slider-next = Ribokoang
+
+keyboard-open = Sungke papan katti'
+keyboard-close = Tongko' papan katti'
+
+choice-input-remove-choice = Pela'i { $choice }
+
+matrix-remove-row = Pela'i baris
+matrix-add-row = Tambai baris
+matrix-remove-column = Pela'i kolom
+matrix-add-column = Tambai kolom
+
+subset-add-remove-points = Tamba/Pela' titik
+subset-toggle-points-intervals = Sambei titik siagang selang
+subset-move-points = Palette'i titik
+subset-clear = Bissai
+
+orbital-add-row = Tambai baris
+orbital-remove-row = Pela'i baris
+orbital-add-box = Tambai kotak
+orbital-remove-box = Pela'i kotak
+orbital-add-up-arrow = Tambai pana mange rate
+orbital-add-down-arrow = Tambai pana mange rawa
+orbital-remove-arrow = Pela'i pana
+
+orbital-row-label = Label untu' baris { $row }
+
+pretzel-answer = Jawaban
+
+summary-statistics-caption = Ringkasan statistik battu ri { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ungkapan matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ungkapan sala:
+
+
+## Document status
+
+viewer-initializing = Nipasadia...
+
+
+## Errors
+
+error-heading = Kasalang
+
+error-found-at =
+    { $span ->
+        [line] Nigappa ri baris { $startLine }.
+       *[lines] Nigappa ri baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Anne dokumenga nia' kasalanna!
+
+diagnostic-heading-error = Kasalang
+diagnostic-heading-warning = Pappakainga'
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Petunju'
+
+accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Pappakainga' aksesibilitas
+
+something-went-wrong = Nia' apa-apa sala.
+
+renderer-load-failed = se're perender tena nakkulle nigappa. Muat pole anne halamanga.
+
+core-start-failed = Anne dokumenga tena nakkulle nipa'jari. Muat pole anne halamanga.
+
+core-start-failed-busy = Anne dokumenga tena nakkulle nipa'jari. Nia' siapa are dokumen appakkaramula sipa'rua, na akkulle la'bi sallo ri alat lambaka. Muat pole anne halamanga punna le'ba' ngaseng dokumen maraenga.
+
+core-start-failed-retry = Anne dokumenga tena nakkulle nipa'jari.
+
+core-start-failed-busy-retry = Anne dokumenga tena nakkulle nipa'jari. Nia' siapa are dokumen appakkaramula sipa'rua, na akkulle la'bi sallo ri alat lambaka.
+
+core-start-retry = Coba pole
+
+saved-state-unavailable = Jama-jamang katte le'baka niboli' tena nakkulle nigappa.

--- a/packages/i18n/locales/mak/content.ftl
+++ b/packages/i18n/locales/mak/content.ftl
@@ -16,7 +16,7 @@
 # ## Word order
 #
 # **The noun comes first and every modifier follows it**, in the order width,
-# dash pattern, colour: «garis kapala' te'te'-te'te' eja» is *thick dashed red
+# dash pattern, colour: «garis kapala' tappolo-polo eja» is *thick dashed red
 # line*. So `style-with-noun` and `style-filled-with-noun` put `{ $noun }`
 # before `{ $description }` — the reverse of English's sequence of placeables,
 # and a fact about Makasar rather than a failure to translate. `style-stroke`

--- a/packages/i18n/locales/mak/content.ftl
+++ b/packages/i18n/locales/mak/content.ftl
@@ -1,0 +1,292 @@
+# Makasar (Basa Mangkasara') content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, not Lontara and not Ukiri' Jangang-jangang**, for the
+# reasons `chrome.ftl`'s header sets out in full — Latin is what Makasar is
+# printed in today, and neither historic script writes the final glottal stop,
+# the geminates or the syllable-final nasal, so a seed written in one could not
+# be checked word against word. The final glottal stop is the **ASCII
+# apostrophe `'` (U+0027)** here as in every other file of this catalog; U+2019
+# appears nowhere.
+#
+# ## Word order
+#
+# **The noun comes first and every modifier follows it**, in the order width,
+# dash pattern, colour: «garis kapala' te'te'-te'te' eja» is *thick dashed red
+# line*. So `style-with-noun` and `style-filled-with-noun` put `{ $noun }`
+# before `{ $description }` — the reverse of English's sequence of placeables,
+# and a fact about Makasar rather than a failure to translate. `style-stroke`
+# keeps English's internal order of the three adjectives, which is Makasar's
+# order too.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «poligon biasa { $numSides } sisina» and leaves `tail` empty, as English
+# does: the side count follows the noun here as well.
+#
+# ## Gender, role and number
+#
+# **No `$gender` fork and no `$role` fork.** Makasar has no grammatical gender,
+# so `noun-gender` answers the single token `neuter`, and it does not inflect a
+# modifier for the position its phrase is going into, so the three clause
+# positions are written identically. Both are claims about the language rather
+# than gaps in the seed.
+#
+# **Nothing selects on a count.** A Makasar noun is unmarked after a numeral,
+# and CLDR has no plural data for `mak` in any case.
+#
+# ## Vocabulary, and what this file does not know
+#
+# The geometry words are **Indonesian, declared as such**: Makasar-speaking
+# schools teach mathematics in Indonesian, and «segitiga», «persegi panjang»,
+# «lingkaran», «poligon», «vektor» and «fungsi» are the words a Makasar student
+# has met. Where Makasar has its own word the seed is confident of, it is
+# used: «le'leng», «kebo'», «eja», «kunyi'» for the four colours it knows;
+# «kapala'» and «nipisi'» for thick and thin; «bone» for what fills a shape and
+# «nibonei» for *filled*; «tanra» for a mark; «tojeng» and «sala» for true and
+# false; «pakkuta'nang» for a question; «bageang» for a part; «pattujuang» for
+# an aim; «punna» for *if* and «yareka» for *or*.
+#
+# **The colours are the weakest part of this file and a reviewer should start
+# there.** Four are Makasar; the other eight are written as plain Indonesian
+# loans («abu-abu», «oranye», «hijau», «sian», «biru», «ungu», «merah muda»,
+# «coklat») because the seed has no Makasar term for them that it trusts.
+# Nothing was invented to fill the gap.
+#
+# **`.point` is «titik», the Indonesian word.** The Buginese catalog beside
+# this one writes «tetti'»; the seed is not confident of the Makasar cognate's
+# shape, and would rather write the loan a Makasar reader certainly knows than
+# a spelling it guessed.
+
+
+## Style vocabulary
+
+color =
+    .black = le'leng
+    .white = kebo'
+    .gray = abu-abu
+    .red = eja
+    .orange = oranye
+    .yellow = kunyi'
+    .green = hijau
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = merah muda
+    .brown = coklat
+
+line-width =
+    .thick = kapala'
+    .thin = nipisi'
+
+line-style =
+    .dashed = tappolo-polo
+    .dotted = te'te'-te'te'
+
+fill-style =
+    .horizontal = garis anrawang
+    .vertical = garis ammenteng
+    .diagonal = garis miring
+    .backdiagonal = garis miring tibali
+    .dots = te'te'
+    .diamonds = katupa'
+
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = kurva
+    .function = fungsi
+    .slope-field = medan kemiringan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis tappolo
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = persegi panjang
+    .circle = lingkaran
+    .region = daera
+    .point = titik
+    .square = persegi
+    .diamond = katupa'
+    .cross = tanra silang
+    .plus = tanra tamba
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon biasa { $numSides } sisina
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = nibonei
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } siagang { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } siagang { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } siagang { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] siagang batas { $border }
+        [and] siagang tommi batas { $border }
+        [and-article] siagang tommi batas { $border }
+       *[with] siagang batas { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = tena nanibonei
+
+style-text =
+    { $parts ->
+        [background] { $color } siagang latar { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = tena nia'
+
+
+## Boolean words
+
+boolean-true = tojeng
+boolean-false = sala
+
+
+## Answer buttons
+
+answer-submit-label = Paressai
+answer-submit-label-no-correctness = Kiringi jawaban
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kagiatang
+    .aside = Sisipang
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Conto
+    .exercise = Latihang
+    .exercises = Latihang
+    .given-answer = Jawaban
+    .note = Catatang
+    .objectives = Pattujuang
+    .paragraphs = Paragraf
+    .part = Bageang
+    .problem = Soala'
+    .problems = Soala'
+    .proof = Bukti
+    .question = Pakkuta'nang
+    .section = Bab
+    .solution = Solusi
+    .task = Tugasa'
+    .theorem = Teoréma
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Petunju'
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gambara' { $enumeration }
+        [numbered-caption] Gambara' { $enumeration }{ ": " }
+        [unnumbered-caption] Gambara'{ ": " }
+       *[unnumbered] Gambara'
+    }
+
+
+## Paginator controls
+
+paginator-previous = Riolo
+paginator-next = Ribokoang
+paginator-page = Halaman
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = yareka
+
+piecewise-condition-if = punna
+
+piecewise-condition-otherwise = punna tena nakamma
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so those
+## 130 keys fall back to English. South Sulawesi teaches secondary chemistry in
+## Indonesian, out of Indonesian textbooks, so the element names a Makasar
+## student meets are the Indonesian ones, and a Makasar table would be a claim
+## about spelling rather than about the language.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Lambang kimia sala
+chemistry-invalid-ionic-compound = Senyawa ion sala
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = kosong
+
+math-embedded-input-blank-ordinal = kosong { $ordinal } battu ri { $total }

--- a/packages/i18n/locales/mak/diagnostics.ftl
+++ b/packages/i18n/locales/mak/diagnostics.ftl
@@ -1,0 +1,693 @@
+# Makasar (Basa Mangkasara') diagnostics: the warnings and errors the worker
+# raises and the reader is shown. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth. Selected by `uiLocale`, not by the language the
+# document was written in.
+#
+# Message ids are never translated — only the text to the right of `=`. Neither
+# are the DoenetML identifiers quoted inside these sentences: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence` and every tag and attribute name like them are part of
+# the language an author writes, not prose, and stay in English exactly as
+# written. So does the `[deprecation]` marker, which is a label rather than a
+# word.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and apostrophe** are `chrome.ftl`'s: Latin rather than Lontara or
+# Ukiri' Jangang-jangang, and the final glottal stop written with the ASCII
+# apostrophe `'` (U+0027) everywhere.
+#
+# **The technical vocabulary is Indonesian and is declared as such** —
+# komponen, atribut, variabel, dimensi, matriks, referensi, fungsi, persamaan.
+# Makasar speakers are schooled in Indonesian, and these are the words the
+# community uses; inventing Makasar equivalents would put words in front of a
+# reader that no Makasar reader has met.
+#
+# **What is Makasar is the frame**, and it carries the whole file:
+#
+#   «tena»             *tidak*, the plain negator
+#   «tena nakkulle»    *tidak dapat* — «akkulle» is *dapat*
+#   «tena nia'»        *tidak ada*
+#   «tenapa»           *belum*; «tenapa nipare'» is *belum diterapkan*
+#   «tanipaduli»       *diabaikan*
+#   «nigappa»          *ditemukan*; «tena nigappa» is *tidak ditemukan*
+#   «musti»            *harus*
+#   «lanri»            *karena*
+#   «punna»            *jika*
+#   «mingka»           *tetapi*
+#   «siagang»          *dengan*, and also *dan*
+#   «yareka»           *atau*
+#   «battu ri»         *dari*; «untu'» *untuk*; «ri» *di*; «ri lalanna» *di dalam*
+#   «ngaseng»          *semua*; «tunggala'» *tiap*; «lebbi na» *lebih dari*
+#   «dudu»             *terlalu*, written after the adjective: «ca'di dudu»
+#   «anne» / «anjo»    *ini* / *itu*
+#
+# **This is not the Buginese catalog respelled.** `locales/bug` is the
+# neighbouring language, and its function words are different words: «de'»,
+# «wedding», «sibawa», «iyaré'ga», «nasaba», «rékko», «naé», «pole ri»,
+# «maneng». A sentence here written with one of those is a mistake, not a
+# variant, and so is one that has slipped back into Indonesian «tidak», «yang»
+# or «karena».
+#
+# This is a **framed** catalog: the sentences are Makasar, the nouns inside
+# them are declared Indonesian, and a speaker should expect to correct the
+# sentences as often as the words.
+#
+# **No plural branches.** CLDR has no plural data for `mak`, so every
+# `[one]`/`[other]` fork English writes over a count is collapsed here; most
+# become a plain message, since a Makasar noun is unmarked after a numeral.
+# The one exception is `field-function-wrong-num-outputs`, where English is
+# not counting but distinguishing a one-output field from a two-output one;
+# that fork is kept as the numeric literal `[1]`, which Fluent matches against
+# the number itself rather than against a plural category.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } tanipaduli punna rua titik ujung nipattantu
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } tanipaduli punna titik ujung siagang titik tangnga nipattantu ngaseng
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tena nia' matu-matunna punna tena nia' titik tangnga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis anrolai titik-titik dimensina tena nakkulle nipattantu.
+
+line-points-too-few-dimensions = Garis musti anrolai titik-titik dimensina kurang-kurangna rua.
+
+line-points-depend-on-variables = Garis anrolai titik-titik anturukia variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis ri variabel { $variable1 } siagang { $variable2 } sala.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar nipattantu sipa'rua ri through, endpoint, siagang direction. Through le'baka nipattantu tanipaduli.
+
+ray-dimension-mismatch = numDimensions ri sinar tena nasiratang.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor nipattantu sipa'rua ri head, tail, siagang displacement. Head le'baka nipattantu tanipaduli.
+
+vector-dimension-mismatch = numDimensions ri vektor tena nasiratang.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Tena nakkulle nibesok mange ri `<{ $component }>` lanri tena nia' variabel keadaan nearestPoint.
+
+constrain-to-without-nearest-point = Tena nakkulle nibatasi mange ri `<{ $component }>` lanri tena nia' variabel keadaan nearestPoint.
+
+constrain-to-interior-without-nearest-point = Tena nakkulle nibatasi mange ri lalanna `<{ $component }>` lanri tena nia' variabel keadaan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition tanipaduli untu' choiceInput teaya inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indices le'baka nipattantu untu' choiceInput tanipaduli lanri jaina indices tena nasiratang siagang jaina ana' choice.
+
+pretzel-indices-count-mismatch = Indices le'baka nipattantu untu' problem tanipaduli lanri jaina indices tena nasiratang siagang jaina ana' problem.
+
+shuffle-indices-count-mismatch = Indices le'baka nipattantu untu' shuffle tanipaduli lanri jaina indices tena nasiratang siagang jaina komponen.
+
+indices-ignored-out-of-range = Indices le'baka nipattantu untu' { $component } tanipaduli lanri nia' indeks assulu' battu ri jangkauang.
+
+pretzel-indices-repeated = Indices le'baka nipattantu untu' pretzel tanipaduli lanri nia' indeks nipakamma pole.
+
+pretzel-circuit-first-index = Indices le'baka nipattantu untu' pretzel ri mode circuit tanipaduli lanri indeks uruna musti 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Sollanna `<{ $component }>` anjama siagang ana' rupa string, atribut `type` musti nipattantu.
+
+invalid-type-defaulting-to-math = Tipe { $type } sala untu' komponen { $component }. Musti se're battu ri math, text, number, yareka boolean. Ammake math.
+
+string-not-valid-component-to-arrange = String "{ $value }" teai komponen baji' untu' { $component }. Tanipaduli.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipe { $type } sala, tipe nipattantu ri number.
+
+invalid-variable-value = Nilai variabel sala: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } musti rupa bilangan
+
+variant-index-must-be-integer = Indeks varian { $index } musti rupa bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` tenapa nipare' untu' ukuran absolut. Sangkara' nipinra a'jari relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` tenapa nipare' untu' ukuran absolut. Margin nipinra a'jari relatif.
+
+side-by-side-no-block-child = `<{ $component }>` sala: musti nia' kurang-kurangna se're ana' rupa blok.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` ri `<label>` grafis tanipaduli.
+
+label-for-must-resolve-to-one = Atribut `for` ri `<label>` musti annuju tepa' ri se're komponen.
+
+label-for-unresolved = Atribut `for` ri `<label>` tena nakkulle nituju mange ri se're komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` ri `<label>` annuju ri `<answer>` masukanna nitulisi' langsung; tujui anjo masukanga langsung.
+
+label-for-answer-without-input = Atribut `for` ri `<label>` annuju ri `<answer>` tenaya nia' masukanna untu' nilabeli.
+
+label-for-must-reference-input-or-answer = Atribut `for` ri `<label>` musti annuju ri se're masukan yareka se're jawaban.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Untu' aksesibilitas, `<{ $component }>` musti nia' katarangang bodona yareka nipattantu salaku dekoratif.
+
+accessibility-video-short-description = Untu' aksesibilitas, `<video>` musti nia' katarangang bodona.
+
+accessibility-input-short-description-or-label = Untu' aksesibilitas, `<{ $component }>` musti nia' katarangang bodona yareka label.
+
+accessibility-answer-input-short-description-or-label = Untu' aksesibilitas, se're `<answer>` ampareka masukan musti nia' katarangang bodona yareka label.
+
+accessibility-short-description-contains-math = Katarangang bodo tena nabaji' punna nia' komponen matematika kamma `<{ $component }>`. Tulisi' isi matematikana siagang kana-kana.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kontrasna tena nagannaki untu' teks judul bageang (mode le'leng) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; naparalluang kurang-kurangna { $threshold }:1).
+       *[other] { $colorName } kontrasna tena nagannaki untu' teks judul bageang ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; naparalluang kurang-kurangna { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Tenapa nipare' `<circle>` anrolai { $count } titik punna titik-titikna tena nia' nilai numerikna.
+
+circle-too-many-through-points = Tena nakkulle nirekeng lingkaran anrolaia lebbi na 3 titik.
+
+circle-overprescribed-radius-center-points = Tena nakkulle nirekeng lingkaran jari-jarina, posina siagang titik nirolaina nipattantu ngaseng.
+
+circle-center-with-multiple-points = Tena nakkulle nirekeng lingkaran siagang posi tertentu anrolaia lebbi na 1 titik.
+
+circle-radius-too-small = Tena nakkulle nirekeng lingkaran: lanri bella'na rua titika iamintu { $distance }, jari-jari { $radius } le'baka nipattantu ca'di dudu.
+
+circle-radius-with-many-points = Tena nakkulle nipare' lingkaran anrolaia lebbi na rua titik siagang jari-jari tertentu.
+
+circle-invalid-center-or-through-points = Posi yareka titik nirolaina lingkaran sala.
+
+circle-radius-center-with-multiple-points = Tena nakkulle nirekeng jari-jarina lingkaran siagang posi tertentu anrolaia lebbi na 1 titik.
+
+circle-change-radius-non-numerical = Tena nakkulle nipinra jari-jarina lingkaran titik nirolaina teaya numerik
+
+circle-radius-with-points-non-numerical = Tena nakkulle nipare' lingkaran anrolaia lebbi na se're titik siagang jari-jari tertentu punna tena nia' nilai numerik.
+
+circle-change-center-non-numerical = Tenapa nipare' pappinra posina lingkaran anrolaia titik-titik teaya numerik.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Dimensi domainna fungsi tena nagannaki. Domain nia' { $intervals } selanna mingka fungsi nia' { $inputs } masukanna.
+
+function-domain-invalid-format = Format domainna fungsi sala.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Maksimum fungsi teaya numerik tanipaduli.
+        [minimum] Minimum fungsi teaya numerik tanipaduli.
+        [extremum] Ekstremum fungsi teaya numerik tanipaduli.
+        [point] Titik fungsi teaya numerik tanipaduli.
+        [slope] Kemiringan fungsi teaya numerik tanipaduli.
+       *[other] { $type } fungsi teaya numerik tanipaduli.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Maksimum fungsi kosonga tanipaduli.
+        [minimum] Minimum fungsi kosonga tanipaduli.
+        [extremum] Ekstremum fungsi kosonga tanipaduli.
+        [point] Titik fungsi kosonga tanipaduli.
+       *[other] { $type } fungsi kosonga tanipaduli.
+    }
+
+function-points-too-close = Fungsi nia' rua titikna reppe' dudu tampa'na. Fungsi tena nakkulle nipattantu.
+
+function-iterates-input-output-mismatch = Iterasi fungsi akkulle bawang punna jaina masukanna sangkamma jaina assuluna. Anne fungsia nia' { $inputs } masukanna siagang { $outputs } assuluna.
+
+## `<sequence>`
+
+sequence-invalid-length = La'buna barisan sala. Musti rupa bilangan bulat teaya negatif.
+
+sequence-invalid-step = Langkana barisan sala. Musti rupa bilangan untu' barisan tipe { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ri barisan bilangan sala. Musti rupa bilangan.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ri barisan huruf sala. Musti rupa kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" ri barisan sala.
+
+select-from-sequence-coprime-not-numbers = coprime tanipaduli lanri nipileya teai bilangan
+
+select-from-sequence-coprime-with-exclude-combinations = coprime tanipaduli lanri excludeCombinations nipattantu
+
+## Resolving a `target`
+
+target-not-found = Target untu' `<{ $source }>` sala: target tena nigappa.
+
+target-state-variable-not-found = Target untu' `<{ $source }>` sala: tena nigappa variabel keadaan niarenga "{ $property }" ri `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabelna `<odeSystem>` musti maraeng battu ri variabel bebas.
+
+ode-system-duplicate-variable-names = Tena nakkulle nipattantu fungsi ruas kanan ODE siagang areng variabel terikat nipakamma pole.
+
+ode-system-rhs-function-error = Tena nakkulle nipattantu fungsi ruas kanan ODE. Nia' kasalang ri wattunna nipare' fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Tena nakkulle nipattantu sudu' ri alla'na { $count } garis
+
+angle-invalid-through-point = Nia' titik sala ri through battu ri `<angle>`
+
+parabola-vertex-too-many-points = Tenapa nipare' parabola siagang titik puncak tertentu anrolaia lebbi na 1 titik.
+
+parabola-too-many-points = Tenapa nipare' parabola anrolaia lebbi na 3 titik.
+
+intersection-too-many-items = Tenapa nipare' irisan untu' lebbi na rua objek
+
+## Other math components
+
+ionic-compound-not-two-ions = Tenapa nipare' senyawa ion pantaranganna untu' rua ion.
+
+ionic-compound-needs-cation-and-anion = Senyawa ion nipare' bawang untu' se're kation siagang se're anion.
+
+solve-equations-cannot-evaluate = Tena nakkulle nipassala' persamaan lanri persamaanna tena nakkulle nievaluasi: { $equation }
+
+math-operators-operand-number-required = operandNumber musti nipattantu punna eroki nialle se're operan matematika.
+
+eigen-decomposition-failed = Tena nakkulle nirekeng nilai eigenna matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } tena nammumba ri lalanna pola, jari tuli siratangi siagang kakosongang.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: tena nakkulle nipahang grid="{ $grid }". Nilaina musti none, medium, dense, yareka rua bilangan positif nipasisa'la' spasi, contona grid="1 0.5". Kisi tena nipare'.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` naparalluang fungsi siagang { $expected ->
+        [1] se're assulu', iamintu kemiringan y' ri tunggala' titik, contona `y - x`
+       *[other] rua assulu', iamintu vektor ri tunggala' titik, contona `(y, -x)`
+    }, mingka fungsi nisarea nia' { $found ->
+       *[other] { $found } assulu'
+    }. { $alternative ->
+        [none] Tena nia' nipare'.
+       *[other] `<{ $alternative }>` iamintu komponen untu' fungsi kammaya anjo. Tena nia' nipare'.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` tanipaduli lanri fungsina nisare tommi ri lalanna komponen; ia ri lalanga nipake. Sarei fungsina se're bawang battu ri rua caraya.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` angngarengi variabelna ungkapan nitulisia langsung ri lalanna komponen. { $reason ->
+        [function-child] Fungsi anrinni nisare salaku ana' `<function>`, angngarengia variabelna kalenna, jari `variables` tanipaduli.
+       *[no-expression] Tena nia' ungkapan kammaya anjo anrinni, jari `variables` tanipaduli.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" tena nirurungang ri perender prefigure; ammake sipa' posisi kanang.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" tena nirurungang ri perender prefigure; ammake sipa' posisi rate.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbu sala untu' konversi prefigure; ammake bbox bawaan (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: sangkara' sala untu' konversi prefigure; ammake sangkara' diagram bawaan 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio sala untu' konversi prefigure; ammake rasio aspek bawaan 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: bella'na kisi reppe' dudu untu' batas sumbuna; kisi nipela' ri perender prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi tena nanipare' punna perender PreFigure tena nipake.
+
+multiple-annotations-children = Nigappa jai ana' `<annotations>` ri lalanna `<graph>`; tanipaduli ngaseng pantaranganna ia kala'busanga.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tena nakkulle nipalua yareka nisalin tipe komponen tenaya niasseng: { $type }.
+
+copy-prop-not-found = Tena nigappa prop { $property } ri komponen tipe { $component }
+
+collect-no-source = Tena nia' sumber nigappa untu' collect.
+
+collect-invalid-component-type = Tena nakkulle nipa'rappungang komponen tipe `<{ $component }>` lanri anjo teai tipe komponen baji'.
+
+reference-index-unavailable = Tena nakkulle nituju indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Tena nakkulle nikio' { $action } ri komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Rupanna data sala. La'buna baris tena nasangkamma. Nigappa ri componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data nia' areng kolom nipakamma pole. Nigappa ri componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data tappela' se're areng kolom. Nigappa ri componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Se're award untu' anne jawabanga a'jari battu ri jawaban nikiringa ri tag answer kalenna, na anjo ampareki sipa' tenaya nikapang.
+
+answer-max-num-attempts-in-section-wide-check-work = Ampattantui `maxNumAttempts` ri `<answer>` niaka ri lalanna wadah siagang `sectionWideCheckWork` tena nia' matu-matunna, lanri jaina percobaan nakuasai anjo wadaha. Pattantui `maxNumAttempts` ri wadahna.
+
+nested-section-wide-check-work-max-num-attempts = Ampattantui `maxNumAttempts` ri wadah siagang `sectionWideCheckWork` niaka ri lalanna wadah maraeng siagang `sectionWideCheckWork` tena nia' matu-matunna, lanri jaina percobaan nakuasai wadah kaminang pantaraka. Pattantui `maxNumAttempts` ri wadah kaminang pantaraka.
+
+answer-attributes-need-symbolic-equality = Atribut { $attributes } tena nia' matu-matunna punna symbolicEquality tena nipattantu.
+
+answer-invalid-type = Tipe untu' answer sala: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Lanri komponen `<{ $component }>` tena nia' arenna, tena nakkulle nipake salaku atribut modul
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` tena nakkulle nipake salaku atribut se're modul lanri tipe komponen `<module>` le'ba'mi nia' atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` tanipaduli ri komponen `<conditionalContent>` niaka ana' case yareka else.
+
+slider-markers-type-mismatch = Tipe tanra tena nasiratang siagang tipe panggeser.
+
+pretzel-problem-needs-statement-and-answer = Pretzel sala: tunggala' `<problem>` musti nia' se're `<statement>` siagang se're `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel sala: ri mode="circuit", `<problem>` uruna tena nakkulle a'jari pangicu'.
+
+## Attribute values
+
+attribute-invalid-values = Nilai { $values } untu' atribut `{ $attribute }` sala; tanipaduli.
+
+attribute-must-be-references = Nilai `{ $value }` untu' atribut `{ $attribute }` sala. Atribut musti nipare' battu ri referensi appakkaramulaya siagang `$`.
+
+math-input-invalid-function-names = <mathInput>: areng fungsi salaya ri { $attribute } tanipaduli: { $names }. Bageang tampilanna tunggala' areng musti kurang-kurangna 2 karakter (huruf yareka tanra sambung); akkulle naturuki akhiran pilihang `|<alternatif mathspeak>`.
+
+## Building components from the source
+
+component-type-invalid = Tipe komponen sala: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } tena nakkulle nipakamma pole.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" sala untu' komponen tipe `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definisi gaya { $styleNumber } kontrasna tena nagannaki untu' { $context ->
+        [text-on-background] warna teks mange ri warna latar
+        [high-contrast] warna kontras tinggi mange ri kanvas
+        [line] warna garis mange ri kanvas
+        [marker] warna tanra mange ri kanvas
+       *[text-on-canvas] warna teks mange ri kanvas
+    }{ $mode ->
+        [dark] { " (mode le'leng)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; naparalluang kurang-kurangna { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Manna definisi gaya { $styleNumber } ampattantui warna kontrasna gannaki untu' mode singara', warna mode le'leng nipa'jaria battu ri anjo nilaia kontrasna tena nagannaki ri alla'na warna teks siagang warna latar ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; naparalluang kurang-kurangna { $threshold }:1). { $suggestion ->
+        [available] Sollanna kontrasna gannaki ri mode le'leng, tinggikangi kontras mode singara' (contona pattantui { $lightAttribute }="{ $lightColor }") yareka timpai warna mode le'leng (contona pattantui { $darkAttribute }="{ $darkColor }").
+       *[none] Sollanna kontrasna gannaki ri mode le'leng, tinggikangi kontras mode singara' yareka timpai warna nipa'jaria siagang textColorDarkMode siagang/yareka backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Manna definisi gaya { $styleNumber } ampattantui warna teks kontrasna gannaki untu' mode singara', warna teks mode le'leng nipa'jaria battu ri anjo nilaia kontrasna tena nagannaki mange ri kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; naparalluang kurang-kurangna { $threshold }:1). { $suggestion ->
+        [available] Sollanna kontrasna gannaki ri mode le'leng, tinggikangi kontras mode singara' (contona pattantui textColor="{ $lightColor }") yareka timpai warna mode le'leng (contona pattantui textColorDarkMode="{ $darkColor }").
+       *[none] Sollanna kontrasna gannaki ri mode le'leng, tinggikangi kontras mode singara' yareka timpai warna nipa'jaria siagang textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Se're bageang akkulle bawang ampilei se're <stylePalette>; ammake ia kala'busanga.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = tena nakkulle nipattantu varian unik battu ri { $component } lanri numToSelect teai bilangan bulat teaya negatif.
+
+variant-num-to-select-not-constant-number = tena nakkulle nipattantu varian unik battu ri { $component } lanri numToSelect teai bilangan tetap.
+
+variant-with-replacement-not-constant-boolean = tena nakkulle nipattantu varian unik battu ri { $component } lanri withReplacement teai boolean tetap.
+
+variant-select-weight-disables-unique = Varian unik untu' select nipa'jari tena punna nia' opsi ampattantua selectWeight yareka selectForVariants
+
+variant-coprime-undetermined = tena nakkulle nipattantu varian unik battu ri { $component } lanri tena nakkulle nipattantu angkana coprime tuli sala.
+
+variant-attribute-not-constant = tena nakkulle nipattantu varian unik battu ri { $component } lanri { $attribute } teai nilai tetap.
+
+variant-attribute-not-number = tena nakkulle nipattantu varian unik battu ri { $component } lanri { $attribute } teai bilangan.
+
+variant-attribute-wrong-type-for-sequence =
+    tena nakkulle nipattantu varian unik battu ri { $component } tipe { $type } lanri { $attribute } teai { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ungkapan matematika baji'
+        [integer] bilangan bulat
+       *[number] bilangan
+    }.
+
+variant-length-not-integer = tena nakkulle nipattantu varian unik battu ri { $component } lanri length teai bilangan bulat.
+
+variant-sort-not-implemented = tenapa nipare' varian unik battu ri { $component } siagang sort
+
+variant-exclude-combinations-not-implemented = tenapa nipare' varian unik battu ri { $component } siagang excludeCombinations
+
+variant-math-exclude-not-implemented = tenapa nipare' varian unik battu ri { $component } tipe math siagang exclude
+
+variant-non-constant-exclude-not-implemented = tenapa nipare' varian unik battu ri { $component } siagang exclude teaya tetap
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: tena nirurungang ri perender prefigure grafik; turunanna nilaloi.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri tena nappantu' yareka tena nasukku'; turunanna nilaloi.
+
+prefigure-curve-label-omitted = { $subject }: label tena nirurungang ri elemen kurva battua ri konversi; label nipela'.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipe definisi fungsi kurva '{ $definitionType }' tena nirurungang; turunanna nilaloi.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions ri regionBetweenCurves tena nirurungang; turunanna nilaloi.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves anrurungangi bawang fungsi ana' tipe formula; turunanna nilaloi.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' tena nirurungang untu' { $labelKind ->
+        [line-family] label golongang garis
+       *[point] label titik
+    }; ammake perataan bawaan PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya bone '{ $fillStyle }' tena nirurungang ri PreFigure; ammotere' mange ri bone padat.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' tena niasseng na nipela' battu ri assuluna PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya tanra '{ $markerStyle }' nipalette' mange ri gaya 'diamond' battu ri PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya tanra '{ $markerStyle }' tena nirurungang ri PreFigure; ammake gaya bawaan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` sala; target tena nakkulle nituju. Anotasi nipela'.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` annuju ri jai target; ammake target uruna.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` sala; target nia' ri pantaranna grafik ampakemaea. Anotasi nipela'.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` sala; target teai objek grafis nirurungang ri konversi prefigure. Anotasi nipela'.
+
+annotation-text-missing = `<annotation>`: `text` tappela' yareka kosong; ampare' teks kosong.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Nigappa pattoli' anggulilinga.
+       *[other] Nigappa pattoli' anggulilinga anrurungangi komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Tena nia' acuan nigappa untu' referensi: `{ $reference }`
+
+reference-multiple-referents = Nigappa jai acuan untu' referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } ri `<{ $componentType }>` sala.
+
+children-invalid = Ana' `<{ $componentType }>` sala: nigappa ana' salaya: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` untu' atribut `{ $attribute }` sala, ammake nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML versi { $version } tena nigappa.
+       *[other] DoenetML versi { $version } tena nigappa. Ammotere' mange ri versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML sala: { $content }
+
+parse-tag-missing-close-tag = DoenetML sala: Tag `{ $tag }` tena nia' tag pattongko'na. Nitayang nia' tag antongko' kalenna yareka tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML sala: Nia' kasalang ri tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML sala: Atribut `{ $attribute }` kamma tappela' nilai.
+
+parse-attribute-invalid = DoenetML sala: Atribut `{ $attribute }` sala
+
+parse-attribute-value-invalid = DoenetML sala: Nilai atribut `{ $value }` sala
+
+parse-attribute-value-quote-mismatch = DoenetML sala: Nilai atribut `{ $value }` sala. Tanra kutipna tena nasiratang. Kamma tappela'ki se're `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML sala: Nigappa tag tenaya nia' areng tagna, contona `<`
+
+parse-tag-not-closed = DoenetML sala: Tag `{ $tag }` tenapa nitongko' (kamma tappela' `>`).
+
+parse-self-closing-tag-name-missing = DoenetML sala: Nigappa tag tenaya nia' areng tagna `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML sala: Tag `{ $tag }` tenapa nitongko' (kamma tappela' `/>`).
+
+parse-tag-invalid-attributes = DoenetML sala: Tag `{ $tag }` sala. Atributna akkulle sala.
+
+parse-close-tag-name-missing = DoenetML sala: Nigappa tag pattongko' tenaya nia' areng tagna, contona `</`
+
+parse-attribute-value-unquoted = Nilai atribut musti nialle siagang tanra kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML sala: Nigappa tag pattongko' `{ $tag }`, mingka tena nia' tag passungke siratanna
+
+parse-close-tag-mismatched = DoenetML sala: Tag pattongko' tena nasiratang. Nitayang `</{ $expected }>`. Nigappa `{ $found }`
+
+parser-node-unconvertible = Tena nakkulle nipinra simpul { $node } a'jari simpul Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' sala. { $reason ->
+        [characters] Areng akkulle bawang nia' huruf, angka, garis rawa, yareka tanra sambung.
+       *[start] Areng musti appakkaramula siagang huruf.
+    }
+
+component-name-invalid-start = Areng komponen "{ $name }" sala. Areng musti appakkaramula siagang huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer tipe videoWatched musti nia' atribut video
+
+answer-video-watched-video-not-reference = Answer tipe videoWatched musti nia' atribut video rupa referensi
+
+answer-name-not-single-text = Atribut name ri answer musti nia' tepa' se're ana' rupa teks
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Tena nakkulle nialle DoenetML pantara' lanri jai dudu tingkat rekursi. Nia'ka referensi anggulilinga?
+
+external-doenetml-unavailable = Tena nakkulle nialle DoenetML battu ri { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML nialleya battu ri { $attribute }="{ $uri }" sala: tena nasiratang siagang tipe komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` le'ba'mi tappela'; pake `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` ri `<{ $component }>` le'ba'mi tappela'; pake `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` le'ba'mi tappela' na tanipaduli lanri `{ $to }` nipattantu tommi.
+       *[other] [deprecation] Atribut `{ $from }` ri `<{ $component }>` le'ba'mi tappela' na tanipaduli lanri `{ $to }` nipattantu tommi.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` ri `<{ $component }>` le'ba'mi tappela' na tanipaduli.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` ri `<{ $component }>` le'ba'mi tappela'; pake bawang ana' `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` battu ri atribut `{ $attribute }` ri `<{ $component }>` le'ba'mi tappela'; pake `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` akkulle bawang ampa'jari jamak basa Inggris, jari teksna niboli' kamma anjo ri dokumen nitulisia ri { $locale }. Tulisi' bentu' jamakna langsung, yareka pattantui siagang atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` teai elemen Doenet niassenga.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` tena nipa'biang ri aka'na dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` tena nipa'biang ri lalanna `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` tena nia' atribut niarenga `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` ri elemen `<{ $tag }>` musti rupa daftar tunggala' isina se're battu ri: { $allowed }
+       *[other] Atribut `{ $attribute }` ri elemen `<{ $tag }>` musti se're battu ri: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Areng varian untu' select sala. Areng varian { $variantName } ammumba ri { $numOptions } opsi mingka jaina nipilea { $numToSelect }.
+
+select-variant-name-without-options = Nia' varian nipattantu untu' select mingka tena nia' opsi untu' areng varian akkullea: { $variantName }.
+
+select-variant-name-not-possible = Areng varian { $variantName } nipattantua untu' select teai areng varian akkullea.
+
+select-too-few-options = Tena nakkulle nipilei { $numToSelect } komponen battu ri { $numOptions } bawang.
+
+select-from-sequence-too-few-values = Tena nakkulle nipilei { $numToSelect } nilai battu ri barisan la'buna { $length }.
+
+select-from-sequence-indices-count-mismatch = Jaina indeks nipattantua untu' select musti sangkamma jaina nipilea
+
+select-from-sequence-indices-not-integers = Ngaseng indeks nipattantua untu' select musti rupa bilangan bulat
+
+select-from-sequence-index-excluded = Indeks nipattantua untu' selectfromsequence antamai ri nipasalaya
+
+select-from-sequence-indices-excluded-combination = Indeks nipattantua untu' selectfromsequence ampare' kombinasi nipasalaya
+
+select-from-sequence-coprime-not-positive-integers = Tena nakkulle nipilei kombinasi siprima lanri nipileya teai bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Tena nakkulle nipilei bilangan siprima. Ngaseng nilai akkullea nia' faktor passamanna. (Nilai "from" yareka "to" nipattantua musti siprima siagang "step".)
+
+select-from-sequence-coprime-single-number = Tena nakkulle nipilei kombinasi siprima battu ri se're bilangan kalenna teaya 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebbi na 70% kombinasi nipasala ri selectFromSequence
+
+select-from-sequence-coprime-none-found = Tena akkulle nipilei bilangan siprima. Ngaseng nilai akkullea nia' faktor passamanna.
+
+select-from-sequence-too-few-unique-values = Tena nakkulle nipilei { $numToSelect } nilai maraeng battu ri barisan la'buna { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Tena nakkulle nipilei { $numToSelect } nilai battu ri daftar bilangan prima la'buna { $numValues }
+
+select-prime-numbers-values-count-mismatch = Jaina nilai nipattantua untu' select musti sangkamma jaina nipilea
+
+select-prime-numbers-values-not-prime = Ngaseng nilai nipattantua untu' select prime number musti nia' ri daftar bilangan prima
+
+select-prime-numbers-values-excluded-combination = Nilai nipattantua untu' selectPrimeNumbers ampare' kombinasi nipasalaya
+
+select-prime-numbers-excluded-too-many-combinations = Lebbi na 70% kombinasi nipasala ri selectPrimeNumbers
+
+select-random-combination-fluke = Lanri kabatulang jarang dudu, kombinasi nilai acak tena akkulle nipilei
+
+select-random-value-fluke = Lanri kabatulang jarang dudu, nilai acak tena akkulle nipilei
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Anne `<{ $component }>` tena nipaccinikang lanri nia'i ri lalanna matematika mingka teai `inline`. Tambai `inline` sollanna a'jari daftar naung, akkullea antama ri lalanna ungkapan.
+        [expanded] Anne `<{ $component }>` tena nipaccinikang lanri nia'i ri lalanna matematika na `expanded`. Pela'i `expanded`; kotak jaia barisna tena nakkulle antama ri lalanna ungkapan.
+        [on-graph] Anne `<{ $component }>` tena nipaccinikang lanri nia'i ri lalanna matematika nipare'a ri grafik, tenaya nia' tampa'na untu' masukan.
+       *[relative-width] Anne `<{ $component }>` tena nipaccinikang lanri nia'i ri lalanna matematika na sangkara'na relatif. Sarei sangkara'na ri satuan absolut, contona `px`.
+    }

--- a/packages/i18n/locales/mak/editor.ftl
+++ b/packages/i18n/locales/mak/editor.ftl
@@ -1,0 +1,225 @@
+# Makasar (Basa Mangkasara') editor and language-server surfaces: the footer,
+# the diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script, apostrophe and register** are `chrome.ftl`'s: Latin rather than
+# Lontara or Ukiri' Jangang-jangang, the final glottal stop written with the
+# ASCII apostrophe `'` (U+0027), and an Indonesian technical vocabulary
+# declared as a loan register around a Makasar frame — «tena», «tena
+# nakkulle», «tena nia'», «siagang», «yareka», «lanri», «punna», «mingka»,
+# «battu ri», «untu'», «ri», «ngaseng», «tunggala'», «nigappa», «pole».
+#
+# **`WCAG`, `DoenetML`, `styleNumber` and every element and attribute name
+# stay in English.** They are identifiers an author types, not words.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `mak`, so an English-selected
+# branch would be worse than none, and a Makasar noun is unmarked after a
+# numeral in any case.
+#
+# **`help-name-summary` is punctuation.** It renders with `{ $name }` empty
+# for a suggestion the panel has already named, so the em dash and its spaces
+# have to read on their own.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ammotere'
+       *[update] Baru'
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Panampi'
+       *[other] { $word } Panampi' { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+
+editor-variant-filter = Saring...
+
+editor-variant-next = Pilei varian ribokoang
+
+editor-variant-previous = Pilei varian riolo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Nigappa pelanggaran aksesibilitas WCAG AA. Klik untu' { $action ->
+            [close] tongko'
+           *[open] sungke
+        } laporan aksesibilitas.
+        [advisories] Klik untu' { $action ->
+            [close] tongko'
+           *[open] sungke
+        } laporan aksesibilitas. Tena nia' pelanggaran WCAG AA nigappa, mingka nia' saran aksesibilitas maraeng.
+       *[clean] Klik untu' { $action ->
+            [close] tongko'
+           *[open] sungke
+        } laporan aksesibilitas. Tena nia' masala aksesibilitas nigappa.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Nigappa pelanggaran aksesibilitas WCAG AA. Nigappa { $count ->
+           *[other] { $count } pelanggaran WCAG AA
+        }. Klik untu' { $action ->
+            [close] tongko'
+           *[open] sungke
+        } laporan aksesibilitas.
+        [advisories] Tena nia' pelanggaran WCAG AA nigappa. Nigappa { $count ->
+           *[other] { $count } saran aksesibilitas tamba
+        }. Klik untu' { $action ->
+            [close] tongko'
+           *[open] sungke
+        } laporan aksesibilitas.
+       *[clean] Tena nia' pelanggaran WCAG AA nigappa. Klik untu' { $action ->
+            [close] tongko'
+           *[open] sungke
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Bantuang situru' konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Kasalang
+editor-tab-warnings = Pappakainga'
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Jawaban le'baka nikiring
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihang panyunting
+editor-format-as-doenetml = Atoro' salaku DoenetML
+editor-format-as-xml = Atoro' salaku XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Tena nia' kasalang
+editor-no-warnings = Tena nia' pappakainga'
+editor-no-info = Tena nia' diagnostik info
+
+editor-show-info-annotations = Paccinikangi diagnostik info ri panyunting
+editor-show-accessibility-annotations = Paccinikangi diagnostik aksesibilitas ri panyunting
+
+editor-accessibility-learn-more = Pelajari antekamma Doenet anjama aksesibilitas
+
+editor-accessibility-violations-heading = Pelanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masala aksesibilitas maraeng
+editor-none-found = Tena nia' nigappa
+
+
+## Submitted responses
+
+editor-no-responses = Tenapa nia' jawaban nikiring
+editor-response-answer-id = Id jawaban
+editor-response-response = Jawaban
+editor-response-credit = Nilai
+editor-response-submitted = Le'ba' nikiring
+
+
+## The context-help panel
+
+help-placeholder = Boli'i kursor ri areng tag, atribut, yareka { $ref } untu' dokumentasi.
+
+help-unsupported-ref-chain = Bantuang untu' referensi jai bageang kamma { $example } tenapa nipare'.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Tena nia' acuan nigappa untu' referensi: { $ref }.
+        [multiple] Nigappa jai acuan untu' referensi: { $ref }.
+       *[indeterminate] Acuan untu' { $ref } tena nakkulle nipattantu.
+    }
+
+help-learn-about-references = Pelajari passala' referensi →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ri lalanna { $element }
+       *[top] Ri tingkat kaminang rate
+    }{ $allowed ->
+        [none] { " — tena nia' akkullea niboli' anrinni." }
+        [text] { " — tulisi teks anrinni." }
+        [text-and-components] { " — tulisi teks anrinni, yareka coba:" }
+       *[components] { " — akkullea nicoba:" }
+    }
+
+help-suggestions-footer = Katti' { $shortcut } untu' anciniki ngaseng { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } iamintu referensi mange ri { $target }.
+       *[other] { $ref } iamintu referensi mange ri { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Nipa'jari ri { $owner } salaku { $role }.
+       *[other] Nipa'jari ri { $owner } ri baris { $line } salaku { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } iamintu referensi mange ri properti { $property } battu ri { $element }.
+       *[other] { $ref } iamintu referensi mange ri properti { $property } battu ri { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = pa'gang
+help-kind-array-entry = isi larik
+
+help-default = Bawaan:
+help-active-default = Bawaan anjamaya:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai nipa'biang (se're untu' tunggala' item):
+       *[other] Nilai nipa'biang:
+    }
+
+help-suggested-values = Nilai nisarangkang:
+
+help-inserts = Ansisipi:
+
+help-coordinates =
+    { $count ->
+       *[other] Koordinat:
+    }
+
+help-type = Tipe:
+
+help-resolved-style = Gaya le'baka nipattantu (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Areng fungsi le'baka nipattantu:
+help-reset-list = Daftar nipammotere' ri anne masukanga:
+help-added-on-input = Nitamba ri anne masukanga:
+help-removed-on-input = Nipela' ri anne masukanga:
+
+help-reset-overrides = { $reset } antimpai { $additional } siagang { $removed }.

--- a/packages/i18n/locales/mnw/chrome.ftl
+++ b/packages/i18n/locales/mnw/chrome.ftl
@@ -1,0 +1,203 @@
+# Mon (ဘာသာမန်) viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and script.** Mon (ဘာသာမန်) as written in Mon State and in the
+# Mon communities of Thailand, in the Mon-Burmese script. Mon shares most of
+# its letters with Burmese and adds letters of its own, and this catalog uses
+# them rather than their Burmese substitutes: **ၚ** (Mon nga, U+105A) where
+# Burmese writes င, **ၜ** (bba, U+105C), and the Mon medials **ၞ ၟ ၠ**. Mon's
+# other own letters — ၝ (bbe) and ဿ (ssa) — are not in this catalog, because
+# no word it happens to use needs them; their absence is not a claim that Mon
+# lacks them. A corrector must not fold ၚ into င: the two
+# are indistinguishable at a glance, the substitution is invisible on screen,
+# and it breaks every search for a Mon word. Where Burmese letters do appear
+# below they are inside declared Burmese loanwords, listed further down, and
+# they are not Mon spellings of Mon words.
+#
+# **Tone and register are where this seed is weakest, and it says so first.**
+# Mon's register (breathy against clear voice) is carried by the choice of
+# consonant series rather than by a diacritic, so a wrong consonant is a wrong
+# word rather than a misspelling. Where the seed could not choose the series
+# with confidence it chose a different word, or a Burmese loan, rather than
+# guessing.
+#
+# **Spacing.** Mon publishing follows the Burmese convention: no spaces inside
+# a phrase, a space at a phrase or clause boundary. This catalog does the
+# same, which is what decides where these messages may wrap in a narrow panel.
+# It is the opposite of `locales/shn`'s practice, and the difference is real
+# rather than an inconsistency between two files of one batch.
+#
+# **Register, and what is a loan.** Every Mon speaker in Myanmar is schooled
+# in Burmese, and meets computing and higher mathematics in English. This
+# catalog is a **Mon frame around two declared loan vocabularies**, and
+# neither is respelled into invented Mon syllables:
+#
+#   * **Burmese, in its own Burmese spelling**, for the school register Mon
+#     genuinely borrows: သတိပေးချက် (warning), အချက်အလက် (information),
+#     တုံ့ပြန်ချက် (feedback), အောက်ခြေမှတ်စု (footnote), အမှတ် (point),
+#     မြား (arrow), ဇယား (table), အပိုင်း (part), လေ့ကျင့်ခန်း (exercise),
+#     လုပ်ငန်း (task), သက်သေပြချက် (proof), ကွက်လပ် (blank), and — see
+#     `content.ftl` — the whole colour list.
+#   * **English, in the Latin alphabet**, for computing and the DoenetML
+#     vocabulary: `keyboard`, `row`, `column`, `box`, `credit`, `preview`,
+#     `math expression`, `interval`, `document`, `renderer`, `load`,
+#     `summary statistics`, `WCAG AA`, `accessibility`. Myanmar-script
+#     technical writing leaves such terms in Latin letters, and writing them
+#     out in Mon syllables would invent a spelling no reader has seen.
+#
+# The Mon is the frame: နွံ (there is), ဟွံမွဲ (there is not), ဒှ် (to be),
+# ဟွံ (not), ဂှ် (that), မ (relativizer), လဝ် (perfective), မံၚ်
+# (progressive), ပ္ဍဲ (in, at), နူ (from), ကဵု (to, give), သွက်ဂွံ (in order
+# to), နကဵု (with), တုဲ (and then), ဟွံသေၚ် (or, is not), ဟိုတ်နူ (because),
+# ညိ (please), ရ (final particle), and the verbs စၟဳစၟတ် (check), ပ္တိုန်
+# (submit), စွံ (keep), ပံက် (open), ကၟာတ် (close), စုတ် (add, put in),
+# ပတိတ် (take out), ပြံၚ် (move), ပလီု (clear), ထ္ၜး (show), ဍဵု (press),
+# ကလေၚ် (again), ဆဵု (find), ဗၠေတ် (be wrong), ဒးရး (be correct).
+#
+# **Counting.** CLDR has no plural data for `mnw`, so `Intl.PluralRules`
+# resolves it against the runtime's default locale and a category branch here
+# would be text chosen by English's rules. Mon leaves a noun unmarked after a
+# numeral, so one form is correct anyway: every count select below collapses
+# to a single `*[other]`. English's explicit `[0]` is kept, because Fluent
+# matches it against the number itself before consulting any plural rule. No
+# `[zero]`, `[one]`, `[two]`, `[few]` or `[many]` branch appears in any of
+# these four files.
+
+
+## Answer submission
+
+answer-checking = စၟဳစၟတ်မံၚ်…
+answer-submitting = ပ္တိုန်မံၚ်…
+
+answer-checking-status = စၟဳစၟတ်မံၚ် သွဟ်
+answer-submitting-status = ပ္တိုန်မံၚ် သွဟ်
+
+answer-correct = ဒးရး
+answer-incorrect = ဟွံဒးရး
+
+answer-response-saved = သွဟ် စွံလဝ်ရ
+
+answer-percent-credit = { $percent }% credit
+answer-percent-correct = { $percent }% ဒးရး
+answer-percent-short = { $percent } %
+
+max-credit-available = credit ဂၠိုၚ်အိုတ်: { $percent }%
+
+# Single `*[other]`: Mon does not mark a noun for number after a numeral, and
+# `mnw` has no CLDR plural data. `[0]` is matched against the number and fires.
+attempts-remaining =
+    { $count ->
+        [0] အလန် ဟွံမွဲ ကွာ်ရ
+       *[other] ဂွံအခေါၚ် { $count } အလန် ပၠန်
+    }
+
+validation-correct = (ဒးရး)
+validation-incorrect = (ဟွံဒးရး)
+validation-partially-correct = (ဒးရး တၞဟ်ခြာ)
+
+answer-show-responses = ထ္ၜး သွဟ် { $count } တၚ် ကု { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = တုံ့ပြန်ချက်
+
+collapsible-click-to-open = (ဍဵု သွက်ဂွံပံက်)
+collapsible-click-to-close = (ဍဵု သွက်ဂွံကၟာတ်)
+
+collapsible-initializing = စတမ်မံၚ်…
+
+footnote-show = ထ္ၜး အောက်ခြေမှတ်စု
+footnote-hide = ကၟာတ် အောက်ခြေမှတ်စု
+
+description-more-information = အချက်အလက် ဂၠိုၚ်တိုန်
+
+
+## Controls
+
+slider-previous = ကၠာ
+slider-next = လက္ကရဴ
+
+keyboard-open = ပံက် keyboard
+keyboard-close = ကၟာတ် keyboard
+
+choice-input-remove-choice = ပတိတ် { $choice }
+
+matrix-remove-row = ပတိတ် row
+matrix-add-row = စုတ် row
+matrix-remove-column = ပတိတ် column
+matrix-add-column = စုတ် column
+
+subset-add-remove-points = စုတ်/ပတိတ် အမှတ်
+subset-toggle-points-intervals = ပြံၚ် အမှတ် ကဵု interval
+subset-move-points = ပြံၚ် အမှတ်
+subset-clear = ပလီု
+
+orbital-add-row = စုတ် row
+orbital-remove-row = ပတိတ် row
+orbital-add-box = စုတ် box
+orbital-remove-box = ပတိတ် box
+orbital-add-up-arrow = စုတ် မြား တိုန်
+orbital-add-down-arrow = စုတ် မြား စှေ်
+orbital-remove-arrow = ပတိတ် မြား
+
+orbital-row-label = ယၟု သွက် row { $row }
+
+pretzel-answer = သွဟ်
+
+summary-statistics-caption = summary statistics နူ { $column }
+
+
+## Math input
+
+math-input-preview-region = preview နူ math expression
+math-input-preview = preview
+math-input-invalid-expression = expression ဟွံဒးရး:
+
+
+## Document status
+
+viewer-initializing = စတမ်မံၚ်…
+
+
+## Errors
+
+error-heading = တၚ်ဗၠေတ်
+
+error-found-at =
+    { $span ->
+        [line] ဆဵုကေတ် ပ္ဍဲ line { $startLine } ရ။
+       *[lines] ဆဵုကေတ် ပ္ဍဲ line { $startLine }–{ $endLine } ရ။
+    }
+
+document-contains-errors = document ဏအ် တၚ်ဗၠေတ် နွံမံၚ်ရ!
+
+diagnostic-heading-error = တၚ်ဗၠေတ်
+diagnostic-heading-warning = သတိပေးချက်
+diagnostic-heading-information = အချက်အလက်
+diagnostic-heading-hint = ကသပ်
+
+accessibility-heading-level-1 = WCAG AA accessibility တၚ်ဗၠေတ်
+accessibility-heading-level-2 = accessibility သတိပေးချက်
+
+something-went-wrong = မွဲမွဲ ဗၠေတ်အာရ။
+
+renderer-load-failed = renderer မွဲ load ဟွံဂွံ။ ကလေၚ် load မုက်လိက် ညိ။
+
+core-start-failed = document ဏအ် စတမ် ဟွံဂွံ။ ကလေၚ် load မုက်လိက် ညိ။
+
+core-start-failed-busy = document ဏအ် စတမ် ဟွံဂွံ။ document ဂၠိုၚ်ဂၠိုၚ် စတမ်မွဲစွံဟိုတ်နူ ပ္ဍဲစက် လျိုၚ်ဂှ် အခိၚ်ကၠာဲ။ document တၞဟ် အိုတ်တုဲ ကလေၚ် load မုက်လိက်မ္ဂး ကၠောန်ဂွံမာန်ရ။
+
+core-start-failed-retry = document ဏအ် စတမ် ဟွံဂွံ။
+
+core-start-failed-busy-retry = document ဏအ် စတမ် ဟွံဂွံ။ document ဂၠိုၚ်ဂၠိုၚ် စတမ်မွဲစွံဟိုတ်နူ ပ္ဍဲစက် လျိုၚ်ဂှ် အခိၚ်ကၠာဲ။
+
+core-start-retry = ကလေၚ်စမ်ရံၚ်
+
+saved-state-unavailable = ကမၠောန် မစွံလဝ်ဂှ် load ဟွံဂွံ။

--- a/packages/i18n/locales/mnw/content.ftl
+++ b/packages/i18n/locales/mnw/content.ftl
@@ -1,0 +1,317 @@
+# Mon (ဘာသာမန်) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in. `locales/en/content.ftl` is the source of truth, and message ids
+# and attribute names are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# Mon of Mon State and the Thai Mon communities, in the Mon-Burmese script
+# with the Mon letters ၚ ၜ and the Mon medials ၞ ၟ ၠ — never Burmese င
+# for Mon ၚ — and Burmese spacing, a space at a phrase boundary rather than
+# between words.
+#
+# ## Word order: the noun comes first
+#
+# **Mon puts the head noun first and every modifier after it**, as its
+# Austroasiatic relatives do. So `style-with-noun` places `{ $noun }` in front
+# of `{ $description }`, and inside the description the order is fixed as
+# **colour, then dash pattern, then thickness** — "line red dashed thick"
+# rather than English's "thick dashed red line". That order is consistent
+# across every message in this file and it is what the style-description tests
+# pin.
+#
+# **`[noun-tail]` is unused.** Modifiers follow the head, so a regular
+# polygon's side count can sit after the noun without splitting it, and
+# `noun-regular-polygon` fills `head` and leaves `tail` empty as English does.
+#
+# ## No gender fork and no `$role` fork
+#
+# Mon has no grammatical gender and no case inflection on a modifier, so
+# `noun-gender` answers the single token `neuter` and nothing forks on
+# `$gender` or `$role`. What Mon would want and this frame cannot give it is a
+# **classifier** between a numeral and a noun, and no message here counts a
+# noun.
+#
+# ## What this catalog does not know, stated plainly
+#
+# **This is the thinnest of the three Myanmar-script catalogs in its own
+# content words, and the colour list is where that shows.** The seed could not
+# establish Mon's own basic colour terms with any confidence, so **all twelve
+# colours below are Burmese loans in Burmese spelling** — အနက်, အဖြူ,
+# မီးခိုး, အနီ, လိမ္မော်, အဝါ, အစိမ်း, စိမ်းပြာ, အပြာ, ခရမ်း, ပန်း, အညို.
+# Mon certainly has its own words for at least black, white and red; they are
+# not here because this seed does not know them, not because they do not
+# exist. **This is the first place a speaker should look**, and correcting the
+# twelve is a bigger improvement to this catalog than correcting anything
+# else in it.
+#
+# The geometric nouns are the same case one step further out: `<circle>`,
+# `<triangle>` and `<point>` are written with the Burmese school words
+# စက်ဝိုင်း, တြိဂံ and အမှတ်, which is what a Mon pupil meets in a Burmese
+# maths lesson, and everything from `line segment` outwards is left in English
+# in Latin letters. What is Mon here is the frame around them.
+#
+# ## The conditional, and a limit the catalog cannot fix from inside
+#
+# **Mon marks a conditional clause-finally**, with မ္ဂး after the condition,
+# where English writes "if" in front of it. `piecewise-condition-if` is
+# rendered before the mathematics by the core, so the word cannot be moved
+# from inside this catalog. It is written as မ္ဂး anyway, in the position the
+# core gives it, and this is recorded rather than papered over: a Mon reader
+# will see the marker on the wrong side of its clause, and fixing it means
+# changing what the composition message is handed, not changing this string.
+#
+# ## Chemistry: both element tables are deliberately absent
+#
+# `element-name` and `element-anion-name` are the **only English keys this
+# file does not cover**, 130 of them, and the reason is a fact about a school
+# system rather than about Mon. Secondary science in Mon State is taught in
+# **Burmese**, out of the national curriculum's textbooks; Mon national
+# schools and the Mon literature programme teach the language and the primary
+# grades, and do not run to the grades where the periodic table is taught. So
+# there is no settled, checkable Mon list of the 118 elements to seed from,
+# and coining one would invent a nomenclature no reader has met. The 130 keys
+# fall back to English. `ion-name-oxidation-state` and the two invalid-symbol
+# messages are frames rather than vocabulary and are covered below.
+
+
+## Style vocabulary
+
+# All twelve are Burmese loans in Burmese spelling. See the header: this is
+# the least confident line in the catalog and the first a speaker should fix.
+color =
+    .black = အနက်
+    .white = အဖြူ
+    .gray = မီးခိုး
+    .red = အနီ
+    .orange = လိမ္မော်
+    .yellow = အဝါ
+    .green = အစိမ်း
+    .cyan = စိမ်းပြာ
+    .blue = အပြာ
+    .purple = ခရမ်း
+    .pink = ပန်း
+    .brown = အညို
+
+# Both are Burmese loans: ထူ (thick) and ပါး (thin). The seed could not
+# establish Mon's own pair, and says so rather than guessing at one.
+line-width =
+    .thick = ထူ
+    .thin = ပါး
+
+line-style =
+    .dashed = အပြတ်
+    .dotted = အစက်
+
+fill-style =
+    .horizontal = မျဉ်း အလျားလိုက်
+    .vertical = မျဉ်း ဒေါင်လိုက်
+    .diagonal = မျဉ်း ထောင့်ဖြတ်
+    .backdiagonal = မျဉ်း ထောင့်ဖြတ် ပြောင်းပြန်
+    .dots = အစက်
+    .diamonds = စိန်ပုံ
+
+noun =
+    .line = မျဉ်း
+    .line-segment = line segment
+    .ray = ray
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = တြိဂံ
+    .rectangle = rectangle
+    .circle = စက်ဝိုင်း
+    .region = ဒေသ
+    .point = အမှတ်
+    .square = square
+    .diamond = စိန်ပုံ
+    .cross = ကြက်ခြေခတ်
+    .plus = အပေါင်း
+
+# Modifiers follow the head noun in Mon, so the side count sits after the
+# noun and `tail` stays empty, as it does in English.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] regular polygon { $numSides } ထောင့်
+    }
+
+# One token for everything: Mon has no grammatical gender, so nothing below
+# forks on `$gender`.
+noun-gender = neuter
+
+
+## Style composition
+
+# Colour, then dash pattern, then thickness — the reverse of English's order.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $color } { $lineStyle } { $width }
+        [width-color] { $color } { $width }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $lineStyle } { $width }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun comes first and the description follows it.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = ပေၚ်
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } နကဵု { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } နကဵု { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } နကဵု { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+# Mon has no article, so the two `-article` branches say what the two without
+# it say. What survives is နကဵု ('with') against တုဲ ('and then') — a first
+# clause against a further one.
+style-border-clause =
+    { $parts ->
+        [with-article] နကဵု border { $border }
+        [and] တုဲ border { $border }
+        [and-article] တုဲ border { $border }
+       *[with] နကဵု border { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = ဟွံပေၚ်
+
+style-text =
+    { $parts ->
+        [background] { $color } နကဵု background { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ဟွံမွဲ
+
+
+## Boolean words
+
+boolean-true = ဒှ်
+boolean-false = ဟွံဒှ်
+
+
+## Answer buttons
+
+answer-submit-label = စၟဳစၟတ် ကမၠောန်
+answer-submit-label-no-correctness = ပ္တိုန် သွဟ်
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ကမၠောန်
+    .aside = aside
+    .cascade = cascade
+    .definition = တၚ်အဓိပ္ပါယ်
+    .example = ဥပမာ
+    .exercise = လေ့ကျင့်ခန်း
+    .exercises = လေ့ကျင့်ခန်း
+    .given-answer = သွဟ်
+    .note = စၟတ်သမ္တီ
+    .objectives = ရန်တၟံ
+    .paragraphs = paragraph
+    .part = အပိုင်း
+    .problem = ပြသၞာ
+    .problems = ပြသၞာ
+    .proof = သက်သေပြချက်
+    .question = သၟာန်
+    .section = ကဏ္ဍ
+    .solution = နဲသွဟ်
+    .task = လုပ်ငန်း
+    .theorem = theorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = ကသပ်
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] ဇယား { $enumeration }
+        [numbered-title] ဇယား { $enumeration }{ ": " }
+        [unnumbered-title] ဇယား{ ": " }
+       *[unnumbered] ဇယား
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] ဗီု { $enumeration }
+        [numbered-caption] ဗီု { $enumeration }{ ": " }
+        [unnumbered-caption] ဗီု{ ": " }
+       *[unnumbered] ဗီု
+    }
+
+
+## Paginator controls
+
+paginator-previous = ကၠာ
+paginator-next = လက္ကရဴ
+paginator-page = မုက်လိက်
+
+paginator-page-status = { $pageLabel } { $currentPage } နူ { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ဟွံသေၚ်
+# Mon marks a conditional clause-finally; the core renders this word in front
+# of the mathematics, which is the wrong side for Mon. See the header: it
+# cannot be fixed from inside this catalog.
+piecewise-condition-if = မ္ဂး
+piecewise-condition-otherwise = ဟွံသေၚ်မ္ဂး
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are absent on purpose; the header
+## says why. What is here is the frames, which are not vocabulary.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = symbol ဟွံဒးရး
+chemistry-invalid-ionic-compound = ionic compound ဟွံဒးရး
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = ကွက်လပ်
+math-embedded-input-blank-ordinal = ကွက်လပ် { $ordinal } နူ { $total }

--- a/packages/i18n/locales/mnw/content.ftl
+++ b/packages/i18n/locales/mnw/content.ftl
@@ -47,11 +47,16 @@
 # twelve is a bigger improvement to this catalog than correcting anything
 # else in it.
 #
-# The geometric nouns are the same case one step further out: `<circle>`,
-# `<triangle>` and `<point>` are written with the Burmese school words
-# စက်ဝိုင်း, တြိဂံ and အမှတ်, which is what a Mon pupil meets in a Burmese
-# maths lesson, and everything from `line segment` outwards is left in English
-# in Latin letters. What is Mon here is the frame around them.
+# The geometric nouns are the same case one step further out. Eight entries of
+# the `noun` table are written in the script: `line` မျဉ်း, `circle`
+# စက်ဝိုင်း, `triangle` တြိဂံ, `point` အမှတ်, `region` ဒေသ, `diamond` စိန်ပုံ,
+# `cross` ကြက်ခြေခတ် and `plus` အပေါင်း, every one of them a Burmese school
+# word in Burmese spelling, which is what a Mon pupil meets in a Burmese maths
+# lesson. **The other twelve entries — `line segment`, `ray`, `vector`,
+# `curve`, `function`, `slope field`, `vector field`, `parabola`, `polyline`,
+# `polygon`, `rectangle` and `square` — are left in English in Latin
+# letters**, because that is where a Mon pupil meets those. What is Mon here
+# is the frame around them.
 #
 # ## The conditional, and a limit the catalog cannot fix from inside
 #

--- a/packages/i18n/locales/mnw/diagnostics.ftl
+++ b/packages/i18n/locales/mnw/diagnostics.ftl
@@ -179,11 +179,11 @@ accessibility-section-title-insufficient-contrast =
 
 circle-through-points-non-numerical = အမှတ် { $count } တၚ် မလုပ်အာ `<circle>` ဂှ် အမှတ် တန်ဖိုးဂၞန် ဟွံမွဲမ္ဂး ဟွံကၠောန်လဝ်ဏီ။
 
-circle-too-many-through-points = အမှတ် ဂၠိုၚ်နူ ၃ တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ချူဓဇက် ဟွံဂွံ။
+circle-too-many-through-points = အမှတ် ဂၠိုၚ်နူ 3 တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ချူဓဇက် ဟွံဂွံ။
 
 circle-overprescribed-radius-center-points = radius, center ကဵု through point ပိ မွဲစွံ စၟတ်သမ္တီလဝ်မ္ဂး စက်ဝိုင်း ချူဓဇက် ဟွံဂွံ။
 
-circle-center-with-multiple-points = center မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၁ တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ချူဓဇက် ဟွံဂွံ။
+circle-center-with-multiple-points = center မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ 1 တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ချူဓဇက် ဟွံဂွံ။
 
 circle-radius-too-small = စက်ဝိုင်း ချူဓဇက် ဟွံဂွံ - အမှတ် ၜါ အကြာ ဇမၠိၚ်ဂှ် { $distance } ဒှ်တုဲ radius မစၟတ်သမ္တီလဝ် { $radius } ဂှ် ဍောတ်အာရ။
 
@@ -191,7 +191,7 @@ circle-radius-with-many-points = radius မစၟတ်သမ္တီလဝ် 
 
 circle-invalid-center-or-through-points = စက်ဝိုင်း နူ center ဟွံသေၚ် through point ဟွံဒးရး။
 
-circle-radius-center-with-multiple-points = center မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၁ တၚ် မလုပ်အာ စက်ဝိုင်း နူ radius ဂှ် ချူဓဇက် ဟွံဂွံ။
+circle-radius-center-with-multiple-points = center မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ 1 တၚ် မလုပ်အာ စက်ဝိုင်း နူ radius ဂှ် ချူဓဇက် ဟွံဂွံ။
 
 circle-change-radius-non-numerical = through point တန်ဖိုးဂၞန် ဟွံမွဲမ္ဂး စက်ဝိုင်း နူ radius ဂှ် ပြံၚ်လှာဲ ဟွံဂွံ
 
@@ -270,9 +270,9 @@ angle-too-many-lines = မျဉ်း { $count } ကြပ် အကြာ ထ�
 
 angle-invalid-through-point = `<angle>` နူ through ပ္ဍဲ အမှတ် ဟွံဒးရး
 
-parabola-vertex-too-many-points = vertex နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၁ တၚ် မလုပ်အာ parabola ဂှ် ဟွံကၠောန်လဝ်ဏီ။
+parabola-vertex-too-many-points = vertex နွံတုဲ အမှတ် ဂၠိုၚ်နူ 1 တၚ် မလုပ်အာ parabola ဂှ် ဟွံကၠောန်လဝ်ဏီ။
 
-parabola-too-many-points = အမှတ် ဂၠိုၚ်နူ ၃ တၚ် မလုပ်အာ parabola ဂှ် ဟွံကၠောန်လဝ်ဏီ။
+parabola-too-many-points = အမှတ် ဂၠိုၚ်နူ 3 တၚ် မလုပ်အာ parabola ဂှ် ဟွံကၠောန်လဝ်ဏီ။
 
 intersection-too-many-items = အရာ ဂၠိုၚ်နူ ၜါ သွက် intersection ဂှ် ဟွံကၠောန်လဝ်ဏီ
 
@@ -398,7 +398,7 @@ attribute-invalid-values =
 
 attribute-must-be-references = attribute `{ $attribute }` သွက် တန်ဖိုး `{ $value }` ဟွံဒးရး။ attribute ဂှ် `$` နကဵု မစတမ် reference နူ ဒးဒှ်။
 
-math-input-invalid-function-names = <mathInput>: { $attribute } ပ္ဍဲ ဟွံဒးရး function ယၟု ဟွံသုၚ်စောဲ: { $names }။ ယၟု နာနာ နူ ကထ္ၜးအခန် ဂှ် အက္ခရ် ဟွံသေၚ် ဂၞိန် ဟွံအောန်နူ ၂ တၞး ဒးနွံ; လက္ကရဴ `|<mathspeak alternative>` ဂှ် စုတ်ကီု ဟွံစုတ်ကီု ဒှ်ဂွံ။
+math-input-invalid-function-names = <mathInput>: { $attribute } ပ္ဍဲ ဟွံဒးရး function ယၟု ဟွံသုၚ်စောဲ: { $names }။ ယၟု နာနာ နူ ကထ္ၜးအခန် ဂှ် အက္ခရ် ဟွံသေၚ် ဂၞိန် ဟွံအောန်နူ 2 တၞး ဒးနွံ; လက္ကရဴ `|<mathspeak alternative>` ဂှ် စုတ်ကီု ဟွံစုတ်ကီု ဒှ်ဂွံ။
 
 ## Building components from the source
 

--- a/packages/i18n/locales/mnw/diagnostics.ftl
+++ b/packages/i18n/locales/mnw/diagnostics.ftl
@@ -1,0 +1,702 @@
+# Mon (ဘာသာမန်) warnings and errors. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# Mon in the Mon-Burmese script with the Mon letters ၚ ၜ and the medials
+# ၞ ၟ ၠ — never Burmese င for Mon ၚ — and Burmese spacing.
+#
+# **Every DoenetML name stays in English exactly as written**: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `selectFromSequence`, every
+# tag and every attribute. They are part of the language rather than prose.
+#
+# **This file is a Mon frame around English technical nouns**, and it is the
+# most heavily loaned of the four. A diagnostic names DoenetML objects almost
+# every time it opens its mouth — component, attribute, function, sequence,
+# variant, reference, index — and Mon has no established word for any of them,
+# so they stay in Latin letters as the classroom leaves them. What is Mon is
+# the sentence, built from a small fixed set of phrases used the same way
+# throughout so that a corrector can fix one pattern in one place:
+#
+#   * «X ဟွံဒးရး» — X is invalid
+#   * «ဟွံသုၚ်စောဲ» — ignored
+#   * «ဟွံဂွံ» — cannot
+#   * «ဒး» — must
+#   * «ဟွံကၠောန်လဝ်ဏီ» — has not been implemented yet
+#   * «ဟွံဆဵု» — cannot find
+#   * «ဟိုတ်နူ» — because
+#   * «စၟတ်သမ္တီ» — to specify; «မစၟတ်သမ္တီလဝ်» — specified
+#   * «ဂၞန်» — number, count
+#
+# The Burmese loans, in Burmese spelling, are သတိပေးချက် (warning),
+# အချက်အလက် (information), အမှတ် (point), စက်ဝိုင်း (circle), မျဉ်း (line)
+# and ဇယား (table); everything else non-Mon is English in Latin letters.
+#
+# **What this catalog does not know.** Mon has no settled terminology for
+# software diagnostics or for the higher-mathematics vocabulary these
+# messages use, and this seed did not invent one. Where English says
+# "prescribed", "overprescribed", "coprime", "eigenvalue" or "circular
+# dependency", the Mon around the English term is a paraphrase of what the
+# sentence means rather than a translation of the term. Those are the places a
+# speaker with the mathematical register will want to rewrite, and they are
+# marked by the English word standing bare in the sentence.
+#
+# **Counting.** CLDR has no plural data for `mnw`. Every count select English
+# writes is collapsed to a single `*[other]`, because Mon leaves a noun
+# unmarked after a numeral and a category branch here would be text chosen by
+# English's rules. No `[zero]`, `[one]`, `[two]`, `[few]` or `[many]` branch
+# appears anywhere in these four files.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] { $attributes } ဂှ် endpoint ၜါ မစၟတ်သမ္တီလဝ်မ္ဂး ဟွံသုၚ်စောဲ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] { $attributes } ဂှ် endpoint ကဵု midpoint ၜါ မစၟတ်သမ္တီလဝ်မ္ဂး ဟွံသုၚ်စောဲ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ဂှ် midpoint ဟွံမွဲမ္ဂး အကာဲအရာ ဟွံမွဲ
+
+## `<line>`
+
+line-points-undetermined-dimensions = မျဉ်း မလုပ်အာ ပ္ဍဲ အမှတ် မဒှ်တၚ် dimension ဟွံစၟတ်သမ္တီလဝ်။
+
+line-points-too-few-dimensions = မျဉ်း ဒးလုပ်အာ ပ္ဍဲ အမှတ် မနွံကဵု dimension ဟွံအောန်နူ ၜါ။
+
+line-points-depend-on-variables = မျဉ်း လုပ်အာ ပ္ဍဲ အမှတ် မဆေၚ်စပ် ကု variable: { $variables }။
+
+line-equation-invalid-format = ဗီုပြၚ် equation နူ မျဉ်း ပ္ဍဲ variable { $variable1 } ကဵု { $variable2 } ဟွံဒးရး။
+
+## `<ray>`
+
+ray-overprescribed-through = ray ဂှ် through, endpoint ကဵု direction ပိ မွဲစွံ စၟတ်သမ္တီလဝ်ရ။ through မစၟတ်သမ္တီလဝ်ဂှ် ဟွံသုၚ်စောဲ။
+
+ray-dimension-mismatch = numDimensions ပ္ဍဲ ray ဟွံဒးရး။
+
+## `<vector>`
+
+vector-overprescribed-head = vector ဂှ် head, tail ကဵု displacement ပိ မွဲစွံ စၟတ်သမ္တီလဝ်ရ။ head မစၟတ်သမ္တီလဝ်ဂှ် ဟွံသုၚ်စောဲ။
+
+vector-dimension-mismatch = numDimensions ပ္ဍဲ vector ဟွံဒးရး။
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` ကု attract ဟွံဂွံ ဟိုတ်နူ ညးဂှ် state variable nearestPoint ဟွံမွဲ။
+
+constrain-to-without-nearest-point = `<{ $component }>` ကု constrain ဟွံဂွံ ဟိုတ်နူ ညးဂှ် state variable nearestPoint ဟွံမွဲ။
+
+constrain-to-interior-without-nearest-point = ပ္ဍဲ `<{ $component }>` ကု constrain ဟွံဂွံ ဟိုတ်နူ ညးဂှ် state variable nearestPoint ဟွံမွဲ။
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ဂှ် choiceInput မဟွံဒှ် inline ကု ဟွံသုၚ်စောဲ
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices မစၟတ်သမ္တီလဝ် သွက် choiceInput ဂှ် ဟွံသုၚ်စောဲ ဟိုတ်နူ ဂၞန် indices ကဵု ဂၞန် choice ကောန်ဇာတ် ဟွံဒးရးရ။
+
+pretzel-indices-count-mismatch = indices မစၟတ်သမ္တီလဝ် သွက် problem ဂှ် ဟွံသုၚ်စောဲ ဟိုတ်နူ ဂၞန် indices ကဵု ဂၞန် problem ကောန်ဇာတ် ဟွံဒးရးရ။
+
+shuffle-indices-count-mismatch = indices မစၟတ်သမ္တီလဝ် သွက် shuffle ဂှ် ဟွံသုၚ်စောဲ ဟိုတ်နူ ဂၞန် indices ကဵု ဂၞန် component ဟွံဒးရးရ။
+
+indices-ignored-out-of-range = indices မစၟတ်သမ္တီလဝ် သွက် { $component } ဂှ် ဟွံသုၚ်စောဲ ဟိုတ်နူ index လ္ၚဵု တိတ်နူ အကွက်။
+
+pretzel-indices-repeated = indices မစၟတ်သမ္တီလဝ် သွက် pretzel ဂှ် ဟွံသုၚ်စောဲ ဟိုတ်နူ index လ္ၚဵု ကလေၚ်ပါလုပ်ဗွဲမဂၠိုၚ်။
+
+pretzel-circuit-first-index = indices မစၟတ်သမ္တီလဝ် သွက် pretzel ပ္ဍဲ circuit mode ဂှ် ဟွံသုၚ်စောဲ ဟိုတ်နူ index ကၠာအိုတ် ဒးဒှ် 1။
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ဂှ် string ကောန်ဇာတ် ကု ကၠောန်မာန်ဂွံဂှ် attribute `type` ဒးစၟတ်သမ္တီ။
+
+invalid-type-defaulting-to-math = type { $type } ဂှ် component { $component } သွက် ဟွံဒးရး။ ဒးဒှ် math, text, number ဟွံသေၚ် boolean။ math ဂှ် default ဒှ်အာရ။
+
+string-not-valid-component-to-arrange = string "{ $value }" ဂှ် { $component } ကၠောန်ဂွံ component ဟွံသေၚ်။ ဟွံသုၚ်စောဲ။
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ဟွံဒးရး၊ type ဂှ် number စွံရ။
+
+invalid-variable-value = တန်ဖိုး နူ variable ဟွံဒးရး: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = variant index { $index } ဒးဒှ် number
+
+variant-index-must-be-integer = variant index { $index } ဒးဒှ် integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ဂှ် ဗီုပြၚ်ခဏ်လၟိဟ်တၟေၚ် သွက် ဟွံကၠောန်လဝ်ဏီ။ width ဂှ် relative စွံရ။
+
+side-by-side-absolute-margins = `<{ $component }>` ဂှ် ဗီုပြၚ်ခဏ်လၟိဟ်တၟေၚ် သွက် ဟွံကၠောန်လဝ်ဏီ။ margin ဂှ် relative စွံရ။
+
+side-by-side-no-block-child = `<{ $component }>` ဟွံဒးရး - block ကောန်ဇာတ် ဟွံအောန်နူ မွဲ ဒးနွံ။
+
+## `<label>`
+
+label-for-ignored-on-graphical = attribute `for` ပ္ဍဲ `<label>` မဒှ်ဗီု ဂှ် ဟွံသုၚ်စောဲ။
+
+label-for-must-resolve-to-one = attribute `for` ပ္ဍဲ `<label>` ဂှ် component မွဲဓဝ် ကု ဒးထ္ၜး။
+
+label-for-unresolved = attribute `for` ပ္ဍဲ `<label>` ဂှ် component ကု ထ္ၜး ဟွံဂွံ။
+
+label-for-answer-with-authored-inputs = attribute `for` ပ္ဍဲ `<label>` ဂှ် `<answer>` မနွံကဵု input မချူလဝ်ဂှ် ထ္ၜးမံၚ်ရ၊ input ဂှ်ကီု ဒးထ္ၜးဗွဲမ္ၚးဒမြိပ်။
+
+label-for-answer-without-input = attribute `for` ပ္ဍဲ `<label>` ဂှ် `<answer>` မဟွံမွဲ input သွက် label ဂှ် ထ္ၜးမံၚ်ရ။
+
+label-for-must-reference-input-or-answer = attribute `for` ပ္ဍဲ `<label>` ဂှ် input ဟွံသေၚ် answer ကု ဒးထ္ၜး။
+
+## Accessibility
+
+accessibility-short-description-or-decorative = accessibility သွက်ဂှ် `<{ $component }>` ဂှ် ကထ္ၜးဗွဲမဂတိုၚ် မွဲ ဒးနွံ ဟွံသေၚ် decorative ဒးစၟတ်သမ္တီ။
+
+accessibility-video-short-description = accessibility သွက်ဂှ် `<video>` ဂှ် ကထ္ၜးဗွဲမဂတိုၚ် ဒးနွံ။
+
+accessibility-input-short-description-or-label = accessibility သွက်ဂှ် `<{ $component }>` ဂှ် ကထ္ၜးဗွဲမဂတိုၚ် ဟွံသေၚ် label ဒးနွံ။
+
+accessibility-answer-input-short-description-or-label = accessibility သွက်ဂှ် `<answer>` မဖန်ဗဒှ် input ဂှ် ကထ္ၜးဗွဲမဂတိုၚ် ဟွံသေၚ် label ဒးနွံ။
+
+accessibility-short-description-contains-math = ကထ္ၜးဗွဲမဂတိုၚ် ဂှ် `<{ $component }>` ဗီု math component ဟွံဒးပါလုပ်။ math ဂှ် နကဵု စကာ ချူထ္ၜးညိ။
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ဂှ် ကဏ္ဍ ခေါၚ်ခဝ် text သွက် contrast ဟွံပေၚ် (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ဟွံအောန်နူ { $threshold }:1 ဒးနွံ)။
+       *[other] { $colorName } ဂှ် ကဏ္ဍ ခေါၚ်ခဝ် text သွက် contrast ဟွံပေၚ် ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ဟွံအောန်နူ { $threshold }:1 ဒးနွံ)။
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = အမှတ် { $count } တၚ် မလုပ်အာ `<circle>` ဂှ် အမှတ် တန်ဖိုးဂၞန် ဟွံမွဲမ္ဂး ဟွံကၠောန်လဝ်ဏီ။
+
+circle-too-many-through-points = အမှတ် ဂၠိုၚ်နူ ၃ တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ချူဓဇက် ဟွံဂွံ။
+
+circle-overprescribed-radius-center-points = radius, center ကဵု through point ပိ မွဲစွံ စၟတ်သမ္တီလဝ်မ္ဂး စက်ဝိုင်း ချူဓဇက် ဟွံဂွံ။
+
+circle-center-with-multiple-points = center မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၁ တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ချူဓဇက် ဟွံဂွံ။
+
+circle-radius-too-small = စက်ဝိုင်း ချူဓဇက် ဟွံဂွံ - အမှတ် ၜါ အကြာ ဇမၠိၚ်ဂှ် { $distance } ဒှ်တုဲ radius မစၟတ်သမ္တီလဝ် { $radius } ဂှ် ဍောတ်အာရ။
+
+circle-radius-with-many-points = radius မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၜါ တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ဖန်ဗဒှ် ဟွံဂွံ။
+
+circle-invalid-center-or-through-points = စက်ဝိုင်း နူ center ဟွံသေၚ် through point ဟွံဒးရး။
+
+circle-radius-center-with-multiple-points = center မစၟတ်သမ္တီလဝ် နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၁ တၚ် မလုပ်အာ စက်ဝိုင်း နူ radius ဂှ် ချူဓဇက် ဟွံဂွံ။
+
+circle-change-radius-non-numerical = through point တန်ဖိုးဂၞန် ဟွံမွဲမ္ဂး စက်ဝိုင်း နူ radius ဂှ် ပြံၚ်လှာဲ ဟွံဂွံ
+
+circle-radius-with-points-non-numerical = တန်ဖိုးဂၞန် ဟွံမွဲမ္ဂး radius မစၟတ်သမ္တီလဝ် နကဵု အမှတ် ဂၠိုၚ်နူ မွဲ တၚ် မလုပ်အာ စက်ဝိုင်း ဂှ် ဖန်ဗဒှ် ဟွံဂွံ။
+
+circle-change-center-non-numerical = အမှတ် တန်ဖိုးဂၞန်ဟွံမွဲ မလုပ်အာ စက်ဝိုင်း နူ center ပြံၚ်လှာဲ ဂှ် ဟွံကၠောန်လဝ်ဏီ။
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] function သွက် domain နူ dimension ဟွံပေၚ်။ domain ဂှ် interval { $intervals } နွံတုဲ function ဂှ် input { $inputs } နွံရ။
+    }
+
+function-domain-invalid-format = function သွက် domain နူ ဗီုပြၚ် ဟွံဒးရး။
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] function နူ maximum မဟွံဒှ်ဂၞန် ဂှ် ဟွံသုၚ်စောဲ။
+        [minimum] function နူ minimum မဟွံဒှ်ဂၞန် ဂှ် ဟွံသုၚ်စောဲ။
+        [extremum] function နူ extremum မဟွံဒှ်ဂၞန် ဂှ် ဟွံသုၚ်စောဲ။
+        [point] function နူ အမှတ် မဟွံဒှ်ဂၞန် ဂှ် ဟွံသုၚ်စောဲ။
+        [slope] function နူ slope မဟွံဒှ်ဂၞန် ဂှ် ဟွံသုၚ်စောဲ။
+       *[other] function နူ { $type } မဟွံဒှ်ဂၞန် ဂှ် ဟွံသုၚ်စောဲ။
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] function နူ maximum မလလေၚ် ဂှ် ဟွံသုၚ်စောဲ။
+        [minimum] function နူ minimum မလလေၚ် ဂှ် ဟွံသုၚ်စောဲ။
+        [extremum] function နူ extremum မလလေၚ် ဂှ် ဟွံသုၚ်စောဲ။
+        [point] function နူ အမှတ် မလလေၚ် ဂှ် ဟွံသုၚ်စောဲ။
+       *[other] function နူ { $type } မလလေၚ် ဂှ် ဟွံသုၚ်စောဲ။
+    }
+
+function-points-too-close = function ဂှ် အမှတ် ၜါ တၚ် ဒၞာဲဇၞော်ကဵုဒြဟတ် ဇရေၚ်လောန်အာရ။ function စၟတ်သမ္တီ ဟွံဂွံ။
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] function iterate ဂှ် function နူ input ဂၞန် ကဵု output ဂၞန် တုပ်မ္ဂးဟေၚ် ဒှ်မာန်။ function ဏအ် input { $inputs } ကဵု output { $outputs } နွံရ။
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = sequence နူ length ဟွံဒးရး။ ဂၞန်ဟွံစှေ်နူသုည integer ဒးဒှ်။
+
+sequence-invalid-step = sequence နူ step ဟွံဒးရး။ sequence type { $type } သွက် number ဒးဒှ်။
+
+sequence-invalid-endpoint-number = number sequence နူ "{ $attribute }" ဟွံဒးရး။ number ဒးဒှ်။
+
+sequence-invalid-endpoint-letters = letters sequence နူ "{ $attribute }" ဟွံဒးရး။ အက္ခရ် မပံၚ်လဝ် ဒးဒှ်။
+
+sequence-invalid-endpoint = sequence နူ "{ $attribute }" ဟွံဒးရး။
+
+select-from-sequence-coprime-not-numbers = number ဟွံရုဲမ္ဂး coprime ဟွံသုၚ်စောဲ
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations စၟတ်သမ္တီလဝ်မ္ဂး coprime ဟွံသုၚ်စောဲ
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` သွက် target ဟွံဒးရး - target ဟွံဆဵု။
+
+target-state-variable-not-found = `<{ $source }>` သွက် target ဟွံဒးရး - `<{ $component }>` ပ္ဍဲ state variable ယၟု "{ $property }" ဟွံဆဵု။
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` နူ variable ဂှ် independent variable ကု ဒးတၞဟ်ခြာ။
+
+ode-system-duplicate-variable-names = dependent variable ယၟု တုပ်ရဴသၟဟ်နွံမ္ဂး ODE RHS function စၟတ်သမ္တီ ဟွံဂွံ။
+
+ode-system-rhs-function-error = ODE RHS function စၟတ်သမ္တီ ဟွံဂွံ။ mathjs function ဖန်ဗဒှ်ရိုက် တၚ်ဗၠေတ် ဒှ်အာရ။
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = မျဉ်း { $count } ကြပ် အကြာ ထောၚ် စၟတ်သမ္တီ ဟွံဂွံ
+
+angle-invalid-through-point = `<angle>` နူ through ပ္ဍဲ အမှတ် ဟွံဒးရး
+
+parabola-vertex-too-many-points = vertex နွံတုဲ အမှတ် ဂၠိုၚ်နူ ၁ တၚ် မလုပ်အာ parabola ဂှ် ဟွံကၠောန်လဝ်ဏီ။
+
+parabola-too-many-points = အမှတ် ဂၠိုၚ်နူ ၃ တၚ် မလုပ်အာ parabola ဂှ် ဟွံကၠောန်လဝ်ဏီ။
+
+intersection-too-many-items = အရာ ဂၠိုၚ်နူ ၜါ သွက် intersection ဂှ် ဟွံကၠောန်လဝ်ဏီ
+
+## Other math components
+
+ionic-compound-not-two-ions = ion ၜါ တၞဟ်နူဂှ် သွက် ionic compound ဟွံကၠောန်လဝ်ဏီ။
+
+ionic-compound-needs-cation-and-anion = ionic compound ဂှ် cation မွဲ ကဵု anion မွဲ သွက်ဟေၚ် ကၠောန်လဝ်ရ။
+
+solve-equations-cannot-evaluate = equation ဂၞန်ချူ ဟွံဂွံဟိုတ်နူ equation ဖျေံသွဟ် ဟွံဂွံ: { $equation }
+
+math-operators-operand-number-required = math operand ပတိတ်မ္ဂး operandNumber ဒးစၟတ်သမ္တီ။
+
+eigen-decomposition-failed = matrix နူ eigenvalue ဂၞန်ချူ ဟွံဂွံ
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: parameter { $parameters } ဂှ် pattern ပ္ဍဲ ဟွံမွဲ၊ ကွက်လပ် ကု လၟိုန် match ဒှ်အာရ။
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ဂှ် အဓိပ္ပါယ် ဟွံဂွံကေတ်။ none, medium, dense ဟွံသေၚ် အကြာ ကွက် နွံကဵု number ဂၠိုၚ်နူသုည ၜါ ဗီုကဵု grid="1 0.5" ဒးဒှ်။ grid ဟွံဓဇက်။
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` ဂှ် { $expected ->
+        [1] output မွဲ၊ အမှတ် နာနာ ပ္ဍဲ slope y'၊ ဗီုကဵု `y - x`
+       *[other] output ၜါ၊ အမှတ် နာနာ ပ္ဍဲ vector၊ ဗီုကဵု `(y, -x)`
+    } မနွံ function ဒးလိုၚ်၊ ဆဂး function မကဵုလဝ်ဂှ် output { $found } နွံရ။ { $alternative ->
+        [none] မွဲမွဲ ဟွံဓဇက်။
+       *[other] function ဂှ် သွက် `<{ $alternative }>` ဒှ် component ရ။ မွဲမွဲ ဟွံဓဇက်။
+    }
+
+field-function-attribute-ignored-with-child = function ဂှ် component ပ္ဍဲကီု ကဵုလဝ်ဟိုတ်နူ attribute `function` ဟွံသုၚ်စောဲ၊ ပ္ဍဲကဵုဂှ် သုၚ်စောဲရ။ function ဂှ် နဲမွဲဟေၚ် ကဵုညိ။
+
+field-variables-ignored =
+    `<{ $component }>`: attribute `variables` ဂှ် component ပ္ဍဲကဵု မချူလဝ်ဗွဲမ္ၚးဒမြိပ် expression နူ variable ဂှ် ထ္ၜးရ။ { $reason ->
+        [function-child] ဏအ် function ဂှ် `<function>` ကောန်ဇာတ် နကဵု ကဵုလဝ်တုဲ ညးဂှ် variable ဇကုညး ထ္ၜးမံၚ်ဟိုတ်နူ `variables` ဟွံသုၚ်စောဲ။
+       *[no-expression] ဏအ် expression ဗီုဂှ် ဟွံမွဲဟိုတ်နူ `variables` ဟွံသုၚ်စောဲ။
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ဂှ် prefigure renderer ပ္ဍဲ သုၚ်စောဲ ဟွံဂွံ; right-position ဗီု သုၚ်စောဲရ။
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ဂှ် prefigure renderer ပ္ဍဲ သုၚ်စောဲ ဟွံဂွံ; top-position ဗီု သုၚ်စောဲရ။
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure သွက် axis bound ဟွံဒးရး; default bbox (-10,-10,10,10) သုၚ်စောဲရ။
+
+prefigure-invalid-width = `<graph>`: prefigure သွက် width ဟွံဒးရး; default width 425 သုၚ်စောဲရ။
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure သွက် aspectRatio ဟွံဒးရး; default aspect ratio 1 သုၚ်စောဲရ။
+
+prefigure-grid-spacing-too-fine = `<graph>`: axis အကွက် သွက် grid အကြာ ဂှ် ဍောတ်လောန်အာ; prefigure renderer ပ္ဍဲ grid ဂှ် ဟွံဓဇက်။
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure renderer ဟွံသုၚ်စောဲမ္ဂး annotation ဟွံဓဇက်။
+
+multiple-annotations-children = `<graph>` ပ္ဍဲ `<annotations>` ကောန်ဇာတ် ဂၠိုၚ်တၞး ဆဵုကေတ်; လက္ကရဴအိုတ် မွဲဟေၚ် သုၚ်စောဲရ။
+
+## Referring to other components
+
+copy-unrecognized-component-type = ဟွံတီကေတ် component type ကု extend ဟွံသေၚ် copy ဟွံဂွံ: { $type }။
+
+copy-prop-not-found = component type { $component } ပ္ဍဲ prop { $property } ဟွံဆဵု
+
+collect-no-source = collect သွက် source ဟွံဆဵု။
+
+collect-invalid-component-type = component type `<{ $component }>` ဂှ် ဟွံဒးရး ဟိုတ်နူ collect ဟွံဂွံ။
+
+reference-index-unavailable = index `{ $reference }` ကု ထ္ၜး ဟွံဂွံ
+
+## `<callAction>`
+
+component-action-unavailable = component `{ $reference }` ပ္ဍဲ { $action } ကော် ဟွံဂွံ
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = data နူ ဗီုပြၚ် ဟွံဒးရး။ row နူ ဇမၠိၚ် ဟွံတုပ်ရ။ componentIdx :{ $componentIdx } ပ္ဍဲ ဆဵုကေတ်
+
+data-frame-duplicate-column-names = data ဂှ် column ယၟု တုပ်ရဴသၟဟ် နွံရ။ componentIdx :{ $componentIdx } ပ္ဍဲ ဆဵုကေတ်
+
+data-frame-missing-column-name = data ဂှ် column ယၟု မွဲ ဟွံမွဲ။ componentIdx :{ $componentIdx } ပ္ဍဲ ဆဵုကေတ်
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = answer ဏအ် နူ award ဂှ် answer tag ဇကုညး နူ သွဟ် မပ္တိုန်လဝ်ဂှ် ဇိုၚ်တဲစွံမံၚ်တုဲ၊ ဗွဲမဟွံရုဲစှ်မာန် ဒှ်အာရ။
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` မနွံ container ပ္ဍဲ `<answer>` ကု `maxNumAttempts` စွံဂှ် အကာဲအရာ ဟွံမွဲ ဟိုတ်နူ အလန် ဂၞန် ဂှ် container ဟေၚ် ကၠုၚ်ဒက်ဒဝ်ရ။ `maxNumAttempts` ဂှ် container ကု စွံညိ။
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` မနွံ container တၞဟ် ပ္ဍဲ `sectionWideCheckWork` မနွံ container ကု `maxNumAttempts` စွံဂှ် အကာဲအရာ ဟွံမွဲ ဟိုတ်နူ အလန် ဂၞန် ဂှ် ဗွဲမ္ၚး container ဟေၚ် ကၠုၚ်ဒက်ဒဝ်ရ။ `maxNumAttempts` ဂှ် ဗွဲမ္ၚး container ကု စွံညိ။
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality ဟွံစွံမ္ဂး attribute { $attributes } ဂှ် အကာဲအရာ ဟွံမွဲ။
+    }
+
+answer-invalid-type = answer သွက် type ဟွံဒးရး: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = component `<{ $component }>` ဂှ် ယၟု ဟွံမွဲဟိုတ်နူ module နူ attribute ဒှ် သုၚ်စောဲ ဟွံဂွံ
+
+module-attribute-name-already-defined = component type `<module>` ဂှ် attribute "{ $name }" စၟတ်သမ္တီလဝ်တုဲဟိုတ်နူ component `<{ $component } name="{ $name }">` ဂှ် module နူ attribute ဒှ် သုၚ်စောဲ ဟွံဂွံ။
+
+conditional-content-condition-ignored = case ဟွံသေၚ် else ကောန်ဇာတ် မနွံ `<conditionalContent>` ပ္ဍဲ attribute `condition` ဟွံသုၚ်စောဲ။
+
+slider-markers-type-mismatch = marker နူ type ကဵု slider နူ type ဟွံတုပ်။
+
+pretzel-problem-needs-statement-and-answer = pretzel ဟွံဒးရး - `<problem>` နာနာ ဂှ် `<statement>` မွဲ ကဵု `<answer>` မွဲ ဒးနွံ။
+
+pretzel-circuit-first-problem-distractor = pretzel ဟွံဒးရး - mode="circuit" ပ္ဍဲ `<problem>` ကၠာအိုတ် ဂှ် distractor ဒှ် ဟွံဂွံ။
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] attribute `{ $attribute }` သွက် တန်ဖိုး { $values } ဟွံဒးရး; ဟွံသုၚ်စောဲ။
+    }
+
+attribute-must-be-references = attribute `{ $attribute }` သွက် တန်ဖိုး `{ $value }` ဟွံဒးရး။ attribute ဂှ် `$` နကဵု မစတမ် reference နူ ဒးဒှ်။
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ပ္ဍဲ ဟွံဒးရး function ယၟု ဟွံသုၚ်စောဲ: { $names }။ ယၟု နာနာ နူ ကထ္ၜးအခန် ဂှ် အက္ခရ် ဟွံသေၚ် ဂၞိန် ဟွံအောန်နူ ၂ တၞး ဒးနွံ; လက္ကရဴ `|<mathspeak alternative>` ဂှ် စုတ်ကီု ဟွံစုတ်ကီု ဒှ်ဂွံ။
+
+## Building components from the source
+
+component-type-invalid = component type ဟွံဒးရး: `<{ $componentType }>`
+
+attribute-repeated = attribute { $attribute } ကလေၚ်ချူ ဟွံဂွံ။
+
+attribute-invalid-for-component = component type `<{ $componentType }>` သွက် attribute "{ $attribute }" ဟွံဒးရး။
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    style definition { $styleNumber } ဂှ် { $context ->
+        [text-on-background] background အဆံၚ်ဗီု ကု text အဆံၚ်ဗီု
+        [high-contrast] canvas ကု high-contrast အဆံၚ်ဗီု
+        [line] canvas ကု မျဉ်း အဆံၚ်ဗီု
+        [marker] canvas ကု marker အဆံၚ်ဗီု
+       *[text-on-canvas] canvas ကု text အဆံၚ်ဗီု
+    } သွက် contrast ဟွံပေၚ်{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ဟွံအောန်နူ { $threshold }:1 ဒးနွံ)။
+
+style-definition-dark-mode-text-background-contrast =
+    style definition { $styleNumber } ဂှ် light mode သွက် contrast ပေၚ်မံၚ် အဆံၚ်ဗီု စၟတ်သမ္တီလဝ်ကီုလေဝ်၊ ဂှ်နူ တိတ်ကၠုၚ် dark mode အဆံၚ်ဗီု ဂှ် background အဆံၚ်ဗီု ကု text အဆံၚ်ဗီု သွက် contrast ဟွံပေၚ် ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ဟွံအောန်နူ { $threshold }:1 ဒးနွံ)။ { $suggestion ->
+        [available] dark mode ပ္ဍဲ contrast ပေၚ်ဂွံဂှ် light mode နူ contrast ဂၠိုၚ်တိုန်ကဵုညိ (ဗီုကဵု { $lightAttribute }="{ $lightColor }" စွံ) ဟွံသေၚ် dark mode အဆံၚ်ဗီု ပြံၚ်စွံညိ (ဗီုကဵု { $darkAttribute }="{ $darkColor }" စွံ)။
+       *[none] dark mode ပ္ဍဲ contrast ပေၚ်ဂွံဂှ် light mode နူ contrast ဂၠိုၚ်တိုန်ကဵုညိ ဟွံသေၚ် တိတ်ကၠုၚ် အဆံၚ်ဗီု ဂှ် textColorDarkMode ကဵု/ဟွံသေၚ် backgroundColorDarkMode နကဵု ပြံၚ်စွံညိ။
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    style definition { $styleNumber } ဂှ် light mode သွက် contrast ပေၚ်မံၚ် text အဆံၚ်ဗီု စၟတ်သမ္တီလဝ်ကီုလေဝ်၊ ဂှ်နူ တိတ်ကၠုၚ် dark mode text အဆံၚ်ဗီု ဂှ် canvas ကု contrast ဟွံပေၚ် ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ဟွံအောန်နူ { $threshold }:1 ဒးနွံ)။ { $suggestion ->
+        [available] dark mode ပ္ဍဲ contrast ပေၚ်ဂွံဂှ် light mode နူ contrast ဂၠိုၚ်တိုန်ကဵုညိ (ဗီုကဵု textColor="{ $lightColor }" စွံ) ဟွံသေၚ် dark mode အဆံၚ်ဗီု ပြံၚ်စွံညိ (ဗီုကဵု textColorDarkMode="{ $darkColor }" စွံ)။
+       *[none] dark mode ပ္ဍဲ contrast ပေၚ်ဂွံဂှ် light mode နူ contrast ဂၠိုၚ်တိုန်ကဵုညိ ဟွံသေၚ် တိတ်ကၠုၚ် အဆံၚ်ဗီု ဂှ် textColorDarkMode နကဵု ပြံၚ်စွံညိ။
+    }
+
+section-multiple-style-palettes = ကဏ္ဍ မွဲ ဂှ် <stylePalette> မွဲဓဝ် ရုဲဂွံ; လက္ကရဴအိုတ် သုၚ်စောဲရ။
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect ဂှ် ဂၞန်ဟွံစှေ်နူသုည integer ဟွံသေၚ်ဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-num-to-select-not-constant-number = numToSelect ဂှ် ဟွံပြံၚ်လှာဲ number ဟွံသေၚ်ဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-with-replacement-not-constant-boolean = withReplacement ဂှ် ဟွံပြံၚ်လှာဲ boolean ဟွံသေၚ်ဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-select-weight-disables-unique = selectWeight ဟွံသေၚ် selectForVariants မစၟတ်သမ္တီလဝ် option နွံမ္ဂး select သွက် unique variant ကၟာတ်လဝ်ရ
+
+variant-coprime-undetermined = coprime ဂှ် လၟိုန် ဟွံဒှ် ဟီုစၟတ်သမ္တီ ဟွံဂွံဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-attribute-not-constant = { $attribute } ဂှ် ဟွံပြံၚ်လှာဲ ဟွံသေၚ်ဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-attribute-not-number = { $attribute } ဂှ် number ဟွံသေၚ်ဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } ဂှ် { $expected ->
+        [letters-combination] အက္ခရ် မပံၚ်လဝ်
+        [math-expression] မဒးရး math expression
+        [integer] integer
+       *[number] number
+    } ဟွံသေၚ်ဟိုတ်နူ type { $type } နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-length-not-integer = length ဂှ် integer ဟွံသေၚ်ဟိုတ်နူ { $component } နူ unique variant စၟတ်သမ္တီ ဟွံဂွံ။
+
+variant-sort-not-implemented = sort မနွံ { $component } နူ unique variant ဂှ် ဟွံကၠောန်လဝ်ဏီ
+
+variant-exclude-combinations-not-implemented = excludeCombinations မနွံ { $component } နူ unique variant ဂှ် ဟွံကၠောန်လဝ်ဏီ
+
+variant-math-exclude-not-implemented = exclude မနွံ type math { $component } နူ unique variant ဂှ် ဟွံကၠောန်လဝ်ဏီ
+
+variant-non-constant-exclude-not-implemented = ဟွံပြံၚ်လှာဲ ဟွံသေၚ် exclude မနွံ { $component } နူ unique variant ဂှ် ဟွံကၠောန်လဝ်ဏီ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure renderer ပ္ဍဲ သုၚ်စောဲ ဟွံဂွံ; ကောန်စဴ ကၠေံပလီုရ။
+
+prefigure-descendant-invalid-geometry = { $subject }: ဗီုပြၚ် ဟွံပေၚ် ဟွံသေၚ် ဟွံဒှ်အကွက်; ကောန်စဴ ကၠေံပလီုရ။
+
+prefigure-curve-label-omitted = { $subject }: မပြံၚ်လဝ် curve ပ္ဍဲ label သုၚ်စောဲ ဟွံဂွံ; label ကၠေံပလီုရ။
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve function definition type '{ $definitionType }' သုၚ်စောဲ ဟွံဂွံ; ကောန်စဴ ကၠေံပလီုရ။
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves ပ္ဍဲ attribute flipFunctions သုၚ်စောဲ ဟွံဂွံ; ကောန်စဴ ကၠေံပလီုရ။
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves ပ္ဍဲ formula type function ကောန်ဇာတ်ဟေၚ် သုၚ်စောဲဂွံ; ကောန်စဴ ကၠေံပလီုရ။
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] line family နူ label
+       *[point] အမှတ် နူ label
+    } သွက် labelPosition '{ $labelPosition }' သုၚ်စောဲ ဟွံဂွံ; default PreFigure alignment သုၚ်စောဲရ။
+
+prefigure-fill-style-unsupported = { $subject }: fill style '{ $fillStyle }' ဂှ် PreFigure သုၚ်စောဲ ဟွံဂွံ; မပေၚ် fill ကု ကလေၚ်စှေ်ရ။
+
+prefigure-line-style-unknown = { $subject }: ဟွံတီကေတ် line style '{ $lineStyle }' ဂှ် PreFigure output ပ္ဍဲ ဟွံပါလုပ်။
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }' ဂှ် PreFigure style 'diamond' ကု ပြံၚ်စွံရ။
+
+prefigure-marker-style-unsupported = { $subject }: marker style '{ $markerStyle }' ဂှ် PreFigure သုၚ်စောဲ ဟွံဂွံ; default style သုၚ်စောဲရ။
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ဟွံဒးရး; target ထ္ၜး ဟွံဂွံ။ annotation ကၠေံပလီုရ။
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ဂှ် target ဂၠိုၚ်တၞး ထ္ၜးရ; ကၠာအိုတ် target သုၚ်စောဲရ။
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ဟွံဒးရး; target ဂှ် graph မဒုၚ်လဝ် ဗွဲမ္ၚး နွံရ။ annotation ကၠေံပလီုရ။
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ဟွံဒးရး; target ဂှ် prefigure ပ္ဍဲ သုၚ်စောဲဂွံ ဗီု ဟွံသေၚ်။ annotation ကၠေံပလီုရ။
+
+annotation-text-missing = `<annotation>`: `text` ဟွံမွဲ ဟွံသေၚ် လလေၚ်; လလေၚ် text ပတိတ်ရ။
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] circular dependency ဆဵုကေတ်ရ။
+       *[other] component `<{ $componentType }>` ကု ဆေၚ်စပ် circular dependency ဆဵုကေတ်ရ။
+    }
+
+reference-no-referent = အရာ မဆေၚ်စပ် ကု reference ဟွံဆဵု: `{ $reference }`
+
+reference-multiple-referents = အရာ မဆေၚ်စပ် ကု reference ဂၠိုၚ်တၞး ဆဵုကေတ်: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` နူ attribute { $attribute } နူ ဗီုပြၚ် ဟွံဒးရး။
+
+children-invalid = `<{ $componentType }>` သွက် ကောန်ဇာတ် ဟွံဒးရး - ဟွံဒးရး ကောန်ဇာတ် ဆဵုကေတ်: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = attribute `{ $attribute }` သွက် တန်ဖိုး `{ $value }` ဟွံဒးရး၊ တန်ဖိုး `{ $default }` သုၚ်စောဲရ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML version { $version } ဟွံဆဵု။
+       *[other] DoenetML version { $version } ဟွံဆဵု။ version { $fallback } ကု ကလေၚ်စှေ်ရ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ဟွံဒးရး: { $content }
+
+parse-tag-missing-close-tag = DoenetML ဟွံဒးရး: tag `{ $tag }` ဂှ် ကၟာတ် tag ဟွံမွဲ။ ဇကုညး မကၟာတ် tag ဟွံသေၚ် `</{ $tagName }>` tag ဒးဒှ်။
+
+parse-tag-error = DoenetML ဟွံဒးရး: tag `<{ $tagName }>` ပ္ဍဲ တၚ်ဗၠေတ်
+
+parse-attribute-missing-value = DoenetML ဟွံဒးရး: ဟွံဒးရး attribute `{ $attribute }` ဂှ် တန်ဖိုး ဟွံမွဲ ဗီုဒှ်ရ။
+
+parse-attribute-invalid = DoenetML ဟွံဒးရး: attribute `{ $attribute }` ဟွံဒးရး
+
+parse-attribute-value-invalid = DoenetML ဟွံဒးရး: attribute တန်ဖိုး `{ $value }` ဟွံဒးရး
+
+parse-attribute-value-quote-mismatch = DoenetML ဟွံဒးရး: attribute တန်ဖိုး `{ $value }` ဟွံဒးရး။ ကွက်ဗ္စိုပ် ဟွံတုပ်။ `{ $quote }` ဟွံမွဲ ဗီုဒှ်ရ
+
+parse-open-tag-name-missing = DoenetML ဟွံဒးရး: tag ယၟု ဟွံမွဲ tag ဆဵုကေတ်၊ ဗီုကဵု `<`
+
+parse-tag-not-closed = DoenetML ဟွံဒးရး: tag `{ $tag }` ဟွံကၟာတ်လဝ် (`>` ဟွံမွဲ ဗီုဒှ်)။
+
+parse-self-closing-tag-name-missing = DoenetML ဟွံဒးရး: tag ယၟု ဟွံမွဲ tag ဆဵုကေတ် `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ဟွံဒးရး: tag `{ $tag }` ဟွံကၟာတ်လဝ် (`/>` ဟွံမွဲ ဗီုဒှ်)။
+
+parse-tag-invalid-attributes = DoenetML ဟွံဒးရး: tag `{ $tag }` ဟွံဒးရး။ attribute ဗၠေတ်မံၚ် ဒှ်မာန်။
+
+parse-close-tag-name-missing = DoenetML ဟွံဒးရး: tag ယၟု ဟွံမွဲ ကၟာတ် tag ဆဵုကေတ်၊ ဗီုကဵု `</`
+
+parse-attribute-value-unquoted = attribute တန်ဖိုး ဂှ် ကွက်ဗ္စိုပ် ပ္ဍဲ ဒးစုတ်: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ဟွံဒးရး: ကၟာတ် tag `{ $tag }` ဆဵုကေတ်ကီုလေဝ် မဒးရး ပံက် tag ဟွံမွဲ
+
+parse-close-tag-mismatched = DoenetML ဟွံဒးရး: ကၟာတ် tag ဟွံတုပ်။ `</{ $expected }>` ဒးဒှ်။ `{ $found }` ဆဵုကေတ်
+
+parser-node-unconvertible = node { $node } ဂှ် Dast node ကု ပြံၚ် ဟွံဂွံ။
+
+## Names
+
+name-attribute-invalid =
+    attribute name='{ $name }' ဟွံဒးရး။ { $reason ->
+        [characters] ယၟု ဂှ် အက္ခရ်, ဂၞန်, ကွက်သၟဝ် ဟွံသေၚ် ဂၞိန်ဟေၚ် ပါလုပ်ဂွံ။
+       *[start] ယၟု ဂှ် အက္ခရ် နကဵု ဒးစတမ်။
+    }
+
+component-name-invalid-start = component ယၟု "{ $name }" ဟွံဒးရး။ ယၟု ဂှ် အက္ခရ် နကဵု ဒးစတမ်။
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = type videoWatched မနွံ answer ဂှ် attribute video ဒးနွံ
+
+answer-video-watched-video-not-reference = type videoWatched မနွံ answer ဂှ် reference မဒှ် attribute video ဒးနွံ
+
+answer-name-not-single-text = answer နူ attribute name ဂှ် text ကောန်ဇာတ် မွဲဓဝ် ဒးနွံ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = recursion အဆံၚ် ဂၠိုၚ်လောန်အာဟိုတ်နူ ဗွဲမ္ၚး DoenetML ကေတ် ဟွံဂွံ။ circular reference နွံမံၚ်ဟာ?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" နူ DoenetML ကေတ် ဟွံဂွံ
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" နူ ကေတ်လဝ် DoenetML ဟွံဒးရး - component type "{ $componentType }" ကု ဟွံတုပ်
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] attribute `{ $from }` ဂှ် ဟွံသုၚ်စောဲယျ; `{ $to }` သုၚ်စောဲညိ။
+       *[other] [deprecation] `<{ $component }>` ပ္ဍဲ attribute `{ $from }` ဂှ် ဟွံသုၚ်စောဲယျ; `{ $to }` သုၚ်စောဲညိ။
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }` ကီု စၟတ်သမ္တီလဝ်ဟိုတ်နူ attribute `{ $from }` ဂှ် ဟွံသုၚ်စောဲယျ တုဲ ဟွံသုၚ်စောဲ။
+       *[other] [deprecation] `{ $to }` ကီု စၟတ်သမ္တီလဝ်ဟိုတ်နူ `<{ $component }>` ပ္ဍဲ attribute `{ $from }` ဂှ် ဟွံသုၚ်စောဲယျ တုဲ ဟွံသုၚ်စောဲ။
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` ပ္ဍဲ attribute `{ $attribute }` ဂှ် ဟွံသုၚ်စောဲယျ တုဲ ဟွံသုၚ်စောဲ။
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` ပ္ဍဲ attribute `{ $attribute }` ဂှ် ဟွံသုၚ်စောဲယျ; `<{ $child }>` ကောန်ဇာတ် သုၚ်စောဲညိ။
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` ပ္ဍဲ attribute `{ $attribute }` နူ တန်ဖိုး `{ $value }` ဂှ် ဟွံသုၚ်စောဲယျ; `{ $to }` သုၚ်စောဲညိ။
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ဂှ် အၚ်္ဂလိက် ဘာသာဟေၚ် ဂၞန်ဂၠိုၚ် ကၠောန်မာန်တုဲ၊ { $locale } နကဵု မချူလဝ် document ပ္ဍဲ ဍေံနူ text ဂှ် ဟွံပြံၚ်လှာဲ။ ဂၞန်ဂၠိုၚ် ဗီုပြၚ် ဗွဲမ္ၚးဒမြိပ် ချူညိ ဟွံသေၚ် attribute `pluralForm` နကဵု စွံညိ။
+
+
+## Checking against the schema
+
+schema-element-unrecognized = element `<{ $tag }>` ဂှ် Doenet element မတီကေတ် ဟွံသေၚ်။
+
+schema-element-not-allowed-at-root = element `<{ $tag }>` ဂှ် document နူ root ပ္ဍဲ စုတ် ဟွံဂွံ။
+
+schema-element-not-allowed-inside = element `<{ $tag }>` ဂှ် `<{ $parent }>` ပ္ဍဲ စုတ် ဟွံဂွံ။
+
+schema-attribute-unrecognized = element `<{ $tag }>` ဂှ် `{ $attribute }` ယၟု မနွံ attribute ဟွံမွဲ။
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] element `<{ $tag }>` နူ attribute `{ $attribute }` ဂှ် တၞး နာနာ ဏအ် နူ မွဲမွဲ မဒှ် list ဒးဒှ်: { $allowed }
+       *[other] element `<{ $tag }>` နူ attribute `{ $attribute }` ဂှ် ဏအ် နူ မွဲမွဲ ဒးဒှ်: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select သွက် variant name ဟွံဒးရး။ variant name { $variantName } ဂှ် option { $numOptions } ပ္ဍဲ နွံကီုလေဝ် ရုဲဂၞန် ဂှ် { $numToSelect } ဒှ်ရ။
+
+select-variant-name-without-options = select သွက် variant လ္ၚဵု စၟတ်သမ္တီလဝ်ကီုလေဝ် မဒှ်မာန် variant name သွက် option ဟွံမွဲ: { $variantName }။
+
+select-variant-name-not-possible = select သွက် မစၟတ်သမ္တီလဝ် variant name { $variantName } ဂှ် မဒှ်မာန် variant name ဟွံသေၚ်။
+
+select-too-few-options = { $numOptions } ဟေၚ် နူ component { $numToSelect } ရုဲ ဟွံဂွံ။
+
+select-from-sequence-too-few-values = ဇမၠိၚ် { $length } မနွံ sequence နူ တန်ဖိုး { $numToSelect } ရုဲ ဟွံဂွံ။
+
+select-from-sequence-indices-count-mismatch = select သွက် မစၟတ်သမ္တီလဝ် indices ဂၞန် ဂှ် ရုဲဂၞန် ကု ဒးတုပ်
+
+select-from-sequence-indices-not-integers = select သွက် မစၟတ်သမ္တီလဝ် indices နာနာ ဂှ် integer ဒးဒှ်
+
+select-from-sequence-index-excluded = selectfromsequence နူ မစၟတ်သမ္တီလဝ် index ဂှ် ပတိတ်လဝ်ရ
+
+select-from-sequence-indices-excluded-combination = selectfromsequence နူ မစၟတ်သမ္တီလဝ် indices ဂှ် ပတိတ်လဝ် combination ဒှ်ရ
+
+select-from-sequence-coprime-not-positive-integers = ဂၠိုၚ်နူသုည integer ဟွံရုဲဟိုတ်နူ coprime combination ရုဲ ဟွံဂွံ။
+
+select-from-sequence-coprime-common-factor = coprime number ရုဲ ဟွံဂွံ။ မဒှ်မာန် တန်ဖိုး နာနာ ဂှ် ကောန်ဂၞန် တုပ် နွံရ။ (မစၟတ်သမ္တီလဝ် "from" ဟွံသေၚ် "to" ဂှ် "step" ကု coprime ဒးဒှ်။)
+
+select-from-sequence-coprime-single-number = 1 ဟွံသေၚ် number မွဲဓဝ် နူ coprime combination ရုဲ ဟွံဂွံ။
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ပ္ဍဲ combination 70% ဂၠိုၚ်နူ ပတိတ်လဝ်ရ
+
+select-from-sequence-coprime-none-found = coprime number ရုဲ ဟွံဂွံ။ မဒှ်မာန် တန်ဖိုး နာနာ ဂှ် ကောန်ဂၞန် တုပ် နွံရ။
+
+select-from-sequence-too-few-unique-values = ဇမၠိၚ် { $numPossibleValues } မနွံ sequence နူ unique တန်ဖိုး { $numToSelect } ရုဲ ဟွံဂွံ
+
+select-prime-numbers-too-few-values = ဇမၠိၚ် { $numValues } မနွံ prime စရၚ် နူ တန်ဖိုး { $numToSelect } ရုဲ ဟွံဂွံ
+
+select-prime-numbers-values-count-mismatch = select သွက် မစၟတ်သမ္တီလဝ် တန်ဖိုး ဂၞန် ဂှ် ရုဲဂၞန် ကု ဒးတုပ်
+
+select-prime-numbers-values-not-prime = select prime number သွက် မစၟတ်သမ္တီလဝ် တန်ဖိုး နာနာ ဂှ် prime စရၚ် ပ္ဍဲ ဒးနွံ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers နူ မစၟတ်သမ္တီလဝ် တန်ဖိုး ဂှ် ပတိတ်လဝ် combination ဒှ်ရ
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ပ္ဍဲ combination 70% ဂၠိုၚ်နူ ပတိတ်လဝ်ရ
+
+select-random-combination-fluke = ဗွဲမဟွံဒှ်မာန်ဂတိုၚ် random တန်ဖိုး နူ combination ရုဲ ဟွံဂွံ
+
+select-random-value-fluke = ဗွဲမဟွံဒှ်မာန်ဂတိုၚ် random တန်ဖိုး ရုဲ ဟွံဂွံ
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` ဏအ် ဟွံထ္ၜး၊ ဟိုတ်နူ math ပ္ဍဲ နွံကီုလေဝ် `inline` ဟွံသေၚ်။ `inline` စုတ်ညိ၊ ဂှ်မ္ဂး expression ပ္ဍဲ လုပ်ဂွံ drop-down list ဒှ်အာရ။
+        [expanded] `<{ $component }>` ဏအ် ဟွံထ္ၜး၊ ဟိုတ်နူ math ပ္ဍဲ နွံတုဲ `expanded` ဒှ်မံၚ်။ `expanded` ပတိတ်ညိ; လ္တူဗွဲမဂၠိုၚ်တၞး ကွက် ဂှ် expression ပ္ဍဲ ဟွံလုပ်။
+        [on-graph] `<{ $component }>` ဏအ် ဟွံထ္ၜး၊ ဟိုတ်နူ graph လ္တူ မဓဇက်လဝ် math ပ္ဍဲ နွံတုဲ input သွက် ဒၞာဲ ဟွံမွဲ။
+       *[relative-width] `<{ $component }>` ဏအ် ဟွံထ္ၜး၊ ဟိုတ်နူ math ပ္ဍဲ နွံတုဲ relative width နွံ။ `px` ဗီု ခဏ်လၟိဟ်တၟေၚ် နကဵု width ကဵုညိ။
+    }

--- a/packages/i18n/locales/mnw/editor.ftl
+++ b/packages/i18n/locales/mnw/editor.ftl
@@ -1,0 +1,233 @@
+# Mon (ဘာသာမန်) editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# Mon in the Mon-Burmese script with the Mon letters ၚ ၜ and the medials
+# ၞ ၟ ၠ — never Burmese င for Mon ၚ — and Burmese spacing.
+#
+# **This is the file where the loans are heaviest, and it should be read as
+# such.** The editor's own nouns are English almost without exception —
+# `editor`, `viewer`, `variant`, `filter`, `component`, `attribute`,
+# `reference`, `property`, `snippet`, `array entry`, `type`, `style`,
+# `default`, `coordinate`, `function`, `line`, `tag`, `report`, `credit`,
+# `accessibility`, `Answer Id` — **around a Mon frame**. What is Mon here is
+# the word order (verb before object, modifier after head noun), the
+# relativizer မ with the perfective လဝ်, and the ordinary verbs ထ္ၜး (show),
+# ရုဲ (choose), ဆဵု (find), နွံ (there is), ဒှ် (be), ဍဵု (press). The
+# Burmese loans, in Burmese spelling, are သတိပေးချက် (warning), အချက်အလက်
+# (information) and အကြံပြုချက် (recommendation).
+#
+# **`editor-update-viewer`'s two words are Mon**: ပလေဝ် ('put right, revise')
+# for Update and ကလေၚ်စွံ ('set back') for Reset. Both sit on a narrow
+# toolbar button; if they do not fit, that is a layout problem to report
+# rather than a reason to shorten them wrongly.
+#
+# **What this catalog does not know.** The context-help panel's register —
+# what a Mon-speaking mathematics teacher calls a reference, a property or a
+# default — is not something this seed could establish, so those sentences are
+# a Mon frame around the English words and read as such. The panel is the
+# first place a speaker's rewriting will show.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ကလေၚ်စွံ
+       *[update] ပလေဝ်
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } viewer
+       *[other] { $word } viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = variant
+
+editor-variant-filter = filter…
+
+editor-variant-next = ရုဲ variant လက္ကရဴ
+
+editor-variant-previous = ရုဲ variant ကၠာ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] ဆဵုကေတ် WCAG AA accessibility တၚ်ဗၠေတ် ရ။ ဍဵု သွက်ဂွံ{ $action ->
+            [close] ကၟာတ်
+           *[open] ပံက်
+        } accessibility report။
+        [advisories] ဍဵု သွက်ဂွံ{ $action ->
+            [close] ကၟာတ်
+           *[open] ပံက်
+        } accessibility report။ WCAG AA တၚ်ဗၠေတ် ဟွံဆဵု ကီုလေဝ် အကြံပြုချက် accessibility တၞဟ် နွံမံၚ်ရ။
+       *[clean] ဍဵု သွက်ဂွံ{ $action ->
+            [close] ကၟာတ်
+           *[open] ပံက်
+        } accessibility report။ တၚ်ပြသၞာ accessibility မွဲမွဲ ဟွံဆဵု။
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] ဆဵုကေတ် WCAG AA accessibility တၚ်ဗၠေတ် ရ။ WCAG AA တၚ်ဗၠေတ် { $count } တၚ် ဆဵုကေတ်။ ဍဵု သွက်ဂွံ{ $action ->
+            [close] ကၟာတ်
+           *[open] ပံက်
+        } accessibility report။
+        [advisories] WCAG AA တၚ်ဗၠေတ် ဟွံဆဵု။ အကြံပြုချက် accessibility တၞဟ် { $count } တၚ် ဆဵုကေတ်။ ဍဵု သွက်ဂွံ{ $action ->
+            [close] ကၟာတ်
+           *[open] ပံက်
+        } accessibility report။
+       *[clean] WCAG AA တၚ်ဗၠေတ် ဟွံဆဵု။ ဍဵု သွက်ဂွံ{ $action ->
+            [close] ကၟာတ်
+           *[open] ပံက်
+        } accessibility report။
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = တၚ်ရီုဗၚ် ဗွဲမလုပ်စ ကုအရာမနွံ
+editor-tab-help-short = ရီုဗၚ်
+editor-tab-errors = တၚ်ဗၠေတ်
+editor-tab-warnings = သတိပေးချက်
+editor-tab-info = အချက်အလက်
+editor-tab-accessibility = accessibility
+editor-tab-responses = သွဟ် မပ္တိုန်လဝ်
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = တၚ်ရုဲစှ် နူ editor
+editor-format-as-doenetml = ဗီုပြၚ် ဒှ် DoenetML
+editor-format-as-xml = ဗီုပြၚ် ဒှ် XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = line #{ $line }
+
+editor-no-errors = တၚ်ဗၠေတ် ဟွံမွဲ
+editor-no-warnings = သတိပေးချက် ဟွံမွဲ
+editor-no-info = info diagnostic ဟွံမွဲ
+
+editor-show-info-annotations = ထ္ၜး info diagnostic ပ္ဍဲ editor
+editor-show-accessibility-annotations = ထ္ၜး accessibility diagnostic ပ္ဍဲ editor
+
+editor-accessibility-learn-more = ဗ္တောန်ကေတ် ပရူ Doenet ကၠောန်ဗဒှ် accessibility
+
+editor-accessibility-violations-heading = accessibility တၚ်ဗၠေတ် ({ $standard })
+
+editor-accessibility-other-heading = တၚ်ပြသၞာ accessibility တၞဟ်
+editor-none-found = မွဲမွဲ ဟွံဆဵု
+
+
+## Submitted responses
+
+editor-no-responses = သွဟ် မပ္တိုန်လဝ် ဟွံမွဲဏီ
+editor-response-answer-id = Answer Id
+editor-response-response = သွဟ်
+editor-response-credit = credit
+editor-response-submitted = ပ္တိုန်လဝ်
+
+
+## The context-help panel
+
+help-placeholder = စွံ cursor ပ္ဍဲ tag, attribute ဟွံသေၚ် { $ref } သွက်ဂွံရံၚ် documentation။
+
+help-unsupported-ref-chain = reference ဗွဲမဂၠိုၚ်တၞး ဗီုကဵု { $example } ဂှ် ဟွံကၠောန်လဝ်ဏီ။
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] အရာ မဆေၚ်စပ် ကု reference ဟွံဆဵု: { $ref }။
+        [multiple] အရာ မဆေၚ်စပ် ကု reference ဂၠိုၚ်တၞး ဆဵုကေတ်: { $ref }။
+       *[indeterminate] အရာ မဆေၚ်စပ် ကု { $ref } ဂှ် စၟတ်သမ္တီ ဟွံဂွံ။
+    }
+
+help-learn-about-references = ဗ္တောန်ကေတ် ပရူ reference →
+help-reference-page = မုက်လိက် reference →
+
+help-suggestions-header =
+    { $location ->
+        [inside] ပ္ဍဲ { $element }
+       *[top] ပ္ဍဲ top level
+    }{ $allowed ->
+        [none] { " — မွဲမွဲ စုတ်ဟွံဂွံ။" }
+        [text] { " — စုတ် text ဗွဲမဒှ်။" }
+        [text-and-components] { " — စုတ် text ဟွံသေၚ် စမ်ရံၚ်:" }
+       *[components] { " — အရာ မစမ်ရံၚ်ဂွံ:" }
+    }
+
+help-suggestions-footer = ဍဵု { $shortcut } သွက်ဂွံရံၚ် component အလုံ { $total } တၞး။
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ဂှ် reference ကု { $target } ရ။
+       *[other] { $ref } ဂှ် reference ကု { $target } ရ (line { $line })။
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } စုတ်လဝ် ဒှ် { $role }။
+       *[other] { $owner } စုတ်လဝ် ပ္ဍဲ line { $line } ဒှ် { $role }။
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ဂှ် reference ကု property { $property } နူ { $element } ရ။
+       *[other] { $ref } ဂှ် reference ကု property { $property } နူ { $element } ရ (line { $line })။
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = default:
+help-active-default = default မသုၚ်စောဲမံၚ်:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] တန်ဖိုး မစုတ်ဂွံ (မွဲတၞးမွဲ):
+       *[other] တန်ဖိုး မစုတ်ဂွံ:
+    }
+
+help-suggested-values = တန်ဖိုး မဒုၚ်သဇိုၚ်:
+
+help-inserts = စုတ်ကဵု:
+
+help-coordinates =
+    { $count ->
+       *[other] coordinate:
+    }
+
+help-type = type:
+
+help-resolved-style = style မတိတ်ကၠုၚ် (styleNumber { $styleNumber }):
+
+help-resolved-function-names = ယၟု function မတိတ်ကၠုၚ်:
+help-reset-list = reset list ပ္ဍဲ input ဏအ်:
+help-added-on-input = စုတ်လဝ် ပ္ဍဲ input ဏအ်:
+help-removed-on-input = ပတိတ်လဝ် ပ္ဍဲ input ဏအ်:
+
+help-reset-overrides = { $reset } ဂှ် အာလ္ပာ်လတူ { $additional } ကဵု { $removed } ရ။

--- a/packages/i18n/locales/mrw/chrome.ftl
+++ b/packages/i18n/locales/mrw/chrome.ftl
@@ -1,0 +1,166 @@
+# Maranao (Basa a Mëranaw) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **This is the thinnest of the three Philippine catalogs added with it, and
+# it says so first rather than last.** Maranao is the language of the Lanao
+# provinces in Mindanao, and the published lexical material a seed can reach
+# is small and mostly religious and lexicographic rather than technical.
+# **Almost every content word below is a declared loan.** What is Maranao here
+# is the *frame* — the markers, the linker, the negators, a short list of
+# function words and a handful of verbs — and a speaker should expect to
+# rewrite sentences rather than to correct words inside them.
+#
+# **The schwa is written «ë» (U+00EB).** Maranao has four vowels — a, i, o and
+# a mid central one — and the fourth is written here as **ë**, in «Mëranaw»,
+# «maitëm», «pën», «pëkhagamit», «galëbëk», «madakël», «sëmbag». Print uses
+# other conventions for the same vowel: a bare **e**, an **e'** with an
+# apostrophe, and in older material a **u**. A reviewer who prefers one of
+# those should **respell rather than retranslate**, and should respell all
+# four files at once: a catalog that writes «pën» in one file and «pen» in
+# another is unsearchable. The claim is checkable — no bare «e» carries the
+# schwa anywhere in these files.
+#
+# **The Latin script is otherwise plain**: no other diacritic appears, and the
+# glottal stop is not written.
+#
+# **The technical register is English, and it is a real register rather than a
+# gap.** Lanao's schools teach mathematics and science in English, so the
+# words a Maranao speaker uses for these things *are* the English ones. They
+# are kept here as they stand — `point`, `line`, `graph`, `renderer`, `input`,
+# `preview`, `row`, `column`, `keyboard`, `WCAG` — rather than respelled into
+# an invented Maranao phonology. A few Filipino loans do the same job where
+# Filipino rather than English is what is said: «alisën» (move), «punasën»
+# (clear), «sarahën» (close), «sobok» (attempt). Every one of those is a loan
+# and is named as one.
+#
+# **The verb morphology is the least certain thing in this catalog.** The seed
+# writes «pëng-/pëk-/pëph-» for an ongoing action, «mi-/miya-» for a completed
+# one and «-ën»/«-an» for an undergoer form. Those affixes are the first thing
+# a speaker should correct, ahead of any word choice.
+#
+# **Two words to check first**, because they carry many messages each:
+# «sëmbag» for *answer* and «kasalaan» for *error*. If either is wrong, it is
+# wrong in dozens of places and one search fixes it.
+
+answer-checking = Pëngilayn...
+answer-submitting = Pësogoën...
+
+answer-checking-status = Pëngilayn so sëmbag
+answer-submitting-status = Pësogoën so sëmbag
+
+answer-correct = Ontol
+answer-incorrect = Di ontol
+
+answer-response-saved = Miyatago so Sëmbag
+
+answer-percent-credit = { $percent }% a kredito
+answer-percent-correct = { $percent }% a ontol
+answer-percent-short = { $percent } %
+
+max-credit-available = Mala a kredito a khakowa: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] da a somobra a sobok
+       *[other] { $count } a sobok i somobra
+    }
+
+validation-correct = (Ontol)
+validation-incorrect = (Di ontol)
+validation-partially-correct = (Bagi a ontol)
+
+answer-show-responses =
+    { $count ->
+       *[other] Pakiilayin so { $count } a sëmbag ko { $answerId }
+    }
+
+feedback-heading = Feedback
+
+collapsible-click-to-open = (i-click a an malokaan)
+collapsible-click-to-close = (i-click a an masarahan)
+
+collapsible-initializing = Pëphoonan...
+
+footnote-show = Pakiilayin so footnote
+footnote-hide = Di pakiilayin so footnote
+
+description-more-information = madakël a impormasyon
+
+slider-previous = Miyaona
+slider-next = Somonod
+
+keyboard-open = Lokaan so Keyboard
+keyboard-close = Sarahën so Keyboard
+
+choice-input-remove-choice = Awaan so { $choice }
+
+matrix-remove-row = Awaan so row
+matrix-add-row = Omanan sa row
+matrix-remove-column = Awaan so column
+matrix-add-column = Omanan sa column
+
+subset-add-remove-points = Omanan/Awaan so manga point
+subset-toggle-points-intervals = Somambi ko manga point go manga interval
+subset-move-points = Alisën so manga point
+subset-clear = Punasën
+
+orbital-add-row = Omanan sa row
+orbital-remove-row = Awaan so row
+orbital-add-box = Omanan sa box
+orbital-remove-box = Awaan so box
+orbital-add-up-arrow = Omanan sa up arrow
+orbital-add-down-arrow = Omanan sa down arrow
+orbital-remove-arrow = Awaan so arrow
+
+orbital-row-label = Label ko row { $row }
+
+pretzel-answer = Sëmbag
+
+summary-statistics-caption = Summary statistics o { $column }
+
+math-input-preview-region = preview o math expression
+math-input-preview = Preview
+math-input-invalid-expression = Di ontol a expression:
+
+viewer-initializing = Pëphoonan...
+
+error-heading = Kasalaan
+
+error-found-at =
+    { $span ->
+        [line] Miyailay ko line { $startLine }.
+       *[lines] Miyailay ko manga line { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Aden a kasalaan ko sangkai a document!
+
+diagnostic-heading-error = Kasalaan
+diagnostic-heading-warning = Pakatanod
+diagnostic-heading-information = Impormasyon
+diagnostic-heading-hint = Hint
+
+accessibility-heading-level-1 = Violation ko WCAG AA a Accessibility
+accessibility-heading-level-2 = Pakatanod ko accessibility
+
+something-went-wrong = Aden a miyasalaan.
+
+renderer-load-failed = da makaload so isa a renderer. Ipa-reload sa so page.
+
+core-start-failed = Di khagaga a phoonan so sangkai a document. Ipa-reload sa so page.
+
+core-start-failed-busy = Di khagaga a phoonan so sangkai a document. Madakël a document i miyaphoonan a sama-sama, na mapëthagaan oto amay ka malëbod so aparato. Amay ka miyapasad den so manga salakaw a document, khatabang o kapaka-reload ko page.
+
+core-start-failed-retry = Di khagaga a phoonan so sangkai a document.
+
+core-start-failed-busy-retry = Di khagaga a phoonan so sangkai a document. Madakël a document i miyaphoonan a sama-sama, na mapëthagaan oto amay ka malëbod so aparato.
+
+core-start-retry = Sobok pëman
+
+saved-state-unavailable = Da makaload so miyatago a galëbëk ëngka.

--- a/packages/i18n/locales/mrw/chrome.ftl
+++ b/packages/i18n/locales/mrw/chrome.ftl
@@ -8,7 +8,7 @@
 # UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
 # Correct anything here freely; nothing in it was written by a translator.
 #
-# **This is the thinnest of the three Philippine catalogs added with it, and
+# **This is the thinnest of the four Philippine catalogs added with it, and
 # it says so first rather than last.** Maranao is the language of the Lanao
 # provinces in Mindanao, and the published lexical material a seed can reach
 # is small and mostly religious and lexicographic rather than technical.

--- a/packages/i18n/locales/mrw/content.ftl
+++ b/packages/i18n/locales/mrw/content.ftl
@@ -54,7 +54,7 @@
 #
 # **The two chemistry tables — `element-name` and `element-anion-name` — are
 # omitted.** Secondary science in Lanao is taught in English, so the English
-# fallback is the language of the classroom, and filling those 132 keys in
+# fallback is the language of the classroom, and filling those 130 keys in
 # would claim a translation that had not happened. `ion-name-oxidation-state`
 # and the two `chemistry-invalid-` messages are prose and are translated.
 

--- a/packages/i18n/locales/mrw/content.ftl
+++ b/packages/i18n/locales/mrw/content.ftl
@@ -1,0 +1,297 @@
+# Maranao (Basa a Mëranaw) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in. `locales/en/content.ftl` is the source of truth, and message ids,
+# placeables and variant keys are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **The schwa is written «ë» (U+00EB)** — «maitëm», «pëkhagamit», «galëbëk»,
+# «madakël». Print also writes that vowel as a bare **e**, as **e'**, and in
+# older material as **u**. Respell rather than retranslate, and respell all
+# four files at once.
+#
+# ## Word order, and the linker
+#
+# **The describing word comes first, the noun after it, with the linker «a»
+# between them**: «makapal a mariga a linya» is *thick red line*. That is
+# English's order and Maranao's ordinary order for an attributive phrase, so
+# `style-stroke`, `style-with-noun` and `style-filled-with-noun` keep English's
+# sequence of placeables.
+#
+# **The linker is one shape.** Maranao writes «a» whatever stands on either
+# side of it, so this catalog does not have the problem the other Philippine
+# catalogs in the roster do — Tagalog's «na»/«-ng», Cebuano's «nga»/`-ng`,
+# Ilocano's «a»/«nga», Pangasinan's «a»/«-n» — where a neighbouring word the
+# catalog cannot see picks the form. Nothing here can misfire against an
+# author's own `lineColorWord`. That is worth stating because it is the one
+# place this thin catalog is on firmer ground than the fuller ones beside it.
+#
+# **«manga» is the plural word**, written only where the sense is genuinely
+# plural — the fill patterns. The noun is otherwise unmarked, so «linya» is
+# the word for one line and for many alike.
+#
+# ## Vocabulary — what is Maranao and what is a loan
+#
+# **Five colour words are Maranao**: «maitëm» (black), «mapoti» (white),
+# «mariga» (red), «binaning» (yellow), «gadong» (green). **The other seven are
+# the English words as they stand** — gray, orange, cyan, blue, purple, pink,
+# brown — because the seed found no Maranao term for them it could vouch for
+# and Lanao's classrooms say the English ones. That is the same shape
+# `locales/fon` has, where three reduplicated colour statives sit beside nine
+# French loans, and the seam is in the same place: a speaker correcting this
+# should expect to *add* Maranao words to that table rather than to find the
+# loans wrong as loans.
+#
+# «makapal» (thick) and «manipis» (thin) are Maranao. `line-style`'s two words
+# and **the whole of the `noun` table are English**, for the same reason: the
+# geometry vocabulary a Maranao speaker has is the English one they were
+# taught in. Nothing was coined and nothing was respelled into an invented
+# loan phonology.
+#
+# Maranao has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or `$role`.
+#
+# **The two chemistry tables — `element-name` and `element-anion-name` — are
+# omitted.** Secondary science in Lanao is taught in English, so the English
+# fallback is the language of the classroom, and filling those 132 keys in
+# would claim a translation that had not happened. `ion-name-oxidation-state`
+# and the two `chemistry-invalid-` messages are prose and are translated.
+
+
+## Style vocabulary
+
+# Five Maranao words and seven English ones; see the header.
+color =
+    .black = maitëm
+    .white = mapoti
+    .gray = gray
+    .red = mariga
+    .orange = orange
+    .yellow = binaning
+    .green = gadong
+    .cyan = cyan
+    .blue = blue
+    .purple = purple
+    .pink = pink
+    .brown = brown
+
+line-width =
+    .thick = makapal
+    .thin = manipis
+
+line-style =
+    .dashed = dashed
+    .dotted = dotted
+
+# «manga» is written here because a fill pattern is genuinely many marks.
+fill-style =
+    .horizontal = horizontal a manga linya
+    .vertical = vertical a manga linya
+    .diagonal = diagonal a manga linya
+    .backdiagonal = reverse diagonal a manga linya
+    .dots = manga dot
+    .diamonds = manga diamond
+
+noun =
+    .line = linya
+    .line-segment = line segment
+    .ray = ray
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = triangle
+    .rectangle = rectangle
+    .circle = circle
+    .region = region
+    .point = point
+    .square = square
+    .diamond = diamond
+    .cross = cross
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay in
+# front of the noun. «aden a» is 'there is', and «kilid» ('edge, side') is one
+# of the few content words in this file that is not a loan.
+noun-regular-polygon =
+    { $part ->
+        [tail] a aden a { $numSides } a kilid iyan
+       *[head] regular polygon
+    }
+
+# One answer for every noun: Maranao has no grammatical gender, so nothing
+# downstream has anything to agree with.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } a { $lineStyle } a { $color }
+        [width-color] { $width } a { $color }
+        [style-color] { $lineStyle } a { $color }
+        [width-style] { $width } a { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } a { $noun } { $nounTail }
+       *[noun] { $description } a { $noun }
+    }
+
+style-filled-word = napno
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } a { $color } a aden a { $pattern } iyan
+       *[plain] { $filled } a { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } a { $color } a { $noun } a aden a { $pattern } iyan
+        [plain-tail] { $filled } a { $color } a { $noun } { $nounTail }
+        [pattern-tail] { $filled } a { $color } a { $noun } { $nounTail } a aden a { $pattern } iyan
+       *[plain] { $filled } a { $color } a { $noun }
+    }
+
+# Maranao has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, and this file does mark that: «a aden a … iyan»
+# against «go».
+style-border-clause =
+    { $parts ->
+        [with-article] a aden a { $border } a border iyan
+        [and] go { $border } a border
+        [and-article] go { $border } a border
+       *[with] a aden a { $border } a border iyan
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } a { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = di napno
+
+style-text =
+    { $parts ->
+        [background] { $color } a aden a { $background } a background iyan
+       *[plain] { $color }
+    }
+
+style-background-none = da
+
+
+## Boolean words
+
+boolean-true = bënar
+boolean-false = di bënar
+
+
+## Answer buttons
+
+answer-submit-label = Ilayn so Galëbëk
+answer-submit-label-no-correctness = Isogo so Sëmbag
+
+
+## Sectional blocks
+##
+## Mostly English, for the reason the header gives. «Ma-ana» (meaning),
+## «Ibarat» (example), «Bagi» (part), «Sëmbag» (answer) and «Galëbëk» (work)
+## are Maranao; «Nota» is a Spanish loan carried in through Filipino.
+
+section-name =
+    .activity = Activity
+    .aside = Aside
+    .cascade = Cascade
+    .definition = Ma-ana
+    .example = Ibarat
+    .exercise = Exercise
+    .exercises = Manga Exercise
+    .given-answer = Sëmbag
+    .note = Nota
+    .objectives = Manga Objective
+    .paragraphs = Manga Paragraph
+    .part = Bagi
+    .problem = Problem
+    .problems = Manga Problem
+    .proof = Proof
+    .question = Question
+    .section = Section
+    .solution = Solution
+    .task = Galëbëk
+    .theorem = Theorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Hint
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Table { $enumeration }
+        [numbered-title] Table { $enumeration }{ ": " }
+        [unnumbered-title] Table{ ": " }
+       *[unnumbered] Table
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figure { $enumeration }
+        [numbered-caption] Figure { $enumeration }{ ": " }
+        [unnumbered-caption] Figure{ ": " }
+       *[unnumbered] Figure
+    }
+
+
+## Paginator controls
+
+paginator-previous = Miyaona
+paginator-next = Somonod
+paginator-page = Page
+
+paginator-page-status = { $pageLabel } { $currentPage } ko { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = odi na
+
+piecewise-condition-if = amay ka
+
+piecewise-condition-otherwise = amay ka di
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Di Ontol a Chemical Symbol
+chemistry-invalid-ionic-compound = Di Ontol a Ionic Compound
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blangko
+
+math-embedded-input-blank-ordinal = blangko { $ordinal } ko { $total }

--- a/packages/i18n/locales/mrw/content.ftl
+++ b/packages/i18n/locales/mrw/content.ftl
@@ -44,10 +44,13 @@
 # loans wrong as loans.
 #
 # «makapal» (thick) and «manipis» (thin) are Maranao. `line-style`'s two words
-# and **the whole of the `noun` table are English**, for the same reason: the
-# geometry vocabulary a Maranao speaker has is the English one they were
-# taught in. Nothing was coined and nothing was respelled into an invented
-# loan phonology.
+# and **every entry in the `noun` table but one are English**, for the same
+# reason: the geometry vocabulary a Maranao speaker has is the English one
+# they were taught in. The exception is `noun.line`, written «linya» — the
+# everyday Maranao word, which a speaker uses without reaching for English —
+# and it is why the rendered style phrases below end in «linya» rather than in
+# «line». Nothing was coined and nothing was respelled into an invented loan
+# phonology.
 #
 # Maranao has no grammatical gender and no case, so `noun-gender` answers one
 # token for every noun and nothing here selects on `$gender` or `$role`.

--- a/packages/i18n/locales/mrw/diagnostics.ftl
+++ b/packages/i18n/locales/mrw/diagnostics.ftl
@@ -1,0 +1,708 @@
+# Maranao (Basa a Mëranaw) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **The schwa is written «ë» (U+00EB)**, as `chrome.ftl`'s header sets out.
+# Print also writes it **e**, **e'** or **u**; respell rather than
+# retranslate, and respell all four files at once.
+#
+# **The frames.** This file is some 220 sentences built out of a dozen
+# recurring frames, and reading the frames is the fastest way to review it:
+#
+#     Di pëkhagamit so …      it is ignored — literally 'is not used'
+#     Di khagaga a …          cannot / is not possible
+#     Paliyogat a …           must / is required
+#     Di ontol a …            invalid …
+#     Da mailay so …          not found — literally 'is not seen'
+#     Da a …                  there is no …
+#     Aden a …                there is …
+#     Da a epekto iyan        has no effect
+#     Da pën mapasad so …     has not been implemented
+#     sabap ko …              because of …
+#     … a miyatëndo           … that was specified
+#     Pëkhagamit so …         … is used
+#
+# Two of those are **paraphrases rather than translations**, and both are
+# worth replacing first because each carries dozens of messages: "ignored"
+# reads 'is not used', and "not found" reads 'is not seen'. The seed had no
+# Maranao verb for either that it could vouch for, and each is one search.
+#
+# **The technical nouns are English, and that is the register rather than a
+# gap** — Lanao's schools teach these subjects in English. `component`,
+# `attribute`, `value`, `type`, `version`, `index`, `matrix`, `expression`,
+# `dimension`, `function`, `region`, `color`, `line`, `point`, `row`,
+# `column`, `input`, `output`, `renderer`, `grid`, `default`, `mode`,
+# `state variable` are kept as they stand. A few Spanish loans reach Maranao
+# through Filipino and are used where they are what is said: «impormasyon»,
+# «problema», «kredito», «nota». Nothing was coined.
+#
+# **No plural-category branches.** CLDR has no plural data for `mrw`, so a
+# `[one]` branch would be text selected by English's rules; and Maranao leaves
+# a noun unmarked after a numeral, so one form is correct anyway. Every
+# `$…Count` and `$count` select is collapsed to a single `*[other]`. The
+# explicit numeric literals English forks on are kept where the branch is a
+# real distinction rather than a plural rule.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] di pëkhagamit so { $attributes } amay ka dowa a endpoint i miyatëndo
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] di pëkhagamit so { $attributes } amay ka miyatëndo so endpoint go so midpoint
+    }
+
+line-segment-midpoint-offset-without-midpoint = da a epekto o midpointOffset amay ka da a midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = Line a somasagad ko manga point a di matëndo i dimension iyan.
+
+line-points-too-few-dimensions = Paliyogat a somagad so line ko manga point a dowa bo i dimension iyan.
+
+line-points-depend-on-variables = Somasagad so line ko manga point a sarig ko manga variable: { $variables }.
+
+line-equation-invalid-format = Di ontol a format o equation o line ko manga variable a { $variable1 } go { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = So ray na miyatëndo sabap ko through, endpoint, go direction.  Di pëkhagamit so miyatëndo a through.
+
+ray-dimension-mismatch = Di makaphagayon so numDimensions ko ray.
+
+## `<vector>`
+
+vector-overprescribed-head = So vector na miyatëndo sabap ko head, tail, go displacement.  Di pëkhagamit so miyatëndo a head.
+
+vector-dimension-mismatch = Di makaphagayon so numDimensions ko vector.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Di khagaga a makaokit ko `<{ $component }>` sabap ko da a nearestPoint a state variable iyan.
+
+constrain-to-without-nearest-point = Di khagaga a marëkët ko `<{ $component }>` sabap ko da a nearestPoint a state variable iyan.
+
+constrain-to-interior-without-nearest-point = Di khagaga a marëkët ko soled o `<{ $component }>` sabap ko da a nearestPoint a state variable iyan.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = di pëkhagamit so labelPosition ko choiceInput a di inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Di pëkhagamit so manga index a miyatëndo ko choiceInput sabap ko di makaphagayon so bilangan o manga index go so bilangan o manga wata a choice.
+
+pretzel-indices-count-mismatch = Di pëkhagamit so manga index a miyatëndo ko problem sabap ko di makaphagayon so bilangan o manga index go so bilangan o manga wata a problem.
+
+shuffle-indices-count-mismatch = Di pëkhagamit so manga index a miyatëndo ko shuffle sabap ko di makaphagayon so bilangan o manga index go so bilangan o manga component.
+
+indices-ignored-out-of-range = Di pëkhagamit so manga index a miyatëndo ko { $component } sabap ko aden a manga index a liyo ko range.
+
+pretzel-indices-repeated = Di pëkhagamit so manga index a miyatëndo ko pretzel sabap ko aden a manga index a miyakadowa.
+
+pretzel-circuit-first-index = Di pëkhagamit so manga index a miyatëndo ko pretzel ko circuit mode sabap ko paliyogat a 1 so paganay a index.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = A an makagalëbëk so `<{ $component }>` ago so manga wata a string, paliyogat a matëndo so `type` a attribute.
+
+invalid-type-defaulting-to-math = Di ontol a type { $type } ko { $component } a component. Paliyogat a isa ko math, text, number, odi na boolean. Pëkhagamit so math.
+
+string-not-valid-component-to-arrange = So string a "{ $value }" na di ontol a component ko { $component }. Di pëkhagamit.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Di ontol a type { $type }, pëtagoon so type sa number.
+
+invalid-variable-value = Di ontol a value o isa a variable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = So variant index a { $index } na paliyogat a number
+
+variant-index-must-be-integer = So variant index a { $index } na paliyogat a integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Da pën mapasad so `<{ $component }>` ko manga absolute a sokatan. Pëtagoon so manga width sa relative.
+
+side-by-side-absolute-margins = Da pën mapasad so `<{ $component }>` ko manga absolute a sokatan. Pëtagoon so manga margin sa relative.
+
+side-by-side-no-block-child = Di ontol a `<{ $component }>`: paliyogat a aden a isa bo a wata iyan a block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Di pëkhagamit so `for` a attribute ko graphical a `<label>`.
+
+label-for-must-resolve-to-one = So `for` a attribute ko `<label>` na paliyogat a mitoro ko isa bo a component.
+
+label-for-unresolved = Di khagaga a mitoro ko isa a component so `for` a attribute ko `<label>`.
+
+label-for-answer-with-authored-inputs = So `for` a attribute ko `<label>` na pëtoro ko `<answer>` a aden a manga input a siyorat o author; toro-a so input a ginawa niyan.
+
+label-for-answer-without-input = So `for` a attribute ko `<label>` na pëtoro ko `<answer>` a da a input a khalabelan.
+
+label-for-must-reference-input-or-answer = So `for` a attribute ko `<label>` na paliyogat a pëtoro ko isa a input odi na ko isa a answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Makapantag ko accessibility, so `<{ $component }>` na paliyogat a aden a maikot a description iyan odi na matëndo a decorative.
+
+accessibility-video-short-description = Makapantag ko accessibility, so `<video>` na paliyogat a aden a maikot a description iyan.
+
+accessibility-input-short-description-or-label = Makapantag ko accessibility, so `<{ $component }>` na paliyogat a aden a maikot a description iyan odi na label.
+
+accessibility-answer-input-short-description-or-label = Makapantag ko accessibility, so `<answer>` a pëmbaal sa input na paliyogat a aden a maikot a description iyan odi na label.
+
+accessibility-short-description-contains-math = Di paliyogat a aden a math component a datar o `<{ $component }>` ko manga maikot a description. Isorat sa katharo so langon a math.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Di makatarotop so contrast o { $colorName } ko text o section heading (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; paliyogat a { $threshold }:1 pën).
+       *[other] Di makatarotop so contrast o { $colorName } ko text o section heading ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; paliyogat a { $threshold }:1 pën).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Da pën mapasad so `<circle>` a somasagad ko { $count } a point amay ka da a numerical a value o manga point.
+
+circle-too-many-through-points = Di khagaga a makalkula so circle a somasagad ko labi ko 3 a point.
+
+circle-overprescribed-radius-center-points = Di khagaga a makalkula so circle a miyatëndo i radius, center, go manga through point iyan.
+
+circle-center-with-multiple-points = Di khagaga a makalkula so circle a miyatëndo i center iyan go somasagad ko labi ko 1 a point.
+
+circle-radius-too-small = Di khagaga a makalkula so circle: sabap ko so kawatan o dowa a point na { $distance }, so miyatëndo a radius a { $radius } na maito a maito.
+
+circle-radius-with-many-points = Di khagaga a mabaal so circle a somasagad ko labi ko dowa a point a miyatëndo i radius iyan.
+
+circle-invalid-center-or-through-points = Di ontol a center odi na manga through point o circle.
+
+circle-radius-center-with-multiple-points = Di khagaga a makalkula so radius o circle a miyatëndo i center iyan go somasagad ko labi ko 1 a point.
+
+circle-change-radius-non-numerical = Di khagaga a masambian so radius o circle a di numerical so manga through point iyan
+
+circle-radius-with-points-non-numerical = Di khagaga a mabaal so circle a somasagad ko labi ko isa a point a miyatëndo i radius iyan amay ka da a numerical a value.
+
+circle-change-center-non-numerical = Da pën mapasad so kasambi ko center o circle a somasagad ko manga point a di numerical.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Di makatarotop so dimension o domain o function. So domain na aden a { $intervals } a interval iyan ogaid na so function na aden a { $inputs ->
+           *[other] { $inputs } a input
+        } iyan.
+    }
+
+function-domain-invalid-format = Di ontol a format o domain o function.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Di pëkhagamit so maximum o function a di numerical.
+        [minimum] Di pëkhagamit so minimum o function a di numerical.
+        [extremum] Di pëkhagamit so extremum o function a di numerical.
+        [point] Di pëkhagamit so point o function a di numerical.
+        [slope] Di pëkhagamit so slope o function a di numerical.
+       *[other] Di pëkhagamit so { $type } o function a di numerical.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Di pëkhagamit so maximum o function a da a soled iyan.
+        [minimum] Di pëkhagamit so minimum o function a da a soled iyan.
+        [extremum] Di pëkhagamit so extremum o function a da a soled iyan.
+        [point] Di pëkhagamit so point o function a da a soled iyan.
+       *[other] Di pëkhagamit so { $type } o function a da a soled iyan.
+    }
+
+function-points-too-close = Aden a dowa a point o function a marani a marani i darpa iyan. Di khagaga a matëndo so function.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] So manga iterate o function na khagaga bo amay ka lagid o bilangan o input so bilangan o output. Sangkai a function na aden a { $inputs } a input go { $outputs ->
+           *[other] { $outputs } a output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Di ontol a length o sequence.  Paliyogat a integer a di negative.
+
+sequence-invalid-step = Di ontol a step o sequence.  Paliyogat a number ko sequence a { $type } i type iyan.
+
+sequence-invalid-endpoint-number = Di ontol a "{ $attribute }" o number a sequence.  Paliyogat a number.
+
+sequence-invalid-endpoint-letters = Di ontol a "{ $attribute }" o letters a sequence.  Paliyogat a combination a manga letter.
+
+sequence-invalid-endpoint = Di ontol a "{ $attribute }" o sequence.
+
+select-from-sequence-coprime-not-numbers = di pëkhagamit so coprime sabap ko di manga number so pëpilin
+
+select-from-sequence-coprime-with-exclude-combinations = di pëkhagamit so coprime sabap ko miyatëndo so excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Di ontol a target ko `<{ $source }>`: da mailay so target.
+
+target-state-variable-not-found = Di ontol a target ko `<{ $source }>`: da mailay so state variable a "{ $property }" i ngaran iyan ko isa a `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = So manga variable o `<odeSystem>` na paliyogat a salakaw ko independent variable.
+
+ode-system-duplicate-variable-names = Di khagaga a matëndo so manga ODE RHS a function a lagid i ngaran o dependent variable iyan.
+
+ode-system-rhs-function-error = Di khagaga a matëndo so ODE RHS a function.  Aden a kasalaan ko kambaal ko mathjs a function.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Di khagaga a matëndo so angle ko lët o { $count } a line
+
+angle-invalid-through-point = Di ontol a point ko through o `<angle>`
+
+parabola-vertex-too-many-points = Da pën mapasad so parabola a aden a vertex iyan go somasagad ko labi ko 1 a point.
+
+parabola-too-many-points = Da pën mapasad so parabola a somasagad ko labi ko 3 a point.
+
+intersection-too-many-items = Da pën mapasad so intersection ko labi ko dowa a shay
+
+## Other math components
+
+ionic-compound-not-two-ions = Da pën mapasad so ionic compound a di dowa a ion.
+
+ionic-compound-needs-cation-and-anion = Miyapasad bo so ionic compound ko isa a cation go isa a anion.
+
+solve-equations-cannot-evaluate = Di khagaga a masolba so equation sabap ko di khagaga a ma-evaluate: { $equation }
+
+math-operators-operand-number-required = Paliyogat a matëndo so operandNumber amay ka pëkhowa so isa a math operand.
+
+eigen-decomposition-failed = Di khagaga a makalkula so manga eigenvalue o matrix
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: so parameter a { $parameters } na da ko pattern, na blangko i khaphagayonan iyan sa dayon sa dayon.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: di khagaga a masabot so grid="{ $grid }". Paliyogat a none, medium, dense, odi na dowa a positive a number a miyabëlag o isa a space, a datar o grid="1 0.5". Da a grid a miyabaal.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    So `<{ $component }>` na paliyogat a aden a function iyan a aden a { $expected ->
+        [1] isa a output, so slope a y' ko oman i point, a datar o `y - x`
+       *[other] dowa a output, so vector ko oman i point, a datar o `(y, -x)`
+    }, ogaid na so miyabëgay a function na aden a { $found ->
+       *[other] { $found } a output
+    } iyan. { $alternative ->
+        [none] Da a miyabaal.
+       *[other] So `<{ $alternative }>` i component ko oto a function. Da a miyabaal.
+    }
+
+field-function-attribute-ignored-with-child = Di pëkhagamit so `function` a attribute sabap ko miyabëgay mambo so function ko soled o component; so soled i pëkhagamit. Isa bo ko dowa a okit i kabëgi ko function.
+
+field-variables-ignored =
+    `<{ $component }>`: so `variables` a attribute na pëngaranan iyan so manga variable o expression a siyorat ko mismo a soled o component. { $reason ->
+        [function-child] So function sii na miyabëgay a wata a `<function>`, a pëngaranan iyan so manga variable iyan a ginawa niyan, na di pëkhagamit so `variables`.
+       *[no-expression] Da a datar oto a expression sii, na di pëkhagamit so `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: da masuporta so xLabelPosition="left" ko prefigure renderer; pëkhagamit so okit o right-position.
+
+prefigure-y-label-position-unsupported = `<graph>`: da masuporta so yLabelPosition="bottom" ko prefigure renderer; pëkhagamit so okit o top-position.
+
+prefigure-invalid-axis-bounds = `<graph>`: di ontol a manga axis bound ko prefigure conversion; pëkhagamit so default a bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: di ontol a width ko prefigure conversion; pëkhagamit so default a diagram width a 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: di ontol a aspectRatio ko prefigure conversion; pëkhagamit so default a aspect ratio a 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: maikot a maikot so lët o grid ko manga axis limit; di pëkhagamit so grid ko prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: di khabaal so manga annotation amay ka di PreFigure renderer i pëkhagamit.
+
+multiple-annotations-children = Madakël a wata a `<annotations>` i miyailay ko `<graph>`; di pëkhagamit so langon inonta bo so oriyan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Di khagaga a ma-extend odi na makopya so di kakatawan a component type: { $type }.
+
+copy-prop-not-found = Da mailay so prop a { $property } ko isa a component a { $component } i type iyan
+
+collect-no-source = Da mailay a source ko collect.
+
+collect-invalid-component-type = Di khagaga a matimo so manga component a `<{ $component }>` i type iyan sabap ko di ontol a component type.
+
+reference-index-unavailable = Di khagaga a matoro so index a `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Di khagaga a matawag so { $action } ko component a `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Di ontol i baay o data.  Di makaphagayon so length o manga row. Miyailay ko componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Aden a lagid a manga ngaran a column ko data.  Miyailay ko componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Da a isa a ngaran a column ko data.  Miyailay ko componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = So isa a award ko sangkai a answer na sarig ko sëmbag a miyasogo o answer tag a ginawa niyan, na khabaloy oto a di khatandaan a galëbëk.
+
+answer-max-num-attempts-in-section-wide-check-work = Da a epekto o katago ko `maxNumAttempts` ko isa a `<answer>` a soled o isa a container a aden a `sectionWideCheckWork` iyan, sabap ko so container i pëthanggong ko bilangan o sobok. Tagoi so `maxNumAttempts` ko container.
+
+nested-section-wide-check-work-max-num-attempts = Da a epekto o katago ko `maxNumAttempts` ko isa a container a aden a `sectionWideCheckWork` iyan a soled o salakaw a container a aden mambo a `sectionWideCheckWork` iyan, sabap ko so container ko liyo i pëthanggong ko bilangan o sobok. Tagoi so `maxNumAttempts` ko container ko liyo.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] Da a epekto o { $attributes } a attribute amay ka da matago so symbolicEquality.
+    }
+
+answer-invalid-type = Di ontol a type ko answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sabap ko da a ngaran o component a `<{ $component }>`, di khagaga a magamit oto a attribute o module
+
+module-attribute-name-already-defined = Di khagaga a magamit so component a `<{ $component } name="{ $name }">` a attribute o module sabap ko aden den a "{ $name }" a attribute o `<module>` a component type.
+
+conditional-content-condition-ignored = Di pëkhagamit so `condition` a attribute ko `<conditionalContent>` a component a aden a manga wata iyan a case odi na else.
+
+slider-markers-type-mismatch = Di makaphagayon so type o manga marker go so type o slider.
+
+pretzel-problem-needs-statement-and-answer = Di ontol a pretzel: so oman i `<problem>` na paliyogat a aden a isa a `<statement>` go isa a `<answer>` iyan.
+
+pretzel-circuit-first-problem-distractor = Di ontol a pretzel: ko mode="circuit", di khagaga a distractor so paganay a `<problem>`.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Di ontol a value a { $values } ko `{ $attribute }` a attribute; di pëkhagamit.
+    }
+
+attribute-must-be-references = Di ontol a value a `{ $value }` ko `{ $attribute }` a attribute. Paliyogat a mabaal so attribute a phoon ko manga reference a `$` i pëphoonan iyan.
+
+math-input-invalid-function-names = <mathInput>: di pëkhagamit so manga di ontol a ngaran a function ko { $attribute }: { $names }. So pakaphayag a bagi o oman i ngaran na paliyogat a dowa a character pën (manga letter odi na manga dash); khaonot so `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Di ontol a component type: `<{ $componentType }>`
+
+attribute-repeated = Di khagaga a maphakadowa so { $attribute } a attribute.
+
+attribute-invalid-for-component = Di ontol a "{ $attribute }" a attribute ko isa a component a `<{ $componentType }>` i type iyan.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    So style definition a { $styleNumber } na di makatarotop so contrast iyan ko { $context ->
+        [text-on-background] color o text a i-ayon ko color o background
+        [high-contrast] high-contrast a color a i-ayon ko canvas
+        [line] color o line a i-ayon ko canvas
+        [marker] color o marker a i-ayon ko canvas
+       *[text-on-canvas] color o text a i-ayon ko canvas
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; paliyogat a { $threshold }:1 pën).
+
+style-definition-dark-mode-text-background-contrast =
+    Apiya pën so style definition a { $styleNumber } na aden a manga color iyan a makatarotop i contrast ko light mode, so manga dark-mode a color a miyaphoon sangkai a manga value na di makatarotop so contrast o color o text a i-ayon ko color o background ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; paliyogat a { $threshold }:1 pën). { $suggestion ->
+        [available] A an makatarotop so contrast ko dark mode, pakaporo-a so contrast ko light mode (datar o katago ko { $lightAttribute }="{ $lightColor }") odi na sambii so dark-mode a color (datar o katago ko { $darkAttribute }="{ $darkColor }").
+       *[none] A an makatarotop so contrast ko dark mode, pakaporo-a so contrast ko light mode odi na sambii so manga miyaphoon a color sa textColorDarkMode go/odi na backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Apiya pën so style definition a { $styleNumber } na aden a text color iyan a makatarotop i contrast ko light mode, so dark-mode a text color a miyaphoon sangkai a value na di makatarotop so contrast iyan a i-ayon ko canvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; paliyogat a { $threshold }:1 pën). { $suggestion ->
+        [available] A an makatarotop so contrast ko dark mode, pakaporo-a so contrast ko light mode (datar o katago ko textColor="{ $lightColor }") odi na sambii so dark-mode a color (datar o katago ko textColorDarkMode="{ $darkColor }").
+       *[none] A an makatarotop so contrast ko dark mode, pakaporo-a so contrast ko light mode odi na sambii so miyaphoon a color sa textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Isa bo a <stylePalette> i khapili o isa a section; pëkhagamit so oriyan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = di matëndo so manga unique variant o { $component } sabap ko so numToSelect na di integer a di negative.
+
+variant-num-to-select-not-constant-number = di matëndo so manga unique variant o { $component } sabap ko so numToSelect na di constant a number.
+
+variant-with-replacement-not-constant-boolean = di matëndo so manga unique variant o { $component } sabap ko so withReplacement na di constant a boolean.
+
+variant-select-weight-disables-unique = Di khagaga so manga unique variant ko select amay ka aden a option a miyatëndo i selectWeight odi na selectForVariants iyan
+
+variant-coprime-undetermined = di matëndo so manga unique variant o { $component } sabap ko di matëndo o so coprime na false sa dayon sa dayon.
+
+variant-attribute-not-constant = di matëndo so manga unique variant o { $component } sabap ko so { $attribute } na di constant.
+
+variant-attribute-not-number = di matëndo so manga unique variant o { $component } sabap ko so { $attribute } na di number.
+
+variant-attribute-wrong-type-for-sequence =
+    di matëndo so manga unique variant o { $component } a { $type } i type iyan sabap ko so { $attribute } na di { $expected ->
+        [letters-combination] combination a manga letter
+        [math-expression] ontol a math expression
+        [integer] integer
+       *[number] number
+    }.
+
+variant-length-not-integer = di matëndo so manga unique variant o { $component } sabap ko so length na di integer.
+
+variant-sort-not-implemented = da pën mapasad so manga unique variant o isa a { $component } a aden a sort iyan
+
+variant-exclude-combinations-not-implemented = da pën mapasad so manga unique variant o isa a { $component } a aden a excludeCombinations iyan
+
+variant-math-exclude-not-implemented = da pën mapasad so manga unique variant o isa a { $component } a math i type iyan a aden a exclude iyan
+
+variant-non-constant-exclude-not-implemented = da pën mapasad so manga unique variant o isa a { $component } a di constant so exclude iyan
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: da masuporta ko graph prefigure renderer; miyalëpasan so descendant.
+
+prefigure-descendant-invalid-geometry = { $subject }: di makatarotop odi na di khadaan a geometry; miyalëpasan so descendant.
+
+prefigure-curve-label-omitted = { $subject }: da masuporta so manga label ko manga miyasambian a curve element; da matago so label.
+
+prefigure-curve-unsupported-definition-type = { $subject }: da masuporta a curve function definition type a '{ $definitionType }'; miyalëpasan so descendant.
+
+prefigure-region-flip-functions-unsupported = { $subject }: da masuporta a flipFunctions a attribute ko regionBetweenCurves; miyalëpasan so descendant.
+
+prefigure-region-non-formula-child = { $subject }: so manga wata a function a formula i type iyan bo i masuporta ko regionBetweenCurves; miyalëpasan so descendant.
+
+prefigure-label-position-unsupported =
+    { $subject }: da masuporta a labelPosition a '{ $labelPosition }' ko { $labelKind ->
+        [line-family] label o line-family
+       *[point] label o point
+    }; pëkhagamit so default a alignment o PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: da masuporta o PreFigure so fill style a '{ $fillStyle }'; pëkhagamit so solid a fill.
+
+prefigure-line-style-unknown = { $subject }: di kakatawan a line style a '{ $lineStyle }'; da matago ko output o PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: so marker style a '{ $markerStyle }' na miyasambi ko 'diamond' a style o PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: da masuporta o PreFigure so marker style a '{ $markerStyle }'; pëkhagamit so default a style.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: di ontol a `ref`; di khagaga a matoon so target. Da matago so annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: madakël a target i miyaphoon ko `ref`; pëkhagamit so paganay a target.
+
+annotation-ref-outside-graph = `<annotation>`: di ontol a `ref`; so target na liyo ko graph a katatagoan iyan. Da matago so annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: di ontol a `ref`; so target na di masuporta a graphical object ko prefigure conversion. Da matago so annotation.
+
+annotation-text-missing = `<annotation>`: da odi na blangko so `text`; blangko a text i miyabaal.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Aden a miyailay a circular dependency.
+       *[other] Aden a miyailay a circular dependency a khaonotan o `<{ $componentType }>` a component.
+    }
+
+reference-no-referent = Da mailay a pëtoroon o reference: `{ $reference }`
+
+reference-multiple-referents = Madakël a pëtoroon a miyailay o reference: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Di ontol a format o { $attribute } a attribute o `<{ $componentType }>`.
+
+children-invalid = Di ontol a manga wata ko `<{ $componentType }>`: Miyailay so manga di ontol a wata: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Di ontol a value a `{ $value }` ko `{ $attribute }` a attribute, pëkhagamit so value a `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Da mailay so DoenetML version a { $version }.
+       *[other] Da mailay so DoenetML version a { $version }. Pëkhagamit so version a { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Di ontol a DoenetML: { $content }
+
+parse-tag-missing-close-tag = Di ontol a DoenetML: Da a closing tag o tag a `{ $tag }`. Paliyogat a self-closing a tag odi na `</{ $tagName }>` a tag.
+
+parse-tag-error = Di ontol a DoenetML: Aden a kasalaan ko tag a `<{ $tagName }>`
+
+parse-attribute-missing-value = Di ontol a DoenetML: So di ontol a attribute a `{ $attribute }` na datar o da a value iyan.
+
+parse-attribute-invalid = Di ontol a DoenetML: Di ontol a attribute a `{ $attribute }`
+
+parse-attribute-value-invalid = Di ontol a DoenetML: Di ontol a attribute value a `{ $value }`
+
+parse-attribute-value-quote-mismatch = Di ontol a DoenetML: Di ontol a attribute value a `{ $value }`. Di makaphagayon so manga quote mark. Datar o da a isa a `{ $quote }`
+
+parse-open-tag-name-missing = Di ontol a DoenetML: Miyailay so isa a tag a da a ngaran iyan, datar o `<`
+
+parse-tag-not-closed = Di ontol a DoenetML: Da masara so tag a `{ $tag }` (datar o da a `>`).
+
+parse-self-closing-tag-name-missing = Di ontol a DoenetML: Miyailay so isa a tag a da a ngaran iyan `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Di ontol a DoenetML: Da masara so tag a `{ $tag }` (datar o da a `/>`).
+
+parse-tag-invalid-attributes = Di ontol a DoenetML: Di ontol so tag a `{ $tag }`. Khabaloy a di ontol so manga attribute iyan.
+
+parse-close-tag-name-missing = Di ontol a DoenetML: Miyailay so isa a closing tag a da a ngaran iyan, datar o `</`
+
+parse-attribute-value-unquoted = Paliyogat a matago ko manga quote so manga attribute value: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Di ontol a DoenetML: Miyailay so closing tag a `{ $tag }`, ogaid na da a mapëmbaal iyan a opening tag
+
+parse-close-tag-mismatched = Di ontol a DoenetML: Di makaphagayon so closing tag. Aantapën so `</{ $expected }>`. Miyailay so `{ $found }`
+
+parser-node-unconvertible = Di khagaga a masambi so node a { $node } sa Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Di ontol a attribute a name='{ $name }'. { $reason ->
+        [characters] So manga ngaran na khatagoan bo sa manga letter, manga number, underscore odi na hyphen.
+       *[start] Paliyogat a phoon ko isa a letter so manga ngaran.
+    }
+
+component-name-invalid-start = Di ontol a ngaran a component a "{ $name }". Paliyogat a phoon ko isa a letter so manga ngaran.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = So answer a videoWatched i type iyan na paliyogat a aden a video a attribute iyan
+
+answer-video-watched-video-not-reference = So answer a videoWatched i type iyan na paliyogat a so video a attribute iyan na isa a reference
+
+answer-name-not-single-text = So name a attribute o answer na paliyogat a aden a isa bo a wata iyan a text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Di khagaga a makowa so DoenetML ko liyo sabap ko madakël a maito a level o recursion. Ba aden a circular reference?
+
+external-doenetml-unavailable = Di khagaga a makowa so DoenetML a phoon ko { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Di ontol a DoenetML i miyakowa phoon ko { $attribute }="{ $uri }": da makaphagayon ko "{ $componentType }" a component type
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Deprecated den so `{ $from }` a attribute; gamita so `{ $to }`.
+       *[other] [deprecation] Deprecated den so `{ $from }` a attribute ko `<{ $component }>`; gamita so `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Deprecated den so `{ $from }` a attribute go di pëkhagamit sabap ko miyatëndo mambo so `{ $to }`.
+       *[other] [deprecation] Deprecated den so `{ $from }` a attribute ko `<{ $component }>` go di pëkhagamit sabap ko miyatëndo mambo so `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Deprecated den so `{ $attribute }` a attribute ko `<{ $component }>` go di pëkhagamit.
+
+deprecated-attribute-to-child = [deprecation] Deprecated den so `{ $attribute }` a attribute ko `<{ $component }>`; gamita so isa a wata a `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Deprecated den so value a `{ $value }` o `{ $attribute }` a attribute ko `<{ $component }>`; gamita so `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = So `<pluralize>` na khagaga niyan bo a pakadakëlën so Ingles, na di pëkhasambian so text iyan ko document a miyasorat sa { $locale }. Isorat a ginawa niyan so plural form, odi na tagoi oto ko `pluralForm` a attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = So element a `<{ $tag }>` na di kakatawan a element o Doenet.
+
+schema-element-not-allowed-at-root = Di khibëgay so element a `<{ $tag }>` ko root o document.
+
+schema-element-not-allowed-inside = Di khibëgay so element a `<{ $tag }>` ko soled o `<{ $parent }>`.
+
+schema-attribute-unrecognized = So element a `<{ $tag }>` na da a attribute iyan a `{ $attribute }` i ngaran iyan.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] So `{ $attribute }` a attribute o element a `<{ $tag }>` na paliyogat a list a so oman i item iyan na isa ko: { $allowed }
+       *[other] So `{ $attribute }` a attribute o element a `<{ $tag }>` na paliyogat a isa ko: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Di ontol a variant name ko select.  So variant name a { $variantName } na pëkhailay ko { $numOptions } a option ogaid na so bilangan a khapili na { $numToSelect }.
+
+select-variant-name-without-options = Aden a manga variant a miyatëndo ko select ogaid na da a option a miyatëndo ko khabaloy a variant name: { $variantName }.
+
+select-variant-name-not-possible = So variant name a { $variantName } a miyatëndo ko select na di khabaloy a variant name.
+
+select-too-few-options = Di khagaga a mapili so { $numToSelect } a component ko { $numOptions } bo.
+
+select-from-sequence-too-few-values = Di khagaga a mapili so { $numToSelect } a value ko sequence a { $length } i length iyan.
+
+select-from-sequence-indices-count-mismatch = Paliyogat a makaphagayon so bilangan o manga index a miyatëndo ko select go so bilangan a khapili
+
+select-from-sequence-indices-not-integers = Paliyogat a manga integer so langon a index a miyatëndo ko select
+
+select-from-sequence-index-excluded = Miyatëndo so index o selectfromsequence a miyaawa
+
+select-from-sequence-indices-excluded-combination = Miyatëndo so manga index o selectfromsequence a miyaawa a combination
+
+select-from-sequence-coprime-not-positive-integers = Di khagaga a mapili so manga coprime a combination sabap ko di manga positive a integer so pëpilin.
+
+select-from-sequence-coprime-common-factor = Di khagaga a mapili so manga coprime a number. So langon a khabaloy a value na lagid i factor iyan. (Paliyogat a coprime ko "step" so miyatëndo a manga value o "from" odi na "to".)
+
+select-from-sequence-coprime-single-number = Di khagaga a mapili so manga coprime a combination ko isa bo a number a di 1.
+
+select-from-sequence-excluded-too-many-combinations = Miyaawa so labi ko 70% o manga combination ko selectFromSequence
+
+select-from-sequence-coprime-none-found = Da khagaga a mapili so manga coprime a number. So langon a khabaloy a value na lagid i factor iyan.
+
+select-from-sequence-too-few-unique-values = Di khagaga a mapili so { $numToSelect } a unique a value ko sequence a { $numPossibleValues } i length iyan
+
+select-prime-numbers-too-few-values = Di khagaga a mapili so { $numToSelect } a value ko list o manga prime a { $numValues } i length iyan
+
+select-prime-numbers-values-count-mismatch = Paliyogat a makaphagayon so bilangan o manga value a miyatëndo ko select go so bilangan a khapili
+
+select-prime-numbers-values-not-prime = Paliyogat a matago ko list o manga prime so langon a value a miyatëndo ko select prime number
+
+select-prime-numbers-values-excluded-combination = Miyatëndo so manga value o selectPrimeNumbers a miyaawa a combination
+
+select-prime-numbers-excluded-too-many-combinations = Miyaawa so labi ko 70% o manga combination ko selectPrimeNumbers
+
+select-random-combination-fluke = Sabap ko tanto a di khatandaan a kiyaokitan, da khapili so combination o manga random a value
+
+select-random-value-fluke = Sabap ko tanto a di khatandaan a kiyaokitan, da khapili so random a value
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Di pëkhailay ini a `<{ $component }>` sabap ko matatago ko math go di `inline`. Omani sa `inline` a an mabaloy a drop-down list, a khatago ko soled o isa a expression.
+        [expanded] Di pëkhailay ini a `<{ $component }>` sabap ko matatago ko math go `expanded`. Awa-a so `expanded`; di khatago ko soled o isa a expression so box a madakël i line.
+        [on-graph] Di pëkhailay ini a `<{ $component }>` sabap ko matatago ko math a miyabaal ko isa a graph, a da a darpa niyan a bagian o input.
+       *[relative-width] Di pëkhailay ini a `<{ $component }>` sabap ko matatago ko math go relative i width iyan. Bëgi so width sa manga absolute a unit, a datar o `px`.
+    }

--- a/packages/i18n/locales/mrw/editor.ftl
+++ b/packages/i18n/locales/mrw/editor.ftl
@@ -1,0 +1,238 @@
+# Maranao (Basa a Mëranaw) editor and language-server surfaces. Translated
+# from `locales/en/editor.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber`, `Answer Id` and every attribute
+# or element name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **The schwa is written «ë» (U+00EB)**, as `chrome.ftl`'s header sets out.
+# Print also writes it **e**, **e'** or **u**; respell rather than
+# retranslate, and respell all four files at once.
+#
+# **This is the file where the English is heaviest, and in this catalog that
+# is saying something.** The editor's own nouns have no Maranao currency and
+# are kept as they stand — `editor`, `viewer`, `variant`, `filter`,
+# `component`, `attribute`, `reference`, `property`, `snippet`, `array entry`,
+# `value`, `type`, `style`, `default`, `coordinate`, `function`, `line`,
+# `tag`, `documentation`, `accessibility`, `report`, `credit`, `cursor`,
+# `Answer Id`, `WCAG` — **around a Maranao frame**. What is Maranao here is
+# the markers «so», «o», «ko» and «na», the linker «a», the plural «manga»,
+# the negators «di» and «da», «aden» ('there is'), «paliyogat» ('required'),
+# «di khagaga» ('cannot'), «sabap ko» ('because of'), and the verbs «ilay»
+# (see), «gamit» (use), «pili» (choose), «oman» (add), «awa» (remove) and
+# «tago» (keep).
+#
+# `editor-update-viewer`'s two words are kept as the English **Update** and
+# **Reset**: they sit on a narrow toolbar button, and the seed had no Maranao
+# pair it could vouch for that would fit. The tooltip around them is Maranao,
+# and it puts the object last — «Update so Viewer» — which is the word order
+# rather than an untranslated string.
+#
+# **No plural-category branches.** CLDR has no plural data for `mrw`, so a
+# `[one]` branch would be text selected by English's rules; and Maranao leaves
+# a noun unmarked after a numeral — «{ $count } a violation» is right for one
+# and for many — so one form is correct anyway. Every count select is
+# collapsed to a single `*[other]`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reset
+       *[update] Update
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } so Viewer
+       *[other] { $word } so Viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+
+editor-variant-filter = Filter...
+
+editor-variant-next = Pilin so somonod a variant
+
+editor-variant-previous = Pilin so miyaona a variant
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Aden a miyailay a violation ko WCAG AA a accessibility. I-click a an { $action ->
+            [close] masarahan
+           *[open] malokaan
+        } so accessibility report.
+        [advisories] I-click a an { $action ->
+            [close] masarahan
+           *[open] malokaan
+        } so accessibility report. Da a miyailay a violation ko WCAG AA, ogaid na aden a manga salakaw a recommendation ko accessibility.
+       *[clean] I-click a an { $action ->
+            [close] masarahan
+           *[open] malokaan
+        } so accessibility report. Da a miyailay a problema ko accessibility.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Aden a miyailay a violation ko WCAG AA a accessibility. Miyailay so { $count ->
+           *[other] { $count } a violation ko WCAG AA
+        }. I-click a an { $action ->
+            [close] masarahan
+           *[open] malokaan
+        } so accessibility report.
+        [advisories] Da a miyailay a violation ko WCAG AA. Miyailay so { $count ->
+           *[other] { $count } a salakaw a recommendation ko accessibility
+        }. I-click a an { $action ->
+            [close] masarahan
+           *[open] malokaan
+        } so accessibility report.
+       *[clean] Da a miyailay a violation ko WCAG AA. I-click a an { $action ->
+            [close] masarahan
+           *[open] malokaan
+        } so accessibility report.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Version o DoenetML { $version }
+
+editor-tab-help = Tabang a sarig ko context
+editor-tab-help-short = Context
+editor-tab-errors = Manga Kasalaan
+editor-tab-warnings = Manga Pakatanod
+editor-tab-info = Impormasyon
+editor-tab-accessibility = Accessibility
+editor-tab-responses = Manga miyasogo a sëmbag
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Manga option o editor
+editor-format-as-doenetml = I-format a DoenetML
+editor-format-as-xml = I-format a XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Line #{ $line }
+
+editor-no-errors = Da a Kasalaan
+editor-no-warnings = Da a Pakatanod
+editor-no-info = Da a Info a Diagnostic
+
+editor-show-info-annotations = Pakiilayin ko editor so manga info a diagnostic
+editor-show-accessibility-annotations = Pakiilayin ko editor so manga accessibility a diagnostic
+
+editor-accessibility-learn-more = Tanodi o andamanaya i kapëmbatiyaa o Doenet ko accessibility
+
+editor-accessibility-violations-heading = Manga violation ko accessibility ({ $standard })
+
+editor-accessibility-other-heading = Manga salakaw a problema ko accessibility
+editor-none-found = Da a miyailay
+
+
+## Submitted responses
+
+editor-no-responses = Da pën a miyasogo a sëmbag
+editor-response-answer-id = Answer Id
+editor-response-response = Sëmbag
+editor-response-credit = Kredito
+editor-response-submitted = Miyasogo
+
+
+## The context-help panel
+
+help-placeholder = Tagoon so cursor ko isa a ngaran a tag, attribute, odi na { $ref } a an makowa so documentation.
+
+help-unsupported-ref-chain = Da pën masuporta so tabang ko manga reference a madakël i bagi, a datar o { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Da a miyailay a pëtoroon o reference: { $ref }.
+        [multiple] Madakël a pëtoroon a miyailay o reference: { $ref }.
+       *[indeterminate] Di khagaga a matëndo so pëtoroon o { $ref }.
+    }
+
+help-learn-about-references = Tanodi so makapantag ko manga reference →
+help-reference-page = Reference page →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ko soled o { $element }
+       *[top] Ko poporoan a level
+    }{ $allowed ->
+        [none] { " — da a khatago sii." }
+        [text] { " — panorat sa text sii." }
+        [text-and-components] { " — panorat sa text sii, odi na sobokan:" }
+       *[components] { " — manga khasobokan:" }
+    }
+
+help-suggestions-footer = Pindotën so { $shortcut } a an mailay so langon a { $total } a component.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] So { $ref } na reference ko { $target }.
+       *[other] So { $ref } na reference ko { $target } (line { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Piyakasoled o { $owner } a { $role }.
+       *[other] Piyakasoled o { $owner } ko line { $line } a { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] So { $ref } na reference ko { $property } a property o { $element }.
+       *[other] So { $ref } na reference ko { $property } a property o { $element } (line { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = Default:
+help-active-default = Pëkhagamit a default:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Manga khibëgay a value (isa ko oman i item):
+       *[other] Manga khibëgay a value:
+    }
+
+help-suggested-values = Manga misusuggest a value:
+
+help-inserts = Pëtagoon:
+
+help-coordinates =
+    { $count ->
+       *[other] Coordinate:
+    }
+
+help-type = Type:
+
+help-resolved-style = Miyatëndo a style (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Manga miyatëndo a ngaran o function:
+help-reset-list = I-reset so list ko sangkai a input:
+help-added-on-input = Miyaoman ko sangkai a input:
+help-removed-on-input = Miyaawa ko sangkai a input:
+
+help-reset-overrides = So { $reset } i pëkhasambi ko { $additional } go so { $removed }.

--- a/packages/i18n/locales/nia/chrome.ftl
+++ b/packages/i18n/locales/nia/chrome.ftl
@@ -1,0 +1,200 @@
+# Nias (Li Niha) viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and orthography: the northern standard, in Latin.** Nias is spoken
+# on Nias and the Batu islands off western Sumatra, and its three main
+# varieties — northern (Gunungsitoli), central and southern (Teluk Dalam) —
+# differ enough that a southern reader will notice. This catalog is written in
+# the **northern variety**, because that is the variety of the Nias Bible, of
+# the standard orthography, and of nearly everything published in the language;
+# a southern speaker should feel free to respell, and should do it to **all
+# four files at once** rather than to one.
+#
+# The alphabet is `a b d e f g h i j k l m n o ö r s t u w y z` plus the
+# digraphs and clusters `ng mb nd ndr`. `ö` is the mid central vowel and is a
+# letter of its own: it must not be folded to `o`, and a search for «börö» will
+# not find «boro».
+#
+# **Nias words end in a vowel — and the loans in this catalog do not.** That is
+# the most visible thing about the language and the most visible compromise in
+# the file. Every native Nias word here ends in a vowel («börö», «tebai»,
+# «halöwö», «duma-duma», «sindruhu»), and every Indonesian technical loan is
+# written the way Indonesian writes it, consonant and all: «atribut»,
+# «komponen», «dokumen», «versi», «garis», «titik». The seed does **not** know
+# how the community actually adapts these words in speech — whether it says
+# «atribut» or «atributu» — and respelling them on a guess would invent a loan
+# phonology rather than record one. So the Indonesian spellings stand, and this
+# is the one place the file knowingly reads as two languages at once. A speaker
+# who knows the spoken adaptations should put them in.
+#
+# **Initial mutation is not applied, and that is a stated limit.** A Nias noun
+# changes its initial consonant in certain syntactic positions — the property
+# the language is best known for. The seed cannot apply it reliably, and
+# applying it in some places and not others would be worse than not applying it
+# at all, so **every noun here is in its citation form**. A reviewer should
+# expect to mutate rather than to correct: the words are meant to be right, the
+# mutation is simply missing.
+#
+# **The technical register is Indonesian, declared as a loan register.** Nias
+# speakers are schooled in Indonesian, and the vocabulary of a viewer's
+# controls is Indonesian in a Nias classroom. What is Nias here is the frame:
+# «lö» (not), «tebai» (cannot), «tola» (can), «so» (there is), «moroi» (from),
+# «ba» (in, at, and), «awö» (with), «ma» (or), «na» (if, when), «börö me»
+# (because), «fefu» (all), «oya» (many), «sibai» (very), «andrö» (that), and
+# the verb-forming prefixes «fa-», «mu-» and the passive «ni-».
+#
+# **Nias words used here that are not loans**, so a reviewer can see the seam:
+# «halöwö» (work, activity), «fanofu» (question), «fanema li» (answer),
+# «duma-duma» (example), «sindruhu» (true), «atulö» (correct, straight),
+# «fasala» (error), «töi» (name), «li» (word, language), «sökhi» (good),
+# «sebua» (big), «side-ide» (small), «ahatö» (near), «oroma» (visible),
+# «bunia» (hidden), «bokai» (open), «faudu» (fitting), «moguna» (needed),
+# «nibe'e» (given), «fazökhi» (make), «sara», «dua», «tölu» (one, two, three).
+#
+# «Tutu» (close) is an **adapted loan** and is the one word in this catalog
+# spelled with a Nias-shaped final vowel rather than Indonesian's: it stands
+# opposite «bokai», and writing «tutup» beside a native imperative was worse
+# than either choice. It is flagged here because it is the exception to the
+# paragraph above, not because the seed is confident in it.
+#
+# Nias has a single plural category — a noun after a numeral is unmarked — so
+# `attempts-remaining` and `answer-show-responses` collapse to a single
+# `*[other]` branch. The `[0]` branch stays: Fluent matches a numeric literal
+# against the number itself, before any plural rule.
+
+
+## Answer submission
+
+answer-checking = Nifareso...
+answer-submitting = Nifa'ohe...
+
+answer-checking-status = Nifareso wanema li
+answer-submitting-status = Nifa'ohe wanema li
+
+answer-correct = Atulö
+answer-incorrect = Lö atulö
+
+answer-response-saved = No terohu wanema li
+
+answer-percent-credit = Nilai { $percent }%
+answer-percent-correct = { $percent }% atulö
+answer-percent-short = { $percent } %
+
+max-credit-available = Nilai sebua zi tola tesöndra: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] lö sa'ae so wanandraigö
+       *[other] so nasa { $count } wanandraigö
+    }
+
+validation-correct = (Atulö)
+validation-incorrect = (Lö atulö)
+validation-partially-correct = (Atulö ösa)
+
+answer-show-responses = Oroma'ö { $count } wanema li ba { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Fangumaigö
+
+collapsible-click-to-open = (klik ba wamokai)
+collapsible-click-to-close = (klik ba wanutu)
+
+collapsible-initializing = Mufa'anö...
+
+footnote-show = Oroma'ö catatan ba dalu
+footnote-hide = Bunia'ö catatan ba dalu
+
+description-more-information = keterangan tanö bö'ö
+
+
+## Controls
+
+slider-previous = Si fatua
+slider-next = Si so föna
+
+keyboard-open = Bokai papan ketik
+keyboard-close = Tutu papan ketik
+
+choice-input-remove-choice = Heta { $choice }
+
+matrix-remove-row = Heta baris
+matrix-add-row = Tambö baris
+matrix-remove-column = Heta kolom
+matrix-add-column = Tambö kolom
+
+subset-add-remove-points = Tambö/Heta titik
+subset-toggle-points-intervals = Falalini titik awö selang
+subset-move-points = Fa'ohe titik
+subset-clear = Sasai
+
+orbital-add-row = Tambö baris
+orbital-remove-row = Heta baris
+orbital-add-box = Tambö kotak
+orbital-remove-box = Heta kotak
+orbital-add-up-arrow = Tambö panah ba yawa
+orbital-add-down-arrow = Tambö panah ba tou
+orbital-remove-arrow = Heta panah
+
+orbital-row-label = Label ba baris { $row }
+
+pretzel-answer = Fanema li
+
+summary-statistics-caption = Statistik ringkas moroi ba { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ekspresi matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ekspresi si lö atulö:
+
+
+## Document status
+
+viewer-initializing = Mufa'anö...
+
+
+## Errors
+
+error-heading = Fasala
+
+error-found-at =
+    { $span ->
+        [line] Tesöndra ba baris { $startLine }.
+       *[lines] Tesöndra ba baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = So fasala ba dokumen andre!
+
+diagnostic-heading-error = Fasala
+diagnostic-heading-warning = Fango'ou
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Fanuturu
+
+accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Fango'ou aksesibilitas
+
+something-went-wrong = So zi lö atulö.
+
+renderer-load-failed = sara perender tebai mufa'anö. Fatambai wamokai halaman andre.
+
+core-start-failed = Dokumen andre tebai mufamula. Fatambai wamokai halaman andre.
+
+core-start-failed-busy = Dokumen andre tebai mufamula. Oya dokumen si famula ba ginötö si sara, ba tola ara ba alat samalö-malö. Fatambai wamokai halaman andre na no aefa dokumen tanö bö'ö.
+
+core-start-failed-retry = Dokumen andre tebai mufamula.
+
+core-start-failed-busy-retry = Dokumen andre tebai mufamula. Oya dokumen si famula ba ginötö si sara, ba tola ara ba alat samalö-malö.
+
+core-start-retry = Fatambai
+
+saved-state-unavailable = Halöwöu si no terohu tebai mufa'ema.

--- a/packages/i18n/locales/nia/content.ftl
+++ b/packages/i18n/locales/nia/content.ftl
@@ -1,0 +1,284 @@
+# Nias (Li Niha) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and orthography: the northern standard, in Latin**, with `ö` as a
+# letter of its own that must never be folded to `o`. `chrome.ftl`'s header
+# sets out the alphabet, the final-vowel property and the compromise this
+# catalog makes with it, and the reason initial mutation is not applied
+# anywhere; read that first, because all three bear on this file more than on
+# any other.
+#
+# ## Word order, and the attributive that is missing
+#
+# **The noun comes first and its modifiers follow it**: «omo sebua» is *big
+# house*, and so «garis meramba» would be *red line*. Every composition
+# message here inverts English's order.
+#
+# What is missing is the shape of the modifier. A Nias property word takes an
+# attributive form built with `s-` — «ebua» becomes «sebua» — and the seed
+# cannot form that on an Indonesian loan: there is no «stebal». So the loan
+# adjectives in this file stand **bare, in their Indonesian citation form**,
+# behind the noun. That is the same limit as the missing initial mutation, in
+# a second place, and it is stated rather than papered over. A speaker
+# correcting this file will be adding morphology, not changing words.
+#
+# It is also what separates this file from the two beside it in the batch.
+# `locales/bbc` puts a relator «na» between the noun and its modifiers,
+# `locales/gor` puts nothing there at all, and Nias wants a prefix *on the
+# modifier* that this catalog cannot supply. Three Austronesian languages of
+# Indonesia, one word order, three different answers about what joins the two
+# halves.
+#
+# **`[noun-tail]` is unused.** The side count of a regular polygon binds to the
+# noun rather than to the adjectives, so it folds into the head exactly as
+# English's does and the tail stays empty.
+#
+# ## Gender and role
+#
+# Nias has no grammatical gender and does not inflect a modifier for the
+# position its phrase sits in, so `noun-gender` answers one token for every
+# noun and nothing here selects on `$gender` or on `$role`.
+#
+# ## The colour table, and how far to trust it
+#
+# **Two of the twelve are attempted in Nias** — «aitö» (black) and «afusi»
+# (white). The seed believes these to be the Nias basic terms and has **not
+# verified them against a dictionary**; they are the first two words a reviewer
+# should check in this file. The other ten are Indonesian, because the seed has
+# no reliable Nias term for them and inventing one would be worse than
+# borrowing. That includes red, which almost certainly *has* a Nias word: its
+# absence here is a gap in the seed rather than a claim about the language.
+#
+# Everything else — the geometry, the widths, the dash patterns, the section
+# words, the table and figure words — is Indonesian, because that is the
+# register a Nias pupil learns mathematics in. What is Nias is «halöwö»
+# (activity), «duma-duma» (example), «fanofu» (question), «fanema li» (answer)
+# and the boolean pair «sindruhu» / «lö sindruhu».
+#
+# ## Chemistry
+#
+# **The 118 element names and the 12 anion names are deliberately absent**, and
+# fall back to English. Chemistry is taught on Nias out of Indonesian-language
+# textbooks, so the periodic table a Nias pupil meets is `locales/id`'s.
+# Copying the Indonesian table wholesale into this file would record a fact
+# about a textbook rather than about Nias. The three messages that are *frames*
+# rather than names are translated, because a frame is this catalog's business
+# whether or not the names in it ever are.
+
+
+## Style vocabulary
+
+color =
+    .black = aitö
+    .white = afusi
+    .gray = abu-abu
+    .red = merah
+    .orange = oranye
+    .yellow = kuning
+    .green = hijau
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = merah muda
+    .brown = cokelat
+line-width =
+    .thick = tebal
+    .thin = tipis
+line-style =
+    .dashed = putus-putus
+    .dotted = titik-titik
+# Noun phrases, not adjectives: they follow «awö» and modify nothing.
+fill-style =
+    .horizontal = garis melintang
+    .vertical = garis muzizio
+    .diagonal = garis diagonal
+    .backdiagonal = garis diagonal sanulöni
+    .dots = titik
+    .diamonds = belah ketupat
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = kurva
+    .function = fungsi
+    .slope-field = medan kemiringan
+    .vector-field = medan vektor
+    .parabola = parabola
+    .polyline = garis patah
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = persegi panjang
+    .circle = lingkaran
+    .region = daerah
+    .point = titik
+    .square = persegi
+    .diamond = belah ketupat
+    .cross = silang
+    .plus = tanda tambah
+# The side count binds to the noun, so it folds into the head and there is no
+# tail — putting it after the adjectives would read as though the colour had
+# the sides.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] poligon beraturan si so { $numSides } sisi
+    }
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The noun leads and its modifiers follow it: «garis tebal putus-putus merah».
+# The attributive `s-` a Nias property word would carry is missing here; see
+# the header.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+style-filled-word = afönu
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } awö { $pattern }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } awö { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } awö { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+# Nias has no article, so the two `-article` branches read the same as the ones
+# without. «ba» is the linking *and*.
+style-border-clause =
+    { $parts ->
+        [with-article] awö batas { $border }
+        [and] ba batas { $border }
+        [and-article] ba batas { $border }
+       *[with] awö batas { $border }
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+style-unfilled = lö afönu
+style-text =
+    { $parts ->
+        [background] { $color } awö latar { $background }
+       *[plain] { $color }
+    }
+style-background-none = lö hadöi
+
+
+## Boolean words
+
+boolean-true = sindruhu
+boolean-false = lö sindruhu
+
+
+## Answer buttons
+
+answer-submit-label = Fareso
+answer-submit-label-no-correctness = Fa'ohe wanema li
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Halöwö
+    .aside = Sisipan
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Duma-duma
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Fanema li
+    .note = Catatan
+    .objectives = Tujuan
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Fanofu
+    .section = Pasal
+    .solution = Penyelesaian
+    .task = Tugas
+    .theorem = Teorema
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Fanuturu
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = Si fatua
+paginator-next = Si so föna
+paginator-page = Halaman
+paginator-page-status = { $pageLabel } { $currentPage } moroi ba { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ma
+piecewise-condition-if = na
+piecewise-condition-otherwise = na lö da'ö
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header. These three are frames rather than vocabulary, so they are
+## translated whether or not the names ever are.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Simbol kimia si lö atulö
+chemistry-invalid-ionic-compound = Senyawa ionik si lö atulö
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = lowong
+math-embedded-input-blank-ordinal = lowong si { $ordinal } moroi ba { $total }

--- a/packages/i18n/locales/nia/diagnostics.ftl
+++ b/packages/i18n/locales/nia/diagnostics.ftl
@@ -1,0 +1,687 @@
+# Nias (Li Niha) diagnostics. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and orthography: the northern standard, in Latin**, with `ö` a
+# letter of its own that must never be folded to `o` — a search for «börö»
+# will not find «boro». `chrome.ftl`'s header sets out the alphabet, the
+# final-vowel property and the compromise this catalog makes with it, and why
+# initial mutation is not applied to any noun in any of the four files.
+#
+# **The frames.** This file is 220 sentences built out of a dozen recurring
+# frames, and reading the frames is the fastest way to review it:
+#
+#     … lö tefaigi            … is not looked at   (stands for *is ignored*)
+#     Tebai …                 cannot …
+#     … moguna …              … must / is needed
+#     … si lö atulö           invalid …
+#     Lö nasa mufazökhi …     has not yet been made …
+#     lö tesöndra             not found
+#     lö faudu                does not match
+#     börö me …               because …
+#     lö moguna               has no effect
+#     Lö so … / Lö hadöi …    there is no …
+#     … nibe'e                … is given / is specified
+#
+# **Two of those are paraphrases and are declared as such.** «lö tefaigi» is
+# literally *is not looked at*, from «faigi» (to see); Nias has a word for
+# *ignore* and the seed does not know it, so one paraphrase is used at every
+# site rather than a scatter of guesses, and replacing it is one search.
+# «nibe'e» is literally *given*, the `ni-` passive of «be'e», and stands for
+# English's *specified*.
+#
+# «minimal» is an **Indonesian loan used deliberately** where English says *at
+# least*: the Nias construction the seed would otherwise reach for is one it
+# cannot form confidently, and a loan a reader understands beats a phrase the
+# seed invented.
+#
+# **Register.** Indonesian for the technical nouns — `atribut`, `komponen`,
+# `nilai`, `variabel`, `titik`, `garis`, `lingkaran`, `fungsi`, `dimensi`,
+# `indeks`, `referensi`, `versi`, `format`, `dokumen` — declared as a loan
+# register in `chrome.ftl`'s header, in their Indonesian spellings, consonant
+# finals and all. Nothing here is a coinage.
+#
+# **Plural.** Nias leaves a noun unmarked after a numeral, so every
+# `[one]`/`[other]` fork in the English collapses to a single `*[other]`
+# branch. One message keeps an explicit `[1]` literal, because English forks
+# there on *one output* against *two outputs* and the distinction is about the
+# shape of the function rather than about agreement; Fluent matches a numeric
+# literal against the number itself, before any plural rule, so it stays
+# selectable.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } lö tefaigi na dua titik ujung nibe'e
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } lö tefaigi na titik ujung awö titik tengah nibe'e fefu
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset lö moguna na lö so titik tengah
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis si möi ba titik si tebai mu'ila dimensinia.
+
+line-points-too-few-dimensions = Garis moguna möi ba titik si so minimal dua dimensi.
+
+line-points-depend-on-variables = Garis si möi ba titik si faoma variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis ba variabel { $variable1 } awö { $variable2 } lö atulö.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar nibe'e faoma through, endpoint awö direction. through nibe'e andrö lö tefaigi.
+
+ray-dimension-mismatch = numDimensions sinar lö faudu.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor nibe'e faoma head, tail awö displacement. head nibe'e andrö lö tefaigi.
+
+vector-dimension-mismatch = numDimensions vektor lö faudu.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Tebai mufa'ahatö ba `<{ $component }>` börö me lö so variabel keadaan nearestPoint ba da'ö.
+
+constrain-to-without-nearest-point = Tebai mufabatasi ba `<{ $component }>` börö me lö so variabel keadaan nearestPoint ba da'ö.
+
+constrain-to-interior-without-nearest-point = Tebai mufabatasi ba bakha `<{ $component }>` börö me lö so variabel keadaan nearestPoint ba da'ö.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition lö tefaigi ba choiceInput si lö inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices nibe'e ba choiceInput lö tefaigi börö me oyania indices lö faudu ba oyania ono choice.
+
+pretzel-indices-count-mismatch = indices nibe'e ba problem lö tefaigi börö me oyania indices lö faudu ba oyania ono problem.
+
+shuffle-indices-count-mismatch = indices nibe'e ba shuffle lö tefaigi börö me oyania indices lö faudu ba oyania komponen.
+
+indices-ignored-out-of-range = indices nibe'e ba { $component } lö tefaigi börö me so indeks si baero moroi ba jangkauan.
+
+pretzel-indices-repeated = indices nibe'e ba pretzel lö tefaigi börö me so indeks si mufuli.
+
+pretzel-circuit-first-index = indices nibe'e ba pretzel ba mode circuit lö tefaigi börö me indeks si föföna moguna 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ena'ö mohalöwö `<{ $component }>` awö ono si string, atribut `type` moguna nibe'e.
+
+invalid-type-defaulting-to-math = Tipe { $type } lö atulö ba komponen { $component }. Moguna sara moroi ba math, text, number, ma boolean. math nioguna'ö.
+
+string-not-valid-component-to-arrange = String "{ $value }" tenga komponen si atulö ba { $component }. Lö tefaigi.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipe { $type } lö atulö, tipe mufalalini ba number.
+
+invalid-variable-value = Nilai variabel lö atulö: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } moguna bilangan
+
+variant-index-must-be-integer = Indeks varian { $index } moguna bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` lö nasa mufazökhi ba ukuran absolut. Lebar mufalalini ba relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` lö nasa mufazökhi ba ukuran absolut. Margin mufalalini ba relatif.
+
+side-by-side-no-block-child = `<{ $component }>` lö atulö: moguna so minimal sara ono si blok.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` ba `<label>` grafis lö tefaigi.
+
+label-for-must-resolve-to-one = Atribut `for` ba `<label>` moguna tumunö ba sara komponen manö.
+
+label-for-unresolved = Atribut `for` ba `<label>` tebai tumunö ba sara komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` ba `<label>` tumunö ba `<answer>` si no musura masukanania samösa; tunö masukan andrö sanöndra.
+
+label-for-answer-without-input = Atribut `for` ba `<label>` tumunö ba `<answer>` si lö so masukanania nilabeli.
+
+label-for-must-reference-input-or-answer = Atribut `for` ba `<label>` moguna tumunö ba sara masukan ma sara jawaban.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ena'ö atulö aksesibilitas, `<{ $component }>` moguna so deskripsi si adogo ma mutandrai simane hiasan.
+
+accessibility-video-short-description = Ena'ö atulö aksesibilitas, `<video>` moguna so deskripsi si adogo.
+
+accessibility-input-short-description-or-label = Ena'ö atulö aksesibilitas, `<{ $component }>` moguna so deskripsi si adogo ma label.
+
+accessibility-answer-input-short-description-or-label = Ena'ö atulö aksesibilitas, `<answer>` samazökhi masukan moguna so deskripsi si adogo ma label.
+
+accessibility-short-description-contains-math = Deskripsi si adogo lö sökhi na so komponen matematika simane `<{ $component }>`. Sura isi matematikania faoma li.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } lö adöni kontrasnia ba teks judul bagian (mode saitö) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; moguna minimal { $threshold }:1).
+       *[other] { $colorName } lö adöni kontrasnia ba teks judul bagian ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; moguna minimal { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Lö nasa mufazökhi `<circle>` si möi ba { $count } titik na titik andrö lö so nilai numerik.
+
+circle-too-many-through-points = Tebai mu'erai lingkaran si möi ba abölö moroi ba 3 titik.
+
+circle-overprescribed-radius-center-points = Tebai mu'erai lingkaran na jari-jari, pusat awö titik nitörö nibe'e fefu.
+
+circle-center-with-multiple-points = Tebai mu'erai lingkaran si so pusat si möi ba abölö moroi ba 1 titik.
+
+circle-radius-too-small = Tebai mu'erai lingkaran: börö me jarak dua titik andrö { $distance }, jari-jari { $radius } nibe'e andrö side-ide sibai.
+
+circle-radius-with-many-points = Tebai mufazökhi lingkaran si möi ba abölö moroi ba dua titik na jari-jari nibe'e.
+
+circle-invalid-center-or-through-points = Pusat ma titik nitörö lingkaran lö atulö.
+
+circle-radius-center-with-multiple-points = Tebai mu'erai jari-jari lingkaran si so pusat si möi ba abölö moroi ba 1 titik.
+
+circle-change-radius-non-numerical = Tebai mufalalini jari-jari lingkaran si titik nitöröia lö numerik
+
+circle-radius-with-points-non-numerical = Tebai mufazökhi lingkaran si möi ba abölö moroi ba sara titik awö jari-jari nibe'e na lö so nilai numerik.
+
+circle-change-center-non-numerical = Lö nasa mufazökhi wamalalini pusat lingkaran si möi ba titik si lö numerik.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Lö adöni dimensi domain fungsi. Domain so { $intervals } selang ba fungsi andrö so { $inputs } masukan.
+
+function-domain-invalid-format = Format domain fungsi lö atulö.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] maximum fungsi si lö numerik lö tefaigi.
+        [minimum] minimum fungsi si lö numerik lö tefaigi.
+        [extremum] extremum fungsi si lö numerik lö tefaigi.
+        [point] titik fungsi si lö numerik lö tefaigi.
+        [slope] kemiringan fungsi si lö numerik lö tefaigi.
+       *[other] { $type } fungsi si lö numerik lö tefaigi.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] maximum fungsi si lowong lö tefaigi.
+        [minimum] minimum fungsi si lowong lö tefaigi.
+        [extremum] extremum fungsi si lowong lö tefaigi.
+        [point] titik fungsi si lowong lö tefaigi.
+       *[other] { $type } fungsi si lowong lö tefaigi.
+    }
+
+function-points-too-close = Fungsi so dua titik si ahatö sibai. Tebai mufazökhi fungsi.
+
+function-iterates-input-output-mismatch = Iterasi fungsi tola ha na oyania masukan faudu ba oyania luaran. Fungsi andre so { $inputs } masukan awö { $outputs } luaran.
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang sequence lö atulö.  Moguna bilangan bulat si lö negatif.
+
+sequence-invalid-step = Step sequence lö atulö.  Moguna bilangan ba sequence tipe { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" sequence bilangan lö atulö.  Moguna bilangan.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" sequence huruf lö atulö.  Moguna rangkaian huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" sequence lö atulö.
+
+select-from-sequence-coprime-not-numbers = coprime lö tefaigi börö me si nifili tenga bilangan
+
+select-from-sequence-coprime-with-exclude-combinations = coprime lö tefaigi börö me excludeCombinations nibe'e
+
+## Resolving a `target`
+
+target-not-found = Target `<{ $source }>` lö atulö: target lö tesöndra.
+
+target-state-variable-not-found = Target `<{ $source }>` lö atulö: variabel keadaan si möi töi "{ $property }" ba `<{ $component }>` lö tesöndra.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel `<odeSystem>` moguna faböi faudu ba variabel bebas.
+
+ode-system-duplicate-variable-names = Tebai mufazökhi fungsi RHS ODE si so töi variabel si mufuli.
+
+ode-system-rhs-function-error = Tebai mufazökhi fungsi RHS ODE.  Fasala ba wamazökhi fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Tebai mufazökhi sudut ba talaga { $count } garis
+
+angle-invalid-through-point = Titik ba through `<angle>` lö atulö
+
+parabola-vertex-too-many-points = Lö nasa mufazökhi parabola si so puncak si möi ba abölö moroi ba 1 titik.
+
+parabola-too-many-points = Lö nasa mufazökhi parabola si möi ba abölö moroi ba 3 titik.
+
+intersection-too-many-items = Lö nasa mufazökhi perpotongan ba abölö moroi ba dua ngawalö
+
+## Other math components
+
+ionic-compound-not-two-ions = Lö nasa mufazökhi senyawa ionik ba zi tenga dua ion.
+
+ionic-compound-needs-cation-and-anion = Senyawa ionik ha mufazökhi ba sara kation awö sara anion.
+
+solve-equations-cannot-evaluate = Tebai mufa'ohe persamaan andre börö me persamaania tebai mu'erai: { $equation }
+
+math-operators-operand-number-required = operandNumber moguna nibe'e na muhalö operand matematika.
+
+eigen-decomposition-failed = Tebai mu'erai nilai eigen matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } lö so ba pola andrö, andrö wa lö mamalö faudu ia ba zi lowong.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" tebai mu'ila. Moguna none, medium, dense, ma dua bilangan positif nifabali spasi, simane grid="1 0.5". Lö hadöi kisi nisura.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` moguna fungsi si so { $expected ->
+        [1] sara luaran, ya'ia kemiringan y' ba zi sambua titik, simane `y - x`
+       *[other] dua luaran, ya'ia vektor ba zi sambua titik, simane `(y, -x)`
+    }, ba fungsi nibe'e andrö so { $found } luaran. { $alternative ->
+        [none] Lö hadöi nisura.
+       *[other] `<{ $alternative }>` komponen ba fungsi si manö. Lö hadöi nisura.
+    }
+
+field-function-attribute-ignored-with-child = Atribut `function` lö tefaigi börö me fungsi andrö nibe'e göi ba bakha komponen; si bakha andrö nioguna'ö. Be'e fungsi andrö ha sara lala.
+
+field-variables-ignored =
+    `<{ $component }>`: atribut `variables` mamotokhi töi variabel ekspresi nisura sanöndra ba bakha komponen. { $reason ->
+        [function-child] Fungsi ba da'e nibe'e simane ono `<function>`, si mamotokhi töi variabelnia samösa, andrö wa `variables` lö tefaigi.
+       *[no-expression] Lö so ekspresi si manö ba da'e, andrö wa `variables` lö tefaigi.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" lö tola ba perender prefigure; nioguna'ö parangi posisi kamböla.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" lö tola ba perender prefigure; nioguna'ö parangi posisi yawa.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbu lö atulö ba konversi prefigure; nioguna'ö bbox bawaan (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lebar lö atulö ba konversi prefigure; nioguna'ö lebar diagram bawaan 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio lö atulö ba konversi prefigure; nioguna'ö rasio aspek bawaan 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: talaga kisi andrö adogo sibai ba batas sumbu; kisi andrö lö tesura ba perender prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: anotasi lö tesura na lö nioguna'ö perender PreFigure.
+
+multiple-annotations-children = Oya ono `<annotations>` tesöndra ba `<graph>`; fefu si tenga si ahonoa lö tefaigi.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tebai mutambö ma musalin tipe komponen si lö mu'ila: { $type }.
+
+copy-prop-not-found = prop { $property } ba komponen tipe { $component } lö tesöndra
+
+collect-no-source = Sumber ba collect lö tesöndra.
+
+collect-invalid-component-type = Tebai mu'owuloi komponen tipe `<{ $component }>` börö me tipe komponen andrö lö atulö.
+
+reference-index-unavailable = Tebai mutunö indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Tebai mufalua { $action } ba komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk data lö atulö.  Panjang baris lö faudu. Tesöndra ba componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data so töi kolom si mufuli.  Tesöndra ba componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data lö so sara töi kolom.  Tesöndra ba componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award wanema li andre faoma fanema li si no mufa'ohe khö tag jawaban andrö samösa, ba da'ö mamazökhi parangi si lö nifalukhaisa.
+
+answer-max-num-attempts-in-section-wide-check-work = Wamazökhi `maxNumAttempts` ba `<answer>` si bakha ba wadah si so `sectionWideCheckWork` lö moguna, börö me oyania fanandraigö nitatö wadah andrö. Fazökhi `maxNumAttempts` ba wadah andrö.
+
+nested-section-wide-check-work-max-num-attempts = Wamazökhi `maxNumAttempts` ba wadah si so `sectionWideCheckWork` si bakha ba wadah bö'ö si so `sectionWideCheckWork` lö moguna, börö me oyania fanandraigö nitatö wadah si baero. Fazökhi `maxNumAttempts` ba wadah si baero andrö.
+
+answer-attributes-need-symbolic-equality = Atribut { $attributes } lö moguna na lö nibe'e symbolicEquality.
+
+answer-invalid-type = Tipe wanema li lö atulö: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Börö me lö so töi komponen `<{ $component }>`, tebai da'ö nioguna'ö simane atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` tebai nioguna'ö simane atribut module börö me tipe komponen `<module>` no so atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` lö tefaigi ba komponen `<conditionalContent>` si so ono case ma else.
+
+slider-markers-type-mismatch = Tipe marker lö faudu ba tipe slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel lö atulö: zi sambua `<problem>` moguna so sara `<statement>` awö sara `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel lö atulö: ba mode="circuit", `<problem>` si föföna tebai tobali distraktor.
+
+## Attribute values
+
+attribute-invalid-values = Nilai { $values } lö atulö ba atribut `{ $attribute }`; lö tefaigi.
+
+attribute-must-be-references = Nilai `{ $value }` lö atulö ba atribut `{ $attribute }`. Atribut moguna mufazökhi moroi ba referensi si mamöböi faoma `$`.
+
+math-input-invalid-function-names = <mathInput>: töi fungsi si lö atulö ba { $attribute } lö tefaigi: { $names }. Zi sambua töi moguna so minimal 2 karakter (huruf ma garis fabali); tola mutambö akhiran `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Tipe komponen lö atulö: `<{ $componentType }>`
+
+attribute-repeated = Tebai mufuli atribut { $attribute }.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" lö atulö ba komponen tipe `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definisi gaya { $styleNumber } lö adöni kontrasnia ba { $context ->
+        [text-on-background] warna teks ba warna latar
+        [high-contrast] warna kontras si yawa ba kanvas
+        [line] warna garis ba kanvas
+        [marker] warna marker ba kanvas
+       *[text-on-canvas] warna teks ba kanvas
+    }{ $mode ->
+        [dark] { " (mode saitö)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; moguna minimal { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Definisi gaya { $styleNumber } so warna si adöni kontrasnia ba mode sahaga, warna mode saitö si otarai nilai andrö lö adöni kontrasnia ba warna teks ba warna latar ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; moguna minimal { $threshold }:1). { $suggestion ->
+        [available] Ena'ö adöni kontrasnia ba mode saitö, fa'abölö kontras mode sahaga (duma-duma fazökhi { $lightAttribute }="{ $lightColor }") ma falalini warna mode saitö (duma-duma fazökhi { $darkAttribute }="{ $darkColor }").
+       *[none] Ena'ö adöni kontrasnia ba mode saitö, fa'abölö kontras mode sahaga ma falalini warna si otarai andrö faoma textColorDarkMode ba/ma backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Definisi gaya { $styleNumber } so warna teks si adöni kontrasnia ba mode sahaga, warna teks mode saitö si otarai nilai andrö lö adöni kontrasnia ba kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; moguna minimal { $threshold }:1). { $suggestion ->
+        [available] Ena'ö adöni kontrasnia ba mode saitö, fa'abölö kontras mode sahaga (duma-duma fazökhi textColor="{ $lightColor }") ma falalini warna mode saitö (duma-duma fazökhi textColorDarkMode="{ $darkColor }").
+       *[none] Ena'ö adöni kontrasnia ba mode saitö, fa'abölö kontras mode sahaga ma falalini warna si otarai andrö faoma textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Sara bagian ha tola mamili sara <stylePalette>; si ahonoa nioguna'ö.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = varian si unik khö { $component } tebai mu'ila börö me numToSelect tenga bilangan bulat si lö negatif.
+
+variant-num-to-select-not-constant-number = varian si unik khö { $component } tebai mu'ila börö me numToSelect tenga bilangan si lö falalini.
+
+variant-with-replacement-not-constant-boolean = varian si unik khö { $component } tebai mu'ila börö me withReplacement tenga boolean si lö falalini.
+
+variant-select-weight-disables-unique = Varian si unik ba select lö mohalöwö na so option si so selectWeight ma selectForVariants
+
+variant-coprime-undetermined = varian si unik khö { $component } tebai mu'ila börö me tebai mu'ila hadia coprime lö atulö mamalö.
+
+variant-attribute-not-constant = varian si unik khö { $component } tebai mu'ila börö me { $attribute } falalini.
+
+variant-attribute-not-number = varian si unik khö { $component } tebai mu'ila börö me { $attribute } tenga bilangan.
+
+variant-attribute-wrong-type-for-sequence =
+    varian si unik khö { $component } tipe { $type } tebai mu'ila börö me { $attribute } tenga { $expected ->
+        [letters-combination] rangkaian huruf
+        [math-expression] ekspresi matematika si atulö
+        [integer] bilangan bulat
+       *[number] bilangan
+    }.
+
+variant-length-not-integer = varian si unik khö { $component } tebai mu'ila börö me length tenga bilangan bulat.
+
+variant-sort-not-implemented = lö nasa mufazökhi varian si unik khö { $component } si so sort
+
+variant-exclude-combinations-not-implemented = lö nasa mufazökhi varian si unik khö { $component } si so excludeCombinations
+
+variant-math-exclude-not-implemented = lö nasa mufazökhi varian si unik khö { $component } tipe math si so exclude
+
+variant-non-constant-exclude-not-implemented = lö nasa mufazökhi varian si unik khö { $component } si so exclude si falalini
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: lö tola ba perender prefigure khö graph; ono nifalua'ö.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri si lö atulö ma si lö ahono; ono nifalua'ö.
+
+prefigure-curve-label-omitted = { $subject }: label lö tola ba elemen kurva nifalalini; label nifalua'ö.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipe definisi fungsi kurva '{ $definitionType }' lö tola; ono nifalua'ö.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions ba regionBetweenCurves lö tola; ono nifalua'ö.
+
+prefigure-region-non-formula-child = { $subject }: ha ono fungsi tipe formula si tola ba regionBetweenCurves; ono nifalua'ö.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' lö tola ba { $labelKind ->
+        [line-family] label kelompok garis
+       *[point] label titik
+    }; nioguna'ö perataan PreFigure bawaan.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' lö tola ba PreFigure; mangawuli ba isi si solid.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' si lö mu'ila nifalua'ö moroi ba luaran PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' mufalalini ba gaya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' lö tola ba PreFigure; nioguna'ö gaya bawaan.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` lö atulö; target tebai mu'ila. Anotasi nifalua'ö.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` tumunö ba oya target; si föföna nioguna'ö.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` lö atulö; target andrö si baero moroi ba graph si mangosambua ia. Anotasi nifalua'ö.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` lö atulö; target andrö tenga objek grafis si tola ba konversi prefigure. Anotasi nifalua'ö.
+
+annotation-text-missing = `<annotation>`: `text` lö so ma lowong; teks si lowong nifazökhi.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Tesöndra katergantungan si mangawuli.
+       *[other] Tesöndra katergantungan si mangawuli si so komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Nitunö referensi lö tesöndra: `{ $reference }`
+
+reference-multiple-referents = Oya nitunö referensi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } khö `<{ $componentType }>` lö atulö.
+
+children-invalid = Ono `<{ $componentType }>` lö atulö: Tesöndra ono si lö atulö: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` lö atulö ba atribut `{ $attribute }`, nilai `{ $default }` nioguna'ö
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } lö tesöndra.
+       *[other] Versi DoenetML { $version } lö tesöndra. Mangawuli ba versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML lö atulö: { $content }
+
+parse-tag-missing-close-tag = DoenetML lö atulö: Tag `{ $tag }` lö so tag wanutu. Moguna tag samatutu ia samösa ma tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML lö atulö: Fasala ba tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML lö atulö: Atribut `{ $attribute }` si lö atulö andre hulö lö so nilainia.
+
+parse-attribute-invalid = DoenetML lö atulö: Atribut `{ $attribute }` lö atulö
+
+parse-attribute-value-invalid = DoenetML lö atulö: Nilai atribut `{ $value }` lö atulö
+
+parse-attribute-value-quote-mismatch = DoenetML lö atulö: Nilai atribut `{ $value }` lö atulö. Tanda kutip lö faudu. Hulö lö so sara `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML lö atulö: Tesöndra tag si lö so töi tag, simane `<`
+
+parse-tag-not-closed = DoenetML lö atulö: Tag `{ $tag }` lö tefatutu (hulö lö so `>`).
+
+parse-self-closing-tag-name-missing = DoenetML lö atulö: Tesöndra tag si lö so töi tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML lö atulö: Tag `{ $tag }` lö tefatutu (hulö lö so `/>`).
+
+parse-tag-invalid-attributes = DoenetML lö atulö: Tag `{ $tag }` lö atulö. Hulö lö atulö atributnia.
+
+parse-close-tag-name-missing = DoenetML lö atulö: Tesöndra tag wanutu si lö so töi tag, simane `</`
+
+parse-attribute-value-unquoted = Nilai atribut moguna ba bakha tanda kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML lö atulö: Tesöndra tag wanutu `{ $tag }`, ba lö so tag wamokai si faudu
+
+parse-close-tag-mismatched = DoenetML lö atulö: Tag wanutu lö faudu. Nifalukhaisa `</{ $expected }>`. Si tesöndra `{ $found }`
+
+parser-node-unconvertible = Node { $node } tebai mufalalini tobali node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Töi atribut name='{ $name }' lö atulö. { $reason ->
+        [characters] Töi ha tola so huruf, angka, garis ba dou ma garis fabali.
+       *[start] Töi moguna mamöböi faoma sara huruf.
+    }
+
+component-name-invalid-start = Töi komponen "{ $name }" lö atulö. Töi moguna mamöböi faoma sara huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Jawaban tipe videoWatched moguna so atribut video
+
+answer-video-watched-video-not-reference = Jawaban tipe videoWatched moguna so atribut video si sara referensi
+
+answer-name-not-single-text = Atribut name khö jawaban moguna so sara ono text manö
+
+## Referencing another document
+
+external-doenetml-recursion-limit = DoenetML si baero tebai muhalö börö me oya sibai lapisan rekursinia. Hadia so referensi si mangawuli?
+
+external-doenetml-unavailable = DoenetML moroi ba { $attribute }="{ $uri }" tebai muhalö
+
+external-doenetml-type-mismatch = DoenetML nihalö moroi ba { $attribute }="{ $uri }" lö atulö: lö faudu ba tipe komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` no tebolokhi; oguna'ö `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` ba `<{ $component }>` no tebolokhi; oguna'ö `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` no tebolokhi ba lö tefaigi börö me `{ $to }` nibe'e göi.
+       *[other] [deprecation] Atribut `{ $from }` ba `<{ $component }>` no tebolokhi ba lö tefaigi börö me `{ $to }` nibe'e göi.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` ba `<{ $component }>` no tebolokhi ba lö tefaigi.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` ba `<{ $component }>` no tebolokhi; oguna'ö ono `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` khö atribut `{ $attribute }` ba `<{ $component }>` no tebolokhi; oguna'ö `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ha tola mamazökhi bentuk jamak li Inggris, andrö wa teksnia lö mufalalini ba dokumen nisura faoma { $locale }. Sura bentuk jamaknia sanöndra, ma fazökhi faoma atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` tenga elemen Doenet si mu'ila.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` lö tola ba wamöböi dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` lö tola ba bakha `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` lö so atribut si möi töi `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` khö elemen `<{ $tag }>` moguna sara daftar si zi sambua itemnia sara moroi ba: { $allowed }
+       *[other] Atribut `{ $attribute }` khö elemen `<{ $tag }>` moguna sara moroi ba: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Töi varian khö select lö atulö.  Töi varian { $variantName } so ba { $numOptions } option ba oyania nifili { $numToSelect }.
+
+select-variant-name-without-options = So varian nibe'e ba select ba lö so option ba töi varian si tola: { $variantName }.
+
+select-variant-name-not-possible = Töi varian { $variantName } nibe'e ba select tenga töi varian si tola.
+
+select-too-few-options = Tebai mufili { $numToSelect } komponen moroi ba { $numOptions } manö.
+
+select-from-sequence-too-few-values = Tebai mufili { $numToSelect } nilai moroi ba sequence si so panjang { $length }.
+
+select-from-sequence-indices-count-mismatch = Oyania indices nibe'e ba select moguna faudu ba oyania nifili
+
+select-from-sequence-indices-not-integers = Fefu indices nibe'e ba select moguna bilangan bulat
+
+select-from-sequence-index-excluded = Indeks selectfromsequence nibe'e andrö no niheta
+
+select-from-sequence-indices-excluded-combination = indices selectfromsequence nibe'e andrö sara kombinasi niheta
+
+select-from-sequence-coprime-not-positive-integers = Tebai mufili kombinasi coprime börö me si nifili tenga bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Tebai mufili bilangan coprime. Fefu nilai si tola so faktor si sara. (Nilai "from" ma "to" nibe'e moguna coprime awö "step".)
+
+select-from-sequence-coprime-single-number = Tebai mufili kombinasi coprime moroi ba sara bilangan si tenga 1.
+
+select-from-sequence-excluded-too-many-combinations = Abölö moroi ba 70% kombinasi niheta ba selectFromSequence
+
+select-from-sequence-coprime-none-found = Tebai mufili bilangan coprime. Fefu nilai si tola so faktor si sara.
+
+select-from-sequence-too-few-unique-values = Tebai mufili { $numToSelect } nilai si unik moroi ba sequence si so panjang { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Tebai mufili { $numToSelect } nilai moroi ba daftar bilangan prima si so panjang { $numValues }
+
+select-prime-numbers-values-count-mismatch = Oyania nilai nibe'e ba select moguna faudu ba oyania nifili
+
+select-prime-numbers-values-not-prime = Fefu nilai nibe'e ba select bilangan prima moguna so ba daftar bilangan prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers nibe'e andrö sara kombinasi niheta
+
+select-prime-numbers-excluded-too-many-combinations = Abölö moroi ba 70% kombinasi niheta ba selectPrimeNumbers
+
+select-random-combination-fluke = Börö me hulö si lö falukha sibai, kombinasi nilai acak tebai mufili
+
+select-random-value-fluke = Börö me hulö si lö falukha sibai, nilai acak tebai mufili
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` andre lö tesura börö me ba bakha matematika ia ba lö `inline`. Tambö `inline` ena'ö tobali daftar si mangawuli tou, si faudu ba bakha sara ekspresi.
+        [expanded] `<{ $component }>` andre lö tesura börö me ba bakha matematika ia ba `expanded`. Heta `expanded`; kotak si oya barisnia lö faudu ba bakha sara ekspresi.
+        [on-graph] `<{ $component }>` andre lö tesura börö me ba bakha matematika nisura ba graph ia, si lö so nahia ba masukan.
+       *[relative-width] `<{ $component }>` andre lö tesura börö me ba bakha matematika ia ba so lebar relatif. Be'e lebarnia faoma satuan absolut, simane `px`.
+    }

--- a/packages/i18n/locales/nia/editor.ftl
+++ b/packages/i18n/locales/nia/editor.ftl
@@ -1,0 +1,234 @@
+# Nias (Li Niha) editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and orthography: the northern standard, in Latin**, with `ö` a
+# letter of its own that must never be folded to `o`. `chrome.ftl`'s header
+# sets out the alphabet, the final-vowel property and what this catalog does
+# about it, and why initial mutation is not applied.
+#
+# **This is the file where the Indonesian loan register is heaviest**, and it
+# should be read as such rather than as a failure to translate. An editor's
+# nouns — «editor», «penampil», «varian», «saringan», «komponen», «atribut»,
+# «referensi», «properti», «cuplikan», «larik», «nilai», «tipe», «gaya»,
+# «koordinat», «fungsi», «baris», «tag», «dokumentasi», «aksesibilitas»,
+# «laporan», «versi», «format», «konteks», «diagnostik» — are Indonesian in a
+# Nias speaker's computing vocabulary, and none of them ends in a vowel. The
+# file therefore reads as two languages at once in a way `content.ftl` does
+# not, and that is the honest state of the register rather than an oversight.
+#
+# What is Nias here is the frame: «lö» (not), «tebai» (cannot), «tola» (can),
+# «so» (there is), «moroi» (from), «ba» (in, at, and), «awö» (with), «ma»
+# (or), «na» (if, when), «börö me» (because), «fefu» (all), «oya» (many),
+# «andrö» (that), the passive «ni-» and the verbal «fa-» and «mu-», and the
+# words «fanofu», «fanema li», «töi», «oroma», «bunia», «bokai», «faudu»,
+# «moguna», «fazökhi» and «tesöndra».
+#
+# **The count selects.** Nias leaves a noun unmarked after a numeral, so
+# «koordinat» is the same word for one and for many; `help-coordinates` and the
+# two counts inside `editor-accessibility-label` collapse to a single
+# `*[other]` branch. That is also what the plural rule requires — `nia` has no
+# CLDR plural data, so an `[one]` branch here would be selected by English's
+# rules — but it would be the right form even if it did.
+#
+# **What this catalog does not know.** The spoken adaptation of any of the
+# loans above, the initial mutation every noun in it is missing, and whether
+# «penampil» or a Nias phrase reads better for *viewer*.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Fatambai
+       *[update] Fabö'ö
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } penampil
+       *[other] { $word } penampil { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+
+editor-variant-filter = Saring...
+
+editor-variant-next = Fili varian si so föna
+editor-variant-previous = Fili varian si fatua
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Tesöndra pelanggaran aksesibilitas WCAG AA. Klik ba { $action ->
+            [close] wanutu
+           *[open] wamokai
+        } laporan aksesibilitas.
+        [advisories] Klik ba { $action ->
+            [close] wanutu
+           *[open] wamokai
+        } laporan aksesibilitas. Lö tesöndra pelanggaran WCAG AA, ba so nasa saran aksesibilitas tanö bö'ö.
+       *[clean] Klik ba { $action ->
+            [close] wanutu
+           *[open] wamokai
+        } laporan aksesibilitas. Lö tesöndra masalah aksesibilitas.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Tesöndra pelanggaran aksesibilitas WCAG AA. Tesöndra { $count } pelanggaran WCAG AA. Klik ba { $action ->
+            [close] wanutu
+           *[open] wamokai
+        } laporan aksesibilitas.
+        [advisories] Lö tesöndra pelanggaran WCAG AA. Tesöndra { $count } saran aksesibilitas tanö bö'ö. Klik ba { $action ->
+            [close] wanutu
+           *[open] wamokai
+        } laporan aksesibilitas.
+       *[clean] Lö tesöndra pelanggaran WCAG AA. Klik ba { $action ->
+            [close] wanutu
+           *[open] wamokai
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versi { $version }
+
+editor-tab-help = Fanolo si faudu ba konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Fasala
+editor-tab-warnings = Fango'ou
+editor-tab-info = Info
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Fanema li si no mufa'ohe
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Format simane DoenetML
+editor-format-as-xml = Format simane XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Lö fasala
+editor-no-warnings = Lö fango'ou
+editor-no-info = Lö diagnostik info
+
+editor-show-info-annotations = Oroma'ö diagnostik info ba editor
+editor-show-accessibility-annotations = Oroma'ö diagnostik aksesibilitas ba editor
+
+editor-accessibility-learn-more = Fahaö ba wamalua aksesibilitas ba Doenet
+
+editor-accessibility-violations-heading = Pelanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masalah aksesibilitas tanö bö'ö
+editor-none-found = Lö tesöndra
+
+
+## Submitted responses
+
+editor-no-responses = Lö nasa fanema li si no mufa'ohe
+editor-response-answer-id = Id wanema li
+editor-response-response = Fanema li
+editor-response-credit = Nilai
+editor-response-submitted = No mufa'ohe
+
+
+## The context-help panel
+
+help-placeholder = Be'e kursor ba döi tag, atribut, ma { $ref } ba wamaigi dokumentasi.
+
+help-unsupported-ref-chain = Fanolo ba referensi si oya ngawalö simane { $example } lö nasa so.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Lö tesöndra nitunö referensi andre: { $ref }.
+        [multiple] Oya nitunö referensi andre: { $ref }.
+       *[indeterminate] Nitunö { $ref } tebai mu'ila.
+    }
+
+help-learn-about-references = Fahaö sanandrösa ba referensi →
+help-reference-page = Halaman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Bakha ba { $element }
+       *[top] Ba tingkat si yawa sibai
+    }{ $allowed ->
+        [none] { " — lö hadöi zi tola muhalö ba da'e." }
+        [text] { " — sura teks ba da'e." }
+        [text-and-components] { " — sura teks ba da'e, ma andrö tandraigö:" }
+       *[components] { " — hadia zi tola tandraigö:" }
+    }
+
+help-suggestions-footer = Ta'u { $shortcut } ba wamaigi fefu { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } no referensi ba { $target }.
+       *[other] { $ref } no referensi ba { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ni'ombakha'ö { $owner } simane { $role }.
+       *[other] Ni'ombakha'ö { $owner } ba baris { $line } simane { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } no referensi ba properti { $property } khö { $element }.
+       *[other] { $ref } no referensi ba properti { $property } khö { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = cuplikan
+help-kind-array-entry = entri larik
+
+help-default = Bawaan:
+help-active-default = Bawaan si mohalöwö:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai si tola (sara ba zi sambua item):
+       *[other] Nilai si tola:
+    }
+
+help-suggested-values = Nilai ni'ombakha'ö:
+
+help-inserts = Nifasui:
+
+help-coordinates = Koordinat:
+
+help-type = Tipe:
+
+help-resolved-style = Gaya si tesöndra (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Töi fungsi si tesöndra:
+help-reset-list = Daftar nifatambai ba masukan andre:
+help-added-on-input = Nitambö ba masukan andre:
+help-removed-on-input = Niheta ba masukan andre:
+
+help-reset-overrides = { $reset } famalalini { $additional } awö { $removed }.

--- a/packages/i18n/locales/pag/chrome.ftl
+++ b/packages/i18n/locales/pag/chrome.ftl
@@ -1,0 +1,163 @@
+# Pangasinan (Salitan Pangasinan) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: the modernised spelling.** Pangasinan has two spelling
+# traditions still in use. The older one is Spanish-influenced and writes «c»
+# and «qu» for /k/, «gu» for /g/ before a front vowel, and «o» where the
+# modern one writes «u» in some closed syllables — the spelling of the
+# nineteenth-century dictionaries and of most devotional printing. The
+# modernised one, used by the Pangasinan-language press and in the schools,
+# writes «k» throughout and has no «c», «q», «f», «v», «z» or «x» outside
+# untranslated identifiers. This catalog writes the **modernised** one.
+#
+# A reviewer who prefers the older spelling should **respell rather than
+# retranslate**: the disagreement between the two is a letter-for-letter
+# mapping and none of the word choices below depend on it. What must not
+# happen is one file being respelled and the other three left alone.
+#
+# **The technical register is a loan register, and it is a real one.**
+# Pangasinan speakers are schooled in Filipino and English, and Pangasinan
+# mathematics teaching carries a Spanish-derived vocabulary that predates
+# both — «linya», «punto», «sirkulo», «poligono», «kolor», «hilera»,
+# «kolumna», «estadistika», «ekspresyon». Those are used here as the words
+# the community uses, not as English respelled. Where the seed had no such
+# established loan and no Pangasinan word it could vouch for, it kept the
+# English term outright — `Feedback`, `WCAG`, `keyboard`, `renderer`,
+# `reload`, `load` — rather than coining one.
+#
+# **What is Pangasinan here** is the frame: the markers «so», «na», «ed»,
+# «say»; the linker «a»/«ya»; the negator «ag»; «walay» ('there is') and
+# «anggapoy» ('there is none'); «nepeg» ('must'); «nayari» ('is possible');
+# «lapud» ('because'); and the verb morphology on «nengneng», «pawit»,
+# «ekal», «iyarum», «romog» and «sinop». A speaker should expect to rewrite
+# whole sentences rather than to correct words inside them.
+#
+# **The linker.** Pangasinan joins an attributive word to what it describes
+# with a linker whose shape the **preceding** word decides: «a» after a
+# consonant, enclitic «-n» (often written «ya») after a vowel. This catalog
+# writes the free «a» everywhere, which is right after a consonant-final word
+# and wrong after a vowel-final one. `content.ftl`'s header names the exact
+# entries in its own tables where that misfires.
+
+answer-checking = Nenengnengen...
+answer-submitting = Ipapawit...
+
+answer-checking-status = Nenengnengen so ebat
+answer-submitting-status = Ipapawit so ebat
+
+answer-correct = Duga
+answer-incorrect = Aliwa
+
+answer-response-saved = Nisinop so Ebat
+
+answer-percent-credit = { $percent }% a Kredito
+answer-percent-correct = { $percent }% a Duga
+answer-percent-short = { $percent } %
+
+max-credit-available = Sankarakelan a kredito: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] anggapo lay akeran sali
+       *[other] { $count } a sali so akera
+    }
+
+validation-correct = (Duga)
+validation-incorrect = (Aliwa)
+validation-partially-correct = (Kabiangan a duga)
+
+answer-show-responses =
+    { $count ->
+       *[other] Ipanengneng so { $count } ya ebat ed { $answerId }
+    }
+
+feedback-heading = Feedback
+
+collapsible-click-to-open = (i-click pian nalukasan)
+collapsible-click-to-close = (i-click pian nakapotan)
+
+collapsible-initializing = Manggagapo...
+
+footnote-show = Ipanengneng so nota ed leksab
+footnote-hide = Iyamot so nota ed leksab
+
+description-more-information = arum ni ran impormasyon
+
+slider-previous = Akauna
+slider-next = Onsublay
+
+keyboard-open = Lukasan so Keyboard
+keyboard-close = Kapotan so Keyboard
+
+choice-input-remove-choice = Ekalen so { $choice }
+
+matrix-remove-row = Ekalen so hilera
+matrix-add-row = Mangiyarum na hilera
+matrix-remove-column = Ekalen so kolumna
+matrix-add-column = Mangiyarum na kolumna
+
+subset-add-remove-points = Mangiyarum/Mangekal na saray punto
+subset-toggle-points-intervals = Manguman ed saray punto tan interbalo
+subset-move-points = Iyalis iray punto
+subset-clear = Punasen
+
+orbital-add-row = Mangiyarum na hilera
+orbital-remove-row = Ekalen so hilera
+orbital-add-box = Mangiyarum na kahon
+orbital-remove-box = Ekalen so kahon
+orbital-add-up-arrow = Mangiyarum na pana ya patagey
+orbital-add-down-arrow = Mangiyarum na pana ya paleksab
+orbital-remove-arrow = Ekalen so pana
+
+orbital-row-label = Label parad hilera { $row }
+
+pretzel-answer = Ebat
+
+summary-statistics-caption = Sumaryo na estadistika na { $column }
+
+math-input-preview-region = pakanengnengan na ekspresyon a matematika
+math-input-preview = Pakanengnengan
+math-input-invalid-expression = Aliwan ekspresyon:
+
+viewer-initializing = Manggagapo...
+
+error-heading = Lingo
+
+error-found-at =
+    { $span ->
+        [line] Naromog ed linya { $startLine }.
+       *[lines] Naromog ed saray linya { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Walay lingo na sayan dokumento!
+
+diagnostic-heading-error = Lingo
+diagnostic-heading-warning = Pasakbay
+diagnostic-heading-information = Impormasyon
+diagnostic-heading-hint = Bilin
+
+accessibility-heading-level-1 = Kasumlangan ed WCAG AA ya Aksesibilidad
+accessibility-heading-level-2 = Pasakbay ed aksesibilidad
+
+something-went-wrong = Walay lingo ya agawa.
+
+renderer-load-failed = ag akaload so sakey a renderer. Ipa-reload pa so pahina.
+
+core-start-failed = Ag ayari ya igapo so sayan dokumento. Ipa-reload pa so pahina.
+
+core-start-failed-busy = Ag ayari ya igapo so sayan dokumento. Dakel a dokumento so ginapoan ya sanbaan, tan mas manbayag itan ed mairap a debais. No asumpal la ray arum a dokumento, nayarin ontulong so pangi-reload ed pahina.
+
+core-start-failed-retry = Ag ayari ya igapo so sayan dokumento.
+
+core-start-failed-busy-retry = Ag ayari ya igapo so sayan dokumento. Dakel a dokumento so ginapoan ya sanbaan, tan mas manbayag itan ed mairap a debais.
+
+core-start-retry = Salien lamet
+
+saved-state-unavailable = Ag ayari ya naload so nisinop mon kimey.

--- a/packages/i18n/locales/pag/content.ftl
+++ b/packages/i18n/locales/pag/content.ftl
@@ -1,0 +1,299 @@
+# Pangasinan (Salitan Pangasinan) content catalog: the prose the core computes
+# into the document. Selected by `documentLocale` — the language the activity
+# was written in. `locales/en/content.ftl` is the source of truth, and message
+# ids, placeables and variant keys are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: the modernised spelling**, as `chrome.ftl`'s header sets out —
+# «k» throughout, no «c» or «qu», and none of «f v z x» outside untranslated
+# identifiers. The older Spanish-influenced spelling is the one a reviewer
+# might have expected; **respell rather than retranslate**, and respell all
+# four files at once.
+#
+# ## Word order
+#
+# **The describing word comes first, the noun after it, with a linker between
+# them**: «makapal a ambalanga a linya» is *thick red line*. That is English's
+# order, and it is Pangasinan's ordinary order for an attributive phrase — not
+# a failure to translate. So `style-stroke`, `style-with-noun` and
+# `style-filled-with-noun` keep English's sequence of placeables, and what this
+# catalog adds between them is the linker.
+#
+# ## The linker, and where it is wrong
+#
+# Pangasinan's linker has two shapes and the **preceding** word picks them: «a»
+# after a consonant, enclitic «-n» — usually written «ya» when it stands free —
+# after a vowel. No one shape is right in both positions, so this catalog does
+# what `locales/pam` and `locales/bik` do: it writes the free **«a»**
+# everywhere and names the exception rather than hiding it.
+#
+# «a» is wrong wherever the word in front of it ends in a vowel. In this
+# catalog's own tables that is **«ambalanga»** (red), **«lila»** (purple),
+# **«kape»** (brown), **«diamante»** and **«tuldek-tuldek»** — a description
+# built on any of those renders «ambalanga a linya» where a speaker says
+# «ambalangan linya». It is also wrong after an author's own `lineColorWord`
+# whenever that word ends in a vowel, which the catalog cannot see. A fix is a
+# change to what the composition messages are handed, not a change to the
+# tables.
+#
+# ## Vocabulary
+#
+# The colours, the two widths, `style-filled-word`, `style-unfilled`,
+# `noun-gender`'s answer and every function word are Pangasinan. The geometry
+# is the **Spanish-derived vocabulary Philippine mathematics teaching
+# carries** — «linya», «punto», «sirkulo», «poligono», «kuadrado»,
+# «triyanggulo», «kurba», «parabola», «bektor» — used because it is what the
+# community uses, not because English was respelled. «gris» (grey), «sian»
+# (cyan), «kampo» (field, in the two `-field` nouns), «orisontal»,
+# «bertikal», «reberso» and «tabla» are Spanish loans on the same footing.
+# `.slope-field` and `.vector-field` keep `slope` and `vector`'s loan forms
+# because the seed found no settled Pangasinan term for either.
+#
+# Pangasinan has no grammatical gender and no case, so `noun-gender` answers
+# one token for every noun and nothing here selects on `$gender` or `$role`.
+#
+# **The two chemistry tables — `element-name` and `element-anion-name` — are
+# omitted.** Secondary science in Pangasinan's provinces is taught in English,
+# so the English fallback is the language of the classroom and filling those
+# 132 keys in would claim a translation that had not happened. `ion-name-`
+# `oxidation-state` and the two `chemistry-invalid-` messages are prose and
+# are translated.
+
+
+## Style vocabulary
+
+color =
+    .black = andeket
+    .white = amputi
+    .gray = gris
+    .red = ambalanga
+    .orange = kahel
+    .yellow = duyaw
+    .green = berde
+    .cyan = sian
+    .blue = asul
+    .purple = lila
+    .pink = rosas
+    .brown = kape
+
+line-width =
+    .thick = makapal
+    .thin = manipis
+
+# The reduplication is distributive, not a plural: «tuldek-tuldek» is 'dots
+# here and there' rather than 'more than one dot'.
+line-style =
+    .dashed = putol-putol
+    .dotted = tuldek-tuldek
+
+# Pangasinan marks no plural on the noun, so «linya» is the word for one line
+# and for many alike; none of these is a plural of anything.
+fill-style =
+    .horizontal = orisontal a linya
+    .vertical = bertikal a linya
+    .diagonal = diagonal a linya
+    .backdiagonal = reberso a diagonal a linya
+    .dots = tuldek
+    .diamonds = diamante
+
+noun =
+    .line = linya
+    .line-segment = segmento na linya
+    .ray = sinag
+    .vector = bektor
+    .curve = kurba
+    .function = punsion
+    .slope-field = kampo na slope
+    .vector-field = kampo na bektor
+    .parabola = parabola
+    .polyline = polilinya
+    .polygon = poligono
+    .triangle = triyanggulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = rehyon
+    .point = punto
+    .square = kuadrado
+    .diamond = diamante
+    .cross = krus
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe. «ya» here is correct and fixed: «walaay» is
+# vowel-initial, and the linker in front of it is decided by «poligono», which
+# this catalog writes itself.
+noun-regular-polygon =
+    { $part ->
+        [tail] ya walaay { $numSides } a gilig
+       *[head] regular a poligono
+    }
+
+# One answer for every noun: Pangasinan has no grammatical gender, so nothing
+# downstream has anything to agree with.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } a { $lineStyle } a { $color }
+        [width-color] { $width } a { $color }
+        [style-color] { $lineStyle } a { $color }
+        [width-style] { $width } a { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } a { $noun } { $nounTail }
+       *[noun] { $description } a { $noun }
+    }
+
+style-filled-word = napno
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } a { $color } ya walaay { $pattern }
+       *[plain] { $filled } a { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } a { $color } a { $noun } ya walaay { $pattern }
+        [plain-tail] { $filled } a { $color } a { $noun } { $nounTail }
+        [pattern-tail] { $filled } a { $color } a { $noun } { $nounTail } ya walaay { $pattern }
+       *[plain] { $filled } a { $color } a { $noun }
+    }
+
+# Pangasinan has no article, so the two `-article` branches say what the other
+# two say. They are kept apart because English's distinction is between a first
+# clause and a further one, and this file does mark that: «ya walaay» against
+# «tan».
+style-border-clause =
+    { $parts ->
+        [with-article] ya walaay { $border } a gilig
+        [and] tan { $border } a gilig
+        [and-article] tan { $border } a gilig
+       *[with] ya walaay { $border } a gilig
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } a { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = ag napno
+
+style-text =
+    { $parts ->
+        [background] { $color } ya walaay { $background } a beneg
+       *[plain] { $color }
+    }
+
+style-background-none = anggapo
+
+
+## Boolean words
+
+boolean-true = tua
+boolean-false = palso
+
+
+## Answer buttons
+
+answer-submit-label = Nengnengen so Kimey
+answer-submit-label-no-correctness = Ipawit so Ebat
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktibidad
+    .aside = Aparte
+    .cascade = Kaskada
+    .definition = Kabaliksan
+    .example = Alimbawa
+    .exercise = Ehersisyo
+    .exercises = Saray Ehersisyo
+    .given-answer = Ebat
+    .note = Nota
+    .objectives = Saray Getma
+    .paragraphs = Saray Parapo
+    .part = Kabiangan
+    .problem = Problema
+    .problems = Saray Problema
+    .proof = Paneknek
+    .question = Tepet
+    .section = Seksion
+    .solution = Solusyon
+    .task = Kimey
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Bilin
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Pigura { $enumeration }
+        [numbered-caption] Pigura { $enumeration }{ ": " }
+        [unnumbered-caption] Pigura{ ": " }
+       *[unnumbered] Pigura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Akauna
+paginator-next = Onsublay
+paginator-page = Pahina
+
+paginator-page-status = { $pageLabel } { $currentPage } ed { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = odino
+
+piecewise-condition-if = no
+
+piecewise-condition-otherwise = no andi
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Aliwan Simbolo a Kemikal
+chemistry-invalid-ionic-compound = Aliwan Kompuesto ya Ioniko
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blangko
+
+math-embedded-input-blank-ordinal = blangko { $ordinal } ed { $total }

--- a/packages/i18n/locales/pag/content.ftl
+++ b/packages/i18n/locales/pag/content.ftl
@@ -57,7 +57,7 @@
 # **The two chemistry tables — `element-name` and `element-anion-name` — are
 # omitted.** Secondary science in Pangasinan's provinces is taught in English,
 # so the English fallback is the language of the classroom and filling those
-# 132 keys in would claim a translation that had not happened. `ion-name-`
+# 130 keys in would claim a translation that had not happened. `ion-name-`
 # `oxidation-state` and the two `chemistry-invalid-` messages are prose and
 # are translated.
 

--- a/packages/i18n/locales/pag/diagnostics.ftl
+++ b/packages/i18n/locales/pag/diagnostics.ftl
@@ -1,0 +1,706 @@
+# Pangasinan (Salitan Pangasinan) diagnostics. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: the modernised spelling**, as `chrome.ftl`'s header sets out.
+# The older Spanish-influenced spelling is a respelling, not a retranslation;
+# convert all four files at once or none.
+#
+# **The frames.** This file is some 220 sentences built out of a dozen
+# recurring frames, and reading the frames is the fastest way to review it:
+#
+#     Ag-uusaren …         it is ignored — rendered literally as 'is not used'
+#     Ag ayari a …         cannot / is not possible
+#     Nepeg a …            must / is required
+#     Aliwan …             invalid …
+#     Ag naromog …         not found
+#     Anggapoy …           there is no …
+#     Walay …              there is …
+#     Anggapoy epekto to   has no effect
+#     Ag ni nagagawa …     has not been implemented
+#     lapud …              because …
+#     … a nibaga           … that was specified
+#     … so uusaren         … is used
+#
+# «Ag-uusaren» is worth naming because it is a **paraphrase, not a
+# translation**: the seed found no Pangasinan verb for 'ignore' it could vouch
+# for, so every "is ignored" in this file reads 'is not used'. That is the
+# first thing a speaker should replace, and replacing it is one search.
+#
+# **Loans, declared.** The technical nouns are the Spanish-derived vocabulary
+# Philippine schooling carries — «komponente», «atributo», «balor», «tipo»,
+# «bersyon», «indeks», «matriks», «ekspresyon», «dimensyon», «punsion»,
+# «rehyon», «kolor», «linya», «punto» — plus a handful of English words the
+# code itself uses (`renderer`, `input`, `list`, `default`, `mode`). What is
+# Pangasinan is the frame around them.
+#
+# **No plural-category branches.** CLDR has no plural data for `pag`, so a
+# `[one]` branch would be text selected by English's rules; and Pangasinan
+# leaves a noun unmarked after a numeral anyway, so one form is correct.
+# Every `$…Count` and `$count` select is collapsed to a single `*[other]`.
+# The explicit numeric literals English forks on are kept where the branch is
+# a real distinction rather than a plural rule.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] ag-uusaren so { $attributes } no duaran endpoint so nibaga
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] ag-uusaren so { $attributes } no nibaga so endpoint tan midpoint ya dua
+    }
+
+line-segment-midpoint-offset-without-midpoint = anggapoy epekto na midpointOffset no anggapoy midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linya ya ondalan ed saray punto ya ag nadeterminaan so dimensyon da.
+
+line-points-too-few-dimensions = Nepeg ya ondalan so linya ed saray punto ya duara nid dimensyon da.
+
+line-points-depend-on-variables = Ondadalan so linya ed saray punto ya akadepende ed saray baryable: { $variables }.
+
+line-equation-invalid-format = Aliwan format na ekwasyon na linya ed saray baryable ya { $variable1 } tan { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Say sinag et nibaga ed through, endpoint, tan direction.  Ag-uusaren so nibagan through.
+
+ray-dimension-mismatch = Ag manpaparaan so numDimensions ed sinag.
+
+## `<vector>`
+
+vector-overprescribed-head = Say bektor et nibaga ed head, tail, tan displacement.  Ag-uusaren so nibagan head.
+
+vector-dimension-mismatch = Ag manpaparaan so numDimensions ed bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ag ayari ya iyasingger ed `<{ $component }>` lapud anggapoy nearestPoint a state variable to.
+
+constrain-to-without-nearest-point = Ag ayari ya ipasen ya nasesengeg ed `<{ $component }>` lapud anggapoy nearestPoint a state variable to.
+
+constrain-to-interior-without-nearest-point = Ag ayari ya ipasen ya nasesengeg ed loob na `<{ $component }>` lapud anggapoy nearestPoint a state variable to.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ag-uusaren so labelPosition parad choiceInput ya aliwan inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ag-uusaren iray indeks a nibaga parad choiceInput lapud ag manpaparaan so bilang na indeks tan say bilang na saray anak a choice.
+
+pretzel-indices-count-mismatch = Ag-uusaren iray indeks a nibaga parad problem lapud ag manpaparaan so bilang na indeks tan say bilang na saray anak a problem.
+
+shuffle-indices-count-mismatch = Ag-uusaren iray indeks a nibaga parad shuffle lapud ag manpaparaan so bilang na indeks tan say bilang na saray komponente.
+
+indices-ignored-out-of-range = Ag-uusaren iray indeks a nibaga parad { $component } lapud walaray indeks ya paway ed sakop.
+
+pretzel-indices-repeated = Ag-uusaren iray indeks a nibaga parad pretzel lapud walaray indeks ya inulit.
+
+pretzel-circuit-first-index = Ag-uusaren iray indeks a nibaga parad pretzel ed circuit mode lapud nepeg a 1 so unonan indeks.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Pian ondalan so `<{ $component }>` ed saray anak a string, nepeg a nibaga so atributon `type`.
+
+invalid-type-defaulting-to-math = Aliwan tipo { $type } parad komponenten { $component }. Nepeg a sakey ed math, text, number, odino boolean. Say math so uusaren.
+
+string-not-valid-component-to-arrange = Say string ya "{ $value }" et aliwan komponente ya nayarin { $component }. Ag-uusaren.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Aliwan tipo { $type }, number so iyan a tipo.
+
+invalid-variable-value = Aliwan balor na sakey a baryable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Nepeg a bilang so indeks na baryante ya { $index }
+
+variant-index-must-be-integer = Nepeg a integer so indeks na baryante ya { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Ag ni nagagawa so `<{ $component }>` parad saray absoluton sukat. Relatibo so iyan a kaawang.
+
+side-by-side-absolute-margins = Ag ni nagagawa so `<{ $component }>` parad saray absoluton sukat. Relatibo so iyan a margin.
+
+side-by-side-no-block-child = Aliwan `<{ $component }>`: nepeg a walay sakey ya anak ton block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ag-uusaren so atributon `for` ed grapikon `<label>`.
+
+label-for-must-resolve-to-one = Say atributon `for` ed `<label>` et nepeg ya ontukoy ed sakey labat a komponente.
+
+label-for-unresolved = Ag ayari ya ipatukoy ed sakey a komponente so atributon `for` ed `<label>`.
+
+label-for-answer-with-authored-inputs = Say atributon `for` ed `<label>` et ontutukoy ed `<answer>` ya walaay saray input a sinulat na autor; say input a mismo so tukoyen.
+
+label-for-answer-without-input = Say atributon `for` ed `<label>` et ontutukoy ed `<answer>` ya anggapoy input ya nalabelan.
+
+label-for-must-reference-input-or-answer = Say atributon `for` ed `<label>` et nepeg ya ontukoy ed sakey ya input odino ed sakey ya answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Parad aksesibilidad, nepeg a walaay antikey a deskripsyon so `<{ $component }>` odino nibaga a dekoratibo.
+
+accessibility-video-short-description = Parad aksesibilidad, nepeg a walaay antikey a deskripsyon so `<video>`.
+
+accessibility-input-short-description-or-label = Parad aksesibilidad, nepeg a walaay antikey a deskripsyon odino label so `<{ $component }>`.
+
+accessibility-answer-input-short-description-or-label = Parad aksesibilidad, say `<answer>` ya manggagawa na input et nepeg a walaay antikey a deskripsyon odino label.
+
+accessibility-short-description-contains-math = Ag nepeg a walaay komponente na matematika a singa `<{ $component }>` ed saray antikey a deskripsyon. Isulat ed salita so anggan anton matematika.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Ag magenap so kontraste na { $colorName } parad teksto na ulo na seksion (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nepeg a { $threshold }:1 nid).
+       *[other] Ag magenap so kontraste na { $colorName } parad teksto na ulo na seksion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nepeg a { $threshold }:1 nid).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Ag ni nagagawa so `<circle>` ya ondalan ed { $count } a punto sano anggapoy numeron balor da.
+
+circle-too-many-through-points = Ag ayari ya kalkuloen so sirkulo ya ondalan ed masulok ya 3 a punto.
+
+circle-overprescribed-radius-center-points = Ag ayari ya kalkuloen so sirkulo ya walaay nibagan radius, sentro, tan saray punto ya dalanen.
+
+circle-center-with-multiple-points = Ag ayari ya kalkuloen so sirkulo ya walaay nibagan sentro tan ondalan ed masulok ya 1 a punto.
+
+circle-radius-too-small = Ag ayari ya kalkuloen so sirkulo: lapud say kaarawi na duaran punto et { $distance }, say nibagan radius ya { $radius } et masyadon melag.
+
+circle-radius-with-many-points = Ag ayari ya gawaen so sirkulo ya ondalan ed masulok ya duaran punto tan walaay nibagan radius.
+
+circle-invalid-center-or-through-points = Aliwan sentro odino saray punto ya dalanen na sirkulo.
+
+circle-radius-center-with-multiple-points = Ag ayari ya kalkuloen so radius na sirkulo ya walaay nibagan sentro tan ondalan ed masulok ya 1 a punto.
+
+circle-change-radius-non-numerical = Ag ayari ya umanen so radius na sirkulo ya aliwan numero iray punto ya dalanen to
+
+circle-radius-with-points-non-numerical = Ag ayari ya gawaen so sirkulo ya ondalan ed masulok ya sakey a punto tan walaay nibagan radius sano anggapoy numeron balor da.
+
+circle-change-center-non-numerical = Ag ni nagagawa so pangaman ed sentro na sirkulo ya ondalan ed saray punto ya aliwan numero.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Ag magenap so dimensyon na domain na punsion. Say domain et walaay { $intervals } ya interbalo, balet say punsion et walaay { $inputs ->
+           *[other] { $inputs } ya input
+        }.
+    }
+
+function-domain-invalid-format = Aliwan format na domain na punsion.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ag-uusaren so maximum na punsion ya aliwan numero.
+        [minimum] Ag-uusaren so minimum na punsion ya aliwan numero.
+        [extremum] Ag-uusaren so extremum na punsion ya aliwan numero.
+        [point] Ag-uusaren so punto na punsion ya aliwan numero.
+        [slope] Ag-uusaren so slope na punsion ya aliwan numero.
+       *[other] Ag-uusaren so { $type } na punsion ya aliwan numero.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ag-uusaren so maximum na punsion ya anggapoy karga.
+        [minimum] Ag-uusaren so minimum na punsion ya anggapoy karga.
+        [extremum] Ag-uusaren so extremum na punsion ya anggapoy karga.
+        [point] Ag-uusaren so punto na punsion ya anggapoy karga.
+       *[other] Ag-uusaren so { $type } na punsion ya anggapoy karga.
+    }
+
+function-points-too-close = Walaray duaran punto na punsion ya masyadon maasingger so pasen da. Ag ayari ya nadeterminaan so punsion.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] Say pangiter ed punsion et nayari labat no say bilang na input to et parehon parehod bilang na output to. Sayan punsion et walaay { $inputs } ya input tan { $outputs ->
+           *[other] { $outputs } ya output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Aliwan kaandukey na sequence.  Nepeg ya integer ya aliwan negatibo.
+
+sequence-invalid-step = Aliwan step na sequence.  Nepeg a numero parad sequence ya tipon { $type }.
+
+sequence-invalid-endpoint-number = Aliwan "{ $attribute }" na sequence na numero.  Nepeg a numero.
+
+sequence-invalid-endpoint-letters = Aliwan "{ $attribute }" na sequence na letra.  Nepeg a kombinasyon na letra.
+
+sequence-invalid-endpoint = Aliwan "{ $attribute }" na sequence.
+
+select-from-sequence-coprime-not-numbers = ag-uusaren so coprime lapud aliwan numero so pipilien
+
+select-from-sequence-coprime-with-exclude-combinations = ag-uusaren so coprime lapud nibaga so excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Aliwan target parad `<{ $source }>`: ag naromog so target.
+
+target-state-variable-not-found = Aliwan target parad `<{ $source }>`: ag naromog so state variable ya manngaran na "{ $property }" ed sakey a `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Saray baryable na `<odeSystem>` et nepeg a duma ed independent variable.
+
+ode-system-duplicate-variable-names = Ag ayari ya nadeterminaan iray punsion na ODE RHS ya walaay parehon ngaran na dependent variable.
+
+ode-system-rhs-function-error = Ag ayari ya nadeterminaan so punsion na ODE RHS.  Walay lingo ed panggawa na punsion a mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ag ayari ya nadeterminaan so anggulo ed baetan na { $count } a linya
+
+angle-invalid-through-point = Aliwan punto ed through na `<angle>`
+
+parabola-vertex-too-many-points = Ag ni nagagawa so parabola ya walaay vertex tan ondalan ed masulok ya 1 a punto.
+
+parabola-too-many-points = Ag ni nagagawa so parabola ya ondalan ed masulok ya 3 a punto.
+
+intersection-too-many-items = Ag ni nagagawa so intersection parad masulok ya duaran bengatla
+
+## Other math components
+
+ionic-compound-not-two-ions = Ag ni nagagawa so kompuesto ya ioniko ya aliwan duaran ion.
+
+ionic-compound-needs-cation-and-anion = Say kompuesto ya ioniko et nagagawa labat parad sakey a cation tan sakey ya anion.
+
+solve-equations-cannot-evaluate = Ag ayari ya solbaren so ekwasyon lapud ag ayari ya ebalwaren: { $equation }
+
+math-operators-operand-number-required = Nepeg a nibaga so operandNumber no mangala na operand a matematika.
+
+eigen-decomposition-failed = Ag ayari ya kalkuloen iray eigenvalue na matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: say parametro ya { $parameters } et ag onaalagey ed pattern, kanian naynay a blangko so natumbok to.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ag ayari ya natalosan so grid="{ $grid }". Nepeg a none, medium, dense, odino duaran positibon numero ya nisian na espasyo, singa grid="1 0.5". Anggapoy grid ya niyanak.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    Say `<{ $component }>` et mankaukolan na punsion ya walaay { $expected ->
+        [1] sakey ya output, say slope ya y' ed kada punto, singa `y - x`
+       *[other] duaran output, say bektor ed kada punto, singa `(y, -x)`
+    }, balet say inter ya punsion et walaay { $found ->
+       *[other] { $found } ya output
+    }. { $alternative ->
+        [none] Anggapoy niyanak.
+       *[other] Say `<{ $alternative }>` so komponente parad satan a punsion. Anggapoy niyanak.
+    }
+
+field-function-attribute-ignored-with-child = Ag-uusaren so atributon `function` lapud say punsion et niiter met ed loob na komponente; say walad loob so uusaren. Sakey labat ed saduara so panggawaan na punsion.
+
+field-variables-ignored =
+    `<{ $component }>`: say atributon `variables` et manngaran ed saray baryable na ekspresyon ya insulat ed mismon loob na komponente. { $reason ->
+        [function-child] Say punsion dia et niiter bilang anak a `<function>`, ya manngaran ed dilin baryable to, kanian ag-uusaren so `variables`.
+       *[no-expression] Anggapoy ontan ya ekspresyon dia, kanian ag-uusaren so `variables`.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: ag suportado so xLabelPosition="left" ed prefigure renderer; say kagagawa na right-position so uusaren.
+
+prefigure-y-label-position-unsupported = `<graph>`: ag suportado so yLabelPosition="bottom" ed prefigure renderer; say kagagawa na top-position so uusaren.
+
+prefigure-invalid-axis-bounds = `<graph>`: aliwan saray ketegan na axis parad panagsalat ed prefigure; say default a bbox (-10,-10,10,10) so uusaren.
+
+prefigure-invalid-width = `<graph>`: aliwan kaawang parad panagsalat ed prefigure; say default a kaawang na diagram ya 425 so uusaren.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aliwan aspectRatio parad panagsalat ed prefigure; say default ya aspect ratio ya 1 so uusaren.
+
+prefigure-grid-spacing-too-fine = `<graph>`: masyadon maliit so espasyo na grid parad saray ketegan na axis; ag-uusaren so grid ed prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: ag niyanak iray annotation no aliwan PreFigure renderer so uusaren.
+
+multiple-annotations-children = Dakel so anak ya `<annotations>` ya naromog ed `<graph>`; ag-uusaren so amin likud ed sampot.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ag ayari ya paatagayen odino kopyaen so ag abirbir a tipo na komponente: { $type }.
+
+copy-prop-not-found = Ag naromog so prop ya { $property } ed sakey a komponenten tipon { $component }
+
+collect-no-source = Anggapoy naromog a source parad collect.
+
+collect-invalid-component-type = Ag ayari ya tiponen iray komponente ya tipon `<{ $component }>` lapud aliwan tipo na komponente.
+
+reference-index-unavailable = Ag ayari ya tukoyen so indeks ya `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ag ayari ya tawagen so { $action } ed komponenten `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Aliwan porma na datos.  Ag manpaparaan so kaandukey na saray hilera. Naromog ed componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Walaray parehon ngaran na kolumna ed datos.  Naromog ed componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Anggapoy ngaran na sakey a kolumna ed datos.  Naromog ed componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Say sakey ya award parad sayan answer et akabase ed dilin ebat ya inpawit na mismon answer tag, tan mansumpal itan ed ag iilaloan a kagagawa.
+
+answer-max-num-attempts-in-section-wide-check-work = Anggapoy epekto na pangiyan na `maxNumAttempts` ed sakey ya `<answer>` ya walad loob na kontenedor ya walaay `sectionWideCheckWork`, lapud say kontenedor so mangokontrol ed bilang na sali. Say kontenedor so pangiyanan na `maxNumAttempts`.
+
+nested-section-wide-check-work-max-num-attempts = Anggapoy epekto na pangiyan na `maxNumAttempts` ed kontenedor ya walaay `sectionWideCheckWork` ya walad loob na sananey a kontenedor ya walaay `sectionWideCheckWork`, lapud say paway a kontenedor so mangokontrol ed bilang na sali. Say paway a kontenedor so pangiyanan na `maxNumAttempts`.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] Anggapoy epekto na atributon { $attributes } no ag niyan so symbolicEquality.
+    }
+
+answer-invalid-type = Aliwan tipo parad answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Lapud anggapoy ngaran na komponenten `<{ $component }>`, ag itan nayarin usaren bilang atributo na module
+
+module-attribute-name-already-defined = Ag nayarin usaren so komponenten `<{ $component } name="{ $name }">` bilang atributo na module lapud say tipon `<module>` et walaan lay atributon "{ $name }".
+
+conditional-content-condition-ignored = Ag-uusaren so atributon `condition` ed sakey a komponenten `<conditionalContent>` ya walaay anak a case odino else.
+
+slider-markers-type-mismatch = Ag manpaparaan so tipo na saray marker tan say tipo na slider.
+
+pretzel-problem-needs-statement-and-answer = Aliwan pretzel: nepeg a walaay sakey a `<statement>` tan sakey a `<answer>` so kada `<problem>`.
+
+pretzel-circuit-first-problem-distractor = Aliwan pretzel: diad mode="circuit", ag nayarin distractor so unonan `<problem>`.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Aliwan balor ya { $values } parad atributon `{ $attribute }`; ag-uusaren.
+    }
+
+attribute-must-be-references = Aliwan balor ya `{ $value }` parad atributon `{ $attribute }`. Nepeg ya nagawa so atributo ed saray reference ya ongagapo ed `$`.
+
+math-input-invalid-function-names = <mathInput>: ag-uusaren iray aliwan ngaran na punsion ed { $attribute }: { $names }. Nepeg a duara nid karakter so segment ya nanengneng na kada ngaran (letra odino gitlingan); nayarin ontumbok so `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Aliwan tipo na komponente: `<{ $componentType }>`
+
+attribute-repeated = Ag nayarin uliten so atributon { $attribute }.
+
+attribute-invalid-for-component = Aliwan atributon "{ $attribute }" parad sakey a komponenten tipon `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Say style definition ya { $styleNumber } et ag magenap so kontraste to parad { $context ->
+        [text-on-background] kolor na teksto sumpad kolor na beneg
+        [high-contrast] kolor ya atagey so kontraste sumpad canvas
+        [line] kolor na linya sumpad canvas
+        [marker] kolor na marker sumpad canvas
+       *[text-on-canvas] kolor na teksto sumpad canvas
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nepeg a { $threshold }:1 nid).
+
+style-definition-dark-mode-text-background-contrast =
+    Anggaman ta say style definition ya { $styleNumber } et walaay saray kolor ya magenap so kontraste da parad light mode, saray kolor ed dark mode ya nanlapud saraya et ag magenap so kontraste na kolor na teksto sumpad kolor na beneg ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nepeg a { $threshold }:1 nid). { $suggestion ->
+        [available] Pian magenap so kontraste ed dark mode, paatagayen so kontraste ed light mode (alimbawa, iyan so { $lightAttribute }="{ $lightColor }") odino salatan so kolor ed dark mode (alimbawa, iyan so { $darkAttribute }="{ $darkColor }").
+       *[none] Pian magenap so kontraste ed dark mode, paatagayen so kontraste ed light mode odino salatan iray nanlapuan a kolor ed textColorDarkMode tan/odino backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Anggaman ta say style definition ya { $styleNumber } et walaay kolor na teksto ya magenap so kontraste to parad light mode, say kolor na teksto ed dark mode ya nanlapud satan et ag magenap so kontraste to sumpad canvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nepeg a { $threshold }:1 nid). { $suggestion ->
+        [available] Pian magenap so kontraste ed dark mode, paatagayen so kontraste ed light mode (alimbawa, iyan so textColor="{ $lightColor }") odino salatan so kolor ed dark mode (alimbawa, iyan so textColorDarkMode="{ $darkColor }").
+       *[none] Pian magenap so kontraste ed dark mode, paatagayen so kontraste ed light mode odino salatan so nanlapuan a kolor ed textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Sakey labat a <stylePalette> so nayarin pilien na sakey a seksion; say sampot so uusaren.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ag nadeterminaan iray unique variant na { $component } lapud say numToSelect et aliwan integer ya ag negatibo.
+
+variant-num-to-select-not-constant-number = ag nadeterminaan iray unique variant na { $component } lapud say numToSelect et aliwan konstante a numero.
+
+variant-with-replacement-not-constant-boolean = ag nadeterminaan iray unique variant na { $component } lapud say withReplacement et aliwan konstante a boolean.
+
+variant-select-weight-disables-unique = Ag ayari iray unique variant parad select no walay opsyon ya walaay nibagan selectWeight odino selectForVariants
+
+variant-coprime-undetermined = ag nadeterminaan iray unique variant na { $component } lapud ag nadeterminaan no naynay a false so coprime.
+
+variant-attribute-not-constant = ag nadeterminaan iray unique variant na { $component } lapud say { $attribute } et aliwan konstante.
+
+variant-attribute-not-number = ag nadeterminaan iray unique variant na { $component } lapud say { $attribute } et aliwan numero.
+
+variant-attribute-wrong-type-for-sequence =
+    ag nadeterminaan iray unique variant na { $component } ya tipon { $type } lapud say { $attribute } et aliwan { $expected ->
+        [letters-combination] kombinasyon na letra
+        [math-expression] duga ya ekspresyon a matematika
+        [integer] integer
+       *[number] numero
+    }.
+
+variant-length-not-integer = ag nadeterminaan iray unique variant na { $component } lapud say length et aliwan integer.
+
+variant-sort-not-implemented = ag ni nagagawa iray unique variant na sakey a { $component } ya walaay sort
+
+variant-exclude-combinations-not-implemented = ag ni nagagawa iray unique variant na sakey a { $component } ya walaay excludeCombinations
+
+variant-math-exclude-not-implemented = ag ni nagagawa iray unique variant na sakey a { $component } ya tipon math ya walaay exclude
+
+variant-non-constant-exclude-not-implemented = ag ni nagagawa iray unique variant na sakey a { $component } ya aliwan konstante so exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ag suportado ed graph prefigure renderer; nilaktawan so kabiangan.
+
+prefigure-descendant-invalid-geometry = { $subject }: ag naanggaan odino ag nasumpal a geometriya; nilaktawan so kabiangan.
+
+prefigure-curve-label-omitted = { $subject }: ag suportado iray label ed saray asalatan a curve; ag-uusaren so label.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ag suportadon tipo na definition na curve ya '{ $definitionType }'; nilaktawan so kabiangan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ag suportadon atributon flipFunctions ed regionBetweenCurves; nilaktawan so kabiangan.
+
+prefigure-region-non-formula-child = { $subject }: saray anak a punsion ya tipon formula labat so suportado ed regionBetweenCurves; nilaktawan so kabiangan.
+
+prefigure-label-position-unsupported =
+    { $subject }: ag suportadon labelPosition ya '{ $labelPosition }' parad { $labelKind ->
+        [line-family] label na pamilya na linya
+       *[point] label na punto
+    }; say default a pakaparaan na PreFigure so uusaren.
+
+prefigure-fill-style-unsupported = { $subject }: ag suportado na PreFigure so fill style ya '{ $fillStyle }'; solidon punoan so uusaren.
+
+prefigure-line-style-unknown = { $subject }: ag kabat a line style ya '{ $lineStyle }'; ag-uusaren ed output na PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: say marker style ya '{ $markerStyle }' et niyalis ed style na PreFigure ya 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: ag suportado na PreFigure so marker style ya '{ $markerStyle }'; say default a style so uusaren.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: aliwan `ref`; ag ayari ya naromog so target. Ag-uusaren so annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: dakel so naromog a target na `ref`; say unonan target so uusaren.
+
+annotation-ref-outside-graph = `<annotation>`: aliwan `ref`; say target et paway ed graph ya kaiba to. Ag-uusaren so annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: aliwan `ref`; say target et aliwan suportadon grapikon bengatla ed panagsalat ed prefigure. Ag-uusaren so annotation.
+
+annotation-text-missing = `<annotation>`: anggapo odino blangko so `text`; blangkon teksto so niyanak.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Walay naromog ya sirkular a dependency.
+       *[other] Walay naromog ya sirkular a dependency ya akaiba so komponenten `<{ $componentType }>`.
+    }
+
+reference-no-referent = Anggapoy naromog a tutukoyen na reference: `{ $reference }`
+
+reference-multiple-referents = Dakel so naromog a tutukoyen na reference: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Aliwan format na atributon { $attribute } na `<{ $componentType }>`.
+
+children-invalid = Aliwan anak parad `<{ $componentType }>`: Naromog iray aliwan anak: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Aliwan balor ya `{ $value }` parad atributon `{ $attribute }`, say balor ya `{ $default }` so uusaren
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ag naromog so bersyon na DoenetML ya { $version }.
+       *[other] Ag naromog so bersyon na DoenetML ya { $version }. Say bersyon ya { $fallback } so uusaren
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Aliwan DoenetML: { $content }
+
+parse-tag-missing-close-tag = Aliwan DoenetML: Anggapoy panagsara na tag ya `{ $tag }`. Nepeg a sakey a self-closing a tag odino sakey a `</{ $tagName }>` a tag.
+
+parse-tag-error = Aliwan DoenetML: Walay lingo ed tag ya `<{ $tagName }>`
+
+parse-attribute-missing-value = Aliwan DoenetML: Say aliwan atributon `{ $attribute }` et singa anggapoy balor to.
+
+parse-attribute-invalid = Aliwan DoenetML: Aliwan atributon `{ $attribute }`
+
+parse-attribute-value-invalid = Aliwan DoenetML: Aliwan balor na atributon `{ $value }`
+
+parse-attribute-value-quote-mismatch = Aliwan DoenetML: Aliwan balor na atributon `{ $value }`. Ag manpaparaan iray marka na sipi. Singa anggapoy sakey a `{ $quote }`
+
+parse-open-tag-name-missing = Aliwan DoenetML: Walay naromog a tag ya anggapoy ngaran to, alimbawa `<`
+
+parse-tag-not-closed = Aliwan DoenetML: Ag asaraan so tag ya `{ $tag }` (singa anggapoy `>`).
+
+parse-self-closing-tag-name-missing = Aliwan DoenetML: Walay naromog a tag ya anggapoy ngaran to `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Aliwan DoenetML: Ag asaraan so tag ya `{ $tag }` (singa anggapoy `/>`).
+
+parse-tag-invalid-attributes = Aliwan DoenetML: Aliwa so tag ya `{ $tag }`. Nayarin aliwa iray atributo to.
+
+parse-close-tag-name-missing = Aliwan DoenetML: Walay naromog a panagsara ya tag ya anggapoy ngaran to, alimbawa `</`
+
+parse-attribute-value-unquoted = Nepeg ya walad loob na sipi iray balor na atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Aliwan DoenetML: Naromog so panagsara ya tag ya `{ $tag }`, balet anggapoy toon panaglukas a tag
+
+parse-close-tag-mismatched = Aliwan DoenetML: Ag manpaparaan so panagsara ya tag. Say ilaloan et `</{ $expected }>`. Say naromog et `{ $found }`
+
+parser-node-unconvertible = Ag ayari ya salatan so node ya { $node } bilang Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Aliwan atributon name='{ $name }'. { $reason ->
+        [characters] Saray ngaran et nayarin walaay letra, numero, underscore odino gitlingan labat.
+       *[start] Nepeg ya ongapo ed letra iray ngaran.
+    }
+
+component-name-invalid-start = Aliwan ngaran na komponente ya "{ $name }". Nepeg ya ongapo ed letra iray ngaran.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Say answer ya tipon videoWatched et nepeg a walaay atributon video
+
+answer-video-watched-video-not-reference = Say answer ya tipon videoWatched et nepeg a say atributon video to et sakey a reference
+
+answer-name-not-single-text = Say atributon name na answer et nepeg a walaay sakey labat ya anak a text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ag ayari ya naala so paway a DoenetML lapud masyadon dakel so lebel na rekursion. Kasin walay sirkular a reference?
+
+external-doenetml-unavailable = Ag ayari ya naala so DoenetML manlapud { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Aliwan DoenetML so naala manlapud { $attribute }="{ $uri }": ag manpaparaan ed tipo na komponenten "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Deprecated lay atributon `{ $from }`; say `{ $to }` so usaren.
+       *[other] [deprecation] Deprecated lay atributon `{ $from }` ed `<{ $component }>`; say `{ $to }` so usaren.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Deprecated lay atributon `{ $from }` tan ag-uusaren lapud nibaga met so `{ $to }`.
+       *[other] [deprecation] Deprecated lay atributon `{ $from }` ed `<{ $component }>` tan ag-uusaren lapud nibaga met so `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Deprecated lay atributon `{ $attribute }` ed `<{ $component }>` tan ag-uusaren.
+
+deprecated-attribute-to-child = [deprecation] Deprecated lay atributon `{ $attribute }` ed `<{ $component }>`; sakey ya anak a `<{ $child }>` so usaren.
+
+deprecated-attribute-value-renamed = [deprecation] Deprecated lay balor ya `{ $value }` na atributon `{ $attribute }` ed `<{ $component }>`; say `{ $to }` so usaren.
+
+
+## Language coverage
+
+pluralize-english-only = Say `<pluralize>` et nayarin manggawa na pangaruman labat ed Ingles, kanian ag nauman so teksto to ed sakey a dokumento ya insulat ed { $locale }. Isulat a mismo so porman dakel, odino iyan itan ed atributon `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Say elementon `<{ $tag }>` et aliwan abirbir ya elemento na Doenet.
+
+schema-element-not-allowed-at-root = Ag abuloyan so elementon `<{ $tag }>` ed lamot na dokumento.
+
+schema-element-not-allowed-inside = Ag abuloyan so elementon `<{ $tag }>` ed loob na `<{ $parent }>`.
+
+schema-attribute-unrecognized = Say elementon `<{ $tag }>` et anggapoy atributo ton manngaran na `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Say atributon `{ $attribute }` na elementon `<{ $tag }>` et nepeg a sakey a lista ya kada item to et sakey ed: { $allowed }
+       *[other] Say atributon `{ $attribute }` na elementon `<{ $tag }>` et nepeg a sakey ed: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Aliwan ngaran na baryante parad select.  Say ngaran na baryante ya { $variantName } et onaalagey ed { $numOptions } ya opsyon balet say bilang ya pilien et { $numToSelect }.
+
+select-variant-name-without-options = Walaray baryante ya nibaga parad select balet anggapoy opsyon ya nibaga parad posiblin ngaran na baryante: { $variantName }.
+
+select-variant-name-not-possible = Say ngaran na baryante ya { $variantName } ya nibaga parad select et aliwan posiblin ngaran na baryante.
+
+select-too-few-options = Ag ayari ya pilien so { $numToSelect } a komponente ed { $numOptions } labat.
+
+select-from-sequence-too-few-values = Ag ayari ya pilien so { $numToSelect } a balor ed sequence ya { $length } so kaandukey to.
+
+select-from-sequence-indices-count-mismatch = Nepeg a manpaparaan so bilang na indeks a nibaga parad select tan say bilang ya pilien
+
+select-from-sequence-indices-not-integers = Nepeg ya integer so amin ya indeks a nibaga parad select
+
+select-from-sequence-index-excluded = Nibaga so indeks na selectfromsequence ya niekal
+
+select-from-sequence-indices-excluded-combination = Nibaga iray indeks na selectfromsequence ya niekal a kombinasyon
+
+select-from-sequence-coprime-not-positive-integers = Ag ayari ya pilien iray coprime a kombinasyon lapud aliwan positibon integer so pipilien.
+
+select-from-sequence-coprime-common-factor = Ag ayari ya pilien iray coprime a numero. Amin a posiblin balor et walaay parehon paktor. (Nepeg a coprime ed "step" iray nibagan balor na "from" odino "to".)
+
+select-from-sequence-coprime-single-number = Ag ayari ya pilien iray coprime a kombinasyon ed sakey a numero ya aliwan 1.
+
+select-from-sequence-excluded-too-many-combinations = Niekal so masulok ya 70% na saray kombinasyon ed selectFromSequence
+
+select-from-sequence-coprime-none-found = Ag ayari ya nipili iray coprime a numero. Amin a posiblin balor et walaay parehon paktor.
+
+select-from-sequence-too-few-unique-values = Ag ayari ya pilien so { $numToSelect } a bukbukor a balor ed sequence ya { $numPossibleValues } so kaandukey to
+
+select-prime-numbers-too-few-values = Ag ayari ya pilien so { $numToSelect } a balor ed lista na saray prime ya { $numValues } so kaandukey to
+
+select-prime-numbers-values-count-mismatch = Nepeg a manpaparaan so bilang na balor a nibaga parad select tan say bilang ya pilien
+
+select-prime-numbers-values-not-prime = Nepeg a walad lista na saray prime so amin a balor a nibaga parad select prime number
+
+select-prime-numbers-values-excluded-combination = Nibaga iray balor na selectPrimeNumbers ya niekal a kombinasyon
+
+select-prime-numbers-excluded-too-many-combinations = Niekal so masulok ya 70% na saray kombinasyon ed selectPrimeNumbers
+
+select-random-combination-fluke = Lapud alay-bengat ya suerte, ag ayari ya nipili so kombinasyon na saray random a balor
+
+select-random-value-fluke = Lapud alay-bengat ya suerte, ag ayari ya nipili so random a balor
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Ag nipanengneng iyan `<{ $component }>` lapud walad loob na matematika tan aliwan `inline`. Iyarum so `inline` pian magmaliw a drop-down list, ya onkasi ed loob na sakey ya ekspresyon.
+        [expanded] Ag nipanengneng iyan `<{ $component }>` lapud walad loob na matematika tan `expanded`. Ekalen so `expanded`; ag onkasi ed loob na sakey ya ekspresyon so kahon ya dakel so linya to.
+        [on-graph] Ag nipanengneng iyan `<{ $component }>` lapud walad loob na matematika ya niyanak ed sakey a graph, ya anggapoy pasen parad input.
+       *[relative-width] Ag nipanengneng iyan `<{ $component }>` lapud walad loob na matematika tan relatibo so kaawang to. Iyan so kaawang ed absoluton sukat, singa `px`.
+    }

--- a/packages/i18n/locales/pag/editor.ftl
+++ b/packages/i18n/locales/pag/editor.ftl
@@ -1,0 +1,239 @@
+# Pangasinan (Salitan Pangasinan) editor and language-server surfaces.
+# Translated from `locales/en/editor.ftl`, which is the source of truth:
+# `lint:i18n` rejects a key that does not exist there, and reports a key that
+# exists there but not here as missing coverage.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber`, `Answer Id` and every attribute
+# or element name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Orthography: the modernised spelling**, as `chrome.ftl`'s header sets out.
+# The older Spanish-influenced spelling is a respelling of this one, not a
+# different translation; convert all four files at once or none.
+#
+# **This is the file where the loans are heaviest, and it should be read as
+# such.** The editor's technical nouns are Spanish-derived or English —
+# `editor`, `viewer`, `baryante`, `filter`, `komponente`, `atributo`,
+# `reference`, `property`, `snippet`, `array entry`, `balor`, `koordinado`,
+# `punsion`, `dokumentasyon`, `aksesibilidad`, `report`, `kredito`,
+# `Answer Id`, `default`, `cursor`, `tag` — **around a Pangasinan frame**.
+# What is Pangasinan here is the verb-initial word order, the markers «so»,
+# «na» and «ed», the linker «a»/«ya», the negator «ag», «walay» and
+# «anggapoy», and the verbs «balowen» ('renew'), «ipawil» ('return'),
+# «peselen» ('press'), «pilien» ('choose'), «naromog» ('is found') and
+# «ipanengneng» ('show').
+#
+# `editor-update-viewer` is **translated rather than kept in English**:
+# «Balowen» for Update and «Ipawil» for Reset are both short enough for a
+# toolbar button. If either turns out to be too long in a real toolbar, the
+# English words are the fallback a corrector should reach for, not a coinage.
+#
+# `Filter...` is kept as the English word: it stands in an empty input as a
+# placeholder, and the seed had no Pangasinan word for it short enough and
+# settled enough to vouch for.
+#
+# **No plural-category branches.** Pangasinan leaves a noun unmarked after a
+# numeral — «{ $count } a kasumlangan» is right for one and for many — and CLDR
+# has no plural data for `pag`, so a `[one]` branch here would be text selected
+# by English's rules. Every count select is collapsed to a single `*[other]`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ipawil
+       *[update] Balowen
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } so Viewer
+       *[other] { $word } so Viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Baryante
+
+editor-variant-filter = Filter...
+
+editor-variant-next = Pilien so onsublay a baryante
+
+editor-variant-previous = Pilien so akaunan baryante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Walay abirbir a kasumlangan ed WCAG AA ya aksesibilidad. I-click pian { $action ->
+            [close] nakapotan
+           *[open] nalukasan
+        } so report ed aksesibilidad.
+        [advisories] I-click pian { $action ->
+            [close] nakapotan
+           *[open] nalukasan
+        } so report ed aksesibilidad. Anggapoy naromog a kasumlangan ed WCAG AA, balet walay arum ni ran rekomendasyon ed aksesibilidad.
+       *[clean] I-click pian { $action ->
+            [close] nakapotan
+           *[open] nalukasan
+        } so report ed aksesibilidad. Anggapoy naromog a problema ed aksesibilidad.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Walay abirbir a kasumlangan ed WCAG AA ya aksesibilidad. { $count ->
+           *[other] { $count } a kasumlangan ed WCAG AA
+        } so naromog. I-click pian { $action ->
+            [close] nakapotan
+           *[open] nalukasan
+        } so report ed aksesibilidad.
+        [advisories] Anggapoy abirbir a kasumlangan ed WCAG AA. { $count ->
+           *[other] { $count } ya arum a rekomendasyon ed aksesibilidad
+        } so naromog. I-click pian { $action ->
+            [close] nakapotan
+           *[open] nalukasan
+        } so report ed aksesibilidad.
+       *[clean] Anggapoy abirbir a kasumlangan ed WCAG AA. I-click pian { $action ->
+            [close] nakapotan
+           *[open] nalukasan
+        } so report ed aksesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersyon na DoenetML { $version }
+
+editor-tab-help = Tulong ya unong ed konteksto
+editor-tab-help-short = Konteksto
+editor-tab-errors = Saray Lingo
+editor-tab-warnings = Saray Pasakbay
+editor-tab-info = Impormasyon
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Saray niipawit ya ebat
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Saray opsyon na editor
+editor-format-as-doenetml = I-format bilang DoenetML
+editor-format-as-xml = I-format bilang XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linya #{ $line }
+
+editor-no-errors = Anggapoy Lingo
+editor-no-warnings = Anggapoy Pasakbay
+editor-no-info = Anggapoy Impormasyon a Diagnostic
+
+editor-show-info-annotations = Ipanengneng ed editor iray diagnostic ya impormasyon
+editor-show-accessibility-annotations = Ipanengneng ed editor iray diagnostic ed aksesibilidad
+
+editor-accessibility-learn-more = Aralen no panon ya asikasoen na Doenet so aksesibilidad
+
+editor-accessibility-violations-heading = Saray kasumlangan ed aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Arum ni ran problema ed aksesibilidad
+editor-none-found = Anggapoy naromog
+
+
+## Submitted responses
+
+editor-no-responses = Anggapo ni ran niipawit ya ebat
+editor-response-answer-id = Answer Id
+editor-response-response = Ebat
+editor-response-credit = Kredito
+editor-response-submitted = Niipawit
+
+
+## The context-help panel
+
+help-placeholder = Iyan so cursor ed sakey a ngaran na tag, atributo, odino { $ref } parad dokumentasyon.
+
+help-unsupported-ref-chain = Ag ni suportado so tulong parad saray reference ya dakel so kabiangan to a singa { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Anggapoy naromog a tutukoyen na reference: { $ref }.
+        [multiple] Dakel so naromog a tutukoyen na reference: { $ref }.
+       *[indeterminate] Ag ayari ya nadeterminaan so tutukoyen na { $ref }.
+    }
+
+help-learn-about-references = Aralen so nipaakar ed saray reference →
+help-reference-page = Pahina na reference →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Diad loob na { $element }
+       *[top] Diad tagey a lebel
+    }{ $allowed ->
+        [none] { " — anggapoy nayarin iyan dia." }
+        [text] { " — mansulat na teksto dia." }
+        [text-and-components] { " — mansulat na teksto dia, odino salien:" }
+       *[components] { " — saray nayarin salien:" }
+    }
+
+help-suggestions-footer = Peselen so { $shortcut } pian nanengneng so amin ya { $total } a komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] Say { $ref } et reference ed { $target }.
+       *[other] Say { $ref } et reference ed { $target } (linya { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Inggapo na { $owner } bilang { $role }.
+       *[other] Inggapo na { $owner } ed linya { $line } bilang { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] Say { $ref } et reference ed say { $property } a property na { $element }.
+       *[other] Say { $ref } et reference ed say { $property } a property na { $element } (linya { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = Default:
+help-active-default = Aktibon default:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Saray abuloyan a balor (sakey ed kada item):
+       *[other] Saray abuloyan a balor:
+    }
+
+help-suggested-values = Saray nisusuheridon balor:
+
+help-inserts = Iyan to:
+
+help-coordinates =
+    { $count ->
+       *[other] Koordinado:
+    }
+
+help-type = Klase:
+
+help-resolved-style = Nadeterminaan a style (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Saray nadeterminaan a ngaran na punsion:
+help-reset-list = Ipawil so lista ed sayan input:
+help-added-on-input = Inyarum ed sayan input:
+help-removed-on-input = Inekal ed sayan input:
+
+help-reset-overrides = Say { $reset } so mansasalat ed { $additional } tan { $removed }.

--- a/packages/i18n/locales/shn/chrome.ftl
+++ b/packages/i18n/locales/shn/chrome.ftl
@@ -43,9 +43,10 @@
 #
 #   * **Burmese**, in its own Burmese spelling, for the school register Shan
 #     genuinely borrows: သတိပေးချက် (warning), အချက်အလက် (information),
-#     တုံ့ပြန်ချက် (feedback), အောက်ခြေမှတ်စု (footnote), အမှတ် (point),
-#     မြား (arrow), ဇယား (table). These are the only Burmese-spelled words in
-#     the file, and they are recognizable as loans precisely because they keep
+#     တုံ့ပြန်ချက် (feedback), အောက်ခြေမှတ်စု (footnote), အမှတ် (point) and
+#     မြား (arrow). These six are the only Burmese-spelled words in this file
+#     — the other three files declare their own, `content.ftl`'s geometry and
+#     colour terms among them — and they are recognizable as loans because they keep
 #     Burmese letters (က ခ စ ဖ ဟ အ) that no Shan word below is written with.
 #     `န` is the one letter both registers use — the Shan «နဵၵ်း» (press)
 #     carries it — so it is not a marker of a loan on its own.

--- a/packages/i18n/locales/shn/chrome.ftl
+++ b/packages/i18n/locales/shn/chrome.ftl
@@ -46,7 +46,9 @@
 #     တုံ့ပြန်ချက် (feedback), အောက်ခြေမှတ်စု (footnote), အမှတ် (point),
 #     မြား (arrow), ဇယား (table). These are the only Burmese-spelled words in
 #     the file, and they are recognizable as loans precisely because they keep
-#     Burmese letters (က ခ စ န ဖ ဟ အ) that Shan words above never use.
+#     Burmese letters (က ခ စ ဖ ဟ အ) that no Shan word below is written with.
+#     `န` is the one letter both registers use — the Shan «နဵၵ်း» (press)
+#     carries it — so it is not a marker of a loan on its own.
 #   * **English, in the Latin alphabet**, for computing and for the DoenetML
 #     vocabulary: `keyboard`, `row`, `column`, `box`, `credit`, `preview`,
 #     `math expression`, `interval`, `document`, `page`, `renderer`, `load`,

--- a/packages/i18n/locales/shn/chrome.ftl
+++ b/packages/i18n/locales/shn/chrome.ftl
@@ -1,0 +1,205 @@
+# Shan (လိၵ်ႈတႆး) viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety and script.** Shan (Tai Long, ၵႂၢမ်းတႆး) of Shan State, written in
+# the modern reformed Shan orthography — the one used in Shan-language
+# schooling, newspapers and Unicode publishing today, not the older
+# pre-reform spelling that leaves the tones unmarked. The consonants are the
+# **Shan letters**, not their Burmese look-alikes: ၵ ၶ ၸ ၺ ၼ ပ ၽ ၾ မ ယ ရ လ ဝ
+# **ႁ** ဢ, with the Shan vowels **ႃ ႄ ႅ ႆ ွ ႂ** and the Shan tone marks
+# **ႇ ႈ း ႉ ႊ**. A corrector must not fold ႁ into Burmese ဟ, ၵ into က, ၶ into
+# ခ, ၸ into စ, ၼ into န, ၽ into ဖ, ၾ into ဖ or ဢ into အ: they are different
+# characters, they look nearly alike at small sizes, and a substitution is
+# invisible on screen and fatal to a search.
+#
+# **One more letter is in these files and is easy to mistake for a Karen
+# one.** /aa/ is written **ႃ** (U+1083) in an open syllable — မႃး — and **ၢ**
+# (U+1062) before a final consonant — ၵၢၼ်, တၢင်း, ၶၢဝ်း. U+1062 is named
+# MYANMAR VOWEL SIGN SGAW KAREN EU in Unicode and is shared between Shan and
+# S'gaw Karen; it appears here because Shan spelling wants it, not because a
+# Karen letter leaked in. Do not "correct" it to ႃ, and do not write ႃ where
+# a final consonant follows.
+#
+# **Tone.** Shan writes five tones with ႇ ႈ း ႉ ႊ and leaves one unmarked.
+# Where the seed could not place a tone mark with confidence it chose a word
+# it could rather than guessing at a diacritic, which is why some sentences
+# below are blunter than a speaker would write them.
+#
+# **Spacing.** Shan publishing separates words with spaces, unlike the Burmese
+# convention of running a clause together, and this catalog follows the Shan
+# practice throughout. That matters for how these messages wrap in a narrow
+# panel, so it is stated rather than left to be inferred.
+#
+# **Register, and what is a loan.** Shan speakers are schooled in Burmese, and
+# meet computing and higher mathematics in English. This catalog is a **Shan
+# frame around two declared loan vocabularies**, and neither is respelled into
+# an invented Shan phonology:
+#
+#   * **Burmese**, in its own Burmese spelling, for the school register Shan
+#     genuinely borrows: သတိပေးချက် (warning), အချက်အလက် (information),
+#     တုံ့ပြန်ချက် (feedback), အောက်ခြေမှတ်စု (footnote), အမှတ် (point),
+#     မြား (arrow), ဇယား (table). These are the only Burmese-spelled words in
+#     the file, and they are recognizable as loans precisely because they keep
+#     Burmese letters (က ခ စ န ဖ ဟ အ) that Shan words above never use.
+#   * **English, in the Latin alphabet**, for computing and for the DoenetML
+#     vocabulary: `keyboard`, `row`, `column`, `box`, `credit`, `preview`,
+#     `math expression`, `interval`, `document`, `page`, `renderer`, `load`,
+#     `summary statistics`, `WCAG AA`, `accessibility`. Myanmar-script
+#     technical writing routinely leaves such terms in Latin letters, and
+#     writing them out in Shan syllables would invent a spelling no reader has
+#     seen.
+#
+# The Shan is the frame: ဢၼ် (relative), တီႈ (at), ၼႂ်း (in), လူၺ်ႈ (with),
+# လႄႈ (and), ဢမ်ႇၼၼ် (or), ဢမ်ႇ (not), မီး (have), ပဵၼ် (be), လႆႈ (get, can),
+# ႁဵတ်း (do), ပၼ် (give), ၼႄ (show), ၶိုၼ်း (again), တႃႇ (for), ၶွင် (of),
+# ၶႅၼ်းတေႃႈ (please), and the verbs ၸႅတ်ႈတူၺ်း (check), သူင်ႇ (send),
+# သိမ်း (save), ပိုတ်ႇ (open), ပိၵ်ႉ (close), ထႅမ် (add), ဢဝ်ဢွၵ်ႇ (remove),
+# ၶၢႆႉ (move), မွတ်ႇ (erase), နဵၵ်း (press).
+#
+# **Counting.** CLDR has no plural data for `shn`, so `Intl.PluralRules`
+# resolves it against the runtime's default locale and a category branch here
+# would be text chosen by English's rules. Shan leaves a noun unmarked after a
+# numeral and counts with a classifier instead, so one form is correct anyway:
+# every count select below collapses to a single `*[other]`. English's
+# explicit `[0]` is kept, because Fluent matches it against the number itself
+# before it consults any plural rule. No `[zero]`, `[one]`, `[two]`, `[few]`
+# or `[many]` branch appears in any of these four files.
+
+
+## Answer submission
+
+answer-checking = ၸႅတ်ႈတူၺ်းယူႇ…
+answer-submitting = သူင်ႇယူႇ…
+
+answer-checking-status = ၸႅတ်ႈတူၺ်း ၶေႃႈတွပ်ႇ
+answer-submitting-status = သူင်ႇ ၶေႃႈတွပ်ႇ
+
+answer-correct = ထုၵ်ႇမႅၼ်ႈ
+answer-incorrect = ဢမ်ႇထုၵ်ႇမႅၼ်ႈ
+
+answer-response-saved = ၶေႃႈတွပ်ႇ သိမ်းဝႆႉယဝ်ႉ
+
+answer-percent-credit = { $percent }% credit
+answer-percent-correct = { $percent }% ထုၵ်ႇမႅၼ်ႈ
+answer-percent-short = { $percent } %
+
+max-credit-available = credit ၼမ်သုတ်း: { $percent }%
+
+# Single `*[other]`: Shan does not mark a noun for number after a numeral, and
+# `shn` has no CLDR plural data. `[0]` is matched against the number and fires.
+attempts-remaining =
+    { $count ->
+        [0] ဢမ်ႇမီး ပွၵ်ႈ လိူဝ်ယဝ်ႉ
+       *[other] လိူဝ်ဝႆႉ { $count } ပွၵ်ႈ
+    }
+
+validation-correct = (ထုၵ်ႇမႅၼ်ႈ)
+validation-incorrect = (ဢမ်ႇထုၵ်ႇမႅၼ်ႈ)
+validation-partially-correct = (ထုၵ်ႇမႅၼ်ႈ ၸိုင်ႈပွတ်း)
+
+answer-show-responses = ၼႄ ၶေႃႈတွပ်ႇ { $count } ၶေႃႈ ၶွင် { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = တုံ့ပြန်ချက်
+
+collapsible-click-to-open = (နဵၵ်း တႃႇ ပိုတ်ႇ)
+collapsible-click-to-close = (နဵၵ်း တႃႇ ပိၵ်ႉ)
+
+collapsible-initializing = တႄႇယူႇ…
+
+footnote-show = ၼႄ အောက်ခြေမှတ်စု
+footnote-hide = ႁၢမ်ႈ အောက်ခြေမှတ်စု
+
+description-more-information = အချက်အလက် ထႅင်ႈ
+
+
+## Controls
+
+slider-previous = ဢွၼ်တၢင်း
+slider-next = တေႃႇၼႃႈ
+
+keyboard-open = ပိုတ်ႇ keyboard
+keyboard-close = ပိၵ်ႉ keyboard
+
+choice-input-remove-choice = ဢဝ်ဢွၵ်ႇ { $choice }
+
+matrix-remove-row = ဢဝ်ဢွၵ်ႇ row
+matrix-add-row = ထႅမ် row
+matrix-remove-column = ဢဝ်ဢွၵ်ႇ column
+matrix-add-column = ထႅမ် column
+
+subset-add-remove-points = ထႅမ်/ဢဝ်ဢွၵ်ႇ အမှတ်
+subset-toggle-points-intervals = လႅၵ်ႈ အမှတ် လႄႈ interval
+subset-move-points = ၶၢႆႉ အမှတ်
+subset-clear = မွတ်ႇပႅတ်ႈ
+
+orbital-add-row = ထႅမ် row
+orbital-remove-row = ဢဝ်ဢွၵ်ႇ row
+orbital-add-box = ထႅမ် box
+orbital-remove-box = ဢဝ်ဢွၵ်ႇ box
+orbital-add-up-arrow = ထႅမ် မြား ၶိုၼ်ႈ
+orbital-add-down-arrow = ထႅမ် မြား လူင်း
+orbital-remove-arrow = ဢဝ်ဢွၵ်ႇ မြား
+
+orbital-row-label = ၸိုဝ်ႈ တႃႇ row { $row }
+
+pretzel-answer = ၶေႃႈတွပ်ႇ
+
+summary-statistics-caption = summary statistics ၶွင် { $column }
+
+
+## Math input
+
+math-input-preview-region = preview ၶွင် math expression
+math-input-preview = preview
+math-input-invalid-expression = expression ဢမ်ႇထုၵ်ႇမႅၼ်ႈ:
+
+
+## Document status
+
+viewer-initializing = တႄႇယူႇ…
+
+
+## Errors
+
+error-heading = ၽိတ်းပိူင်ႈ
+
+error-found-at =
+    { $span ->
+        [line] ႁၼ်တီႈ line { $startLine }။
+       *[lines] ႁၼ်တီႈ line { $startLine }–{ $endLine }။
+    }
+
+document-contains-errors = document ဢၼ်ၼႆႉ မီးလွင်ႈၽိတ်းပိူင်ႈယူႇ!
+
+diagnostic-heading-error = ၽိတ်းပိူင်ႈ
+diagnostic-heading-warning = သတိပေးချက်
+diagnostic-heading-information = အချက်အလက်
+diagnostic-heading-hint = ၶေႃႈၸီႉၼႄ
+
+accessibility-heading-level-1 = WCAG AA accessibility ၽိတ်းပိူင်ႈ
+accessibility-heading-level-2 = accessibility သတိပေးချက်
+
+something-went-wrong = ပဵၼ်လွင်ႈၽိတ်းပိူင်ႈဝႆႉ။
+
+renderer-load-failed = renderer ဢၼ်ၼိုင်ႈ load ဢမ်ႇလႆႈ။ ၶႅၼ်းတေႃႈ ၶိုၼ်း load ၼႃႈလိၵ်ႈ။
+
+core-start-failed = document ဢၼ်ၼႆႉ တႄႇဢမ်ႇလႆႈ။ ၶႅၼ်းတေႃႈ ၶိုၼ်း load ၼႃႈလိၵ်ႈ။
+
+core-start-failed-busy = document ဢၼ်ၼႆႉ တႄႇဢမ်ႇလႆႈ။ document လၢႆလၢႆဢၼ် တႄႇမႃးၸွမ်းၵၼ်လႄႈ ၶိူင်ႈဢၼ်ဢွၼ်ႈ တေၸႂ်ႉၶၢဝ်းယၢမ်းႁိုင်။ document တၢင်ႇဢၼ် ယဝ်ႉတူဝ်ႈယဝ်ႉ ၶိုၼ်း load ၼႃႈလိၵ်ႈ တေၸွႆႈလႆႈ။
+
+core-start-failed-retry = document ဢၼ်ၼႆႉ တႄႇဢမ်ႇလႆႈ။
+
+core-start-failed-busy-retry = document ဢၼ်ၼႆႉ တႄႇဢမ်ႇလႆႈ။ document လၢႆလၢႆဢၼ် တႄႇမႃးၸွမ်းၵၼ်လႄႈ ၶိူင်ႈဢၼ်ဢွၼ်ႈ တေၸႂ်ႉၶၢဝ်းယၢမ်းႁိုင်။
+
+core-start-retry = ၶိုၼ်းႁဵတ်းထႅင်ႈ
+
+saved-state-unavailable = ၵၢၼ် ဢၼ်သိမ်းဝႆႉ load ဢမ်ႇလႆႈ။

--- a/packages/i18n/locales/shn/content.ftl
+++ b/packages/i18n/locales/shn/content.ftl
@@ -1,0 +1,320 @@
+# Shan (လိၵ်ႈတႆး) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in. `locales/en/content.ftl` is the source of truth, and message ids
+# and attribute names are never translated.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# modern reformed Shan orthography, the Shan letters ၵ ၶ ၸ ၺ ၼ ပ ၽ ၾ ႁ ဢ with
+# the Shan vowels ႃ ႄ ႅ ႆ ွ ႂ and the Shan tone marks ႇ ႈ း ႉ ႊ, never their
+# Burmese look-alikes; and spaces between words, following Shan practice
+# rather than the Burmese convention of running a clause together.
+#
+# ## Word order: the noun comes first
+#
+# **Shan puts the head noun first and every modifier after it**, which is the
+# opposite of English. So this file writes «စက်ဝိုင်း သီၾႃႉ တဵမ်» where
+# English writes "filled blue circle", and `style-with-noun` places
+# `{ $noun }` in front of `{ $description }` rather than behind it. Inside the
+# description the order is fixed as **colour, then dash pattern, then
+# thickness** — «သဵၼ်ႈ သီလႅင် ၶၢတ်ႇ ၼႃ» for "thick dashed red line". That is
+# the reverse of English's stacking, it is consistent across every message in
+# this file, and it is what the style-description tests pin.
+#
+# **`[noun-tail]` is unused.** Because modifiers follow the head, the side
+# count of a regular polygon can sit after the noun without splitting it, so
+# `noun-regular-polygon` fills `head` and leaves `tail` empty as English does.
+#
+# ## No gender fork, and no `$role` fork
+#
+# Shan has no grammatical gender and no case inflection: an adjective is
+# invariant, and a word standing alone is the same word inside a border or a
+# background clause. `noun-gender` therefore answers the single token
+# `neuter` for everything and nothing below selects on `$gender` or `$role`.
+# That is a fact about the language rather than a limit of the seed — the one
+# thing Shan would want that this frame cannot give it is a **classifier**
+# before a counted noun, and no message here counts a noun.
+#
+# ## Register, and what is a loan
+#
+# The frame is Shan; the technical vocabulary is two declared loan sets, and
+# neither is respelled into invented Shan syllables.
+#
+#   * **Burmese, in Burmese spelling**, for the school register Shan borrows:
+#     the six colour words မီးခိုး (gray), လိမ္မော် (orange), စိမ်းပြာ
+#     (cyan), ခရမ်း (purple), ပန်း (pink), အညို (brown); အလျားလိုက်
+#     (horizontal), ဒေါင်လိုက် (vertical), ထောင့်ဖြတ် (diagonal), အစက်
+#     (dot), စိန်ပုံ (diamond shape), ကြက်ခြေခတ် (cross), အပေါင်း (plus),
+#     အမှတ် (point), စက်ဝိုင်း (circle), သက်သေပြချက် (proof), ဇယား (table).
+#     They keep Burmese letters (က ခ စ ည န ဖ သ အ) and so are visible as loans.
+#   * **English, in the Latin alphabet**, for the mathematics a Shan pupil
+#     meets in English: `line segment`, `ray`, `vector`, `curve`, `function`,
+#     `slope field`, `vector field`, `parabola`, `polyline`, `polygon`,
+#     `regular polygon`, `rectangle`, `square`, `paragraph`, `section`,
+#     `aside`, `cascade`, `theorem`, `symbol`, `ionic compound`. Leaving them
+#     in Latin is what Myanmar-script technical writing does; transcribing
+#     them into Shan letters would invent a spelling no reader has seen.
+#
+# **The six Shan colour terms are the file's most confident line and the
+# other six its least.** လမ် (black), ၶၢဝ် (white), လႅင် (red), လိူင်
+# (yellow), ၶဵဝ် (green) and ၾႃႉ (sky, hence blue) are Shan words; the other
+# six are the Burmese words above, written because the seed could not
+# establish a Shan term for them, not because Shan lacks one. This is the
+# first place a speaker should look.
+#
+# ## Chemistry: both element tables are deliberately absent
+#
+# `element-name` and `element-anion-name` are the **only English keys this
+# file does not cover**, 130 of them, and the reason is a fact about a school
+# system rather than about Shan. Secondary science in Shan State is taught in
+# **Burmese**, out of the national curriculum's textbooks, and above that in
+# English; Shan-medium schooling — the Shan State monastic and community
+# schools, and the Shan literature classes — does not run to the grades where
+# the periodic table is taught. There is therefore no settled, checkable Shan
+# list of the 118 elements to seed from, and coining one would invent a
+# nomenclature no reader has met. The 130 keys fall back to English. A
+# speaker who wants them filled should start from the Burmese names their own
+# textbooks print rather than from this file. `ion-name-oxidation-state` and
+# the two invalid-symbol messages are frames rather than vocabulary and are
+# covered below.
+
+
+## Style vocabulary
+
+# Six Shan colour words and six Burmese loans; see the header. All twelve
+# take the Shan frame word သီ ('colour') so that the phrase reads the same
+# way whichever half a word comes from.
+color =
+    .black = သီလမ်
+    .white = သီၶၢဝ်
+    .gray = သီမီးခိုး
+    .red = သီလႅင်
+    .orange = သီလိမ္မော်
+    .yellow = သီလိူင်
+    .green = သီၶဵဝ်
+    .cyan = သီစိမ်းပြာ
+    .blue = သီၾႃႉ
+    .purple = သီခရမ်း
+    .pink = သီပန်း
+    .brown = သီအညို
+
+line-width =
+    .thick = ၼႃ
+    .thin = မၢင်
+
+# ၶၢတ်ႇ is Shan 'cut, broken'; အစက် is the Burmese loan for a dot.
+line-style =
+    .dashed = ၶၢတ်ႇ
+    .dotted = အစက်
+
+fill-style =
+    .horizontal = သဵၼ်ႈ အလျားလိုက်
+    .vertical = သဵၼ်ႈ ဒေါင်လိုက်
+    .diagonal = သဵၼ်ႈ ထောင့်ဖြတ်
+    .backdiagonal = သဵၼ်ႈ ထောင့်ဖြတ် ပိၼ်ႈ
+    .dots = အစက်
+    .diamonds = စိန်ပုံ
+
+noun =
+    .line = သဵၼ်ႈ
+    .line-segment = line segment
+    .ray = ray
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = သၢမ်ၸဵင်ႇ
+    .rectangle = rectangle
+    .circle = စက်ဝိုင်း
+    .region = ဢွင်ႈတီႈ
+    .point = အမှတ်
+    .square = square
+    .diamond = စိန်ပုံ
+    .cross = ကြက်ခြေခတ်
+    .plus = အပေါင်း
+
+# Modifiers follow the head noun in Shan, so the side count sits after the
+# noun and `tail` stays empty, as it does in English. ၸဵင်ႇ is Shan 'corner,
+# angle'.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] regular polygon { $numSides } ၸဵင်ႇ
+    }
+
+# One token for everything: Shan has no grammatical gender, so nothing below
+# forks on `$gender`.
+noun-gender = neuter
+
+
+## Style composition
+
+# Colour, then dash pattern, then thickness — the reverse of English's order.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $color } { $lineStyle } { $width }
+        [width-color] { $color } { $width }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $lineStyle } { $width }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun comes first and the description follows it.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = တဵမ်
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } လူၺ်ႈ { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } လူၺ်ႈ { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } လူၺ်ႈ { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+# Shan has no article, so the two `-article` branches say what the two
+# without it say. What survives is လူၺ်ႈ ('with') against လႄႈ ('and') — a
+# first clause against a further one. The noun `border` precedes its
+# description, as every noun in this file does.
+style-border-clause =
+    { $parts ->
+        [with-article] လူၺ်ႈ border { $border }
+        [and] လႄႈ border { $border }
+        [and-article] လႄႈ border { $border }
+       *[with] လူၺ်ႈ border { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = ဢမ်ႇတဵမ်
+
+style-text =
+    { $parts ->
+        [background] { $color } လူၺ်ႈ background { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ဢမ်ႇမီး
+
+
+## Boolean words
+
+boolean-true = မၢၼ်ႇ
+boolean-false = ဢမ်ႇမၢၼ်ႇ
+
+
+## Answer buttons
+
+answer-submit-label = ၸႅတ်ႈတူၺ်း ၵၢၼ်
+answer-submit-label-no-correctness = သူင်ႇ ၶေႃႈတွပ်ႇ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ၵၢၼ်ႁဵတ်းသၢင်ႈ
+    .aside = aside
+    .cascade = cascade
+    .definition = ၶေႃႈပွင်ႇ
+    .example = တူဝ်ယၢင်ႇ
+    .exercise = ၵၢၼ်ၾိုၵ်း
+    .exercises = ၵၢၼ်ၾိုၵ်း
+    .given-answer = ၶေႃႈတွပ်ႇ
+    .note = မၢႆတွင်း
+    .objectives = ပဝ်ႉမၢႆ
+    .paragraphs = paragraph
+    .part = ပွတ်း
+    .problem = ပၼ်ႁႃ
+    .problems = ပၼ်ႁႃ
+    .proof = သက်သေပြချက်
+    .question = ၶေႃႈထၢမ်
+    .section = တွၼ်ႈ
+    .solution = ၶေႃႈၵႄႈ
+    .task = ၵၢၼ်
+    .theorem = theorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = ၶေႃႈၸီႉၼႄ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] ဇယား { $enumeration }
+        [numbered-title] ဇယား { $enumeration }{ ": " }
+        [unnumbered-title] ဇယား{ ": " }
+       *[unnumbered] ဇယား
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] ႁၢင်ႈ { $enumeration }
+        [numbered-caption] ႁၢင်ႈ { $enumeration }{ ": " }
+        [unnumbered-caption] ႁၢင်ႈ{ ": " }
+       *[unnumbered] ႁၢင်ႈ
+    }
+
+
+## Paginator controls
+
+paginator-previous = ဢွၼ်တၢင်း
+paginator-next = တေႃႇၼႃႈ
+paginator-page = ၼႃႈလိၵ်ႈ
+
+paginator-page-status = { $pageLabel } { $currentPage } ၼႂ်း { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ဢမ်ႇၼၼ်
+piecewise-condition-if = သင်ဝႃႈ
+piecewise-condition-otherwise = လိူဝ်သေၼၼ်ႉ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are absent on purpose; the header
+## says why. What is here is the frames, which are not vocabulary.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = symbol ဢမ်ႇထုၵ်ႇမႅၼ်ႈ
+chemistry-invalid-ionic-compound = ionic compound ဢမ်ႇထုၵ်ႇမႅၼ်ႈ
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = ပဝ်ႇ
+math-embedded-input-blank-ordinal = ပဝ်ႇ { $ordinal } ၼႂ်း { $total }

--- a/packages/i18n/locales/shn/diagnostics.ftl
+++ b/packages/i18n/locales/shn/diagnostics.ftl
@@ -1,0 +1,703 @@
+# Shan (လိၵ်ႈတႆး) warnings and errors. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth: `lint:i18n`
+# rejects a key that does not exist there, and reports a key that exists there
+# but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# modern reformed Shan orthography with the Shan letters ၵ ၶ ၸ ၺ ၼ ပ ၽ ၾ ႁ ဢ,
+# the Shan vowels ႃ ႄ ႅ ႆ ွ ႂ and the Shan tone marks ႇ ႈ း ႉ ႊ — never their
+# Burmese look-alikes — and spaces between words.
+#
+# **Every DoenetML name stays in English exactly as written**: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `selectFromSequence`, every
+# tag and every attribute. They are part of the language rather than prose.
+#
+# **This file is a Shan frame around English technical nouns**, and it is the
+# most heavily loaned of the four. A diagnostic names DoenetML objects almost
+# every time it opens its mouth — component, attribute, function, sequence,
+# variant, reference, index — and Shan has no established word for any of
+# them, so they stay in Latin letters as the classroom leaves them. What is
+# Shan is the sentence: the verb-first predicate, the postposed relative ဢၼ်,
+# and a small fixed set of phrases used the same way throughout, so that a
+# corrector can fix one pattern in one place:
+#
+#   * «X ဢမ်ႇထုၵ်ႇမႅၼ်ႈ» — X is invalid
+#   * «ဢမ်ႇဢဝ်ၸႂ်ႉ» — ignored
+#   * «ဢမ်ႇလႆႈ» — cannot
+#   * «လူဝ်ႇ» — must
+#   * «ပႆႇႁဵတ်းဝႆႉ» — has not been implemented
+#   * «ႁႃဢမ်ႇႁၼ်» — cannot find
+#   * «ယွၼ်ႉဝႃႈ» — because
+#   * «မၵ်းမၼ်ႈ» — to specify
+#   * «ဢၼ်မၵ်းမၼ်ႈဝႆႉ» — specified
+#
+# The Burmese loans, in Burmese spelling, are သတိပေးချက် (warning),
+# အချက်အလက် (information), အမှတ် (point) and ဇယား (table); everything else
+# non-Shan is English in Latin letters.
+#
+# **What this catalog does not know.** Shan has no settled terminology for
+# software diagnostics, and this seed did not invent one. Where English says
+# "prescribed", "overprescribed", "coprime", "eigenvalue" or "circular
+# dependency", the Shan around the English term is a paraphrase of what the
+# sentence means rather than a translation of the term, and a speaker with the
+# mathematical register will want to rewrite those. They are marked by the
+# English word standing bare in the sentence.
+#
+# **Counting.** CLDR has no plural data for `shn`. Every count select English
+# writes is collapsed to a single `*[other]`, because Shan leaves a noun
+# unmarked after a numeral and a category branch here would be text chosen by
+# English's rules. No `[zero]`, `[one]`, `[two]`, `[few]` or `[many]` branch
+# appears anywhere in these four files.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] { $attributes } ဢမ်ႇဢဝ်ၸႂ်ႉ မိူဝ်ႈမၵ်းမၼ်ႈ endpoint သွင်ဢၼ်
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] { $attributes } ဢမ်ႇဢဝ်ၸႂ်ႉ မိူဝ်ႈမၵ်းမၼ်ႈ endpoint လႄႈ midpoint ႁူမ်ႈၵၼ်
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ဢမ်ႇမီးၽွၼ်းလီ သင်ဢမ်ႇမီး midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = သဵၼ်ႈ ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် ဢၼ်ဢမ်ႇမၵ်းမၼ်ႈ dimension ဝႆႉ။
+
+line-points-too-few-dimensions = သဵၼ်ႈ လူဝ်ႇလတ်းၽၢၼ်ႇ အမှတ် ဢၼ်မီး dimension ဢမ်ႇယွမ်းသွင်ဢၼ်။
+
+line-points-depend-on-variables = သဵၼ်ႈ လတ်းၽၢၼ်ႇ အမှတ် ဢၼ်ၶိုၼ်းၸွမ်း variable: { $variables }။
+
+line-equation-invalid-format = ႁၢင်ႈႁႅၼ်း ၶွင် equation ၶွင်သဵၼ်ႈ ၼႂ်း variable { $variable1 } လႄႈ { $variable2 } ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+## `<ray>`
+
+ray-overprescribed-through = ray ၺႃးမၵ်းမၼ်ႈ လူၺ်ႈ through, endpoint လႄႈ direction ႁူမ်ႈၵၼ်။ through ဢၼ်မၵ်းမၼ်ႈဝႆႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+
+ray-dimension-mismatch = numDimensions ၼႂ်း ray ဢမ်ႇမႅၼ်ႈၵၼ်။
+
+## `<vector>`
+
+vector-overprescribed-head = vector ၺႃးမၵ်းမၼ်ႈ လူၺ်ႈ head, tail လႄႈ displacement ႁူမ်ႈၵၼ်။ head ဢၼ်မၵ်းမၼ်ႈဝႆႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+
+vector-dimension-mismatch = numDimensions ၼႂ်း vector ဢမ်ႇမႅၼ်ႈၵၼ်။
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = ဢမ်ႇလႆႈ attract ၸူး `<{ $component }>` ယွၼ်ႉဝႃႈ မၼ်းဢမ်ႇမီး state variable nearestPoint။
+
+constrain-to-without-nearest-point = ဢမ်ႇလႆႈ constrain ၸူး `<{ $component }>` ယွၼ်ႉဝႃႈ မၼ်းဢမ်ႇမီး state variable nearestPoint။
+
+constrain-to-interior-without-nearest-point = ဢမ်ႇလႆႈ constrain ၸူး ၼႂ်း `<{ $component }>` ယွၼ်ႉဝႃႈ မၼ်းဢမ်ႇမီး state variable nearestPoint။
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ဢမ်ႇဢဝ်ၸႂ်ႉ တႃႇ choiceInput ဢၼ်ဢမ်ႇပဵၼ် inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ choiceInput ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ ႁူဝ်ၼပ်ႉ indices ဢမ်ႇမႅၼ်ႈၵၼ်တင်း ႁူဝ်ၼပ်ႉ choice လုၵ်ႈဢွၼ်ႇ။
+
+pretzel-indices-count-mismatch = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ problem ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ ႁူဝ်ၼပ်ႉ indices ဢမ်ႇမႅၼ်ႈၵၼ်တင်း ႁူဝ်ၼပ်ႉ problem လုၵ်ႈဢွၼ်ႇ။
+
+shuffle-indices-count-mismatch = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ shuffle ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ ႁူဝ်ၼပ်ႉ indices ဢမ်ႇမႅၼ်ႈၵၼ်တင်း ႁူဝ်ၼပ်ႉ component။
+
+indices-ignored-out-of-range = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ { $component } ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ index လၢႆဢၼ် ပူၼ်ႉၶွပ်ႇ။
+
+pretzel-indices-repeated = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ pretzel ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ index လၢႆဢၼ် သမ်ႉၶႃႈသွၼ်ႉၵၼ်။
+
+pretzel-circuit-first-index = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ pretzel ၼႂ်း circuit mode ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ index ဢွၼ်တၢင်းသုတ်း လူဝ်ႇပဵၼ် 1။
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = တႃႇ `<{ $component }>` ႁဵတ်းၵၢၼ်လႆႈ လူၺ်ႈ string လုၵ်ႈဢွၼ်ႇ လူဝ်ႇမၵ်းမၼ်ႈ attribute `type`။
+
+invalid-type-defaulting-to-math = type { $type } ဢမ်ႇထုၵ်ႇမႅၼ်ႈ တႃႇ component { $component }။ လူဝ်ႇပဵၼ် math, text, number ဢမ်ႇၼၼ် boolean။ ၸႂ်ႉ math ပဵၼ် default။
+
+string-not-valid-component-to-arrange = string "{ $value }" ဢမ်ႇပဵၼ် component ဢၼ်ႁဵတ်း { $component } လႆႈ။ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ဢမ်ႇထုၵ်ႇမႅၼ်ႈ၊ တင်ႈ type ပဵၼ် number။
+
+invalid-variable-value = တူဝ်ၵႃႈ ၶွင် variable ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = variant index { $index } လူဝ်ႇပဵၼ် number
+
+variant-index-must-be-integer = variant index { $index } လူဝ်ႇပဵၼ် integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ပႆႇႁဵတ်းဝႆႉ တႃႇ ၶၼႃးဢၼ်တၢႆတူဝ်။ တင်ႈ width ပဵၼ် relative။
+
+side-by-side-absolute-margins = `<{ $component }>` ပႆႇႁဵတ်းဝႆႉ တႃႇ ၶၼႃးဢၼ်တၢႆတူဝ်။ တင်ႈ margin ပဵၼ် relative။
+
+side-by-side-no-block-child = `<{ $component }>` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: လူဝ်ႇမီး block လုၵ်ႈဢွၼ်ႇ ဢမ်ႇယွမ်းၼိုင်ႈဢၼ်။
+
+## `<label>`
+
+label-for-ignored-on-graphical = attribute `for` ၼိူဝ် `<label>` ဢၼ်ပဵၼ်ႁၢင်ႈ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+
+label-for-must-resolve-to-one = attribute `for` ၼိူဝ် `<label>` လူဝ်ႇၸီႉၼႄ component ဢၼ်ၼိုင်ႈလဵဝ်။
+
+label-for-unresolved = attribute `for` ၼိူဝ် `<label>` ၸီႉၼႄ component ဢမ်ႇလႆႈ။
+
+label-for-answer-with-authored-inputs = attribute `for` ၼိူဝ် `<label>` ၸီႉၼႄ `<answer>` ဢၼ်မီး input ဢၼ်ၽူႈတႅမ်ႈသႂ်ႇဝႆႉ၊ ၸီႉၼႄ input ၼၼ်ႉ သိုဝ်ႈသိုဝ်ႈ။
+
+label-for-answer-without-input = attribute `for` ၼိူဝ် `<label>` ၸီႉၼႄ `<answer>` ဢၼ်ဢမ်ႇမီး input တႃႇ label။
+
+label-for-must-reference-input-or-answer = attribute `for` ၼိူဝ် `<label>` လူဝ်ႇၸီႉၼႄ input ဢမ်ႇၼၼ် answer။
+
+## Accessibility
+
+accessibility-short-description-or-decorative = တႃႇ accessibility, `<{ $component }>` လူဝ်ႇမီး ၶေႃႈပွင်ႇပွတ်း ဢမ်ႇၼၼ် လူဝ်ႇမၵ်းမၼ်ႈပဵၼ် decorative။
+
+accessibility-video-short-description = တႃႇ accessibility, `<video>` လူဝ်ႇမီး ၶေႃႈပွင်ႇပွတ်း။
+
+accessibility-input-short-description-or-label = တႃႇ accessibility, `<{ $component }>` လူဝ်ႇမီး ၶေႃႈပွင်ႇပွတ်း ဢမ်ႇၼၼ် label။
+
+accessibility-answer-input-short-description-or-label = တႃႇ accessibility, `<answer>` ဢၼ်သၢင်ႈ input လူဝ်ႇမီး ၶေႃႈပွင်ႇပွတ်း ဢမ်ႇၼၼ် label။
+
+accessibility-short-description-contains-math = ၶေႃႈပွင်ႇပွတ်း ဢမ်ႇထုၵ်ႇလီမီး math component ၸိူင်ႉၼင်ႇ `<{ $component }>`။ တႅမ်ႈ math လူၺ်ႈ ၵႂၢမ်း။
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } မီး contrast ဢမ်ႇၵုမ်ႇထူၼ်ႈ တႃႇ text ႁူဝ်ၶေႃႈ ၶွင် section (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; လူဝ်ႇမီး ဢမ်ႇယွမ်း { $threshold }:1)။
+       *[other] { $colorName } မီး contrast ဢမ်ႇၵုမ်ႇထူၼ်ႈ တႃႇ text ႁူဝ်ၶေႃႈ ၶွင် section ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; လူဝ်ႇမီး ဢမ်ႇယွမ်း { $threshold }:1)။
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ပႆႇႁဵတ်းဝႆႉ `<circle>` ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် { $count } ဢၼ် မိူဝ်ႈ အမှတ် ဢမ်ႇမီးတူဝ်ၵႃႈ ဢၼ်ပဵၼ်ၼပ်ႉ။
+
+circle-too-many-through-points = ၼပ်ႉဢမ်ႇလႆႈ စက်ဝိုင်း ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ် 3 ဢၼ်။
+
+circle-overprescribed-radius-center-points = ၼပ်ႉဢမ်ႇလႆႈ စက်ဝိုင်း ဢၼ်မၵ်းမၼ်ႈ radius, center လႄႈ through point ႁူမ်ႈၵၼ်။
+
+circle-center-with-multiple-points = ၼပ်ႉဢမ်ႇလႆႈ စက်ဝိုင်း ဢၼ်မီး center မၵ်းမၼ်ႈဝႆႉ သေလတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ် 1 ဢၼ်။
+
+circle-radius-too-small = ၼပ်ႉဢမ်ႇလႆႈ စက်ဝိုင်း: ၶၢဝ်းတၢင်း ၼႂ်းၵႄႈ အမှတ် သွင်ဢၼ် ပဵၼ် { $distance } လႄႈ radius { $radius } ဢၼ်မၵ်းမၼ်ႈဝႆႉ ၼၼ်ႉ ဢွၼ်ႇလူင်း။
+
+circle-radius-with-many-points = သၢင်ႈဢမ်ႇလႆႈ စက်ဝိုင်း ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ်သွင်ဢၼ် လူၺ်ႈ radius ဢၼ်မၵ်းမၼ်ႈဝႆႉ။
+
+circle-invalid-center-or-through-points = center ဢမ်ႇၼၼ် through point ၶွင် စက်ဝိုင်း ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+circle-radius-center-with-multiple-points = ၼပ်ႉဢမ်ႇလႆႈ radius ၶွင် စက်ဝိုင်း ဢၼ်မီး center မၵ်းမၼ်ႈဝႆႉ သေလတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ် 1 ဢၼ်။
+
+circle-change-radius-non-numerical = လႅၵ်ႈဢမ်ႇလႆႈ radius ၶွင် စက်ဝိုင်း ဢၼ်မီး through point ဢမ်ႇပဵၼ်ၼပ်ႉ
+
+circle-radius-with-points-non-numerical = သၢင်ႈဢမ်ႇလႆႈ စက်ဝိုင်း ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ်ၼိုင်ႈဢၼ် လူၺ်ႈ radius ဢၼ်မၵ်းမၼ်ႈဝႆႉ မိူဝ်ႈဢမ်ႇမီးတူဝ်ၵႃႈ ဢၼ်ပဵၼ်ၼပ်ႉ။
+
+circle-change-center-non-numerical = ပႆႇႁဵတ်းဝႆႉ ၵၢၼ်လႅၵ်ႈ center ၶွင် စက်ဝိုင်း ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ။
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] dimension ၶွင် domain တႃႇ function ဢမ်ႇၵုမ်ႇထူၼ်ႈ။ domain မီး interval { $intervals } ဢၼ် သေတႃႉ function မီး input { $inputs } ဢၼ်။
+    }
+
+function-domain-invalid-format = ႁၢင်ႈႁႅၼ်း ၶွင် domain တႃႇ function ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] maximum ၶွင် function ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [minimum] minimum ၶွင် function ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [extremum] extremum ၶွင် function ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [point] အမှတ် ၶွင် function ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [slope] slope ၶွင် function ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+       *[other] { $type } ၶွင် function ဢၼ်ဢမ်ႇပဵၼ်ၼပ်ႉ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] maximum ၶွင် function ဢၼ်ပဝ်ႇ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [minimum] minimum ၶွင် function ဢၼ်ပဝ်ႇ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [extremum] extremum ၶွင် function ဢၼ်ပဝ်ႇ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+        [point] အမှတ် ၶွင် function ဢၼ်ပဝ်ႇ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+       *[other] { $type } ၶွင် function ဢၼ်ပဝ်ႇ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+    }
+
+function-points-too-close = function မီး အမှတ် သွင်ဢၼ် ဢၼ်တီႈယူႇၸမ်ၵၼ်ပူၼ်ႉတီႈ။ မၵ်းမၼ်ႈ function ဢမ်ႇလႆႈ။
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] function iterate ပဵၼ်လႆႈ ၵူၺ်းမိူဝ်ႈ ႁူဝ်ၼပ်ႉ input ၶွင် function မႅၼ်ႈၵၼ်တင်း ႁူဝ်ၼပ်ႉ output။ function ဢၼ်ၼႆႉ မီး input { $inputs } ဢၼ် လႄႈ output { $outputs } ဢၼ်။
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = length ၶွင် sequence ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ လူဝ်ႇပဵၼ် integer ဢၼ်ဢမ်ႇလူင်းတႂ်ႈသုၼ်။
+
+sequence-invalid-step = step ၶွင် sequence ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ တႃႇ sequence type { $type } လူဝ်ႇပဵၼ် number။
+
+sequence-invalid-endpoint-number = "{ $attribute }" ၶွင် number sequence ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ လူဝ်ႇပဵၼ် number။
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ၶွင် letters sequence ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ လူဝ်ႇပဵၼ် တူဝ်လိၵ်ႈ ႁူမ်ႈၵၼ်။
+
+sequence-invalid-endpoint = "{ $attribute }" ၶွင် sequence ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+select-from-sequence-coprime-not-numbers = coprime ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ ဢမ်ႇလိူၵ်ႈ number
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ မီး excludeCombinations မၵ်းမၼ်ႈဝႆႉ
+
+## Resolving a `target`
+
+target-not-found = target တႃႇ `<{ $source }>` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁႃဢမ်ႇႁၼ် target။
+
+target-state-variable-not-found = target တႃႇ `<{ $source }>` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁႃဢမ်ႇႁၼ် state variable ၸိုဝ်ႈ "{ $property }" ၼိူဝ် `<{ $component }>`။
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = variable ၶွင် `<odeSystem>` လူဝ်ႇပႅၵ်ႈၵၼ်တင်း independent variable။
+
+ode-system-duplicate-variable-names = မၵ်းမၼ်ႈဢမ်ႇလႆႈ ODE RHS function ဢၼ်မီး ၸိုဝ်ႈ dependent variable ၶႃႈသွၼ်ႉၵၼ်။
+
+ode-system-rhs-function-error = မၵ်းမၼ်ႈဢမ်ႇလႆႈ ODE RHS function။ ၽိတ်းပိူင်ႈ မိူဝ်ႈသၢင်ႈ mathjs function။
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = မၵ်းမၼ်ႈဢမ်ႇလႆႈ ၸဵင်ႇ ၼႂ်းၵႄႈ သဵၼ်ႈ { $count } သဵၼ်ႈ
+
+angle-invalid-through-point = အမှတ် ၼႂ်း through ၶွင် `<angle>` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ
+
+parabola-vertex-too-many-points = ပႆႇႁဵတ်းဝႆႉ parabola ဢၼ်မီး vertex သေလတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ် 1 ဢၼ်။
+
+parabola-too-many-points = ပႆႇႁဵတ်းဝႆႉ parabola ဢၼ်လတ်းၽၢၼ်ႇ အမှတ် ၼမ်လိူဝ် 3 ဢၼ်။
+
+intersection-too-many-items = ပႆႇႁဵတ်းဝႆႉ intersection တႃႇ ဢၼ်ၼမ်လိူဝ်သွင်ဢၼ်
+
+## Other math components
+
+ionic-compound-not-two-ions = ပႆႇႁဵတ်းဝႆႉ ionic compound တႃႇ ဢၼ်ပႅၵ်ႈသေ ion သွင်ဢၼ်။
+
+ionic-compound-needs-cation-and-anion = ionic compound ႁဵတ်းဝႆႉ တႃႇ cation ဢၼ်ၼိုင်ႈလႄႈ anion ဢၼ်ၼိုင်ႈ ၵူၺ်း။
+
+solve-equations-cannot-evaluate = ၵႄႈဢမ်ႇလႆႈ equation ယွၼ်ႉဝႃႈ ၼပ်ႉဢမ်ႇလႆႈ equation: { $equation }
+
+math-operators-operand-number-required = လူဝ်ႇမၵ်းမၼ်ႈ operandNumber မိူဝ်ႈဢဝ်ဢွၵ်ႇ math operand။
+
+eigen-decomposition-failed = ၼပ်ႉဢမ်ႇလႆႈ eigenvalue ၶွင် matrix
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: parameter { $parameters } ဢမ်ႇမီးၼႂ်း pattern လႄႈ တေမႅၼ်ႈၵၼ်တင်း ဢၼ်ပဝ်ႇ ၵူႈပွၵ်ႈ။
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ဢဝ်ပွင်ႇဢမ်ႇလႆႈ grid="{ $grid }"။ လူဝ်ႇပဵၼ် none, medium, dense ဢမ်ႇၼၼ် number ဢၼ်လိူဝ်သုၼ် သွင်ဢၼ် ဢၼ်မီးၶၢဝ်ႇဝႆႉ ၸိူင်ႉၼင်ႇ grid="1 0.5"။ ဢမ်ႇတမ်း grid သင်။
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` လူဝ်ႇ function ဢၼ်မီး { $expected ->
+        [1] output ဢၼ်ၼိုင်ႈ၊ slope y' တီႈၵူႈ အမှတ်၊ ၸိူင်ႉၼင်ႇ `y - x`
+       *[other] output သွင်ဢၼ်၊ vector တီႈၵူႈ အမှတ်၊ ၸိူင်ႉၼင်ႇ `(y, -x)`
+    }၊ ၵူၺ်းၵႃႈ function ဢၼ်ပၼ်မႃးၼၼ်ႉ မီး output { $found } ဢၼ်။ { $alternative ->
+        [none] ဢမ်ႇတမ်းသင်။
+       *[other] `<{ $alternative }>` ပဵၼ် component တႃႇ function ၼၼ်ႉ။ ဢမ်ႇတမ်းသင်။
+    }
+
+field-function-attribute-ignored-with-child = attribute `function` ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ function ၺႃးပၼ်ဝႆႉ ၼႂ်း component ၸွမ်း၊ ဢၼ်ၼႂ်းၼၼ်ႉ ၺႃးဢဝ်ၸႂ်ႉ။ ပၼ် function ၼိုင်ႈတၢင်းၵူၺ်း။
+
+field-variables-ignored =
+    `<{ $component }>`: attribute `variables` ၸီႉၼႄ variable ၶွင် expression ဢၼ်တႅမ်ႈဝႆႉ ၼႂ်း component သိုဝ်ႈသိုဝ်ႈ။ { $reason ->
+        [function-child] function တီႈၼႆႈ ၺႃးပၼ်ပဵၼ် `<function>` လုၵ်ႈဢွၼ်ႇ ဢၼ်ၸီႉၼႄ variable ႁင်းၵူၺ်း လႄႈ `variables` ဢမ်ႇဢဝ်ၸႂ်ႉ။
+       *[no-expression] ဢမ်ႇမီး expression ၸိူင်ႉၼၼ်တီႈၼႆႈ လႄႈ `variables` ဢမ်ႇဢဝ်ၸႂ်ႉ။
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ၸႂ်ႉဢမ်ႇလႆႈ ၼႂ်း prefigure renderer; ၸႂ်ႉပိူင် right-position။
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ၸႂ်ႉဢမ်ႇလႆႈ ၼႂ်း prefigure renderer; ၸႂ်ႉပိူင် top-position။
+
+prefigure-invalid-axis-bounds = `<graph>`: axis bound တႃႇ prefigure ဢမ်ႇထုၵ်ႇမႅၼ်ႈ; ၸႂ်ႉ bbox default (-10,-10,10,10)။
+
+prefigure-invalid-width = `<graph>`: width တႃႇ prefigure ဢမ်ႇထုၵ်ႇမႅၼ်ႈ; ၸႂ်ႉ width default 425။
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio တႃႇ prefigure ဢမ်ႇထုၵ်ႇမႅၼ်ႈ; ၸႂ်ႉ aspect ratio default 1။
+
+prefigure-grid-spacing-too-fine = `<graph>`: ၶၢဝ်ႇ ၶွင် grid ဢွၼ်ႇပူၼ်ႉတီႈ တႃႇ ၶွပ်ႇ axis; ဢမ်ႇတမ်း grid ၼႂ်း prefigure renderer။
+
+prefigure-annotations-not-rendered = `<graph>`: annotation တေဢမ်ႇၺႃးတမ်း မိူဝ်ႈဢမ်ႇၸႂ်ႉ PreFigure renderer။
+
+multiple-annotations-children = ႁၼ် `<annotations>` လုၵ်ႈဢွၼ်ႇ လၢႆဢၼ် ၼႂ်း `<graph>`; ဢၼ်လိုၼ်းသုတ်း ၵူၺ်းၺႃးဢဝ်ၸႂ်ႉ။
+
+## Referring to other components
+
+copy-unrecognized-component-type = extend ဢမ်ႇၼၼ် copy ဢမ်ႇလႆႈ component type ဢၼ်ဢမ်ႇႁူႉၸၵ်း: { $type }။
+
+copy-prop-not-found = ႁႃဢမ်ႇႁၼ် prop { $property } ၼိူဝ် component type { $component }
+
+collect-no-source = ႁႃဢမ်ႇႁၼ် source တႃႇ collect။
+
+collect-invalid-component-type = collect ဢမ်ႇလႆႈ component type `<{ $component }>` ယွၼ်ႉဝႃႈ ပဵၼ် component type ဢၼ်ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+reference-index-unavailable = ၸီႉၼႄ index `{ $reference }` ဢမ်ႇလႆႈ
+
+## `<callAction>`
+
+component-action-unavailable = ႁွင်ႉ { $action } ၼိူဝ် component `{ $reference }` ဢမ်ႇလႆႈ
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ႁၢင်ႈႁႅၼ်း ၶွင် data ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ row မီးလွင်ႈယၢဝ်း ဢမ်ႇမႅၼ်ႈၵၼ်။ ႁၼ်တီႈ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = data မီး ၸိုဝ်ႈ column ၶႃႈသွၼ်ႉၵၼ်။ ႁၼ်တီႈ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = data ဢမ်ႇမီး ၸိုဝ်ႈ column ဢၼ်ၼိုင်ႈ။ ႁၼ်တီႈ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = award ၶွင် answer ဢၼ်ၼႆႉ ဢိင်ၼိူဝ် ၶေႃႈတွပ်ႇ ၶွင် answer tag ႁင်းၵူၺ်း၊ ၼၼ်ႉတေႁဵတ်းႁႂ်ႈပဵၼ် လွင်ႈဢၼ်ဢမ်ႇထၢင်ႇ။
+
+answer-max-num-attempts-in-section-wide-check-work = ၵၢၼ်တင်ႈ `maxNumAttempts` ၼိူဝ် `<answer>` ဢၼ်ယူႇၼႂ်း container ဢၼ်မီး `sectionWideCheckWork` ဢမ်ႇမီးၽွၼ်းလီ ယွၼ်ႉဝႃႈ ႁူဝ်ၼပ်ႉ ပွၵ်ႈ ၺႃးၵုမ်းလူၺ်ႈ container။ တင်ႈ `maxNumAttempts` ၼိူဝ် container ၼၼ်ႉ။
+
+nested-section-wide-check-work-max-num-attempts = ၵၢၼ်တင်ႈ `maxNumAttempts` ၼိူဝ် container ဢၼ်မီး `sectionWideCheckWork` ဢၼ်ယူႇၼႂ်း container တၢင်ႇဢၼ် ဢၼ်မီး `sectionWideCheckWork` ၼၼ်ႉ ဢမ်ႇမီးၽွၼ်းလီ ယွၼ်ႉဝႃႈ ႁူဝ်ၼပ်ႉ ပွၵ်ႈ ၺႃးၵုမ်းလူၺ်ႈ container ဢၼ်ၼွၵ်ႈ။ တင်ႈ `maxNumAttempts` ၼိူဝ် container ဢၼ်ၼွၵ်ႈ။
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] attribute { $attributes } တေဢမ်ႇမီးၽွၼ်းလီ သင်ဢမ်ႇတင်ႈ symbolicEquality။
+    }
+
+answer-invalid-type = type တႃႇ answer ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = ယွၼ်ႉဝႃႈ component `<{ $component }>` ဢမ်ႇမီးၸိုဝ်ႈ လႄႈ ဢဝ်ၸႂ်ႉပဵၼ် attribute ၶွင် module ဢမ်ႇလႆႈ
+
+module-attribute-name-already-defined = component `<{ $component } name="{ $name }">` ဢဝ်ၸႂ်ႉပဵၼ် attribute ၶွင် module ဢမ်ႇလႆႈ ယွၼ်ႉဝႃႈ component type `<module>` မီး attribute "{ $name }" ဝႆႉယဝ်ႉ။
+
+conditional-content-condition-ignored = attribute `condition` ဢမ်ႇဢဝ်ၸႂ်ႉ ၼိူဝ် `<conditionalContent>` ဢၼ်မီး case ဢမ်ႇၼၼ် else လုၵ်ႈဢွၼ်ႇ။
+
+slider-markers-type-mismatch = type ၶွင် marker ဢမ်ႇမႅၼ်ႈၵၼ်တင်း type ၶွင် slider။
+
+pretzel-problem-needs-statement-and-answer = pretzel ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: `<problem>` ၵူႈဢၼ် လူဝ်ႇမီး `<statement>` ဢၼ်ၼိုင်ႈလႄႈ `<answer>` ဢၼ်ၼိုင်ႈ။
+
+pretzel-circuit-first-problem-distractor = pretzel ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ၼႂ်း mode="circuit" `<problem>` ဢွၼ်တၢင်းသုတ်း ပဵၼ် distractor ဢမ်ႇလႆႈ။
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] တူဝ်ၵႃႈ { $values } ဢမ်ႇထုၵ်ႇမႅၼ်ႈ တႃႇ attribute `{ $attribute }`; ဢမ်ႇဢဝ်ၸႂ်ႉ။
+    }
+
+attribute-must-be-references = တူဝ်ၵႃႈ `{ $value }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ တႃႇ attribute `{ $attribute }`။ attribute လူဝ်ႇမီးၽၢင်ႁၢင်ႈ ပဵၼ် reference ဢၼ်တႄႇလူၺ်ႈ `$`။
+
+math-input-invalid-function-names = <mathInput>: ၸိုဝ်ႈ function ဢၼ်ဢမ်ႇထုၵ်ႇမႅၼ်ႈ ၼႂ်း { $attribute } ဢမ်ႇဢဝ်ၸႂ်ႉ: { $names }။ တွၼ်ႈဢၼ်ၼႄ ၶွင် ၸိုဝ်ႈၵူႈဢၼ် လူဝ်ႇမီး ဢမ်ႇယွမ်း 2 တူဝ် (တူဝ်လိၵ်ႈ ဢမ်ႇၼၼ် ဢွၼ်ႇသဵၼ်ႈ); ဢၼ်လိုၼ်း `|<mathspeak alternative>` သႂ်ႇလႆႈ ဢမ်ႇသႂ်ႇၵေႃႈလႆႈ။
+
+## Building components from the source
+
+component-type-invalid = component type ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: `<{ $componentType }>`
+
+attribute-repeated = attribute { $attribute } တႅမ်ႈသွၼ်ႉၵၼ် ဢမ်ႇလႆႈ။
+
+attribute-invalid-for-component = attribute "{ $attribute }" ဢမ်ႇထုၵ်ႇမႅၼ်ႈ တႃႇ component type `<{ $componentType }>`။
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    style definition { $styleNumber } မီး contrast ဢမ်ႇၵုမ်ႇထူၼ်ႈ တႃႇ { $context ->
+        [text-on-background] သီၶွင် text ၽႃႇၼင်ႇ သီၶွင် background
+        [high-contrast] သီ high-contrast ၽႃႇၼင်ႇ canvas
+        [line] သီၶွင် သဵၼ်ႈ ၽႃႇၼင်ႇ canvas
+        [marker] သီၶွင် marker ၽႃႇၼင်ႇ canvas
+       *[text-on-canvas] သီၶွင် text ၽႃႇၼင်ႇ canvas
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; လူဝ်ႇမီး ဢမ်ႇယွမ်း { $threshold }:1)။
+
+style-definition-dark-mode-text-background-contrast =
+    style definition { $styleNumber } မၵ်းမၼ်ႈ သီ ဢၼ်မီး contrast ၵုမ်ႇထူၼ်ႈ တႃႇ light mode သေတႃႉ သီ dark mode ဢၼ်ဢွၵ်ႇမႃးၼၼ်ႉ မီး contrast ဢမ်ႇၵုမ်ႇထူၼ်ႈ တႃႇ သီၶွင် text ၽႃႇၼင်ႇ သီၶွင် background ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; လူဝ်ႇမီး ဢမ်ႇယွမ်း { $threshold }:1)။ { $suggestion ->
+        [available] တႃႇႁႂ်ႈ contrast ၼႂ်း dark mode ၵုမ်ႇထူၼ်ႈ ႁဵတ်းႁႂ်ႈ contrast ၶွင် light mode ၼမ်ၶိုၼ်ႈ (ၸိူင်ႉၼင်ႇ တင်ႈ { $lightAttribute }="{ $lightColor }") ဢမ်ႇၼၼ် လႅၵ်ႈသီ dark mode (ၸိူင်ႉၼင်ႇ တင်ႈ { $darkAttribute }="{ $darkColor }")။
+       *[none] တႃႇႁႂ်ႈ contrast ၼႂ်း dark mode ၵုမ်ႇထူၼ်ႈ ႁဵတ်းႁႂ်ႈ contrast ၶွင် light mode ၼမ်ၶိုၼ်ႈ ဢမ်ႇၼၼ် လႅၵ်ႈသီ ဢၼ်ဢွၵ်ႇမႃးၼၼ်ႉ လူၺ်ႈ textColorDarkMode လႄႈ/ဢမ်ႇၼၼ် backgroundColorDarkMode။
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    style definition { $styleNumber } မၵ်းမၼ်ႈ သီၶွင် text ဢၼ်မီး contrast ၵုမ်ႇထူၼ်ႈ တႃႇ light mode သေတႃႉ သီၶွင် text ၼႂ်း dark mode ဢၼ်ဢွၵ်ႇမႃးၼၼ်ႉ မီး contrast ဢမ်ႇၵုမ်ႇထူၼ်ႈ ၽႃႇၼင်ႇ canvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; လူဝ်ႇမီး ဢမ်ႇယွမ်း { $threshold }:1)။ { $suggestion ->
+        [available] တႃႇႁႂ်ႈ contrast ၼႂ်း dark mode ၵုမ်ႇထူၼ်ႈ ႁဵတ်းႁႂ်ႈ contrast ၶွင် light mode ၼမ်ၶိုၼ်ႈ (ၸိူင်ႉၼင်ႇ တင်ႈ textColor="{ $lightColor }") ဢမ်ႇၼၼ် လႅၵ်ႈသီ dark mode (ၸိူင်ႉၼင်ႇ တင်ႈ textColorDarkMode="{ $darkColor }")။
+       *[none] တႃႇႁႂ်ႈ contrast ၼႂ်း dark mode ၵုမ်ႇထူၼ်ႈ ႁဵတ်းႁႂ်ႈ contrast ၶွင် light mode ၼမ်ၶိုၼ်ႈ ဢမ်ႇၼၼ် လႅၵ်ႈသီ ဢၼ်ဢွၵ်ႇမႃးၼၼ်ႉ လူၺ်ႈ textColorDarkMode။
+    }
+
+section-multiple-style-palettes = section လိူၵ်ႈလႆႈ <stylePalette> ဢၼ်ၼိုင်ႈလဵဝ်; ဢဝ်ၸႂ်ႉ ဢၼ်လိုၼ်းသုတ်း။
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ numToSelect ဢမ်ႇပဵၼ် integer ဢၼ်ဢမ်ႇလူင်းတႂ်ႈသုၼ်။
+
+variant-num-to-select-not-constant-number = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ numToSelect ဢမ်ႇပဵၼ် number ဢၼ်တၢႆတူဝ်။
+
+variant-with-replacement-not-constant-boolean = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ withReplacement ဢမ်ႇပဵၼ် boolean ဢၼ်တၢႆတူဝ်။
+
+variant-select-weight-disables-unique = unique variant တႃႇ select ၺႃးပိၵ်ႉ သင်မီး option ဢၼ်မၵ်းမၼ်ႈ selectWeight ဢမ်ႇၼၼ် selectForVariants
+
+variant-coprime-undetermined = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ မၵ်းမၼ်ႈဢမ်ႇလႆႈဝႃႈ coprime ပဵၼ်ဢၼ်ဢမ်ႇမၢၼ်ႇ ၵူႈပွၵ်ႈ။
+
+variant-attribute-not-constant = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ { $attribute } ဢမ်ႇတၢႆတူဝ်။
+
+variant-attribute-not-number = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ { $attribute } ဢမ်ႇပဵၼ် number။
+
+variant-attribute-wrong-type-for-sequence =
+    မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } type { $type } ယွၼ်ႉဝႃႈ { $attribute } ဢမ်ႇပဵၼ် { $expected ->
+        [letters-combination] တူဝ်လိၵ်ႈ ႁူမ်ႈၵၼ်
+        [math-expression] math expression ဢၼ်ထုၵ်ႇမႅၼ်ႈ
+        [integer] integer
+       *[number] number
+    }။
+
+variant-length-not-integer = မၵ်းမၼ်ႈဢမ်ႇလႆႈ unique variant ၶွင် { $component } ယွၼ်ႉဝႃႈ length ဢမ်ႇပဵၼ် integer။
+
+variant-sort-not-implemented = ပႆႇႁဵတ်းဝႆႉ unique variant ၶွင် { $component } ဢၼ်မီး sort
+
+variant-exclude-combinations-not-implemented = ပႆႇႁဵတ်းဝႆႉ unique variant ၶွင် { $component } ဢၼ်မီး excludeCombinations
+
+variant-math-exclude-not-implemented = ပႆႇႁဵတ်းဝႆႉ unique variant ၶွင် { $component } type math ဢၼ်မီး exclude
+
+variant-non-constant-exclude-not-implemented = ပႆႇႁဵတ်းဝႆႉ unique variant ၶွင် { $component } ဢၼ်မီး exclude ဢၼ်ဢမ်ႇတၢႆတူဝ်
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ၸႂ်ႉဢမ်ႇလႆႈ ၼႂ်း graph prefigure renderer; ၶၢမ်ႈပႅတ်ႈ ဢၼ်ယူႇတႂ်ႈ။
+
+prefigure-descendant-invalid-geometry = { $subject }: ႁၢင်ႈႁႅၼ်း ဢမ်ႇတဵမ် ဢမ်ႇၼၼ် ဢမ်ႇမီးၶွပ်ႇ; ၶၢမ်ႈပႅတ်ႈ ဢၼ်ယူႇတႂ်ႈ။
+
+prefigure-curve-label-omitted = { $subject }: label ၸႂ်ႉဢမ်ႇလႆႈ ၼိူဝ် curve ဢၼ်လႅၵ်ႈမႃး; ၶၢမ်ႈပႅတ်ႈ label။
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve function definition type '{ $definitionType }' ၸႂ်ႉဢမ်ႇလႆႈ; ၶၢမ်ႈပႅတ်ႈ ဢၼ်ယူႇတႂ်ႈ။
+
+prefigure-region-flip-functions-unsupported = { $subject }: attribute flipFunctions ၼိူဝ် regionBetweenCurves ၸႂ်ႉဢမ်ႇလႆႈ; ၶၢမ်ႈပႅတ်ႈ ဢၼ်ယူႇတႂ်ႈ။
+
+prefigure-region-non-formula-child = { $subject }: ၼိူဝ် regionBetweenCurves ၸႂ်ႉလႆႈ ၵူၺ်း function လုၵ်ႈဢွၼ်ႇ ဢၼ်ပဵၼ် formula type; ၶၢမ်ႈပႅတ်ႈ ဢၼ်ယူႇတႂ်ႈ။
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ၸႂ်ႉဢမ်ႇလႆႈ တႃႇ { $labelKind ->
+        [line-family] label ၶွင် line family
+       *[point] label ၶွင် အမှတ်
+    }; ၸႂ်ႉ PreFigure alignment default။
+
+prefigure-fill-style-unsupported = { $subject }: fill style '{ $fillStyle }' PreFigure ၸႂ်ႉဢမ်ႇလႆႈ; ဢဝ်ၸႂ်ႉ fill ဢၼ်တဵမ်။
+
+prefigure-line-style-unknown = { $subject }: line style '{ $lineStyle }' ဢၼ်ဢမ်ႇႁူႉၸၵ်း ဢမ်ႇသႂ်ႇၼႂ်း PreFigure output။
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }' လႅၵ်ႈပဵၼ် PreFigure style 'diamond'။
+
+prefigure-marker-style-unsupported = { $subject }: marker style '{ $markerStyle }' PreFigure ၸႂ်ႉဢမ်ႇလႆႈ; ၸႂ်ႉ style default။
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ; ႁႃဢမ်ႇႁၼ် target။ ၶၢမ်ႈပႅတ်ႈ annotation။
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ၸီႉၼႄ target လၢႆဢၼ်; ဢဝ်ၸႂ်ႉ target ဢွၼ်တၢင်းသုတ်း။
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ; target ယူႇၼွၵ်ႈ graph ဢၼ်ဢုမ်ႈဝႆႉ။ ၶၢမ်ႈပႅတ်ႈ annotation။
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ; target ဢမ်ႇပဵၼ် ႁၢင်ႈ ဢၼ်ၸႂ်ႉလႆႈ ၼႂ်း prefigure။ ၶၢမ်ႈပႅတ်ႈ annotation။
+
+annotation-text-missing = `<annotation>`: `text` ဢမ်ႇမီး ဢမ်ႇၼၼ် ပဝ်ႇ; ဢွၵ်ႇပၼ် text ပဝ်ႇ။
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] ႁၼ် circular dependency။
+       *[other] ႁၼ် circular dependency ဢၼ်ၵဵဝ်ႇလူၺ်ႈ component `<{ $componentType }>`။
+    }
+
+reference-no-referent = ႁႃဢမ်ႇႁၼ် တီႈဢၼ် reference ၼႄ: `{ $reference }`
+
+reference-multiple-referents = ႁၼ် တီႈဢၼ် reference ၼႄ လၢႆဢၼ်: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = ႁၢင်ႈႁႅၼ်း ၶွင် attribute { $attribute } ၶွင် `<{ $componentType }>` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+children-invalid = လုၵ်ႈဢွၼ်ႇ ၶွင် `<{ $componentType }>` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁၼ်လုၵ်ႈဢွၼ်ႇ ဢၼ်ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = တူဝ်ၵႃႈ `{ $value }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ တႃႇ attribute `{ $attribute }`၊ ဢဝ်ၸႂ်ႉတူဝ်ၵႃႈ `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] ႁႃဢမ်ႇႁၼ် DoenetML version { $version }။
+       *[other] ႁႃဢမ်ႇႁၼ် DoenetML version { $version }။ ဢဝ်ၸႂ်ႉ version { $fallback } တႅၼ်း
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: { $content }
+
+parse-tag-missing-close-tag = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: tag `{ $tag }` ဢမ်ႇမီး tag ပိၵ်ႉ။ လူဝ်ႇပဵၼ် tag ဢၼ်ပိၵ်ႉႁင်းၵူၺ်း ဢမ်ႇၼၼ် tag `</{ $tagName }>`။
+
+parse-tag-error = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ၽိတ်းပိူင်ႈ ၼႂ်း tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: attribute `{ $attribute }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ၊ ႁၼ်ဝႃႈ ဢမ်ႇမီးတူဝ်ၵႃႈ။
+
+parse-attribute-invalid = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: attribute `{ $attribute }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ
+
+parse-attribute-value-invalid = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: တူဝ်ၵႃႈ ၶွင် attribute `{ $value }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ
+
+parse-attribute-value-quote-mismatch = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: တူဝ်ၵႃႈ ၶွင် attribute `{ $value }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ ၶိူင်ႈမၢႆၶူႈ ဢမ်ႇမႅၼ်ႈၵၼ်။ ႁၼ်ဝႃႈ ဢမ်ႇမီး `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁၼ် tag ဢၼ်ဢမ်ႇမီးၸိုဝ်ႈ tag ၸိူင်ႉၼင်ႇ `<`
+
+parse-tag-not-closed = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: tag `{ $tag }` ဢမ်ႇၺႃးပိၵ်ႉ (ႁၼ်ဝႃႈ ဢမ်ႇမီး `>`)။
+
+parse-self-closing-tag-name-missing = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁၼ် tag ဢၼ်ဢမ်ႇမီးၸိုဝ်ႈ tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: tag `{ $tag }` ဢမ်ႇၺႃးပိၵ်ႉ (ႁၼ်ဝႃႈ ဢမ်ႇမီး `/>`)။
+
+parse-tag-invalid-attributes = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: tag `{ $tag }` ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ ၸၢင်ႈပဵၼ် attribute ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။
+
+parse-close-tag-name-missing = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁၼ် tag ပိၵ်ႉ ဢၼ်ဢမ်ႇမီးၸိုဝ်ႈ tag ၸိူင်ႉၼင်ႇ `</`
+
+parse-attribute-value-unquoted = တူဝ်ၵႃႈ ၶွင် attribute လူဝ်ႇသႂ်ႇၼႂ်း ၶိူင်ႈမၢႆၶူႈ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: ႁၼ် tag ပိၵ်ႉ `{ $tag }` သေတႃႉ ဢမ်ႇမီး tag ပိုတ်ႇ ဢၼ်မႅၼ်ႈၵၼ်
+
+parse-close-tag-mismatched = DoenetML ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: tag ပိၵ်ႉ ဢမ်ႇမႅၼ်ႈၵၼ်။ လူဝ်ႇပဵၼ် `</{ $expected }>`။ ႁၼ် `{ $found }`
+
+parser-node-unconvertible = လႅၵ်ႈ node { $node } ပဵၼ် Dast node ဢမ်ႇလႆႈ။
+
+## Names
+
+name-attribute-invalid =
+    attribute name='{ $name }' ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ { $reason ->
+        [characters] ၸိုဝ်ႈ သႂ်ႇလႆႈ ၵူၺ်း တူဝ်လိၵ်ႈ, ၼပ်ႉ, ဢွၼ်ႇသဵၼ်ႈတႂ်ႈ ဢမ်ႇၼၼ် ဢွၼ်ႇသဵၼ်ႈ။
+       *[start] ၸိုဝ်ႈ လူဝ်ႇတႄႇလူၺ်ႈ တူဝ်လိၵ်ႈ။
+    }
+
+component-name-invalid-start = ၸိုဝ်ႈ component "{ $name }" ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ ၸိုဝ်ႈ လူဝ်ႇတႄႇလူၺ်ႈ တူဝ်လိၵ်ႈ။
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = answer type videoWatched လူဝ်ႇမီး attribute video
+
+answer-video-watched-video-not-reference = answer type videoWatched လူဝ်ႇမီး attribute video ဢၼ်ပဵၼ် reference
+
+answer-name-not-single-text = attribute name ၶွင် answer လူဝ်ႇမီး text လုၵ်ႈဢွၼ်ႇ ဢၼ်ၼိုင်ႈလဵဝ်
+
+## Referencing another document
+
+external-doenetml-recursion-limit = ဢဝ် DoenetML ၼွၵ်ႈ ဢမ်ႇလႆႈ ယွၼ်ႉဝႃႈ recursion ၼမ်ပူၼ်ႉတီႈ။ မီး circular reference ႁိုဝ်?
+
+external-doenetml-unavailable = ဢဝ် DoenetML ဢမ်ႇလႆႈ တီႈ { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ဢၼ်ဢဝ်မႃးတီႈ { $attribute }="{ $uri }" ဢမ်ႇထုၵ်ႇမႅၼ်ႈ: မၼ်းဢမ်ႇမႅၼ်ႈၵၼ်တင်း component type "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] attribute `{ $from }` ဢမ်ႇၸႂ်ႉယဝ်ႉ; ၸႂ်ႉ `{ $to }` တႅၼ်း။
+       *[other] [deprecation] attribute `{ $from }` ၼိူဝ် `<{ $component }>` ဢမ်ႇၸႂ်ႉယဝ်ႉ; ၸႂ်ႉ `{ $to }` တႅၼ်း။
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] attribute `{ $from }` ဢမ်ႇၸႂ်ႉယဝ်ႉ လႄႈ ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ မီး `{ $to }` မၵ်းမၼ်ႈဝႆႉၸွမ်း။
+       *[other] [deprecation] attribute `{ $from }` ၼိူဝ် `<{ $component }>` ဢမ်ႇၸႂ်ႉယဝ်ႉ လႄႈ ဢမ်ႇဢဝ်ၸႂ်ႉ ယွၼ်ႉဝႃႈ မီး `{ $to }` မၵ်းမၼ်ႈဝႆႉၸွမ်း။
+    }
+
+deprecated-attribute-ignored = [deprecation] attribute `{ $attribute }` ၼိူဝ် `<{ $component }>` ဢမ်ႇၸႂ်ႉယဝ်ႉ လႄႈ ဢမ်ႇဢဝ်ၸႂ်ႉ။
+
+deprecated-attribute-to-child = [deprecation] attribute `{ $attribute }` ၼိူဝ် `<{ $component }>` ဢမ်ႇၸႂ်ႉယဝ်ႉ; ၸႂ်ႉ `<{ $child }>` လုၵ်ႈဢွၼ်ႇ တႅၼ်း။
+
+deprecated-attribute-value-renamed = [deprecation] တူဝ်ၵႃႈ `{ $value }` ၶွင် attribute `{ $attribute }` ၼိူဝ် `<{ $component }>` ဢမ်ႇၸႂ်ႉယဝ်ႉ; ၸႂ်ႉ `{ $to }` တႅၼ်း။
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ႁဵတ်းလႆႈ ၵူၺ်း ၽႃႇသႃႇဢိင်းၵလဵတ်ႈ လႄႈ ၼႂ်း document ဢၼ်တႅမ်ႈလူၺ်ႈ { $locale } ၼၼ်ႉ text ၶွင်မၼ်း ယူႇၸိူင်ႉၼင်ႇၵဝ်ႇ။ တႅမ်ႈ ႁၢင်ႈၼမ် သိုဝ်ႈသိုဝ်ႈ ဢမ်ႇၼၼ် တင်ႈလူၺ်ႈ attribute `pluralForm`။
+
+
+## Checking against the schema
+
+schema-element-unrecognized = element `<{ $tag }>` ဢမ်ႇပဵၼ် element ၶွင် Doenet ဢၼ်ႁူႉၸၵ်း။
+
+schema-element-not-allowed-at-root = element `<{ $tag }>` သႂ်ႇဢမ်ႇလႆႈ တီႈ root ၶွင် document။
+
+schema-element-not-allowed-inside = element `<{ $tag }>` သႂ်ႇဢမ်ႇလႆႈ ၼႂ်း `<{ $parent }>`။
+
+schema-attribute-unrecognized = element `<{ $tag }>` ဢမ်ႇမီး attribute ၸိုဝ်ႈ `{ $attribute }`။
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] attribute `{ $attribute }` ၶွင် element `<{ $tag }>` လူဝ်ႇပဵၼ် list ဢၼ်ဢၼ်ၼိုင်ႈလႄႈဢၼ်ၼိုင်ႈ ပဵၼ်ဢၼ်ၼိုင်ႈၼႂ်း: { $allowed }
+       *[other] attribute `{ $attribute }` ၶွင် element `<{ $tag }>` လူဝ်ႇပဵၼ်ဢၼ်ၼိုင်ႈၼႂ်း: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = variant name တႃႇ select ဢမ်ႇထုၵ်ႇမႅၼ်ႈ။ variant name { $variantName } မီးၼႂ်း option { $numOptions } ဢၼ် သေတႃႉ ႁူဝ်ၼပ်ႉဢၼ်လိူၵ်ႈ ပဵၼ် { $numToSelect }။
+
+select-variant-name-without-options = မီး variant မၵ်းမၼ်ႈဝႆႉ တႃႇ select သေတႃႉ ဢမ်ႇမီး option တႃႇ variant name ဢၼ်ပဵၼ်လႆႈ: { $variantName }။
+
+select-variant-name-not-possible = variant name { $variantName } ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ select ၼၼ်ႉ ဢမ်ႇပဵၼ် variant name ဢၼ်ပဵၼ်လႆႈ။
+
+select-too-few-options = လိူၵ်ႈဢမ်ႇလႆႈ component { $numToSelect } ဢၼ် ၼႂ်း { $numOptions } ဢၼ်ၵူၺ်း။
+
+select-from-sequence-too-few-values = လိူၵ်ႈဢမ်ႇလႆႈ တူဝ်ၵႃႈ { $numToSelect } ဢၼ် ၼႂ်း sequence ဢၼ်ယၢဝ်း { $length }။
+
+select-from-sequence-indices-count-mismatch = ႁူဝ်ၼပ်ႉ indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ select လူဝ်ႇမႅၼ်ႈၵၼ်တင်း ႁူဝ်ၼပ်ႉဢၼ်လိူၵ်ႈ
+
+select-from-sequence-indices-not-integers = indices ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ select ၵူႈဢၼ် လူဝ်ႇပဵၼ် integer
+
+select-from-sequence-index-excluded = index ၶွင် selectfromsequence ဢၼ်မၵ်းမၼ်ႈဝႆႉၼၼ်ႉ ၺႃးဢဝ်ဢွၵ်ႇဝႆႉ
+
+select-from-sequence-indices-excluded-combination = indices ၶွင် selectfromsequence ဢၼ်မၵ်းမၼ်ႈဝႆႉၼၼ်ႉ ပဵၼ် combination ဢၼ်ဢဝ်ဢွၵ်ႇဝႆႉ
+
+select-from-sequence-coprime-not-positive-integers = လိူၵ်ႈဢမ်ႇလႆႈ coprime combination ယွၼ်ႉဝႃႈ ဢမ်ႇလိူၵ်ႈ integer ဢၼ်လိူဝ်သုၼ်။
+
+select-from-sequence-coprime-common-factor = လိူၵ်ႈဢမ်ႇလႆႈ coprime number။ တူဝ်ၵႃႈ ဢၼ်ပဵၼ်လႆႈၵူႈဢၼ် မီး factor ႁူမ်ႈၵၼ်။ (တူဝ်ၵႃႈ "from" ဢမ်ႇၼၼ် "to" ဢၼ်မၵ်းမၼ်ႈဝႆႉ လူဝ်ႇပဵၼ် coprime တင်း "step"။)
+
+select-from-sequence-coprime-single-number = လိူၵ်ႈဢမ်ႇလႆႈ coprime combination ၼႂ်း number ဢၼ်ၼိုင်ႈလဵဝ် ဢၼ်ဢမ်ႇၸႂ်ႈ 1။
+
+select-from-sequence-excluded-too-many-combinations = ဢဝ်ဢွၵ်ႇဝႆႉ combination ၼမ်လိူဝ် 70% ၼႂ်း selectFromSequence
+
+select-from-sequence-coprime-none-found = လိူၵ်ႈဢမ်ႇလႆႈ coprime number။ တူဝ်ၵႃႈ ဢၼ်ပဵၼ်လႆႈၵူႈဢၼ် မီး factor ႁူမ်ႈၵၼ်။
+
+select-from-sequence-too-few-unique-values = လိူၵ်ႈဢမ်ႇလႆႈ တူဝ်ၵႃႈ unique { $numToSelect } ဢၼ် ၼႂ်း sequence ဢၼ်ယၢဝ်း { $numPossibleValues }
+
+select-prime-numbers-too-few-values = လိူၵ်ႈဢမ်ႇလႆႈ တူဝ်ၵႃႈ { $numToSelect } ဢၼ် ၼႂ်းသဵၼ်ႈမၢႆ prime ဢၼ်ယၢဝ်း { $numValues }
+
+select-prime-numbers-values-count-mismatch = ႁူဝ်ၼပ်ႉ တူဝ်ၵႃႈ ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ select လူဝ်ႇမႅၼ်ႈၵၼ်တင်း ႁူဝ်ၼပ်ႉဢၼ်လိူၵ်ႈ
+
+select-prime-numbers-values-not-prime = တူဝ်ၵႃႈ ဢၼ်မၵ်းမၼ်ႈဝႆႉ တႃႇ select prime number ၵူႈဢၼ် လူဝ်ႇမီးၼႂ်း သဵၼ်ႈမၢႆ prime
+
+select-prime-numbers-values-excluded-combination = တူဝ်ၵႃႈ ၶွင် selectPrimeNumbers ဢၼ်မၵ်းမၼ်ႈဝႆႉၼၼ်ႉ ပဵၼ် combination ဢၼ်ဢဝ်ဢွၵ်ႇဝႆႉ
+
+select-prime-numbers-excluded-too-many-combinations = ဢဝ်ဢွၵ်ႇဝႆႉ combination ၼမ်လိူဝ် 70% ၼႂ်း selectPrimeNumbers
+
+select-random-combination-fluke = ယွၼ်ႉၶၢင်ႈပဵၼ်ယၢပ်ႇတႄႉတႄႉ လိူၵ်ႈဢမ်ႇလႆႈ combination ၶွင် တူဝ်ၵႃႈ random
+
+select-random-value-fluke = ယွၼ်ႉၶၢင်ႈပဵၼ်ယၢပ်ႇတႄႉတႄႉ လိူၵ်ႈဢမ်ႇလႆႈ တူဝ်ၵႃႈ random
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` ဢၼ်ၼႆႉ ဢမ်ႇၼႄ ယွၼ်ႉဝႃႈ မၼ်းယူႇၼႂ်း math သေတႃႉ ဢမ်ႇပဵၼ် `inline`။ သႂ်ႇ `inline` ႁႂ်ႈမၼ်းပဵၼ် drop-down list ဢၼ်လုၵ်ႈၼႂ်း expression။
+        [expanded] `<{ $component }>` ဢၼ်ၼႆႉ ဢမ်ႇၼႄ ယွၼ်ႉဝႃႈ မၼ်းယူႇၼႂ်း math သေ ပဵၼ် `expanded`။ ဢဝ် `expanded` ဢွၵ်ႇ; ႁွင်ႈ ဢၼ်မီးလၢႆထႅဝ် ဢမ်ႇလုၵ်ႈၼႂ်း expression။
+        [on-graph] `<{ $component }>` ဢၼ်ၼႆႉ ဢမ်ႇၼႄ ယွၼ်ႉဝႃႈ မၼ်းယူႇၼႂ်း math ဢၼ်တမ်းဝႆႉၼိူဝ် graph ဢၼ်ဢမ်ႇမီးတီႈတႃႇ input။
+       *[relative-width] `<{ $component }>` ဢၼ်ၼႆႉ ဢမ်ႇၼႄ ယွၼ်ႉဝႃႈ မၼ်းယူႇၼႂ်း math သေ မီး width ဢၼ်ပဵၼ် relative။ ပၼ် width လူၺ်ႈ ၶၼႃးဢၼ်တၢႆတူဝ် ၸိူင်ႉၼင်ႇ `px` တႅၼ်း။
+    }

--- a/packages/i18n/locales/shn/editor.ftl
+++ b/packages/i18n/locales/shn/editor.ftl
@@ -1,0 +1,234 @@
+# Shan (လိၵ်ႈတႆး) editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Variety, script and spacing** are as `chrome.ftl`'s header sets them out:
+# modern reformed Shan orthography with the Shan letters ၵ ၶ ၸ ၺ ၼ ပ ၽ ၾ ႁ ဢ,
+# the Shan vowels ႃ ႄ ႅ ႆ ွ ႂ and the Shan tone marks ႇ ႈ း ႉ ႊ — never their
+# Burmese look-alikes — and spaces between words.
+#
+# **This is the file where the loans are heaviest, and it should be read as
+# such.** The editor's own nouns are English almost without exception —
+# `editor`, `viewer`, `variant`, `filter`, `component`, `attribute`,
+# `reference`, `property`, `snippet`, `array entry`, `type`, `style`,
+# `default`, `coordinate`, `function`, `line`, `tag`, `report`, `credit`,
+# `accessibility`, `Answer Id` — **around a Shan frame**. What is Shan here is
+# the word order (verb before object, modifier after head noun), the
+# postposed relative ဢၼ်, and the ordinary verbs ၼႄ (show), လိူၵ်ႈ (choose),
+# ႁႃ (look for), ႁၼ် (find), မီး (have), ပဵၼ် (be), နဵၵ်း (press). The Burmese
+# loans, in Burmese spelling, are သတိပေးချက် (warning), အချက်အလက်
+# (information) and ၶေႃႈၸီႉၼႄ's neighbour အကြံပြုချက် (recommendation).
+#
+# **`editor-update-viewer`'s two words are Shan**: မႄးမႂ်ႇ ('renew') for
+# Update and ၶိုၼ်းတင်ႈ ('set again') for Reset. Both sit on a narrow toolbar
+# button and both are longer than the English; if they do not fit, that is a
+# layout problem to report rather than a reason to shorten them wrongly.
+#
+# **What this catalog does not know.** The context-help panel's register —
+# what a Shan mathematics teacher actually calls a reference, a property or a
+# default — is not something this seed could establish, so those sentences are
+# a Shan frame around the English words and read as such. The panel is the
+# first place a speaker's rewriting will show.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ၶိုၼ်းတင်ႈ
+       *[update] မႄးမႂ်ႇ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } viewer
+       *[other] { $word } viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = variant
+
+editor-variant-filter = filter…
+
+editor-variant-next = လိူၵ်ႈ variant တေႃႇၼႃႈ
+
+editor-variant-previous = လိူၵ်ႈ variant ဢွၼ်တၢင်း
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] ႁၼ် WCAG AA accessibility ၽိတ်းပိူင်ႈ။ နဵၵ်း တႃႇ { $action ->
+            [close] ပိၵ်ႉ
+           *[open] ပိုတ်ႇ
+        } accessibility report။
+        [advisories] နဵၵ်း တႃႇ { $action ->
+            [close] ပိၵ်ႉ
+           *[open] ပိုတ်ႇ
+        } accessibility report။ ဢမ်ႇႁၼ် WCAG AA ၽိတ်းပိူင်ႈ သေတႃႉ မီး အကြံပြုချက် accessibility ထႅင်ႈ။
+       *[clean] နဵၵ်း တႃႇ { $action ->
+            [close] ပိၵ်ႉ
+           *[open] ပိုတ်ႇ
+        } accessibility report။ ဢမ်ႇႁၼ် ပၼ်ႁႃ accessibility သင်။
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] ႁၼ် WCAG AA accessibility ၽိတ်းပိူင်ႈ။ ႁၼ် WCAG AA ၽိတ်းပိူင်ႈ { $count } ဢၼ်။ နဵၵ်း တႃႇ { $action ->
+            [close] ပိၵ်ႉ
+           *[open] ပိုတ်ႇ
+        } accessibility report။
+        [advisories] ဢမ်ႇႁၼ် WCAG AA ၽိတ်းပိူင်ႈ။ ႁၼ် အကြံပြုချက် accessibility ထႅင်ႈ { $count } ဢၼ်။ နဵၵ်း တႃႇ { $action ->
+            [close] ပိၵ်ႉ
+           *[open] ပိုတ်ႇ
+        } accessibility report။
+       *[clean] ဢမ်ႇႁၼ် WCAG AA ၽိတ်းပိူင်ႈ။ နဵၵ်း တႃႇ { $action ->
+            [close] ပိၵ်ႉ
+           *[open] ပိုတ်ႇ
+        } accessibility report။
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = ၵၢၼ်ၸွႆႈထႅမ် ၸွမ်းၼင်ႇ ဢွင်ႈတီႈ
+editor-tab-help-short = ၸွႆႈထႅမ်
+editor-tab-errors = ၽိတ်းပိူင်ႈ
+editor-tab-warnings = သတိပေးချက်
+editor-tab-info = အချက်အလက်
+editor-tab-accessibility = accessibility
+editor-tab-responses = ၶေႃႈတွပ်ႇ ဢၼ်သူင်ႇယဝ်ႉ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = လွင်ႈလိူၵ်ႈ ၶွင် editor
+editor-format-as-doenetml = ႁဵတ်းႁၢင်ႈ ပဵၼ် DoenetML
+editor-format-as-xml = ႁဵတ်းႁၢင်ႈ ပဵၼ် XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = line #{ $line }
+
+editor-no-errors = ဢမ်ႇမီး ၽိတ်းပိူင်ႈ
+editor-no-warnings = ဢမ်ႇမီး သတိပေးချက်
+editor-no-info = ဢမ်ႇမီး info diagnostic
+
+editor-show-info-annotations = ၼႄ info diagnostic ၼႂ်း editor
+editor-show-accessibility-annotations = ၼႄ accessibility diagnostic ၼႂ်း editor
+
+editor-accessibility-learn-more = ႁဵၼ်းႁူႉ လွင်ႈ Doenet ႁဵတ်းသၢင်ႈ accessibility
+
+editor-accessibility-violations-heading = accessibility ၽိတ်းပိူင်ႈ ({ $standard })
+
+editor-accessibility-other-heading = ပၼ်ႁႃ accessibility တၢင်ႇဢၼ်
+editor-none-found = ဢမ်ႇႁၼ်သင်
+
+
+## Submitted responses
+
+editor-no-responses = ပႆႇမီး ၶေႃႈတွပ်ႇ ဢၼ်သူင်ႇယဝ်ႉ
+editor-response-answer-id = Answer Id
+editor-response-response = ၶေႃႈတွပ်ႇ
+editor-response-credit = credit
+editor-response-submitted = သူင်ႇယဝ်ႉ
+
+
+## The context-help panel
+
+help-placeholder = ဝၢင်း cursor တီႈ tag, attribute ဢမ်ႇၼၼ် { $ref } တႃႇ လူတူၺ်း documentation။
+
+help-unsupported-ref-chain = ပႆႇႁဵတ်းဝႆႉ ၵၢၼ်ၸွႆႈထႅမ် တႃႇ reference လၢႆတွၼ်ႈ ၸိူင်ႉၼင်ႇ { $example }။
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ႁႃဢမ်ႇႁၼ် တီႈဢၼ် reference ၼႄ: { $ref }။
+        [multiple] ႁၼ် တီႈဢၼ် reference ၼႄ လၢႆဢၼ်: { $ref }။
+       *[indeterminate] မၵ်းမၼ်ႈဢမ်ႇလႆႈ တီႈဢၼ် { $ref } ၼႄ။
+    }
+
+help-learn-about-references = ႁဵၼ်းႁူႉ လွင်ႈ reference →
+help-reference-page = ၼႃႈလိၵ်ႈ reference →
+
+help-suggestions-header =
+    { $location ->
+        [inside] ၼႂ်း { $element }
+       *[top] တီႈ top level
+    }{ $allowed ->
+        [none] { " — ဢမ်ႇသႂ်ႇလႆႈသင်တီႈၼႆႈ။" }
+        [text] { " — သႂ်ႇ text တီႈၼႆႈ။" }
+        [text-and-components] { " — သႂ်ႇ text တီႈၼႆႈ ဢမ်ႇၼၼ် ၸၢမ်းတူၺ်း:" }
+       *[components] { " — ဢၼ်ၸၢမ်းလႆႈ:" }
+    }
+
+help-suggestions-footer = နဵၵ်း { $shortcut } တႃႇ တူၺ်း component ၵူႈဢၼ် { $total } ဢၼ်။
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ပဵၼ် reference ၸူး { $target }။
+       *[other] { $ref } ပဵၼ် reference ၸူး { $target } (line { $line })။
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ဢွၼ်သႂ်ႇဝႆႉ ပဵၼ် { $role }။
+       *[other] { $owner } ဢွၼ်သႂ်ႇဝႆႉ တီႈ line { $line } ပဵၼ် { $role }။
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ပဵၼ် reference ၸူး property { $property } ၶွင် { $element }။
+       *[other] { $ref } ပဵၼ် reference ၸူး property { $property } ၶွင် { $element } (line { $line })။
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = default:
+help-active-default = default ဢၼ်ၸႂ်ႉယူႇ:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] တူဝ်ၵႃႈ ဢၼ်သႂ်ႇလႆႈ (ဢၼ်ၼိုင်ႈလႄႈဢၼ်ၼိုင်ႈ):
+       *[other] တူဝ်ၵႃႈ ဢၼ်သႂ်ႇလႆႈ:
+    }
+
+help-suggested-values = တူဝ်ၵႃႈ ဢၼ်ၸီႉၼႄ:
+
+help-inserts = သႂ်ႇပၼ်:
+
+help-coordinates =
+    { $count ->
+       *[other] coordinate:
+    }
+
+help-type = type:
+
+help-resolved-style = style ဢၼ်ဢွၵ်ႇမႃး (styleNumber { $styleNumber }):
+
+help-resolved-function-names = ၸိုဝ်ႈ function ဢၼ်ဢွၵ်ႇမႃး:
+help-reset-list = reset list တီႈ input ဢၼ်ၼႆႉ:
+help-added-on-input = ထႅမ်သႂ်ႇ တီႈ input ဢၼ်ၼႆႉ:
+help-removed-on-input = ဢဝ်ဢွၵ်ႇ တီႈ input ဢၼ်ၼႆႉ:
+
+help-reset-overrides = { $reset } ၶိုၼ်ႈပူၼ်ႉ { $additional } လႄႈ { $removed }။

--- a/packages/i18n/locales/tsg/chrome.ftl
+++ b/packages/i18n/locales/tsg/chrome.ftl
@@ -24,10 +24,16 @@
 # nothing in this file should be converted piecemeal: **all four files at
 # once, or none.**
 #
-# ORTHOGRAPHY. Tausug has three vowels — **a, i, u** — and this catalog writes
-# only those. The glottal stop is written with an **apostrophe** («puti'»,
-# «sala'», «pana'»), and a doubled consonant is a real length contrast
-# («bunnal», «gaddung»), not a typo. Loanwords are the one place the three
+# ORTHOGRAPHY. Tausug has three vowel qualities — **a, i, u** — and this
+# catalog writes only those, each in a plain and a **macron** form: «ā», «ī»,
+# «ū» mark the long vowel the Tausug dictionary tradition marks, in «Sūg»,
+# «sāya», «katān», «pī'», «siyusūd». The macron is a length mark rather than a
+# stress mark or a fourth vowel, it is written on the same words every time
+# they appear, and **stripping it is a respelling rather than a
+# simplification**. The glottal stop is written with an **apostrophe**
+# («puti'», «sala'», «pana'») — the ASCII `'`, never a curly quote — and a
+# doubled consonant is a real length contrast in a consonant («bunnal»,
+# «gaddung»), not a typo. Loanwords are the one place the three
 # vowels break down: rather than respell a borrowing into an invented Tausug
 # phonology, this catalog **keeps a loan in the spelling of the language it
 # was borrowed from** — «kolum», «pahina», «solusyon», «rombo», «sirkulo»,

--- a/packages/i18n/locales/tsg/chrome.ftl
+++ b/packages/i18n/locales/tsg/chrome.ftl
@@ -1,0 +1,182 @@
+# Tausug viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Tausug** (Bahasa Sūg), the Bisayan language of the Sulu archipelago, of
+# Zamboanga and Basilan in the Philippines, and of Sabah in Malaysia.
+#
+# **SCRIPT: LATIN, AND THE ARGUMENT FOR IT.** Tausug has two written
+# traditions. **Sulat Sūg** — the Jawi-derived Arabic script — is the older,
+# is still written for religious material and in personal use, and is the one
+# a reader may feel the language properly belongs in. **Latin** is what
+# Philippine MTB-MLE schoolbooks, dictionaries, Bible and Qur'an translations
+# and everything on a screen are set in today. This catalog is **Latin**, for
+# a reason about this software rather than about the language: these strings
+# sit beside DoenetML source, attribute names and mathematics that are Latin
+# and left-to-right, and a right-to-left Arabic-script catalog would put a
+# bidi boundary in the middle of nearly every message here. A reader who
+# wants Sulat Sūg should have a catalog of its own rather than a mixture, and
+# nothing in this file should be converted piecemeal: **all four files at
+# once, or none.**
+#
+# ORTHOGRAPHY. Tausug has three vowels — **a, i, u** — and this catalog writes
+# only those. The glottal stop is written with an **apostrophe** («puti'»,
+# «sala'», «pana'»), and a doubled consonant is a real length contrast
+# («bunnal», «gaddung»), not a typo. Loanwords are the one place the three
+# vowels break down: rather than respell a borrowing into an invented Tausug
+# phonology, this catalog **keeps a loan in the spelling of the language it
+# was borrowed from** — «kolum», «pahina», «solusyon», «rombo», «sirkulo»,
+# «teorema» — and says so here.
+#
+# **THE LINKER.** Tausug joins a modifier to what it modifies with **«nga»**,
+# and «nga» is a free word in every position — it does not contract onto the
+# word before it the way Kapampangan's and Bikol's linkers do. So this catalog
+# writes it out everywhere and never has to know what stands beside a
+# placeable. That is the escape `locales/ceb`, `locales/war` and `locales/hil`
+# already take, and it is why the composition messages in
+# `locales/tsg/content.ftl` can put the adjectives **in front of** the noun.
+#
+# THREE LAYERS, ALL DECLARED. Tausug's technical register is not one thing:
+#
+#   - a **Malay layer**, old and thoroughly Tausug: «atawa» (or), «iban»
+#     (and, with), «kuning», «biru», «titik», «baris»;
+#   - an **Arabic layer** through Islam: «ma'na» (definition), «misalan»
+#     (example), «parakala'» (problem, matter);
+#   - a **Filipino/Spanish and English layer** from the school system, which
+#     is where the mathematics comes from: «sirkulo», «rombo»,
+#     «triyanggulo», «kuwadrado», «solusyon», and the English terms this
+#     catalog keeps whole because the classroom does.
+#
+# **THE GRAMMATICAL ASSUMPTION THIS SEED MAKES, STATED IN ONE PLACE.** Tausug
+# verbs are written here as **`nag-` plus CV-reduplication for the
+# progressive** («Nagpapariksa») and as **bare or `-a`-suffixed roots for the
+# imperative** («Dugang», «Tapuka»). If Tausug builds either otherwise, every
+# verb in these four files is wrong in the same predictable way, and one pass
+# fixes all of them. The particles around them are not assumed: **«in»**
+# (topic), **«sin»** (genitive), **«ha»** (oblique), **«dayn ha»** (from),
+# **«manga»** (plural), **«awn»** (there is) and **«way»** (there is none)
+# are Tausug and are the words to check this file by.
+#
+# **THE THREE NEGATORS ARE KEPT APART**, which is the other quick check:
+# **«di'»** before a verb, **«bukun»** before a noun or an identification,
+# **«way»** for "there is none". A stray Filipino «hindi» or «wala» would be
+# a defect.
+#
+# WHAT THIS CATALOG DOES NOT KNOW. It has no settled Tausug word for
+# "feedback" and writes «Panghindu'», which properly means instruction; and
+# it keeps the English `renderer` and `keyboard`. Those three are the first
+# places to look.
+#
+# PLURALS. `Intl.PluralRules` has no data for `tsg`, so a `[one]` branch would
+# be selected by the runtime's default locale rather than by Tausug — and
+# Tausug would not want one, since a noun after a numeral takes no «manga» and
+# no other marking. Every count select is collapsed to a single `*[other]`. An
+# explicit `[0]` is matched against the number itself rather than against a
+# plural category, so it stays.
+
+
+## Answer submission
+
+answer-checking = Nagpapariksa…
+answer-submitting = Nagpapasampay…
+answer-checking-status = Nagpapariksa sin sambag
+answer-submitting-status = Nagpapasampay sin sambag
+answer-correct = Tama'
+answer-incorrect = Sala'
+answer-response-saved = Naitipun na in sambag
+answer-percent-credit = { $percent }% nga marka
+answer-percent-correct = { $percent }% tama'
+answer-percent-short = { $percent } %
+max-credit-available = In marka nga landu' mataas: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] way na pagsulay
+       *[other] { $count } pagsulay pa
+    }
+validation-correct = (Tama')
+validation-incorrect = (Sala')
+validation-partially-correct = (Tama' in kaibanan)
+answer-show-responses =
+    { $count ->
+       *[other] Pakita' in { $count } sambag ha { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Panghindu'
+collapsible-click-to-open = (pindut ha pag-ukab)
+collapsible-click-to-close = (pindut ha pagtambul)
+collapsible-initializing = Nagsasakap…
+footnote-show = Pakita' in nuta ha babaan
+footnote-hide = Tapuka in nuta ha babaan
+description-more-information = dugang kaingatan
+
+
+## Controls
+
+slider-previous = Nakauna
+slider-next = Sumunud
+keyboard-open = Ukab Keyboard
+keyboard-close = Tambul Keyboard
+choice-input-remove-choice = Tanggal { $choice }
+matrix-remove-row = Tanggal baris
+matrix-add-row = Dugang baris
+matrix-remove-column = Tanggal kolum
+matrix-add-column = Dugang kolum
+subset-add-remove-points = Dugang/Tanggal manga titik
+subset-toggle-points-intervals = Pagsalli' manga titik iban interval
+subset-move-points = Pinda Manga Titik
+subset-clear = Hapus
+orbital-add-row = Dugang Baris
+orbital-remove-row = Tanggal Baris
+orbital-add-box = Dugang Kahun
+orbital-remove-box = Tanggal Kahun
+orbital-add-up-arrow = Dugang Pana' Pataas
+orbital-add-down-arrow = Dugang Pana' Pababa'
+orbital-remove-arrow = Tanggal Pana'
+orbital-row-label = Label sin baris { $row }
+pretzel-answer = Sambag
+summary-statistics-caption = Kabuuran sin statistik sin { $column }
+
+
+## Math input
+
+math-input-preview-region = pagkita' pauna sin ekspresyon matematika
+math-input-preview = Pagkita' Pauna
+math-input-invalid-expression = Ekspresyon sala':
+
+
+## Document status
+
+viewer-initializing = Nagsasakap…
+
+
+## Errors
+
+error-heading = Kasala'an
+error-found-at =
+    { $span ->
+        [line] Kiyabaakan ha baris { $startLine }.
+       *[lines] Kiyabaakan ha manga baris { $startLine }–{ $endLine }.
+    }
+document-contains-errors = In dukumintu ini awn kasala'an!
+diagnostic-heading-error = Kasala'an
+diagnostic-heading-warning = Pagpahati'
+diagnostic-heading-information = Kaingatan
+diagnostic-heading-hint = Panuntun
+accessibility-heading-level-1 = Paglanggal sin akses WCAG AA
+accessibility-heading-level-2 = Pagpahati' pasal akses
+something-went-wrong = Awn nasala'.
+renderer-load-failed = way nakarga hambuuk renderer. Balika pagkarga in pahina.
+core-start-failed = In dukumintu ini di' nakatagna'. Balika pagkarga in pahina.
+core-start-failed-busy = In dukumintu ini di' nakatagna'. Mataud dukumintu in nagtagna' ha hangka-waktu, iban malugay pa ini ha kasangkapan nga mahinay. Bang nakaubus na in kaibanan dukumintu, in pagbalik pagkarga sin pahina makatabang.
+core-start-failed-retry = In dukumintu ini di' nakatagna'.
+core-start-failed-busy-retry = In dukumintu ini di' nakatagna'. Mataud dukumintu in nagtagna' ha hangka-waktu, iban malugay pa ini ha kasangkapan nga mahinay.
+core-start-retry = Sulaya Magbalik
+saved-state-unavailable = In hinang mu nga naitipun di' nakarga.

--- a/packages/i18n/locales/tsg/content.ftl
+++ b/packages/i18n/locales/tsg/content.ftl
@@ -1,0 +1,294 @@
+# Tausug content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Tausug** (Bahasa Sūg) of the Sulu archipelago, Zamboanga, Basilan and
+# Sabah, written in the **Latin** orthography of Philippine schoolbooks and
+# dictionaries rather than in Sulat Sūg, the Jawi-derived Arabic script that
+# is the language's older tradition. `locales/tsg/chrome.ftl` argues that
+# choice and states the spelling rules — three vowels, the apostrophe for the
+# glottal stop, doubled consonants for length, and loanwords kept in the
+# spelling of the language they came from.
+#
+# **WORD ORDER, AND WHY IT IS NOT THE ONE ITS TWO NEIGHBOURS IN THIS BATCH
+# USE.** The describing words come **in front of** the noun and every join is
+# the linker **«nga»**: "thick dashed red line" is «makapal nga pinutu'-putu'
+# nga pula nga linya» — width, dash pattern, colour, then the noun, which is
+# English's order among the adjectives. `locales/iba` and `locales/dtp` both
+# put their adjectives behind the noun; Tausug does not, and a reviewer should
+# not "fix" this file to match them.
+#
+# **«nga» IS A FREE WORD IN EVERY POSITION.** It never contracts onto what
+# precedes it, so it can be written before and after a placeable without
+# knowing what lands there — the escape the Bisayan catalogs already take (see
+# "A ligature is an affix too" in the package README). Every «nga» in
+# `style-stroke`, `style-with-noun` and `style-filled-with-noun` is there for
+# that reason. Where a description is a single word, no linker is written,
+# because there is nothing to link it to yet — the linker before the noun is
+# supplied by `style-with-noun`.
+#
+# The side count folds into the head — «regular nga polygon nga taga 5 sisi» —
+# so `[tail]` is empty.
+#
+# GENDER AND NUMBER. Tausug has no grammatical gender and does not inflect a
+# describing word to agree with its noun, so `$gender` and `$role` are
+# received and ignored, as in English. A noun after a numeral takes no
+# «manga» and no other marking. Tausug has no article; «in» is a topic marker
+# and not one, so the two `-article` branches read like the ones without.
+#
+# **THE MATHEMATICS IS THE CLASSROOM'S, AND THE CLASSROOM IS PHILIPPINE.**
+# The shape names are the **Spanish-derived forms that reached Tausug through
+# Filipino** and are in ordinary use — «sirkulo», «rombo», «triyanggulo»,
+# «rektanggulo», «kuwadrado», «parabola». The terms with no such form are
+# **kept in English whole**, because that is the word a Tausug pupil meets:
+# `slope field`, `vector field`, `polyline`, `polygon`, `vector`, `function`.
+# Writing a Tausug-looking respelling of those would invent a word rather than
+# report one.
+#
+# WHAT IS TAUSUG HERE. «itum», «puti'», «pula», «gaddung», «makapal»,
+# «manipis»; «titik» for the point and «lugal» for the region; «napnu'» for
+# filled and «di' napnu'» for unfilled; «kilid» for a border; «atawa», «bang»,
+# «bang bukun», «iban», «dayn ha», «awn», «way»; «sambag» for the answer,
+# «ladawan» for the figure, «pangasubu» for the question, «bunnal» for true.
+#
+# CONFIDENCE. The colour list is the thinnest part of the file. «kahil»
+# (orange) is the citrus fruit and is a reach for the colour; «rusas» (pink)
+# and «cuklat» (brown) are loans a speaker uses rather than Tausug words;
+# «abu-abu» (gray) and «ungu» (purple) are the Malay-layer forms, and a
+# speaker may prefer the Filipino ones. «biru gaddung» for cyan is a
+# description, not a term.
+#
+# CHEMISTRY. `element-name` and `element-anion-name` are deliberately **left
+# out**, so their ~130 keys fall back to English. This is the case
+# `locales/fil` and `locales/ceb` already record: the Philippines teaches
+# science in English from the intermediate grades, so the fallback **is** the
+# curriculum, and a Tausug pupil meets the periodic table in the same English
+# the fallback supplies. The frames around the names are translated, because
+# they are frames rather than vocabulary.
+
+
+## Style vocabulary
+
+color =
+    .black = itum
+    .white = puti'
+    .gray = abu-abu
+    .red = pula
+    .orange = kahil
+    .yellow = kuning
+    .green = gaddung
+    .cyan = biru gaddung
+    .blue = biru
+    .purple = ungu
+    .pink = rusas
+    .brown = cuklat
+line-width =
+    .thick = makapal
+    .thin = manipis
+line-style =
+    .dashed = pinutu'-putu'
+    .dotted = titik-titik
+# Noun phrases: they follow «iban» and modify nothing themselves. «manga» is
+# the plural marker.
+fill-style =
+    .horizontal = manga linya nga horizontal
+    .vertical = manga linya nga vertical
+    .diagonal = manga linya nga diagonal
+    .backdiagonal = manga linya nga diagonal pabalik
+    .dots = manga titik
+    .diamonds = manga rombo
+noun =
+    .line = linya
+    .line-segment = bahagi' sin linya
+    .ray = sinag
+    .vector = vector
+    .curve = kurba
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = triyanggulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = lugal
+    .point = titik
+    .square = kuwadrado
+    .diamond = rombo
+    .cross = kurus
+    .plus = plus
+# «taga» — "having" — has to stay beside the number counting the sides, so the
+# count folds into the head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] regular nga polygon nga taga { $numSides } sisi
+    }
+# Tausug has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } nga { $lineStyle } nga { $color }
+        [width-color] { $width } nga { $color }
+        [style-color] { $lineStyle } nga { $color }
+        [width-style] { $width } nga { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# The describing words lead and the linker joins them to the noun: «makapal
+# nga pula nga linya».
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } nga { $noun } { $nounTail }
+       *[noun] { $description } nga { $noun }
+    }
+style-filled-word = napnu'
+# «iban» carries English's "with"; «iban isab» — "and also" — is what chains a
+# further clause on, which is the only thing separating the `[and]` branches
+# below from the `[with]` ones.
+style-filled =
+    { $parts ->
+        [pattern] { $filled } nga { $color } iban { $pattern }
+       *[plain] { $filled } nga { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } nga { $color } nga { $noun } iban { $pattern }
+        [plain-tail] { $filled } nga { $color } nga { $noun } { $nounTail }
+        [pattern-tail] { $filled } nga { $color } nga { $noun } { $nounTail } iban { $pattern }
+       *[plain] { $filled } nga { $color } nga { $noun }
+    }
+# Tausug has no article, so the `-article` branches read like the ones
+# without.
+style-border-clause =
+    { $parts ->
+        [with-article] iban { $border } nga kilid
+        [and] iban isab { $border } nga kilid
+        [and-article] iban isab { $border } nga kilid
+       *[with] iban { $border } nga kilid
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } nga { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = di' napnu'
+style-text =
+    { $parts ->
+        [background] { $color } iban { $background } nga likuran
+       *[plain] { $color }
+    }
+# «way» is Tausug's "there is none", the negative counterpart of «awn».
+style-background-none = way
+
+
+## Boolean words
+
+boolean-true = bunnal
+boolean-false = bukun bunnal
+
+
+## Answer buttons
+
+answer-submit-label = Pariksa in Hinang
+answer-submit-label-no-correctness = Papasampay in Sambag
+
+
+## Sectional blocks
+##
+## Tausug does not mark number on a noun, so `.exercise` and `.exercises`, and
+## `.problem` and `.problems`, are the same word. «Ma'na», «Misalan» and
+## «Parakala'» are the Arabic layer; «Seksyon», «Solusyon» and «Teorema» are
+## the Filipino one, kept in Filipino spelling for the reason the header
+## gives.
+
+section-name =
+    .activity = Hinang
+    .aside = Sulat ha Kilid
+    .cascade = Cascade
+    .definition = Ma'na
+    .example = Misalan
+    .exercise = Pagsanay
+    .exercises = Pagsanay
+    .given-answer = Sambag
+    .note = Nuta
+    .objectives = Manga Tuyu'
+    .paragraphs = Manga Parapo
+    .part = Bahagi'
+    .problem = Parakala'
+    .problems = Parakala'
+    .proof = Bukti
+    .question = Pangasubu
+    .section = Seksyon
+    .solution = Solusyon
+    .task = Tugas
+    .theorem = Teorema
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Panuntun
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Talaan { $enumeration }
+        [numbered-title] Talaan { $enumeration }{ ": " }
+        [unnumbered-title] Talaan{ ": " }
+       *[unnumbered] Talaan
+    }
+figure-name =
+    { $parts ->
+        [numbered] Ladawan { $enumeration }
+        [numbered-caption] Ladawan { $enumeration }{ ": " }
+        [unnumbered-caption] Ladawan{ ": " }
+       *[unnumbered] Ladawan
+    }
+
+
+## Paginator controls
+
+paginator-previous = Nakauna
+paginator-next = Sumunud
+paginator-page = Pahina
+paginator-page-status = { $pageLabel } { $currentPage } dayn ha { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = atawa
+piecewise-condition-if = bang
+piecewise-condition-otherwise = bang bukun
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header for why. These three are frames rather than vocabulary, so they are
+## translated whether or not the names ever are.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Sala' nga Simbul Kimika
+chemistry-invalid-ionic-compound = Sala' nga Ionic Compound
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = lu'ang
+math-embedded-input-blank-ordinal = lu'ang { $ordinal } dayn ha { $total }

--- a/packages/i18n/locales/tsg/content.ftl
+++ b/packages/i18n/locales/tsg/content.ftl
@@ -61,7 +61,7 @@
 # description, not a term.
 #
 # CHEMISTRY. `element-name` and `element-anion-name` are deliberately **left
-# out**, so their ~130 keys fall back to English. This is the case
+# out**, so their 130 keys fall back to English. This is the case
 # `locales/fil` and `locales/ceb` already record: the Philippines teaches
 # science in English from the intermediate grades, so the fallback **is** the
 # curriculum, and a Tausug pupil meets the periodic table in the same English

--- a/packages/i18n/locales/tsg/content.ftl
+++ b/packages/i18n/locales/tsg/content.ftl
@@ -8,9 +8,10 @@
 # Sabah, written in the **Latin** orthography of Philippine schoolbooks and
 # dictionaries rather than in Sulat Sūg, the Jawi-derived Arabic script that
 # is the language's older tradition. `locales/tsg/chrome.ftl` argues that
-# choice and states the spelling rules — three vowels, the apostrophe for the
-# glottal stop, doubled consonants for length, and loanwords kept in the
-# spelling of the language they came from.
+# choice and states the spelling rules — three vowel qualities with a macron
+# for length, the apostrophe for the glottal stop, doubled consonants for a
+# long consonant, and loanwords kept in the spelling of the language they came
+# from.
 #
 # **WORD ORDER, AND WHY IT IS NOT THE ONE ITS TWO NEIGHBOURS IN THIS BATCH
 # USE.** The describing words come **in front of** the noun and every join is

--- a/packages/i18n/locales/tsg/diagnostics.ftl
+++ b/packages/i18n/locales/tsg/diagnostics.ftl
@@ -1,0 +1,701 @@
+# Tausug diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of the other three files of this locale;
+# see `locales/tsg/chrome.ftl` for the argument against Sulat Sūg, for the
+# spelling rules, and for the verb-formation assumption every verb here rests
+# on.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source, and so do `PreFigure`, `DoenetML` and `Dast`.
+#
+# FOUR PHRASES CARRY MOST OF THIS FILE, and naming them here means a
+# corrector can change all of them at once:
+#
+#   - "is ignored" is **«di' iyaagad»** — "is not heeded";
+#   - "cannot" is **«di' mahinang»**;
+#   - "must" is **«subay»**;
+#   - "have not implemented" is **«wala' pa nahinang»**.
+#
+# The particles are Tausug and are the quick check: **«in»** (topic),
+# **«sin»** (genitive), **«ha»** (oblique), **«dayn ha»** (from), **«nga»**
+# (linker), **«manga»** (plural), **«awn»** / **«way»** (there is / there is
+# none), **«iban»** (and), **«atawa»** (or), **«sagawa'»** (but), **«bang»**
+# (if), **«sabab»** (because). The three negators stay apart: **«di'»** before
+# a verb, **«bukun»** before a noun, **«way»** for "there is none".
+#
+# DECLARED LOANS. The technical nouns are the Filipino and English school
+# words — `komponin`, `atribut`, `indeks`, `matriks`, `parameter`, `format`,
+# `bersyon`, `rekursyon`, `dimensyon`, `function`, `vector`, `grid`, `label`,
+# `input`, `output` — because those are what a Tausug reader has met them as.
+# Where a shape or a quantity has a Spanish-derived Filipino form in ordinary
+# use, that form is written instead.
+#
+# Every count selection is a single `*[other]`: Tausug does not mark number on
+# a noun after a numeral, and `Intl.PluralRules` has no data for `tsg` to
+# select a `[one]` branch with. The one `[1]` below is a numeric literal
+# matched against the number itself, which stays legal.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] in { $attributes } di' iyaagad bang duwa in tungud siyabbut
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] in { $attributes } di' iyaagad bang in hangka-tungud iban in titik ha tunga' siyabbut magsama
+    }
+
+line-segment-midpoint-offset-without-midpoint = way kapūsan sin midpointOffset bang way titik ha tunga'
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linya nga dumaralan ha manga titik nga di' matantu in dimensyon.
+
+line-points-too-few-dimensions = In linya subay dumaralan ha manga titik nga duwa in kaputusan dimensyon.
+
+line-points-depend-on-variables = In linya dumaralan ha manga titik nga masandal ha manga variable: { $variables }.
+
+line-equation-invalid-format = Sala' in format sin ekwasyon sin linya ha manga variable { $variable1 } iban { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = In sinag siyabbut dayn ha through, endpoint iban direction.  In through siyabbut di' iyaagad.
+
+ray-dimension-mismatch = Di' magsibu' in numDimensions ha sinag.
+
+## `<vector>`
+
+vector-overprescribed-head = In vector siyabbut dayn ha head, tail iban displacement.  In head siyabbut di' iyaagad.
+
+vector-dimension-mismatch = Di' magsibu' in numDimensions ha vector.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Di' mahinang in pagbutang pa `<{ $component }>` sabab way nearestPoint niya nga state variable.
+
+constrain-to-without-nearest-point = Di' mahinang in paglimbang pa `<{ $component }>` sabab way nearestPoint niya nga state variable.
+
+constrain-to-interior-without-nearest-point = Di' mahinang in paglimbang pa lawm sin `<{ $component }>` sabab way nearestPoint niya nga state variable.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = In labelPosition di' iyaagad ha choiceInput nga bukun inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = In manga indeks siyabbut ha choiceInput di' iyaagad sabab di' magsibu' in taud sin indeks iban in taud sin manga anak choice.
+
+pretzel-indices-count-mismatch = In manga indeks siyabbut ha problem di' iyaagad sabab di' magsibu' in taud sin indeks iban in taud sin manga anak problem.
+
+shuffle-indices-count-mismatch = In manga indeks siyabbut ha shuffle di' iyaagad sabab di' magsibu' in taud sin indeks iban in taud sin manga komponin.
+
+indices-ignored-out-of-range = In manga indeks siyabbut ha { $component } di' iyaagad sabab awn indeks ha guwa' sin lugal.
+
+pretzel-indices-repeated = In manga indeks siyabbut ha pretzel di' iyaagad sabab awn indeks naulit.
+
+pretzel-circuit-first-index = In manga indeks siyabbut ha pretzel ha mode circuit di' iyaagad sabab in nakauna nga indeks subay 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ha supaya makahinang in `<{ $component }>` iban manga anak string, subay siyabbut in atribut `type`.
+
+invalid-type-defaulting-to-math = Sala' in type { $type } ha komponin { $component }. Subay hambuuk dayn ha math, text, number atawa boolean. Biyalik pa math.
+
+string-not-valid-component-to-arrange = In string "{ $value }" bukun komponin nga mahinang { $component }. Di' iyaagad.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Sala' in type { $type }, in type biyalik pa number.
+
+invalid-variable-value = Sala' in timbang sin variable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = In indeks sin varyant { $index } subay number
+
+variant-index-must-be-integer = In indeks sin varyant { $index } subay integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = In `<{ $component }>` wala' pa nahinang ha sukud nga absolute. In luag biyalik pa relative.
+
+side-by-side-absolute-margins = In `<{ $component }>` wala' pa nahinang ha sukud nga absolute. In kilid biyalik pa relative.
+
+side-by-side-no-block-child = Sala' in `<{ $component }>`: subay awn hangka-anak nga block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = In atribut `for` ha `<label>` nga ladawan di' iyaagad.
+
+label-for-must-resolve-to-one = In atribut `for` ha `<label>` subay tumuyu' pa hambuuk-buuk nga komponin.
+
+label-for-unresolved = In atribut `for` ha `<label>` di' matantu bang unu komponin in tinuyu' niya.
+
+label-for-answer-with-authored-inputs = In atribut `for` ha `<label>` tumuyu' pa `<answer>` nga awn input siyulat sin nagsulat; tuyu'a in input ha di' na maglabay.
+
+label-for-answer-without-input = In atribut `for` ha `<label>` tumuyu' pa `<answer>` nga way input hilabelan.
+
+label-for-must-reference-input-or-answer = In atribut `for` ha `<label>` subay tumuyu' pa input atawa pa answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Pasal akses, in `<{ $component }>` subay awn maikut nga paglaral atawa siyabbut nga hiyas.
+
+accessibility-video-short-description = Pasal akses, in `<video>` subay awn maikut nga paglaral.
+
+accessibility-input-short-description-or-label = Pasal akses, in `<{ $component }>` subay awn maikut nga paglaral atawa label.
+
+accessibility-answer-input-short-description-or-label = Pasal akses, in `<answer>` nga naghihinang input subay awn maikut nga paglaral atawa label.
+
+accessibility-short-description-contains-math = In maikut nga paglaral subay way komponin matematika biya' sin `<{ $component }>`. Sulata in matematika ha manga kabtangan.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] In { $colorName } way kaganap nga kontrast ha tiksti sin ū sin seksyon (mode maitum) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kagunahan in kabawgbugan { $threshold }:1).
+       *[other] In { $colorName } way kaganap nga kontrast ha tiksti sin ū sin seksyon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kagunahan in kabawgbugan { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = In `<circle>` nga dumaralan ha { $count } titik wala' pa nahinang bang in manga titik way timbang nga number.
+
+circle-too-many-through-points = Di' mahinang in pag-itung sin sirkulo nga dumaralan ha labi dayn ha 3 titik.
+
+circle-overprescribed-radius-center-points = Di' mahinang in pag-itung sin sirkulo bang siyabbut in radius, in tunga' iban in manga titik magsama.
+
+circle-center-with-multiple-points = Di' mahinang in pag-itung sin sirkulo nga siyabbut in tunga' iban dumaralan ha labi dayn ha 1 titik.
+
+circle-radius-too-small = Di' mahinang in pag-itung sin sirkulo: sabab in lawak sin duwa titik { $distance }, landu' asibi' in radius { $radius } siyabbut.
+
+circle-radius-with-many-points = Di' mahinang in paghinang sin sirkulo nga dumaralan ha labi dayn ha duwa titik iban siyabbut in radius.
+
+circle-invalid-center-or-through-points = Sala' in tunga' atawa in manga titik daralanan sin sirkulo.
+
+circle-radius-center-with-multiple-points = Di' mahinang in pag-itung sin radius sin sirkulo nga siyabbut in tunga' iban dumaralan ha labi dayn ha 1 titik.
+
+circle-change-radius-non-numerical = Di' mahinang in pagsalli' sin radius sin sirkulo nga dumaralan ha manga titik nga way timbang nga number
+
+circle-radius-with-points-non-numerical = Di' mahinang in paghinang sin sirkulo nga dumaralan ha labi dayn ha hambuuk titik iban siyabbut in radius bang way timbang nga number.
+
+circle-change-center-non-numerical = In pagsalli' sin tunga' sin sirkulo nga dumaralan ha manga titik nga way timbang nga number wala' pa nahinang.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Way kaganap nga dimensyon sin domain sin function. In domain awn { $intervals } interval sagawa' in function awn { $inputs ->
+           *[other] { $inputs } input
+        }.
+    }
+
+function-domain-invalid-format = Sala' in format sin domain sin function.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] In maximum sin function nga bukun number di' iyaagad.
+        [minimum] In minimum sin function nga bukun number di' iyaagad.
+        [extremum] In extremum sin function nga bukun number di' iyaagad.
+        [point] In titik sin function nga bukun number di' iyaagad.
+        [slope] In slope sin function nga bukun number di' iyaagad.
+       *[other] In { $type } sin function nga bukun number di' iyaagad.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] In maximum sin function nga way laman di' iyaagad.
+        [minimum] In minimum sin function nga way laman di' iyaagad.
+        [extremum] In extremum sin function nga way laman di' iyaagad.
+        [point] In titik sin function nga way laman di' iyaagad.
+       *[other] In { $type } sin function nga way laman di' iyaagad.
+    }
+
+function-points-too-close = In function awn duwa titik nga landu' masuuk. Di' mahinang in paglaral sin function.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] In manga iterate sin function mahinang sadja bang magsibu' in taud sin input iban in taud sin output. In function ini awn { $inputs } input iban { $outputs ->
+           *[other] { $outputs } output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sala' in haba' sin sequence.  Subay integer nga bukun negative.
+
+sequence-invalid-step = Sala' in step sin sequence.  Subay number ha sequence nga ginis { $type }.
+
+sequence-invalid-endpoint-number = Sala' in "{ $attribute }" sin sequence sin number.  Subay number.
+
+sequence-invalid-endpoint-letters = Sala' in "{ $attribute }" sin sequence sin sulat.  Subay pagtipun sin manga sulat.
+
+sequence-invalid-endpoint = Sala' in "{ $attribute }" sin sequence.
+
+select-from-sequence-coprime-not-numbers = In coprime di' iyaagad sabab bukun manga number in pinī'
+
+select-from-sequence-coprime-with-exclude-combinations = In coprime di' iyaagad sabab siyabbut in excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Sala' in target sin `<{ $source }>`: way kiyabaakan nga target.
+
+target-state-variable-not-found = Sala' in target sin `<{ $source }>`: way kiyabaakan nga state variable nga in ngan "{ $property }" ha `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = In manga variable sin `<odeSystem>` subay ma'in dayn ha independent variable.
+
+ode-system-duplicate-variable-names = Di' mahinang in paglaral sin manga function RHS sin ODE bang magsibu' in manga ngan sin dependent variable.
+
+ode-system-rhs-function-error = Di' mahinang in paglaral sin function RHS sin ODE.  Awn kasala'an ha paghinang sin function mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Di' mahinang in paglaral sin anggulu ha pagtunga' sin { $count } linya
+
+angle-invalid-through-point = Sala' in titik ha through sin `<angle>`
+
+parabola-vertex-too-many-points = In parabola nga awn vertex iban dumaralan ha labi dayn ha 1 titik wala' pa nahinang.
+
+parabola-too-many-points = In parabola nga dumaralan ha labi dayn ha 3 titik wala' pa nahinang.
+
+intersection-too-many-items = In intersection ha labi dayn ha duwa nga hinang wala' pa nahinang
+
+## Other math components
+
+ionic-compound-not-two-ions = In ionic compound ha bukun duwa nga ion wala' pa nahinang.
+
+ionic-compound-needs-cation-and-anion = In ionic compound nahinang sadja ha hambuuk cation iban hambuuk anion.
+
+solve-equations-cannot-evaluate = Di' mahinang in pagsulbat sin ekwasyon sabab di' maitung in ekwasyon: { $equation }
+
+math-operators-operand-number-required = Subay siyabbut in operandNumber bang kawaun in operand matematika.
+
+eigen-decomposition-failed = Di' mahinang in pag-itung sin manga eigenvalue sin matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: in parameter { $parameters } way ha lawm sin pattern, hangkan magsibu' sadja pa lu'ang.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: di' kahatihan in grid="{ $grid }". Subay none, medium, dense atawa duwa number nga positive nga tiyagilid sin hangka-lu'ang, biya' sin grid="1 0.5". Way grid hiyuwad.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    In `<{ $component }>` kagunahan hambuuk function nga awn { $expected ->
+        [1] hambuuk output, amuna in slope y' ha katān titik, biya' sin `y - x`
+       *[other] duwa output, amuna in vector ha katān titik, biya' sin `(y, -x)`
+    }, sagawa' in function dīhil awn { $found ->
+       *[other] { $found } output
+    }. { $alternative ->
+        [none] Way hiyuwad.
+       *[other] In `<{ $alternative }>` amuna in komponin ha function yan. Way hiyuwad.
+    }
+
+field-function-attribute-ignored-with-child = In atribut `function` di' iyaagad sabab in function dīhil da isab ha lawm sin komponin; in ha lawm in ginamit. Dīhili in function ha hambuuk dalan sadja.
+
+field-variables-ignored =
+    `<{ $component }>`: in atribut `variables` amuna in nagngangan ha manga variable sin ekspresyon siyulat ha lawm sin komponin. { $reason ->
+        [function-child] In function dī dīhil biya' anak `<function>`, amu in nagngangan sin manga variable niya, hangkan in `variables` di' iyaagad.
+       *[no-expression] Way ekspresyon biya' hādtu dī, hangkan in `variables` di' iyaagad.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: in xLabelPosition="left" di' kasuppurtahan ha renderer prefigure; in dalan sin dapit-tuu in ginamit.
+
+prefigure-y-label-position-unsupported = `<graph>`: in yLabelPosition="bottom" di' kasuppurtahan ha renderer prefigure; in dalan sin dapit-taas in ginamit.
+
+prefigure-invalid-axis-bounds = `<graph>`: sala' in manga hangganan sin axis ha pagsalli' pa prefigure; in bbox hantang (-10,-10,10,10) in ginamit.
+
+prefigure-invalid-width = `<graph>`: sala' in luag ha pagsalli' pa prefigure; in luag hantang sin diagram 425 in ginamit.
+
+prefigure-invalid-aspect-ratio = `<graph>`: sala' in aspectRatio ha pagsalli' pa prefigure; in aspect ratio hantang 1 in ginamit.
+
+prefigure-grid-spacing-too-fine = `<graph>`: landu' kikit in lawak sin grid ha manga hangganan sin axis; in grid di' hiyuwad ha renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: in manga annotation di' hiyuwad bang bukun renderer PreFigure in ginamit.
+
+multiple-annotations-children = Mataud anak `<annotations>` in kiyabaakan ha `<graph>`; katān luwal sin kahuli-hulihan di' iyaagad.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Di' mahinang in pag-extend atawa pagsalin sin ginis komponin nga di' kaingatan: { $type }.
+
+copy-prop-not-found = Way kiyabaakan nga prop { $property } ha komponin nga ginis { $component }
+
+collect-no-source = Way kiyabaakan nga source ha collect.
+
+collect-invalid-component-type = Di' mahinang in pagtipun sin manga komponin nga ginis `<{ $component }>` sabab sala' in ginis komponin yan.
+
+reference-index-unavailable = Di' mahinang in pagtuyu' pa indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Di' mahinang in pagtawag sin { $action } ha komponin `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Sala' in rupa sin data.  Di' magsibu' in haba' sin manga baris. Kiyabaakan ha componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = In data awn manga ngan sin kolum nga magsibu'.  Kiyabaakan ha componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = In data kulang sin hangka-ngan sin kolum.  Kiyabaakan ha componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = In hambuuk award ha sambag ini masandal ha sambag naipasampay sin answer ini da isab, iban makarā ini pa hinang nga di' hiyuhulat.
+
+answer-max-num-attempts-in-section-wide-check-work = In pagbutang sin `maxNumAttempts` ha `<answer>` nga ha lawm sin lulanan nga awn `sectionWideCheckWork` way kapūsan, sabab in taud sin pagsulay iyaayad sin lulanan. Butanga in `maxNumAttempts` ha lulanan.
+
+nested-section-wide-check-work-max-num-attempts = In pagbutang sin `maxNumAttempts` ha lulanan nga awn `sectionWideCheckWork` iban ha lawm sin dugaing lulanan nga awn da isab `sectionWideCheckWork` way kapūsan, sabab in taud sin pagsulay iyaayad sin lulanan ha guwa'. Butanga in `maxNumAttempts` ha lulanan ha guwa'.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] In atribut { $attributes } way kapūsan bang di' hibutang in symbolicEquality.
+    }
+
+answer-invalid-type = Sala' in ginis sin answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sabab way ngan sin komponin `<{ $component }>`, di' mahinang in paggamit niya biya' atribut sin module
+
+module-attribute-name-already-defined = In komponin `<{ $component } name="{ $name }">` di' mahinang gamitun biya' atribut sin module sabab in ginis komponin `<module>` awn na atribut nga "{ $name }".
+
+conditional-content-condition-ignored = In atribut `condition` di' iyaagad ha komponin `<conditionalContent>` nga awn anak case atawa else.
+
+slider-markers-type-mismatch = Di' magsibu' in ginis sin markers iban in ginis sin slider.
+
+pretzel-problem-needs-statement-and-answer = Sala' in pretzel: in katān `<problem>` subay awn hambuuk `<statement>` iban hambuuk `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Sala' in pretzel: ha mode="circuit", in nakauna nga `<problem>` di' mahinang distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Sala' in timbang { $values } ha atribut `{ $attribute }`; di' iyaagad.
+    }
+
+attribute-must-be-references = Sala' in timbang `{ $value }` ha atribut `{ $attribute }`. In atribut subay hinangun dayn ha manga rupa nga magtagna' ha `$`.
+
+math-input-invalid-function-names = <mathInput>: in manga ngan sin function nga sala' ha { $attribute } di' iyaagad: { $names }. In katān ngan subay awn duwa in kaputusan aksara ha bahagi' hikita' (manga sulat atawa gitik); makasunud in `|<mathspeak alternative>` bang kabayaan.
+
+## Building components from the source
+
+component-type-invalid = Sala' in ginis komponin: `<{ $componentType }>`
+
+attribute-repeated = Di' mahinang in pag-ulit sin atribut { $attribute }.
+
+attribute-invalid-for-component = Sala' in atribut "{ $attribute }" ha komponin nga ginis `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    In style definition { $styleNumber } way kaganap nga kontrast ha { $context ->
+        [text-on-background] kulay sin tiksti kuntra ha kulay sin likuran
+        [high-contrast] kulay nga mataas in kontrast kuntra ha kanvas
+        [line] kulay sin linya kuntra ha kanvas
+        [marker] kulay sin marker kuntra ha kanvas
+       *[text-on-canvas] kulay sin tiksti kuntra ha kanvas
+    }{ $mode ->
+        [dark] { " (mode maitum)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kagunahan in kabawgbugan { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Minsan siyabbut sin style definition { $styleNumber } in manga kulay nga kaganap in kontrast ha mode masawa, in manga kulay sin mode maitum nga naguwa' dayn ha manga timbang yan way kaganap nga kontrast ha kulay sin tiksti kuntra ha kulay sin likuran ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kagunahan in kabawgbugan { $threshold }:1). { $suggestion ->
+        [available] Ha supaya kaganap in kontrast ha mode maitum, dugangi in kontrast sin mode masawa (misalan, butanga in { $lightAttribute }="{ $lightColor }") atawa salli'a in kulay sin mode maitum (misalan, butanga in { $darkAttribute }="{ $darkColor }").
+       *[none] Ha supaya kaganap in kontrast ha mode maitum, dugangi in kontrast sin mode masawa atawa salli'a in manga kulay naguwa' iban textColorDarkMode atawa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Minsan siyabbut sin style definition { $styleNumber } in kulay sin tiksti nga kaganap in kontrast ha mode masawa, in kulay sin tiksti ha mode maitum nga naguwa' dayn ha timbang yan way kaganap nga kontrast kuntra ha kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kagunahan in kabawgbugan { $threshold }:1). { $suggestion ->
+        [available] Ha supaya kaganap in kontrast ha mode maitum, dugangi in kontrast sin mode masawa (misalan, butanga in textColor="{ $lightColor }") atawa salli'a in kulay sin mode maitum (misalan, butanga in textColorDarkMode="{ $darkColor }").
+       *[none] Ha supaya kaganap in kontrast ha mode maitum, dugangi in kontrast sin mode masawa atawa salli'a in kulay naguwa' iban textColorDarkMode.
+    }
+
+section-multiple-style-palettes = In hangka-seksyon makapī' hambuuk <stylePalette> sadja; in kahuli-hulihan in ginamit.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = di' matantu in manga unique variant sin { $component } sabab in numToSelect bukun integer nga bukun negative.
+
+variant-num-to-select-not-constant-number = di' matantu in manga unique variant sin { $component } sabab in numToSelect bukun number nga di' magsalli'.
+
+variant-with-replacement-not-constant-boolean = di' matantu in manga unique variant sin { $component } sabab in withReplacement bukun boolean nga di' magsalli'.
+
+variant-select-weight-disables-unique = In manga unique variant sin select napatay bang awn option nga siyabbut in selectWeight atawa selectForVariants
+
+variant-coprime-undetermined = di' matantu in manga unique variant sin { $component } sabab di' matantu bang in coprime false sadja.
+
+variant-attribute-not-constant = di' matantu in manga unique variant sin { $component } sabab in { $attribute } magsalli'.
+
+variant-attribute-not-number = di' matantu in manga unique variant sin { $component } sabab in { $attribute } bukun number.
+
+variant-attribute-wrong-type-for-sequence =
+    di' matantu in manga unique variant sin { $component } nga ginis { $type } sabab in { $attribute } bukun { $expected ->
+        [letters-combination] pagtipun sin manga sulat
+        [math-expression] ekspresyon matematika nga tama'
+        [integer] integer
+       *[number] number
+    }.
+
+variant-length-not-integer = di' matantu in manga unique variant sin { $component } sabab in length bukun integer.
+
+variant-sort-not-implemented = in manga unique variant sin { $component } nga awn sort wala' pa nahinang
+
+variant-exclude-combinations-not-implemented = in manga unique variant sin { $component } nga awn excludeCombinations wala' pa nahinang
+
+variant-math-exclude-not-implemented = in manga unique variant sin { $component } nga ginis math iban awn exclude wala' pa nahinang
+
+variant-non-constant-exclude-not-implemented = in manga unique variant sin { $component } nga awn exclude nga magsalli' wala' pa nahinang
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: di' kasuppurtahan ha renderer prefigure sin graph; in panubu' liyabayan.
+
+prefigure-descendant-invalid-geometry = { $subject }: in geometry way hangganan atawa kulang; in panubu' liyabayan.
+
+prefigure-curve-label-omitted = { $subject }: in manga label di' kasuppurtahan ha manga elemento sin kurba nga siyalli'; in label wala' hiyuwad.
+
+prefigure-curve-unsupported-definition-type = { $subject }: in ginis sin paglaral sin function sin kurba '{ $definitionType }' di' kasuppurtahan; in panubu' liyabayan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: in atribut flipFunctions ha regionBetweenCurves di' kasuppurtahan; in panubu' liyabayan.
+
+prefigure-region-non-formula-child = { $subject }: in manga anak function nga ginis formula sadja in kasuppurtahan ha regionBetweenCurves; in panubu' liyabayan.
+
+prefigure-label-position-unsupported =
+    { $subject }: in labelPosition '{ $labelPosition }' di' kasuppurtahan ha { $labelKind ->
+        [line-family] label sin manga linya
+       *[point] label sin titik
+    }; in pagtangkud hantang sin PreFigure in ginamit.
+
+prefigure-fill-style-unsupported = { $subject }: in fill style '{ $fillStyle }' di' kasuppurtahan sin PreFigure; in fill nga buun in ginamit.
+
+prefigure-line-style-unknown = { $subject }: in line style '{ $lineStyle }' di' kaingatan iban wala' liyaman ha output sin PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: in marker style '{ $markerStyle }' siyalli' pa style sin PreFigure nga 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: in marker style '{ $markerStyle }' di' kasuppurtahan sin PreFigure; in style hantang in ginamit.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: sala' in `ref`; di' matantu in target. In annotation wala' hiyuwad.
+
+annotation-ref-multiple-targets = `<annotation>`: in `ref` tumuyu' pa mataud target; in nakauna nga target in ginamit.
+
+annotation-ref-outside-graph = `<annotation>`: sala' in `ref`; in target ha guwa' sin graph nga naglulukup kaniya. In annotation wala' hiyuwad.
+
+annotation-ref-unsupported-target = `<annotation>`: sala' in `ref`; in target bukun ladawan nga kasuppurtahan ha pagsalli' pa prefigure. In annotation wala' hiyuwad.
+
+annotation-text-missing = `<annotation>`: kulang atawa way laman in `text`; tiksti nga way laman in giyuwa'.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Awn kiyabaakan nga pagsandal nga malibut.
+       *[other] Awn kiyabaakan nga pagsandal nga malibut ha komponin `<{ $componentType }>`.
+    }
+
+reference-no-referent = Way kiyabaakan nga tinuyu' sin rupa: `{ $reference }`
+
+reference-multiple-referents = Mataud tinuyu' in kiyabaakan sin rupa: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Sala' in format sin atribut { $attribute } sin `<{ $componentType }>`.
+
+children-invalid = Sala' in manga anak sin `<{ $componentType }>`: awn kiyabaakan nga manga anak nga sala': { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Sala' in timbang `{ $value }` ha atribut `{ $attribute }`, in timbang `{ $default }` in ginamit
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Way kiyabaakan nga bersyon sin DoenetML { $version }.
+       *[other] Way kiyabaakan nga bersyon sin DoenetML { $version }. In bersyon { $fallback } in ginamit
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Sala' in DoenetML: { $content }
+
+parse-tag-missing-close-tag = Sala' in DoenetML: In tag `{ $tag }` way tag hikatambul niya. Hiyuhulat in tag nga magtambul ha baran atawa in tag `</{ $tagName }>`.
+
+parse-tag-error = Sala' in DoenetML: Awn kasala'an ha tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Sala' in DoenetML: In atribut `{ $attribute }` nga sala' biya' way timbang niya.
+
+parse-attribute-invalid = Sala' in DoenetML: Sala' in atribut `{ $attribute }`
+
+parse-attribute-value-invalid = Sala' in DoenetML: Sala' in timbang sin atribut `{ $value }`
+
+parse-attribute-value-quote-mismatch = Sala' in DoenetML: Sala' in timbang sin atribut `{ $value }`. Di' magsibu' in manga tanda' quote. Biya' kulang kaw sin hangka `{ $quote }`
+
+parse-open-tag-name-missing = Sala' in DoenetML: Awn kiyabaakan nga tag nga way ngan, biya' sin `<`
+
+parse-tag-not-closed = Sala' in DoenetML: In tag `{ $tag }` wala' natambul (biya' kulang in hangka `>`).
+
+parse-self-closing-tag-name-missing = Sala' in DoenetML: Awn kiyabaakan nga tag nga way ngan `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Sala' in DoenetML: In tag `{ $tag }` wala' natambul (biya' kulang in `/>`).
+
+parse-tag-invalid-attributes = Sala' in DoenetML: Sala' in tag `{ $tag }`. Kaymu' sala' in manga atribut niya.
+
+parse-close-tag-name-missing = Sala' in DoenetML: Awn kiyabaakan nga tag panambul nga way ngan, biya' sin `</`
+
+parse-attribute-value-unquoted = In manga timbang sin atribut subay lukupan sin manga tanda' quote: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Sala' in DoenetML: Awn kiyabaakan nga tag panambul `{ $tag }`, sagawa' way tag pang-ukab nga magsibu' kaniya
+
+parse-close-tag-mismatched = Sala' in DoenetML: Di' magsibu' in tag panambul. Hiyuhulat in `</{ $expected }>`. Kiyabaakan in `{ $found }`
+
+parser-node-unconvertible = Di' mahinang in pagsalli' sin node { $node } pa node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Sala' in ngan sin atribut name='{ $name }'. { $reason ->
+        [characters] In manga ngan makalaman sadja sin manga sulat, number, underscore atawa gitik.
+       *[start] In manga ngan subay magtagna' ha sulat.
+    }
+
+component-name-invalid-start = Sala' in ngan sin komponin "{ $name }". In manga ngan subay magtagna' ha sulat.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = In answer nga ginis videoWatched subay awn atribut video
+
+answer-video-watched-video-not-reference = In answer nga ginis videoWatched subay awn atribut video nga rupa
+
+answer-name-not-single-text = In atribut name sin answer subay awn hambuuk-buuk nga anak text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Di' makawa' in DoenetML dayn ha guwa' sabab landu' mataud in lapis sin rekursyon. Awn ka rupa nga malibut?
+
+external-doenetml-unavailable = Di' makawa' in DoenetML dayn ha { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Sala' in DoenetML kiyawa' dayn ha { $attribute }="{ $uri }": di' magsibu' ha ginis komponin nga "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] In atribut `{ $from }` luma' na; gamita in `{ $to }` ganti.
+       *[other] [deprecation] In atribut `{ $from }` ha `<{ $component }>` luma' na; gamita in `{ $to }` ganti.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] In atribut `{ $from }` luma' na iban di' iyaagad sabab siyabbut da isab in `{ $to }`.
+       *[other] [deprecation] In atribut `{ $from }` ha `<{ $component }>` luma' na iban di' iyaagad sabab siyabbut da isab in `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] In atribut `{ $attribute }` ha `<{ $component }>` luma' na iban di' iyaagad.
+
+deprecated-attribute-to-child = [deprecation] In atribut `{ $attribute }` ha `<{ $component }>` luma' na; gamita in anak `<{ $child }>` ganti.
+
+deprecated-attribute-value-renamed = [deprecation] In timbang `{ $value }` sin atribut `{ $attribute }` ha `<{ $component }>` luma' na; gamita in `{ $to }` ganti.
+
+
+## Language coverage
+
+pluralize-english-only = In `<pluralize>` makapagmataud sadja sin Inglis, hangkan in tiksti niya di' siyalli' ha dukumintu nga siyulat ha { $locale }. Sulata da in rupa nga mataud, atawa butanga iban sin atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = In elemento `<{ $tag }>` bukun elemento sin Doenet nga kaingatan.
+
+schema-element-not-allowed-at-root = In elemento `<{ $tag }>` di' makajari ha jambatan sin dukumintu.
+
+schema-element-not-allowed-inside = In elemento `<{ $tag }>` di' makajari ha lawm sin `<{ $parent }>`.
+
+schema-attribute-unrecognized = In elemento `<{ $tag }>` way atribut nga in ngan `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] In atribut `{ $attribute }` sin elemento `<{ $tag }>` subay listahan nga in katān laman niya hambuuk dayn ha: { $allowed }
+       *[other] In atribut `{ $attribute }` sin elemento `<{ $tag }>` subay hambuuk dayn ha: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Sala' in ngan sin varyant ha select.  In ngan sin varyant { $variantName } kiyabaakan ha { $numOptions } option sagawa' in taud hipī' { $numToSelect }.
+
+select-variant-name-without-options = Awn manga varyant siyabbut ha select sagawa' way option siyabbut ha ngan sin varyant: { $variantName }.
+
+select-variant-name-not-possible = In ngan sin varyant { $variantName } nga siyabbut ha select bukun ngan sin varyant nga mahinang.
+
+select-too-few-options = Di' mahinang in pagpī' sin { $numToSelect } komponin dayn ha { $numOptions } sadja.
+
+select-from-sequence-too-few-values = Di' mahinang in pagpī' sin { $numToSelect } timbang dayn ha sequence nga in haba' { $length }.
+
+select-from-sequence-indices-count-mismatch = In taud sin manga indeks siyabbut ha select subay magsibu' ha taud hipī'
+
+select-from-sequence-indices-not-integers = In katān indeks siyabbut ha select subay integer
+
+select-from-sequence-index-excluded = In indeks sin selectfromsequence siyabbut kiyaluwa' na
+
+select-from-sequence-indices-excluded-combination = In manga indeks sin selectfromsequence siyabbut amuna in pagtipun kiyaluwa'
+
+select-from-sequence-coprime-not-positive-integers = Di' mahinang in pagpī' sin manga pagtipun coprime sabab bukun manga integer nga positive in pinī'.
+
+select-from-sequence-coprime-common-factor = Di' mahinang in pagpī' sin manga number coprime. In katān timbang awn factor magsibu'. (In manga timbang sin "from" atawa "to" siyabbut subay coprime ha "step".)
+
+select-from-sequence-coprime-single-number = Di' mahinang in pagpī' sin manga pagtipun coprime dayn ha hambuuk number nga bukun 1.
+
+select-from-sequence-excluded-too-many-combinations = Labi 70% sin manga pagtipun in kiyaluwa' ha selectFromSequence
+
+select-from-sequence-coprime-none-found = Way nakapī' sin manga number coprime. In katān timbang awn factor magsibu'.
+
+select-from-sequence-too-few-unique-values = Di' mahinang in pagpī' sin { $numToSelect } timbang nga unique dayn ha sequence nga in haba' { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Di' mahinang in pagpī' sin { $numToSelect } timbang dayn ha listahan sin manga prime nga in haba' { $numValues }
+
+select-prime-numbers-values-count-mismatch = In taud sin manga timbang siyabbut ha select subay magsibu' ha taud hipī'
+
+select-prime-numbers-values-not-prime = In katān timbang siyabbut ha select sin prime number subay awn ha listahan sin manga prime
+
+select-prime-numbers-values-excluded-combination = In manga timbang sin selectPrimeNumbers siyabbut amuna in pagtipun kiyaluwa'
+
+select-prime-numbers-excluded-too-many-combinations = Labi 70% sin manga pagtipun in kiyaluwa' ha selectPrimeNumbers
+
+select-random-combination-fluke = Sabab sin sukud nga landu' malayu' mahinang, way nakapī' sin pagtipun sin manga timbang random
+
+select-random-value-fluke = Sabab sin sukud nga landu' malayu' mahinang, way nakapī' sin timbang random
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] In `<{ $component }>` ini di' hikita' sabab ha lawm ini sin matematika iban bukun `inline`. Dugangi in `inline` ha supaya mahinang drop-down list, amu in makasūd ha lawm sin ekspresyon.
+        [expanded] In `<{ $component }>` ini di' hikita' sabab ha lawm ini sin matematika iban `expanded`. Tanggala in `expanded`; in kahun nga mataud baris di' makasūd ha lawm sin ekspresyon.
+        [on-graph] In `<{ $component }>` ini di' hikita' sabab ha lawm ini sin matematika nga hiyuwad ha graph, amu in way lugal niya ha input.
+       *[relative-width] In `<{ $component }>` ini di' hikita' sabab ha lawm ini sin matematika iban awn luag nga relative. Dīhili in luag ha manga unit nga absolute, biya' sin `px`.
+    }

--- a/packages/i18n/locales/tsg/editor.ftl
+++ b/packages/i18n/locales/tsg/editor.ftl
@@ -9,8 +9,9 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # Written in the Latin orthography of the other three files of this locale —
-# three vowels, an apostrophe for the glottal stop, doubled consonants for
-# length, and loans kept in the spelling of the language they came from. See
+# three vowel qualities with a macron for length, an apostrophe for the
+# glottal stop, doubled consonants for a long consonant, and loans kept in the
+# spelling of the language they came from. See
 # `locales/tsg/chrome.ftl` for the argument against writing this catalog in
 # Sulat Sūg, and for the verb-formation assumption every verb here rests on.
 #

--- a/packages/i18n/locales/tsg/editor.ftl
+++ b/packages/i18n/locales/tsg/editor.ftl
@@ -1,0 +1,229 @@
+# Tausug editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of the other three files of this locale —
+# three vowels, an apostrophe for the glottal stop, doubled consonants for
+# length, and loans kept in the spelling of the language they came from. See
+# `locales/tsg/chrome.ftl` for the argument against writing this catalog in
+# Sulat Sūg, and for the verb-formation assumption every verb here rests on.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay in English exactly as written.
+#
+# The linker **«nga»** is written out in full everywhere, and the particles
+# **«in»**, **«sin»**, **«ha»**, **«dayn ha»**, **«manga»**, **«awn»** and
+# **«way»** are what a reviewer should read this file by. The three negators
+# stay apart: «di'» before a verb, «bukun» before a noun, «way» for "there is
+# none".
+#
+# DECLARED LOANS. `editor`, `input`, `array`, `kursor`, `tag`, `atribut`,
+# `kordinat`, `varyant`, `bersyon` and `kontekst` are written as the Filipino
+# or English words they are. Tausug has no coinage for them and this catalog
+# does not invent one.
+#
+# Tausug does not mark number on a noun after a numeral, and
+# `Intl.PluralRules` has no data for `tsg` in any case, so every count
+# selection here is collapsed to a single `*[other]`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Balika
+       *[update] Baguha
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } in Pagkita'an
+       *[other] { $word } in Pagkita'an { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varyant
+editor-variant-filter = Sāya…
+editor-variant-next = Pī' in sumunud nga varyant
+editor-variant-previous = Pī' in nakauna nga varyant
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Awn paglanggal sin akses WCAG AA kiyabaakan. Pindut ha { $action ->
+            [close] pagtambul
+           *[open] pag-ukab
+        } sin taluk pasal akses.
+        [advisories] Pindut ha { $action ->
+            [close] pagtambul
+           *[open] pag-ukab
+        } sin taluk pasal akses. Way paglanggal sin WCAG AA kiyabaakan, sagawa' awn dugang panuntun pasal akses.
+       *[clean] Pindut ha { $action ->
+            [close] pagtambul
+           *[open] pag-ukab
+        } sin taluk pasal akses. Way kasala'an pasal akses kiyabaakan.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Awn paglanggal sin akses WCAG AA kiyabaakan. Awn { $count ->
+           *[other] { $count } paglanggal sin WCAG AA
+        } kiyabaakan. Pindut ha { $action ->
+            [close] pagtambul
+           *[open] pag-ukab
+        } sin taluk pasal akses.
+        [advisories] Way paglanggal sin WCAG AA kiyabaakan. Awn { $count ->
+           *[other] { $count } dugang panuntun pasal akses
+        } kiyabaakan. Pindut ha { $action ->
+            [close] pagtambul
+           *[open] pag-ukab
+        } sin taluk pasal akses.
+       *[clean] Way paglanggal sin WCAG AA kiyabaakan. Pindut ha { $action ->
+            [close] pagtambul
+           *[open] pag-ukab
+        } sin taluk pasal akses.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersyon sin DoenetML { $version }
+
+editor-tab-help = Tabang siyusūd sin kontekst
+editor-tab-help-short = Kontekst
+editor-tab-errors = Manga Kasala'an
+editor-tab-warnings = Manga Pagpahati'
+editor-tab-info = Kaingatan
+editor-tab-accessibility = Akses
+editor-tab-responses = Manga sambag naipasampay
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Manga pī'anan sin editor
+editor-format-as-doenetml = Ayuha biya' DoenetML
+editor-format-as-xml = Ayuha biya' XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Way Kasala'an
+editor-no-warnings = Way Pagpahati'
+editor-no-info = Way Kaingatan
+
+editor-show-info-annotations = Pakita' in kaingatan ha editor
+editor-show-accessibility-annotations = Pakita' in pagpahati' pasal akses ha editor
+
+editor-accessibility-learn-more = Kaingati bang biya' diin in pag-atud sin Doenet ha akses
+
+editor-accessibility-violations-heading = Manga paglanggal sin akses ({ $standard })
+
+editor-accessibility-other-heading = Kaibanan kasala'an pasal akses
+editor-none-found = Way kiyabaakan
+
+
+## Submitted responses
+
+editor-no-responses = Way pa sambag naipasampay
+editor-response-answer-id = Id sin Sambag
+editor-response-response = Sambag
+editor-response-credit = Marka
+editor-response-submitted = Naipasampay
+
+
+## The context-help panel
+
+help-placeholder = Butanga in kursor ha ngan sin tag, ha atribut atawa ha { $ref } ha supaya kumita' sin dukumintasyon.
+
+help-unsupported-ref-chain = In tabang ha manga rupa nga mataud bahagi' biya' ha { $example } di' pa kasuppurtahan.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Way kiyabaakan nga tinuyu' sin rupa: { $ref }.
+        [multiple] Mataud tinuyu' in kiyabaakan sin rupa: { $ref }.
+       *[indeterminate] In tinuyu' sin { $ref } di' matantu.
+    }
+
+help-learn-about-references = Kaingati in pasal sin manga rupa →
+help-reference-page = Pahina sin rupa →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ha lawm sin { $element }
+       *[top] Ha taas nga lugal
+    }{ $allowed ->
+        [none] { " — way makasūd dī." }
+        [text] { " — sulat sin tiksti dī." }
+        [text-and-components] { " — sulat sin tiksti dī, atawa sulaya ini:" }
+       *[components] { " — manga hikasulay:" }
+    }
+
+help-suggestions-footer = Pindut in { $shortcut } ha supaya kumita' sin katān { $total } komponin.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] In { $ref } rupa pa { $target }.
+       *[other] In { $ref } rupa pa { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Piyaguwa' sin { $owner } biya' { $role }.
+       *[other] Piyaguwa' sin { $owner } ha baris { $line } biya' { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] In { $ref } rupa pa kabtangan { $property } sin { $element }.
+       *[other] In { $ref } rupa pa kabtangan { $property } sin { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = bahagi' sin kod
+help-kind-array-entry = laman sin array
+
+help-default = Timbang nga hantang:
+help-active-default = Timbang nga hantang naghihinang:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Manga timbang kaingatan (hangka-timbang ha hangka-laman):
+       *[other] Manga timbang kaingatan:
+    }
+
+help-suggested-values = Manga timbang piyanuntun:
+
+help-inserts = Isuksuk:
+
+help-coordinates =
+    { $count ->
+       *[other] Manga kordinat:
+    }
+
+help-type = Ginis:
+
+help-resolved-style = Istilu natantu (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Manga ngan sin function natantu:
+help-reset-list = Listahan sin pagbalik ha input ini:
+help-added-on-input = Diyugangan ha input ini:
+help-removed-on-input = Tiyanggal dayn ha input ini:
+
+help-reset-overrides = In { $reset } makalabi ha { $additional } iban ha { $removed }.

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -921,8 +921,9 @@ export const LOCALE_NAME_FALLBACKS: Record<
     // The five locales of the Southeast Asian batch CLDR has no data for. The
     // split is geographic rather than about speaker numbers: ICU names
     // `bug`, `mak`, `bjn`, `gor`, `nia`, `bbc`, `iba`, `dtp`, `pag` and `shn`
-    // — every Indonesian and Malaysian tag in the batch, and the one Myanmar
-    // tag whose language a state is named after — and stops at the five below,
+    // — all six Indonesian tags in the batch, both Malaysian ones, the one
+    // Philippine tag from Luzon rather than the south, and the one Myanmar tag
+    // whose language a state is named after — and stops at the five below,
     // which are three languages of the southern Philippines and two more of
     // Myanmar.
     //

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -918,6 +918,31 @@ export const LOCALE_NAME_FALLBACKS: Record<
     dng: { englishName: "Dungan" },
     sgh: { englishName: "Shughni" },
     haz: { englishName: "Hazaragi" },
+    // The five locales of the Southeast Asian batch CLDR has no data for. The
+    // split is geographic rather than about speaker numbers: ICU names
+    // `bug`, `mak`, `bjn`, `gor`, `nia`, `bbc`, `iba`, `dtp`, `pag` and `shn`
+    // — every Indonesian and Malaysian tag in the batch, and the one Myanmar
+    // tag whose language a state is named after — and stops at the five below,
+    // which are three languages of the southern Philippines and two more of
+    // Myanmar.
+    //
+    // Four of the five get endonyms, because each names its language exactly
+    // one way wherever its headers name it at all, so those spellings are
+    // copied letter for letter. `shn` needs no row here in either column:
+    // CLDR gives it «တႆး» already, which is the spelling `locales/shn` writes
+    // too.
+    //
+    // `cbk` is the exception, and it takes `locales/olo`'s shape for the
+    // reason `dng`, `sgh` and `haz` do above: its header names the language
+    // **two** ways — «Chavacano» beside «Chabacano de Zamboanga» — and both
+    // spellings are in live use for it. Picking one here would settle in the
+    // roster what the catalog deliberately leaves open, so the label reads
+    // "Chavacano (cbk)": an admitted gap rather than a guess.
+    tsg: { englishName: "Tausug", endonym: "Bahasa Sūg" },
+    mrw: { englishName: "Maranao", endonym: "Basa a Mëranaw" },
+    mnw: { englishName: "Mon", endonym: "ဘာသာမန်" },
+    ksw: { englishName: "S'gaw Karen", endonym: "ကညီကျိာ်" },
+    cbk: { englishName: "Chavacano" },
 };
 
 /**

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -24,6 +24,7 @@ export type SupportedLocale =
     | "ba"
     | "bal"
     | "ban"
+    | "bbc"
     | "bci"
     | "be"
     | "bem"
@@ -32,6 +33,7 @@ export type SupportedLocale =
     | "bi"
     | "bik"
     | "bin"
+    | "bjn"
     | "bm"
     | "bn"
     | "bo"
@@ -39,8 +41,10 @@ export type SupportedLocale =
     | "brx"
     | "bs"
     | "bua"
+    | "bug"
     | "bum"
     | "ca"
+    | "cbk"
     | "ce"
     | "ceb"
     | "ch"
@@ -60,6 +64,7 @@ export type SupportedLocale =
     | "dng"
     | "doi"
     | "dsb"
+    | "dtp"
     | "dv"
     | "dyo"
     | "dyu"
@@ -90,6 +95,7 @@ export type SupportedLocale =
     | "gl"
     | "glk"
     | "gn"
+    | "gor"
     | "gsw"
     | "gu"
     | "ha"
@@ -104,6 +110,7 @@ export type SupportedLocale =
     | "ht"
     | "hu"
     | "hy"
+    | "iba"
     | "id"
     | "ig"
     | "ilo"
@@ -138,6 +145,7 @@ export type SupportedLocale =
     | "krl"
     | "ks"
     | "ksh"
+    | "ksw"
     | "ktu"
     | "kum"
     | "ky"
@@ -157,6 +165,7 @@ export type SupportedLocale =
     | "lv"
     | "mad"
     | "mai"
+    | "mak"
     | "mdf"
     | "men"
     | "mg"
@@ -170,9 +179,11 @@ export type SupportedLocale =
     | "mni"
     | "mnk"
     | "mns"
+    | "mnw"
     | "mos"
     | "mr"
     | "mrj"
+    | "mrw"
     | "ms"
     | "mt"
     | "my"
@@ -183,6 +194,7 @@ export type SupportedLocale =
     | "nb"
     | "nds"
     | "ne"
+    | "nia"
     | "niu"
     | "nl"
     | "nn"
@@ -197,6 +209,7 @@ export type SupportedLocale =
     | "or"
     | "os"
     | "pa"
+    | "pag"
     | "pam"
     | "pcm"
     | "pl"
@@ -224,6 +237,7 @@ export type SupportedLocale =
     | "sg"
     | "sgh"
     | "shi"
+    | "shn"
     | "si"
     | "sjd"
     | "sk"
@@ -262,6 +276,7 @@ export type SupportedLocale =
     | "tpi"
     | "tr"
     | "ts"
+    | "tsg"
     | "tt"
     | "ttt"
     | "tvl"
@@ -418,6 +433,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Balinese",
     },
     {
+        locale: "bbc",
+        englishName: "Batak Toba",
+        endonym: "Batak Toba",
+        label: "Batak Toba",
+    },
+    {
         locale: "bci",
         englishName: "Baoulé",
         endonym: "bci",
@@ -456,6 +477,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     { locale: "bik", englishName: "Bikol", endonym: "Bikol", label: "Bikol" },
     { locale: "bin", englishName: "Bini", endonym: "Bini", label: "Bini" },
     {
+        locale: "bjn",
+        englishName: "Banjar",
+        endonym: "Banjar",
+        label: "Banjar",
+    },
+    {
         locale: "bm",
         englishName: "Bambara",
         endonym: "bamanakan",
@@ -492,12 +519,24 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "буряад",
         label: "Buriat (буряад)",
     },
+    {
+        locale: "bug",
+        englishName: "Buginese",
+        endonym: "Buginese",
+        label: "Buginese",
+    },
     { locale: "bum", englishName: "Bulu", endonym: "Bulu", label: "Bulu" },
     {
         locale: "ca",
         englishName: "Catalan",
         endonym: "català",
         label: "Catalan (català)",
+    },
+    {
+        locale: "cbk",
+        englishName: "Chavacano",
+        endonym: "cbk",
+        label: "Chavacano (cbk)",
     },
     {
         locale: "ce",
@@ -612,6 +651,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Lower Sorbian",
         endonym: "dolnoserbšćina",
         label: "Lower Sorbian (dolnoserbšćina)",
+    },
+    {
+        locale: "dtp",
+        englishName: "Central Dusun",
+        endonym: "Central Dusun",
+        label: "Central Dusun",
     },
     { locale: "dv", englishName: "Divehi", endonym: "Divehi", label: "Divehi" },
     {
@@ -764,6 +809,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Guarani",
     },
     {
+        locale: "gor",
+        englishName: "Gorontalo",
+        endonym: "Gorontalo",
+        label: "Gorontalo",
+    },
+    {
         locale: "gsw",
         englishName: "Swiss German",
         endonym: "Schwiizertüütsch",
@@ -842,6 +893,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "հայերեն",
         label: "Armenian (հայերեն)",
     },
+    { locale: "iba", englishName: "Iban", endonym: "Iban", label: "Iban" },
     {
         locale: "id",
         englishName: "Indonesian",
@@ -1017,6 +1069,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Colognian (Kölsch)",
     },
     {
+        locale: "ksw",
+        englishName: "S'gaw Karen",
+        endonym: "ကညီကျိာ်",
+        label: "S'gaw Karen (ကညီကျိာ်)",
+    },
+    {
         locale: "ktu",
         englishName: "Kituba",
         endonym: "Kikongo ya leta",
@@ -1116,6 +1174,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Maithili (मैथिली)",
     },
     {
+        locale: "mak",
+        englishName: "Makasar",
+        endonym: "Makasar",
+        label: "Makasar",
+    },
+    {
         locale: "mdf",
         englishName: "Moksha",
         endonym: "Moksha",
@@ -1178,6 +1242,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "мāньси лāтыӈ",
         label: "Mansi (мāньси лāтыӈ)",
     },
+    {
+        locale: "mnw",
+        englishName: "Mon",
+        endonym: "ဘာသာမန်",
+        label: "Mon (ဘာသာမန်)",
+    },
     { locale: "mos", englishName: "Mossi", endonym: "Mossi", label: "Mossi" },
     {
         locale: "mr",
@@ -1190,6 +1260,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Western Mari",
         endonym: "Western Mari",
         label: "Western Mari",
+    },
+    {
+        locale: "mrw",
+        englishName: "Maranao",
+        endonym: "Basa a Mëranaw",
+        label: "Maranao (Basa a Mëranaw)",
     },
     {
         locale: "ms",
@@ -1246,6 +1322,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "नेपाली",
         label: "Nepali (नेपाली)",
     },
+    { locale: "nia", englishName: "Nias", endonym: "Nias", label: "Nias" },
     {
         locale: "niu",
         englishName: "Niuean",
@@ -1314,6 +1391,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Punjabi",
         endonym: "ਪੰਜਾਬੀ",
         label: "Punjabi (ਪੰਜਾਬੀ)",
+    },
+    {
+        locale: "pag",
+        englishName: "Pangasinan",
+        endonym: "Pangasinan",
+        label: "Pangasinan",
     },
     {
         locale: "pam",
@@ -1467,6 +1550,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "ⵜⴰⵛⵍⵃⵉⵜ",
         label: "Tachelhit (ⵜⴰⵛⵍⵃⵉⵜ)",
     },
+    { locale: "shn", englishName: "Shan", endonym: "တႆး", label: "Shan (တႆး)" },
     {
         locale: "si",
         englishName: "Sinhala",
@@ -1655,6 +1739,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Turkish (Türkçe)",
     },
     { locale: "ts", englishName: "Tsonga", endonym: "Tsonga", label: "Tsonga" },
+    {
+        locale: "tsg",
+        englishName: "Tausug",
+        endonym: "Bahasa Sūg",
+        label: "Tausug (Bahasa Sūg)",
+    },
     {
         locale: "tt",
         englishName: "Tatar",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -340,6 +340,66 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // than English — and the answer to it is a second catalog rather than a
     // change here.
     bal: ["bcc", "bgn", "bgp"],
+    // Malay, and the largest entry in this map by some distance. `locales/ms`
+    // is Standard Malay, which is `zsm` — the member `Intl.getCanonicalLocales`
+    // already rewrites to `ms`, listed here for the reason the other
+    // already-folded codes above are. The other thirty-two reach a catalog
+    // only because this list exists.
+    //
+    // The entry is owed by this repository's own roster rather than by
+    // anything ICU does. Three members have catalogs of their own — `ind`
+    // (`locales/id`), `min` (`locales/min`) and now `bjn` (`locales/bjn`) —
+    // and each is deliberately absent, which is the `bam`/`dyu` shape under
+    // `mnk`: a member this repository answers for itself must not be folded
+    // onto a sibling. `ind` would be inert here anyway, since ICU rewrites it
+    // to `id` before negotiation is consulted; `min` and `bjn` would not, and
+    // listing either would take a Minangkabau or Banjar reader off the catalog
+    // written for them and put them on Standard Malay.
+    //
+    // Two costs are worth naming rather than discovering. `mfa` (Pattani
+    // Malay) maximizes to `mfa-Arab-TH`, so a reader most likely arriving in
+    // Jawi is served Rumi — `locales/kr`'s asymmetry with `kby` and
+    // `locales/dje`'s with `tda`, and the answer to it is a second catalog
+    // rather than a change here. And `max` (North Moluccan Malay) and `xmm`
+    // (Manado Malay) are Malay-lexifier *trade creoles* rather than varieties
+    // of Malay; they are listed all the same, because unlike `ktu` under `kg`
+    // ISO 639-3 puts them inside the macrolanguage, and this map follows
+    // membership rather than second-guessing it.
+    ms: [
+        "btj",
+        "bve",
+        "bvu",
+        "coa",
+        "dup",
+        "hji",
+        "jak",
+        "jax",
+        "kvb",
+        "kvr",
+        "kxd",
+        "lce",
+        "lcf",
+        "liw",
+        "max",
+        "meo",
+        "mfa",
+        "mfb",
+        "mqg",
+        "msi",
+        "mui",
+        "orn",
+        "ors",
+        "pel",
+        "pse",
+        "tmw",
+        "urk",
+        "vkk",
+        "vkt",
+        "xmm",
+        "zlm",
+        "zmi",
+        "zsm",
+    ],
     // Komi and Mari have no entry here at all, and that is the whole of what
     // renaming their catalogs cost. Each list had shrunk to a single member —
     // `kv: ["kpv"]`, `chm: ["mhr"]` — once `koi` and `mrj` left it in the

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -340,7 +340,8 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // than English — and the answer to it is a second catalog rather than a
     // change here.
     bal: ["bcc", "bgn", "bgp"],
-    // Malay, and the largest entry in this map by some distance. `locales/ms`
+    // Malay, and the second-largest entry in this map — only Quechua's
+    // forty-three members are more, and nothing else comes close. `locales/ms`
     // is Standard Malay, which is `zsm` — the member `Intl.getCanonicalLocales`
     // already rewrites to `ms`, listed here for the reason the other
     // already-folded codes above are. The other thirty-two reach a catalog

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -341,7 +341,8 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // change here.
     bal: ["bcc", "bgn", "bgp"],
     // Malay, and the second-largest entry in this map — only Quechua's
-    // forty-three members are more, and nothing else comes close. `locales/ms`
+    // forty-three members are more, with Nahuatl's thirty just behind.
+    // `locales/ms`
     // is Standard Malay, which is `zsm` — the member `Intl.getCanonicalLocales`
     // already rewrites to `ms`, listed here for the reason the other
     // already-folded codes above are. The other thirty-two reach a catalog

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1342,18 +1342,23 @@ describe("the letter inventories the Southeast Asian headers state exactly", () 
     );
 
     /**
-     * The glottal stop, which five of the twelve write and all five write the
+     * The glottal stop, which six of the twelve write and all six write the
      * same way: **ASCII `'` (U+0027)**, never U+2019 or U+02BC.
      *
-     * This is the deliberate opposite of the Americas batch's `yua` and `kek`,
-     * which are held to U+02BC because the glottal stop is a *letter* of Mayan
-     * orthography. In Buginese, Makasar and the Philippine languages the mark
-     * is punctuation-shaped in ordinary print, the surrounding catalogs quote
-     * values with straight quotes, and a curly apostrophe in a value a reader
-     * might retype is a hazard rather than a nicety. Either convention is
-     * defensible; what a batch cannot afford is both.
+     * This is the deliberate opposite of `locales/quc`, whose Kʼicheʼ is
+     * written with U+02BC throughout because there the glottal stop is a
+     * *letter* of Mayan orthography. In Buginese, Makasar, Gorontalo, Nias,
+     * Kadazandusun and Tausug the mark is punctuation-shaped in ordinary
+     * print, the surrounding catalogs quote values with straight quotes, and a
+     * curly apostrophe in a value a reader might retype is a hazard rather
+     * than a nicety. Either convention is defensible; what a batch cannot
+     * afford is both.
+     *
+     * The other six Latin catalogs are not listed because they do not write
+     * the sound at all — the only apostrophes in `bjn`, `bbc`, `iba`, `pag`,
+     * `cbk` and `mrw` are the primes of `y'` and `d'` in mathematical prose.
      */
-    it.each(["bug", "mak", "bjn", "tsg", "pag"])(
+    it.each(["bug", "mak", "gor", "nia", "dtp", "tsg"])(
         "writes %s's glottal stop as ASCII apostrophe",
         (locale) => {
             const offenders: string[] = [];

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1173,3 +1173,263 @@ describe("plural categories a locale cannot select", () => {
         );
     });
 });
+
+/**
+ * No catalog writes a number in its own script's digits.
+ *
+ * This is the README's "Digits are Latin, separators are not" rule met from the
+ * catalog side. The rule is enforced on every *formatter* — `intlLocale` pins
+ * the numbering system, and `lint:i18n` rejects a catalog passing
+ * `numberingSystem` to a Fluent builtin — but a literal digit typed into a
+ * message value goes through no formatter at all, and there was nothing
+ * checking it.
+ *
+ * The failure it produces is worse than an inconsistency between locales. It is
+ * an inconsistency *inside one sentence*: a message reading "more than 3 points"
+ * with the 3 in Myanmar digits sits beside a `{ $count }` in the next message
+ * rendering in Latin ones, and beside mathematics that is Latin-digit
+ * regardless. `locales/mnw` and `locales/ksw` were seeded with exactly that, six
+ * messages each, and this is the property that found it.
+ *
+ * Every digit range CLDR would otherwise count in is checked rather than only
+ * the ones the roster has languages for, since the next batch is what this is
+ * for.
+ */
+describe("every catalog's digits", () => {
+    /**
+     * The decimal-digit blocks of the scripts this roster writes in, plus the
+     * ones it plausibly will. Latin `0`–`9` is deliberately absent: it is the
+     * answer, not an offender.
+     */
+    const NON_LATIN_DIGITS =
+        /[٠-٩۰-۹०-९০-৯੦-੯૦-૯୦-୯௦-௯౦-౯೦-೯൦-൯๐-๙໐-໙༠-༩၀-၉႐-႙០-៩᥆-᥏᧐-᧙]/u;
+
+    it.each(listLocales())("%s counts in Latin digits", (locale) => {
+        const offenders: string[] = [];
+        for (const namespace of CATALOG_NAMESPACES) {
+            const source = readCatalog(locale, namespace);
+            if (source === null) {
+                continue;
+            }
+            source.split("\n").forEach((line, index) => {
+                // Header prose may name a script's digits to say it does not
+                // use them, which is the opposite of the defect.
+                if (line.trimStart().startsWith("#")) {
+                    return;
+                }
+                if (NON_LATIN_DIGITS.test(line)) {
+                    offenders.push(`${namespace}:${index + 1}: ${line.trim()}`);
+                }
+            });
+        }
+        expect(offenders).toEqual([]);
+    });
+});
+
+/**
+ * The letter inventories the Southeast Asian batch's headers state exactly.
+ *
+ * Twelve of the fifteen catalogs are written in Latin, and the interesting fact
+ * about them is how *little* they need beyond ASCII: seven use nothing at all,
+ * and the other five commit to exactly one or three characters apiece. Each of
+ * those five is a letter of the language rather than decoration — `nia`'s «ö»,
+ * `mrw`'s schwa «ë», `tsg`'s Malay-derived macrons, the «é» `bug` and `mak`
+ * write for a vowel their Lontara tradition does not distinguish — and each
+ * header says which and warns against folding it away. A catalog that acquired
+ * a sixth diacritic would have acquired it by guess.
+ */
+describe("the letter inventories the Southeast Asian headers state exactly", () => {
+    /** Non-ASCII letters each Latin-script catalog's header allows. */
+    const LATIN_EXTRA: Record<string, string> = {
+        bug: "é",
+        mak: "é",
+        bjn: "",
+        gor: "",
+        nia: "ö",
+        bbc: "",
+        iba: "",
+        dtp: "",
+        pag: "",
+        cbk: "",
+        tsg: "āīū",
+        mrw: "ë",
+    };
+
+    /** Every letter a catalog writes outside ASCII, as it appears. */
+    const lettersOutsideAscii = (locale: string): Set<string> => {
+        const found = new Set<string>();
+        for (const namespace of CATALOG_NAMESPACES) {
+            const source = readCatalog(locale, namespace);
+            if (source === null) {
+                continue;
+            }
+            for (const line of source.split("\n")) {
+                // Headers quote the look-alikes they warn against, and every
+                // catalog writes DoenetML's own identifiers in Latin, so only
+                // the prose a reader sees is checked.
+                if (line.trimStart().startsWith("#")) {
+                    continue;
+                }
+                for (const letter of line.replace(/`[^`]*`/g, " ")) {
+                    if (/\p{L}/u.test(letter) && letter.codePointAt(0)! > 127) {
+                        found.add(letter);
+                    }
+                }
+            }
+        }
+        return found;
+    };
+
+    /**
+     * The same, widened to combining marks. The Myanmar script writes its
+     * vowels as marks rather than as letters, so `\p{L}` alone sees none of
+     * `ၢ`, `ႃ` or `ၣ` — the very characters the three headers below make
+     * claims about.
+     */
+    const signsOutsideAscii = (locale: string): Set<string> => {
+        const found = new Set<string>();
+        for (const namespace of CATALOG_NAMESPACES) {
+            const source = readCatalog(locale, namespace);
+            if (source === null) {
+                continue;
+            }
+            for (const line of source.split("\n")) {
+                if (line.trimStart().startsWith("#")) {
+                    continue;
+                }
+                for (const sign of line.replace(/`[^`]*`/g, " ")) {
+                    if (
+                        /[\p{L}\p{M}]/u.test(sign) &&
+                        sign.codePointAt(0)! > 127
+                    ) {
+                        found.add(sign);
+                    }
+                }
+            }
+        }
+        return found;
+    };
+
+    it.each(Object.keys(LATIN_EXTRA))(
+        "keeps %s to ASCII and the letters its header names",
+        (locale) => {
+            const allowed = new Set(
+                [...LATIN_EXTRA[locale]].flatMap((letter) => [
+                    letter,
+                    letter.toUpperCase(),
+                ]),
+            );
+            expect(
+                [...lettersOutsideAscii(locale)].filter(
+                    (letter) => !allowed.has(letter),
+                ),
+            ).toEqual([]);
+        },
+    );
+
+    /**
+     * Seven of the twelve need nothing beyond ASCII at all, asserted as a fact
+     * about those catalogs rather than left implicit in an empty string above.
+     * `cbk` is the one worth naming: printed Chavacano inherits Spanish's
+     * accents, and `locales/cbk` commits to writing none — so an «á» appearing
+     * here later is a change of orthography, not a typo.
+     */
+    it.each(["bjn", "gor", "bbc", "iba", "dtp", "pag", "cbk"])(
+        "writes %s in ASCII letters alone",
+        (locale) => {
+            expect([...lettersOutsideAscii(locale)]).toEqual([]);
+        },
+    );
+
+    /**
+     * The glottal stop, which five of the twelve write and all five write the
+     * same way: **ASCII `'` (U+0027)**, never U+2019 or U+02BC.
+     *
+     * This is the deliberate opposite of the Americas batch's `yua` and `kek`,
+     * which are held to U+02BC because the glottal stop is a *letter* of Mayan
+     * orthography. In Buginese, Makasar and the Philippine languages the mark
+     * is punctuation-shaped in ordinary print, the surrounding catalogs quote
+     * values with straight quotes, and a curly apostrophe in a value a reader
+     * might retype is a hazard rather than a nicety. Either convention is
+     * defensible; what a batch cannot afford is both.
+     */
+    it.each(["bug", "mak", "bjn", "tsg", "pag"])(
+        "writes %s's glottal stop as ASCII apostrophe",
+        (locale) => {
+            const offenders: string[] = [];
+            for (const namespace of CATALOG_NAMESPACES) {
+                const source = readCatalog(locale, namespace) ?? "";
+                for (const line of source.split("\n")) {
+                    if (line.trimStart().startsWith("#")) {
+                        continue;
+                    }
+                    if (/[’ʼʻ]/.test(line)) {
+                        offenders.push(`${namespace}: ${line.trim()}`);
+                    }
+                }
+            }
+            expect(offenders).toEqual([]);
+        },
+    );
+
+    /**
+     * The three Myanmar-script catalogs, and the two header claims a homoglyph
+     * audit corrected during seeding rather than after review.
+     *
+     * These languages share a script and do not share its letters, and the
+     * failure mode is silent: a Burmese letter standing in for the Shan or
+     * Karen one it resembles renders, lints and reads as text. So each catalog
+     * is held to the letters its own header names, in both directions — the
+     * ones it must have and the ones it must not.
+     */
+    it("holds shn, mnw and ksw to their own letters", () => {
+        const has = (locale: string, sign: string) =>
+            signsOutsideAscii(locale).has(sign);
+
+        // Shan's own consonants, and `ၢ` U+1062 — correct Shan spelling for
+        // /aa/ before a final consonant, which `shn/chrome.ftl` warns against
+        // "correcting" to `ႃ`. Both are present; neither replaces the other.
+        for (const letter of ["ၵ", "ၶ", "ၸ", "ၺ", "ၼ", "ၽ", "ၾ", "ႁ", "ဢ"]) {
+            expect(has("shn", letter)).toBe(true);
+        }
+        expect(has("shn", "ၢ")).toBe(true);
+        expect(has("shn", "ႃ")).toBe(true);
+
+        // Mon's own letters. The header first claimed `ဿ` and `ၝ` and the audit
+        // found neither in the text, so the header was corrected to match the
+        // catalog rather than the catalog padded to match the header.
+        for (const letter of ["ၚ", "ၜ", "ၞ", "ၟ", "ၠ"]) {
+            expect(has("mnw", letter)).toBe(true);
+        }
+        for (const letter of ["ဿ", "ၝ"]) {
+            expect(has("mnw", letter)).toBe(false);
+        }
+
+        // S'gaw Karen's own letters, and the sharper correction: `ၦ` and `ၯ`
+        // are **Pwo** letters, not S'gaw ones, and the seeding brief asked for
+        // them by mistake. The catalog uses neither, and `blk` and `kjp` are
+        // left to fall to English in `negotiate.test.ts` for the same reason.
+        for (const letter of ["ၢ", "ၣ", "ၤ"]) {
+            expect(has("ksw", letter)).toBe(true);
+        }
+        for (const letter of ["ၦ", "ၯ", "ၡ", "ဢ"]) {
+            expect(has("ksw", letter)).toBe(false);
+        }
+    });
+
+    /**
+     * And the negative control across the three: no catalog here writes a
+     * letter from *outside* the Myanmar block, apart from the Latin the
+     * declared English and Burmese loan registers are written in. A Thai or
+     * Khmer letter would be a seeding accident rather than a language.
+     */
+    it.each(["shn", "mnw", "ksw"])(
+        "keeps %s inside the Myanmar block",
+        (locale) => {
+            const strays = [...signsOutsideAscii(locale)].filter(
+                (sign) => !/[က-႟ꩠ-ꩿ]/u.test(sign),
+            );
+            expect(strays).toEqual([]);
+        },
+    );
+});

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1412,8 +1412,11 @@ describe("the letter inventories the Southeast Asian headers state exactly", () 
 
         // S'gaw Karen's own letters, and the sharper correction: `ၦ` and `ၯ`
         // are **Pwo** letters, not S'gaw ones, and the seeding brief asked for
-        // them by mistake. The catalog uses neither, and `blk` and `kjp` are
-        // left to fall to English in `negotiate.test.ts` for the same reason.
+        // them by mistake. The catalog uses neither. The negotiation side of
+        // the same boundary is in `negotiate.test.ts`, where `kjp` (Eastern
+        // Pwo) and `blk` (Pa'o) fall to English rather than to this catalog —
+        // there because `kar` is an ISO 639-5 collection rather than a
+        // macrolanguage, not because of any letter.
         for (const letter of ["ၢ", "ၣ", "ၤ"]) {
             expect(has("ksw", letter)).toBe(true);
         }

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -1232,11 +1232,12 @@ describe("every catalog's digits", () => {
  * Twelve of the fifteen catalogs are written in Latin, and the interesting fact
  * about them is how *little* they need beyond ASCII: seven use nothing at all,
  * and the other five commit to exactly one or three characters apiece. Each of
- * those five is a letter of the language rather than decoration — `nia`'s «ö»,
- * `mrw`'s schwa «ë», `tsg`'s Malay-derived macrons, the «é» `bug` and `mak`
- * write for a vowel their Lontara tradition does not distinguish — and each
- * header says which and warns against folding it away. A catalog that acquired
- * a sixth diacritic would have acquired it by guess.
+ * those five carries a distinction of the language rather than decoration —
+ * `nia`'s «ö», `mrw`'s schwa «ë», `tsg`'s macrons for a long vowel, the «é»
+ * `bug` and `mak` write for a vowel their Lontara tradition does not
+ * distinguish — and each locale's header names its own and warns against
+ * folding it away. A catalog that acquired a sixth diacritic would have
+ * acquired it by guess.
  */
 describe("the letter inventories the Southeast Asian headers state exactly", () => {
     /** Non-ASCII letters each Latin-script catalog's header allows. */

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -879,7 +879,7 @@ describe("the Southeast Asian batch's plural categories", () => {
     type Row = [string, string, string];
 
     /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
-    const both = ([, chrome, diagnostics]: Row) =>
+    const both = (chrome: string, diagnostics: string) =>
         `${branches(chrome)}\n${branches(diagnostics)}`;
 
     /**
@@ -904,7 +904,7 @@ describe("the Southeast Asian batch's plural categories", () => {
         ["ksw", kswChrome, kswDiagnostics],
     ];
 
-    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+    it.each(SOUTHEAST_ASIA)(
         "resolves %s against some other language's rules",
         (locale) => {
             // CLDR has no rules for the tag, so the categories on offer belong
@@ -929,11 +929,10 @@ describe("the Southeast Asian batch's plural categories", () => {
      * finds a category branch in one of these files has found a drift rather
      * than a judgement call.
      */
-    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+    it.each(SOUTHEAST_ASIA)(
         "gives %s no plural category branch anywhere",
-        (locale) => {
-            const row = SOUTHEAST_ASIA.find(([tag]) => tag === locale)!;
-            const text = both(row);
+        (_locale, chrome, diagnostics) => {
+            const text = both(chrome, diagnostics);
             for (const category of ["zero", "one", "two", "few", "many"]) {
                 expect(text).not.toContain(`[${category}]`);
             }
@@ -948,15 +947,14 @@ describe("the Southeast Asian batch's plural categories", () => {
      * against the number rather than against a category, and so legal in a
      * locale with no rules of its own.
      */
-    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+    it.each(SOUTHEAST_ASIA)(
         "keeps %s's numeric literals, which no plural rule selects",
-        (locale) => {
-            const row = SOUTHEAST_ASIA.find(([tag]) => tag === locale)!;
-            expect(branches(row[2])).toContain(
+        (_locale, chrome, diagnostics) => {
+            expect(branches(diagnostics)).toContain(
                 "field-function-wrong-num-outputs",
             );
-            expect(both(row)).toContain("[1]");
-            expect(branches(row[1])).toContain("[0]");
+            expect(both(chrome, diagnostics)).toContain("[1]");
+            expect(branches(chrome)).toContain("[0]");
         },
     );
 
@@ -965,12 +963,8 @@ describe("the Southeast Asian batch's plural categories", () => {
      * branch" by dropping `{ $count }` would pass every assertion above and
      * serve a reader a sentence with the number missing from it.
      */
-    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
-        "still renders %s's counts",
-        (locale) => {
-            const row = SOUTHEAST_ASIA.find(([tag]) => tag === locale)!;
-            const t = createChromeTranslator(locale, { [locale]: row[1] });
-            expect(t("attempts-remaining", { count: 3 })).toContain("3");
-        },
-    );
+    it.each(SOUTHEAST_ASIA)("still renders %s's counts", (locale, chrome) => {
+        const t = createChromeTranslator(locale, { [locale]: chrome });
+        expect(t("attempts-remaining", { count: 3 })).toContain("3");
+    });
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -54,6 +54,36 @@ import zzaChrome from "../locales/zza/chrome.ftl?raw";
 import dngChrome from "../locales/dng/chrome.ftl?raw";
 import sghChrome from "../locales/sgh/chrome.ftl?raw";
 import wblChrome from "../locales/wbl/chrome.ftl?raw";
+import bugChrome from "../locales/bug/chrome.ftl?raw";
+import bugDiagnostics from "../locales/bug/diagnostics.ftl?raw";
+import makChrome from "../locales/mak/chrome.ftl?raw";
+import makDiagnostics from "../locales/mak/diagnostics.ftl?raw";
+import bjnChrome from "../locales/bjn/chrome.ftl?raw";
+import bjnDiagnostics from "../locales/bjn/diagnostics.ftl?raw";
+import gorChrome from "../locales/gor/chrome.ftl?raw";
+import gorDiagnostics from "../locales/gor/diagnostics.ftl?raw";
+import niaChrome from "../locales/nia/chrome.ftl?raw";
+import niaDiagnostics from "../locales/nia/diagnostics.ftl?raw";
+import bbcChrome from "../locales/bbc/chrome.ftl?raw";
+import bbcDiagnostics from "../locales/bbc/diagnostics.ftl?raw";
+import ibaChrome from "../locales/iba/chrome.ftl?raw";
+import ibaDiagnostics from "../locales/iba/diagnostics.ftl?raw";
+import dtpChrome from "../locales/dtp/chrome.ftl?raw";
+import dtpDiagnostics from "../locales/dtp/diagnostics.ftl?raw";
+import pagChrome from "../locales/pag/chrome.ftl?raw";
+import pagDiagnostics from "../locales/pag/diagnostics.ftl?raw";
+import cbkChrome from "../locales/cbk/chrome.ftl?raw";
+import cbkDiagnostics from "../locales/cbk/diagnostics.ftl?raw";
+import tsgChrome from "../locales/tsg/chrome.ftl?raw";
+import tsgDiagnostics from "../locales/tsg/diagnostics.ftl?raw";
+import mrwChrome from "../locales/mrw/chrome.ftl?raw";
+import mrwDiagnostics from "../locales/mrw/diagnostics.ftl?raw";
+import shnChrome from "../locales/shn/chrome.ftl?raw";
+import shnDiagnostics from "../locales/shn/diagnostics.ftl?raw";
+import mnwChrome from "../locales/mnw/chrome.ftl?raw";
+import mnwDiagnostics from "../locales/mnw/diagnostics.ftl?raw";
+import kswChrome from "../locales/ksw/chrome.ftl?raw";
+import kswDiagnostics from "../locales/ksw/diagnostics.ftl?raw";
 // The Silk Road batch's `diagnostics.ftl` too: it holds every count select
 // that is not in `chrome.ftl`, so where each catalog's `[one]` falls is only
 // checkable across both files.
@@ -834,6 +864,113 @@ describe("the Silk Road batch's plural categories", () => {
                 t("attempts-remaining", { count: 3 }),
             );
             expect(none).not.toBe(some);
+        },
+    );
+});
+
+describe("the Southeast Asian batch's plural categories", () => {
+    /** Comment lines dropped: several headers discuss `[one]` in prose. */
+    const branches = (catalog: string) =>
+        catalog
+            .split("\n")
+            .filter((line) => !line.trimStart().startsWith("#"))
+            .join("\n");
+
+    type Row = [string, string, string];
+
+    /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
+    const both = ([, chrome, diagnostics]: Row) =>
+        `${branches(chrome)}\n${branches(diagnostics)}`;
+
+    /**
+     * All fifteen, and — unlike the Silk Road batch, which had `bal` — there is
+     * no sub-list here, because not one of the fifteen has CLDR plural data.
+     */
+    const SOUTHEAST_ASIA: Row[] = [
+        ["bug", bugChrome, bugDiagnostics],
+        ["mak", makChrome, makDiagnostics],
+        ["bjn", bjnChrome, bjnDiagnostics],
+        ["gor", gorChrome, gorDiagnostics],
+        ["nia", niaChrome, niaDiagnostics],
+        ["bbc", bbcChrome, bbcDiagnostics],
+        ["iba", ibaChrome, ibaDiagnostics],
+        ["dtp", dtpChrome, dtpDiagnostics],
+        ["pag", pagChrome, pagDiagnostics],
+        ["cbk", cbkChrome, cbkDiagnostics],
+        ["tsg", tsgChrome, tsgDiagnostics],
+        ["mrw", mrwChrome, mrwDiagnostics],
+        ["shn", shnChrome, shnDiagnostics],
+        ["mnw", mnwChrome, mnwDiagnostics],
+        ["ksw", kswChrome, kswDiagnostics],
+    ];
+
+    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+        "resolves %s against some other language's rules",
+        (locale) => {
+            // CLDR has no rules for the tag, so the categories on offer belong
+            // to the runtime's default locale rather than to the language.
+            expect(new Intl.PluralRules(locale).resolvedOptions().locale) //
+                .not.toBe(locale);
+        },
+    );
+
+    /**
+     * The whole batch writes no category branch at all — not even `[one]`,
+     * which the Silk Road batch allowed itself in eleven of fifteen catalogs
+     * and which `allowedPluralCategories` still permits a no-data locale.
+     *
+     * This is stricter than the lint requires, and it is a decision rather than
+     * an accident: the one message that forks in English forks on how many
+     * outputs a component *needs* rather than on a quantity the reader is
+     * looking at, so every catalog here writes it as the numeric literal `[1]`,
+     * which Fluent matches against the number before consulting any plural rule
+     * and which therefore does not depend on whose rules the runtime picked.
+     * Uniformity across a batch is worth something on its own: a reviewer who
+     * finds a category branch in one of these files has found a drift rather
+     * than a judgement call.
+     */
+    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+        "gives %s no plural category branch anywhere",
+        (locale) => {
+            const row = SOUTHEAST_ASIA.find(([tag]) => tag === locale)!;
+            const text = both(row);
+            for (const category of ["zero", "one", "two", "few", "many"]) {
+                expect(text).not.toContain(`[${category}]`);
+            }
+        },
+    );
+
+    /**
+     * The other half, which is what would fail if a catalog had answered the
+     * rule above by dropping the fork instead of rewriting it. All fifteen keep
+     * English's `[1]` in `field-function-wrong-num-outputs`, and all fifteen
+     * keep the explicit `[0]` that says "no attempts remaining" — matched
+     * against the number rather than against a category, and so legal in a
+     * locale with no rules of its own.
+     */
+    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+        "keeps %s's numeric literals, which no plural rule selects",
+        (locale) => {
+            const row = SOUTHEAST_ASIA.find(([tag]) => tag === locale)!;
+            expect(branches(row[2])).toContain(
+                "field-function-wrong-num-outputs",
+            );
+            expect(both(row)).toContain("[1]");
+            expect(branches(row[1])).toContain("[0]");
+        },
+    );
+
+    /**
+     * And the counts still render. A catalog that answered "write no category
+     * branch" by dropping `{ $count }` would pass every assertion above and
+     * serve a reader a sentence with the number missing from it.
+     */
+    it.each(SOUTHEAST_ASIA.map(([locale]) => locale))(
+        "still renders %s's counts",
+        (locale) => {
+            const row = SOUTHEAST_ASIA.find(([tag]) => tag === locale)!;
+            const t = createChromeTranslator(locale, { [locale]: row[1] });
+            expect(t("attempts-remaining", { count: 3 })).toContain("3");
         },
     );
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -942,29 +942,42 @@ describe("the Southeast Asian batch's plural categories", () => {
     /**
      * The other half, which is what would fail if a catalog had answered the
      * rule above by dropping the fork instead of rewriting it. All fifteen keep
-     * English's `[1]` in `field-function-wrong-num-outputs`, and all fifteen
-     * keep the explicit `[0]` that says "no attempts remaining" — matched
+     * English's `[1]` fork in `field-function-wrong-num-outputs` — matched
      * against the number rather than against a category, and so legal in a
      * locale with no rules of its own.
+     *
+     * The `[1]` is looked for inside that one message rather than anywhere in
+     * the file, since a stray literal elsewhere would otherwise stand in for
+     * the fork this is about.
      */
     it.each(SOUTHEAST_ASIA)(
-        "keeps %s's numeric literals, which no plural rule selects",
-        (_locale, chrome, diagnostics) => {
-            expect(branches(diagnostics)).toContain(
-                "field-function-wrong-num-outputs",
-            );
-            expect(both(chrome, diagnostics)).toContain("[1]");
-            expect(branches(chrome)).toContain("[0]");
+        "keeps %s's numeric literal, which no plural rule selects",
+        (_locale, _chrome, diagnostics) => {
+            const message = branches(diagnostics)
+                .split("\nfield-function-wrong-num-outputs =")[1]
+                ?.split(/\n(?=\S)/)[0];
+            expect(message).toBeDefined();
+            expect(message).toContain("[1]");
         },
     );
 
     /**
-     * And the counts still render. A catalog that answered "write no category
-     * branch" by dropping `{ $count }` would pass every assertion above and
-     * serve a reader a sentence with the number missing from it.
+     * And the counts still render, which is the half that would break if a
+     * catalog had answered "write no category branch" by dropping `{ $count }`
+     * or its default branch rather than by rewriting the select. The zero case
+     * is asserted through the renderer for the same reason: `[0]` is selected
+     * by the number itself, so what matters is that it *reaches* the reader,
+     * not that the literal appears in the file.
      */
     it.each(SOUTHEAST_ASIA)("still renders %s's counts", (locale, chrome) => {
         const t = createChromeTranslator(locale, { [locale]: chrome });
-        expect(t("attempts-remaining", { count: 3 })).toContain("3");
+        for (const count of [1, 2, 5]) {
+            expect(
+                stripBidiIsolates(t("attempts-remaining", { count })),
+            ).toContain(String(count));
+        }
+        expect(t("attempts-remaining", { count: 0 })).not.toBe(
+            t("attempts-remaining", { count: 3 }),
+        );
     });
 });

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -466,13 +466,26 @@ describe("negotiateLocales", () => {
             },
         );
 
-        // Pangasinan is a Philippine language with no catalog that belongs to
-        // no macrolanguage with one, so it falls all the way to English — the
-        // rule working rather than a gap in it.
-        it("leaves Pangasinan on English rather than guessing", () => {
+        // Ibanag is a Philippine language with no catalog that belongs to no
+        // macrolanguage with one, so it falls all the way to English — the rule
+        // working rather than a gap in it.
+        //
+        // Pangasinan stood here until the Southeast Asian batch, and what
+        // replacing it cost is the whole of what seeding `pag` cost this
+        // block: the tag now reaches `locales/pag`, and nothing else in the
+        // Bikol list changed, because Pangasinan was never a member of
+        // anything. A negative control has to name a language the roster does
+        // not have, so the row moves rather than being deleted.
+        it("leaves Ibanag on English rather than guessing", () => {
+            expect(
+                negotiateLocales([normalizeLocaleTag("ibg")], available),
+            ).toEqual(["en"]);
+        });
+
+        it("takes Pangasinan to the catalog it now has", () => {
             expect(
                 negotiateLocales([normalizeLocaleTag("pag")], available),
-            ).toEqual(["en"]);
+            ).toEqual(["pag", "en"]);
         });
     });
 
@@ -2273,6 +2286,244 @@ describe("a host catalog keyed on an aliased tag", () => {
             // the pair above reads as the exception it is.
             for (const locale of ["kjh", "alt", "dng", "sgh"]) {
                 expect(new Intl.Locale(locale).maximize().script).toBe("Cyrl");
+            }
+        });
+    });
+    describe("the Southeast Asian batch", () => {
+        /** The fifteen tags this batch adds, in the order the README lists them. */
+        const SOUTHEAST_ASIA = [
+            "bug",
+            "mak",
+            "bjn",
+            "gor",
+            "nia",
+            "bbc",
+            "iba",
+            "dtp",
+            "pag",
+            "cbk",
+            "tsg",
+            "mrw",
+            "shn",
+            "mnw",
+            "ksw",
+        ];
+
+        /**
+         * Every one of the fifteen reaches the directory it names when the
+         * whole roster is on offer, and reaches English when only English is.
+         * The second half is what would fail if the new `ms` row were quietly
+         * folding one of these tags onto Standard Malay instead of letting it
+         * arrive under its own name — which is a live hazard here rather than a
+         * theoretical one, since `bjn` really is a member of `msa`.
+         */
+        it("gives each of the fifteen its own catalog and nothing else", () => {
+            for (const locale of SOUTHEAST_ASIA) {
+                expect(negotiateLocales([locale], ["en"])).toEqual(["en"]);
+                expect(negotiateLocales([locale], available)).toEqual([
+                    locale,
+                    "en",
+                ]);
+            }
+        });
+
+        /**
+         * The three members of Malay this repository answers for itself, which
+         * is the reason the `ms` row is an exclusion list rather than the
+         * macrolanguage's whole membership.
+         *
+         * `ind` is inert either way — ICU rewrites it to `id` before
+         * negotiation is consulted — so `min` and `bjn` are the two that carry
+         * the point: both are ISO 639-3 members of `msa`, both are left out of
+         * the row on purpose, and listing either would take a Minangkabau or
+         * Banjar reader off the catalog written for them and put them on
+         * Standard Malay. That is the `bam`/`dyu` shape under `mnk`, met in a
+         * macrolanguage with thirty-six members instead of eight.
+         */
+        it.each(["min", "bjn"])(
+            "keeps %s on its own catalog rather than folding it onto ms",
+            (member) => {
+                expect(normalizeLocaleTag(member)).toBe(member);
+                expect(negotiateLocales([member], available)).toEqual([
+                    member,
+                    "en",
+                ]);
+            },
+        );
+
+        it("folds ind onto id before the map is consulted at all", () => {
+            expect(normalizeLocaleTag("ind")).toBe("id");
+            expect(negotiateLocales([normalizeLocaleTag("ind")], available)) //
+                .toEqual(["id", "en"]);
+        });
+
+        /**
+         * The rest of the macrolanguage, which reaches `locales/ms` only
+         * because the row exists. `zsm` is the one ICU folds on its own and is
+         * listed for the reason the other already-folded codes in that map are;
+         * the others are left unresolvable by CLDR and would each filter
+         * against a language subtag no directory is named for.
+         *
+         * `max` and `xmm` are the pair worth naming. Both are Malay-lexifier
+         * *trade creoles* rather than varieties of Malay, and the map's own
+         * `ktu`-under-`kg` comment refuses exactly that kind of fold — the
+         * difference being that ISO 639-3 puts these two *inside* `msa` and
+         * puts Kituba outside `kg`. The rule stays published membership rather
+         * than a judgement about how close two varieties are.
+         */
+        it.each([
+            ["zsm", true],
+            ["kxd", false],
+            ["meo", false],
+            ["mfa", false],
+            ["pse", false],
+            ["zlm", false],
+            ["max", false],
+            ["xmm", false],
+            ["msi", false],
+            ["urk", false],
+        ])("reaches ms's catalog as %s", (member, foldedByIcu) => {
+            expect(normalizeLocaleTag(member) === "ms").toBe(foldedByIcu);
+            expect(
+                negotiateLocales([normalizeLocaleTag(member)], available),
+            ).toEqual(["ms", "en"]);
+        });
+
+        /**
+         * The script asymmetry the `ms` row buys, which is `locales/kr`'s with
+         * `kby` and `locales/dje`'s with `tda` reached a third time.
+         *
+         * `mfa` (Pattani Malay) maximizes to **`mfa-Arab-TH`**, so CLDR's own
+         * data says the likeliest Pattani reader arrives in Jawi, and
+         * `locales/ms` is Rumi. Script subtags are filtered away, so the
+         * request is served an alphabet its reader may not use rather than
+         * missing — a debt the roster records, whose answer is a second catalog
+         * rather than a change in the map.
+         */
+        it("serves Rumi to the one member CLDR maximizes into Jawi", () => {
+            expect(new Intl.Locale("mfa").maximize().script).toBe("Arab");
+            expect(
+                negotiateLocales([normalizeLocaleTag("mfa-Arab")], available),
+            ).toEqual(["ms", "en"]);
+        });
+
+        /**
+         * The one fold in this batch that needs no map row at all: ICU
+         * canonicalizes `kzj` (Coastal Kadazan) onto `dtp`, so a Coastal
+         * Kadazan reader reaches the Kadazandusun catalog for free.
+         *
+         * `locales/dtp` is written in the Bundu-Liwan-based standard of Sabah
+         * schooling and its header names `dtb` and `drg` as siblings a reader
+         * may have to respell from — «opurak» against Coastal «oputi'». Those
+         * two are deliberately *not* folded: `dtp` is not an ISO 639-3
+         * macrolanguage, so there is no published membership to follow and
+         * adding them would be the judgement `MACROLANGUAGE_MEMBERS` exists to
+         * avoid. `kzj` is different in kind — ICU already decided it.
+         */
+        it("takes kzj to dtp through ICU and leaves dtb and drg to miss", () => {
+            expect(normalizeLocaleTag("kzj")).toBe("dtp");
+            expect(negotiateLocales([normalizeLocaleTag("kzj")], available)) //
+                .toEqual(["dtp", "en"]);
+            for (const sibling of ["dtb", "drg"]) {
+                expect(normalizeLocaleTag(sibling)).toBe(sibling);
+                expect(
+                    negotiateLocales([normalizeLocaleTag(sibling)], available),
+                ).toEqual(["en"]);
+            }
+        });
+
+        /**
+         * The near misses, which in this batch are mostly *siblings inside one
+         * island group* rather than the far-flung relatives the Silk Road block
+         * lists.
+         *
+         * `bbc` (Toba) has four other Batak codes beside it — `btd` Dairi,
+         * `bts` Simalungun, `btx` Karo, `btz` Alas-Kluet — and ISO 639-3 makes
+         * every one a separate language rather than a member of a
+         * macrolanguage, so there is nothing to fold. `bug` and `mak` sit
+         * beside `mdr` (Mandar) in South Sulawesi on the same footing. `mrw`
+         * (Maranao) and `mdh` (Maguindanaon) are the two Danao languages and
+         * only one has a catalog; `krj` (Kinaray-a) and `akl` (Aklanon) are
+         * Bisayan neighbours of `tsg`; and `nij` (Ngaju) is `bjn`'s Bornean
+         * neighbour and, being Barito rather than Malayic, is not in `msa`
+         * either.
+         *
+         * `blk` (Pa'o Karen) and `kjp` (Eastern Pwo) are the Karen languages
+         * beside `ksw`, and they are the sharpest of the group: `kar` is an
+         * ISO 639-5 **collection** code rather than a macrolanguage, so there
+         * is no membership fact that would let either reach the S'gaw catalog,
+         * and `locales/ksw`'s own header records that `ၦ` and `ၯ` are Pwo
+         * letters it does not use.
+         */
+        it.each([
+            "btd",
+            "bts",
+            "btx",
+            "btz",
+            "mdr",
+            "mdh",
+            "krj",
+            "akl",
+            "nij",
+            "blk",
+            "kjp",
+        ])(
+            "leaves %s on English rather than folding it onto a neighbour",
+            (requested) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual(["en"]);
+            },
+        );
+
+        /**
+         * The collection codes, left to miss for `map`'s and `smi`'s reason:
+         * ISO 639-5 groups are not languages, no catalog can be written in one,
+         * and `Intl` leaves all three exactly as typed. `btk` (Batak) and
+         * `kar` (Karen) each sit directly over a catalog in this batch, which
+         * is what makes them worth asserting rather than assuming.
+         */
+        it.each(["btk", "kar"])(
+            "leaves the collection code %s on English",
+            (requested) => {
+                expect(normalizeLocaleTag(requested)).toBe(requested);
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual(["en"]);
+            },
+        );
+
+        /**
+         * Script and region subtags are filtered away, so the tags a document
+         * or a browser is likely to send reach the same catalog the bare tag
+         * does. The three Myanmar-script catalogs are the ones worth writing
+         * out: all three maximize to `-Mymr-MM`, and all three *are* written in
+         * that script, so unlike `mfa` above they carry no debt.
+         */
+        it.each([
+            ["shn-Mymr", "shn"],
+            ["mnw-Mymr", "mnw"],
+            ["ksw-Mymr", "ksw"],
+            ["shn-Mymr-MM", "shn"],
+            ["bjn-Latn", "bjn"],
+            ["cbk-Latn-PH", "cbk"],
+            ["tsg-Latn", "tsg"],
+            ["iba-Latn-MY", "iba"],
+        ])("reaches %s's catalog as %s", (requested, expected) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual([expected, "en"]);
+        });
+
+        it("has all three Myanmar-script catalogs maximize into the script they are written in", () => {
+            for (const locale of ["shn", "mnw", "ksw"]) {
+                expect(new Intl.Locale(locale).maximize().script).toBe("Mymr");
             }
         });
     });

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -472,20 +472,15 @@ describe("negotiateLocales", () => {
         //
         // Pangasinan stood here until the Southeast Asian batch, and what
         // replacing it cost is the whole of what seeding `pag` cost this
-        // block: the tag now reaches `locales/pag`, and nothing else in the
-        // Bikol list changed, because Pangasinan was never a member of
-        // anything. A negative control has to name a language the roster does
-        // not have, so the row moves rather than being deleted.
+        // block: nothing else in the Bikol list changed, because Pangasinan
+        // was never a member of anything. A negative control has to name a
+        // language the roster does not have, so the row moves rather than
+        // being deleted; where `pag` goes now is asserted with the rest of its
+        // batch, in "the Southeast Asian batch" below.
         it("leaves Ibanag on English rather than guessing", () => {
             expect(
                 negotiateLocales([normalizeLocaleTag("ibg")], available),
             ).toEqual(["en"]);
-        });
-
-        it("takes Pangasinan to the catalog it now has", () => {
-            expect(
-                negotiateLocales([normalizeLocaleTag("pag")], available),
-            ).toEqual(["pag", "en"]);
         });
     });
 
@@ -2310,12 +2305,19 @@ describe("a host catalog keyed on an aliased tag", () => {
         ];
 
         /**
-         * Every one of the fifteen reaches the directory it names when the
-         * whole roster is on offer, and reaches English when only English is.
-         * The second half is what would fail if the new `ms` row were quietly
-         * folding one of these tags onto Standard Malay instead of letting it
-         * arrive under its own name — which is a live hazard here rather than a
-         * theoretical one, since `bjn` really is a member of `msa`.
+         * Every one of the fifteen reaches the directory it names, and reaches
+         * *only* that directory before English.
+         *
+         * The exact chain rather than a `toContain` is the point: a `["bjn",
+         * "ms", "en"]` would pass a containment check and would mean the new
+         * `ms` row had folded a tag of this batch onto Standard Malay behind
+         * its own catalog. That is a live hazard rather than a theoretical one,
+         * since `bjn` really is a member of `msa`.
+         *
+         * The English-only roster is asserted beside it for a different reason:
+         * it is the fallback these fifteen had before this PR, so it pins that
+         * seeding a catalog did not change what happens on a host that ships
+         * none of them.
          */
         it("gives each of the fifteen its own catalog and nothing else", () => {
             for (const locale of SOUTHEAST_ASIA) {
@@ -2414,8 +2416,9 @@ describe("a host catalog keyed on an aliased tag", () => {
          * Kadazan reader reaches the Kadazandusun catalog for free.
          *
          * `locales/dtp` is written in the Bundu-Liwan-based standard of Sabah
-         * schooling and its header names `dtb` and `drg` as siblings a reader
-         * may have to respell from — «opurak» against Coastal «oputi'». Those
+         * schooling and its header names `dtb` (Labuk-Kinabatangan Kadazan)
+         * and `drg` (Rungus) as siblings a reader may have to respell from —
+         * «opurak» against Coastal «oputi'». Those
          * two are deliberately *not* folded: `dtp` is not an ISO 639-3
          * macrolanguage, so there is no published membership to follow and
          * adding them would be the judgement `MACROLANGUAGE_MEMBERS` exists to

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -2338,7 +2338,8 @@ describe("a host catalog keyed on an aliased tag", () => {
          * the row on purpose, and listing either would take a Minangkabau or
          * Banjar reader off the catalog written for them and put them on
          * Standard Malay. That is the `bam`/`dyu` shape under `mnk`, met in a
-         * macrolanguage with thirty-six members instead of eight.
+         * thirty-six-member macrolanguage rather than in the handful of
+         * Manding siblings that row lists.
          */
         it.each(["min", "bjn"])(
             "keeps %s on its own catalog rather than folding it onto ms",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65459,6 +65459,10 @@
                             "description": "Balinese"
                         },
                         {
+                            "value": "bbc",
+                            "description": "Batak Toba"
+                        },
+                        {
                             "value": "bci",
                             "description": "Baoulé (bci)"
                         },
@@ -65491,6 +65495,10 @@
                             "description": "Bini"
                         },
                         {
+                            "value": "bjn",
+                            "description": "Banjar"
+                        },
+                        {
                             "value": "bm",
                             "description": "Bambara (bamanakan)"
                         },
@@ -65519,12 +65527,20 @@
                             "description": "Buriat (буряад)"
                         },
                         {
+                            "value": "bug",
+                            "description": "Buginese"
+                        },
+                        {
                             "value": "bum",
                             "description": "Bulu"
                         },
                         {
                             "value": "ca",
                             "description": "Catalan (català)"
+                        },
+                        {
+                            "value": "cbk",
+                            "description": "Chavacano (cbk)"
                         },
                         {
                             "value": "ce",
@@ -65601,6 +65617,10 @@
                         {
                             "value": "dsb",
                             "description": "Lower Sorbian (dolnoserbšćina)"
+                        },
+                        {
+                            "value": "dtp",
+                            "description": "Central Dusun"
                         },
                         {
                             "value": "dv",
@@ -65723,6 +65743,10 @@
                             "description": "Guarani"
                         },
                         {
+                            "value": "gor",
+                            "description": "Gorontalo"
+                        },
+                        {
                             "value": "gsw",
                             "description": "Swiss German (Schwiizertüütsch)"
                         },
@@ -65777,6 +65801,10 @@
                         {
                             "value": "hy",
                             "description": "Armenian (հայերեն)"
+                        },
+                        {
+                            "value": "iba",
+                            "description": "Iban"
                         },
                         {
                             "value": "id",
@@ -65915,6 +65943,10 @@
                             "description": "Colognian (Kölsch)"
                         },
                         {
+                            "value": "ksw",
+                            "description": "S'gaw Karen (ကညီကျိာ်)"
+                        },
+                        {
                             "value": "ktu",
                             "description": "Kituba (Kikongo ya leta)"
                         },
@@ -65991,6 +66023,10 @@
                             "description": "Maithili (मैथिली)"
                         },
                         {
+                            "value": "mak",
+                            "description": "Makasar"
+                        },
+                        {
                             "value": "mdf",
                             "description": "Moksha"
                         },
@@ -66043,6 +66079,10 @@
                             "description": "Mansi (мāньси лāтыӈ)"
                         },
                         {
+                            "value": "mnw",
+                            "description": "Mon (ဘာသာမန်)"
+                        },
+                        {
                             "value": "mos",
                             "description": "Mossi"
                         },
@@ -66053,6 +66093,10 @@
                         {
                             "value": "mrj",
                             "description": "Western Mari"
+                        },
+                        {
+                            "value": "mrw",
+                            "description": "Maranao (Basa a Mëranaw)"
                         },
                         {
                             "value": "ms",
@@ -66093,6 +66137,10 @@
                         {
                             "value": "ne",
                             "description": "Nepali (नेपाली)"
+                        },
+                        {
+                            "value": "nia",
+                            "description": "Nias"
                         },
                         {
                             "value": "niu",
@@ -66149,6 +66197,10 @@
                         {
                             "value": "pa",
                             "description": "Punjabi (ਪੰਜਾਬੀ)"
+                        },
+                        {
+                            "value": "pag",
+                            "description": "Pangasinan"
                         },
                         {
                             "value": "pam",
@@ -66257,6 +66309,10 @@
                         {
                             "value": "shi",
                             "description": "Tachelhit (ⵜⴰⵛⵍⵃⵉⵜ)"
+                        },
+                        {
+                            "value": "shn",
+                            "description": "Shan (တႆး)"
                         },
                         {
                             "value": "si",
@@ -66409,6 +66465,10 @@
                         {
                             "value": "ts",
                             "description": "Tsonga"
+                        },
+                        {
+                            "value": "tsg",
+                            "description": "Tausug (Bahasa Sūg)"
                         },
                         {
                             "value": "tt",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -4852,8 +4852,9 @@ describe("the Southeast Asian batch's word order", () => {
      * Indonesian word reaching six languages through one school system, not
      * six languages arriving at it. `bug` and `mak` are pinned beside them
      * precisely because they do *not* — «pettu-pettu» and «tappolo-polo» —
-     * and seven of the eight supply a colour word of their own where `nia` still
-     * falls back to Indonesian «merah». Replacing a loan should be a visible
+     * and seven of the eight supply a red of their own where `nia` still
+     * falls back to Indonesian «merah» — `nia`'s two native colour words are
+     * black and white, and red is not among them. Replacing a loan should be a visible
      * diff here rather than a silent improvement.
      */
     const postnominal: [string, string, string][] = [
@@ -4963,12 +4964,21 @@ describe("the Southeast Asian batch's word order", () => {
      * of asserting it, since the Silk Road batch split on exactly this and
      * along a different line than its adjectives did.
      *
-     * All fifteen use `[noun-tail]`, because in all fifteen the count follows
-     * the noun whatever the adjectives do: «poligon biasa iya 5 sisina»,
-     * «poligono que tiene 5 lado», «regular polygon 5 ၸဵင်ႇ». So the four
-     * prenominal catalogs put their modifiers in front of a noun that still
-     * carries its count behind it, and no catalog in the batch folds the count
-     * into the head the way eleven Silk Road catalogs did.
+     * In all fifteen the count sits **behind** the noun whatever the
+     * adjectives do — «poligon biasa iya 5 sisina», «poligono que tiene 5
+     * lado», «regular polygon 5 ၸဵင်ႇ» — so the four prenominal catalogs put
+     * their modifiers in front of a noun that still carries its count behind
+     * it.
+     *
+     * Which of `style-with-noun`'s two variants gets there is a separate
+     * question, and on that the batch does split, three against twelve.
+     * `noun-regular-polygon`'s `[tail]` is written only in `pag`, `cbk` and
+     * `mrw` — «ya walaay { $numSides } a gilig», «que tiene { $numSides }
+     * lado», «a aden a { $numSides } a kilid iyan» — and only those three
+     * therefore select `[noun-tail]`. The other twelve leave `[tail]` empty
+     * exactly as `locales/en` does, fold the count into `[head]`, and select
+     * `[noun]`. Both shapes put the count in the same place, which is why the
+     * assertion below is on the rendered phrase rather than on the variant.
      */
     it.each([
         ["bug", "poligon biasa iya 5 sisina tebal pettu-pettu macella'"],
@@ -5001,8 +5011,10 @@ describe("the Southeast Asian batch's word order", () => {
             withNoun: true,
         });
         expect(phrase).toBe(expected);
-        // The count is behind the noun in all fifteen, so none of them can be
-        // rendering `[noun-tail]` as empty.
+        // The count reaches the reader in all fifteen, whichever of the two
+        // variants carries it — a catalog that dropped `{ $numSides }` from
+        // whichever branch it uses would still match the shape of the phrase
+        // above but not this.
         expect(phrase).toContain("5");
     });
 

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -4853,9 +4853,11 @@ describe("the Southeast Asian batch's word order", () => {
      * six languages arriving at it. `bug` and `mak` are pinned beside them
      * precisely because they do *not* — «pettu-pettu» and «tappolo-polo» —
      * and seven of the eight supply a red of their own where `nia` still
-     * falls back to Indonesian «merah» — `nia`'s two native colour words are
-     * black and white, and red is not among them. Replacing a loan should be a visible
-     * diff here rather than a silent improvement.
+     * falls back to Indonesian «merah» — the only two colour words
+     * `locales/nia` attempts in Nias are black and white, and its header calls
+     * the missing red a gap in the seed rather than a fact about the language.
+     * Replacing a loan should be a visible diff here rather than a silent
+     * improvement.
      */
     const postnominal: [string, string, string][] = [
         [

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -4811,3 +4811,219 @@ describe("the Silk Road batch's word order", () => {
         },
     );
 });
+
+describe("the Southeast Asian batch's word order", () => {
+    /**
+     * Fifteen languages of maritime and mainland Southeast Asia, and the line
+     * between the two orders is neither family nor script — it is a **border**.
+     * Eleven catalogs put the modifiers behind the noun and four put them in
+     * front, and the four are exactly the four catalogs of the Philippines.
+     *
+     * That is a sharper claim than "Austronesian splits", because eleven of the
+     * fifteen are Austronesian and they fall on both sides of it. The eight
+     * catalogs of Indonesia and Malaysian Borneo are head-initial like the
+     * Malay their technical register comes from; the three Philippine
+     * non-creoles are the Central Philippine order English happens to share;
+     * and the three Myanmar-script catalogs land with the first group for
+     * reasons of their own — Tai, Austroasiatic and Sino-Tibetan all being
+     * head-initial in the noun phrase.
+     *
+     * `cbk` is the row worth reading twice. Chavacano's vocabulary is Spanish
+     * and its order is not: «grueso cortao rojo linea» is the reverse of
+     * Spanish's «línea roja», and `locales/cbk`'s header names this as the
+     * thing a reviewer is most likely to "correct" wrongly. A creole's word
+     * order follows its substrate rather than its lexifier, and this is the
+     * row that says so.
+     *
+     * The **linker** is the other half, and it cuts differently again. Three
+     * Philippine catalogs write one out — `tsg`'s «nga» and `pag`'s and
+     * `mrw`'s «a», repeated before every modifier — while `cbk`, alone among
+     * the four, writes none at all. `bbc` writes one too and writes it
+     * *postnominally*, the attributive relator «na», which no other catalog on
+     * its side of the split uses. The remaining ten juxtapose with nothing.
+     * Each linker is a free word in every position, so none of them is welded
+     * to a placeable and the README's affix rule is not reached here.
+     *
+     * Finally, the convergences are real and are not agreement. Eight catalogs
+     * write «garis» and six of those write «putus-putus»: that is one
+     * Indonesian word reaching six languages through one school system, not
+     * six languages arriving at it. `bug` and `mak` are pinned beside them
+     * precisely because they do *not* — «pettu-pettu» and «tappolo-polo» —
+     * and seven of the eight supply a colour word of their own where `nia` still
+     * falls back to Indonesian «merah». Replacing a loan should be a visible
+     * diff here rather than a silent improvement.
+     */
+    const postnominal: [string, string, string][] = [
+        [
+            "bug",
+            "garis tebal pettu-pettu macella'",
+            "tebal pettu-pettu macella'",
+        ],
+        ["mak", "garis kapala' tappolo-polo eja", "kapala' tappolo-polo eja"],
+        ["bjn", "garis kandal putus-putus habang", "kandal putus-putus habang"],
+        ["gor", "garis tebal putus-putus meela", "tebal putus-putus meela"],
+        ["nia", "garis tebal putus-putus merah", "tebal putus-putus merah"],
+        ["bbc", "garis na hapal putus-putus rara", "hapal putus-putus rara"],
+        ["iba", "garis tebal putus-putus mirah", "tebal putus-putus mirah"],
+        ["dtp", "garis tebal putus-putus aragang", "tebal putus-putus aragang"],
+        ["shn", "သဵၼ်ႈ သီလႅင် ၶၢတ်ႇ ၼႃ", "သီလႅင် ၶၢတ်ႇ ၼႃ"],
+        ["mnw", "မျဉ်း အနီ အပြတ် ထူ", "အနီ အပြတ် ထူ"],
+        ["ksw", "မျဉ်း ဂီၤ အပြတ် ဖးထီၣ်", "ဂီၤ အပြတ် ဖးထီၣ်"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
+        it(`puts ${locale}'s adjectives after the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: true }),
+            ).toBe(withNoun);
+            // The description is the tail of the phrase verbatim, which is what
+            // would break if a catalog started welding `bbc`'s «na» — the one
+            // linker on this side of the split — onto `{ $description }`.
+            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: false }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    const prenominal: [string, string, string][] = [
+        [
+            "tsg",
+            "makapal nga pinutu'-putu' nga pula nga linya",
+            "makapal nga pinutu'-putu' nga pula",
+        ],
+        [
+            "pag",
+            "makapal a putol-putol a ambalanga a linya",
+            "makapal a putol-putol a ambalanga",
+        ],
+        ["cbk", "grueso cortao rojo linea", "grueso cortao rojo"],
+        [
+            "mrw",
+            "makapal a dashed a mariga a linya",
+            "makapal a dashed a mariga",
+        ],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of prenominal) {
+        it(`puts ${locale}'s adjectives in front of the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: true }),
+            ).toBe(withNoun);
+            // The linker belongs to `style-with-noun` rather than to the
+            // adjective run, so the run still starts the phrase and still
+            // stands alone without a trailing «nga» or «a».
+            expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: false }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    it("puts all four of the Philippine catalogs on the prenominal side", () => {
+        expect(prenominal.map(([locale]) => locale).sort()).toEqual([
+            "cbk",
+            "mrw",
+            "pag",
+            "tsg",
+        ]);
+        expect(postnominal).toHaveLength(11);
+    });
+
+    /**
+     * Chavacano against the Spanish it takes its words from. Every content word
+     * in «grueso cortao rojo linea» is Spanish or a Chavacano reflex of one,
+     * and the arrangement is Spanish's exact reverse: `es` leads with «línea»
+     * and trails the adjectives. This is `mzn`/`glk`-against-`fa` from the
+     * Silk Road batch met in a creole, and the row exists so that a reviewer
+     * replacing a loan cannot also "fix" the order back toward Spanish without
+     * failing a test.
+     */
+    it("reverses Spanish's order in the Spanish-lexifier creole", () => {
+        const spanish = describeStrokedShape(es, words, {
+            noun: line,
+            withNoun: true,
+        });
+        const chavacano = describeStrokedShape(forLocale("cbk"), words, {
+            noun: line,
+            withNoun: true,
+        });
+        expect(spanish.startsWith("línea")).toBe(true);
+        expect(chavacano.startsWith("linea")).toBe(false);
+        expect(chavacano.endsWith("linea")).toBe(true);
+    });
+
+    /**
+     * The side count, where this batch does **not** split — which is the point
+     * of asserting it, since the Silk Road batch split on exactly this and
+     * along a different line than its adjectives did.
+     *
+     * All fifteen use `[noun-tail]`, because in all fifteen the count follows
+     * the noun whatever the adjectives do: «poligon biasa iya 5 sisina»,
+     * «poligono que tiene 5 lado», «regular polygon 5 ၸဵင်ႇ». So the four
+     * prenominal catalogs put their modifiers in front of a noun that still
+     * carries its count behind it, and no catalog in the batch folds the count
+     * into the head the way eleven Silk Road catalogs did.
+     */
+    it.each([
+        ["bug", "poligon biasa iya 5 sisina tebal pettu-pettu macella'"],
+        ["mak", "poligon biasa 5 sisina kapala' tappolo-polo eja"],
+        ["bjn", "poligon baraturan basisi 5 kandal putus-putus habang"],
+        ["gor", "poligon beraturan u o sisi 5 tebal putus-putus meela"],
+        ["nia", "poligon beraturan si so 5 sisi tebal putus-putus merah"],
+        ["bbc", "poligon biasa marsisi 5 na hapal putus-putus rara"],
+        ["iba", "poligon rata besisi 5 tebal putus-putus mirah"],
+        ["dtp", "poligon sekata bersisi 5 tebal putus-putus aragang"],
+        [
+            "tsg",
+            "makapal nga pinutu'-putu' nga pula nga regular nga polygon nga taga 5 sisi",
+        ],
+        [
+            "pag",
+            "makapal a putol-putol a ambalanga a regular a poligono ya walaay 5 a gilig",
+        ],
+        ["cbk", "grueso cortao rojo regular poligono que tiene 5 lado"],
+        [
+            "mrw",
+            "makapal a dashed a mariga a regular polygon a aden a 5 a kilid iyan",
+        ],
+        ["shn", "regular polygon 5 ၸဵင်ႇ သီလႅင် ၶၢတ်ႇ ၼႃ"],
+        ["mnw", "regular polygon 5 ထောင့် အနီ အပြတ် ထူ"],
+        ["ksw", "regular polygon လၢအအိၣ်ဒီး 5 ထောင့် ဂီၤ အပြတ် ဖးထီၣ်"],
+    ])("tails %s's side count behind the noun", (locale, expected) => {
+        const phrase = describeClosedShape(forLocale(locale), words, {
+            noun: { key: "regular-polygon", numSides: 5 },
+            withNoun: true,
+        });
+        expect(phrase).toBe(expected);
+        // The count is behind the noun in all fifteen, so none of them can be
+        // rendering `[noun-tail]` as empty.
+        expect(phrase).toContain("5");
+    });
+
+    /**
+     * Two convergences that are one word rather than two agreements, pinned so
+     * that replacing either loan is a visible diff.
+     *
+     * Six of the eight Indonesian and Malaysian catalogs write «putus-putus»
+     * for the dash pattern, and all eight write «garis» for the line. That is
+     * the Malaysian and Indonesian school vocabulary reaching four languages,
+     * and `locales/dtp`'s header says as much about its `noun` table sharing
+     * `iba`'s: a fact about one education ministry, not about two languages.
+     * `bug` and `mak` are the control — adjacent, related, and sharing neither.
+     */
+    it("keeps bug and mak out of the Indonesian dash-pattern convergence", () => {
+        const dashOf = (locale: string) =>
+            describeStrokedShape(forLocale(locale), words, {
+                noun: line,
+                withNoun: false,
+            }).split(" ")[1];
+        for (const locale of ["bjn", "gor", "nia", "bbc", "iba", "dtp"]) {
+            expect(dashOf(locale)).toBe("putus-putus");
+        }
+        expect(dashOf("bug")).toBe("pettu-pettu");
+        expect(dashOf("mak")).toBe("tappolo-polo");
+    });
+});

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -4823,7 +4823,10 @@ describe("the Southeast Asian batch's word order", () => {
      * fifteen are Austronesian and they fall on both sides of it. The eight
      * catalogs of Indonesia and Malaysian Borneo are head-initial like the
      * Malay their technical register comes from; the three Philippine
-     * non-creoles are the Central Philippine order English happens to share;
+     * non-creoles take the modifier-first order English happens to share, and
+     * they do so across three different branches of Austronesian rather than
+     * one — Pangasinan is a Northern Luzon language, not a Central Philippine
+     * one, so this is not a subgroup either;
      * and the three Myanmar-script catalogs land with the first group for
      * reasons of their own — Tai, Austroasiatic and Sino-Tibetan all being
      * head-initial in the noun phrase.
@@ -5009,9 +5012,10 @@ describe("the Southeast Asian batch's word order", () => {
      *
      * Six of the eight Indonesian and Malaysian catalogs write «putus-putus»
      * for the dash pattern, and all eight write «garis» for the line. That is
-     * the Malaysian and Indonesian school vocabulary reaching four languages,
+     * the Malaysian and Indonesian school vocabulary reaching six languages,
      * and `locales/dtp`'s header says as much about its `noun` table sharing
-     * `iba`'s: a fact about one education ministry, not about two languages.
+     * `iba`'s: a fact about two education ministries, not about six
+     * languages.
      * `bug` and `mak` are the control — adjacent, related, and sharing neither.
      */
     it("keeps bug and mak out of the Indonesian dash-pattern convergence", () => {


### PR DESCRIPTION
Seeds fifteen unreviewed machine-generated catalogs for languages of maritime
and mainland Southeast Asia, taking the roster from 301 locales to 316:
Buginese (`bug`), Makasar (`mak`), Banjar (`bjn`), Gorontalo (`gor`), Nias
(`nia`) and Toba Batak (`bbc`) in Indonesia; Iban (`iba`) and Kadazandusun
(`dtp`) in Malaysian Borneo; Pangasinan (`pag`), Chavacano (`cbk`), Tausug
(`tsg`) and Maranao (`mrw`) in the Philippines; and Shan (`shn`), Mon (`mnw`)
and S'gaw Karen (`ksw`) in Myanmar, written in the Myanmar script.

All fifteen are at **445/575** — the whole catalog minus the two chemistry
tables, which every catalog in the roster omits and which here have one reason
in four languages: secondary science is taught in Indonesian, Malay, English or
Burmese depending on the community, so the fallback *is* the curriculum.
`locales/ksw` is the one two-fallback case (Burmese in Myanmar, English or Thai
in the diaspora), which is `locales/wbl`'s split rather than the plain one.

The headlines:

- **The word order follows a border rather than a family, and the border is
  the Philippines'.** Eleven catalogs put the modifiers behind the noun and
  four put them in front, and the four are exactly the four Philippine ones.
  That is sharper than "Austronesian splits", because eleven of the fifteen
  *are* Austronesian and they fall on both sides of it. **`cbk` is the row
  worth reading twice**: Chavacano's vocabulary is Spanish and its order is
  not — «grueso cortao rojo linea» against Spanish's «línea roja» — and its
  header names this as the thing a reviewer is most likely to "correct"
  wrongly. A creole's word order follows its substrate, not its lexifier.
- **The linker gives five different answers and none of them is welded to a
  placeable.** `tsg` repeats «nga» before every modifier, `pag` and `mrw`
  repeat «a», `cbk` alone among the Philippine four writes none, `bbc` writes
  one *postnominally* («na»), and the remaining ten juxtapose with nothing.
  Every one is a free word in every position, so the README's "an affix cannot
  be welded to a placeable" rule is not reached here — unlike `bug`, which
  meets it from the other side and **writes no noun with its definite suffix
  `-é`** for exactly that reason. (The enclitic still closes the relative
  clauses the catalog spells out in full, where no placeable follows it; its
  header distinguishes the two.)
- **One `MACROLANGUAGE_MEMBERS` entry, and it is the map's second-largest.**
  Seeding `bjn` forced it: Banjar is one of the 36 ISO 639-3 members of Malay.
  The new `ms` row lists 33 — behind only `qu`'s forty-three, with `nah`'s
  thirty just behind it — and the three it leaves out are the ones this
  repository answers for itself — `ind`, `min` and `bjn` — which is the
  `bam`/`dyu` shape under `mnk`. Two costs are named in the comment rather
  than left to be found: `mfa` (Pattani Malay) maximizes to `mfa-Arab-TH`, so a
  Jawi reader is served Rumi — `locales/kr`'s asymmetry with `kby` a third
  time — and `max`/`xmm` are Malay-lexifier **trade creoles** listed anyway,
  because unlike `ktu` under `kg` ISO 639-3 puts them *inside* the
  macrolanguage. The rule stays published membership rather than a judgement.
- **Seeding `pag` invalidated an existing negative control**, which is the kind
  of thing a batch this size does quietly. `negotiate.test.ts` asserted that
  Pangasinan "falls all the way to English — the rule working rather than a gap
  in it". It now reaches a catalog, so the row moves to Ibanag (`ibg`) rather
  than being deleted, and where `pag` goes now is asserted once, with the
  rest of its batch.
- **Not one of the fifteen has CLDR plural data**, so this batch writes **no
  category branch at all** — not even `[one]`, which the Silk Road batch allowed
  itself in eleven of fifteen catalogs and which `allowedPluralCategories` still
  permits a no-data locale. All fifteen write the one real fork
  (`field-function-wrong-num-outputs`, which forks on outputs a component
  *needs*) as the numeric literal `[1]`. That is stricter than the lint
  requires, and deliberate: a category branch found in one of these files is
  now a drift rather than a judgement call.
- **Five `LOCALE_NAME_FALLBACKS` entries**, four with endonyms. `cbk` takes
  `locales/olo`'s admitted-gap shape and reads "Chavacano (cbk)", because its
  header names the language two ways and picking one here would settle in the
  roster what the catalog leaves open. `shn` needs no row: CLDR already gives
  it «တႆး», the spelling the catalog writes. Two of the ten CLDR *does* name,
  it names differently from the catalog and both stand — "Batak Toba" for
  `bbc` and "Central Dusun" for `dtp` — because the table fills gaps and never
  overrides ICU.
- **Four catalogs argued their way to Latin rather than defaulting to it** —
  `bug` and `mak` against Lontara, `bbc` against Surat Batak, `tsg` against
  Sulat Sūg on bidi grounds — and each header gives the argument.

**Two defects the work caught, one of them repo-wide.**

`locales/mnw` and `locales/ksw` were seeded with **Myanmar digits in message
prose**, six messages each: "more than ၃ points", sitting beside a `{ $count }`
that renders "3" and beside mathematics that is Latin-digit regardless. The
README's "Digits are Latin, separators are not" rule is enforced on every
*formatter*, but a literal digit typed into a value goes through no formatter,
and nothing was checking it. Fixed in both catalogs, and
`catalogLint.test.ts` now asserts the property **across all 316 locales** for
every non-Latin decimal-digit block, not just the ones the roster currently has
languages for.

A **homoglyph audit** during seeding found two header claims that were false —
`mnw` claimed ဿ/ၝ and `ksw` claimed ဢ/ၡ, and `ၦ`/`ၯ` turn out to be Pwo letters
rather than S'gaw ones. The headers were corrected to match the text rather than
the text padded to match the headers, and `catalogLint.test.ts` now holds all
three Myanmar catalogs to their own letters in both directions. It also pins the
Latin twelve: seven need nothing beyond ASCII at all, and the other five commit
to exactly one or three characters apiece. The batch writes its glottal stop as
**ASCII `'`** in the six catalogs that write the sound at all — the
deliberate opposite of `locales/quc`, which is held to U+02BC because in
Kʼicheʼ it is a letter.

Tests: a batch block in `negotiate.test.ts` (the fifteen, the three excluded
Malay members, ten included ones, the Jawi asymmetry, `kzj`-via-ICU, the
island-group near misses and the `btk`/`kar` collection codes), a plural block
in `chrome.test.ts`, the digit and inventory blocks in `catalogLint.test.ts`,
and a word-order block in `packages/utils/test/styleDescriptions.test.ts` that
also pins the convergences as convergences: eight catalogs write «garis» and six
write «putus-putus», which is one Indonesian word reaching six languages through
one school system rather than six languages agreeing, and `bug` and `mak` are the
control that does not. That block also records where the batch *does* split
mechanically: `noun-regular-polygon`'s `[tail]` is written only in `pag`, `cbk`
and `mrw`, so only those three select `style-with-noun`'s `[noun-tail]`; the
other twelve leave the tail empty and fold the side count into `[head]` exactly
as `locales/en` does. Both shapes put the count behind the noun, which is why
the assertion is on the rendered phrase rather than on the variant.

**A vocabulary audit corrected five more header claims.** `locales/mrw` said
the whole of its `noun` table was English when `noun.line` is «linya»;
`locales/mnw` and `locales/ksw` said everything from `line segment` outwards
was English when eight entries of each table are written in the script (and
`ksw`'s «လီၢ်ကဝီၤ» for the region is Karen rather than a Burmese loan);
`locales/tsg` said it writes only «a», «i» and «u» while writing «ā», «ī» and
«ū» thirty-five times across thirty-one messages, so the macron is now
declared as the length mark it is;
and `locales/dtp` called `dtb` Coastal Kadazan, which is `kzj` — the very tag
the same batch documents ICU folding onto `dtp`. Each header was corrected to
match its catalog.

Every string is machine-generated and unread by a speaker, and each file says so
at the top. `locales/mrw` calls itself the thinnest of the Philippine four,
`locales/dtp` the thinnest of the batch, `locales/mnw` records that **not one**
of its twelve colour words is Mon — all are Burmese loans — and `locales/nia`
records that it applies no initial mutation anywhere and uses citation forms
instead. `locales/mnw` also records that Mon marks a conditional clause-finally
while the renderer places `piecewise-condition-if` first. Nothing was invented
to fill a gap.

**Merged with `main`.** The Americas batch (#1778) landed while this was open,
so `main` is merged in here. The two batches touch seven of the same files and
their blocks sit side by side rather than interleaved: the sixty Americas
`.ftl` files, its README section, its map rows and its test blocks are
untouched by this PR, which adds only its own sixty files. The README's roster
list, its partial-catalog count and name list (238 partial, 236 of them for the
chemistry tables alone) and `supportedLocales.ts` and `doenet-schema.json` were
regenerated over the union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





