### PR TITLE
Wait for jsDelivr to hold the release before purging for it

### DIFF
--- a/.github/scripts/jsdelivr-purge-lib.sh
+++ b/.github/scripts/jsdelivr-purge-lib.sh
@@ -17,14 +17,26 @@
 # publish — fired at 08:03:52 and 12:41:43. Six and a half minutes early, every
 # time.
 #
-# So: wait for the registry to actually serve the version under the tag, purge,
-# and then confirm the tag serves it before calling the step done.
+# jsDelivr then lags npm in turn: it has to fetch the new release before it can
+# serve it, and until it can, a purge has nothing newer to refetch.
+#
+# So: wait for the registry to actually serve the version under the tag, wait
+# for jsDelivr to be able to serve that version at its pinned URL, purge, and
+# then confirm the tag serves it before calling the step done.
 
 # Poll intervals and limits, overridable for testing.
 REGISTRY_POLL_INTERVAL="${REGISTRY_POLL_INTERVAL:-10}"
 REGISTRY_POLL_TIMEOUT="${REGISTRY_POLL_TIMEOUT:-1200}"
-PURGE_ATTEMPTS="${PURGE_ATTEMPTS:-5}"
+PURGE_ATTEMPTS="${PURGE_ATTEMPTS:-8}"
 PURGE_RETRY_DELAY="${PURGE_RETRY_DELAY:-20}"
+# The retry delay grows by half each attempt up to this cap, so the later
+# attempts wait minutes rather than repeating a 20-second poll that has already
+# been answered the same way four times. 20s base over 8 attempts is a little
+# under nine minutes of purging, against the 100 seconds that five flat
+# 20-second retries bought.
+PURGE_RETRY_MAX_DELAY="${PURGE_RETRY_MAX_DELAY:-120}"
+CDN_POLL_INTERVAL="${CDN_POLL_INTERVAL:-15}"
+CDN_POLL_TIMEOUT="${CDN_POLL_TIMEOUT:-900}"
 
 # How often the wait below reports that it is still waiting, in seconds. Only
 # affects log volume.
@@ -112,6 +124,58 @@ _fetch_cdn() {
     fi
 }
 
+# Block until jsDelivr can serve the pinned version, i.e. until it has fetched
+# the new release from npm. This is a second, separate lag after the registry
+# one: the registry served 0.7.25-dev.525 while `cdn.jsdelivr.net/npm/
+# @doenet/standalone@0.7.25-dev.525/...` still answered 404, and four of the
+# five purge attempts in that run were spent against a CDN that had nothing
+# newer to fetch. Purging then is not merely wasted — jsDelivr answers a purge
+# by refetching on the next request, so a purge sent while the pinned version
+# is unreachable is the same "re-cache the previous release for 12 hours" trap
+# the registry wait exists to close, one layer down.
+#
+# Only `VERIFY_PATHS` are polled: they are the paths small enough to fetch, and
+# a release is ingested as a unit, so the CDN having these has it having the
+# rest. As with the registry wait the budget is wall-clock.
+wait_for_cdn_version() {
+    local package="$1" version="$2"
+    local started=${SECONDS}
+    local deadline=$((SECONDS + CDN_POLL_TIMEOUT))
+    local next_report=0 path missing elapsed
+
+    echo "Waiting for jsDelivr to fetch ${package}@${version}..."
+    while true; do
+        missing=""
+        for path in "${VERIFY_PATHS[@]}"; do
+            if ! curl -fsS --max-time 60 \
+                "https://cdn.jsdelivr.net/npm/${package}@${version}/${path}" \
+                -o /dev/null 2>/dev/null; then
+                missing="${missing} ${path}"
+            fi
+        done
+        elapsed=$((SECONDS - started))
+        if [[ -z "${missing}" ]]; then
+            echo "  jsDelivr serves ${package}@${version} (after ${elapsed}s)"
+            return 0
+        fi
+        if [[ ${SECONDS} -ge ${deadline} ]]; then
+            echo "Error: jsDelivr still cannot serve ${package}@${version} after" >&2
+            echo "       ${elapsed}s. Not reachable at its pinned URL:${missing}" >&2
+            echo "       Not purging: jsDelivr answers a purge by refetching, and a" >&2
+            echo "       refetch that cannot see ${version} re-caches the previous" >&2
+            echo "       release for another 12 hours." >&2
+            echo "       The version is on npm — this is the CDN being slow or unwell." >&2
+            echo "       Re-running this step is safe." >&2
+            return 1
+        fi
+        if [[ ${elapsed} -ge ${next_report} ]]; then
+            echo "  not yet on the CDN:${missing} (${elapsed}s elapsed)"
+            next_report=$((elapsed + _REGISTRY_REPORT_INTERVAL))
+        fi
+        sleep "${CDN_POLL_INTERVAL}"
+    done
+}
+
 # Whether the floating tag now serves the same bytes as the immutable pinned
 # version. Compares content rather than looking for a version string: the
 # pinned URL names one npm release and cannot drift, so matching it is the
