### PR TITLE
Read an aligned display row written with a literal ampersand

### DIFF
--- a/.changeset/md-text-literal-ampersand.md
+++ b/.changeset/md-text-literal-ampersand.md
@@ -2,6 +2,8 @@
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
 ---
 
 The `text` property of an `<md>` reads an aligned display whose rows use a
@@ -11,7 +13,8 @@ literal `&`.
 Doenet's `\amp` macro render identically, but only the macro spelling was
 stripped before each row was parsed. A row aligned with `&` could not be read,
 and `text` silently handed back the raw LaTeX — `\notag` and `\\` included —
-instead of the plain-text expression. Both spellings are now removed, by one
-helper shared with the accessible name of an embedded math input. That name
-also reads a marker that opens a row correctly now, instead of breaking the
-`\\` before it.
+instead of the plain-text expression.
+
+Both spellings are stripped now, by one helper shared with the accessible name
+of a math input embedded in an `<mrow>`. That name reads a marker opening a row
+correctly too, rather than consuming the `\\` row break before it.

--- a/.changeset/md-text-literal-ampersand.md
+++ b/.changeset/md-text-literal-ampersand.md
@@ -11,5 +11,7 @@ literal `&`.
 Doenet's `\amp` macro render identically, but only the macro spelling was
 stripped before each row was parsed. A row aligned with `&` could not be read,
 and `text` silently handed back the raw LaTeX — `\notag` and `\\` included —
-instead of the plain-text expression. Both spellings are now removed, by the
-same helper the accessible name of an embedded input already used.
+instead of the plain-text expression. Both spellings are now removed, by one
+helper shared with the accessible name of an embedded math input. That name
+also reads a marker that opens a row correctly now, instead of breaking the
+`\\` before it.

--- a/.changeset/md-text-literal-ampersand.md
+++ b/.changeset/md-text-literal-ampersand.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+The `text` property of an `<md>` reads an aligned display whose rows use a
+literal `&`.
+
+`<md><mrow>q &amp;= \sin(x)</mrow></md>` and the same display written with
+Doenet's `\amp` macro render identically, but only the macro spelling was
+stripped before each row was parsed. A row aligned with `&` could not be read,
+and `text` silently handed back the raw LaTeX — `\notag` and `\\` included —
+instead of the plain-text expression. Both spellings are now removed, by the
+same helper the accessible name of an embedded input already used.

