### PR TITLE
Recognize a tag name ending in a non-word character

### DIFF
--- a/.changeset/tag-name-non-word-character.md
+++ b/.changeset/tag-name-non-word-character.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: keep suggesting a hyphenated snippet name across its hyphens.
+
+Nine of the ten completion snippets have hyphenated names, and the menu emptied on the hyphen: typing `<answer` offered `answer-labeled`, and typing the `-` that comes next offered nothing at all. The same happened to `<multiple-`, `<table-`, `<video-` and `<if-`. The suggestions now survive the hyphen, so a snippet can be reached by typing its name straight through.
+
+More generally, a tag name is now recognized as one whatever character it ends on — `.` and `:` behaved like `-` — so the context-help panel no longer describes the enclosing element while a name is being typed.

--- a/.changeset/tag-name-non-word-character.md
+++ b/.changeset/tag-name-non-word-character.md
@@ -11,3 +11,5 @@ Editor: keep suggesting a hyphenated snippet name across its hyphens.
 Nine of the ten completion snippets have hyphenated names, and the menu emptied on the hyphen: typing `<answer` offered `answer-labeled`, and typing the `-` that comes next offered nothing at all. The same happened to `<multiple-`, `<table-`, `<video-` and `<if-`. The suggestions now survive the hyphen, so a snippet can be reached by typing its name straight through.
 
 More generally, a tag name is now recognized as one whatever character it ends on — `.`, `:` and accented letters behaved like `-` — so the context-help panel no longer describes the enclosing element while a name is being typed.
+
+Closes #1780.

--- a/.changeset/tag-name-non-word-character.md
+++ b/.changeset/tag-name-non-word-character.md
@@ -10,4 +10,4 @@ Editor: keep suggesting a hyphenated snippet name across its hyphens.
 
 Nine of the ten completion snippets have hyphenated names, and the menu emptied on the hyphen: typing `<answer` offered `answer-labeled`, and typing the `-` that comes next offered nothing at all. The same happened to `<multiple-`, `<table-`, `<video-` and `<if-`. The suggestions now survive the hyphen, so a snippet can be reached by typing its name straight through.
 
-More generally, a tag name is now recognized as one whatever character it ends on — `.` and `:` behaved like `-` — so the context-help panel no longer describes the enclosing element while a name is being typed.
+More generally, a tag name is now recognized as one whatever character it ends on — `.`, `:` and accented letters behaved like `-` — so the context-help panel no longer describes the enclosing element while a name is being typed.

--- a/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
+++ b/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
@@ -237,6 +237,40 @@ describe("CodeMirror LSP Autocomplete Plugin", () => {
             .should("not.contain", 'name="mcq"');
     });
 