@@ -166,6 +230,7 @@ purge_and_verify() {
     local package="$1" tag="$2" version="$3"
     local attempt path result stale unreachable
     local purge_failures=0 unverified_failures=0
+    local delay="${PURGE_RETRY_DELAY}"
 
     # A purge that verifies nothing is the failure mode this whole file exists
     # to remove, so refuse to be that rather than exiting 0 on an empty list.
@@ -222,8 +287,17 @@ purge_and_verify() {
             echo "  for paths this run does not verify were refused; retrying those."
         fi
         if [[ ${attempt} -lt ${PURGE_ATTEMPTS} ]]; then
-            echo "  retrying in ${PURGE_RETRY_DELAY}s..."
-            sleep "${PURGE_RETRY_DELAY}"
+            echo "  retrying in ${delay}s..."
+            sleep "${delay}"
+            # Back off by half each time, capped. What the retries are waiting
+            # on is jsDelivr's edge picking up a purge across its POPs, which
+            # takes longer than the interval that was polling it, and the purge
+            # API is rate-limited besides — so re-asking every 20 seconds both
+            # gives up sooner and asks harder than is useful.
+            delay=$((delay * 3 / 2))
+            if [[ ${delay} -gt ${PURGE_RETRY_MAX_DELAY} ]]; then
+                delay=${PURGE_RETRY_MAX_DELAY}
+            fi
         fi
     done
 

--- a/.github/scripts/jsdelivr-purge-lib.sh
+++ b/.github/scripts/jsdelivr-purge-lib.sh
@@ -32,15 +32,15 @@ PURGE_RETRY_DELAY="${PURGE_RETRY_DELAY:-20}"
 # The retry delay grows by half each attempt up to this cap, so the later
 # attempts wait minutes rather than repeating a 20-second poll that has already
 # been answered the same way four times. 20s base over 8 attempts is a little
-# under nine minutes of purging, against the 100 seconds that five flat
+# under nine minutes of purging, against the 80 seconds that five flat
 # 20-second retries bought.
 PURGE_RETRY_MAX_DELAY="${PURGE_RETRY_MAX_DELAY:-120}"
 CDN_POLL_INTERVAL="${CDN_POLL_INTERVAL:-15}"
 CDN_POLL_TIMEOUT="${CDN_POLL_TIMEOUT:-900}"
 
-# How often the wait below reports that it is still waiting, in seconds. Only
-# affects log volume.
-_REGISTRY_REPORT_INTERVAL=60
+# How often the waits below report that they are still waiting, in seconds.
+# Only affects log volume.
+_WAIT_REPORT_INTERVAL=60
 
 # The version the registry currently serves for a tag, or empty if it cannot be
 # read. Asks the registry's dist-tags endpoint rather than `npm view`, which
@@ -93,7 +93,7 @@ wait_for_registry_tag() {
         fi
         if [[ ${elapsed} -ge ${next_report} ]]; then
             echo "  ${package}@${tag} still => ${seen:-<none>} (${elapsed}s elapsed)"
-            next_report=$((elapsed + _REGISTRY_REPORT_INTERVAL))
+            next_report=$((elapsed + _WAIT_REPORT_INTERVAL))
         fi
         sleep "${REGISTRY_POLL_INTERVAL}"
     done
@@ -137,19 +137,34 @@ _fetch_cdn() {
 # Only `VERIFY_PATHS` are polled: they are the paths small enough to fetch, and
 # a release is ingested as a unit, so the CDN having these has it having the
 # rest. As with the registry wait the budget is wall-clock.
+#
+# `_fetch_cdn` is deliberately not reused here: a 404 is the expected answer
+# while the wait is doing its job, and that helper retries and reports each one
+# as a failure, which would both slow the poll and fill the log with alarming
+# lines about a CDN that is merely still catching up.
 wait_for_cdn_version() {
     local package="$1" version="$2"
     local started=${SECONDS}
     local deadline=$((SECONDS + CDN_POLL_TIMEOUT))
     local next_report=0 path missing elapsed
 
+    # With no paths to poll the loop would return immediately and the wait
+    # would silently do nothing, leaving the purge exposed to the very lag this
+    # exists to cover. `purge_and_verify` refuses the same way.
+    if [[ ${#VERIFY_PATHS[@]} -eq 0 ]]; then
+        echo "Error: wait_for_cdn_version called with no VERIFY_PATHS; there would" >&2
+        echo "       be nothing to poll, and the wait would pass whether or not" >&2
+        echo "       jsDelivr had the release. Set VERIFY_PATHS as a bash array." >&2
+        return 1
+    fi
+
     echo "Waiting for jsDelivr to fetch ${package}@${version}..."
     while true; do
         missing=""
         for path in "${VERIFY_PATHS[@]}"; do
-            if ! curl -fsS --max-time 60 \
+            if ! curl -fs --max-time 60 \
                 "https://cdn.jsdelivr.net/npm/${package}@${version}/${path}" \
-                -o /dev/null 2>/dev/null; then
+                -o /dev/null; then
                 missing="${missing} ${path}"
             fi
         done
@@ -170,7 +185,7 @@ wait_for_cdn_version() {
         fi
         if [[ ${elapsed} -ge ${next_report} ]]; then
             echo "  not yet on the CDN:${missing} (${elapsed}s elapsed)"
-            next_report=$((elapsed + _REGISTRY_REPORT_INTERVAL))
+            next_report=$((elapsed + _WAIT_REPORT_INTERVAL))
         fi
         sleep "${CDN_POLL_INTERVAL}"
     done
@@ -293,7 +308,7 @@ purge_and_verify() {
             # on is jsDelivr's edge picking up a purge across its POPs, which
             # takes longer than the interval that was polling it, and the purge
             # API is rate-limited besides — so re-asking every 20 seconds both
-            # gives up sooner and asks harder than is useful.
+            # gave up sooner and asked harder than was useful.
             delay=$((delay * 3 / 2))
             if [[ ${delay} -gt ${PURGE_RETRY_MAX_DELAY} ]]; then
                 delay=${PURGE_RETRY_MAX_DELAY}

--- a/.github/scripts/jsdelivr-purge-lib.sh
+++ b/.github/scripts/jsdelivr-purge-lib.sh
@@ -180,8 +180,11 @@ wait_for_cdn_version() {
             echo "       Not purging: jsDelivr answers a purge by refetching, and a" >&2
             echo "       refetch that cannot see ${version} re-caches the previous" >&2
             echo "       release for another 12 hours." >&2
-            echo "       The version is on npm — this is the CDN being slow or unwell." >&2
-            echo "       Re-running this step is safe." >&2
+            echo "       The version is on npm, so either jsDelivr is slow or unwell —" >&2
+            echo "       in which case re-running this step is safe — or ${version}" >&2
+            echo "       genuinely does not contain these paths, which a 404 looks" >&2
+            echo "       exactly the same as. Check the pinned URL by hand:" >&2
+            echo "         https://cdn.jsdelivr.net/npm/${package}@${version}/" >&2
             return 1
         fi
         if [[ ${elapsed} -ge ${next_report} ]]; then

--- a/.github/scripts/jsdelivr-purge-lib.sh
+++ b/.github/scripts/jsdelivr-purge-lib.sh
@@ -31,9 +31,10 @@ PURGE_ATTEMPTS="${PURGE_ATTEMPTS:-8}"
 PURGE_RETRY_DELAY="${PURGE_RETRY_DELAY:-20}"
 # The retry delay grows by half each attempt up to this cap, so the later
 # attempts wait minutes rather than repeating a 20-second poll that has already
-# been answered the same way four times. 20s base over 8 attempts is a little
-# under nine minutes of purging, against the 80 seconds that five flat
-# 20-second retries bought.
+# been answered the same way four times. From a 20s base the eight attempts are
+# separated by 20, 30, 45, 67, 100, 120 and 120 seconds — a little over eight
+# minutes of waiting, against the 80 seconds that five flat 20-second retries
+# bought.
 PURGE_RETRY_MAX_DELAY="${PURGE_RETRY_MAX_DELAY:-120}"
 CDN_POLL_INTERVAL="${CDN_POLL_INTERVAL:-15}"
 CDN_POLL_TIMEOUT="${CDN_POLL_TIMEOUT:-900}"
@@ -335,7 +336,9 @@ purge_and_verify() {
     fi
     if [[ -n "${unreachable}" ]]; then
         echo "  Could not be fetched from the CDN:${unreachable}" >&2
-        echo "  Either jsDelivr is unwell or ${version} does not contain these files." >&2
+        echo "  jsDelivr served every one of these at ${version} before the purge —" >&2
+        echo "  the wait above would have failed otherwise — so this is the CDN" >&2
+        echo "  having become unwell since, not a file missing from the release." >&2
         echo "  Check https://cdn.jsdelivr.net/npm/${package}@${version}/ by hand." >&2
     fi
     if [[ ${purge_failures} -gt 0 ]]; then

--- a/.github/scripts/purge-jsdelivr-prefigure.sh
+++ b/.github/scripts/purge-jsdelivr-prefigure.sh
@@ -50,4 +50,5 @@ VERIFY_PATHS=(
 )
 
 wait_for_registry_tag "${PACKAGE}" "${TAG}" "${VERSION}"
+wait_for_cdn_version "${PACKAGE}" "${VERSION}"
 purge_and_verify "${PACKAGE}" "${TAG}" "${VERSION}"

--- a/.github/scripts/purge-jsdelivr.sh
+++ b/.github/scripts/purge-jsdelivr.sh
@@ -62,4 +62,5 @@ VERIFY_PATHS=(
 )
 
 wait_for_registry_tag "${PACKAGE}" "${TAG}" "${VERSION}"
+wait_for_cdn_version "${PACKAGE}" "${VERSION}"
 purge_and_verify "${PACKAGE}" "${TAG}" "${VERSION}"

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -218,10 +218,12 @@ jobs:
 
             # Waits for npm to finish processing the publish, and then for
             # jsDelivr to fetch it, before purging — so this is minutes rather
-            # than seconds; see `jsdelivr-purge-lib.sh`. The script bounds both
-            # waits and its purge retries itself (20 + 15 + 9 minutes in the
-            # worst case), and `timeout-minutes` is the backstop that keeps a
-            # wedged request from holding the runner.
+            # than seconds; see `jsdelivr-purge-lib.sh`. The script gives each
+            # wait its own wall-clock budget (20 and 15 minutes) and then sleeps
+            # about another 8 between its purge retries; `timeout-minutes` is
+            # the backstop over the whole of that, since the requests themselves
+            # are bounded one at a time rather than in aggregate, and it keeps a
+            # wedged one from holding the runner.
             - name: Purge jsDelivr cache
               if: >-
                   steps.params.outputs.dry_run != 'true' &&

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -216,10 +216,12 @@ jobs:
               run: |
                   node .github/scripts/npm-publish-with-retry.mjs packages/prefigure/dist --tag "${NPM_TAG}"
 
-            # Waits for npm to finish processing the publish before purging, so
-            # this is minutes rather than seconds; see `jsdelivr-purge-lib.sh`.
-            # The script bounds its own waiting, and `timeout-minutes` is the
-            # backstop that keeps a wedged request from holding the runner.
+            # Waits for npm to finish processing the publish, and then for
+            # jsDelivr to fetch it, before purging — so this is minutes rather
+            # than seconds; see `jsdelivr-purge-lib.sh`. The script bounds both
+            # waits and its purge retries itself (20 + 15 + 9 minutes in the
+            # worst case), and `timeout-minutes` is the backstop that keeps a
+            # wedged request from holding the runner.
             - name: Purge jsDelivr cache
               if: >-
                   steps.params.outputs.dry_run != 'true' &&

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -227,7 +227,7 @@ jobs:
                    needs.check-version-changed.outputs.should_publish == 'true' ||
                    (needs.check-version-changed.outputs.already_published == 'true' &&
                     github.run_attempt > 1))
-              timeout-minutes: 30
+              timeout-minutes: 50
               env:
                   NPM_TAG: ${{ steps.params.outputs.npm_tag }}
               run: bash .github/scripts/purge-jsdelivr-prefigure.sh "${NPM_TAG}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,10 +94,12 @@ jobs:
               env:
                   WIREIT_CACHE: "local"
 
-            # Waits for npm to finish processing the publish before purging, so
-            # this is minutes rather than seconds; see `jsdelivr-purge-lib.sh`.
-            # The script bounds its own waiting, and `timeout-minutes` is the
-            # backstop that keeps a wedged request from holding the runner.
+            # Waits for npm to finish processing the publish, and then for
+            # jsDelivr to fetch it, before purging — so this is minutes rather
+            # than seconds; see `jsdelivr-purge-lib.sh`. The script bounds both
+            # waits and its purge retries itself (20 + 15 + 9 minutes in the
+            # worst case), and `timeout-minutes` is the backstop that keeps a
+            # wedged request from holding the runner.
             #
             # Gated on the publish having *run*, not on it having succeeded:
             # `npm run publish` is four independent workspace publishes and npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
                   !cancelled() &&
                   (steps.publish-npm.outcome == 'success' ||
                    steps.publish-npm.outcome == 'failure')
-              timeout-minutes: 30
+              timeout-minutes: 50
               run: bash .github/scripts/purge-jsdelivr.sh dev
 
     # Publishes a VS Code extension pre-release on every successful CI run on
@@ -380,5 +380,5 @@ jobs:
                   !cancelled() &&
                   (steps.publish-npm.outcome == 'success' ||
                    steps.publish-npm.outcome == 'failure')
-              timeout-minutes: 30
+              timeout-minutes: 50
               run: bash .github/scripts/purge-jsdelivr.sh latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,10 +96,12 @@ jobs:
 
             # Waits for npm to finish processing the publish, and then for
             # jsDelivr to fetch it, before purging — so this is minutes rather
-            # than seconds; see `jsdelivr-purge-lib.sh`. The script bounds both
-            # waits and its purge retries itself (20 + 15 + 9 minutes in the
-            # worst case), and `timeout-minutes` is the backstop that keeps a
-            # wedged request from holding the runner.
+            # than seconds; see `jsdelivr-purge-lib.sh`. The script gives each
+            # wait its own wall-clock budget (20 and 15 minutes) and then sleeps
+            # about another 8 between its purge retries; `timeout-minutes` is
+            # the backstop over the whole of that, since the requests themselves
+            # are bounded one at a time rather than in aggregate, and it keeps a
+            # wedged one from holding the runner.
             #
             # Gated on the publish having *run*, not on it having succeeded:
             # `npm run publish` is four independent workspace publishes and npm
@@ -349,9 +351,10 @@ jobs:
                   OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
             # Last, and deliberately so. The purge waits for npm to finish
-            # processing the publish before it fires, which takes minutes rather
-            # than seconds (see `jsdelivr-purge-lib.sh`), and it now fails the
-            # job when the tag will not move. Neither should stand between a
+            # processing the publish and then for jsDelivr to fetch it before it
+            # fires, which takes minutes rather than seconds (see
+            # `jsdelivr-purge-lib.sh`), and it now fails the job when the tag
+            # will not move. Neither should stand between a
             # published npm release and the extension registries: those do not
             # depend on the CDN, and a purge that has to be re-run should not
             # take the Marketplace publish with it.
@@ -375,8 +378,10 @@ jobs:
             # serves this version under the tag, and fails the step if it never
             # does.
             #
-            # `timeout-minutes` is the backstop on the script's own bounded
-            # waiting, so a wedged request cannot hold the runner.
+            # `timeout-minutes` is the backstop on the script's own waiting —
+            # 20 minutes of registry wait, 15 of CDN wait and roughly 8 of
+            # sleeps between purge retries — so a wedged request cannot hold the
+            # runner.
             - name: Purge jsDelivr cache
               if: >-
                   !cancelled() &&


### PR DESCRIPTION
## The problem

The dev release purge has now failed twice after exhausting all five of its attempts ([run 33334548859](https://github.com/Doenet/DoenetML/actions/runs/33334548859/job/99319554745)). The logs show the cause, and it is not that five attempts was too few — the first four fetched the *pinned* URL and got a 404:

```
curl: (22) The requested URL returned error: 404
  FAILED  fetch https://cdn.jsdelivr.net/npm/@doenet/standalone@0.7.25-dev.525/doenet-standalone.js
  ERROR   doenet-standalone.js (could not be fetched)
  retrying in 20s...
```

npm's registry was serving `0.7.25-dev.525`, so the registry wait added in #1737 passed — but jsDelivr had not yet fetched the release from npm. There are two lags after a publish, not one, and only the first was being waited for.

Purging during the second lag is not merely wasted. jsDelivr answers a purge by dropping its cached copy and refetching on the next request, so a purge sent while the pinned version is unreachable refetches the *previous* release and re-caches it with a fresh 12-hour TTL. That is exactly the trap `jsdelivr-purge-lib.sh` was written to close, one layer down — and it was being sprung four times per release, before the single remaining attempt that could have worked.

## The fix

**Wait for the CDN before purging at all.** New `wait_for_cdn_version()` is the CDN analogue of `wait_for_registry_tag()`: it polls `VERIFY_PATHS` at their immutable pinned URLs until jsDelivr can serve them (15s interval, 900s wall-clock budget), and refuses to purge if it never can. As `purge_and_verify` already does, it also refuses outright if `VERIFY_PATHS` is empty, so an empty list cannot turn the wait into a silent no-op. A release is ingested as a unit, so the CDN holding these paths means it holds the rest.

**Widen the retry budget**, now that attempts are spent on the purge actually propagating rather than on a CDN with nothing newer to fetch. `PURGE_ATTEMPTS` 5 → 8, with the delay growing by half each time from 20s up to a 120s cap (`PURGE_RETRY_MAX_DELAY`) — about 500s of retries against the 80s that five flat 20-second waits bought. What the retries are waiting on is a purge reaching jsDelivr's POPs, which takes longer than the interval that was polling for it, and the purge API is rate-limited besides; re-asking every 20 seconds both gave up sooner and asked harder than was useful.

**`timeout-minutes` 30 → 50** on the three purge steps, covering the new worst case: 20 minutes of registry wait, 15 of CDN wait, and roughly 8 more of sleeps between purge retries. The comment above each step records what the script bounds — the two waits by wall clock, the purge phase only by an attempt count — and the fact that there are now two waits.

Both purge entry points get the new wait: `purge-jsdelivr.sh` (`@doenet/standalone`, `dev` and `latest`) and `purge-jsdelivr-prefigure.sh` (`@doenet/prefigure`, which carries a Pyodide runtime and is exposed to the same lag).

## Verification

- `wait_for_cdn_version` against the live CDN: returns in 5s for the published `@doenet/standalone@0.7.25-dev.525`, and times out with the "not purging" diagnostic for a nonexistent version. On timeout the diagnostic names both possibilities — a CDN still catching up, and a path the release does not contain — since a 404 looks the same either way.
- The backoff schedule under a mocked harness: 20, 30, 45, 67, 100, 120, 120s across the eight attempts.
- `bash -n` on all three scripts.

No changeset: this is CI tooling only, with no user-visible change to any published package.

## Note on the missing publish emails

While diagnosing this we found that the *same* asynchronous publish explains a separate symptom: `@doenet/standalone` is the only one of the four packages whose publish prints `npm notice Your package is being processed and may take a few minutes to become available`, and it is the only one that has stopped sending a publish notification email. Its tarball has grown past npm's synchronous-publish threshold (23 MB, with `@doenet/doenetml` at 22 MB still on the synchronous path). Nothing is wrong with the release — `0.7.25-dev.525` is on the registry with provenance attestations and the `dev` tag correctly pointing at it — and nothing in this PR addresses the email, which is npm-side. It is noted here only because the two symptoms share a cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