--- a/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
+++ b/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
@@ -325,7 +325,13 @@ export class Md extends InlineComponent {
                                 .join("\\\\\n"),
                     );
                 } catch (e) {
-                    // just return latex if can't parse with math-expressions
+                    // A row is not something math-expressions can read. Hand
+                    // the display's LaTeX back as it is, markers and all: it
+                    // is still the content, and it is the same fallback
+                    // `latexToText` makes for an `<m>`. The fallback is
+                    // silent, so an author sees only `text` returning LaTeX;
+                    // a whole spelling landing here is a bug in what is
+                    // stripped before the parse, as #1761 was.
                     return { setValue: { text: dependencyValues.latex } };
                 }
                 return {

--- a/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
+++ b/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
@@ -10,7 +10,11 @@ import {
     returnAnchorAttributes,
     returnAnchorStateVariableDefinition,
 } from "../utils/graphical";
-import { latexToAst, superSubscriptsToUnicode } from "../utils/math";
+import {
+    latexToAst,
+    stripAlignmentMarkers,
+    superSubscriptsToUnicode,
+} from "../utils/math";
 import { convertLatexWithBlanks } from "../utils/embeddedMathInputs";
 
 /**
@@ -301,9 +305,9 @@ export class Md extends InlineComponent {
                     expressionText = convertLatexWithBlanks(
                         dependencyValues.latex,
                         (latex) =>
-                            latex
-                                .replaceAll("\\notag", "")
-                                .replaceAll("\\amp", "")
+                            stripAlignmentMarkers(
+                                latex.replaceAll("\\notag", ""),
+                            )
                                 .split("\\\\")
                                 .map((x) => {
                                     let result = x.match(/\\tag\{(\w+)\}(.*)/);

--- a/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
+++ b/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
@@ -326,12 +326,11 @@ export class Md extends InlineComponent {
                     );
                 } catch (e) {
                     // A row is not something math-expressions can read. Hand
-                    // the display's LaTeX back as it is, markers and all: it
-                    // is still the content, and it is the same fallback
-                    // `latexToText` makes for an `<m>`. The fallback is
-                    // silent, so an author sees only `text` returning LaTeX;
-                    // a whole spelling landing here is a bug in what is
-                    // stripped before the parse, as #1761 was.
+                    // the display's LaTeX back as it is, markers and all --
+                    // the same fallback `latexToText` makes for an `<m>`. It
+                    // is silent, so an author sees only `text` returning
+                    // LaTeX; a whole spelling landing here is a bug in what
+                    // is stripped before the parse, as #1761 was.
                     return { setValue: { text: dependencyValues.latex } };
                 }
                 return {

--- a/packages/doenetml-worker-javascript/src/components/abstract/Input.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Input.js
@@ -12,7 +12,7 @@ import {
     BLANK_PLACEHOLDER,
     SLOT_PATTERN,
 } from "../../utils/embeddedMathInputs";
-import { latexToText } from "../../utils/math";
+import { latexToText, stripAlignmentMarkers } from "../../utils/math";
 
 export default class Input extends InlineComponent {
     constructor(args) {
@@ -1118,13 +1118,10 @@ function describeAsMathBlank({ dependencyValues, componentIdx }) {
     //
     // A row of an aligned display carries its alignment marker, which is
     // layout and not mathematics: it is dropped as `Md.text` drops it, so the
-    // row is spoken as the equation it is. Only the marker goes: a bare `&`,
-    // or `\amp` as a whole control sequence, so a longer name that starts
-    // the same way is left alone.
-    const withPlaceholders = (math.stateValues.latexTemplate ?? "")
-        .replace(/\\amp(?![a-zA-Z])/g, "")
-        .replace(/(?<!\\)&/g, "")
-        .replace(SLOT_PATTERN, BLANK_PLACEHOLDER);
+    // row is spoken as the equation it is.
+    const withPlaceholders = stripAlignmentMarkers(
+        math.stateValues.latexTemplate ?? "",
+    ).replace(SLOT_PATTERN, BLANK_PLACEHOLDER);
 
     // `latexToText` hands back the LaTeX itself when it cannot be parsed,
     // which still has the placeholders in it, so the reader is still told

--- a/packages/doenetml-worker-javascript/src/test/math/stripAlignmentMarkers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/math/stripAlignmentMarkers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { stripAlignmentMarkers } from "../../utils/math";
+
+describe("stripAlignmentMarkers @group4", () => {
+    it("removes a bare ampersand", () => {
+        expect(stripAlignmentMarkers("q & = \\sin(x)")).eq("q  = \\sin(x)");
+    });
+
+    it("removes the \\amp macro", () => {
+        expect(stripAlignmentMarkers("q \\amp = \\sin(x)")).eq("q  = \\sin(x)");
+    });
+
+    it("removes a marker from every row", () => {
+        expect(stripAlignmentMarkers("q & = x\\\\ y \\amp = z")).eq(
+            "q  = x\\\\ y  = z",
+        );
+    });
+
+    it("leaves a longer control sequence that starts with amp alone", () => {
+        expect(stripAlignmentMarkers("\\ampersand \\amplitude")).eq(
+            "\\ampersand \\amplitude",
+        );
+    });
+
+    it("leaves an escaped ampersand alone", () => {
+        expect(stripAlignmentMarkers("a \\& b")).eq("a \\& b");
+        expect(stripAlignmentMarkers("a \\& b & = c")).eq("a \\& b  = c");
+    });
+
+    it("reads a row break as a break, not as an escape", () => {
+        // The `\` of `\\` is spent on the row break, so the `&` that follows
+        // opens the next row and is a marker, and `amp` is plain letters.
+        expect(stripAlignmentMarkers("x = y\\\\&= z")).eq("x = y\\\\= z");
+        expect(stripAlignmentMarkers("x = y\\\\amp")).eq("x = y\\\\amp");
+    });
+
+    it("leaves a string with no markers unchanged", () => {
+        expect(stripAlignmentMarkers("\\sin(x) + 1")).eq("\\sin(x) + 1");
+        expect(stripAlignmentMarkers("")).eq("");
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/mathEmbeddedInputs.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/mathEmbeddedInputs.test.ts
@@ -66,10 +66,6 @@ describe("Inputs embedded in displayed math @group1", async () => {
     });
 
     it("an aligned display blanks only the rows that need it", async () => {
-        // `\amp` rather than a bare `&`: `Md.text` strips the macro but not
-        // the character, so a literal `&` makes the row unparseable and `text`
-        // falls back to raw LaTeX. Pre-existing and orthogonal to blanks —
-        // tracked in #1761; this can use either spelling once that is fixed.
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <md name="md">

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/mathdisplay.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/mathdisplay.test.ts
@@ -542,6 +542,34 @@ describe("Displayed math tag tests @group1", async () => {
         ).eq("q = sin(x)\\\\\ncos(x) = z");
     });
 
+    it("align equations with a literal ampersand", async () => {
+        // The rows are aligned with `&` rather than `\amp`. Both are ways of
+        // writing the same display, so both must give the same text.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <md name="md1">
+      <mrow>q &amp;= \\sin(x)</mrow>
+      <mrow>\\cos(x) &amp;= z</mrow>
+    </md>
+    <mdn name="mdn1">
+      <mrow>q &amp;= \\sin(x)</mrow>
+      <mrow>\\cos(x) &amp;= z</mrow>
+    </mdn>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("md1")].stateValues.latex,
+        ).eq("\\notag q & = \\sin(x)\\\\\\notag \\cos(x) & = z");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("md1")].stateValues.text,
+        ).eq("q = sin(x)\\\\\ncos(x) = z");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("mdn1")].stateValues.text,
+        ).eq("q = sin(x) (1)\\\\\ncos(x) = z (2)");
+    });
+
     it("dynamic numbered aligned equations", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -1217,3 +1217,14 @@ function removeRepeatedSuperSubScripts(latex: string) {
 
     return newLatex;
 }
+
+/**
+ * Remove the alignment marker from a row of an aligned display. The marker is
+ * layout, not part of the expression the row states, and the math parser
+ * cannot read it. Both spellings go: a bare `&`, and `\amp` (one of Doenet's
+ * MathJax macros) as a whole control sequence, so a longer name that starts
+ * the same way is left alone.
+ */
+export function stripAlignmentMarkers(latex: string) {
+    return latex.replace(/\\amp(?![a-zA-Z])/g, "").replace(/(?<!\\)&/g, "");
+}

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -1075,7 +1075,12 @@ export function latexToText(latex: string) {
     try {
         expression = me.fromAst(latexToAst.convert(latex));
     } catch (e) {
-        // just return latex if can't parse with math-expressions
+        // The LaTeX is not something math-expressions can read. Hand it back
+        // as it is: it is still the content, and a reader gets more from the
+        // raw LaTeX than from nothing. The fallback is silent, so a systematic
+        // failure of this kind looks to an author like `text` simply returning
+        // LaTeX; if a whole class of expressions lands here, the fix belongs
+        // where the LaTeX is produced, not in the message.
         return latex;
     }
 
@@ -1219,12 +1224,20 @@ function removeRepeatedSuperSubScripts(latex: string) {
 }
 
 /**
- * Remove the alignment marker from a row of an aligned display. The marker is
- * layout, not part of the expression the row states, and the math parser
- * cannot read it. Both spellings go: a bare `&`, and `\amp` (one of Doenet's
- * MathJax macros) as a whole control sequence, so a longer name that starts
- * the same way is left alone.
+ * Remove the alignment markers from an aligned display. A marker is layout,
+ * not part of the expression its row states, and the math parser cannot read
+ * it. Both spellings go: a bare `&`, and `\amp` (one of Doenet's MathJax
+ * macros) as a whole control sequence, so a longer name that starts the same
+ * way is left alone.
+ *
+ * What is left alone is decided by scanning the string once, so a backslash
+ * is only ever read as the escape for what follows it: `\&` is an ampersand
+ * the author asked to print and stays, and the `\` of a `\\` row break is
+ * spent on that break, so `\\&` opens the next row with a marker that goes
+ * and `\\amp` is a row break followed by the letters `amp`.
  */
 export function stripAlignmentMarkers(latex: string) {
-    return latex.replace(/\\amp(?![a-zA-Z])/g, "").replace(/(?<!\\)&/g, "");
+    return latex.replace(/\\\\|\\&|\\amp(?![a-zA-Z])|&/g, (match) =>
+        match === "&" || match.startsWith("\\amp") ? "" : match,
+    );
 }

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -1076,11 +1076,10 @@ export function latexToText(latex: string) {
         expression = me.fromAst(latexToAst.convert(latex));
     } catch (e) {
         // The LaTeX is not something math-expressions can read. Hand it back
-        // as it is: it is still the content, and a reader gets more from the
-        // raw LaTeX than from nothing. The fallback is silent, so a systematic
-        // failure of this kind looks to an author like `text` simply returning
-        // LaTeX; if a whole class of expressions lands here, the fix belongs
-        // where the LaTeX is produced, not in the message.
+        // as it is: a reader gets more from the raw LaTeX than from nothing.
+        // The fallback is silent, so a systematic failure of this kind looks
+        // to an author like `text` simply returning LaTeX; if a whole class of
+        // expressions lands here, the fix belongs where the LaTeX is produced.
         return latex;
     }
 
@@ -1237,7 +1236,10 @@ function removeRepeatedSuperSubScripts(latex: string) {
  * and `\\amp` is a row break followed by the letters `amp`.
  */
 export function stripAlignmentMarkers(latex: string) {
+    // The alternation is ordered so that a row break and an escaped ampersand
+    // are matched whole, ahead of the markers; those two are put back, and
+    // what is left of a match — a bare `&` or an `\amp` — is dropped.
     return latex.replace(/\\\\|\\&|\\amp(?![a-zA-Z])|&/g, (match) =>
-        match === "&" || match.startsWith("\\amp") ? "" : match,
+        match === "\\\\" || match === "\\&" ? match : "",
     );
 }


### PR DESCRIPTION
`<md>` rows can be aligned with Doenet's `\amp` macro or with a literal `&`.
Both render the same display, but `Md.text` stripped only the macro spelling
before parsing each row. A row aligned with `&` reached the math parser with a
bare `&` in it, failed to parse, and the "just return latex if can't parse"
fallback made `$md.text` the row's raw LaTeX, `\notag` and `\\` included.

Both spellings are now stripped, and by one helper — `stripAlignmentMarkers` in
`utils/math.ts`. `describeAsMathBlank`, which builds the accessible name of an
input embedded in an `<mrow>`, already removed both and now shares the helper
rather than carrying its own list.

The helper scans the string once rather than applying two independent
replacements, so a backslash is read only as the escape for what follows it: a
printed `\&` is kept, while `\\&` is a row break opening a row whose marker
goes, and `\\amp` is a row break followed by the letters `amp`. That also fixes
the accessible name, whose two independent replacements dropped the `\` of a
`\\` that an `\amp` followed and kept a marker that a row break preceded.

The two silent fallbacks the issue asked about — in `Md.text` and in
`latexToText` — are kept, and each now carries a comment saying what it is for
and why a class of expressions landing there is a bug upstream of it rather
than a missing message.

Tests: a new `<md>`/`<mdn>` case in `mathdisplay.test.ts` covering the literal
`&` spelling, and unit tests for the helper in
`src/test/math/stripAlignmentMarkers.test.ts` covering both spellings, a
longer control sequence that starts with `amp`, an escaped `\&`, and a marker
that follows a row break. The comment in `mathEmbeddedInputs.test.ts` pointing
at this bug is removed.

Closes #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)