+    it("keeps element snippets listed across the hyphens of their names (#1780)", () => {
+        // Nine of the ten snippets have hyphenated names, so typing one
+        // straight through is the obvious way to reach it. The menu used to
+        // empty on the hyphen — the tag name was read as the text that
+        // followed it rather than as a name being typed — so the snippet
+        // could only be accepted by stopping short of the hyphen.
+        cy.mount(
+            <div style={{ height: "400px", width: "600px" }}>
+                <CodeMirror value="" doenetWorkerUrl={doenetWorkerUrl} />
+            </div>,
+        );
+
+        cy.get(".cm-content").click().type("<answer", { force: true });
+        cy.get(".cm-tooltip-autocomplete li").should(
+            "have.length.greaterThan",
+            1,
+        );
+
+        // `answer-labeled` is the only name that continues past the hyphen, so
+        // the menu narrowing to it alone is also how we know the list shown is
+        // the one queried after the hyphen rather than the one before it.
+        cy.get(".cm-content").type("-", { force: true });
+        cy.get(".cm-tooltip-autocomplete li").should("have.length", 1);
+        cy.get(".cm-tooltip-autocomplete .cm-completionLabel").should(
+            "have.text",
+            "answer-labeled",
+        );
+
+        // Accepting it replaces everything typed, hyphen included.
+        cy.get(".cm-tooltip-autocomplete .cm-completionLabel").click();
+        cy.get(".cm-content").invoke("text").should("contain", "<label>");
+        cy.get(".cm-content").invoke("text").should("not.contain", "answer-");
+    });
+
     it("completes attribute names", () => {
         cy.mount(
             <div style={{ height: "400px", width: "600px" }}>

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -201,13 +201,16 @@ describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
 
     it("reports no help for a tag name ending in a non-word character (#1780)", async () => {
         // The panel used to describe the *parent* while the author was still
-        // typing a tag name that ended in `-`, `.` or `:`, or show an empty
-        // allowed-children panel for the half-typed name as though it were a
-        // real element. Neither element exists, so there is nothing to say.
-        for (const nameEnd of ["-", ".", ":"]) {
-            for (const after of ["", "}", "/"]) {
+        // typing a tag name that ended in anything `\w` does not cover — `-`,
+        // `.`, `:` or a non-ASCII letter — or show an empty allowed-children
+        // panel for the half-typed name as though it were a real element.
+        // Neither element exists, so there is nothing to say.
+        const followers = ["", "}", "/", ">"];
+        for (const nameEnd of ["-", ".", ":", "ü"]) {
+            for (const after of followers) {
                 const source = `<p><my${nameEnd}${after}</p>`;
-                const help = await helpAt(source, source.indexOf("<my") + 4);
+                const offset = source.indexOf("<my") + 3 + nameEnd.length;
+                const help = await helpAt(source, offset);
                 expect({ source, kind: help.kind }).toEqual({
                     source,
                     kind: "none",
@@ -215,14 +218,16 @@ describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
             }
         }
 
-        // A name that does match an element still gets its help, whatever the
-        // cursor's neighbors.
-        const matchingSource = `<p><math</p>`;
-        const help = await helpAt(
-            matchingSource,
-            matchingSource.indexOf("<math") + 5,
-        );
-        expect(help).toMatchObject({ kind: "element", elementName: "math" });
+        // A name that does match an element still gets its help, whatever
+        // follows the cursor.
+        for (const after of followers) {
+            const source = `<p><math${after}</p>`;
+            const help = await helpAt(source, source.indexOf("<math") + 5);
+            expect({ source, help }).toMatchObject({
+                source,
+                help: { kind: "element", elementName: "math" },
+            });
+        }
     });
 });
 

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -204,17 +204,24 @@ describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
         // typing a tag name that ended in `-`, `.` or `:`, or show an empty
         // allowed-children panel for the half-typed name as though it were a
         // real element. Neither element exists, so there is nothing to say.
-        for (const source of [`<p><my-</p>`, `<p><my-}</p>`, `<p><my-/</p>`]) {
-            const help = await helpAt(source, source.indexOf("<my-") + 4);
-            expect({ source, kind: help.kind }).toEqual({
-                source,
-                kind: "none",
-            });
+        for (const nameEnd of ["-", ".", ":"]) {
+            for (const after of ["", "}", "/"]) {
+                const source = `<p><my${nameEnd}${after}</p>`;
+                const help = await helpAt(source, source.indexOf("<my") + 4);
+                expect({ source, kind: help.kind }).toEqual({
+                    source,
+                    kind: "none",
+                });
+            }
         }
 
         // A name that does match an element still gets its help, whatever the
-        // cursor's neighbours.
-        const help = await helpAt(`<p><math</p>`, 8);
+        // cursor's neighbors.
+        const matchingSource = `<p><math</p>`;
+        const help = await helpAt(
+            matchingSource,
+            matchingSource.indexOf("<math") + 5,
+        );
         expect(help).toMatchObject({ kind: "element", elementName: "math" });
     });
 });

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -198,6 +198,25 @@ describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
         const help = await helpAt(source, source.indexOf("<math}") + 5);
         expect(help).toMatchObject({ kind: "element", elementName: "math" });
     });
+
+    it("reports no help for a tag name ending in a non-word character (#1780)", async () => {
+        // The panel used to describe the *parent* while the author was still
+        // typing a tag name that ended in `-`, `.` or `:`, or show an empty
+        // allowed-children panel for the half-typed name as though it were a
+        // real element. Neither element exists, so there is nothing to say.
+        for (const source of [`<p><my-</p>`, `<p><my-}</p>`, `<p><my-/</p>`]) {
+            const help = await helpAt(source, source.indexOf("<my-") + 4);
+            expect({ source, kind: help.kind }).toEqual({
+                source,
+                kind: "none",
+            });
+        }
+
+        // A name that does match an element still gets its help, whatever the
+        // cursor's neighbours.
+        const help = await helpAt(`<p><math</p>`, 8);
+        expect(help).toMatchObject({ kind: "element", elementName: "math" });
+    });
 });
 
 describe("computeContextHelp — attribute help", () => {

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -109,10 +109,11 @@ export function elementAtOffsetWithContext(
         // is probably still typing a word, or is expecting completions from the word on the left.
         //
         // A tag name being typed takes the node on the left whatever character
-        // it ends on: lezer's `TagName` runs over `-`, `.` and `:` too, so
-        // `<p><my-|</p>` is a cursor at the end of an open tag's name and the
-        // completions belong to that name rather than to whatever follows it
-        // (#1780).
+        // it ends on. A lezer `TagName` runs over much more than `\w` does —
+        // `-`, `.`, `:`, and, since `\w` is ASCII-only, every accented or
+        // non-Latin letter — so `<p><my-|</p>` is a cursor at the end of an
+        // open tag's name, and the completions belong to that name rather than
+        // to whatever follows it (#1780).
         const lezerNode = atNodeBoundary
             ? prevChar.match(/\w/) || atOpenTagNameEnd
                 ? leftNode

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -108,11 +108,11 @@ export function elementAtOffsetWithContext(
         // is a word character. This should help with completion contexts, since the author
         // is probably still typing a word, or is expecting completions from the word on the left.
         //
-        // A tag name being typed also takes the node on the left, whatever its
-        // last character is. Lezer's `TagName` runs over `-`, `.` and `:` as
-        // well as word characters, so `<p><my-|</p>` really is a cursor at the
-        // end of an open tag's name; reading `-` as "not a word, so look
-        // right" hands the position to the following close tag instead (#1780).
+        // A tag name being typed takes the node on the left whatever character
+        // it ends on: lezer's `TagName` runs over `-`, `.` and `:` too, so
+        // `<p><my-|</p>` is a cursor at the end of an open tag's name and the
+        // completions belong to that name rather than to whatever follows it
+        // (#1780).
         const lezerNode = atNodeBoundary
             ? prevChar.match(/\w/) || atOpenTagNameEnd
                 ? leftNode

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -104,16 +104,15 @@ export function elementAtOffsetWithContext(
         // XXX Fix this after the CodeMirror update
         // @ts-ignore
         const atNodeBoundary = leftNode.index !== rightNode.index;
-        // If we're at a node boundary, we pick the node to the left if the previous character
-        // is a word character. This should help with completion contexts, since the author
-        // is probably still typing a word, or is expecting completions from the word on the left.
+        // If we're at a node boundary, we pick the node to the left when the author
+        // is probably still typing what sits there: either the previous character is
+        // a word character (so completions should come from the word on the left), or
+        // the cursor is at the end of an open tag's name.
         //
-        // A tag name being typed takes the node on the left whatever character
-        // it ends on. A lezer `TagName` runs over much more than `\w` does —
-        // `-`, `.`, `:`, and, since `\w` is ASCII-only, every accented or
-        // non-Latin letter — so `<p><my-|</p>` is a cursor at the end of an
-        // open tag's name, and the completions belong to that name rather than
-        // to whatever follows it (#1780).
+        // The second is wider than the first. A lezer `TagName` runs over much more
+        // than `\w` does — `-`, `.`, `:`, and, `\w` being ASCII-only, every accented
+        // or non-Latin letter — so `<p><my-|</p>` is a cursor at the end of a name
+        // being typed, and its completions belong to that name (#1780).
         const lezerNode = atNodeBoundary
             ? prevChar.match(/\w/) || atOpenTagNameEnd
                 ? leftNode

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -107,8 +107,14 @@ export function elementAtOffsetWithContext(
         // If we're at a node boundary, we pick the node to the left if the previous character
         // is a word character. This should help with completion contexts, since the author
         // is probably still typing a word, or is expecting completions from the word on the left.
+        //
+        // A tag name being typed also takes the node on the left, whatever its
+        // last character is. Lezer's `TagName` runs over `-`, `.` and `:` as
+        // well as word characters, so `<p><my-|</p>` really is a cursor at the
+        // end of an open tag's name; reading `-` as "not a word, so look
+        // right" hands the position to the following close tag instead (#1780).
         const lezerNode = atNodeBoundary
-            ? prevChar.match(/\w/)
+            ? prevChar.match(/\w/) || atOpenTagNameEnd
                 ? leftNode
                 : rightNode
             : leftNode;

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -358,7 +358,9 @@ describe("AutoCompleter", () => {
 
         // A name matching nothing offers nothing — in particular not the
         // enclosing element's close tag, whose edit would have replaced `<my-`.
-        for (const nameEnd of ["-", ".", ":"]) {
+        // (`ü` because `\w` is ASCII-only, so a name ending in a non-ASCII
+        // letter was read the same way a hyphenated one was.)
+        for (const nameEnd of ["-", ".", ":", "ü"]) {
             const labels = await labelsFor(`<p><my${nameEnd}|</p>`);
             expect({ nameEnd, labels }).toEqual({ nameEnd, labels: [] });
         }

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -67,6 +67,24 @@ const schema = {
  */
 const TAG_NAME_TERMINATORS = ["}", "{", ")", "]", "$", "&", "%", "\\"];
 
+/**
+ * The completion items offered against the real Doenet schema (so snippets and
+ * ranking are in play) for `withCursor`, a source string whose cursor position
+ * is marked with `|`. The marker is stripped before parsing.
+ */
+async function itemsFor(withCursor: string) {
+    const source = withCursor.replace("|", "");
+    const autoCompleter = new AutoCompleter(source, doenetSchema.elements);
+    return await autoCompleter.getCompletionItems(withCursor.indexOf("|"));
+}
+
+/**
+ * The labels of {@link itemsFor}'s items, in the order they are offered.
+ */
+async function labelsFor(withCursor: string) {
+    return (await itemsFor(withCursor)).map((item) => item.label);
+}
+
 describe("AutoCompleter", () => {
     it("Can suggest completions", async () => {
         let source: string;
@@ -294,19 +312,6 @@ describe("AutoCompleter", () => {
         // same replacement ranges on the snippet items (which replace `<m`,
         // leaving the terminator in place). Checked against the real schema,
         // where snippets and ranking are in play.
-
-        // `withCursor` marks the cursor with `|`, which is stripped before parsing.
-        async function itemsFor(withCursor: string) {
-            const source = withCursor.replace("|", "");
-            const autoCompleter = new AutoCompleter(
-                source,
-                doenetSchema.elements,
-            );
-            return await autoCompleter.getCompletionItems(
-                withCursor.indexOf("|"),
-            );
-        }
-
         const expected = await itemsFor(`<p><m|</p>`);
         expect(expected.map((i) => i.label)).toContain("math");
         for (const terminator of TAG_NAME_TERMINATORS) {
@@ -332,18 +337,6 @@ describe("AutoCompleter", () => {
         // that follows it, so the only item offered was `/p>` — whose edit
         // spanned the typed `<answer-`. Typing the hyphen must keep the
         // snippet that the author is reaching for.
-        async function labelsFor(withCursor: string) {
-            const source = withCursor.replace("|", "");
-            const autoCompleter = new AutoCompleter(
-                source,
-                doenetSchema.elements,
-            );
-            const items = await autoCompleter.getCompletionItems(
-                withCursor.indexOf("|"),
-            );
-            return items.map((i) => i.label);
-        }
-
         expect(await labelsFor(`<p><answer-|</p>`)).toEqual(["answer-labeled"]);
         expect(await labelsFor(`<p><multiple-|</p>`)).toEqual([
             "multiple-choice-answer",
@@ -354,6 +347,14 @@ describe("AutoCompleter", () => {
         expect(await labelsFor(`<p><multiple|</p>`)).toEqual(
             await labelsFor(`<p><multiple-|</p>`),
         );
+
+        // The same at the top level, where the name being typed is all there
+        // is and no close tag follows it.
+        expect(await labelsFor(`<answer-|`)).toEqual(["answer-labeled"]);
+        expect(await labelsFor(`<p>hi</p>\n<multiple-|`)).toEqual([
+            "multiple-choice-answer",
+            "multiple-choice-select-multiple-answer",
+        ]);
 
         // A name matching nothing offers nothing — in particular not the
         // enclosing element's close tag, whose edit would have replaced `<my-`.

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -326,6 +326,47 @@ describe("AutoCompleter", () => {
         expect(inMe).toEqual(await itemsFor(`<me>\\frac{<m|</me>`));
     });
 
+    it("keeps suggesting a hyphenated snippet name across its hyphens (#1780)", async () => {
+        // Nine of the ten completion snippets have hyphenated names, and the
+        // menu emptied on the hyphen: `<answer-` was read as the close tag
+        // that follows it, so the only item offered was `/p>` — whose edit
+        // spanned the typed `<answer-`. Typing the hyphen must keep the
+        // snippet that the author is reaching for.
+        async function labelsFor(withCursor: string) {
+            const source = withCursor.replace("|", "");
+            const autoCompleter = new AutoCompleter(
+                source,
+                doenetSchema.elements,
+            );
+            const items = await autoCompleter.getCompletionItems(
+                withCursor.indexOf("|"),
+            );
+            return items.map((i) => i.label);
+        }
+
+        expect(await labelsFor(`<p><answer-|</p>`)).toEqual(["answer-labeled"]);
+        expect(await labelsFor(`<p><multiple-|</p>`)).toEqual([
+            "multiple-choice-answer",
+            "multiple-choice-select-multiple-answer",
+        ]);
+        // Unchanged one character earlier, where the name still ends in a word
+        // character — the hyphen is the only thing that used to break it.
+        expect(await labelsFor(`<p><multiple|</p>`)).toEqual(
+            await labelsFor(`<p><multiple-|</p>`),
+        );
+
+        // A name matching nothing offers nothing — in particular not the
+        // enclosing element's close tag, whose edit would have replaced `<my-`.
+        for (const nameEnd of ["-", ".", ":"]) {
+            const labels = await labelsFor(`<p><my${nameEnd}|</p>`);
+            expect({ nameEnd, labels }).toEqual({ nameEnd, labels: [] });
+        }
+
+        // The enclosing element's close tag is still offered where it belongs:
+        // on a close tag the author is actually typing.
+        expect(await labelsFor(`<p>hello</p|`)).toContain("/p>");
+    });
+
     it("matches element names by substring, not only by prefix (#1328)", async () => {
         // Typing part of a tag name that appears in the *middle* of other tag
         // names should still surface those tags (e.g. `num` -> `isNumber`), so

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -427,13 +427,15 @@ describe("DoenetSourceObject", () => {
         }
 
         // Regression guard: `atOpenTagNameEnd` covers open tags only, so a
-        // *close* tag's name is never reclassified as one being opened.
+        // half-typed *close* tag name ending the same way is not read as a
+        // name being opened — the cursor stays in the enclosing element's body.
         {
             const source = `<p></my-</p>`;
-            const { cursorPosition } = new DoenetSourceObject(
+            const { cursorPosition, node } = new DoenetSourceObject(
                 source,
             ).elementAtOffsetWithContext(source.indexOf("</my-") + 5);
-            expect(cursorPosition).not.toEqual("openTagName");
+            expect(cursorPosition).toEqual("body");
+            expect(node).toMatchObject({ type: "element", name: "p" });
         }
 
         // Regression guard: a close tag name being typed is still

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -404,6 +404,61 @@ describe("DoenetSourceObject", () => {
         }
     });
 
+    it("Reports openTagName for a tag name ending in a non-word character (#1780)", () => {
+        // Lezer's `TagName` runs over `-`, `.` and `:` as well as word
+        // characters, so `<p><my-|</p>` is a cursor at the end of an open
+        // tag's name. Reading `-` as "not a word character, so look right"
+        // handed the position to whatever followed — the close tag, the
+        // recovered text content, or the `/` of a self-closing tag — and the
+        // element being named was never identified.
+        for (const nameEnd of ["-", ".", ":"]) {
+            for (const after of ["", "}", "/", " ", ' name="a"/>']) {
+                const source = `<p><my${nameEnd}${after}</p>`;
+                const offset = source.indexOf("<my") + 3 + nameEnd.length;
+                const { cursorPosition, node } = new DoenetSourceObject(
+                    source,
+                ).elementAtOffsetWithContext(offset);
+                expect({ source, cursorPosition, name: node?.name }).toEqual({
+                    source,
+                    cursorPosition: "openTagName",
+                    name: `my${nameEnd}`,
+                });
+            }
+        }
+
+        // Regression guard: `atOpenTagNameEnd` covers open tags only, so a
+        // *close* tag's name is never reclassified as one being opened.
+        {
+            const source = `<p></my-</p>`;
+            const { cursorPosition } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(source.indexOf("</my-") + 5);
+            expect(cursorPosition).not.toEqual("openTagName");
+        }
+
+        // Regression guard: a close tag name being typed is still
+        // `closeTagName`, as it always was.
+        {
+            const source = `<p>hello</p`;
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(source.length);
+            expect(cursorPosition).toEqual("closeTagName");
+            expect(node).toMatchObject({ type: "element", name: "p" });
+        }
+
+        // Regression guard: once whitespace separates the cursor from the tag
+        // name, the cursor is in the tag's attribute area rather than its name.
+        {
+            const source = `<math >`;
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(source.indexOf(">"));
+            expect(cursorPosition).toEqual("openTag");
+            expect(node).toMatchObject({ type: "element", name: "math" });
+        }
+    });
+
     it("Reports the container (not the element) when the cursor is on a tag boundary (#1327)", () => {
         for (const { source, offset } of [
             { source: `<text/>`, offset: 0 },

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -405,14 +405,17 @@ describe("DoenetSourceObject", () => {
     });
 
     it("Reports openTagName for a tag name ending in a non-word character (#1780)", () => {
-        // Lezer's `TagName` runs over `-`, `.` and `:` as well as word
-        // characters, so `<p><my-|</p>` is a cursor at the end of an open
-        // tag's name. Reading `-` as "not a word character, so look right"
-        // handed the position to whatever followed — the close tag, the
-        // recovered text content, or the `/` of a self-closing tag — and the
-        // element being named was never identified.
-        for (const nameEnd of ["-", ".", ":"]) {
-            for (const after of ["", "}", "/", " ", ' name="a"/>']) {
+        // Lezer's `TagName` runs over much more than `\w` does: `-`, `.`, `:`,
+        // and — `\w` being ASCII-only — accented and non-Latin letters. So
+        // `<p><my-|</p>` is a cursor at the end of an open tag's name. Reading
+        // those endings as "not a word character, so look right" handed the
+        // position to whatever followed — the close tag, the recovered text
+        // content, or the `/` of a self-closing tag — and the element being
+        // named was never identified. The trailing `>` is the well-formed
+        // control: it needs no error recovery and already reported
+        // `openTagName` for a name ending in a word character.
+        for (const nameEnd of ["-", ".", ":", "ü"]) {
+            for (const after of ["", "}", "/", ">", " ", ' name="a"/>']) {
                 const source = `<p><my${nameEnd}${after}</p>`;
                 const offset = source.indexOf("<my") + 3 + nameEnd.length;
                 const { cursorPosition, node } = new DoenetSourceObject(
@@ -429,13 +432,17 @@ describe("DoenetSourceObject", () => {
         // Regression guard: `atOpenTagNameEnd` covers open tags only, so a
         // half-typed *close* tag name ending the same way is not read as a
         // name being opened — the cursor stays in the enclosing element's body.
-        {
-            const source = `<p></my-</p>`;
+        for (const nameEnd of ["-", ".", ":", "ü"]) {
+            const source = `<p></my${nameEnd}</p>`;
+            const offset = source.indexOf("</my") + 4 + nameEnd.length;
             const { cursorPosition, node } = new DoenetSourceObject(
                 source,
-            ).elementAtOffsetWithContext(source.indexOf("</my-") + 5);
-            expect(cursorPosition).toEqual("body");
-            expect(node).toMatchObject({ type: "element", name: "p" });
+            ).elementAtOffsetWithContext(offset);
+            expect({ source, cursorPosition, name: node?.name }).toEqual({
+                source,
+                cursorPosition: "body",
+                name: "p",
+            });
         }
 
         // Regression guard: a close tag name being typed is still
@@ -450,14 +457,15 @@ describe("DoenetSourceObject", () => {
         }
 
         // Regression guard: once whitespace separates the cursor from the tag
-        // name, the cursor is in the tag's attribute area rather than its name.
+        // name, the cursor is in the tag's attribute area rather than its name,
+        // hyphenated name or not.
         {
-            const source = `<math >`;
+            const source = `<my- >`;
             const { cursorPosition, node } = new DoenetSourceObject(
                 source,
             ).elementAtOffsetWithContext(source.indexOf(">"));
             expect(cursorPosition).toEqual("openTag");
-            expect(node).toMatchObject({ type: "element", name: "math" });
+            expect(node).toMatchObject({ type: "element", name: "my-" });
         }
     });
 


### PR DESCRIPTION
## Summary

Nine of the ten completion snippets have hyphenated names, and the element menu emptied the moment the author typed one of those hyphens.

| Source (cursor at `|`) | Before | After |
| --- | --- | --- |
| `<p><answer\|</p>` | `answer`, `answer-labeled`, `multiple-choice-answer`, … | unchanged |
| `<p><answer-\|</p>` | **nothing** | `answer-labeled` |
| `<p><multiple-\|</p>` | **nothing** | `multiple-choice-answer`, `multiple-choice-select-multiple-answer` |
| `<p><if-\|</p>` | **nothing** | `if-at-(immediate-feedback-assessment-technique)-answer` |
| `<answer-\|` (top level) | **nothing** | `answer-labeled` |

Typing a snippet's name straight through is the obvious way to reach it, and it stopped working at the first hyphen. One more keystroke recovered (`<p><multiple-c|</p>` was fine), which is what made it look arbitrary.

`.` and `:` behave like `-`, as does any letter outside ASCII, and the context-help panel was wrong in the same positions: `<p><my-|</p>` described the enclosing `<p>`, and `<p><my-|}</p>` showed an empty "allowed children" panel for the nonexistent element `my-`.

## Cause

`elementAtOffsetWithContext`, guessing where an unclassified cursor is, picks the lezer node to the *left* of a node boundary only when the previous character is a word character:

```ts
const lezerNode = atNodeBoundary
    ? prevChar.match(/\w/)
        ? leftNode
        : rightNode
    : leftNode;
```

A lezer `TagName` runs over much more than `\w` does. The grammar's `nameChar` adds `-`, `.` and `:`, and `\w` is ASCII-only, so accented and non-Latin letters are outside it too. `<p><answer-</p>` parses as `OpenTag[3,11]`, `TagName[4,11]` = `answer-` — the cursor genuinely is at the end of an open tag's name. But `prevChar` is `-`, so the node to the *right* wins: the following `StartCloseTag`, read by the switch below as `closeTagName`. The element being named is never identified, and `getCompletionItems` never reaches its `openTagName` branch.

## Fix

The function already computes the condition this needs, a few lines above: `atOpenTagNameEnd`, "the lezer node immediately left of the cursor is an open tag's `TagName`" (added in #1328, extended in #1767). Taking the left node when it holds is enough:

```ts
    ? prevChar.match(/\w/) || atOpenTagNameEnd
```

## What it also removes

For a name matching nothing, `<p><my-|</p>` used to return exactly one item: the enclosing element's close tag `/p>`, whose `textEdit` spanned offsets 3–7 — the typed `<my-`. Accepting it would have replaced what the author wrote.

That item never reached the menu — the CodeMirror plugin's own element-menu filter drops it, which is why the reported symptom is an empty menu rather than a destructive suggestion. It is gone at the source now rather than relying on that client-side filter to catch it.

## Verification

The classification was checked exhaustively rather than by inspection: dumping `elementAtOffsetWithContext`, `getCompletionItems` and `computeContextHelp` at **every offset of a 76-source corpus** (1090 positions — well-formed elements, self-closing tags, close tags, attribute-value recovery, macros, unterminated tags, and tag names with `-`/`.`/`:` in every position) before and after gives **15 changed offsets, all intended**: each is a cursor at the end of an open tag name ending in `-`, `.` or `:`, and each moves to `openTagName` with the correct element. Nothing else moves — in particular no close tag, no attribute position, and no macro context.

A name ending in a non-ASCII letter was not in that corpus and belongs to the same class: `<p><mü|</p>` reported `closeTagName` on `<p>` and offered `/p>`, and now reports `openTagName` on `mü` and offers nothing. It is covered by the tests below.

What the author actually sees also depends on the CodeMirror client, which filters the returned items itself, so the menu is checked in the browser too (see the component test below): typing `<answer-` in an empty document leaves the menu open on `answer-labeled` and accepting it replaces the whole `<answer-`, where before the menu closed on the hyphen.

## Tests

- `doenet-source-object.test.ts` — `openTagName` with the right node for names ending in `-`, `.`, `:` and `ü`, across the six things that can follow the cursor (nothing, `}`, `/`, `>`, a space, a full attribute list). Guards that a close tag name is never reclassified as an open one, that a close tag being typed is still `closeTagName`, and that whitespace after a hyphenated name still gives `openTag`.
- `doenet-auto-complete.test.ts` — `<p><answer-|</p>` and `<p><multiple-|</p>` offer their snippets, `<p><multiple|</p>` and `<p><multiple-|</p>` agree, the same holds at the top level with no enclosing element, a name matching nothing offers nothing (in particular not `/p>`), and a close tag being typed still offers `/p>`.
- `computeContextHelp.test.ts` — no help instead of help for the wrong element, for each of `-`, `.`, `:` and `ü` and each of the characters that can follow; an element name that does match still gets its help in all the same positions.
- `autocomplete.cy.tsx` (`@doenet/codemirror` component test) — the editor-level behavior: the menu narrows to `answer-labeled` *after* the hyphen is typed, and accepting it replaces everything typed, hyphen included.

All four fail on `main` and pass here. `@doenet/lsp-tools` 658, `@doenet/lsp` 46 (+1 skipped) and `@doenet/parser` 308 pass, as do the 59 tests in the codemirror autocomplete spec; `tsc` and prettier clean.

## Note

At the top level with nothing following the name, `elementAtOffsetWithContext` on the raw source still reports `unknown` — the recursion that walks back a character only fires for a word character or `<`. No caller sees that: `AutoCompleter` parses `source + " "`, so the name is never the last thing in the source it classifies, which is why the top-level case improves along with the rest.

Closes #1780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
