### PR TITLE
Seed catalogs for fifteen languages of South Asia

### DIFF
--- a/.changeset/seed-south-asian-catalogs.md
+++ b/.changeset/seed-south-asian-catalogs.md
@@ -1,0 +1,53 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for fifteen more languages of South Asia and
+its diaspora: Awadhi (`awa`), Chhattisgarhi (`hne`), Magahi (`mag`), Marwari
+(`mwr`), Garhwali (`gbm`), Kumaoni (`kfy`), Newar (`new`), Sylheti (`syl`),
+Tulu (`tcy`), Mizo (`lus`), Khasi (`kha`), Garo (`grt`), Saraiki (`skr`),
+Brahui (`brh`) and Fiji Hindi (`hif`). A document declaring one of them now
+renders its style descriptions, section headings, boolean words, answer
+buttons, editor chrome and diagnostics in that language instead of falling
+back to English.
+
+Five scripts: Devanagari for the six Hindi-belt and Uttarakhand catalogs and
+for Newar, the Bengali script for Sylheti, Kannada for Tulu, Latin for Mizo,
+Khasi, Garo and Fiji Hindi, and Perso-Arabic for Saraiki and Brahui. **Saraiki
+and Brahui lay out right to left**, which takes the roster's right-to-left
+catalogs from sixteen to eighteen; the other thirteen lay out left to right.
+
+Thirteen of the fifteen put a shape's adjectives in front of its noun, as
+English does. Khasi and Mizo put them behind it, so a Khasi document reads
+«lain bakhraw badash basaw» where a Garo one — the same state, the other
+order — reads «dal·gipa dashgipa gitchak lain». Saraiki is the one catalog of
+the fifteen that agrees its adjectives with the noun's gender; the other
+fourteen write one invariant form, which is a fact about the language in eight
+of them and a stated gap in the seed in six.
+
+The chemistry element tables are left out of all fifteen, so a document in one
+of these languages still shows the element names in English. Thirteen are the
+school-system case — chemistry is taught in Hindi, Nepali, Bengali, Urdu or
+English wherever these languages are spoken — and Marwari has no settled list
+of all 118 in any case. Tulu is the one whose neighbour cannot help either:
+a Tulu pupil meets the table in Kannada, and `locales/kn` omits it too. Each
+catalog's header says which case it is in.
+
+`<document lang>` autocompletes all fifteen. Chhattisgarhi, Garhwali, Kumaoni,
+Sylheti, Garo and Saraiki are offered from hand-written entries, since CLDR
+has no name for those tags in any language.
+
+These are machine-generated seeds pending review by speakers (#1521), and each
+file's header says so and names where it is weakest. In the ten Indo-Aryan
+catalogs the technical vocabulary is largely borrowed — Hindi in the six
+Hindi-belt and Uttarakhand catalogs, Bengali in Sylheti, Urdu in Saraiki — and
+what is the language's own is the grammar around it and, more often than not,
+the colour words. Every header declares that rather than leaving it to be
+discovered.
+
+Numbers written into a message render in Latin digits in every one of the
+fifteen, so a digit inside a sentence matches the count formatted beside it.

--- a/.changeset/seed-south-asian-catalogs.md
+++ b/.changeset/seed-south-asian-catalogs.md
@@ -42,9 +42,10 @@ Sylheti, Garo and Saraiki are offered from hand-written entries, since CLDR
 has no name for those tags in any language.
 
 These are machine-generated seeds pending review by speakers (#1521), and each
-file's header says so and names where it is weakest. In the ten Indo-Aryan
-catalogs the technical vocabulary is largely borrowed — Hindi in the six
-Hindi-belt and Uttarakhand catalogs, Bengali in Sylheti, Urdu in Saraiki — and
+file's header says so and names where it is weakest. In the nine Indo-Aryan
+catalogs, and in Newar beside them, the technical vocabulary is largely
+borrowed — Hindi in the six Hindi-belt and Uttarakhand catalogs, Nepali in
+Newar, Bengali in Sylheti, Urdu in Saraiki — and
 what is the language's own is the grammar around it and, more often than not,
 the colour words. Every header declares that rather than leaving it to be
 discovered.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -403,7 +403,7 @@ for what does divide the batch.
 
 **All fifteen of the second South Asian batch are partial as well, and they
 split two ways rather than the first South Asian batch's five.** Thirteen are
-the school-system case in six mediums: chemistry is taught in Hindi across the
+the school-system case in five mediums: chemistry is taught in Hindi across the
 Hindi belt and Uttarakhand, so `awa`, `hne`, `mag`, `gbm` and `kfy` meet the
 table in the language `locales/hi` carries it in; in Nepali in the Kathmandu
 Valley for `new`; in Bengali in Sylhet for `syl`, which is the

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3507,8 +3507,10 @@ one is uncomfortable.
 
 #### Most of what these files translate is the frame, and the headers say so
 
-Ten of the fifteen are Indo-Aryan languages with no medium of secondary
-education and therefore no settled technical register of their own. What a
+Nine of the fifteen are Indo-Aryan languages with no medium of secondary
+education and therefore no settled technical register of their own, and
+Newar — Sino-Tibetan, not Indo-Aryan — is in the same position with Nepali
+in the loan role, which makes ten catalogs. What a
 seed can supply for them is the **grammar**, and what it cannot supply is the
 **vocabulary**: «रेखा», «बहुभुज», «फलन», «विशेषता» are Hindi in `awa`, `hne`,
 `mag`, `mwr`, `gbm` and `kfy` alike, «মিছা» sits in a Sylheti sentence around
@@ -3537,7 +3539,7 @@ distinction is the one a speaker can fix in a single line.
 
 Thirteen catalogs put the modifiers in front of the noun and two put them
 behind. Thirteen to two is unremarkable — South Asia is left-branching, and
-the ten Indo-Aryan catalogs inherit Hindi's order with its vocabulary. What
+the nine Indo-Aryan catalogs inherit Hindi's order with its vocabulary. What
 the split is *not* is genetic or geographic.
 
 Prenominal, rendered for "thick dashed red line": `awa`, `hne` and `mag`
@@ -3552,8 +3554,10 @@ sen».
 
 **The two are `kha` and `lus`, and `grt` is not one of them.** Khasi and Garo
 are spoken in the same state and seeded in the same batch; Garo and Mizo are
-both Tibeto-Burman. So Meghalaya writes the phrase both ways, and the two
-Tibeto-Burman catalogs of the batch disagree with each other — Garo's `-gipa`
+both Tibeto-Burman. So Meghalaya writes the phrase both ways, and Garo and
+Mizo — the batch's two Tibeto-Burman catalogs of Northeast India — disagree
+with each other, while Newar, Sino-Tibetan as well but half a subcontinent
+away, sits with the prenominal thirteen. Garo's `-gipa`
 attributive precedes its noun, Mizo's follows. Neither family nor geography
 predicts this row, which is why `styleDescriptions.test.ts` pins all fifteen
 rather than a representative from each side.
@@ -3584,7 +3588,7 @@ feminine «لکیر» and «موٹا» before a masculine noun, and `noun-gender
 The other fourteen write one invariant form each, and the reason differs and
 matters:
 
-- **Three cases where it is a claim about the language.** Brahui has no
+- **Eight cases where it is a claim about the language.** Brahui has no
   gender at all; Tulu marks it on verbs and pronouns but not on attributives;
   Fiji Hindi has levelled Hindi's agreement away, so the `-a` form stands in
   every position for a noun of either gender. Newar, Khasi, Mizo, Garo and
@@ -3616,7 +3620,16 @@ script and not about a family.
 wrong about the script — Fiji Hindi is written in Latin letters by the people
 who write it — and right about the direction anyway, because both candidate
 scripts run left to right. The tag reaches the correct answer by a route that
-does not hold in general, and both `hif` headers say so.
+does not hold in general, and `hif`'s `chrome.ftl` and `content.ftl` headers
+both say so.
+
+`grt` is the batch's second instance of the same route: ICU maximizes it to
+`grt-Beng-IN`, and the Garo catalog here is written in the Latin orthography.
+Two of the fifteen, then, get the direction right off a script neither
+catalog is written in. Neither needs an entry in `RTL_LANGUAGES`, because
+both the maximized script and the real one run left to right — but the pair
+is why a maximized script is evidence about direction and not about how a
+catalog is spelled.
 
 Neither right-to-left catalog welds anything to a placeable. Brahui's case
 clitics are normally joined in print and are written separated in all four
@@ -3636,10 +3649,15 @@ back to rather than by the language. `hi`, `bn`, `ur`, `mr` and `ne` sit
 beside them on the roster with rules of their own. Whether a tag has plural
 data follows whether a CLDR locale was ever requested for it.
 
-Each catalog writes exactly one `[0]` — `attempts-remaining` — and one `[1]` —
+Each catalog writes exactly one `[0]` — `attempts-remaining`, where English
+writes `[0]` too — and one `[1]`, in
 `field-function-wrong-num-outputs`, which forks on how many outputs a
-component *needs*. Fluent matches both against the number itself, so neither
-consults a plural rule. `chrome.test.ts` holds both halves.
+component *needs*. The `[1]` is not English's own branch: English selects
+that message on the plural category `[one]`, and a catalog with no plural
+rules substitutes the numeric literal, which Fluent matches against the
+number itself. Neither branch consults a plural rule, which is why both
+survive where the category forks could not. `chrome.test.ts` holds both
+halves.
 
 #### Negotiation gained nothing, and three tags left a list instead
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -68,48 +68,50 @@ locales/<locale>/
 
 English is the source of truth. Every translation —
 `ab`, `ace`, `acf`, `ady`, `af`, `ak`, `alt`, `am`, `ar`, `arn`, `as`,
-`ast`, `av`, `ay`, `az`, `ba`, `bal`, `ban`, `bbc`, `bci`, `be`, `bem`,
-`bg`, `bho`, `bi`, `bik`, `bin`, `bjn`, `bm`, `bn`, `bo`, `br`, `brx`,
-`bs`, `bua`, `bug`, `bum`, `bzj`, `ca`, `cab`, `cbk`, `ce`, `ceb`,
-`ch`, `chk`, `ckb`, `co`, `crh`, `cs`, `csb`, `cv`, `cy`, `da`, `dag`,
-`dar`, `de`, `dje`, `djk`, `dng`, `doi`, `dsb`, `dtp`, `dv`, `dyo`,
-`dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`,
-`fi`, `fil`, `fit`, `fj`, `fo`, `fon`, `fr`, `fur`, `fy`, `ga`, `gaa`,
-`gag`, `gcf`, `gcr`, `gd`, `gil`, `gl`, `glk`, `gn`, `gor`, `gsw`,
-`gu`, `ha`, `haw`, `haz`, `he`, `hi`, `hil`, `hnj`, `hr`, `hsb`, `ht`,
-`hu`, `hy`, `iba`, `id`, `ig`, `ilo`, `inh`, `is`, `it`, `iu`, `ja`,
-`jam`, `jv`, `ka`, `kaa`, `kab`, `kbd`, `kbp`, `kca`, `kek`, `kg`,
+`ast`, `av`, `awa`, `ay`, `az`, `ba`, `bal`, `ban`, `bbc`, `bci`,
+`be`, `bem`, `bg`, `bho`, `bi`, `bik`, `bin`, `bjn`, `bm`, `bn`, `bo`,
+`br`, `brh`, `brx`, `bs`, `bua`, `bug`, `bum`, `bzj`, `ca`, `cab`,
+`cbk`, `ce`, `ceb`, `ch`, `chk`, `ckb`, `co`, `crh`, `cs`, `csb`,
+`cv`, `cy`, `da`, `dag`, `dar`, `de`, `dje`, `djk`, `dng`, `doi`,
+`dsb`, `dtp`, `dv`, `dyo`, `dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`,
+`eu`, `ewo`, `fa`, `ff`, `fi`, `fil`, `fit`, `fj`, `fo`, `fon`, `fr`,
+`fur`, `fy`, `ga`, `gaa`, `gag`, `gbm`, `gcf`, `gcr`, `gd`, `gil`,
+`gl`, `glk`, `gn`, `gor`, `grt`, `gsw`, `gu`, `ha`, `haw`, `haz`,
+`he`, `hi`, `hif`, `hil`, `hne`, `hnj`, `hr`, `hsb`, `ht`, `hu`, `hy`,
+`iba`, `id`, `ig`, `ilo`, `inh`, `is`, `it`, `iu`, `ja`, `jam`, `jv`,
+`ka`, `kaa`, `kab`, `kbd`, `kbp`, `kca`, `kek`, `kfy`, `kg`, `kha`,
 `ki`, `kjh`, `kk`, `kl`, `km`, `kmb`, `kmr`, `kn`, `ko`, `koi`, `kok`,
 `kos`, `kpe`, `kpv`, `kr`, `krc`, `kri`, `krl`, `ks`, `ksh`, `ksw`,
 `ktu`, `kum`, `ky`, `lb`, `lbe`, `lez`, `lg`, `li`, `lij`, `ln`, `lo`,
-`lom`, `lrc`, `lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `mak`, `mdf`,
-`men`, `mg`, `mh`, `mhr`, `mi`, `min`, `miq`, `mk`, `ml`, `mn`, `mni`,
-`mnk`, `mns`, `mnw`, `mos`, `mr`, `mrj`, `mrw`, `ms`, `mt`, `my`,
-`myv`, `mzn`, `nah`, `nap`, `nb`, `nds`, `ne`, `nia`, `niu`, `nl`,
-`nn`, `nog`, `nso`, `ny`, `nyn`, `oc`, `oj`, `olo`, `om`, `or`, `os`,
-`pa`, `pag`, `pam`, `pap`, `pcm`, `pl`, `pms`, `pon`, `ps`, `pt`, `qu`,
-`quc`, `rar`, `rm`, `rn`, `ro`, `ru`, `rue`, `rw`, `sa`, `sah`, `sat`,
-`sc`, `scn`, `sco`, `sd`, `se`, `sg`, `sgh`, `shi`, `shn`, `si`, `sjd`,
-`sk`, `sl`, `sm`, `sma`, `smj`, `smn`, `sms`, `sn`, `so`, `sq`, `sr`,
-`srm`, `srn`, `ss`, `st`, `su`, `sus`, `sv`, `sw`, `szl`, `ta`, `tab`,
-`te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`, `tly`,
-`tn`, `to`, `tpi`, `tr`, `ts`, `tsg`, `tt`, `ttt`, `tvl`, `ty`, `tyv`,
-`udm`, `ug`, `uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vec`, `vep`, `vi`,
-`vro`, `war`, `wbl`, `wls`, `wo`, `xal`, `xh`, `yi`, `yo`, `yua`,
-`zgh`, `zh-Hans`, `zh-Hant`, `zu`, `zza`
+`lom`, `lrc`, `lt`, `lua`, `luo`, `lus`, `lv`, `mad`, `mag`, `mai`,
+`mak`, `mdf`, `men`, `mg`, `mh`, `mhr`, `mi`, `min`, `miq`, `mk`,
+`ml`, `mn`, `mni`, `mnk`, `mns`, `mnw`, `mos`, `mr`, `mrj`, `mrw`,
+`ms`, `mt`, `mwr`, `my`, `myv`, `mzn`, `nah`, `nap`, `nb`, `nds`,
+`ne`, `new`, `nia`, `niu`, `nl`, `nn`, `nog`, `nso`, `ny`, `nyn`,
+`oc`, `oj`, `olo`, `om`, `or`, `os`, `pa`, `pag`, `pam`, `pap`, `pcm`,
+`pl`, `pms`, `pon`, `ps`, `pt`, `qu`, `quc`, `rar`, `rm`, `rn`, `ro`,
+`ru`, `rue`, `rw`, `sa`, `sah`, `sat`, `sc`, `scn`, `sco`, `sd`, `se`,
+`sg`, `sgh`, `shi`, `shn`, `si`, `sjd`, `sk`, `skr`, `sl`, `sm`,
+`sma`, `smj`, `smn`, `sms`, `sn`, `so`, `sq`, `sr`, `srm`, `srn`,
+`ss`, `st`, `su`, `sus`, `sv`, `sw`, `syl`, `szl`, `ta`, `tab`, `tcy`,
+`te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`,
+`tly`, `tn`, `to`, `tpi`, `tr`, `ts`, `tsg`, `tt`, `ttt`, `tvl`, `ty`,
+`tyv`, `udm`, `ug`, `uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vec`,
+`vep`, `vi`, `vro`, `war`, `wbl`, `wls`, `wo`, `xal`, `xh`, `yi`,
+`yo`, `yua`, `zgh`, `zh-Hans`, `zh-Hant`, `zu`, `zza`
 — is an **unreviewed machine-generated seed**, which each file's own
 header says at the top, and which is what #1521's translation platform is for.
 None has been read by a speaker. Correcting one needs no permission and no
 coordination: a wrong string is just wrong, and the English is one key away.
 
-Two hundred and thirty-eight of them are deliberately partial. Two hundred
-and thirty-six are partial in the same place — the two chemistry tables —
+Two hundred and fifty-three of them are deliberately partial. Two hundred
+and fifty-one are partial in the same place — the two chemistry tables —
 while two are partial more widely, each for its own reason: Klingon almost
 everywhere, for the reason in
 [A language with no word for it](#a-language-with-no-word-for-it), and
 Inuktitut over the geometry nouns as well, for the reason in
 [Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws).
-The two hundred and thirty-six are: Somali, Hmong Njua, Amharic, Assamese,
+The two hundred and fifty-one are: Somali, Hmong Njua, Amharic, Assamese,
 Nepali, Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino,
 Vietnamese, Zulu, Xhosa, Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -139,8 +141,9 @@ Shughni, Dungan, Wakhi, Kalaallisut, Yucatec Maya, Qʼeqchiʼ, Garifuna,
 Mískito, Papiamentu, Sranan Tongo, Jamaican Creole, Guadeloupean Creole
 French, Saint Lucian Creole French, Guianese Creole French, Belize Kriol,
 Aukan, Saramaccan, Buginese, Makasar, Banjar, Gorontalo, Nias, Batak Toba,
-Iban, Central Dusun, Pangasinan, Chavacano, Tausug, Maranao, Shan, Mon and
-S'gaw Karen
+Iban, Central Dusun, Pangasinan, Chavacano, Tausug, Maranao, Shan, Mon,
+S'gaw Karen, Awadhi, Chhattisgarhi, Magahi, Marwari, Garhwali, Kumaoni,
+Newari, Sylheti, Tulu, Mizo, Khasi, Garo, Saraiki, Brahui and Fiji Hindi
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -397,6 +400,31 @@ English or Thai, and choosing either would hide the split. Four school systems, 
 a language among them; see [Fifteen languages of Southeast
 Asia](#fifteen-languages-of-southeast-asia-and-the-batch-whose-word-order-follows-a-border)
 for what does divide the batch.
+
+**All fifteen of the second South Asian batch are partial as well, and they
+split two ways rather than the first South Asian batch's five.** Thirteen are
+the school-system case in six mediums: chemistry is taught in Hindi across the
+Hindi belt and Uttarakhand, so `awa`, `hne`, `mag`, `gbm` and `kfy` meet the
+table in the language `locales/hi` carries it in; in Nepali in the Kathmandu
+Valley for `new`; in Bengali in Sylhet for `syl`, which is the
+one of the fifteen whose fallback language is a catalog on this roster that
+*does* carry the names, `locales/bn`; in English across Meghalaya and Mizoram
+for `kha`, `grt` and `lus`; in Urdu in southern Punjab and Balochistan for
+`skr` and `brh`; and in English in Fiji for `hif`.
+
+`tcy` is the fourteenth and the one that is nobody's case above: Tulu-medium
+schooling stops below the grades where the periodic table appears, so a Tulu
+pupil meets it in Kannada — and `locales/kn` omits the tables too, for the
+Kannada reason of having two nomenclatures and no way to pick. So the neighbour
+a Tulu reader would be sent to does not carry the list either, and English falls
+through to a reader whose curriculum is in neither language. `syl` is the
+contrast inside the same batch: its neighbour `locales/bn` does carry it.
+
+The fifteenth is `mwr`, the school-system case with a second reason on top of
+it and the only entry here that is also a claim about a language: Rajasthan
+teaches chemistry in Hindi, and Marwari has no settled list of all 118 to seed
+from in any case. Each catalog's header says which of the three cases it is
+in.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -3460,6 +3488,199 @@ everything around the table.
 
 Every string in all fifteen is machine-generated and unread by a speaker, and
 each file says so at the top. Correcting any of it needs no permission.
+
+### Fifteen catalogs of South Asia, and the batch that is mostly frame
+
+The roster goes from 316 locales to 331: Awadhi (`awa`), Chhattisgarhi
+(`hne`), Magahi (`mag`), Marwari (`mwr`), Garhwali (`gbm`) and Kumaoni
+(`kfy`) — six Indo-Aryan languages of the Hindi belt, Rajasthan and
+Uttarakhand; Newar (`new`) and Sylheti (`syl`) — Nepal and northeastern
+Bangladesh; Tulu (`tcy`) — Dravidian, coastal Karnataka; Mizo (`lus`), Khasi
+(`kha`) and Garo (`grt`) — three languages of Northeast India in three
+families; Saraiki (`skr`) and Brahui (`brh`) — Pakistan, one Indo-Aryan and
+one Dravidian; and Fiji Hindi (`hif`), the batch's one diaspora language.
+
+Like the Southeast Asian batch it is assembled around a region, and like it
+every one of the fifteen sits at **445/575 keys**, the whole catalog minus the
+two chemistry tables. Three properties are worth reading off it, and the first
+one is uncomfortable.
+
+#### Most of what these files translate is the frame, and the headers say so
+
+Ten of the fifteen are Indo-Aryan languages with no medium of secondary
+education and therefore no settled technical register of their own. What a
+seed can supply for them is the **grammar**, and what it cannot supply is the
+**vocabulary**: «रेखा», «बहुभुज», «फलन», «विशेषता» are Hindi in `awa`, `hne`,
+`mag`, `mwr`, `gbm` and `kfy` alike, «মিছা» sits in a Sylheti sentence around
+a Bengali noun, and Saraiki's geometry is Urdu's. The catalogs do not disguise
+this. Each header states the loan register in its own words, which makes it a
+declared property of the seed rather than something a reviewer discovers.
+
+The differentiation is real and it is concentrated in the frame — the copula,
+the negator, the postpositions, the participles, the plural marker and the
+imperative class. `awa` writes «अहै», «नाहीं», genitive «क», dative «खातिर»,
+oblique plural in -न; `hne` writes «हे», «नइ», the dative «बर» that no other
+catalog in the batch uses, the plural «मन» and the habitual «-थे»; `mag`
+writes «हइ», «ना», dative «लेल», plural «सब» and the eastern -ल participles
+(«देल», «कएल», «मिलल»). Those are three languages rather than one language
+spelled three ways, and a reviewer correcting the nouns is correcting the
+half the seed knew it could not do.
+
+The batch's colour words are the one place the vocabulary is native more often
+than not: `awa` उजर/पियर, `hne` पंडरा/पींयर, `mag` उज्जर/पीयर where
+`locales/hi` writes सफ़ेद and पीला, `new`'s हाकु, तुयु, ह्याउँ, `tcy`'s
+ಬೊಲ್ದು, ಮಂಜಲ್, ಪಚ್ಚೆ, Saraiki's ساوا. Each catalog's header names which of its
+twelve colours are the language's own and which are loans, because that
+distinction is the one a speaker can fix in a single line.
+
+#### Word order splits thirteen against two, and the two are neighbours
+
+Thirteen catalogs put the modifiers in front of the noun and two put them
+behind. Thirteen to two is unremarkable — South Asia is left-branching, and
+the ten Indo-Aryan catalogs inherit Hindi's order with its vocabulary. What
+the split is *not* is genetic or geographic.
+
+Prenominal, rendered for "thick dashed red line": `awa`, `hne` and `mag`
+«मोट खंडित लाल रेखा», `mwr` «मोटो खंडित लाल रेखा», `gbm` «मोटु खंडित लाल रेखा»,
+`kfy` «मोटो खंडित लाल रेखा», `new` «बाक्लो धर्के ह्याउँ रेखा», `syl`
+«মোটা দাগ-দাগ লাল রেখা», `tcy` «ದಪ್ಪ ತುಂಡು ತುಂಡುದ ಕೆಂಪು ಗೆರೆ», `grt`
+«dal·gipa dashgipa gitchak lain», `skr` «موٹی منقطع لال لکیر», `brh`
+«دبیز خط چین سرخ خط», `hif` «mota dash waala laal lakiir».
+
+Postnominal: `kha` «lain bakhraw badash basaw», `lus` «line lian dash-nei
+sen».
+
+**The two are `kha` and `lus`, and `grt` is not one of them.** Khasi and Garo
+are spoken in the same state and seeded in the same batch; Garo and Mizo are
+both Tibeto-Burman. So Meghalaya writes the phrase both ways, and the two
+Tibeto-Burman catalogs of the batch disagree with each other — Garo's `-gipa`
+attributive precedes its noun, Mizo's follows. Neither family nor geography
+predicts this row, which is why `styleDescriptions.test.ts` pins all fifteen
+rather than a representative from each side.
+
+`brh` is the other row worth reading twice, from the opposite direction:
+Brahui is Dravidian, sits among Indo-Aryan neighbours, and writes their order.
+`tcy` is Dravidian too and prenominal for the same areal reason. Order
+follows the neighbourhood here, which is the Southeast Asian batch's `cbk`
+finding arriving from the other side — there a creole kept its substrate's
+order against its lexicon, here two Dravidian languages take their
+neighbours'.
+
+Every one of the fifteen keeps English's internal sequence of the three
+adjectives, so what moves in `kha` and `lus` is the noun alone. **No catalog
+in the batch writes a linker between modifier and noun**, so nothing here
+comes near the hazard [A ligature is an affix too](#a-ligature-is-an-affix-too)
+describes — which is what separates this batch from the Philippine half of
+the last one, where three catalogs wrote «nga» or «a» in every position.
+
+#### One catalog agrees its adjectives, and fourteen do not
+
+`skr` is the batch's only `$gender` and `$role` fork. Saraiki keeps
+Indo-Aryan's marked adjective classes whole, so «موٹی» stands before the
+feminine «لکیر» and «موٹا» before a masculine noun, and `noun-gender` forks on
+`$noun` in the shape `locales/ur` and `locales/hi` already use — with
+«پس منظر» masculine where Hindi's «पृष्ठभूमि» is feminine.
+
+The other fourteen write one invariant form each, and the reason differs and
+matters:
+
+- **Three cases where it is a claim about the language.** Brahui has no
+  gender at all; Tulu marks it on verbs and pronouns but not on attributives;
+  Fiji Hindi has levelled Hindi's agreement away, so the `-a` form stands in
+  every position for a noun of either gender. Newar, Khasi, Mizo, Garo and
+  Sylheti are the same case for the same reason — no attributive agreement to
+  lose. In all of these `noun-gender`'s single `neuter` token is an answer
+  rather than a placeholder.
+- **Six cases where it is a gap, and the headers call it the file's largest
+  defect.** Awadhi, Chhattisgarhi, Magahi, Marwari, Garhwali and Kumaoni all
+  *do* inflect marked adjectives, and all six write them unagreed. Reinstating
+  agreement means writing a trustworthy gender for every `noun` entry first,
+  and a confidently wrong agreement table is harder to repair than a uniformly
+  unagreed one; `locales/hi` and now `locales/skr` are the shapes to lift the
+  forks from once the genders exist.
+
+`[noun-tail]` is unused in all fifteen: the side count precedes the noun
+everywhere, so `head` carries the phrase whole.
+
+#### Two right-to-left catalogs, and one that is right by the wrong route
+
+`skr` and `brh` take the roster's right-to-left catalogs from sixteen to
+eighteen, and both are new entries in `direction.ts`'s `RTL_LANGUAGES` on the
+same terms `bal` and `haz` were: each maximizes to `-Arab`, so the script rule
+already answers a parseable tag, and the entry earns its keep on the fallback
+path where nothing could be parsed. Brahui is the first Dravidian language on
+that list, which is `direction.ts`'s own point — direction is a fact about a
+script and not about a family.
+
+`hif` is the instructive one. ICU maximizes it to `hif-Deva-FJ`, which is
+wrong about the script — Fiji Hindi is written in Latin letters by the people
+who write it — and right about the direction anyway, because both candidate
+scripts run left to right. The tag reaches the correct answer by a route that
+does not hold in general, and both `hif` headers say so.
+
+Neither right-to-left catalog welds anything to a placeable. Brahui's case
+clitics are normally joined in print and are written separated in all four
+files, because the word in front of one is so often a placeable; the header
+records that as a spelling decision made for safety rather than a correction.
+
+#### Not one of the fifteen has CLDR plural data
+
+`new Intl.PluralRules(tag).resolvedOptions().locale` is the runtime's own
+default for every one of the fifteen, so no catalog writes a `zero`, `one`,
+`two`, `few` or `many` branch anywhere: sixty files, zero plural categories.
+That is the Southeast Asian batch's finding again, and here it costs
+something. Those fifteen languages did not mark a noun for number after a
+numeral; these do — every one of them — and the catalogs still cannot fork on
+one, because the branch would be selected by whatever locale the runtime fell
+back to rather than by the language. `hi`, `bn`, `ur`, `mr` and `ne` sit
+beside them on the roster with rules of their own. Whether a tag has plural
+data follows whether a CLDR locale was ever requested for it.
+
+Each catalog writes exactly one `[0]` — `attempts-remaining` — and one `[1]` —
+`field-function-wrong-num-outputs`, which forks on how many outputs a
+component *needs*. Fluent matches both against the number itself, so neither
+consults a plural rule. `chrome.test.ts` holds both halves.
+
+#### Negotiation gained nothing, and three tags left a list instead
+
+`MACROLANGUAGE_MEMBERS` and `LANGUAGE_ALIASES` are untouched by this batch.
+Every one of the fifteen tags is one `Intl.getCanonicalLocales` leaves alone
+and filtering negotiation matches on its own, so seeding them cost negotiation
+nothing.
+
+What did change is a list in `negotiate.test.ts`. `kfy`, `mag` and `grt` were
+asserted there as *near misses* — Indo-Aryan and Tibeto-Burman neighbours of
+`mai`, `bho` and `brx` that the membership rule declined to fold onto them,
+falling to English on purpose. All three now have catalogs and are asserted
+against them instead, with `hoc` and `njz` left behind holding the original
+point. Nothing about the map changed to let them through: **the way off that
+list is a directory, not an entry in `MACROLANGUAGE_MEMBERS`.**
+
+Six of the fifteen need `LOCALE_NAME_FALLBACKS`, and the split does not follow
+speaker numbers: ICU names `awa`, `mag`, `mwr`, `new`, `tcy`, `lus`, `kha`,
+`brh` and `hif`, and has nothing for `hne`, `gbm`, `kfy`, `syl`, `grt` or
+`skr` — Chhattisgarhi has more speakers than several tags ICU does name. Each
+of the six gets an endonym in the script its own catalog is written in, Garo's
+in the Latin orthography that writes its raised dot as `·`.
+
+#### Five scripts, and three of the choices are contested
+
+Devanagari for the six Hindi-belt catalogs and for `new`; the Bengali script
+for `syl`; Kannada for `tcy`; Latin for `lus`, `kha`, `grt` and `hif`;
+Perso-Arabic for `skr` and `brh`. Three of those are decisions a reader may
+disagree with, and each header argues its case: **Newar** is written in
+Devanagari rather than Ranjana, which is a living display script with thin
+font coverage rather than the script of continuous prose; **Sylheti** in the
+Bengali script rather than Sylheti Nagri, whose smaller inventory would
+collapse distinctions this seed cannot restore; and **Tulu** in Kannada rather
+than Tigalari, whose revival is real but whose orthography for *modern* Tulu
+is not settled. In all three the answer to a disagreement is a second catalog
+beside the first rather than a rename of it, which is `pa`'s and `sr`'s answer
+in [A language CLDR has no name for](#a-language-cldr-has-no-name-for).
+
+Numbers render in Latin digits in every one of the fifteen, including the
+Devanagari, Bengali, Kannada and Perso-Arabic catalogs, so a digit inside a
+sentence matches the count formatted beside it.
 
 ### A language with no word for it
 

--- a/packages/i18n/locales/awa/chrome.ftl
+++ b/packages/i18n/locales/awa/chrome.ftl
@@ -13,7 +13,8 @@
 # (`1`, `2`, `1,234`), not Devanagari, because that is what DoenetML pins for
 # every locale in `src/intl.ts`; the grouping separator is the locale's own.
 #
-# **What is Awadhi here is the frame, and it is used consistently.** The
+# **What is Awadhi is the frame, and it is used consistently across all four
+# files of this catalog rather than only in this one.** The
 # copula is «अहै» / «अहैं», the negator «नाहीं», the genitive «क» beside the
 # borrowed «के», *for* is «खातिर», *and* is «अउर», *because* is «काहे से कि»,
 # *like* is «जइसे», *this* is «ई» with oblique «एह», *some / any* is «कउनो»,
@@ -27,14 +28,16 @@
 # rather than disguised.** «कीबोर्ड», «पंक्ति», «स्तंभ», «व्यंजक», «त्रुटि»,
 # «सुगम्यता», «पूर्वावलोकन» are the words an Awadhi speaker has met in school
 # and on a screen, in Hindi. Where Awadhi's own everyday word is the one a
-# reader would use, it is used instead: «जवाब» rather than «उत्तर», «गलत»,
-# «करिया», «उजर», «पियर», «हरियर».
+# reader would use, it is used instead — across the catalog, not only in this
+# file: «जवाब» rather than «उत्तर» and «गलत» here, «करिया», «उजर», «पियर»,
+# «हरियर» among `content.ftl`'s colours.
 #
 # **Counts.** CLDR has no plural data for `awa`, so `Intl.PluralRules` would
 # resolve it against the runtime's own locale and any `[one]` branch would be
-# selected by somebody else's rules. Both counted messages collapse to a
-# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
-# Fluent matches against the number itself. An Awadhi noun is unmarked after a
+# selected by somebody else's rules. `answer-show-responses` therefore drops
+# the selector entirely and writes one form, and the only branch on a number
+# left in this file is `attempts-remaining`'s explicit `[0]`, which Fluent
+# matches against the number itself rather than against a category. An Awadhi noun is unmarked after a
 # numeral in any case, so one form is right.
 
 

--- a/packages/i18n/locales/awa/chrome.ftl
+++ b/packages/i18n/locales/awa/chrome.ftl
@@ -1,0 +1,138 @@
+# Awadhi (अवधी) viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is what Awadhi is written in wherever it is
+# written at all — in Ramcharitmanas editions, in schoolbooks about it, and
+# online. Kaithi is historical and is not used here. Digits are **Latin**
+# (`1`, `2`, `1,234`), not Devanagari, because that is what DoenetML pins for
+# every locale in `src/intl.ts`; the grouping separator is the locale's own.
+#
+# **What is Awadhi here is the frame, and it is used consistently.** The
+# copula is «अहै» / «अहैं», the negator «नाहीं», the genitive «क» beside the
+# borrowed «के», *for* is «खातिर», *and* is «अउर», *because* is «काहे से कि»,
+# *like* is «जइसे», *this* is «ई» with oblique «एह», *some / any* is «कउनो»,
+# *again* is «फेर». A button carries the honorific imperative in **-औ** —
+# «खोलौ», «हटावौ», «जोड़ौ», «देखावौ» — which is the form the seed is least
+# sure of: some descriptions of Awadhi give **-अ** («खोला», «देखावा») for the
+# same person, and a reviewer who prefers that shape should change all four
+# files at once rather than message by message.
+#
+# **The technical vocabulary is Hindi and Sanskrit, and that is declared
+# rather than disguised.** «कीबोर्ड», «पंक्ति», «स्तंभ», «व्यंजक», «त्रुटि»,
+# «सुगम्यता», «पूर्वावलोकन» are the words an Awadhi speaker has met in school
+# and on a screen, in Hindi. Where Awadhi's own everyday word is the one a
+# reader would use, it is used instead: «जवाब» rather than «उत्तर», «गलत»,
+# «करिया», «उजर», «पियर», «हरियर».
+#
+# **Counts.** CLDR has no plural data for `awa`, so `Intl.PluralRules` would
+# resolve it against the runtime's own locale and any `[one]` branch would be
+# selected by somebody else's rules. Both counted messages collapse to a
+# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
+# Fluent matches against the number itself. An Awadhi noun is unmarked after a
+# numeral in any case, so one form is right.
+
+
+## Answer submission
+
+answer-checking = जाँचल जात अहै...
+answer-submitting = पठावल जात अहै...
+answer-checking-status = जवाब जाँचल जात अहै
+answer-submitting-status = जवाब पठावल जात अहै
+answer-correct = सही
+answer-incorrect = गलत
+answer-response-saved = जवाब सहेजल गा
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+max-credit-available = सबसे जादा मिलै वाला अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] कउनो मौका नाहीं बचा
+       *[other] { $count } मौका बचा
+    }
+validation-correct = (सही)
+validation-incorrect = (गलत)
+validation-partially-correct = (कुछ हद तक सही)
+answer-show-responses = { $answerId } क { $count } जवाब देखावौ
+
+
+## Disclosure panels
+
+feedback-heading = राय
+collapsible-click-to-open = (खोलै खातिर क्लिक करौ)
+collapsible-click-to-close = (बंद करै खातिर क्लिक करौ)
+collapsible-initializing = सुरू कीन जात अहै...
+footnote-show = पादटिप्पणी देखावौ
+footnote-hide = पादटिप्पणी छिपावौ
+description-more-information = अउर जानकारी
+
+
+## Controls
+
+slider-previous = पहिले
+slider-next = आगे
+keyboard-open = कीबोर्ड खोलौ
+keyboard-close = कीबोर्ड बंद करौ
+choice-input-remove-choice = { $choice } हटावौ
+matrix-remove-row = पंक्ति हटावौ
+matrix-add-row = पंक्ति जोड़ौ
+matrix-remove-column = स्तंभ हटावौ
+matrix-add-column = स्तंभ जोड़ौ
+subset-add-remove-points = बिंदु जोड़ौ/हटावौ
+subset-toggle-points-intervals = बिंदु अउर अंतराल क बीच बदलौ
+subset-move-points = बिंदु सरकावौ
+subset-clear = साफ करौ
+# A `box` here is one orbital, drawn as a square: खाँचा.
+orbital-add-row = पंक्ति जोड़ौ
+orbital-remove-row = पंक्ति हटावौ
+orbital-add-box = खाँचा जोड़ौ
+orbital-remove-box = खाँचा हटावौ
+orbital-add-up-arrow = ऊपर क तीर जोड़ौ
+orbital-add-down-arrow = नीचे क तीर जोड़ौ
+orbital-remove-arrow = तीर हटावौ
+orbital-row-label = पंक्ति { $row } क लेबल
+pretzel-answer = जवाब
+summary-statistics-caption = { $column } क सारांश सांख्यिकी
+
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक क पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+
+## Document status
+
+viewer-initializing = सुरू कीन जात अहै...
+
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } मा मिली।
+       *[lines] पंक्ति { $startLine }–{ $endLine } मा मिली।
+    }
+document-contains-errors = एह दस्तावेज मा त्रुटि अहैं!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+something-went-wrong = कुछ गलत होइ गा।
+renderer-load-failed = एक रेंडरर लोड नाहीं होइ पावा। कृपया पन्ना फेर से लोड करौ।
+core-start-failed = ई दस्तावेज सुरू नाहीं होइ पावा। कृपया पन्ना फेर से लोड करौ।
+core-start-failed-busy = ई दस्तावेज सुरू नाहीं होइ पावा। एक्के संग कई दस्तावेज सुरू होत रहे, अउर धीमे यंत्र पर एह मा जादा समय लागत अहै। दूसर दस्तावेज पूरा होइ जाँय तब पन्ना फेर से लोड करै से काम बनि सकत अहै।
+core-start-failed-retry = ई दस्तावेज सुरू नाहीं होइ पावा।
+core-start-failed-busy-retry = ई दस्तावेज सुरू नाहीं होइ पावा। एक्के संग कई दस्तावेज सुरू होत रहे, अउर धीमे यंत्र पर एह मा जादा समय लागत अहै।
+core-start-retry = फेर कोसिस करौ
+saved-state-unavailable = तोहार सहेजल काम लोड नाहीं होइ पावा।

--- a/packages/i18n/locales/awa/content.ftl
+++ b/packages/i18n/locales/awa/content.ftl
@@ -1,0 +1,292 @@
+# Awadhi (अवधी) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, as in every file of this catalog. Digits are Latin
+# and a number is grouped by the locale's own rules (`1,000`), which is what
+# DoenetML pins for every locale in `src/intl.ts`.
+#
+# ## Word order
+#
+# **The description comes first and the noun last**, as in English and as in
+# Hindi: «मोट खंडित लाल रेखा» is *thick dashed red line*. So `style-with-noun`
+# and `style-filled-with-noun` keep English's order of placeables, and
+# `style-stroke` keeps English's internal order of width, dash pattern and
+# colour, because that is Awadhi's order too.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } भुजा वाला सम बहुभुज» and leaves `tail` empty, as English
+# does: the side count goes in front of the noun here, so nothing has to be
+# split around the adjectives.
+#
+# ## Gender, role and number
+#
+# **Neither `$gender` nor `$role` forks, and that is half a claim about the
+# language and half a gap.** The claim: Awadhi's own colour and width words
+# are the invariant **-अ** shapes — «करिया», «उजर», «पियर», «हरियर», «मोट»,
+# «पातर» — which agree with nothing, so where `locales/hi` forks काला /
+# काली / काले this file writes «करिया» once. That is the clearest way this
+# catalog is not Hindi in a hat, and `noun-gender` answers the single token
+# `neuter` because nothing downstream needs to select on it.
+#
+# The gap: three words in this file **are** marked in Awadhi and are written
+# here in their direct-masculine form regardless — the two colour loans
+# «नीला» and «भूरा», the participle «भरा» in `style-filled-word`, and «वाला»
+# in `style-filled`. «बिंदुन वाला रेखा» should be «बिंदुन वाली रेखा», and
+# «नीला रेखा» should be «नीली रेखा». A reviewer who wants that fixed has to
+# reintroduce the `$gender` fork on those four spots and a `$role` fork for
+# the oblique «नीले» / «भरे» / «वाले» that `border-clause` wants, and give
+# `noun-gender` a real table — रेखा, किरण and बहुरेखा are feminine, and so is
+# पृष्ठभूमि. This is the largest single defect in the file.
+#
+# **Nothing selects on a count.** CLDR has no plural data for `awa`, and an
+# Awadhi noun is unmarked after a numeral anyway.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry and chemistry register is Hindi and Sanskrit, declared as
+# such**: «रेखा», «रेखाखंड», «किरण», «सदिश», «वक्र», «फलन», «परवलय»,
+# «बहुभुज», «त्रिभुज», «आयत», «वृत्त», «समचतुर्भुज». Awadhi-medium schooling
+# does not exist, so these are the words an Awadhi student has actually met,
+# and inventing Awadhi coinages would put words in front of a reader nobody
+# uses. What is Awadhi here is everything around them: «जवाब», «सवाल»,
+# «जदि», «नाहीं त», «क» for the genitive, «अउर», «खातिर», and the oblique
+# plural in **-न** («रेखन», «बिंदुन»), which is the shape the fill patterns
+# take because their other use is in front of «वाला».
+#
+# **The two chemistry tables are absent.** `element-name` and
+# `element-anion-name` — 128 messages between them — are not translated in
+# this batch, so this catalog sits at 445/575 keys with every other file in
+# it. The element names an Awadhi reader would use are the Hindi ones, and a
+# seed that copied them over would be claiming a review it has not had; the
+# renderer already falls back to English for a missing key.
+
+
+## Style vocabulary
+
+color =
+    .black = करिया
+    .white = उजर
+    .gray = सलेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow = पियर
+    .green = हरियर
+    .cyan = फिरोजी
+    .blue = नीला
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown = भूरा
+# Both are invariant in Awadhi, so neither takes a fork.
+line-width =
+    .thick = मोट
+    .thin = पातर
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+# Oblique plurals in -न, because their other use is in front of «वाला», a
+# postpositional word that governs the oblique. They agree with nothing, so
+# `style-fill` gives them a noun to hang off rather than printing them bare.
+fill-style =
+    .horizontal = आड़ी रेखन
+    .vertical = खड़ी रेखन
+    .diagonal = विकर्ण रेखन
+    .backdiagonal = उलटी विकर्ण रेखन
+    .dots = बिंदुन
+    .diamonds = समचतुर्भुजन
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = प्रवणता क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = जोड़ चिह्न
+# The side count goes in front of the noun, so the whole phrase is one head
+# and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजा वाला सम बहुभुज
+    }
+# A single token: nothing in this file selects on gender, so there is no
+# table to fill in. Awadhi does have gender — रेखा, किरण, बहुरेखा and
+# पृष्ठभूमि are feminine, किनारा, भराव and पाठ masculine — and a reviewer who
+# reinstates agreement has to write that table here first.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# Adjectives precede the noun, as in English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# Said only of the shape itself, so it is standalone everywhere. «भरा» is a
+# marked adjective in Awadhi and ought to agree with the shape; the seed
+# writes the masculine throughout. See the header.
+style-filled-word = भरा
+# «वाला» belongs to the shape rather than to the pattern in front of it, and
+# in Awadhi it agrees with the shape — «बिंदुन वाली रेखा», «बिंदुन वाला
+# वर्ग». The seed writes «वाला» unagreed; see the header.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वाला { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «क संग» is postpositional, so «किनारा» stands in the oblique «किनारे». The
+# adjective in front of it should go oblique too, and does not: that is the
+# `$role` gap the header names. Awadhi has no article, so the `-article`
+# branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारे क संग
+        [and] अउर { $border } किनारे क संग
+        [and-article] अउर { $border } किनारे क संग
+       *[with] { $border } किनारे क संग
+    }
+# The fill-pattern words are oblique plurals, so this message supplies a noun
+# for them to hang off — «भराव» — rather than printing them bare.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } भराव
+       *[plain] { $color } भराव
+    }
+style-unfilled = बिना भराव
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि पर { $color }
+       *[plain] { $color }
+    }
+style-background-none = कउनो नाहीं
+
+
+## Boolean words
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## Answer buttons
+
+answer-submit-label = जाँचौ
+answer-submit-label-no-correctness = जवाब पठावौ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = गतिविधि
+    .aside = बगल क बात
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = जवाब
+    .note = टिप्पणी
+    .objectives = उद्देस
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = सवाल
+    .problems = सवाल
+    .proof = प्रमाण
+    .question = परसन
+    .section = अनुभाग
+    .solution = हल
+    .task = काम
+    .theorem = प्रमेय
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = संकेत
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = पहिले
+paginator-next = आगे
+paginator-page = पन्ना
+paginator-page-status = { $numPages } मा से { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = या
+piecewise-condition-if = जदि
+piecewise-condition-otherwise = नाहीं त
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header. What is left is the prose around them.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = खाली जगह
+math-embedded-input-blank-ordinal = { $total } मा से { $ordinal } खाली जगह

--- a/packages/i18n/locales/awa/content.ftl
+++ b/packages/i18n/locales/awa/content.ftl
@@ -32,13 +32,13 @@
 # catalog is not Hindi in a hat, and `noun-gender` answers the single token
 # `neuter` because nothing downstream needs to select on it.
 #
-# The gap: three words in this file **are** marked in Awadhi and are written
+# The gap: four words in this file **are** marked in Awadhi and are written
 # here in their direct-masculine form regardless — the two colour loans
 # «नीला» and «भूरा», the participle «भरा» in `style-filled-word`, and «वाला»
 # in `style-filled`. «बिंदुन वाला रेखा» should be «बिंदुन वाली रेखा», and
 # «नीला रेखा» should be «नीली रेखा». A reviewer who wants that fixed has to
 # reintroduce the `$gender` fork on those four spots and a `$role` fork for
-# the oblique «नीले» / «भरे» / «वाले» that `border-clause` wants, and give
+# the oblique «नीले» / «भरे» / «वाले» that `style-border-clause` wants, and give
 # `noun-gender` a real table — रेखा, किरण and बहुरेखा are feminine, and so is
 # पृष्ठभूमि. This is the largest single defect in the file.
 #
@@ -58,7 +58,7 @@
 # take because their other use is in front of «वाला».
 #
 # **The two chemistry tables are absent.** `element-name` and
-# `element-anion-name` — 128 messages between them — are not translated in
+# `element-anion-name` — 130 messages between them — are not translated in
 # this batch, so this catalog sits at 445/575 keys with every other file in
 # it. The element names an Awadhi reader would use are the Hindi ones, and a
 # seed that copied them over would be claiming a review it has not had; the

--- a/packages/i18n/locales/awa/diagnostics.ftl
+++ b/packages/i18n/locales/awa/diagnostics.ftl
@@ -1,0 +1,674 @@
+# Awadhi (अवधी) diagnostics: the warnings and errors the worker raises and the
+# reader is shown. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth. Selected by `uiLocale`, not by the language the document was
+# written in.
+#
+# Message ids are never translated — only the text to the right of `=`. Neither
+# are the DoenetML identifiers quoted inside these sentences: `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence` and every tag and attribute name like them are part of
+# the language an author writes, not prose, and stay in English exactly as
+# written. So does the `[deprecation]` marker, which is a label rather than a
+# word, and anything quoted back from the author's own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari with Latin digits**, as in every file of this catalog.
+#
+# **The technical vocabulary is Hindi and Sanskrit and is declared as such** —
+# घटक, विशेषता, चर, विमा, आव्यूह, संदर्भ, फलन, समीकरण, अनुक्रम, वैषम्य.
+# Awadhi is not a language of instruction anywhere, so these are the words an
+# Awadhi reader has met; inventing Awadhi equivalents would put words in front
+# of a reader that nobody uses.
+#
+# **What is Awadhi is the frame**, and it carries the whole file:
+#
+#   «अहै» / «अहैं»            the copula
+#   «नाहीं»                   the negator
+#   «नाहीं कीन जाइ सकत»       *cannot be done*
+#   «छोड़ा जात अहै»           *ignoring*
+#   «पर ध्यान नाहीं दीन जात»  *is ignored*
+#   «होय के चाही»             *must be*
+#   «काहे से कि»              *because*
+#   «अबहीं उपलब्ध नाहीं अहै»  *has not been implemented*
+#   «क»                       the genitive, beside the borrowed «के»
+#   «खातिर» / «अउर» / «या»    *for* / *and* / *or*
+#   «जदि» / «जइसे» / «एह»     *if* / *like* / *this*, oblique
+#
+# A sentence that has slipped back into «है», «नहीं», «क्योंकि» or «के लिए»
+# is a mistake to fix rather than a stylistic choice. This is a **framed**
+# catalog: the sentences are Awadhi, the nouns inside them are declared Hindi,
+# and a speaker should expect to correct the sentences as often as the words.
+#
+# **No plural branches.** CLDR has no plural data for `awa`, so every
+# `[one]`/`[other]` fork English writes over a count is collapsed here; most
+# become a plain message, since an Awadhi noun is unmarked after a numeral.
+# The one exception is `field-function-wrong-num-outputs`, where English is
+# not counting but distinguishing a one-output field from a two-output one;
+# that fork is kept as the numeric literal `[1]`, which Fluent matches against
+# the number itself rather than against a plural category.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दुइ सिरा दीन जाय पर { $attributes } पर ध्यान नाहीं दीन जात
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा अउर मध्यबिंदु दुनौ दीन जाय पर { $attributes } पर ध्यान नाहीं दीन जात
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु क बिना midpointOffset क कउनो असर नाहीं होत
+
+## `<line>`
+
+line-points-undetermined-dimensions = अइसे बिंदुन से होइके जाय वाली रेखा जिनकी विमा तय नाहीं अहै।
+
+line-points-too-few-dimensions = रेखा का कम से कम दुइ विमा वाले बिंदुन से होइके जाय के चाही।
+
+line-points-depend-on-variables = रेखा ओह बिंदुन से होइके जात अहै जउन चरन पर निर्भर अहैं: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } अउर { $variable2 } मा रेखा क समीकरण क प्रारूप अमान्य अहै।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एक्के संग through, endpoint अउर direction से तय अहै। दीन गा through छोड़ा जात अहै।
+
+ray-dimension-mismatch = किरण मा numDimensions मेल नाहीं खात।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एक्के संग head, tail अउर displacement से तय अहै। दीन गा head छोड़ा जात अहै।
+
+vector-dimension-mismatch = सदिश मा numDimensions मेल नाहीं खात।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` क ओर खींचा नाहीं जाइ सकत, काहे से कि ओह मा nearestPoint अवस्था चर नाहीं अहै।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित नाहीं कीन जाइ सकत, काहे से कि ओह मा nearestPoint अवस्था चर नाहीं अहै।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` क भीतरी भाग तक सीमित नाहीं कीन जाइ सकत, काहे से कि ओह मा nearestPoint अवस्था चर नाहीं अहै।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होय वाले choiceInput खातिर labelPosition पर ध्यान नाहीं दीन जात
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput खातिर दीन गा indices छोड़ा जात अहै, काहे से कि indices क संख्या choice संतानन क संख्या से मेल नाहीं खात।
+
+pretzel-indices-count-mismatch = problem खातिर दीन गा indices छोड़ा जात अहै, काहे से कि indices क संख्या problem संतानन क संख्या से मेल नाहीं खात।
+
+shuffle-indices-count-mismatch = shuffle खातिर दीन गा indices छोड़ा जात अहै, काहे से कि indices क संख्या घटकन क संख्या से मेल नाहीं खात।
+
+indices-ignored-out-of-range = { $component } खातिर दीन गा indices छोड़ा जात अहै, काहे से कि कुछ अनुक्रमांक परिसर से बाहर अहैं।
+
+pretzel-indices-repeated = pretzel खातिर दीन गा indices छोड़ा जात अहै, काहे से कि कुछ अनुक्रमांक दोहरावल गयल अहैं।
+
+pretzel-circuit-first-index = circuit विधा मा pretzel खातिर दीन गा indices छोड़ा जात अहै, काहे से कि पहिला अनुक्रमांक 1 होय के चाही।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` का पाठ संतानन क संग काम करै खातिर `type` विशेषता देय के चाही।
+
+invalid-type-defaulting-to-math = { $component } घटक खातिर प्रकार { $type } अमान्य अहै। ई math, text, number या boolean मा से एक होय के चाही। math क उपयोग कीन जात अहै।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } खातिर मान्य घटक नाहीं अहै। छोड़ा जात अहै।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य अहै; प्रकार number कीन जात अहै।
+
+invalid-variable-value = चर क मान अमान्य अहै: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } संख्या होय के चाही
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } पूर्णांक होय के चाही
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष माप खातिर अबहीं उपलब्ध नाहीं अहै। चौड़ाई सापेक्ष कीन जात अहै।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष माप खातिर अबहीं उपलब्ध नाहीं अहै। हाशिया सापेक्ष कीन जात अहै।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: एह मा कम से कम एक खंड संतान होय के चाही।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर ध्यान नाहीं दीन जात।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एक्के घटक तक पहुँचै के चाही।
+
+label-for-unresolved = `<label>` पर `for` विशेषता कउनो घटक तक नाहीं पहुँच पाई।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता अइसे `<answer>` क संदर्भ देत अहै जेह मा इनपुट खुद लिखा गा अहै; सीधे ओहि इनपुट क संदर्भ दौ।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता अइसे `<answer>` क संदर्भ देत अहै जेह मा लेबल लगावै लायक इनपुट नाहीं अहै।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता कउनो इनपुट या कउनो जवाब क संदर्भ देय के चाही।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता खातिर `<{ $component }>` क या त संछिप्त विवरण होय के चाही या ओका सजावटी बतावा जाय के चाही।
+
+accessibility-video-short-description = सुगम्यता खातिर `<video>` क संछिप्त विवरण होय के चाही।
+
+accessibility-input-short-description-or-label = सुगम्यता खातिर `<{ $component }>` क संछिप्त विवरण या लेबल होय के चाही।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता खातिर इनपुट बनावै वाले `<answer>` क संछिप्त विवरण या लेबल होय के चाही।
+
+accessibility-short-description-contains-math = संछिप्त विवरण मा `<{ $component }>` जइसे गणितीय घटक नाहीं होय के चाही। गणित का सब्दन मा लिखौ।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } क खंड सीर्षक क पाठ खातिर वैषम्य अपर्याप्त अहै (गहिर विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+       *[other] { $colorName } क खंड सीर्षक क पाठ खातिर वैषम्य अपर्याप्त अहै ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदुन क संख्यात्मक मान न होंय, तब { $count } बिंदुन से होइके जाय वाला `<circle>` अबहीं उपलब्ध नाहीं अहै।
+
+circle-too-many-through-points = 3 से जादा बिंदुन से होइके जाय वाला वृत्त नाहीं निकाला जाइ सकत।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र अउर गुजरै वाले बिंदु एक्के संग दीन जाय पर वृत्त नाहीं निकाला जाइ सकत।
+
+circle-center-with-multiple-points = दीन गा केंद्र क संग 1 से जादा बिंदु से होइके जाय वाला वृत्त नाहीं निकाला जाइ सकत।
+
+circle-radius-too-small = वृत्त नाहीं निकाला जाइ सकत: दुनौ बिंदुन क बीच क दूरी { $distance } अहै, एह से दीन गयल त्रिज्या { $radius } बहुत छोट अहै।
+
+circle-radius-with-many-points = दीन गयल त्रिज्या क संग दुइ से जादा बिंदुन से होइके जाय वाला वृत्त नाहीं बनावा जाइ सकत।
+
+circle-invalid-center-or-through-points = वृत्त क केंद्र या गुजरै वाले बिंदु अमान्य अहैं।
+
+circle-radius-center-with-multiple-points = दीन गा केंद्र क संग 1 से जादा बिंदु से होइके जाय वाले वृत्त क त्रिज्या नाहीं निकाली जाइ सकत।
+
+circle-change-radius-non-numerical = जौन वृत्त क गुजरै वाले बिंदु संख्यात्मक नाहीं अहैं, ओकर त्रिज्या नाहीं बदली जाइ सकत
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होय पर, दीन गयल त्रिज्या क संग एक से जादा बिंदु से होइके जाय वाला वृत्त नाहीं बनावा जाइ सकत।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदुन से होइके जाय वाले वृत्त क केंद्र बदलब अबहीं उपलब्ध नाहीं अहै।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन क प्रांत क विमा अपर्याप्त अहैं। प्रांत मा { $intervals } अंतराल अहैं, बाकी फलन मा { $inputs } इनपुट अहैं।
+
+function-domain-invalid-format = फलन क प्रांत क प्रारूप अमान्य अहै।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन क असंख्यात्मक उच्चिष्ठ छोड़ा जात अहै।
+        [minimum] फलन क असंख्यात्मक निम्निष्ठ छोड़ा जात अहै।
+        [extremum] फलन क असंख्यात्मक चरम मान छोड़ा जात अहै।
+        [point] फलन क असंख्यात्मक बिंदु छोड़ा जात अहै।
+        [slope] फलन क असंख्यात्मक प्रवणता छोड़ी जात अहै।
+       *[other] फलन क असंख्यात्मक { $type } छोड़ा जात अहै।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन क खाली उच्चिष्ठ छोड़ा जात अहै।
+        [minimum] फलन क खाली निम्निष्ठ छोड़ा जात अहै।
+        [extremum] फलन क खाली चरम मान छोड़ा जात अहै।
+        [point] फलन क खाली बिंदु छोड़ा जात अहै।
+       *[other] फलन क खाली { $type } छोड़ा जात अहै।
+    }
+
+function-points-too-close = फलन मा दुइ बिंदु बहुत पास-पास अहैं। फलन परिभाषित नाहीं कीन जाइ सकत।
+
+function-iterates-input-output-mismatch = फलन क पुनरावर्तन तबहीं संभव अहै जब इनपुट क संख्या आउटपुट क संख्या क बराबर होय। एह फलन मा { $inputs } इनपुट अउर { $outputs } आउटपुट अहैं।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम क लंबाई अमान्य अहै। ई ऋणेतर पूर्णांक होय के चाही।
+
+sequence-invalid-step = अनुक्रम क चरण अमान्य अहै। { $type } प्रकार क अनुक्रम खातिर ई संख्या होय के चाही।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम क "{ $attribute }" अमान्य अहै। ई संख्या होय के चाही।
+
+sequence-invalid-endpoint-letters = अच्छर अनुक्रम क "{ $attribute }" अमान्य अहै। ई अच्छरन क संयोजन होय के चाही।
+
+sequence-invalid-endpoint = अनुक्रम क "{ $attribute }" अमान्य अहै।
+
+select-from-sequence-coprime-not-numbers = संख्या नाहीं चुनी जात, एह से coprime छोड़ा गा
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations दीन गा अहै, एह से coprime छोड़ा गा
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` खातिर target अमान्य अहै: लक्ष्य नाहीं मिला।
+
+target-state-variable-not-found = `<{ $source }>` खातिर target अमान्य अहै: `<{ $component }>` पर "{ $property }" नाम क अवस्था चर नाहीं मिला।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` क चर स्वतंत्र चर से अलग होय के चाही।
+
+ode-system-duplicate-variable-names = दोहरावल गयल आश्रित चर नामन क संग ODE क दाहिन पच्छ क फलन परिभाषित नाहीं कीन जाइ सकत।
+
+ode-system-rhs-function-error = ODE क दाहिन पच्छ क फलन परिभाषित नाहीं कीन जाइ सकत। mathjs फलन बनावत समय त्रुटि भई।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखन क बीच क कोण परिभाषित नाहीं कीन जाइ सकत
+
+angle-invalid-through-point = `<angle>` क through मा अमान्य बिंदु अहै
+
+parabola-vertex-too-many-points = दीन गा सीर्ष क संग 1 से जादा बिंदु से होइके जाय वाला परवलय अबहीं उपलब्ध नाहीं अहै।
+
+parabola-too-many-points = 3 से जादा बिंदुन से होइके जाय वाला परवलय अबहीं उपलब्ध नाहीं अहै।
+
+intersection-too-many-items = दुइ से जादा वस्तुन क प्रतिच्छेदन अबहीं उपलब्ध नाहीं अहै
+
+## Other math components
+
+ionic-compound-not-two-ions = दुइ आयनन क अलावा कउनो अउर हालत खातिर आयनिक यौगिक अबहीं उपलब्ध नाहीं अहै।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक खाली एक धनायन अउर एक ऋणायन खातिर उपलब्ध अहै।
+
+solve-equations-cannot-evaluate = समीकरण क मान नाहीं निकाला जाइ सका, एह से ऊ हल नाहीं कीन जाइ सकत: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालत समय operandNumber देब जरूरी अहै।
+
+eigen-decomposition-failed = आव्यूह क अभिलच्छनिक मान नाहीं निकाले जाइ सके
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न मा नाहीं आवत, एह से ऊ सदा खाली से मेल खाई।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" समझा नाहीं जाइ सका। ई none, medium, dense, या खाली जगह से अलगावल दुइ धनात्मक संख्या होय के चाही, जइसे grid="1 0.5"। कउनो ग्रिड नाहीं खींचा जाई।
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` का अइसा फलन चाही जेह मा { $expected ->
+        [1] एक आउटपुट होय, हर बिंदु पर प्रवणता y', जइसे `y - x`
+       *[other] दुइ आउटपुट होंय, हर बिंदु पर सदिश, जइसे `(y, -x)`
+    }, बाकी जौन फलन दीन गा ओह मा { $found } आउटपुट अहैं। { $alternative ->
+        [none] कुछ नाहीं खींचा जाई।
+       *[other] ओह फलन खातिर `<{ $alternative }>` घटक अहै। कुछ नाहीं खींचा जाई।
+    }
+
+field-function-attribute-ignored-with-child = `function` विशेषता पर ध्यान नाहीं दीन जात, काहे से कि फलन घटक क भीतर भी दीन गा अहै; भीतर वाला लीन जात अहै। फलन दुनौ मा से खाली एक्के तरह से दौ।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषता ओह व्यंजक क चरन क नाम देत अहै जौन सीधे घटक क भीतर लिखा गा अहै। { $reason ->
+        [function-child] इहाँ फलन `<function>` संतान क रूप मा दीन गा अहै, जौन आपन चर खुद बतावत अहै, एह से `variables` छोड़ा जात अहै।
+       *[no-expression] इहाँ अइसा कउनो व्यंजक नाहीं दीन गा, एह से `variables` छोड़ा जात अहै।
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर मा xLabelPosition="left" समर्थित नाहीं अहै; दाहिन ओर वाला बरताव लीन जात अहै।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर मा yLabelPosition="bottom" समर्थित नाहीं अहै; ऊपर वाला बरताव लीन जात अहै।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण खातिर अच्छ सीमा अमान्य अहै; पूर्वनिर्धारित bbox (-10,-10,10,10) लीन जात अहै।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण खातिर चौड़ाई अमान्य अहै; पूर्वनिर्धारित आरेख चौड़ाई 425 लीन जात अहै।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण खातिर aspectRatio अमान्य अहै; पूर्वनिर्धारित अनुपात 1 लीन जात अहै।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अच्छ सीमा क हिसाब से ग्रिड क अंतराल बहुत महीन अहै; prefigure रेंडरर मा ग्रिड छोड़ा जात अहै।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर क उपयोग न होय पर टीका नाहीं खींची जाई।
+
+multiple-annotations-children = `<graph>` मा एक से जादा `<annotations>` संतान मिलीं; अंतिम का छोड़िके सब पर ध्यान नाहीं दीन जाई।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार का बढ़ावा या नकल नाहीं कीन जाइ सकत: { $type }।
+
+copy-prop-not-found = { $component } प्रकार क घटक पर { $property } गुण नाहीं मिला
+
+collect-no-source = collect खातिर कउनो स्रोत नाहीं मिला।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार क घटक बटोरे नाहीं जाइ सकत, काहे से कि ई मान्य घटक प्रकार नाहीं अहै।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` क संदर्भ नाहीं दीन जाइ सकत
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } नाहीं बुलावा जाइ सकत
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़न क आकार अमान्य अहै। पंक्तिन क लंबाई असंगत अहै। componentIdx :{ $componentIdx } मा मिला
+
+data-frame-duplicate-column-names = आँकड़न मा स्तंभ नाम दोहरावल गयल अहैं। componentIdx :{ $componentIdx } मा मिला
+
+data-frame-missing-column-name = आँकड़न मा एक स्तंभ नाम नाहीं अहै। componentIdx :{ $componentIdx } मा मिला
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = एह जवाब क एक award खुद answer टैग क पठावल जवाब पर टिका अहै, जेह से अनचाहा बरताव होई।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र क भीतर क `<answer>` पर `maxNumAttempts` राखै क कउनो असर नाहीं होत, काहे से कि मौकन क संख्या पात्र तय करत अहै। `maxNumAttempts` पात्र पर राखौ।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले कउनो अउर पात्र क भीतर बैठे `sectionWideCheckWork` पात्र पर `maxNumAttempts` राखै क कउनो असर नाहीं होत, काहे से कि मौकन क संख्या बाहरी पात्र तय करत अहै। `maxNumAttempts` बाहरी पात्र पर राखौ।
+
+answer-attributes-need-symbolic-equality = symbolicEquality राखे बिना { $attributes } विशेषता क कउनो असर नाहीं होई।
+
+answer-invalid-type = answer खातिर प्रकार अमान्य अहै: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = काहे से कि घटक `<{ $component }>` क नाम नाहीं अहै, एका मॉड्यूल क विशेषता क रूप मा नाहीं लीन जाइ सकत
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` का मॉड्यूल क विशेषता क रूप मा नाहीं लीन जाइ सकत, काहे से कि घटक प्रकार `<module>` मा "{ $name }" विशेषता पहिले से परिभाषित अहै।
+
+conditional-content-condition-ignored = case या else संतानन वाले `<conditionalContent>` घटक पर `condition` विशेषता पर ध्यान नाहीं दीन जात।
+
+slider-markers-type-mismatch = चिह्नकन क प्रकार स्लाइडर क प्रकार से मेल नाहीं खात।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: हर `<problem>` मा एक `<statement>` अउर एक `<answer>` होय के चाही।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" मा पहिला `<problem>` भरमावै वाला विकल्प नाहीं होइ सकत।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` खातिर मान { $values } अमान्य अहै; छोड़ा जात अहै।
+
+attribute-must-be-references = विशेषता `{ $attribute }` खातिर मान `{ $value }` अमान्य अहै। विशेषता `$` से सुरू होय वाले संदर्भन से बनी होय के चाही।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } मा अमान्य फलन नाम छोड़े गए: { $names }। हर नाम क दिखै वाले भाग मा कम से कम 2 वर्ण (अच्छर या योजक चिह्न) होय के चाही; ओकर बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आइ सकत अहै।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य अहै: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहरावी नाहीं जाइ सकत।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार क घटक खातिर विशेषता "{ $attribute }" अमान्य अहै।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } मा { $context ->
+        [text-on-background] पृष्ठभूमि क रंग क आगे पाठ क रंग
+        [high-contrast] कैनवास क आगे उच्च वैषम्य क रंग
+        [line] कैनवास क आगे रेखा क रंग
+        [marker] कैनवास क आगे चिह्नक क रंग
+       *[text-on-canvas] कैनवास क आगे पाठ क रंग
+    } खातिर वैषम्य अपर्याप्त अहै{ $mode ->
+        [dark] { " (गहिर विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+
+style-definition-dark-mode-text-background-contrast =
+    जदपि शैली परिभाषा { $styleNumber } हल्की विधा खातिर पर्याप्त वैषम्य वाले रंग देत अहै, एह मानन से निकले गहिर विधा क रंगन मा पाठ क रंग अउर पृष्ठभूमि क रंग क बीच वैषम्य अपर्याप्त अहै ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)। { $suggestion ->
+        [available] गहिर विधा मा पर्याप्त वैषम्य पावै खातिर या त हल्की विधा क वैषम्य बढ़ावौ (जइसे { $lightAttribute }="{ $lightColor }" राखौ) या गहिर विधा क रंग बदलि दौ (जइसे { $darkAttribute }="{ $darkColor }" राखौ)।
+       *[none] गहिर विधा मा पर्याप्त वैषम्य पावै खातिर हल्की विधा क वैषम्य बढ़ावौ या निकले रंगन का textColorDarkMode अउर/या backgroundColorDarkMode से बदलि दौ।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    जदपि शैली परिभाषा { $styleNumber } हल्की विधा खातिर पर्याप्त वैषम्य वाला पाठ रंग देत अहै, एह मान से निकला गहिर विधा क पाठ रंग कैनवास क आगे अपर्याप्त वैषम्य रखत अहै ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)। { $suggestion ->
+        [available] गहिर विधा मा पर्याप्त वैषम्य पावै खातिर या त हल्की विधा क वैषम्य बढ़ावौ (जइसे textColor="{ $lightColor }" राखौ) या गहिर विधा क रंग बदलि दौ (जइसे textColorDarkMode="{ $darkColor }" राखौ)।
+       *[none] गहिर विधा मा पर्याप्त वैषम्य पावै खातिर हल्की विधा क वैषम्य बढ़ावौ या निकले रंग का textColorDarkMode से बदलि दौ।
+    }
+
+section-multiple-style-palettes = एक खंड खाली एक <stylePalette> चुनि सकत अहै; अंतिम लीन जात अहै।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि numToSelect ऋणेतर पूर्णांक नाहीं अहै।
+
+variant-num-to-select-not-constant-number = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि numToSelect अचर संख्या नाहीं अहै।
+
+variant-with-replacement-not-constant-boolean = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि withReplacement अचर बूलीय मान नाहीं अहै।
+
+variant-select-weight-disables-unique = जदि कउनो विकल्प selectWeight या selectForVariants देत अहै त select क अनोख संस्करण बंद होइ जात अहैं
+
+variant-coprime-undetermined = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि ई तय नाहीं होइ सका कि coprime सदा असत्य अहै।
+
+variant-attribute-not-constant = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि { $attribute } अचर नाहीं अहै।
+
+variant-attribute-not-number = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि { $attribute } संख्या नाहीं अहै।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार क { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि { $attribute } { $expected ->
+        [letters-combination] अच्छरन क संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } नाहीं अहै।
+
+variant-length-not-integer = { $component } क अनोख संस्करण तय नाहीं कीन जाइ सकत, काहे से कि length पूर्णांक नाहीं अहै।
+
+variant-sort-not-implemented = sort वाले { $component } क अनोख संस्करण अबहीं उपलब्ध नाहीं अहैं
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } क अनोख संस्करण अबहीं उपलब्ध नाहीं अहैं
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार क { $component } क अनोख संस्करण अबहीं उपलब्ध नाहीं अहैं
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } क अनोख संस्करण अबहीं उपलब्ध नाहीं अहैं
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख क prefigure रेंडरर मा समर्थित नाहीं; वंसज छोड़ा गा।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित या अधूरी अहै; वंसज छोड़ा गा।
+
+prefigure-curve-label-omitted = { $subject }: बदले गयल वक्र तत्वन पर लेबल समर्थित नाहीं; लेबल छोड़ा गा।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित नाहीं; वंसज छोड़ा गा।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित नाहीं; वंसज छोड़ा गा।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves खाली सूत्र प्रकार क संतान फलनन का मानत अहै; वंसज छोड़ा गा।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल क लेबल
+       *[point] बिंदु क लेबल
+    } खातिर labelPosition '{ $labelPosition }' समर्थित नाहीं; PreFigure क पूर्वनिर्धारित संरेखण लीन जात अहै।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure मा समर्थित नाहीं; ठोस भराव लीन जात अहै।
+
+prefigure-line-style-unknown = { $subject }: अनजान रेखा शैली '{ $lineStyle }' PreFigure क आउटपुट से छोड़ी गई।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure क 'diamond' शैली पर मानचित्रित कीन गई।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure मा समर्थित नाहीं; पूर्वनिर्धारित शैली लीन जात अहै।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य तय नाहीं होइ सका। टीका छोड़ी गई।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` से कई लक्ष्य निकले; पहिला लक्ष्य लीन जात अहै।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य ओका समेटे आलेख क बाहर अहै। टीका छोड़ी गई।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण मा लक्ष्य समर्थित आलेखीय वस्तु नाहीं अहै। टीका छोड़ी गई।
+
+annotation-text-missing = `<annotation>`: `text` नाहीं अहै या खाली अहै; खाली पाठ दीन जात अहै।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता क पता चला।
+       *[other] `<{ $componentType }>` घटक से जुड़ी चक्रीय निर्भरता क पता चला।
+    }
+
+reference-no-referent = एह संदर्भ क कउनो लक्ष्य नाहीं मिला: `{ $reference }`
+
+reference-multiple-referents = एह संदर्भ क कई लक्ष्य मिले: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` क विशेषता { $attribute } क प्रारूप अमान्य अहै।
+
+children-invalid = `<{ $componentType }>` क संतान अमान्य अहैं: अमान्य संतान मिलीं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` खातिर मान `{ $value }` अमान्य अहै; मान `{ $default }` लीन जात अहै
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } नाहीं मिला।
+       *[other] DoenetML संस्करण { $version } नाहीं मिला। संस्करण { $fallback } पर लौटा जात अहै
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` क समापन टैग नाहीं अहै। खुद बंद होय वाला टैग या `</{ $tagName }>` टैग चाही रहा।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` मा त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` क मान नाहीं लागत अहै।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य अहै
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता क मान `{ $value }` अमान्य अहै
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता क मान `{ $value }` अमान्य अहै। उद्धरण चिह्न मेल नाहीं खात। एक `{ $quote }` छूटा लागत अहै
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम क टैग मिला, जइसे `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नाहीं भा (एक `>` छूटा लागत अहै)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम क टैग मिला `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नाहीं भा (`/>` छूटा लागत अहै)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य नाहीं अहै। एकर विशेषता गलत होइ सकत अहैं।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम क समापन टैग मिला, जइसे `</`
+
+parse-attribute-value-unquoted = विशेषता क मान उद्धरण चिह्नन मा होय के चाही: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिला, बाकी ओहसे मेल खात आरंभ टैग नाहीं अहै
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल नाहीं खात। `</{ $expected }>` चाही रहा। `{ $found }` मिला
+
+parser-node-unconvertible = नोड { $node } का Dast नोड मा नाहीं बदला जाइ सका।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य अहै। { $reason ->
+        [characters] नामन मा खाली अच्छर, अंक, अधोरेखा या योजक चिह्न होइ सकत अहैं।
+       *[start] नाम अच्छर से सुरू होय के चाही।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य अहै। नाम अच्छर से सुरू होय के चाही।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार क answer मा video विशेषता होय के चाही
+
+answer-video-watched-video-not-reference = videoWatched प्रकार क answer क video विशेषता एक संदर्भ होय के चाही
+
+answer-name-not-single-text = answer क name विशेषता मा खाली एक पाठ संतान होय के चाही
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन क बहुत जादा स्तरन क कारन बाहरी DoenetML नाहीं मिल सका। कहूँ चक्रीय संदर्भ त नाहीं?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" से DoenetML नाहीं मिल सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" से मिला DoenetML अमान्य अहै: ई घटक प्रकार "{ $componentType }" से मेल नाहीं खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित अहै; एकर बदले `{ $to }` क उपयोग करौ।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित अहै; एकर बदले `{ $to }` क उपयोग करौ।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित अहै अउर छोड़ी गई, काहे से कि `{ $to }` भी दीन गा अहै।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित अहै अउर छोड़ी गई, काहे से कि `{ $to }` भी दीन गा अहै।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित अहै अउर छोड़ी गई।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित अहै; एकर बदले `<{ $child }>` संतान लिखौ।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` क मान `{ $value }` अप्रचलित अहै; एकर बदले `{ $to }` क उपयोग करौ।
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` खाली अंग्रेजी क बहुवचन बनाइ सकत अहै, एह से { $locale } मा लिखे दस्तावेज मा ओकर पाठ जस क तस रहत अहै। बहुवचन रूप सीधे लिखौ, या `pluralForm` विशेषता से दौ।
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कउनो परिचित Doenet तत्व नाहीं अहै।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज क मूल मा मान्य नाहीं अहै।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` क भीतर मान्य नाहीं अहै।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` मा `{ $attribute }` नाम क कउनो विशेषता नाहीं अहै।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` क विशेषता `{ $attribute }` अइसी सूची होय के चाही जेकर हर मद इनमा से एक होय: { $allowed }
+       *[other] तत्व `<{ $tag }>` क विशेषता `{ $attribute }` इनमा से एक होय के चाही: { $allowed }
+    }
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select खातिर संस्करण नाम अमान्य अहै। संस्करण नाम { $variantName } { $numOptions } विकल्पन मा आवत अहै, बाकी चुनै क संख्या { $numToSelect } अहै।
+
+select-variant-name-without-options = select खातिर संस्करण दीन गयल अहैं, बाकी संभव संस्करण नाम खातिर कउनो विकल्प नाहीं अहै: { $variantName }।
+
+select-variant-name-not-possible = select खातिर दीन गा संस्करण नाम { $variantName } संभव संस्करण नाम नाहीं अहै।
+
+select-too-few-options = खाली { $numOptions } घटकन मा से { $numToSelect } नाहीं चुने जाइ सकत।
+
+select-from-sequence-too-few-values = { $length } लंबाई क अनुक्रम से { $numToSelect } मान नाहीं चुने जाइ सकत।
+
+select-from-sequence-indices-count-mismatch = select खातिर दीन गयल अनुक्रमांकन क संख्या चुनै क संख्या से मेल खाय के चाही
+
+select-from-sequence-indices-not-integers = select खातिर दीन गयल सब अनुक्रमांक पूर्णांक होय के चाही
+
+select-from-sequence-index-excluded = selectfromsequence खातिर दीन गा अनुक्रमांक बाहर कीन गा रहा
+
+select-from-sequence-indices-excluded-combination = selectfromsequence खातिर दीन गयल अनुक्रमांक बाहर कीन गा संयोजन रहे
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक नाहीं चुने जात, एह से सहअभाज्य संयोजन नाहीं चुने जाइ सकत।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्या नाहीं चुनी जाइ सकत। सब संभव मानन मा एक उभयनिष्ठ गुणनखंड अहै। (दीन गयल "from" या "to" मान "step" क सहअभाज्य होय के चाही।)
+
+select-from-sequence-coprime-single-number = 1 से अलग कउनो एक्के संख्या से सहअभाज्य संयोजन नाहीं चुने जाइ सकत।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence मा 70% से जादा संयोजन बाहर कीन गयल
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्या नाहीं चुनी जाइ सकी। सब संभव मानन मा एक उभयनिष्ठ गुणनखंड अहै।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई क अनुक्रम से { $numToSelect } अलग मान नाहीं चुने जाइ सकत
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई क अभाज्य सूची से { $numToSelect } मान नाहीं चुने जाइ सकत
+
+select-prime-numbers-values-count-mismatch = select खातिर दीन गयल मानन क संख्या चुनै क संख्या से मेल खाय के चाही
+
+select-prime-numbers-values-not-prime = select prime number खातिर दीन गयल सब मान अभाज्य सूची मा होय के चाही
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers खातिर दीन गयल मान बाहर कीन गा संयोजन रहे
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers मा 70% से जादा संयोजन बाहर कीन गयल
+
+select-random-combination-fluke = बहुतै अनहोनी संजोग से यादृच्छिक मानन क संयोजन नाहीं चुना जाइ सका
+
+select-random-value-fluke = बहुतै अनहोनी संजोग से यादृच्छिक मान नाहीं चुना जाइ सका
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] ई `<{ $component }>` नाहीं देखावा जात, काहे से कि ई गणित क भीतर अहै अउर `inline` नाहीं अहै। `inline` जोड़ौ, जेह से ई ड्रॉप-डाउन सूची बनि जाय, जौन व्यंजक क भीतर समाइ जात अहै।
+        [expanded] ई `<{ $component }>` नाहीं देखावा जात, काहे से कि ई गणित क भीतर अहै अउर `expanded` अहै। `expanded` हटावौ; कई पंक्ति वाला डिब्बा व्यंजक क भीतर नाहीं समात।
+        [on-graph] ई `<{ $component }>` नाहीं देखावा जात, काहे से कि ई आलेख पर खींचे गयल गणित क भीतर अहै, जहाँ इनपुट खातिर जगह नाहीं अहै।
+       *[relative-width] ई `<{ $component }>` नाहीं देखावा जात, काहे से कि ई गणित क भीतर अहै अउर एकर चौड़ाई सापेक्ष अहै। चौड़ाई निरपेक्ष इकाई मा दौ, जइसे `px`।
+    }

--- a/packages/i18n/locales/awa/editor.ftl
+++ b/packages/i18n/locales/awa/editor.ftl
@@ -6,8 +6,9 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # **Script, frame and register** are `chrome.ftl`'s: Devanagari with Latin
-# digits; an Awadhi frame — «अहै», «नाहीं», «क», «अउर», «खातिर», «काहे से
-# कि», «जइसे», «एह», «कउनो», «फेर» — around a Hindi and Sanskrit technical
+# digits; the catalog-wide Awadhi frame — «अहै», «नाहीं», «क», «अउर»,
+# «खातिर», «काहे से कि», «जइसे», «एह», «कउनो», «फेर», not every one of which
+# happens to fall in this file — around a Hindi and Sanskrit technical
 # vocabulary that is declared rather than disguised. Buttons carry the
 # honorific imperative in **-औ** («देखावौ», «दबावौ», «राखौ», «चुनौ»), the one
 # choice in this catalog the seed is least sure of.
@@ -16,8 +17,10 @@
 # name stay in English.** They are identifiers an author types, not words.
 #
 # **The counts do not fork.** `editor-accessibility-label` and
-# `help-coordinates` write a single `*[other]` where English writes `[one]`
-# and `[other]`: CLDR has no plural data for `awa`, so an English-selected
+# `help-coordinates` drop the `$count` selector English writes and give one
+# form outright — `help-coordinates` is a plain message, and
+# `editor-accessibility-label` interpolates `{ $count }` without selecting
+# on it: CLDR has no plural data for `awa`, so an English-selected
 # branch would be worse than none, and an Awadhi noun is unmarked after a
 # numeral in any case.
 #

--- a/packages/i18n/locales/awa/editor.ftl
+++ b/packages/i18n/locales/awa/editor.ftl
@@ -1,0 +1,215 @@
+# Awadhi (अवधी) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script, frame and register** are `chrome.ftl`'s: Devanagari with Latin
+# digits; an Awadhi frame — «अहै», «नाहीं», «क», «अउर», «खातिर», «काहे से
+# कि», «जइसे», «एह», «कउनो», «फेर» — around a Hindi and Sanskrit technical
+# vocabulary that is declared rather than disguised. Buttons carry the
+# honorific imperative in **-औ** («देखावौ», «दबावौ», «राखौ», «चुनौ»), the one
+# choice in this catalog the seed is least sure of.
+#
+# **`WCAG`, `DoenetML`, `XML`, `styleNumber` and every element and attribute
+# name stay in English.** They are identifiers an author types, not words.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `awa`, so an English-selected
+# branch would be worse than none, and an Awadhi noun is unmarked after a
+# numeral in any case.
+#
+# **`help-name-summary` is punctuation.** It renders with `{ $name }` empty
+# for a suggestion the panel has already named, so the em dash and its spaces
+# have to read on their own.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करौ
+       *[update] अद्यतन करौ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्सक { $word }
+       *[other] दर्सक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = रूपांतर
+editor-variant-filter = छानौ...
+editor-variant-next = अगला रूपांतर चुनौ
+editor-variant-previous = पहिले वाला रूपांतर चुनौ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन मिला। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करै
+           *[open] खोलै
+        } खातिर क्लिक करौ।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करै
+           *[open] खोलै
+        } खातिर क्लिक करौ। कउनो WCAG AA उल्लंघन नाहीं मिला, बाकी सुगम्यता क अउर सुझाव अहैं।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करै
+           *[open] खोलै
+        } खातिर क्लिक करौ। कउनो सुगम्यता क समस्या नाहीं मिली।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन मिला। { $count } WCAG AA उल्लंघन मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करै
+           *[open] खोलै
+        } खातिर क्लिक करौ।
+        [advisories] कउनो WCAG AA उल्लंघन नाहीं मिला। सुगम्यता क { $count } अउर सुझाव मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करै
+           *[open] खोलै
+        } खातिर क्लिक करौ।
+       *[clean] कउनो WCAG AA उल्लंघन नाहीं मिला। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करै
+           *[open] खोलै
+        } खातिर क्लिक करौ।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग क हिसाब से मदद
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटि
+editor-tab-warnings = चेतावनी
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = पठावल गयल जवाब
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक क विकल्प
+editor-format-as-doenetml = DoenetML क रूप मा सजावौ
+editor-format-as-xml = XML क रूप मा सजावौ
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कउनो त्रुटि नाहीं
+editor-no-warnings = कउनो चेतावनी नाहीं
+editor-no-info = कउनो सूचनात्मक निदान नाहीं
+
+editor-show-info-annotations = संपादक मा सूचनात्मक निदान देखावौ
+editor-show-accessibility-annotations = संपादक मा सुगम्यता क निदान देखावौ
+
+editor-accessibility-learn-more = जानौ कि Doenet सुगम्यता का कइसे देखत अहै
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = सुगम्यता क अउर समस्या
+editor-none-found = कुछ नाहीं मिला
+
+
+## Submitted responses
+
+editor-no-responses = अबहीं तक कउनो जवाब नाहीं पठावल गा
+editor-response-answer-id = जवाब क आईडी
+editor-response-response = जवाब
+editor-response-credit = अंक
+editor-response-submitted = पठावल गा
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेजीकरण देखै खातिर कर्सर का कउनो टैग नाम, विशेषता या { $ref } पर राखौ।
+
+help-unsupported-ref-chain = { $example } जइसे बहु-भागी संदर्भ क मदद अबहीं नाहीं अहै।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] एह संदर्भ क कउनो लक्ष्य नाहीं मिला: { $ref }।
+        [multiple] एह संदर्भ क कई लक्ष्य मिले: { $ref }।
+       *[indeterminate] { $ref } क लक्ष्य तय नाहीं कीन जाइ सका।
+    }
+
+help-learn-about-references = संदर्भ क बारे मा जानौ →
+help-reference-page = संदर्भ क पन्ना →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } क भीतर
+       *[top] सबसे ऊपर क स्तर पर
+    }{ $allowed ->
+        [none] { " — इहाँ कुछ नाहीं राखा जाइ सकत।" }
+        [text] { " — इहाँ पाठ लिखा जाइ सकत अहै।" }
+        [text-and-components] { " — इहाँ पाठ लिखौ, या ई आजमावौ:" }
+       *[components] { " — ई आजमावौ:" }
+    }
+
+help-suggestions-footer = सब { $total } घटक देखै खातिर { $shortcut } दबावौ।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } क संदर्भ अहै।
+       *[other] { $ref }, { $target } क संदर्भ अहै (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } { $role } क रूप मा एका लावा।
+       *[other] { $owner } पंक्ति { $line } मा { $role } क रूप मा एका लावा।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } क { $property } गुण क संदर्भ अहै।
+       *[other] { $ref }, { $element } क { $property } गुण क संदर्भ अहै (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड क टुकड़ा
+help-kind-array-entry = सरणी क प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = चालू पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] मान्य मान (हर मद खातिर एक):
+       *[other] मान्य मान:
+    }
+
+help-suggested-values = सुझावल मान:
+
+help-inserts = जोड़त अहै:
+
+help-coordinates = निर्देशांक:
+
+help-type = प्रकार:
+
+help-resolved-style = तय शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = तय फलन नाम:
+help-reset-list = एह इनपुट क रीसेट सूची:
+help-added-on-input = एह इनपुट पर जोड़ा गा:
+help-removed-on-input = एह इनपुट पर हटावा गा:
+
+help-reset-overrides = { $reset }, { $additional } अउर { $removed } पर भारी परत अहै।

--- a/packages/i18n/locales/brh/chrome.ftl
+++ b/packages/i18n/locales/brh/chrome.ftl
@@ -1,0 +1,167 @@
+# Brahui (براہوئی) viewer chrome: the buttons, panel headings and status words
+# the reader interacts with. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Brahui is Dravidian**, and it is the only Dravidian language on this
+# roster written right to left. Its nearest neighbours on the map — Balochi,
+# Sindhi, Saraiki, Pashto — are Iranian or Indo-Aryan, and it agrees with none
+# of them about how a word is built: what those languages do with a
+# postposition Brahui does with a case clitic, and what they do with gender it
+# does not do at all. A reader who arrives here from `locales/bal` should
+# expect the vocabulary to look familiar and the grammar not to.
+#
+# **Script and direction: Perso-Arabic, right to left**, on the Urdu letter
+# inventory as Brahui is printed in Quetta — `ٹ ڈ ڑ` for the retroflexes, `ے`
+# for final *ē*, `ہ` rather than `ه`. `directionOf` learns `brh` from
+# `src/direction.ts`'s fallback list, since ICU does not maximize the tag to a
+# script on its own. Nothing about the file format changes for a right-to-left
+# catalog: the text is written in **logical order** — the order it is spoken —
+# and **no bidi control characters are placed by hand**. Fluent's own isolation
+# puts the marks around an interpolated value, and `dir` decides where each run
+# is drawn. Brackets are written opening-first and the bidi algorithm turns
+# them around at render time.
+#
+# **The case clitics are written as separate words here, and that is a
+# decision.** Brahui marks case with `‑نا` (genitive), `‑ٹی` (locative), `‑آن`
+# (ablative), `‑کے` (dative) and `تون` (comitative), and Brahui print usually
+# joins the first four to the word in front of them. This catalog writes all
+# five separated, because the word in front is very often a **placeable** — a
+# column name, an answer id, a component tag — and an affix cannot be welded to
+# a value the catalog never sees without making a claim about what that value
+# ends in. Brahui's clitics happen to have one shape each, so welding them
+# would have come out right; writing them apart is the safer spelling and it
+# costs the file nothing. A corrector who prefers the joined spelling should
+# join them everywhere except after a placeable.
+#
+# **Digits are Latin**, here as everywhere else in the repository, which is
+# what keeps a Brahui sentence and the mathematics beside it counting in the
+# same characters. The separator is not pinned; only the ten characters are.
+#
+# **No plural categories.** CLDR has no plural data for `brh`, so nothing here
+# selects on one and `lint:i18n` would reject a branch that did. Nothing is
+# lost: a Brahui noun after a numeral stays unmarked. `[0]` is kept where
+# English has it — Fluent matches a numeric literal against the number itself
+# before it consults any plural rule, so that branch is reachable whatever the
+# locale.
+#
+# **Register: the verbal noun in `‑نگ`.** A control is named with «کننگ»
+# (*doing*), «دیرنگ» (*showing*) and their kind rather than with an imperative.
+# That is a deliberately conservative choice: Brahui's imperative paradigm is
+# not something this seed can get right unaided, and a verbal noun on a button
+# is idiomatic in the language and unambiguous in a UI. A speaker who wants
+# imperatives should write them.
+#
+# **Loans kept rather than coined, and this is the file's weakest property.**
+# Brahui is not a medium of instruction anywhere: schooling in its area is in
+# Urdu and English, and roughly half the everyday lexicon is Balochi or Persian
+# already. So the technical vocabulary below — `کی بورڈ`, `میٹرکس`, `کالم`,
+# `شماریاتی`, `فیصد`, `آربیٹل`, `WCAG` — is the Urdu and Balochi vocabulary a
+# Brahui-speaking pupil actually meets, and the sentences around it are built
+# on Brahui's own case clitics and word order. The grammar is Brahui; a good
+# deal of the vocabulary is not, and this file says so rather than inventing
+# words.
+
+
+## Answer submission
+
+answer-checking = چک کننگ ٹی اے...
+answer-submitting = دیہنگ ٹی اے...
+answer-checking-status = جواب نا چک کننگ
+answer-submitting-status = جواب نا دیہنگ
+answer-correct = راست
+answer-incorrect = غلط
+answer-response-saved = جواب محفوظ اے
+answer-percent-credit = { $percent }% نمبر
+answer-percent-correct = { $percent }% راست
+answer-percent-short = { $percent } %
+max-credit-available = مزنترین نمبر: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] ہچ کوشش باقی اف
+       *[other] { $count } کوشش باقی اے
+    }
+validation-correct = (راست)
+validation-incorrect = (غلط)
+validation-partially-correct = (بہرے راست)
+# «نا» is the genitive clitic and stands as its own word, so nothing is welded
+# to the placeable.
+answer-show-responses = { $answerId } نا { $count } جواب دیرنگ
+
+## Disclosure panels
+
+feedback-heading = رائے
+collapsible-click-to-open = (پچ کننگ کے کلک کننگ)
+collapsible-click-to-close = (بند کننگ کے کلک کننگ)
+collapsible-initializing = تیار مانگ ٹی اے...
+footnote-show = حاشیہ نا دیرنگ
+footnote-hide = حاشیہ نا لکانگ
+description-more-information = گیشتر معلومات
+
+## Controls
+
+slider-previous = پیشی
+slider-next = رندی
+keyboard-open = کی بورڈ نا پچ کننگ
+keyboard-close = کی بورڈ نا بند کننگ
+choice-input-remove-choice = { $choice } نا در کننگ
+matrix-remove-row = رج نا در کننگ
+matrix-add-row = رج نا ھور کننگ
+matrix-remove-column = کالم نا در کننگ
+matrix-add-column = کالم نا ھور کننگ
+subset-add-remove-points = نقطہ نا ھور کننگ/در کننگ
+subset-toggle-points-intervals = نقطہ او وقفہ نا نیام ٹی گردیننگ
+subset-move-points = نقطہ نا لڑیننگ
+subset-clear = پاک کننگ
+orbital-add-row = رج نا ھور کننگ
+orbital-remove-row = رج نا در کننگ
+orbital-add-box = خانہ نا ھور کننگ
+orbital-remove-box = خانہ نا در کننگ
+orbital-add-up-arrow = برزی تیر نا ھور کننگ
+orbital-add-down-arrow = چیری تیر نا ھور کننگ
+orbital-remove-arrow = تیر نا در کننگ
+orbital-row-label = رج { $row } نا نام
+pretzel-answer = جواب
+# «کالم» names what `$column` is, so the genitive clitic falls behind a word
+# this catalog writes rather than behind the value.
+summary-statistics-caption = کالم { $column } نا شماریاتی خلاصہ
+
+## Math input
+
+math-input-preview-region = ریاضی نا عبارت نا پیش دیرنگ
+math-input-preview = پیش دیرنگ
+math-input-invalid-expression = غلط عبارت:
+
+## Document status
+
+viewer-initializing = تیار مانگ ٹی اے...
+
+## Errors
+
+error-heading = خطا
+error-found-at =
+    { $span ->
+        [line] سطر { $startLine } ٹی خفتا۔
+       *[lines] سطر { $startLine }–{ $endLine } ٹی خفتا۔
+    }
+document-contains-errors = دا دستاویز ٹی خطا اے!
+diagnostic-heading-error = خطا
+diagnostic-heading-warning = ہشدار
+diagnostic-heading-information = معلومات
+diagnostic-heading-hint = اشارہ
+# `WCAG AA` is the standard's own name and is not translated.
+accessibility-heading-level-1 = رسائی نا خلاف ورزی: WCAG AA
+accessibility-heading-level-2 = رسائی نا ہشدار
+something-went-wrong = چیزے غلط مسا۔
+renderer-load-failed = اسٹ رینڈرر بار مانگ ممکن اف۔ مہربانی کننگ او صفحہ نا پدا بار کننگ۔
+core-start-failed = دا دستاویز سرا مانگ ممکن اف۔ مہربانی کننگ او صفحہ نا پدا بار کننگ۔
+core-start-failed-busy = دا دستاویز سرا مانگ ممکن اف۔ گیشتر دستاویز اسٹ وخت ٹی سرا مسا اے، او دا کار سست دستگاہ ٹی گیشتر وخت گرینک۔ دگہ دستاویز نا خلاص مانگ آن رند، صفحہ نا پدا بار کننگ فائدہ کیک۔
+core-start-failed-retry = دا دستاویز سرا مانگ ممکن اف۔
+core-start-failed-busy-retry = دا دستاویز سرا مانگ ممکن اف۔ گیشتر دستاویز اسٹ وخت ٹی سرا مسا اے، او دا کار سست دستگاہ ٹی گیشتر وخت گرینک۔
+core-start-retry = پدا کوشش کننگ
+saved-state-unavailable = نا محفوظ کار بار مانگ ممکن اف۔

--- a/packages/i18n/locales/brh/content.ftl
+++ b/packages/i18n/locales/brh/content.ftl
@@ -1,0 +1,319 @@
+# Brahui (براہوئی) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in, not the reader's interface language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and direction: Perso-Arabic, right to left**, on the Urdu letter
+# inventory as Brahui is printed in Quetta. `chrome.ftl` states the convention
+# in full, including why the case clitics are written as separate words in all
+# four files of this locale. Nothing about the file format changes for a
+# right-to-left catalog: logical order, no hand-placed bidi controls, Latin
+# digits.
+#
+# ## Word order
+#
+# **Every modifier comes before the noun**, in English's own order: «دبیز سرخ
+# خط» is *thick red line*, width first, then the dash pattern, then the colour.
+# Brahui is Dravidian and rigidly head-final, so `style-stroke`,
+# `style-with-noun` and `style-filled-with-noun` all keep English's sequence of
+# placeables rather than reversing it. What does move is everything English
+# puts *in front* of a value: Brahui has no prepositions at all, only case
+# clitics and postpositions, so «تون» (*with*) and «ٹی» (*in, on*) follow the
+# value they govern and the composition messages below put them after the
+# placeable.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } ضلعی باقاعدہ کثیر الاضلاع» and leaves `tail` empty, as English
+# does: a numeral and its classifier-like modifier stand in front of the noun
+# in Brahui, so nothing has to be split around the adjectives. The `-tail`
+# variants of the two composition messages are still written out, because that
+# is what a partly-translated locale falls back to.
+#
+# ## Gender, role and number
+#
+# **No `$gender` fork and no `$role` fork, and neither is a gap.** Brahui has
+# **no grammatical gender** — this is a Dravidian language, and it does not
+# even have the animate/inanimate concord some of its relatives do in the
+# plural — and an attributive modifier in front of a noun is **completely
+# invariable**: it takes no ending for gender, for number or for the case of
+# the phrase it sits in, because the case clitic lands on the last word of the
+# whole noun phrase rather than on each modifier. So `noun-gender` answers the
+# single token `neuter`, no adjective selects on anything, and the four `$role`
+# positions render identically.
+#
+# That is worth saying beside `locales/skr`, which is seeded in the same batch,
+# in the same script, in the same direction, in a district next door — and
+# which *does* inflect its adjectives for gender and records not forking as a
+# gap. Two right-to-left Perso-Arabic catalogs from neighbouring valleys, one
+# with a recorded gap and one with a genuine answer. **Direction is not a
+# language family, and neither is a region.**
+#
+# It also disposes of the affix problem without any work. A Brahui case ending
+# would land on the *noun*, which arrives as `{ $noun }` — but nothing here
+# needs one: every position these phrases go into is one this catalog writes
+# the frame for, and the frames use the free-standing «تون» and «ٹی» rather
+# than a bound ending. Nothing in this file is welded to a placeable.
+#
+# **Nothing selects on a count.** A Brahui noun after a numeral stays unmarked,
+# and CLDR has no plural data for `brh` in any case.
+#
+# ## The chemistry tables are deliberately absent
+#
+# `element-name` and `element-anion-name` are the only English keys this file
+# does not cover. Brahui is not a medium of instruction for science anywhere —
+# chemistry in Balochistan is taught in Urdu and English — so a Brahui-speaking
+# pupil meets the periodic table in one of those two, and there is no settled
+# Brahui list of the hundred and eighteen elements to check a translation
+# against. Recording that is the honest answer; transliterating Urdu into
+# Brahui spelling and calling it a nomenclature is not. `lint:i18n` reports the
+# two keys as missing coverage and that report is correct.
+# `ion-name-oxidation-state` and the two invalid-symbol messages **are**
+# covered: they are frames and punctuation, not vocabulary.
+#
+# ## Where this seed leans on Balochi and Urdu
+#
+# Hard, and the header of `chrome.ftl` says so at length. The colour words and
+# the whole geometry vocabulary below — مثلث، مستطیل، مربع، دائرہ، شعاع،
+# منحنی، معین، کثیر الاضلاع — are Balochi and Urdu loans, which is what a
+# Brahui-speaking pupil reads, and Brahui's own colour terms are the first
+# thing a speaker should restore here. What is genuinely Brahui in this file is
+# its **shape**: the head-final order, the invariable modifier, the case
+# clitics «نا», «ٹی», «آن», «کے» and the comitative «تون», the copula «اے» and
+# its negative «اف», and a handful of everyday words — «اسٹ» for *one*, «ایرا»
+# for *two*, «کار» for a task, «راست» and «دروگ» for the boolean pair.
+
+
+## Style vocabulary
+##
+## Every word here is invariable, and that is a fact about Brahui rather than a
+## choice about which words to write: a Brahui attributive modifier does not
+## inflect for anything.
+
+color =
+    .black = سیاہ
+    .white = سفید
+    .gray = خاکی
+    .red = سرخ
+    .orange = نارنجی
+    .yellow = زرد
+    .green = سبز
+    .cyan = فیروزی
+    .blue = کبود
+    .purple = بنفشی
+    .pink = گلابی
+    .brown = خرمائی
+line-width =
+    .thick = دبیز
+    .thin = باریک
+line-style =
+    .dashed = خط چین
+    .dotted = نقطہ چین
+# Noun phrases rather than modifiers: every place a fill pattern is put, it
+# stands in front of the comitative «تون», so these are written as they are
+# wanted there.
+fill-style =
+    .horizontal = افقی خط
+    .vertical = عمودی خط
+    .diagonal = مائل خط
+    .backdiagonal = برعکس مائل خط
+    .dots = نقطہ
+    .diamonds = معین
+noun =
+    .line = خط
+    .line-segment = قطعہ خط
+    .ray = شعاع
+    .vector = ویکٹر
+    .curve = منحنی
+    .function = فنکشن
+    .slope-field = میلان نا میدان
+    .vector-field = ویکٹر نا میدان
+    .parabola = پیرابولا
+    .polyline = چند خط
+    .polygon = کثیر الاضلاع
+    .triangle = مثلث
+    .rectangle = مستطیل
+    .circle = دائرہ
+    .region = علاقہ
+    .point = نقطہ
+    .square = مربع
+    .diamond = معین
+    .cross = کراس
+    .plus = جمع نا نشان
+# «ضلعی» is invariable, like everything else in front of a Brahui noun, so the
+# side count stands with the other modifiers and there is nothing to split off
+# into a tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } ضلعی باقاعدہ کثیر الاضلاع
+    }
+# Brahui has no grammatical gender. The token is defined anyway rather than
+# left to fall back, so that this catalog says so on purpose.
+noun-gender = neuter
+
+
+## Style composition
+##
+## English's own order of placeables, kept rather than reversed — Brahui is
+## head-final and puts its modifiers in front of the noun as well. What moves
+## is everything English writes in front of a value: Brahui has no
+## prepositions, so «تون» and «ٹی» follow what they govern.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# «پر» — full — against «تہی» below, which is how a filled shape is set against
+# a hollow one here. Invariable, so it takes no branch.
+style-filled-word = پر
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } { $pattern } تون
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } { $pattern } تون
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } تون
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «تون» is the comitative clitic and follows what it governs, so the border and
+# its modifiers come first. Brahui has no article, so the two `-article`
+# branches read as their plain counterparts do; they are kept apart because the
+# distinction belongs to the English message rather than to this one.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } کنارہ تون
+        [and] او { $border } کنارہ تون
+        [and-article] او { $border } کنارہ تون
+       *[with] { $border } کنارہ تون
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = تہی
+style-text =
+    { $parts ->
+        [background] { $background } پشت زمین ٹی { $color }
+       *[plain] { $color }
+    }
+style-background-none = ہچ
+
+
+## Boolean words
+##
+## What a `<boolean>` displays. `true` and `false` as an author writes them in
+## the source stay English; only these two move.
+
+boolean-true = راست
+boolean-false = دروگ
+
+
+## Answer buttons
+
+answer-submit-label = کار نا چک کننگ
+answer-submit-label-no-correctness = جواب نا دیہنگ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = سرگرمی
+    .aside = حاشیہ
+    .cascade = سلسلہ
+    .definition = تعریف
+    .example = مثال
+    .exercise = مشق
+    .exercises = مشق
+    .given-answer = جواب
+    .note = نوٹ
+    .objectives = مقصد
+    .paragraphs = پیراگراف
+    .part = حصہ
+    .problem = مسئلہ
+    .problems = مسئلہ
+    .proof = ثبوت
+    .question = پرس
+    .section = بہر
+    .solution = حل
+    .task = کار
+    .theorem = قضیہ
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ "۔ " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = اشارہ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] جدول { $enumeration }
+        [numbered-title] جدول { $enumeration }{ ": " }
+        [unnumbered-title] جدول{ ": " }
+       *[unnumbered] جدول
+    }
+figure-name =
+    { $parts ->
+        [numbered] شکل { $enumeration }
+        [numbered-caption] شکل { $enumeration }{ ": " }
+        [unnumbered-caption] شکل{ ": " }
+       *[unnumbered] شکل
+    }
+
+
+## Paginator controls
+##
+## «آن» is the ablative clitic — *out of* — and follows what it governs, so the
+## total comes first and the page label and its number follow. That is the
+## reverse of English's order and a fact about Brahui rather than a slip.
+
+paginator-previous = پیشی
+paginator-next = رندی
+paginator-page = صفحہ
+paginator-page-status = { $numPages } آن { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = یا
+piecewise-condition-if = اگر
+piecewise-condition-otherwise = ورنہ
+
+
+## Chemistry
+##
+## The element tables are absent on purpose; see the header. What is here is
+## the frames around a name, which need no nomenclature.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = غلط کیمیائی نشان
+chemistry-invalid-ionic-compound = غلط آئونی ترکیب
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = تہی
+math-embedded-input-blank-ordinal = { $total } آن تہی { $ordinal }

--- a/packages/i18n/locales/brh/diagnostics.ftl
+++ b/packages/i18n/locales/brh/diagnostics.ftl
@@ -1,0 +1,703 @@
+# Brahui (براہوئی) diagnostics: the errors and warnings the core and the
+# language server put in front of whoever is looking at the screen. Translated
+# from `locales/en/diagnostics.ftl`, which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Perso-Arabic on the Urdu letter inventory as Brahui is printed in Quetta,
+# right to left, case clitics written as separate words — the same convention
+# the other three files of this locale state. Digits are Latin.
+#
+# **Element names, attribute names and values are not words.** `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text`, `boolean`,
+# `coprime`, `selectFromSequence` and every `<tag>` written into these
+# sentences are DoenetML identifiers and stay in English exactly as they are.
+# The backticks and angle brackets around them are this catalog's punctuation.
+#
+# **No message here selects on a count.** CLDR has no plural data for `brh`, so
+# a category branch would be one nothing could select and `lint:i18n` would
+# reject; and a Brahui noun after a numeral stays unmarked in any case. Each
+# such message is written once as `*[other]`, with the count kept in the
+# selector so that nothing is lost from the message's shape. The `[1]` in
+# `field-function-wrong-num-outputs` is a numeric literal rather than a
+# category — Fluent matches it against the number itself — so it stays where
+# English has it. The symbolic selectors — `$reason`, `$type`, `$mode`,
+# `$suggestion`, `$isList`, `$context`, `$expected` and the rest — keep every
+# branch English has, because those keys are compared letter for letter and a
+# renamed one is a branch nothing can reach.
+#
+# **A small set of frames, chosen once and used throughout**, so that a
+# correction is one search and so that a speaker can fix the grammar of a
+# hundred sentences by fixing five:
+#
+#   «… نظرانداز اے»    is ignored
+#   «… مقرر اے»        is specified
+#   «… غلط اے»         is invalid
+#   «… موجود اف»       is not there / was not found
+#   «… ممکن اف»        cannot be done
+#   «… لازم اے»        must (behind a verbal noun in ‑نگ)
+#   «چونکہ …»          because
+#
+# The copula «اے» and its negative «اف» are Brahui; most of the words between
+# them are Balochi or Urdu loans — `ریفرنس`, `میٹرکس`, `ٹائپ`, `فنکشن`,
+# `ویکٹر`, `انڈیکس`, `ورینٹ`, `کمپوننٹ`, `ایٹریبیوٹ` — kept rather than coined,
+# because Brahui has no computing register of its own and this file says so
+# rather than inventing one.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] وخت کہ ایرا endpoint مقرر اے، { $attributes } نظرانداز اے
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] وخت کہ اسٹ endpoint او اسٹ midpoint دونی مقرر اے، { $attributes } نظرانداز اے
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpoint نا بغیر midpointOffset نا ہچ اثر اف
+
+## `<line>`
+
+line-points-undetermined-dimensions = خط دا نقطہ آن گڑیک کہ نا ابعاد نامعلوم اے۔
+
+line-points-too-few-dimensions = خط نا دا نقطہ آن گڑنگ لازم اے کہ کمترین ایرا ابعاد دارے۔
+
+line-points-depend-on-variables = خط دا نقطہ آن گڑیک کہ دا متغیر ٹی بستہ اے: { $variables }۔
+
+line-equation-invalid-format = متغیر { $variable1 } او { $variable2 } ٹی خط نا مساوات نا فارمیٹ غلط اے۔
+
+## `<ray>`
+
+ray-overprescribed-through = شعاع through، endpoint او direction آن مقرر اے۔  مقرر through نظرانداز اے۔
+
+ray-dimension-mismatch = شعاع ٹی numDimensions جوڑ اف۔
+
+## `<vector>`
+
+vector-overprescribed-head = ویکٹر head، tail او displacement آن مقرر اے۔  مقرر head نظرانداز اے۔
+
+vector-dimension-mismatch = ویکٹر ٹی numDimensions جوڑ اف۔
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` کے کشنگ ممکن اف، چونکہ نا nearestPoint حالتی متغیر موجود اف۔
+
+constrain-to-without-nearest-point = `<{ $component }>` کے بندنگ ممکن اف، چونکہ نا nearestPoint حالتی متغیر موجود اف۔
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` نا اندرونی بہر کے بندنگ ممکن اف، چونکہ نا nearestPoint حالتی متغیر موجود اف۔
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = دا choiceInput کے کہ inline اف، labelPosition نظرانداز اے
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput کے مقرر انڈیکس نظرانداز اے، چونکہ انڈیکس نا تعداد او choice نا چک نا تعداد جوڑ اف۔
+
+pretzel-indices-count-mismatch = problem کے مقرر انڈیکس نظرانداز اے، چونکہ انڈیکس نا تعداد او problem نا چک نا تعداد جوڑ اف۔
+
+shuffle-indices-count-mismatch = shuffle کے مقرر انڈیکس نظرانداز اے، چونکہ انڈیکس نا تعداد او کمپوننٹ نا تعداد جوڑ اف۔
+
+indices-ignored-out-of-range = { $component } کے مقرر انڈیکس نظرانداز اے، چونکہ چند انڈیکس حد آن در اے۔
+
+pretzel-indices-repeated = pretzel کے مقرر انڈیکس نظرانداز اے، چونکہ چند انڈیکس پدا آسا اے۔
+
+pretzel-circuit-first-index = circuit موڈ ٹی pretzel کے مقرر انڈیکس نظرانداز اے، چونکہ اولی انڈیکس نا 1 مانگ لازم اے۔
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` نا string چک تون کار کننگ کے `type` ایٹریبیوٹ نا مقرر مانگ لازم اے۔
+
+invalid-type-defaulting-to-math = { $component } کمپوننٹ کے ٹائپ { $type } غلط اے۔ نا math، text، number یا boolean مانگ لازم اے۔ پیشدار math کار ٹی گڑیک۔
+
+string-not-valid-component-to-arrange = String "{ $value }" { $component } کے راست کمپوننٹ اف۔ نظرانداز اے۔
+
+## Types and variables
+
+invalid-type-defaulting-to-number = ٹائپ { $type } غلط اے، ٹائپ number مقرر اے۔
+
+invalid-variable-value = متغیر نا قیمت غلط اے: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = ورینٹ نا انڈیکس { $index } نا عدد مانگ لازم اے
+
+variant-index-must-be-integer = ورینٹ نا انڈیکس { $index } نا صحیح عدد مانگ لازم اے
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` مطلق پیمائش کے جوڑ اف۔ پہنائی نسبتی مقرر اے۔
+
+side-by-side-absolute-margins = `<{ $component }>` مطلق پیمائش کے جوڑ اف۔ حاشیہ نسبتی مقرر اے۔
+
+side-by-side-no-block-child = `<{ $component }>` غلط اے: نا کمترین اسٹ بلاک چک دارنگ لازم اے۔
+
+## `<label>`
+
+label-for-ignored-on-graphical = گرافیکی `<label>` ٹی `for` ایٹریبیوٹ نظرانداز اے۔
+
+label-for-must-resolve-to-one = `<label>` نا `for` ایٹریبیوٹ نا ٹھیک اسٹ کمپوننٹ کے نشان دیہنگ لازم اے۔
+
+label-for-unresolved = `<label>` نا `for` ایٹریبیوٹ ہچ کمپوننٹ کے نشان دیرا اف۔
+
+label-for-answer-with-authored-inputs = `<label>` نا `for` ایٹریبیوٹ دا `<answer>` کے نشان دیک کہ نا ان پٹ نبیسوک آن نبشتہ اے؛ سیدا ان پٹ کے ریفرنس دیہنگ۔
+
+label-for-answer-without-input = `<label>` نا `for` ایٹریبیوٹ دا `<answer>` کے نشان دیک کہ نا نام دیہنگ کے ان پٹ موجود اف۔
+
+label-for-must-reference-input-or-answer = `<label>` نا `for` ایٹریبیوٹ نا یا ان پٹ کے یا answer کے ریفرنس دیہنگ لازم اے۔
+
+## Accessibility
+
+accessibility-short-description-or-decorative = رسائی کے `<{ $component }>` نا یا کوتاہ تفصیل دارنگ یا decorative مقرر مانگ لازم اے۔
+
+accessibility-video-short-description = رسائی کے `<video>` نا کوتاہ تفصیل دارنگ لازم اے۔
+
+accessibility-input-short-description-or-label = رسائی کے `<{ $component }>` نا کوتاہ تفصیل یا label دارنگ لازم اے۔
+
+accessibility-answer-input-short-description-or-label = رسائی کے دا `<answer>` نا، کہ اسٹ ان پٹ جوڑ کیک، کوتاہ تفصیل یا label دارنگ لازم اے۔
+
+accessibility-short-description-contains-math = کوتاہ تفصیل ٹی `<{ $component }>` رنگ ریاضی نا کمپوننٹ نا مانگ لازم اف۔ ریاضی نا لفظ تون نبشتہ کننگ۔
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } بہر نا سرگپت نا متن کے بس کنٹراسٹ دیرا اف (تاہار موڈ) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ کمترین { $threshold }:1 لوٹینگ)۔
+       *[other] { $colorName } بہر نا سرگپت نا متن کے بس کنٹراسٹ دیرا اف ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ کمترین { $threshold }:1 لوٹینگ)۔
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = وخت کہ نقطہ نا عددی قیمت موجود اف، { $count } نقطہ آن گڑوک `<circle>` ہنو تانکہ جوڑ اف۔
+
+circle-too-many-through-points = 3 آن گیشتر نقطہ آن گڑوک دائرہ نا حساب ممکن اف۔
+
+circle-overprescribed-radius-center-points = مقرر شعاع، مرکز او نقطہ تون دائرہ نا حساب ممکن اف۔
+
+circle-center-with-multiple-points = مقرر مرکز تون 1 آن گیشتر نقطہ آن گڑوک دائرہ نا حساب ممکن اف۔
+
+circle-radius-too-small = دائرہ نا حساب ممکن اف: ایرا نقطہ نا نیام نا دوری { $distance } اے، دا کے مقرر شعاع { $radius } کمتر اے۔
+
+circle-radius-with-many-points = مقرر شعاع تون ایرا آن گیشتر نقطہ آن گڑوک دائرہ جوڑ مانگ ممکن اف۔
+
+circle-invalid-center-or-through-points = دائرہ نا مرکز یا نقطہ غلط اے۔
+
+circle-radius-center-with-multiple-points = مقرر مرکز تون 1 آن گیشتر نقطہ آن گڑوک دائرہ نا شعاع نا حساب ممکن اف۔
+
+circle-change-radius-non-numerical = عددی قیمت نا دارنگ نقطہ آن گڑوک دائرہ نا شعاع نا بدل کننگ ممکن اف
+
+circle-radius-with-points-non-numerical = وخت کہ عددی قیمت موجود اف، مقرر شعاع تون اسٹ آن گیشتر نقطہ آن گڑوک دائرہ جوڑ مانگ ممکن اف۔
+
+circle-change-center-non-numerical = عددی قیمت نا دارنگ نقطہ آن گڑوک دائرہ نا مرکز نا بدل کننگ ہنو تانکہ جوڑ اف۔
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] فنکشن نا ڈومین کے ابعاد بس اف۔ ڈومین ٹی { $intervals } وقفہ اے، بلے فنکشن ٹی { $inputs ->
+           *[other] { $inputs } ان پٹ
+        } اے۔
+    }
+
+function-domain-invalid-format = فنکشن نا ڈومین نا فارمیٹ غلط اے۔
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] فنکشن نا غیر عددی maximum نظرانداز اے۔
+        [minimum] فنکشن نا غیر عددی minimum نظرانداز اے۔
+        [extremum] فنکشن نا غیر عددی extremum نظرانداز اے۔
+        [point] فنکشن نا غیر عددی نقطہ نظرانداز اے۔
+        [slope] فنکشن نا غیر عددی میلان نظرانداز اے۔
+       *[other] فنکشن نا غیر عددی { $type } نظرانداز اے۔
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] فنکشن نا تہی maximum نظرانداز اے۔
+        [minimum] فنکشن نا تہی minimum نظرانداز اے۔
+        [extremum] فنکشن نا تہی extremum نظرانداز اے۔
+        [point] فنکشن نا تہی نقطہ نظرانداز اے۔
+       *[other] فنکشن نا تہی { $type } نظرانداز اے۔
+    }
+
+function-points-too-close = فنکشن ٹی ایرا نقطہ اے کہ نا جاہ اسٹ ندے کے زیات نزیک اے۔ فنکشن نا تعریف ممکن اف۔
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] فنکشن نا تکرار دا وخت ممکن اے کہ ان پٹ نا تعداد او آؤٹ پٹ نا تعداد برابر اے۔ دا فنکشن ٹی { $inputs } ان پٹ او { $outputs ->
+           *[other] { $outputs } آؤٹ پٹ
+        } اے۔
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = ترتیب نا درازی غلط اے۔  نا غیر منفی صحیح عدد مانگ لازم اے۔
+
+sequence-invalid-step = ترتیب نا گام غلط اے۔  { $type } ٹائپ نا ترتیب کے نا عدد مانگ لازم اے۔
+
+sequence-invalid-endpoint-number = عددی ترتیب نا "{ $attribute }" غلط اے۔  نا عدد مانگ لازم اے۔
+
+sequence-invalid-endpoint-letters = حرفی ترتیب نا "{ $attribute }" غلط اے۔  نا حرف نا ترکیب مانگ لازم اے۔
+
+sequence-invalid-endpoint = ترتیب نا "{ $attribute }" غلط اے۔
+
+select-from-sequence-coprime-not-numbers = عدد گچین اف، دا کے coprime نظرانداز اے
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations مقرر اے، دا کے coprime نظرانداز اے
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` کے target غلط اے: target موجود اف۔
+
+target-state-variable-not-found = `<{ $source }>` کے target غلط اے: `<{ $component }>` ٹی "{ $property }" نام نا حالتی متغیر موجود اف۔
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` نا متغیر نا آزاد متغیر آن پرک مانگ لازم اے۔
+
+ode-system-duplicate-variable-names = پدا آسا بستہ متغیر نا نام تون ODE RHS فنکشن نا تعریف ممکن اف۔
+
+ode-system-rhs-function-error = ODE RHS فنکشن نا تعریف ممکن اف۔  mathjs فنکشن نا جوڑ کننگ ٹی خطا۔
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } خط نا نیام ٹی زاویہ نا تعریف ممکن اف
+
+angle-invalid-through-point = `<angle>` نا through ٹی غلط نقطہ
+
+parabola-vertex-too-many-points = راس تون 1 آن گیشتر نقطہ آن گڑوک پیرابولا ہنو تانکہ جوڑ اف۔
+
+parabola-too-many-points = 3 آن گیشتر نقطہ آن گڑوک پیرابولا ہنو تانکہ جوڑ اف۔
+
+intersection-too-many-items = ایرا آن گیشتر چیز کے تقاطع ہنو تانکہ جوڑ اف
+
+## Other math components
+
+ionic-compound-not-two-ions = ایرا آئون آن دگہ ہچ چیز کے آئونی ترکیب ہنو تانکہ جوڑ اف۔
+
+ionic-compound-needs-cation-and-anion = آئونی ترکیب صرف اسٹ کیٹائون او اسٹ اینائون کے جوڑ اے۔
+
+solve-equations-cannot-evaluate = مساوات نا حساب ممکن اف، دا کے مساوات نا حل ممکن اف: { $equation }
+
+math-operators-operand-number-required = ریاضی نا عامل نا در کشنگ وخت operandNumber نا مقرر مانگ لازم اے۔
+
+eigen-decomposition-failed = میٹرکس نا آئیگن قیمت نا حساب ممکن اف
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: پیرامیٹر { $parameters } پیٹرن ٹی موجود اف، دا کے ہمیشہ تہی تون جوڑ کیک۔
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" نا مطلب معلوم اف۔ نا none، medium، dense یا ایرا مثبت عدد مانگ لازم اے کہ اسٹ تہی جاہ تون پرک اے، دا رنگ grid="1 0.5"۔ ہچ گرڈ کشا اف۔
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` کے دا فنکشن لوٹینگ کہ { $expected ->
+        [1] اسٹ آؤٹ پٹ دیک، یعنی ہر نقطہ ٹی میلان y'، دا رنگ `y - x`
+       *[other] ایرا آؤٹ پٹ دیک، یعنی ہر نقطہ ٹی ویکٹر، دا رنگ `(y, -x)`
+    }، بلے دیہا فنکشن { $found ->
+       *[other] { $found } آؤٹ پٹ
+    } دیک۔ { $alternative ->
+        [none] ہچ چیز کشا اف۔
+       *[other] دا فنکشن کے `<{ $alternative }>` راست کمپوننٹ اے۔ ہچ چیز کشا اف۔
+    }
+
+field-function-attribute-ignored-with-child = `function` ایٹریبیوٹ نظرانداز اے، چونکہ فنکشن کمپوننٹ نا اندر ٹی ہم دیہا اے؛ اندری فنکشن کار ٹی گڑیک۔ فنکشن نا صرف اسٹ رہ آن دیہنگ۔
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` ایٹریبیوٹ دا عبارت نا متغیر کے نام دیک کہ سیدا کمپوننٹ نا اندر ٹی نبشتہ اے۔ { $reason ->
+        [function-child] دیرا فنکشن `<function>` چک نا رنگ ٹی دیہا اے، او دا وت نا متغیر کے نام دیک، دا کے `variables` نظرانداز اے۔
+       *[no-expression] دیرا دا رنگ عبارت موجود اف، دا کے `variables` نظرانداز اے۔
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure رینڈرر ٹی xLabelPosition="left" نا سہار موجود اف؛ راست جاہ نا رنگ کار ٹی گڑیک۔
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure رینڈرر ٹی yLabelPosition="bottom" نا سہار موجود اف؛ برزی جاہ نا رنگ کار ٹی گڑیک۔
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure نا بدل کننگ کے محور نا حد غلط اے؛ پیشدار bbox (-10,-10,10,10) کار ٹی گڑیک۔
+
+prefigure-invalid-width = `<graph>`: prefigure نا بدل کننگ کے پہنائی غلط اے؛ پیشدار خاکہ نا پہنائی 425 کار ٹی گڑیک۔
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure نا بدل کننگ کے aspectRatio غلط اے؛ پیشدار نسبت 1 کار ٹی گڑیک۔
+
+prefigure-grid-spacing-too-fine = `<graph>`: محور نا حد کے گرڈ نا فاصلہ زیات تنگ اے؛ prefigure رینڈرر ٹی گرڈ کشا اف۔
+
+prefigure-annotations-not-rendered = `<graph>`: وخت کہ PreFigure رینڈرر کار ٹی اف، annotation کشا اف۔
+
+multiple-annotations-children = `<graph>` ٹی چند `<annotations>` چک خفتا؛ آخری آن دگہ درست نظرانداز اے۔
+
+## Referring to other components
+
+copy-unrecognized-component-type = نامعلوم کمپوننٹ ٹائپ نا دراج کننگ یا کاپی کننگ ممکن اف: { $type }۔
+
+copy-prop-not-found = { $component } ٹائپ نا کمپوننٹ ٹی { $property } prop موجود اف
+
+collect-no-source = collect کے ہچ سرچمہ موجود اف۔
+
+collect-invalid-component-type = `<{ $component }>` ٹائپ نا کمپوننٹ نا گرنگ ممکن اف، چونکہ دا ٹائپ غلط اے۔
+
+reference-index-unavailable = انڈیکس `{ $reference }` کے ریفرنس دیہنگ ممکن اف
+
+## `<callAction>`
+
+component-action-unavailable = کمپوننٹ `{ $reference }` ٹی { $action } نا گوانک دیہنگ ممکن اف
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ڈیٹا نا شکل غلط اے۔  رج نا درازی اسٹ رنگ اف۔ componentIdx ٹی خفتا :{ $componentIdx }
+
+data-frame-duplicate-column-names = ڈیٹا ٹی کالم نا نام پدا آسا اے۔  componentIdx ٹی خفتا :{ $componentIdx }
+
+data-frame-missing-column-name = ڈیٹا ٹی اسٹ کالم نا نام موجود اف۔  componentIdx ٹی خفتا :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = دا جواب نا award وت نا دیہا جواب ٹی بستہ اے، او دا کار غیر متوقع رویہ کے گڑیک۔
+
+answer-max-num-attempts-in-section-wide-check-work = دا کنٹینر نا اندر کہ sectionWideCheckWork دارے، `<answer>` ٹی `maxNumAttempts` نا مقرر کننگ نا ہچ اثر اف، چونکہ کوشش نا تعداد کنٹینر آن کنٹرول اے۔ `maxNumAttempts` نا کنٹینر ٹی مقرر کننگ۔
+
+nested-section-wide-check-work-max-num-attempts = دا sectionWideCheckWork دارنگ کنٹینر کہ دگہ sectionWideCheckWork دارنگ کنٹینر نا اندر اے، نا سرا `maxNumAttempts` نا مقرر کننگ نا ہچ اثر اف، چونکہ کوشش نا تعداد دری کنٹینر آن کنٹرول اے۔ `maxNumAttempts` نا دری کنٹینر ٹی مقرر کننگ۔
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality نا مقرر کننگ نا بغیر { $attributes } ایٹریبیوٹ نا ہچ اثر اف۔
+    }
+
+answer-invalid-type = جواب کے ٹائپ غلط اے: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` کمپوننٹ نا نام موجود اف، دا کے module نا ایٹریبیوٹ نا رنگ ٹی کار ٹی گڑنگ ممکن اف
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` کمپوننٹ نا module نا ایٹریبیوٹ نا رنگ ٹی کار ٹی گڑنگ ممکن اف، چونکہ `<module>` کمپوننٹ ٹائپ ٹی "{ $name }" ایٹریبیوٹ پیشتر آن تعریف اے۔
+
+conditional-content-condition-ignored = case یا else چک دارنگ `<conditionalContent>` کمپوننٹ ٹی `condition` ایٹریبیوٹ نظرانداز اے۔
+
+slider-markers-type-mismatch = مارکر نا ٹائپ او slider نا ٹائپ جوڑ اف۔
+
+pretzel-problem-needs-statement-and-answer = pretzel غلط اے: ہر `<problem>` ٹی اسٹ `<statement>` او اسٹ `<answer>` مانگ لازم اے۔
+
+pretzel-circuit-first-problem-distractor = pretzel غلط اے: mode="circuit" ٹی اولی `<problem>` نا distractor مانگ ممکن اف۔
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] `{ $attribute }` ایٹریبیوٹ کے غلط قیمت { $values }؛ نظرانداز اے۔
+    }
+
+attribute-must-be-references = `{ $attribute }` ایٹریبیوٹ کے قیمت `{ $value }` غلط اے۔ ایٹریبیوٹ نا دا ریفرنس آن جوڑ مانگ لازم اے کہ `$` تون سرا کیک۔
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ٹی غلط فنکشن نا نام نظرانداز اے: { $names }۔ ہر نام نا نشان دیہنگ نا بہر نا کمترین 2 حرف مانگ لازم اے (حرف یا ڈیش)؛ نا رند اسٹ `|<mathspeak alternative>` ہم آسک۔
+
+## Building components from the source
+
+component-type-invalid = کمپوننٹ نا ٹائپ غلط اے: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } ایٹریبیوٹ نا پدا آنگ ممکن اف۔
+
+attribute-invalid-for-component = `<{ $componentType }>` ٹائپ نا کمپوننٹ کے "{ $attribute }" ایٹریبیوٹ غلط اے۔
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    سٹائل نا تعریف { $styleNumber } ٹی { $context ->
+        [text-on-background] پشت زمین نا خلاف متن نا رنگ
+        [high-contrast] کینوس نا خلاف برزی کنٹراسٹ نا رنگ
+        [line] کینوس نا خلاف خط نا رنگ
+        [marker] کینوس نا خلاف مارکر نا رنگ
+       *[text-on-canvas] کینوس نا خلاف متن نا رنگ
+    } کے بس کنٹراسٹ موجود اف{ $mode ->
+        [dark] { " (تاہار موڈ)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ کمترین { $threshold }:1 لوٹینگ)۔
+
+style-definition-dark-mode-text-background-contrast =
+    سٹائل نا تعریف { $styleNumber } نا مقرر رنگ روشن موڈ کے بس کنٹراسٹ دیک، بلے دا آن در آسا تاہار موڈ نا رنگ ٹی پشت زمین نا خلاف متن نا رنگ نا کنٹراسٹ بس اف ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ کمترین { $threshold }:1 لوٹینگ)۔ { $suggestion ->
+        [available] تاہار موڈ ٹی بس کنٹراسٹ کے یا روشن موڈ نا کنٹراسٹ نا گیش کننگ (مثال نا رنگ { $lightAttribute }="{ $lightColor }" مقرر کننگ) یا تاہار موڈ نا رنگ نا بدل کننگ (مثال نا رنگ { $darkAttribute }="{ $darkColor }" مقرر کننگ)۔
+       *[none] تاہار موڈ ٹی بس کنٹراسٹ کے روشن موڈ نا کنٹراسٹ نا گیش کننگ یا در آسا رنگ نا textColorDarkMode او/یا backgroundColorDarkMode تون بدل کننگ۔
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    سٹائل نا تعریف { $styleNumber } نا مقرر متن نا رنگ روشن موڈ کے بس کنٹراسٹ دیک، بلے دا آن در آسا تاہار موڈ نا متن نا رنگ کینوس نا خلاف بس کنٹراسٹ دیرا اف ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ کمترین { $threshold }:1 لوٹینگ)۔ { $suggestion ->
+        [available] تاہار موڈ ٹی بس کنٹراسٹ کے یا روشن موڈ نا کنٹراسٹ نا گیش کننگ (مثال نا رنگ textColor="{ $lightColor }" مقرر کننگ) یا تاہار موڈ نا رنگ نا بدل کننگ (textColorDarkMode="{ $darkColor }" مقرر کننگ)۔
+       *[none] تاہار موڈ ٹی بس کنٹراسٹ کے روشن موڈ نا کنٹراسٹ نا گیش کننگ یا در آسا رنگ نا textColorDarkMode تون بدل کننگ۔
+    }
+
+section-multiple-style-palettes = اسٹ بہر صرف اسٹ <stylePalette> گچین کیک؛ آخری کار ٹی گڑیک۔
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } نا خاص ورینٹ معلوم اف، چونکہ numToSelect غیر منفی صحیح عدد اف۔
+
+variant-num-to-select-not-constant-number = { $component } نا خاص ورینٹ معلوم اف، چونکہ numToSelect ثابت عدد اف۔
+
+variant-with-replacement-not-constant-boolean = { $component } نا خاص ورینٹ معلوم اف، چونکہ withReplacement ثابت boolean اف۔
+
+variant-select-weight-disables-unique = اگر اسٹ آپشن ٹی selectWeight یا selectForVariants مقرر اے، select کے خاص ورینٹ بند اے
+
+variant-coprime-undetermined = { $component } نا خاص ورینٹ معلوم اف، چونکہ دا معلوم اف کہ coprime ہمیشہ دروگ اے۔
+
+variant-attribute-not-constant = { $component } نا خاص ورینٹ معلوم اف، چونکہ { $attribute } ثابت اف۔
+
+variant-attribute-not-number = { $component } نا خاص ورینٹ معلوم اف، چونکہ { $attribute } عدد اف۔
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } ٹائپ نا { $component } نا خاص ورینٹ معلوم اف، چونکہ { $attribute } { $expected ->
+        [letters-combination] حرف نا ترکیب
+        [math-expression] راست ریاضی نا عبارت
+        [integer] صحیح عدد
+       *[number] عدد
+    } اف۔
+
+variant-length-not-integer = { $component } نا خاص ورینٹ معلوم اف، چونکہ length صحیح عدد اف۔
+
+variant-sort-not-implemented = sort دارنگ { $component } نا خاص ورینٹ ہنو تانکہ جوڑ اف
+
+variant-exclude-combinations-not-implemented = excludeCombinations دارنگ { $component } نا خاص ورینٹ ہنو تانکہ جوڑ اف
+
+variant-math-exclude-not-implemented = exclude دارنگ math ٹائپ نا { $component } نا خاص ورینٹ ہنو تانکہ جوڑ اف
+
+variant-non-constant-exclude-not-implemented = غیر ثابت exclude دارنگ { $component } نا خاص ورینٹ ہنو تانکہ جوڑ اف
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: گراف نا prefigure رینڈرر ٹی دا نا سہار موجود اف؛ نسل ہشتا۔
+
+prefigure-descendant-invalid-geometry = { $subject }: جیومیٹری پورہ یا محدود اف؛ نسل ہشتا۔
+
+prefigure-curve-label-omitted = { $subject }: بدل آسا منحنی نا عنصر ٹی label نا سہار موجود اف؛ label ہشتا۔
+
+prefigure-curve-unsupported-definition-type = { $subject }: منحنی نا فنکشن نا تعریف نا ٹائپ '{ $definitionType }' نا سہار موجود اف؛ نسل ہشتا۔
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves ٹی flipFunctions ایٹریبیوٹ نا سہار موجود اف؛ نسل ہشتا۔
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves ٹی صرف formula ٹائپ نا چک فنکشن نا سہار اے؛ نسل ہشتا۔
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] خط نا رند نا label
+       *[point] نقطہ نا label
+    } کے labelPosition '{ $labelPosition }' نا سہار موجود اف؛ PreFigure نا پیشدار ہمترازی کار ٹی گڑا۔
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure ٹی پر کننگ نا سٹائل '{ $fillStyle }' نا سہار موجود اف؛ سادہ پر کننگ کار ٹی گڑیک۔
+
+prefigure-line-style-unknown = { $subject }: نامعلوم خط نا سٹائل '{ $lineStyle }' PreFigure نا آؤٹ پٹ آن ہشتا۔
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: مارکر نا سٹائل '{ $markerStyle }' PreFigure نا 'diamond' سٹائل ٹی بدل آسا۔
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure ٹی مارکر نا سٹائل '{ $markerStyle }' نا سہار موجود اف؛ پیشدار سٹائل کار ٹی گڑا۔
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` غلط اے؛ ہدف معلوم اف۔ annotation ہشتا۔
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` چند ہدف کے نشان دیرا؛ اولی ہدف کار ٹی گڑیک۔
+
+annotation-ref-outside-graph = `<annotation>`: `ref` غلط اے؛ ہدف گراف آن در اے۔ annotation ہشتا۔
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` غلط اے؛ prefigure نا بدل کننگ ٹی ہدف سہار دارنگ گرافیکی چیز اف۔ annotation ہشتا۔
+
+annotation-text-missing = `<annotation>`: `text` کم یا تہی اے؛ تہی متن در دیہنگ اے۔
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] گرد بستگی خفتا۔
+       *[other] `<{ $componentType }>` کمپوننٹ تون گرد بستگی خفتا۔
+    }
+
+reference-no-referent = ریفرنس `{ $reference }` کے ہچ مرجع موجود اف
+
+reference-multiple-referents = ریفرنس `{ $reference }` کے چند مرجع خفتا
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` نا { $attribute } ایٹریبیوٹ نا فارمیٹ غلط اے۔
+
+children-invalid = `<{ $componentType }>` کے غلط چک: غلط چک خفتا: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` ایٹریبیوٹ کے قیمت `{ $value }` غلط اے، قیمت `{ $default }` کار ٹی گڑیک
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML نا ورژن { $version } موجود اف۔
+       *[other] DoenetML نا ورژن { $version } موجود اف۔ ورژن { $fallback } کار ٹی گڑیک
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = غلط DoenetML: { $content }
+
+parse-tag-missing-close-tag = غلط DoenetML: `{ $tag }` ٹیگ نا بند ٹیگ موجود اف۔ یا وت بند مانگ ٹیگ یا `</{ $tagName }>` ٹیگ لوٹینگ۔
+
+parse-tag-error = غلط DoenetML: `<{ $tagName }>` ٹیگ ٹی خطا
+
+parse-attribute-missing-value = غلط DoenetML: غلط ایٹریبیوٹ `{ $attribute }` نا قیمت کم اے۔
+
+parse-attribute-invalid = غلط DoenetML: غلط ایٹریبیوٹ `{ $attribute }`
+
+parse-attribute-value-invalid = غلط DoenetML: ایٹریبیوٹ نا غلط قیمت `{ $value }`
+
+parse-attribute-value-quote-mismatch = غلط DoenetML: ایٹریبیوٹ نا غلط قیمت `{ $value }`۔ کوٹیشن نا نشان جوڑ اف۔ اسٹ `{ $quote }` کم اے
+
+parse-open-tag-name-missing = غلط DoenetML: بے نام ٹیگ خفتا، مثال نا رنگ `<`
+
+parse-tag-not-closed = غلط DoenetML: `{ $tag }` ٹیگ بند اف (اسٹ `>` کم اے)۔
+
+parse-self-closing-tag-name-missing = غلط DoenetML: بے نام ٹیگ خفتا `<{ $content }>`
+
+parse-self-closing-tag-not-closed = غلط DoenetML: `{ $tag }` ٹیگ بند اف (`/>` کم اے)۔
+
+parse-tag-invalid-attributes = غلط DoenetML: `{ $tag }` ٹیگ راست اف۔ نا ایٹریبیوٹ غلط اے۔
+
+parse-close-tag-name-missing = غلط DoenetML: بے نام بند ٹیگ خفتا، مثال نا رنگ `</`
+
+parse-attribute-value-unquoted = ایٹریبیوٹ نا قیمت نا کوٹیشن نا اندر مانگ لازم اے: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = غلط DoenetML: بند ٹیگ `{ $tag }` خفتا، بلے نا پچ ٹیگ موجود اف
+
+parse-close-tag-mismatched = غلط DoenetML: بند ٹیگ جوڑ اف۔ `</{ $expected }>` لوٹا۔ `{ $found }` خفتا
+
+parser-node-unconvertible = { $node } نوڈ نا Dast نوڈ ٹی بدل کننگ ممکن اف۔
+
+## Names
+
+name-attribute-invalid =
+    غلط ایٹریبیوٹ name='{ $name }'۔ { $reason ->
+        [characters] نام ٹی صرف حرف، عدد، چیری لکیر یا ڈیش آسک۔
+       *[start] نام نا حرف تون سرا مانگ لازم اے۔
+    }
+
+component-name-invalid-start = غلط کمپوننٹ نا نام "{ $name }"۔ نام نا حرف تون سرا مانگ لازم اے۔
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched ٹائپ نا جواب نا video ایٹریبیوٹ دارنگ لازم اے
+
+answer-video-watched-video-not-reference = videoWatched ٹائپ نا جواب نا video ایٹریبیوٹ نا ریفرنس مانگ لازم اے
+
+answer-name-not-single-text = جواب نا name ایٹریبیوٹ نا صرف اسٹ text چک دارنگ لازم اے
+
+## Referencing another document
+
+external-doenetml-recursion-limit = زیات تہ بہ تہ سطح نا سبب آن دری DoenetML نا گرنگ ممکن اف۔ گرد ریفرنس اے؟
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" آن DoenetML نا گرنگ ممکن اف
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" آن گرا DoenetML غلط اے: دا "{ $componentType }" کمپوننٹ نا ٹائپ تون جوڑ اف
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` ایٹریبیوٹ کہنہ اے؛ نا جاہ ٹی `{ $to }` کار ٹی گڑیننگ۔
+       *[other] [deprecation] `<{ $component }>` ٹی `{ $from }` ایٹریبیوٹ کہنہ اے؛ نا جاہ ٹی `{ $to }` کار ٹی گڑیننگ۔
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` ایٹریبیوٹ کہنہ او نظرانداز اے، چونکہ `{ $to }` ہم مقرر اے۔
+       *[other] [deprecation] `<{ $component }>` ٹی `{ $from }` ایٹریبیوٹ کہنہ او نظرانداز اے، چونکہ `{ $to }` ہم مقرر اے۔
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` ٹی `{ $attribute }` ایٹریبیوٹ کہنہ او نظرانداز اے۔
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` ٹی `{ $attribute }` ایٹریبیوٹ کہنہ اے؛ نا جاہ ٹی `<{ $child }>` چک کار ٹی گڑیننگ۔
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` ٹی `{ $attribute }` ایٹریبیوٹ نا قیمت `{ $value }` کہنہ اے؛ نا جاہ ٹی `{ $to }` کار ٹی گڑیننگ۔
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` صرف انگریزی نا جمع کیک، دا کے { $locale } ٹی نبشتہ دستاویز ٹی نا متن دا رنگ مانیک۔ جمع نا شکل نا سیدا نبشتہ کننگ، یا `pluralForm` ایٹریبیوٹ تون مقرر کننگ۔
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` عنصر Doenet نا معلوم عنصر اف۔
+
+schema-element-not-allowed-at-root = `<{ $tag }>` عنصر کے دستاویز نا ریشہ ٹی اجازت اف۔
+
+schema-element-not-allowed-inside = `<{ $tag }>` عنصر کے `<{ $parent }>` نا اندر اجازت اف۔
+
+schema-attribute-unrecognized = `<{ $tag }>` عنصر ٹی `{ $attribute }` نام نا ایٹریبیوٹ موجود اف۔
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` عنصر نا `{ $attribute }` ایٹریبیوٹ نا دا لسٹ مانگ لازم اے کہ نا ہر درجہ دا چیز آن اسٹ اے: { $allowed }
+       *[other] `<{ $tag }>` عنصر نا `{ $attribute }` ایٹریبیوٹ نا دا چیز آن اسٹ مانگ لازم اے: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select کے ورینٹ نا نام غلط اے۔  ورینٹ نا نام { $variantName } { $numOptions } آپشن ٹی آسا، بلے گچین کننگ نا تعداد { $numToSelect } اے۔
+
+select-variant-name-without-options = select کے چند ورینٹ مقرر اے، بلے ممکن ورینٹ نا نام { $variantName } کے ہچ آپشن مقرر اف۔
+
+select-variant-name-not-possible = select کے مقرر ورینٹ نا نام { $variantName } ممکن نام اف۔
+
+select-too-few-options = صرف { $numOptions } آن { $numToSelect } کمپوننٹ نا گچین کننگ ممکن اف۔
+
+select-from-sequence-too-few-values = { $length } درازی نا ترتیب آن { $numToSelect } قیمت نا گچین کننگ ممکن اف۔
+
+select-from-sequence-indices-count-mismatch = select کے مقرر انڈیکس نا تعداد نا گچین کننگ نا تعداد تون جوڑ مانگ لازم اے
+
+select-from-sequence-indices-not-integers = select کے مقرر درست انڈیکس نا صحیح عدد مانگ لازم اے
+
+select-from-sequence-index-excluded = selectfromsequence نا مقرر انڈیکس در ہشتا اے
+
+select-from-sequence-indices-excluded-combination = selectfromsequence نا مقرر انڈیکس در ہشتا ترکیب اے
+
+select-from-sequence-coprime-not-positive-integers = مثبت صحیح عدد گچین اف، دا کے coprime ترکیب نا گچین کننگ ممکن اف۔
+
+select-from-sequence-coprime-common-factor = coprime عدد نا گچین کننگ ممکن اف۔ درست ممکن قیمت اسٹ ہمگ فیکٹر دارے۔ (مقرر "from" یا "to" نا قیمت نا "step" تون coprime مانگ لازم اے۔)
+
+select-from-sequence-coprime-single-number = دا اسٹ عدد آن کہ 1 اف، coprime ترکیب نا گچین کننگ ممکن اف۔
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ٹی ترکیب آن 70% آن گیشتر در ہشتا
+
+select-from-sequence-coprime-none-found = coprime عدد گچین اف۔ درست ممکن قیمت اسٹ ہمگ فیکٹر دارے۔
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } درازی نا ترتیب آن { $numToSelect } خاص قیمت نا گچین کننگ ممکن اف
+
+select-prime-numbers-too-few-values = { $numValues } درازی نا اولی عدد نا لسٹ آن { $numToSelect } قیمت نا گچین کننگ ممکن اف
+
+select-prime-numbers-values-count-mismatch = select کے مقرر قیمت نا تعداد نا گچین کننگ نا تعداد تون جوڑ مانگ لازم اے
+
+select-prime-numbers-values-not-prime = اولی عدد نا گچین کننگ کے مقرر قیمت نا اولی عدد نا لسٹ ٹی مانگ لازم اے
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers نا مقرر قیمت در ہشتا ترکیب اے
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ٹی ترکیب آن 70% آن گیشتر در ہشتا
+
+select-random-combination-fluke = زیات کم اتفاق نا سبب آن، اتفاقی قیمت نا ترکیب گچین اف
+
+select-random-value-fluke = زیات کم اتفاق نا سبب آن، اتفاقی قیمت گچین اف
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] دا `<{ $component }>` کشا اف، چونکہ دا ریاضی نا اندر اے او `inline` اف۔ `inline` نا ھور کننگ، تانکہ دا اسٹ ڈراپ ڈاؤن لسٹ مانے کہ عبارت نا اندر ٹی گنجک۔
+        [expanded] دا `<{ $component }>` کشا اف، چونکہ دا ریاضی نا اندر اے او `expanded` اے۔ `expanded` نا در کننگ؛ چند لینک دبہ عبارت نا اندر ٹی گنجا اف۔
+        [on-graph] دا `<{ $component }>` کشا اف، چونکہ دا گراف ٹی کشا ریاضی نا اندر اے، او آدا ان پٹ کے جاہ موجود اف۔
+       *[relative-width] دا `<{ $component }>` کشا اف، چونکہ دا ریاضی نا اندر اے او نا پہنائی نسبتی اے۔ پہنائی نا مطلق واحد ٹی دیہنگ، دا رنگ `px`۔
+    }

--- a/packages/i18n/locales/brh/diagnostics.ftl
+++ b/packages/i18n/locales/brh/diagnostics.ftl
@@ -23,8 +23,8 @@
 # such message is written once as `*[other]`, with the count kept in the
 # selector so that nothing is lost from the message's shape. The `[1]` in
 # `field-function-wrong-num-outputs` is a numeric literal rather than a
-# category — Fluent matches it against the number itself — so it stays where
-# English has it. The symbolic selectors — `$reason`, `$type`, `$mode`,
+# category — Fluent matches it against the number itself — and it stands
+# where English selects the category `[one]`. The symbolic selectors — `$reason`, `$type`, `$mode`,
 # `$suggestion`, `$isList`, `$context`, `$expected` and the rest — keep every
 # branch English has, because those keys are compared letter for letter and a
 # renamed one is a branch nothing can reach.

--- a/packages/i18n/locales/brh/editor.ftl
+++ b/packages/i18n/locales/brh/editor.ftl
@@ -1,0 +1,229 @@
+# Brahui (براہوئی) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel beside them. Translated from `locales/en/editor.ftl`,
+# which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Perso-Arabic on the Urdu letter inventory as Brahui is printed in Quetta,
+# right to left, case clitics written as separate words — the same convention
+# `chrome.ftl` states, and the four files of this locale must not be split
+# between two orthographies.
+#
+# Brahui is rigidly verb-final, so where English drops a bare verb into the
+# middle of a sentence — "Click to { $action } accessibility report" — the
+# whole sentence sits inside the selector instead. Fluent does not care where a
+# select falls in a pattern.
+#
+# No message here selects on a plural category: CLDR has none for `brh`, and a
+# Brahui noun after a numeral stays unmarked in any case, so every count
+# message is a single `*[other]` with the count kept in the selector.
+#
+# `WCAG`, `DoenetML`, `XML`, `styleNumber` and every element or attribute name
+# are identifiers rather than words and stay exactly as written.
+#
+# **This is the thinnest of the four files.** The context-help panel talks
+# about references, properties, arrays and resolved types, and Brahui has no
+# settled words for any of that; what is written below keeps the Urdu, Balochi
+# and English computing terms — `ریفرنس`, `پراپرٹی`, `اری`, `ٹائپ`, `سٹائل`,
+# `کوآرڈینیٹ` — rather than coining Brahui ones. What is Brahui here is the
+# frame around them: the case clitics, the head-final order, the copula «اے»
+# and its negative «اف», and the verbal noun in `‑نگ` on every control. A
+# speaker replacing the vocabulary needs no permission.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] پدا نو
+       *[update] نوکن
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] چاروک نا { $word }
+       *[other] چاروک نا { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = ورینٹ
+editor-variant-filter = چھاننگ...
+editor-variant-next = رندی ورینٹ نا گچین کننگ
+editor-variant-previous = پیشی ورینٹ نا گچین کننگ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA رسائی نا خلاف ورزی خفتا۔ { $action ->
+            [close] رسائی نا رپورٹ نا بند کننگ کے کلک کننگ۔
+           *[open] رسائی نا رپورٹ نا پچ کننگ کے کلک کننگ۔
+        }
+        [advisories] { $action ->
+            [close] رسائی نا رپورٹ نا بند کننگ کے کلک کننگ۔
+           *[open] رسائی نا رپورٹ نا پچ کننگ کے کلک کننگ۔
+        } WCAG AA نا ہچ خلاف ورزی خفتا اف، بلے رسائی نا دگہ صلاح موجود اے۔
+       *[clean] { $action ->
+            [close] رسائی نا رپورٹ نا بند کننگ کے کلک کننگ۔
+           *[open] رسائی نا رپورٹ نا پچ کننگ کے کلک کننگ۔
+        } رسائی نا ہچ مسئلہ خفتا اف۔
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA رسائی نا خلاف ورزی خفتا۔ { $count } WCAG AA خلاف ورزی خفتا۔ { $action ->
+            [close] رسائی نا رپورٹ نا بند کننگ کے کلک کننگ۔
+           *[open] رسائی نا رپورٹ نا پچ کننگ کے کلک کننگ۔
+        }
+        [advisories] WCAG AA نا ہچ خلاف ورزی خفتا اف۔ رسائی نا { $count } دگہ صلاح خفتا۔ { $action ->
+            [close] رسائی نا رپورٹ نا بند کننگ کے کلک کننگ۔
+           *[open] رسائی نا رپورٹ نا پچ کننگ کے کلک کننگ۔
+        }
+       *[clean] WCAG AA نا ہچ خلاف ورزی خفتا اف۔ { $action ->
+            [close] رسائی نا رپورٹ نا بند کننگ کے کلک کننگ۔
+           *[open] رسائی نا رپورٹ نا پچ کننگ کے کلک کننگ۔
+        }
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML نا ورژن { $version }
+
+editor-tab-help = موقع نا مطابق رہشون
+editor-tab-help-short = موقع
+editor-tab-errors = خطا
+editor-tab-warnings = ہشدار
+editor-tab-info = معلومات
+editor-tab-accessibility = رسائی
+editor-tab-responses = دیہا جواب
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = ایڈیٹر نا گچین
+editor-format-as-doenetml = DoenetML نا رنگ ٹی ترتیب دیہنگ
+editor-format-as-xml = XML نا رنگ ٹی ترتیب دیہنگ
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = سطر #{ $line }
+
+editor-no-errors = ہچ خطا اف
+editor-no-warnings = ہچ ہشدار اف
+editor-no-info = ہچ معلوماتی نشانی اف
+
+editor-show-info-annotations = ایڈیٹر ٹی معلوماتی نشانی نا دیرنگ
+editor-show-accessibility-annotations = ایڈیٹر ٹی رسائی نا نشانی نا دیرنگ
+
+editor-accessibility-learn-more = Doenet رسائی نا کے چون چاریک، دا نا زانگ ←
+
+editor-accessibility-violations-heading = رسائی نا خلاف ورزی ({ $standard })
+
+editor-accessibility-other-heading = رسائی نا دگہ مسئلہ
+editor-none-found = ہچ چیز خفتا اف
+
+
+## Submitted responses
+
+editor-no-responses = ہنو تانکہ ہچ جواب دیہا اف
+editor-response-answer-id = جواب نا نام
+editor-response-response = جواب
+editor-response-credit = نمبر
+editor-response-submitted = دیہنگ نا وخت
+
+
+## The context-help panel
+
+help-placeholder = دستاویز کے کرسر نا ٹیگ نا نام، ایٹریبیوٹ یا { $ref } ٹی ہشنگ۔
+
+help-unsupported-ref-chain = { $example } رنگ چند بہری ریفرنس کے رہشون ہنو تانکہ موجود اف۔
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] { $ref } کے ہچ مرجع موجود اف۔
+        [multiple] { $ref } کے چند مرجع خفتا۔
+       *[indeterminate] { $ref } نا مرجع معلوم اف۔
+    }
+
+# The arrow is direction rather than punctuation, and Brahui runs the other
+# way, so it points where the reader is going.
+help-learn-about-references = ریفرنس نا بارے ٹی زانگ ←
+help-reference-page = ریفرنس نا صفحہ ←
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } نا اندر
+       *[top] سرین سطح ٹی
+    }{ $allowed ->
+        [none] { " — آدا ہچ چیز آسا اف۔" }
+        [text] { " — آدا متن نبشتہ کننگ۔" }
+        [text-and-components] { " — آدا متن نبشتہ کننگ، یا دا چیز نا کوشش کننگ:" }
+       *[components] { " — کوشش کننگ نا چیز:" }
+    }
+
+help-suggestions-footer = درست { $total } کمپوننٹ نا دیدنگ کے { $shortcut } نا دبانگ۔
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } دا { $target } نا ریفرنس اے۔
+       *[other] { $ref } دا { $target } نا ریفرنس اے (سطر { $line })۔
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } دا نا { $role } نا رنگ ٹی آرا۔
+       *[other] { $owner } دا نا سطر { $line } ٹی { $role } نا رنگ ٹی آرا۔
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } دا { $element } نا { $property } پراپرٹی نا ریفرنس اے۔
+       *[other] { $ref } دا { $element } نا { $property } پراپرٹی نا ریفرنس اے (سطر { $line })۔
+    }
+
+help-kind-attribute = ایٹریبیوٹ
+help-kind-snippet = ٹکڑ
+help-kind-array-entry = اری نا درجہ
+
+help-default = پیشدار:
+help-active-default = چالوک پیشدار:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] اجازت نا قیمت (ہر درجہ کے اسٹ):
+       *[other] اجازت نا قیمت:
+    }
+
+help-suggested-values = صلاح نا قیمت:
+
+help-inserts = ھور کیک:
+
+help-coordinates =
+    { $count ->
+       *[other] کوآرڈینیٹ:
+    }
+
+help-type = ٹائپ:
+
+help-resolved-style = معلوم سٹائل (styleNumber { $styleNumber }):
+
+help-resolved-function-names = فنکشن نا معلوم نام:
+help-reset-list = دا ان پٹ ٹی لسٹ نا پدا نو کننگ:
+help-added-on-input = دا ان پٹ ٹی ھور آسا:
+help-removed-on-input = دا ان پٹ آن در آسا:
+
+help-reset-overrides = { $reset }، { $additional } او { $removed } نا سرا کار ٹی گڑیک۔

--- a/packages/i18n/locales/gbm/chrome.ftl
+++ b/packages/i18n/locales/gbm/chrome.ftl
@@ -1,0 +1,132 @@
+# Garhwali (गढ़वळि) viewer chrome: the buttons, panel headers and status words the
+# reader interacts with. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Garhwali is written in.
+#
+# **Method, stated plainly.** Garhwali has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Garhwali
+# speaker meets in an Uttarakhand classroom, which teaches out of Hindi
+# textbooks. What is Garhwali here is the grammatical layer written over it:
+# the genitive कु / की / का rather than Hindi का / की / के, the object marker
+# तैं, the copula च (plural छन), the negative नि, मा for *in*, बटि for
+# *from*, दगड़ि for *with*, अर for *and*, जु for *if*, कुण for *for*, क्यांकि
+# for *because*, and the -आ imperative (करा, दिखावा, हटावा) Garhwali puts on a
+# button. A reviewer should read this as Garhwali grammar over Hindi
+# terminology and is free to replace the terminology wherever Garhwali has its
+# own word.
+#
+# Numbers render as 1,234.5 in **Latin digits**, never in Devanagari
+# numerals: that is what CLDR gives for the Devanagari-writing languages of
+# India, and it is what DoenetML pins for every locale (`src/intl.ts`).
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `gbm`, so `lint:i18n` would reject a `[one]` branch outright. Every count
+# in this file goes through a single `*[other]`, keeping only
+# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
+# number itself rather than against a category.
+
+## Answer submission
+
+answer-checking = जाँचा जा रौं च...
+answer-submitting = भेजा जा रौं च...
+answer-checking-status = उत्तर जाँचा जा रौं च
+answer-submitting-status = उत्तर भेजा जा रौं च
+answer-correct = सही
+answer-incorrect = ग़लत
+answer-response-saved = उत्तर सहेजा गया
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+max-credit-available = अधिकतम संभव अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] कोई प्रयास शेष नि छन
+       *[other] { $count } प्रयास शेष
+    }
+validation-correct = (सही)
+validation-incorrect = (ग़लत)
+validation-partially-correct = (आंशिक रूप से सही)
+answer-show-responses = { $answerId } का { $count } उत्तर दिखावा
+
+## Disclosure panels
+
+feedback-heading = प्रतिक्रिया
+collapsible-click-to-open = (खोलण कुण क्लिक करा)
+collapsible-click-to-close = (बंद करण कुण क्लिक करा)
+collapsible-initializing = आरंभ किया जा रौं च...
+footnote-show = पादटिप्पणी दिखावा
+footnote-hide = पादटिप्पणी छिपावा
+description-more-information = अधिक जानकारी
+
+## Controls
+
+slider-previous = पिछलु
+slider-next = अगलु
+keyboard-open = कीबोर्ड खोला
+keyboard-close = कीबोर्ड बंद करा
+choice-input-remove-choice = { $choice } हटावा
+matrix-remove-row = पंक्ति हटावा
+matrix-add-row = पंक्ति जोड़ा
+matrix-remove-column = स्तंभ हटावा
+matrix-add-column = स्तंभ जोड़ा
+subset-add-remove-points = बिंदु जोड़ा/हटावा
+subset-toggle-points-intervals = बिंदुओं अर अंतरालों का बीच बदलें
+subset-move-points = बिंदु खिसकावा
+subset-clear = साफ़ करा
+orbital-add-row = पंक्ति जोड़ा
+orbital-remove-row = पंक्ति हटावा
+orbital-add-box = खाँचा जोड़ा
+orbital-remove-box = खाँचा हटावा
+orbital-add-up-arrow = ऊपर कु तीर जोड़ा
+orbital-add-down-arrow = नीचे कु तीर जोड़ा
+orbital-remove-arrow = तीर हटावा
+orbital-row-label = पंक्ति { $row } कु लेबल
+pretzel-answer = उत्तर
+summary-statistics-caption = { $column } का वर्णनात्मक सांख्यिकी
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक कु पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+## Document status
+
+viewer-initializing = आरंभ किया जा रौं च...
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } मा मिली।
+       *[lines] पंक्तियों { $startLine }–{ $endLine } मा मिली।
+    }
+document-contains-errors = यै दस्तावेज़ मा त्रुटियाँ छन!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+something-went-wrong = कुछ ग़लत हो गया।
+renderer-load-failed = एक रेंडरर लोड नि हो सका। किरपा कैरिक पृष्ठ दुबारा लोड करा।
+core-start-failed = यु दस्तावेज़ शुरू नि किया जा सका। किरपा कैरिक पृष्ठ दुबारा लोड करा।
+
+core-start-failed-busy = यु दस्तावेज़ शुरू नि किया जा सका। एक साथ कई दस्तावेज़ शुरू हो रैं छा, जै मा धीमे उपकरण पर अधिक समय लगता च। बाकी दस्तावेज़ों का पूरा होण पर पृष्ठ दुबारा लोड करण बटि बात बन सकदि च।
+
+core-start-failed-retry = यु दस्तावेज़ शुरू नि किया जा सका।
+
+core-start-failed-busy-retry = यु दस्तावेज़ शुरू नि किया जा सका। एक साथ कई दस्तावेज़ शुरू हो रैं छा, जै मा धीमे उपकरण पर अधिक समय लगता च।
+
+core-start-retry = दुबारा कोशिश करा
+
+saved-state-unavailable = आपका सहेजा गया काम लोड नि किया जा सका।

--- a/packages/i18n/locales/gbm/content.ftl
+++ b/packages/i18n/locales/gbm/content.ftl
@@ -1,0 +1,308 @@
+# Garhwali (गढ़वळि) content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Garhwali is written in.
+#
+# ## Method, and what this file can only say in Hindi
+#
+# गढ़वळि is spoken in the Garhwal division of Uttarakhand and schooled in Hindi: it has no settled
+# register for mathematics, and the geometry words here — रेखा, रेखाखंड,
+# किरण, सदिश, वक्र, फलन, परवलय, बहुभुज, त्रिभुज, आयत, वृत्त, समचतुर्भुज — are
+# the Hindi terms a student meets in class, written as they stand. The same is
+# true of सारणी, चित्र, पृष्ठभूमि, भराव and the whole of `section-name`. What
+# is गढ़वळि here is the grammar written over that vocabulary:
+# the genitive कु / की / का, the object marker तैं, the copula च
+# (plural छन), the negative नि, मा for *in*, बटि for *from*, दगड़ि for
+# *with*, अर for *and*, and जु for *if*
+# — together with the adjective forms below. **A reviewer should start with
+# the adjectives and the section words**: those are the places where a
+# गढ़वळि word may exist and the seed has used the Hindi one.
+#
+# ## Word order
+#
+# **The adjectives precede the noun**, exactly as they do in English and in
+# Hindi: «मोटु लाल रेखा» is *thick red line*. So
+# `style-with-noun` and `style-filled-with-noun` keep English's order of
+# `{ $description }` and `{ $noun }`, and `style-stroke` keeps English's
+# internal order of width, dash pattern and colour, because that is this
+# language's order too. What does move is everything governed by a
+# postposition: a postposition follows its noun, so the border clause and the
+# background clause come out reversed from English.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` puts the side count in
+# front of the noun — «{ $numSides } भुजाओं वळु सम बहुभुज» — so the whole of it is
+# one `head` and `tail` is empty, as in English and in Hindi. The
+# `-tail` variants of `style-with-noun` and `style-filled-with-noun` are still
+# written out, because they are what a partly-translated locale falls back to.
+#
+# ## Gender and role: the fork is deliberately not taken
+#
+# गढ़वळि **does** inflect a marked adjective for gender and for the
+# direct/oblique distinction, the way Hindi does — the -ओ/-उ masculine here has
+# a feminine in -ी and an oblique in -ा — so English's `$gender` and `$role`
+# arguments are not idle in this language, and the shape Hindi's catalog uses
+# would be the right shape here.
+#
+# **This seed does not fork on either, and writes the masculine singular
+# direct form throughout.** That is a decision about what a seed can honestly
+# claim, not a claim that the language has no agreement. Forking would require
+# a trustworthy gender for every noun in `noun` in *this* language rather than
+# in Hindi, plus an oblique paradigm the seed is sure of for each of the three
+# clause positions; the seed has neither, and a confidently wrong agreement
+# table is harder for a reviewer to repair than a uniformly unagreed one.
+# **This is the single largest gap in the file.** A reviewer who supplies the
+# genders can lift Hindi's `{ $role -> … { $gender -> … } }` shape verbatim.
+#
+# For the same reason `noun-gender` answers the bare token `neuter` that
+# English answers: no adjective in this file selects on it, so a gender table
+# here would be inert until the fork above is taken.
+#
+# ## Number
+#
+# **Nothing selects on a count.** CLDR has no plural data for `gbm`, so
+# `lint:i18n` would reject a plural category outright — and nothing in this
+# file counts in any case. Numbers render in Latin digits, never in Devanagari
+# numerals, which is what DoenetML pins for every locale (`src/intl.ts`).
+#
+# ## Chemistry
+#
+# `element-name` and `element-anion-name` are **deliberately absent**, so
+# those 130 keys fall back to English. Chemistry is taught here out of Hindi
+# textbooks, so the element names a गढ़वळि student meets are the Hindi
+# ones, and a table under this tag would be a claim about spelling rather than
+# about the language. Hindi's own table is in `locales/hi/content.ftl` for
+# anyone who wants to start from it.
+
+## Style vocabulary
+
+color =
+    .black = कालु
+    .white = सफ़ेद
+    .gray = स्लेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow = पीलु
+    .green = हरु
+    .cyan = फ़िरोज़ी
+    .blue = नीलु
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown = भूरु
+
+line-width =
+    .thick = मोटु
+    .thin = पातलु
+
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+
+# Oblique plural noun phrases, because their other use is in front of «वळु»
+# in `style-filled` and `style-fill`. They are the Hindi forms: the seed has
+# no गढ़वळि oblique plural for them that it trusts.
+fill-style =
+    .horizontal = क्षैतिज रेखाओं
+    .vertical = ऊर्ध्वाधर रेखाओं
+    .diagonal = विकर्ण रेखाओं
+    .backdiagonal = विपरीत विकर्ण रेखाओं
+    .dots = बिंदुओं
+    .diamonds = समचतुर्भुजों
+
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = प्रवणता क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = धन चिह्न
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजाओं वळु सम बहुभुज
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = भर्युं
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वळु { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वळु { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वळु { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# The postposition follows its noun, so the whole clause comes out after the
+# adjective and English's preposition-first order is reversed. There is no
+# article, so the `-article` branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारा दगड़ि
+        [and] अर { $border } किनारा दगड़ि
+        [and-article] अर { $border } किनारा दगड़ि
+       *[with] { $border } किनारा दगड़ि
+    }
+
+# The fill-pattern words are oblique plurals, so this message supplies «भराव»
+# for them to hang off rather than printing them bare.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } वळु { $color } भराव
+       *[plain] { $color } भराव
+    }
+
+style-unfilled = बिना भराव
+
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि मा { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = कुछ नि
+
+
+## Boolean words
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## Answer buttons
+
+answer-submit-label = जाँचा
+answer-submit-label-no-correctness = उत्तर भेजा
+
+
+## Sectional blocks
+
+section-name =
+    .activity = गतिविधि
+    .aside = पार्श्व टिप्पणी
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = उत्तर
+    .note = टिप्पणी
+    .objectives = उद्देश्य
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = प्रश्न
+    .problems = प्रश्न
+    .proof = प्रमाण
+    .question = सवाल
+    .section = अनुभाग
+    .solution = हल
+    .task = काम
+    .theorem = प्रमेय
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = संकेत
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = पिछलु
+paginator-next = अगलु
+paginator-page = पृष्ठ
+
+paginator-page-status = { $numPages } मा बटि { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = या
+
+piecewise-condition-if = जु
+
+piecewise-condition-otherwise = नितर
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = रिक्त
+
+math-embedded-input-blank-ordinal = { $total } मा बटि रिक्त { $ordinal }

--- a/packages/i18n/locales/gbm/diagnostics.ftl
+++ b/packages/i18n/locales/gbm/diagnostics.ftl
@@ -1,0 +1,659 @@
+# Garhwali (गढ़वळि) diagnostics: the errors and warnings shown to whoever is looking
+# at the screen. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Garhwali is written in.
+#
+# **Method, stated plainly.** Garhwali has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Garhwali
+# speaker meets in an Uttarakhand classroom, which teaches out of Hindi
+# textbooks. What is Garhwali here is the grammatical layer written over it:
+# the genitive कु / की / का rather than Hindi का / की / के, the object marker
+# तैं, the copula च (plural छन), the negative नि, मा for *in*, बटि for
+# *from*, दगड़ि for *with*, अर for *and*, जु for *if*, कुण for *for*, क्यांकि
+# for *because*, and the -आ imperative (करा, दिखावा, हटावा) Garhwali puts on a
+# button. A reviewer should read this as Garhwali grammar over Hindi
+# terminology and is free to replace the terminology wherever Garhwali has its
+# own word.
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `gbm`, so every count in this file goes through a single `*[other]`. The
+# one exception is `field-function-wrong-num-outputs`, where English is not
+# counting but distinguishing a one-output field from a two-output one; that
+# fork is kept as the numeric literal `[1]`, which Fluent matches against the
+# number itself rather than against a plural category.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दो सिरे दिए जाण पर { $attributes } पर ध्यान नि दिया जांद
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा अर मध्यबिंदु दोनों दिए जाण पर { $attributes } पर ध्यान नि दिया जांद
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु का बिना midpointOffset कु कोई प्रभाव नि हूंद
+
+## `<line>`
+
+line-points-undetermined-dimensions = ऐसे बिंदुओं बटि होकर जाण वाली रेखा जिनकी विमा अनिश्चित च।
+
+line-points-too-few-dimensions = रेखा तैं कम बटि कम द्विविमीय बिंदुओं बटि होकर जाना चैंद।
+
+line-points-depend-on-variables = रेखा उन बिंदुओं बटि होकर जांदि च जो चरों पर निर्भर छन: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } अर { $variable2 } मा रेखा का समीकरण कु प्रारूप अमान्य च।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एक साथ through, endpoint अर direction बटि निर्धारित च। दिए गए through तैं छोड़ा जा रौं च।
+
+ray-dimension-mismatch = किरण मा numDimensions मेल नि खाते।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एक साथ head, tail अर displacement बटि निर्धारित च। दिए गए head तैं छोड़ा जा रौं च।
+
+vector-dimension-mismatch = सदिश मा numDimensions मेल नि खाते।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` की तरफ आकर्षित नि किया जा सकद, क्यांकि वै मा nearestPoint अवस्था चर नि च।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित नि किया जा सकद, क्यांकि वै मा nearestPoint अवस्था चर नि च।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` का भीतरी भाग तक सीमित नि किया जा सकद, क्यांकि वै मा nearestPoint अवस्था चर नि च।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होण वाले choiceInput कुण labelPosition पर ध्यान नि दिया जांद
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput कुण दिए गए indices तैं छोड़ा जा रौं च, क्यांकि indices की संख्या choice संतानों की संख्या बटि मेल नि खाती।
+
+pretzel-indices-count-mismatch = problem कुण दिए गए indices तैं छोड़ा जा रौं च, क्यांकि indices की संख्या problem संतानों की संख्या बटि मेल नि खाती।
+
+shuffle-indices-count-mismatch = shuffle कुण दिए गए indices तैं छोड़ा जा रौं च, क्यांकि indices की संख्या घटकों की संख्या बटि मेल नि खाती।
+
+indices-ignored-out-of-range = { $component } कुण दिए गए indices तैं छोड़ा जा रौं च, क्यांकि कुछ अनुक्रमांक परिसर बटि बाहर छन।
+
+pretzel-indices-repeated = pretzel कुण दिए गए indices तैं छोड़ा जा रौं च, क्यांकि कुछ अनुक्रमांक दोहराए गए छन।
+
+pretzel-circuit-first-index = circuit विधा मा pretzel कुण दिए गए indices तैं छोड़ा जा रौं च, क्यांकि पैलु अनुक्रमांक 1 होण चैंद।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` तैं पाठ संतानों दगड़ि काम करण कुण `type` विशेषता देनी ह्वेलि।
+
+invalid-type-defaulting-to-math = { $component } घटक कुण प्रकार { $type } अमान्य च। यु math, text, number या boolean मा बटि एक होण चैंद। math कु उपयोग किया जा रौं च।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } कुण मान्य घटक नि च। छोड़ा जा रौं च।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य च; प्रकार number पर सेट किया जा रौं च।
+
+invalid-variable-value = चर कु मान अमान्य च: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } एक संख्या होणि चैंद
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } एक पूर्णांक होण चैंद
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष मापों कुण उपलब्ध नि च। चौड़ाइयाँ सापेक्ष की जा रैं छन।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष मापों कुण उपलब्ध नि च। हाशिये सापेक्ष किए जा रैं छन।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: यै मा कम बटि कम एक खंड संतान होणि चैंद।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर ध्यान नि दिया जांद।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एक घटक तक पहुँचनी चैंद।
+
+label-for-unresolved = `<label>` पर `for` विशेषता किसी घटक तक नि पहुँच सकी।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता ऐसे `<answer>` कु संदर्भ देती च जै मा इनपुट स्पष्ट रूप से लिखे गए छन; सीधे उसी इनपुट कु संदर्भ द्या।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता ऐसे `<answer>` कु संदर्भ देती च जै मा लेबल लगाण योग्य इनपुट नि च।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता किसी इनपुट या किसी उत्तर कु संदर्भ देनी चैंद।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता कुण `<{ $component }>` कु या तो संक्षिप्त विवरण होण चैंद या उसे सजावटी बताया जाना चैंद।
+
+accessibility-video-short-description = सुगम्यता कुण `<video>` कु संक्षिप्त विवरण होण चैंद।
+
+accessibility-input-short-description-or-label = सुगम्यता कुण `<{ $component }>` कु संक्षिप्त विवरण या लेबल होण चैंद।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता कुण इनपुट बनाण वाले `<answer>` कु संक्षिप्त विवरण या लेबल होण चैंद।
+
+accessibility-short-description-contains-math = संक्षिप्त विवरणों मा `<{ $component }>` जन गणितीय घटक नि होण चैंद। गणित तैं शब्दों मा लिखा।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } कु खंड शीर्षक पाठ कुण वैषम्य अपर्याप्त च (गहरी विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंद)।
+       *[other] { $colorName } कु खंड शीर्षक पाठ कुण वैषम्य अपर्याप्त च ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंद)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदुओं का संख्यात्मक मान न हों, तब { $count } बिंदुओं बटि होकर जाण वाला `<circle>` अभी उपलब्ध नि च।
+
+circle-too-many-through-points = 3 बटि अधिक बिंदुओं बटि होकर जाण वाला वृत्त परिकलित नि किया जा सकद।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र अर गुज़रने वाले बिंदु एक साथ दिए जाण पर वृत्त परिकलित नि किया जा सकद।
+
+circle-center-with-multiple-points = दिए गए केंद्र दगड़ि 1 बटि अधिक बिंदु बटि होकर जाण वाला वृत्त परिकलित नि किया जा सकद।
+
+circle-radius-too-small = वृत्त परिकलित नि किया जा सकद: दोनों बिंदुओं का बीच की दूरी { $distance } च, इसलिए दी गई त्रिज्या { $radius } बहुत छोटी च।
+
+circle-radius-with-many-points = दी गई त्रिज्या दगड़ि दो बटि अधिक बिंदुओं बटि होकर जाण वाला वृत्त नि बनाया जा सकद।
+
+circle-invalid-center-or-through-points = वृत्त कु केंद्र या गुज़रने वाले बिंदु अमान्य छन।
+
+circle-radius-center-with-multiple-points = दिए गए केंद्र दगड़ि 1 बटि अधिक बिंदु बटि होकर जाण वाले वृत्त की त्रिज्या परिकलित नि की जा सकदि।
+
+circle-change-radius-non-numerical = जै वृत्त का गुज़रने वाले बिंदु संख्यात्मक नि छन, वैकी त्रिज्या नि बदली जा सकदि
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होण पर, दी गई त्रिज्या दगड़ि एक बटि अधिक बिंदु बटि होकर जाण वाला वृत्त नि बनाया जा सकद।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदुओं बटि होकर जाण वाले वृत्त कु केंद्र बदलना अभी उपलब्ध नि च।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन का प्रांत की विमाएँ अपर्याप्त छन। प्रांत मा { $intervals } अंतराल छन, पर फलन मा { $inputs } इनपुट छन।
+
+function-domain-invalid-format = फलन का प्रांत कु प्रारूप अमान्य च।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन कु असंख्यात्मक उच्चिष्ठ छोड़ा जा रौं च।
+        [minimum] फलन कु असंख्यात्मक निम्निष्ठ छोड़ा जा रौं च।
+        [extremum] फलन कु असंख्यात्मक चरम मान छोड़ा जा रौं च।
+        [point] फलन कु असंख्यात्मक बिंदु छोड़ा जा रौं च।
+        [slope] फलन की असंख्यात्मक प्रवणता छोड़ी जा रैं च।
+       *[other] फलन कु असंख्यात्मक { $type } छोड़ा जा रौं च।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन कु रिक्त उच्चिष्ठ छोड़ा जा रौं च।
+        [minimum] फलन कु रिक्त निम्निष्ठ छोड़ा जा रौं च।
+        [extremum] फलन कु रिक्त चरम मान छोड़ा जा रौं च।
+        [point] फलन कु रिक्त बिंदु छोड़ा जा रौं च।
+       *[other] फलन कु रिक्त { $type } छोड़ा जा रौं च।
+    }
+
+function-points-too-close = फलन मा दो बिंदु बहुत पास-पास छन। फलन परिभाषित नि किया जा सकद।
+
+function-iterates-input-output-mismatch = फलन कु पुनरावर्तन तभी संभव च जब इनपुट की संख्या आउटपुट की संख्या का बराबर हो। यै फलन मा { $inputs } इनपुट अर { $outputs } आउटपुट छन।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम की लंबाई अमान्य च। यु ऋणेतर पूर्णांक होणि चैंद।
+
+sequence-invalid-step = अनुक्रम कु चरण अमान्य च। { $type } प्रकार का अनुक्रम कुण यु एक संख्या होणि चैंद।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम कु "{ $attribute }" अमान्य च। यु एक संख्या होणि चैंद।
+
+sequence-invalid-endpoint-letters = अक्षर अनुक्रम कु "{ $attribute }" अमान्य च। यु अक्षरों कु संयोजन होण चैंद।
+
+sequence-invalid-endpoint = अनुक्रम कु "{ $attribute }" अमान्य च।
+
+select-from-sequence-coprime-not-numbers = संख्याएँ नि चुनी जा रहीं, इसलिए coprime छोड़ा गया
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations दिया गया च, इसलिए coprime छोड़ा गया
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` कुण target अमान्य च: लक्ष्य नि मिला।
+
+target-state-variable-not-found = `<{ $source }>` कुण target अमान्य च: `<{ $component }>` पर "{ $property }" नाम कु अवस्था चर नि मिला।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` का चर स्वतंत्र चर बटि भिन्न होण चैंद।
+
+ode-system-duplicate-variable-names = दोहराए गए आश्रित चर नामों दगड़ि ODE का दाएँ पक्ष का फलन परिभाषित नि किए जा सकदा।
+
+ode-system-rhs-function-error = ODE का दाएँ पक्ष कु फलन परिभाषित नि किया जा सकद। mathjs फलन बनाते समय त्रुटि हुई।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखाओं का बीच कु कोण परिभाषित नि किया जा सकद
+
+angle-invalid-through-point = `<angle>` का through मा अमान्य बिंदु च
+
+parabola-vertex-too-many-points = दिए गए शीर्ष दगड़ि 1 बटि अधिक बिंदु बटि होकर जाण वाला परवलय अभी उपलब्ध नि च।
+
+parabola-too-many-points = 3 बटि अधिक बिंदुओं बटि होकर जाण वाला परवलय अभी उपलब्ध नि च।
+
+intersection-too-many-items = दो बटि अधिक वस्तुओं कु प्रतिच्छेदन अभी उपलब्ध नि च
+
+## Other math components
+
+ionic-compound-not-two-ions = दो आयनों का अलावा किसी अर स्थिति कुण आयनिक यौगिक अभी उपलब्ध नि च।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक केवल एक धनायन अर एक ऋणायन कुण उपलब्ध च।
+
+solve-equations-cannot-evaluate = समीकरण कु मान नि निकाला जा सका, इसलिए वु हल नि किया जा सकद: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालते समय operandNumber देना आवश्यक च।
+
+eigen-decomposition-failed = आव्यूह का अभिलक्षणिक मान परिकलित नि किए जा सके
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न मा नि आते, इसलिए वे सदा रिक्त बटि मेल खाएँगे।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" तैं समझा नि जा सका। यु none, medium, dense, या रिक्त स्थान बटि अलग की गई दो धनात्मक संख्याएँ होणि चैंद, जन grid="1 0.5"। कोई ग्रिड नि खींचा जाएगा।
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर मा xLabelPosition="left" समर्थित नि च; दाईं स्थिति वाला व्यवहार अपनाया जा रौं च।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर मा yLabelPosition="bottom" समर्थित नि च; ऊपरी स्थिति वाला व्यवहार अपनाया जा रौं च।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण कुण अक्ष सीमाएँ अमान्य छन; पूर्वनिर्धारित bbox (-10,-10,10,10) अपनाया जा रौं च।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण कुण चौड़ाई अमान्य च; पूर्वनिर्धारित आरेख चौड़ाई 425 अपनाई जा रैं च।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण कुण aspectRatio अमान्य च; पूर्वनिर्धारित अनुपात 1 अपनाया जा रौं च।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अक्ष सीमाओं की तुलना मा ग्रिड कु अंतराल बहुत महीन च; prefigure रेंडरर मा ग्रिड छोड़ा जा रौं च।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर कु उपयोग न होण पर टीकाएँ नि खींची जाएँगी।
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` तैं ऐसा फलन चैंद जै मा { $expected ->
+        [1] एक आउटपुट हो, यानी हर बिंदु पर प्रवणता y', जन `y - x`
+       *[other] दो आउटपुट हों, यानी हर बिंदु पर सदिश, जन `(y, -x)`
+    }, पर दिए गए फलन मा { $found } आउटपुट छन। { $alternative ->
+        [none] कुछ नि खींचा जाएगा।
+       *[other] वै फलन कुण `<{ $alternative }>` घटक च। कुछ नि खींचा जाएगा।
+    }
+
+field-function-attribute-ignored-with-child = `function` विशेषता पर ध्यान नि दिया जांद, क्यांकि फलन घटक का भितर भी दिया गया च; भीतर वाला ही लिया जांद च। फलन दोनों मा बटि केवल एक तरह बटि द्या।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषता वै व्यंजक का चर बताती च जो घटक का भितर सीधे लिखा गया हो। { $reason ->
+        [function-child] यहाँ फलन `<function>` संतान का रूप मा दिया गया च, जो अपने चर स्वयं बताती च, इसलिए `variables` पर ध्यान नि दिया जांद।
+       *[no-expression] यहाँ ऐसा कोई व्यंजक नि दिया गया, इसलिए `variables` पर ध्यान नि दिया जांद।
+    }
+
+multiple-annotations-children = `<graph>` मा एक बटि अधिक `<annotations>` संतानें मिलीं; अंतिम तैं छोड़कर सभी पर ध्यान नि दिया जाएगा।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार तैं विस्तारित या प्रतिलिपित नि किया जा सकद: { $type }।
+
+copy-prop-not-found = { $component } प्रकार का घटक पर { $property } गुण नि मिला
+
+collect-no-source = collect कुण कोई स्रोत नि मिला।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार का घटक एकत्र नि किए जा सकदा, क्यांकि यु मान्य घटक प्रकार नि च।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` कु संदर्भ नि दिया जा सकद
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } नि बुलाया जा सकद
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़ों कु आकार अमान्य च। पंक्तियों की लंबाई असंगत च। componentIdx :{ $componentIdx } मा मिला
+
+data-frame-duplicate-column-names = आँकड़ों मा स्तंभ नाम दोहराए गए छन। componentIdx :{ $componentIdx } मा मिला
+
+data-frame-missing-column-name = आँकड़ों मा एक स्तंभ नाम अनुपस्थित च। componentIdx :{ $componentIdx } मा मिला
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = यै उत्तर कु एक award स्वयं answer टैग द्वारा भेजे गए उत्तर पर आधारित च, जिससे अप्रत्याशित व्यवहार ह्वेलु।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र का भितर का `<answer>` पर `maxNumAttempts` सेट करण कु कोई प्रभाव नि हूंद, क्यांकि प्रयासों की संख्या पात्र नियंत्रित करद च। `maxNumAttempts` पात्र पर सेट करा।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले किसी अन्य पात्र का भितर स्थित `sectionWideCheckWork` पात्र पर `maxNumAttempts` सेट करण कु कोई प्रभाव नि हूंद, क्यांकि प्रयासों की संख्या बाहरी पात्र नियंत्रित करद च। `maxNumAttempts` बाहरी पात्र पर सेट करा।
+
+answer-attributes-need-symbolic-equality = symbolicEquality सेट किए बिना { $attributes } विशेषताओं कु कोई प्रभाव नि ह्वेलु।
+
+answer-invalid-type = answer कुण प्रकार अमान्य च: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = क्यांकि घटक `<{ $component }>` कु नाम नि च, इसे मॉड्यूल विशेषता का रूप मा उपयोग नि किया जा सकद
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` तैं मॉड्यूल की विशेषता का रूप मा उपयोग नि किया जा सकद, क्यांकि घटक प्रकार `<module>` मा "{ $name }" विशेषता पहले बटि परिभाषित च।
+
+conditional-content-condition-ignored = case या else संतानों वाले `<conditionalContent>` घटक पर `condition` विशेषता पर ध्यान नि दिया जांद।
+
+slider-markers-type-mismatch = चिह्नकों कु प्रकार स्लाइडर का प्रकार बटि मेल नि खाता।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: प्रत्येक `<problem>` मा एक `<statement>` अर एक `<answer>` होण चैंद।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" मा पैलु `<problem>` भ्रामक विकल्प नि हो सकद।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` कुण मान { $values } अमान्य छन; छोड़ा जा रौं च।
+
+attribute-must-be-references = विशेषता `{ $attribute }` कुण मान `{ $value }` अमान्य च। विशेषता `$` बटि आरंभ होण वाले संदर्भों बटि बनी होणि चैंद।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } मा अमान्य फलन नाम छोड़े गए: { $names }। प्रत्येक नाम का दृश्य भाग मा कम बटि कम 2 वर्ण (अक्षर या योजक चिह्न) होण चैंद; उसके बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आ सकद च।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य च: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहराई नि जा सकदि।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार का घटक कुण विशेषता "{ $attribute }" अमान्य च।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } मा { $context ->
+        [text-on-background] पृष्ठभूमि रंग की तुलना मा पाठ रंग
+        [high-contrast] कैनवास की तुलना मा उच्च वैषम्य रंग
+        [line] कैनवास की तुलना मा रेखा रंग
+        [marker] कैनवास की तुलना मा चिह्नक रंग
+       *[text-on-canvas] कैनवास की तुलना मा पाठ रंग
+    } कुण वैषम्य अपर्याप्त च{ $mode ->
+        [dark] { " (गहरी विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंद)।
+
+style-definition-dark-mode-text-background-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा कुण पर्याप्त वैषम्य वाले रंग दिए छन, इन मानों बटि व्युत्पन्न गहरी विधा का रंगों मा पाठ रंग अर पृष्ठभूमि रंग का बीच वैषम्य अपर्याप्त च ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंद)। { $suggestion ->
+        [available] गहरी विधा मा पर्याप्त वैषम्य सुनिश्चित करण कुण या तो हल्की विधा कु वैषम्य बढ़ावा (जन { $lightAttribute }="{ $lightColor }" सेट करा) या गहरी विधा कु रंग अधिरोहित करा (जन { $darkAttribute }="{ $darkColor }" सेट करा)।
+       *[none] गहरी विधा मा पर्याप्त वैषम्य सुनिश्चित करण कुण हल्की विधा कु वैषम्य बढ़ावा या व्युत्पन्न रंगों तैं textColorDarkMode अर/या backgroundColorDarkMode बटि अधिरोहित करा।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा कुण पर्याप्त वैषम्य वाला पाठ रंग दिया च, यै मान बटि व्युत्पन्न गहरी विधा का पाठ रंग कु कैनवास की तुलना मा वैषम्य अपर्याप्त च ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंद)। { $suggestion ->
+        [available] गहरी विधा मा पर्याप्त वैषम्य सुनिश्चित करण कुण या तो हल्की विधा कु वैषम्य बढ़ावा (जन textColor="{ $lightColor }" सेट करा) या गहरी विधा कु रंग अधिरोहित करा (जन textColorDarkMode="{ $darkColor }" सेट करा)।
+       *[none] गहरी विधा मा पर्याप्त वैषम्य सुनिश्चित करण कुण हल्की विधा कु वैषम्य बढ़ावा या व्युत्पन्न रंग तैं textColorDarkMode बटि अधिरोहित करा।
+    }
+
+section-multiple-style-palettes = एक खंड केवल एक <stylePalette> चुन सकद च; अंतिम कु उपयोग किया जा रौं च।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि numToSelect ऋणेतर पूर्णांक नि च।
+
+variant-num-to-select-not-constant-number = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि numToSelect अचर नि च।
+
+variant-with-replacement-not-constant-boolean = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि withReplacement अचर बूलीय मान नि च।
+
+variant-select-weight-disables-unique = जु कोई विकल्प selectWeight या selectForVariants देता च तो select का अद्वितीय संस्करण निष्क्रिय हो जांदा छन
+
+variant-coprime-undetermined = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि यु तय नि हो सका कि coprime सदा असत्य च।
+
+variant-attribute-not-constant = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि { $attribute } अचर नि च।
+
+variant-attribute-not-number = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि { $attribute } संख्या नि च।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार का { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि { $attribute } { $expected ->
+        [letters-combination] अक्षरों कु संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } नि च।
+
+variant-length-not-integer = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकदा, क्यांकि length पूर्णांक नि च।
+
+variant-sort-not-implemented = sort वाले { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार का { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख का prefigure रेंडरर मा समर्थित नि; वंशज छोड़ा गया।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित या अपूर्ण च; वंशज छोड़ा गया।
+
+prefigure-curve-label-omitted = { $subject }: रूपांतरित वक्र तत्वों पर लेबल समर्थित नि; लेबल छोड़ा गया।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित नि; वंशज छोड़ा गया।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित नि; वंशज छोड़ा गया।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves केवल सूत्र प्रकार का संतान फलनों कु समर्थन करद च; वंशज छोड़ा गया।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल का लेबल
+       *[point] बिंदु लेबल
+    } कुण labelPosition '{ $labelPosition }' समर्थित नि; PreFigure की पूर्वनिर्धारित संरेखण अपनाई जा रैं च।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure मा समर्थित नि; ठोस भराव अपनाया जा रौं च।
+
+prefigure-line-style-unknown = { $subject }: अज्ञात रेखा शैली '{ $lineStyle }' PreFigure का आउटपुट बटि छोड़ी गई।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure की 'diamond' शैली पर मानचित्रित की गई।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure मा समर्थित नि; पूर्वनिर्धारित शैली अपनाई जा रैं च।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य निर्धारित नि हो सका। टीका छोड़ी गई।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` बटि कई लक्ष्य निकले; पैलु लक्ष्य लिया जा रौं च।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य उसे समेटे आलेख का बाहर च। टीका छोड़ी गई।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण मा लक्ष्य समर्थित आलेखीय वस्तु नि च। टीका छोड़ी गई।
+
+annotation-text-missing = `<annotation>`: `text` अनुपस्थित या रिक्त; रिक्त पाठ दिया जा रौं च।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता कु पता चला।
+       *[other] `<{ $componentType }>` घटक बटि जुड़ी चक्रीय निर्भरता कु पता चला।
+    }
+
+reference-no-referent = यै संदर्भ कु कोई लक्ष्य नि मिला: `{ $reference }`
+
+reference-multiple-referents = यै संदर्भ का कई लक्ष्य मिले: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` की विशेषता { $attribute } कु प्रारूप अमान्य च।
+
+children-invalid = `<{ $componentType }>` की संतानें अमान्य छन: अमान्य संतानें मिलीं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` कुण मान `{ $value }` अमान्य च; मान `{ $default }` कु उपयोग किया जा रौं च
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } नि मिला।
+       *[other] DoenetML संस्करण { $version } नि मिला। संस्करण { $fallback } पर लौटा जा रौं च
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` कु समापन टैग नि च। स्वतः बंद होण वाला टैग या `</{ $tagName }>` टैग अपेक्षित छौ।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` मा त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` कु मान अनुपस्थित प्रतीत हूंद च।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य च
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य च
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य च। उद्धरण चिह्न मेल नि खाते। एक `{ $quote }` अनुपस्थित प्रतीत हूंद च
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम कु टैग मिला, जन `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नि हुआ (एक `>` अनुपस्थित प्रतीत हूंद च)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम कु टैग मिला `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नि हुआ (`/>` अनुपस्थित प्रतीत हूंद च)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य नि च। यैकी विशेषताएँ ग़लत हो सकदि छन।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम कु समापन टैग मिला, जन `</`
+
+parse-attribute-value-unquoted = विशेषता मान उद्धरण चिह्नों मा होण चैंद: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिला, पर वै बटि मेल खाता आरंभ टैग नि च
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल नि खाता। `</{ $expected }>` अपेक्षित छौ। `{ $found }` मिला
+
+parser-node-unconvertible = नोड { $node } तैं Dast नोड मा परिवर्तित नि किया जा सका।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य च। { $reason ->
+        [characters] नामों मा केवल अक्षर, अंक, अधोरेखा या योजक चिह्न हो सकदा छन।
+       *[start] नाम अक्षर बटि आरंभ होण चैंद।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य च। नाम अक्षर बटि आरंभ होण चैंद।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार का answer मा video विशेषता होणि चैंद
+
+answer-video-watched-video-not-reference = videoWatched प्रकार का answer की video विशेषता एक संदर्भ होणि चैंद
+
+answer-name-not-single-text = answer की name विशेषता मा केवल एक पाठ संतान होणि चैंद
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन का बहुत अधिक स्तरों का कारण बाहरी DoenetML प्राप्त नि किया जा सका। कहीं चक्रीय संदर्भ तो नि?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" बटि DoenetML प्राप्त नि किया जा सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" बटि प्राप्त DoenetML अमान्य च: यु घटक प्रकार "{ $componentType }" बटि मेल नि खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित च; यैका बदला `{ $to }` कु उपयोग करा।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित च; यैका बदला `{ $to }` कु उपयोग करा।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित च अर छोड़ दी गई, क्यांकि `{ $to }` भी दिया गया च।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित च अर छोड़ दी गई, क्यांकि `{ $to }` भी दिया गया च।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित च अर छोड़ दी गई।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित च; यैका बदला `<{ $child }>` संतान लिखा।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` कु मान `{ $value }` अप्रचलित च; यैका बदला `{ $to }` कु उपयोग करा।
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` केवल अंग्रेज़ी कु बहुवचन बना सकद च, इसलिए { $locale } मा लिखे दस्तावेज़ मा वैकु पाठ अपरिवर्तित रहता च। बहुवचन रूप सीधे लिखा, या `pluralForm` विशेषता बटि द्या।
+
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कोई परिचित Doenet तत्व नि च।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज़ का मूल मा मान्य नि च।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` का भितर मान्य नि च।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` मा `{ $attribute }` नाम की कोई विशेषता नि च।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` की विशेषता `{ $attribute }` एक सूची होणि चैंद जिसकी हर मद इनमें बटि एक हो: { $allowed }
+       *[other] तत्व `<{ $tag }>` की विशेषता `{ $attribute }` इनमें बटि एक होणि चैंद: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select कुण संस्करण नाम अमान्य च। संस्करण नाम { $variantName } { $numOptions } विकल्पों मा आता च, पर चुनण की संख्या { $numToSelect } च।
+
+select-variant-name-without-options = select कुण संस्करण दिए गए छन, पर संभावित संस्करण नाम कुण कोई विकल्प नि च: { $variantName }।
+
+select-variant-name-not-possible = select कुण दिया गया संस्करण नाम { $variantName } संभावित संस्करण नाम नि च।
+
+select-too-few-options = केवल { $numOptions } घटकों मा बटि { $numToSelect } नि चुने जा सकदा।
+
+select-from-sequence-too-few-values = { $length } लंबाई का अनुक्रम बटि { $numToSelect } मान नि चुने जा सकदा।
+
+select-from-sequence-indices-count-mismatch = select कुण दिए गए अनुक्रमांकों की संख्या चुनण की संख्या बटि मेल खानी चैंद
+
+select-from-sequence-indices-not-integers = select कुण दिए गए सभी अनुक्रमांक पूर्णांक होण चैंद
+
+select-from-sequence-index-excluded = selectfromsequence कुण दिया गया अनुक्रमांक बहिष्कृत छौ
+
+select-from-sequence-indices-excluded-combination = selectfromsequence कुण दिए गए अनुक्रमांक बहिष्कृत संयोजन बनाते छा
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक नि चुने जा रैं, इसलिए सहअभाज्य संयोजन नि चुने जा सकदा।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्याएँ नि चुनी जा सकदीं। सभी संभावित मानों मा एक उभयनिष्ठ गुणनखंड च। (दिए गए "from" या "to" मान "step" का सहअभाज्य होण चैंद।)
+
+select-from-sequence-coprime-single-number = 1 बटि भिन्न किसी एकल संख्या बटि सहअभाज्य संयोजन नि चुने जा सकदा।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence मा 70% बटि अधिक संयोजन बहिष्कृत किए गए
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्याएँ नि चुनी जा सकीं। सभी संभावित मानों मा एक उभयनिष्ठ गुणनखंड च।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई का अनुक्रम बटि { $numToSelect } भिन्न मान नि चुने जा सकदा
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई की अभाज्य सूची बटि { $numToSelect } मान नि चुने जा सकदा
+
+select-prime-numbers-values-count-mismatch = select कुण दिए गए मानों की संख्या चुनण की संख्या बटि मेल खानी चैंद
+
+select-prime-numbers-values-not-prime = select prime number कुण दिए गए सभी मान अभाज्य सूची मा होण चैंद
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers कुण दिए गए मान बहिष्कृत संयोजन बनाते छा
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers मा 70% बटि अधिक संयोजन बहिष्कृत किए गए
+
+select-random-combination-fluke = अत्यंत असंभव संयोग बटि यादृच्छिक मानों कु संयोजन नि चुना जा सका
+
+select-random-value-fluke = अत्यंत असंभव संयोग बटि यादृच्छिक मान नि चुना जा सका
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] यु `<{ $component }>` नि दिखाया जा रौं, क्यांकि यु गणित का भितर च अर `inline` नि च। `inline` जोड़ा, ताकि यु ड्रॉप-डाउन सूची बन जाए, जो व्यंजक का भितर समा जांदि च।
+        [expanded] यु `<{ $component }>` नि दिखाया जा रौं, क्यांकि यु गणित का भितर च अर `expanded` च। `expanded` हटावा; बहु-पंक्ति बक्सा व्यंजक का भितर नि समाता।
+        [on-graph] यु `<{ $component }>` नि दिखाया जा रौं, क्यांकि यु आलेख पर खींचे गए गणित का भितर च, जै मा इनपुट कुण जगह नि च।
+       *[relative-width] यु `<{ $component }>` नि दिखाया जा रौं, क्यांकि यु गणित का भितर च अर यैकी चौड़ाई सापेक्ष च। चौड़ाई निरपेक्ष इकाइयों मा द्या, जन `px`।
+    }

--- a/packages/i18n/locales/gbm/editor.ftl
+++ b/packages/i18n/locales/gbm/editor.ftl
@@ -25,9 +25,10 @@
 #
 # **Nothing selects on a plural category.** CLDR has no plural data for
 # `gbm`, so `lint:i18n` would reject a `[one]` branch outright. Every count
-# in this file goes through a single `*[other]`, keeping only
-# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
-# number itself rather than against a category.
+# in this file is written with one form and no selector at all. The
+# catalog's one branch on a number is `attempts-remaining`'s explicit `[0]`
+# in `chrome.ftl`, which Fluent matches against the number itself rather
+# than against a category.
 
 ## The viewer's controls
 

--- a/packages/i18n/locales/gbm/editor.ftl
+++ b/packages/i18n/locales/gbm/editor.ftl
@@ -1,0 +1,218 @@
+# Garhwali (गढ़वळि) editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker and the context-help panel beside them. Translated
+# from `locales/en/editor.ftl`, which is the source of truth.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Garhwali is written in.
+#
+# **Method, stated plainly.** Garhwali has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Garhwali
+# speaker meets in an Uttarakhand classroom, which teaches out of Hindi
+# textbooks. What is Garhwali here is the grammatical layer written over it:
+# the genitive कु / की / का rather than Hindi का / की / के, the object marker
+# तैं, the copula च (plural छन), the negative नि, मा for *in*, बटि for
+# *from*, दगड़ि for *with*, अर for *and*, जु for *if*, कुण for *for*, क्यांकि
+# for *because*, and the -आ imperative (करा, दिखावा, हटावा) Garhwali puts on a
+# button. A reviewer should read this as Garhwali grammar over Hindi
+# terminology and is free to replace the terminology wherever Garhwali has its
+# own word.
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `gbm`, so `lint:i18n` would reject a `[one]` branch outright. Every count
+# in this file goes through a single `*[other]`, keeping only
+# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
+# number itself rather than against a category.
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करा
+       *[update] अद्यतन करा
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्शक { $word }
+       *[other] दर्शक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = रूपांतर
+editor-variant-filter = फ़िल्टर...
+editor-variant-next = अगलु रूपांतर छांटा
+editor-variant-previous = पिछलु रूपांतर छांटा
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पाया गया। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } कुण क्लिक करा।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } कुण क्लिक करा। कोई WCAG AA उल्लंघन नि मिला, पर सुगम्यता संबंधी अन्य सुझाव छन।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } कुण क्लिक करा। कोई सुगम्यता समस्या नि मिली।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पाया गया। { $count } WCAG AA उल्लंघन मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } कुण क्लिक करा।
+        [advisories] कोई WCAG AA उल्लंघन नि मिला। सुगम्यता संबंधी { $count } अन्य सुझाव मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } कुण क्लिक करा।
+       *[clean] कोई WCAG AA उल्लंघन नि मिला। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } कुण क्लिक करा।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग अनुसार सहायता
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटियाँ
+editor-tab-warnings = चेतावनियाँ
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = भेजे गए उत्तर
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक विकल्प
+editor-format-as-doenetml = DoenetML रूप मा स्वरूपित करा
+editor-format-as-xml = XML रूप मा स्वरूपित करा
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कोई त्रुटि नि
+editor-no-warnings = कोई चेतावनी नि
+editor-no-info = कोई सूचनात्मक निदान नि
+
+editor-show-info-annotations = संपादक मा सूचनात्मक निदान दिखावा
+editor-show-accessibility-annotations = संपादक मा सुगम्यता निदान दिखावा
+
+editor-accessibility-learn-more = जाणा कि Doenet सुगम्यता तैं किस तरह देखता च
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = अन्य सुगम्यता समस्याएँ
+editor-none-found = कुछ नि मिला
+
+
+## Submitted responses
+
+editor-no-responses = अभी तक कोई उत्तर नि भेजा गया
+editor-response-answer-id = उत्तर आईडी
+editor-response-response = उत्तर
+editor-response-credit = अंक
+editor-response-submitted = भेजा गया
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेज़ीकरण देखण कुण कर्सर तैं टैग नाम, विशेषता या { $ref } पर धरा।
+
+help-unsupported-ref-chain = { $example } जन बहु-भागीय संदर्भों की सहायता अभी उपलब्ध नि च।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] यै संदर्भ कु कोई लक्ष्य नि मिला: { $ref }।
+        [multiple] यै संदर्भ का कई लक्ष्य मिले: { $ref }।
+       *[indeterminate] { $ref } कु लक्ष्य निर्धारित नि किया जा सका।
+    }
+
+help-learn-about-references = संदर्भों का बारा मा जाणा →
+help-reference-page = संदर्भ पृष्ठ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } का भितर
+       *[top] शीर्ष स्तर पर
+    }{ $allowed ->
+        [none] { " — यहाँ कुछ नि रखा जा सकद।" }
+        [text] { " — यहाँ पाठ लिखा जा सकद च।" }
+        [text-and-components] { " — यहाँ पाठ लिखा, या ये अजमावा:" }
+       *[components] { " — ये अजमावा:" }
+    }
+
+help-suggestions-footer = सभी { $total } घटक देखण कुण { $shortcut } दबावा।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } कु संदर्भ च।
+       *[other] { $ref }, { $target } कु संदर्भ च (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } द्वारा { $role } का रूप मा लाया गया।
+       *[other] { $owner } द्वारा पंक्ति { $line } मा { $role } का रूप मा लाया गया।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } का { $property } गुण कु संदर्भ च।
+       *[other] { $ref }, { $element } का { $property } गुण कु संदर्भ च (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड अंश
+help-kind-array-entry = सरणी प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = प्रभावी पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] अनुमत मान (प्रति मद एक):
+       *[other] अनुमत मान:
+    }
+
+help-suggested-values = सुझाए गए मान:
+
+help-inserts = जोड़ता च:
+
+help-coordinates = निर्देशांक:
+
+help-type = प्रकार:
+
+help-resolved-style = निर्धारित शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = निर्धारित फलन नाम:
+help-reset-list = यै इनपुट की रीसेट सूची:
+help-added-on-input = यै इनपुट पर जोड़ा गया:
+help-removed-on-input = यै इनपुट पर हटाया गया:
+
+help-reset-overrides = { $reset }, { $additional } अर { $removed } पर वरीयता रखता च।

--- a/packages/i18n/locales/grt/chrome.ftl
+++ b/packages/i18n/locales/grt/chrome.ftl
@@ -1,0 +1,192 @@
+# Garo (A·chik ku·rang) viewer chrome: the buttons, panel headings and status
+# words the reader interacts with. Rendered on the main thread and selected by
+# `uiLocale`. Translated from `locales/en/chrome.ftl`, which is the source of
+# truth: `lint:i18n` rejects a key that does not exist there, and reports a key
+# that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to fix it.
+#
+# **Script: Latin, and this is a deliberate departure from the roster's rule.**
+# Everywhere else in these catalogs the script is whatever CLDR fills the bare
+# tag in as — that is why `sr` is Cyrillic and `mni` is Bengali. ICU maximizes
+# a bare `grt` to **`grt-Beng`**, the Bengali script Garo was also written in
+# across the Assam side of the border. This catalog writes **Latin anyway**,
+# because Latin is what a Garo reader in Meghalaya actually reads: it has been
+# the script of Garo since the mission presses of the 1870s, and it is what
+# Garo schoolbooks, the Garo newspapers and the Garo Bible are set in. The
+# header says so rather than leaving it to be discovered. Converting this
+# catalog to Bengali letters means converting **all four files at once**; a
+# half-converted catalog is worse than either choice.
+#
+# **The raka is written with the middle dot «·» (U+00B7)**, everywhere in all
+# four files — «A·chik», «ong·a», «dal·gipa», «ja·man», «man·ja». It is one
+# character throughout, so a search for `·` finds every one of them. No
+# apostrophe is used for it anywhere.
+#
+# **Much of the technical vocabulary here is an English loan, and that is
+# stated rather than hidden.** Meghalaya teaches mathematics and secondary
+# science in English, and Garo has a long missionary-orthography and
+# English-medium schooling tradition, so the classroom words for a row, a
+# column, a matrix, a keyboard, an interval, a box or an arrow *are* the
+# English ones. They are written here as English rather than respelled into a
+# Garo shape the language does not give them. A second, smaller group is
+# Assamese- or Bengali-derived and is the register Garo prose already carries:
+# «bhul» for an error, «sabdanani» for a warning, «khobor» for information,
+# «khali» for empty, «lebel», «kredit», «bondho».
+#
+# **What is Garo here is the frame**, and it is used consistently: «ong·a» /
+# «ong·ja» for is and is not (so *correct* is «ong·gipa» and *incorrect*
+# «ong·gija», and *invalid* is «ong·gijagipa»), «man·a» / «man·ja» for can and
+# cannot, «nanga» for must, «baha·a» for use, «rakki·a» for keep, «chesot·a»
+# for try, «nik·a» for see, «dongat·a» for add and «ra·kat·a» for remove,
+# «skang» for previous and «ja·man» for next, «aro sa·bsa» for again, «-rang»
+# for a plural, «-ni» for a genitive and «-o» for a locative. The attributive
+# «-gipa» is used to make a describing word, including on a loan stem.
+#
+# **Words a reviewer should check first**, in this file: «sabdanani» for
+# *warning* and «pinigijabo» for *hide* — the second is a transparent "do not
+# show" rather than a word, and Garo will have a better one; «sokna man·ani»
+# for *accessibility*; and «chesotani» for an *attempt*.
+#
+# Numbers render in Latin digits (#1615). **Nothing in this catalog selects on
+# a count**: a Garo noun is unmarked after a numeral, and CLDR has no plural
+# data for `grt` in any case, so every English plural select is collapsed to
+# its `*[other]` wording. The numeric literal `[0]` in `attempts-remaining` is
+# kept exactly where English has it — it is a literal, not a plural category.
+
+
+## Answer submission
+
+answer-checking = Nikenga...
+answer-submitting = On·enga...
+
+answer-checking-status = Aganchakanikon nikenga
+answer-submitting-status = Aganchakanikon on·enga
+
+answer-correct = Ong·gipa
+answer-incorrect = Ong·gija
+
+answer-response-saved = Aganchakani Rakkiaha
+
+answer-percent-credit = { $percent }% Kredit
+answer-percent-correct = { $percent }% Ong·gipa
+answer-percent-short = { $percent } %
+
+max-credit-available = Bang·bata man·gipa kredit: { $percent }%
+
+# No count select: a Garo noun is unmarked after a numeral. The `[0]` branch is
+# English's own numeric literal and stays.
+attempts-remaining =
+    { $count ->
+        [0] chesotani dongja
+       *[other] { $count } chesotani donga
+    }
+
+validation-correct = (Ong·gipa)
+validation-incorrect = (Ong·gija)
+validation-partially-correct = (Bak ong·gipa)
+
+answer-show-responses = { $answerId }-ni { $count } aganchakanikon pinibo
+
+
+## Disclosure panels
+
+feedback-heading = Fidbek
+
+collapsible-click-to-open = (khena klik ka·bo)
+collapsible-click-to-close = (bondho ka·na klik ka·bo)
+
+collapsible-initializing = Ja·rikatenga...
+
+footnote-show = Futnotko pinibo
+footnote-hide = Futnotko pinigijabo
+
+description-more-information = bang·bata khobor
+
+
+## Controls
+
+slider-previous = Skang
+slider-next = Ja·man
+
+keyboard-open = Kibordko Khebo
+keyboard-close = Kibordko Bondho Ka·bo
+
+choice-input-remove-choice = { $choice }-ko ra·katbo
+
+matrix-remove-row = Row-ko ra·katbo
+matrix-add-row = Row dongatbo
+matrix-remove-column = Column-ko ra·katbo
+matrix-add-column = Column dongatbo
+
+subset-add-remove-points = Pointrangko dongatbo/ra·katbo
+subset-toggle-points-intervals = Pointrang aro intervalrangko salbo
+subset-move-points = Pointrangko Chalaibo
+subset-clear = Khali Ka·bo
+
+orbital-add-row = Row Dongatbo
+orbital-remove-row = Row-ko Ra·katbo
+orbital-add-box = Boks Dongatbo
+orbital-remove-box = Boks-ko Ra·katbo
+orbital-add-up-arrow = Up Arrow Dongatbo
+orbital-add-down-arrow = Down Arrow Dongatbo
+orbital-remove-arrow = Arrow-ko Ra·katbo
+
+orbital-row-label = Row { $row }-ni lebel
+
+pretzel-answer = Aganchakani
+
+summary-statistics-caption = { $column }-ni summary statistics
+
+
+## Math input
+
+math-input-preview-region = math expression-ni skang nikani
+math-input-preview = Skang Nikani
+math-input-invalid-expression = Ong·gijagipa expression:
+
+
+## Document status
+
+viewer-initializing = Ja·rikatenga...
+
+
+## Errors
+
+error-heading = Bhul
+
+error-found-at =
+    { $span ->
+        [line] Lain { $startLine }-o man·aha.
+       *[lines] Lain { $startLine }–{ $endLine }-o man·aha.
+    }
+
+document-contains-errors = Ia dokumento bhulrang donga!
+
+diagnostic-heading-error = Bhul
+diagnostic-heading-warning = Sabdanani
+diagnostic-heading-information = Khobor
+diagnostic-heading-hint = Dakchakani
+
+accessibility-heading-level-1 = WCAG AA Sokna man·anini bhul
+accessibility-heading-level-2 = Sokna man·anini sabdanani
+
+something-went-wrong = Maiba bhul ong·aha.
+
+renderer-load-failed = renderer sa·gipa lodo ong·jaha. Pejko aro sa·bsa lodo ka·bo.
+
+core-start-failed = Ia dokumentoko ja·rikatna man·jaha. Pejko aro sa·bsa lodo ka·bo.
+
+core-start-failed-busy = Ia dokumentoko ja·rikatna man·jaha. Bang·gipa dokumentrang sasa somoyo ja·rikatengaha, aro dingdingrata deviceo iaba bang·gipa somoyko ra·gen. Gipin dokumentrang ong·chinaha ja·mano pejko aro sa·bsa lodo ka·ani dakchakgen.
+
+core-start-failed-retry = Ia dokumentoko ja·rikatna man·jaha.
+
+core-start-failed-busy-retry = Ia dokumentoko ja·rikatna man·jaha. Bang·gipa dokumentrang sasa somoyo ja·rikatengaha, aro dingdingrata deviceo iaba bang·gipa somoyko ra·gen.
+
+core-start-retry = Aro sa·bsa chesotbo
+
+saved-state-unavailable = Na·ni rakkigipa kamko lodo ka·na man·jaha.

--- a/packages/i18n/locales/grt/chrome.ftl
+++ b/packages/i18n/locales/grt/chrome.ftl
@@ -41,8 +41,8 @@
 # **What is Garo here is the frame**, and it is used consistently: «ong·a» /
 # «ong·ja» for is and is not (so *correct* is «ong·gipa» and *incorrect*
 # «ong·gija», and *invalid* is «ong·gijagipa»), «man·a» / «man·ja» for can and
-# cannot, «nanga» for must, «baha·a» for use, «rakki·a» for keep, «chesot·a»
-# for try, «nik·a» for see, «dongat·a» for add and «ra·kat·a» for remove,
+# cannot, «nanga» for must, «baha» for use, «rakkia» for keep, «chesota»
+# for try, «nika» for see, «dongata» for add and «ra·kata» for remove,
 # «skang» for previous and «ja·man» for next, «aro sa·bsa» for again, «-rang»
 # for a plural, «-ni» for a genitive and «-o» for a locative. The attributive
 # «-gipa» is used to make a describing word, including on a loan stem.

--- a/packages/i18n/locales/grt/content.ftl
+++ b/packages/i18n/locales/grt/content.ftl
@@ -21,8 +21,9 @@
 # Garo's closest relative in the roster and records the same order for the same
 # reason: a Tibeto-Burman describing word stands in front of its noun and never
 # moves. It is worth saying that this puts Garo at odds with the other two
-# catalogs of its own batch, which are both postnominal — the order here is a
-# fact about the family, not about the batch.
+# catalogs of Northeast India seeded in the same batch — `kha` and `lus`, both
+# postnominal — while agreeing with the batch's twelve others. The order here
+# is a fact about the family, not about the region.
 #
 # **No `$gender` fork and no `$role` fork.** Garo has no grammatical gender and
 # no adjective agreement of any kind, and its describing words — stative verbs

--- a/packages/i18n/locales/grt/content.ftl
+++ b/packages/i18n/locales/grt/content.ftl
@@ -1,0 +1,338 @@
+# Garo (A·chik ku·rang) content catalog: the prose the core computes into the
+# document — style descriptions ("thick red line"), boolean words, section
+# names, the paginator's status line. Selected by `documentLocale`, the
+# language the activity was written in, rather than by the reader's UI
+# language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to fix it.
+#
+# **Script: Latin.** ICU maximizes a bare `grt` to `grt-Beng`, and this
+# catalog writes Latin anyway, because Latin is what a Garo reader in
+# Meghalaya reads. `chrome.ftl` carries the full argument; converting this
+# catalog to Bengali letters means converting all four files at once. The raka
+# is the middle dot «·» throughout.
+#
+# **Word order: prenominal — the description comes BEFORE the noun.**
+# `style-with-noun` and `style-filled-with-noun` keep English's order of
+# `{ $description }` then `{ $noun }`, so a thick dashed red line reads
+# «dal·gipa dashgipa gitchak lain». This follows `locales/brx`, Bodo, which is
+# Garo's closest relative in the roster and records the same order for the same
+# reason: a Tibeto-Burman describing word stands in front of its noun and never
+# moves. It is worth saying that this puts Garo at odds with the other two
+# catalogs of its own batch, which are both postnominal — the order here is a
+# fact about the family, not about the batch.
+#
+# **No `$gender` fork and no `$role` fork.** Garo has no grammatical gender and
+# no adjective agreement of any kind, and its describing words — stative verbs
+# used attributively, carrying the «gi-»/«-gipa» shapes, «gitchak»,
+# «dal·gipa» — never change for the position the phrase they belong to goes
+# into. So `noun-gender` answers the single token `neuter`, and every
+# composition message ignores both arguments. Both of those are claims about
+# the language rather than gaps in the seed. This is `locales/brx`'s finding a
+# second time from the same branch.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` and leaves
+# `tail` empty, as English does: the side count stands in front of the noun
+# with everything else, so there is no complement to put behind the
+# describing words. The `-tail` branches are still written out, because a
+# partly-translated locale falls back through them.
+#
+# **Nothing selects on a count.** A Garo noun is unmarked after a numeral — it
+# counts with a classifier this frame has no place for — and CLDR has no
+# plural data for `grt` in any case. Every English plural select is collapsed
+# to its `*[other]` wording.
+#
+# **`piecewise-condition-if` is where the frame and the grammar disagree, and
+# it is this file's sharpest open question.** Garo's own conditional is the
+# **verbal suffix «-oba»**, which is clause-final: it is welded to the end of
+# the verb of the condition. The renderer places this word *in front of* the
+# mathematics it introduces, so «-oba» cannot be written here at all — there is
+# no verb in the catalog for it to attach to, and nothing follows it that it
+# could attach to either. So the seed takes the README's second way out,
+# *reach for a word that can stand beside it*, and uses the free conjunction
+# **«jodi»**, Assamese-derived and already carried by Garo prose, which can
+# stand in front. `piecewise-condition-otherwise` needs no such trick and uses
+# the well-formed «ong·jaoba», "if it is not" — which is «-oba» doing its
+# proper job, one line below the place it could not.
+#
+# **The vocabulary splits three ways, and the split is declared rather than
+# hidden.** Meghalaya teaches mathematics in English out of English textbooks,
+# so the geometry and computing nouns here — line, ray, vector, curve,
+# function, parabola, polygon, triangle, rectangle, circle, point, square,
+# diamond, region, horizontal, vertical, diagonal — are written as **English
+# loans**, because that is what the classroom says. So are nine of the twelve
+# colours. What is **Garo** is: «gitchak» red, «gipok» white, «gisim» black;
+# «dal·gipa» big and «chon·gipa» small for a stroke's thick and thin; «ong·a»
+# and «ong·ja» for true and false; «sing·ani» question and «aganchakani»
+# answer; «skang» previous and «ja·man» next; «bak» part; «kam» work. A third
+# group is **Assamese- or Bengali-derived** and is the register Garo schooling
+# already carries: «sanggya», «uddahoron», «abbash», «tippani», «anuchhed»,
+# «somossa», «proman», «bibag», «somadan», «upapadya», «sarni», «chitro»,
+# «pata», «jodi», «bhorti».
+#
+# **Four things to check before anything else here.** «dal·gipa» / «chon·gipa»
+# for a stroke's thick and thin is the ordinary pair for large and small, and
+# it is `locales/brx`'s and `locales/mni`'s guess rather than a verified
+# term — it is the first thing to put to a speaker. «bhorti» for *filled* is a
+# loan standing in for a Garo word the seed could not supply. The nine loan
+# colours are loans, not Garo, and are marked as such rather than invented: no
+# colour term is written here that the seed is not confident of. And
+# «ong·jaoba» is the only place «-oba» appears at all.
+
+
+## Style vocabulary
+
+# Three of these are Garo — gitchak, gipok, gisim. The other nine are English
+# loans written as English, not Garo words: the seed does not invent a colour
+# term it is not confident of.
+color =
+    .black = gisim
+    .white = gipok
+    .gray = gray
+    .red = gitchak
+    .orange = orange
+    .yellow = yellow
+    .green = green
+    .cyan = cyan
+    .blue = blue
+    .purple = purple
+    .pink = pink
+    .brown = brown
+
+# The ordinary words for large and small, as Bodo and Meitei both do. Check
+# this pair first.
+line-width =
+    .thick = dal·gipa
+    .thin = chon·gipa
+
+# A loan stem carrying the Garo attributive «-gipa», which is how Garo makes a
+# describing word out of a borrowed one.
+line-style =
+    .dashed = dashgipa
+    .dotted = dotgipa
+
+fill-style =
+    .horizontal = horizontal lainrang
+    .vertical = vertical lainrang
+    .diagonal = diagonal lainrang
+    .backdiagonal = ulta diagonal lainrang
+    .dots = dotrang
+    .diamonds = diamondrang
+
+noun =
+    .line = lain
+    .line-segment = lain segment
+    .ray = ray
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = triangle
+    .rectangle = rectangle
+    .circle = circle
+    .region = region
+    .point = point
+    .square = square
+    .diamond = diamond
+    .cross = cross
+    .plus = plus
+
+# «-bakgipa» takes the side count and stands in front of the noun with
+# everything else, so nothing follows the describing words and the tail is
+# empty. The ending has one shape whatever number lands before it.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides }-bakgipa regular polygon
+    }
+
+# Nothing selects on it: Garo has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# Prenominal, as Bodo is: the description stands in front of the noun.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = bhortigipa
+
+# «-chi» is the instrumental and follows what it governs, so the pattern moves
+# to the front of the phrase where English appends it. It has one shape
+# whatever precedes it, so writing it onto a placeable is sound.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern }-chi { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern }-chi { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern }-chi { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# Garo has no article, so the two `-article` branches read like their
+# neighbours; «aro» is the conjunction and stands in front. «-chi» here is the
+# comitative, and again has one shape.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } border-chi
+        [and] aro { $border } border-chi
+        [and-article] aro { $border } border-chi
+       *[with] { $border } border-chi
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = bhorti ong·gija
+
+# «-o» is the locative and has one shape too.
+style-text =
+    { $parts ->
+        [background] { $background } background-o { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = maiba dongja
+
+
+## Boolean words
+
+boolean-true = ong·a
+boolean-false = ong·ja
+
+
+## Answer buttons
+
+answer-submit-label = Kamko Nikbo
+answer-submit-label-no-correctness = Aganchakanikon On·bo
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kam
+    .aside = Bak ku·ra
+    .cascade = Cascade
+    .definition = Sanggya
+    .example = Uddahoron
+    .exercise = Abbash
+    .exercises = Abbash
+    .given-answer = Aganchakani
+    .note = Tippani
+    .objectives = Uddesyo
+    .paragraphs = Anuchhed
+    .part = Bak
+    .problem = Somossa
+    .problems = Somossa
+    .proof = Proman
+    .question = Sing·ani
+    .section = Bibag
+    .solution = Somadan
+    .task = Dakani kam
+    .theorem = Upapadya
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Dakchakani
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Sarni { $enumeration }
+        [numbered-title] Sarni { $enumeration }{ ": " }
+        [unnumbered-title] Sarni{ ": " }
+       *[unnumbered] Sarni
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Chitro { $enumeration }
+        [numbered-caption] Chitro { $enumeration }{ ": " }
+        [unnumbered-caption] Chitro{ ": " }
+       *[unnumbered] Chitro
+    }
+
+
+## Paginator controls
+
+paginator-previous = Skanggipa
+paginator-next = Ja·mangipa
+paginator-page = Pata
+
+# «-oni» is the ablative — "out of" — and it follows the total, so the two
+# counts change places against English. It has one shape whatever precedes it.
+paginator-page-status = { $numPages }-oni { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+##
+## «jodi» is a free conjunction that can stand in front of the mathematics.
+## Garo's own conditional «-oba» cannot: see the header.
+
+piecewise-condition-or = ba
+piecewise-condition-if = jodi
+piecewise-condition-otherwise = ong·jaoba
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are **deliberately absent**, so all
+## 130 of those keys fall back to English and `lint:i18n` reports the gap.
+##
+## Meghalaya teaches secondary chemistry in English, out of English textbooks,
+## so the element names a Garo student actually meets are the English ones. A
+## Garo table here would not be a translation; it would be a claim about how
+## to spell "Praseodymium" in Garo letters, and no such convention exists to
+## report. Falling back to English shows the student the word their own
+## textbook uses. Whoever fills this in should be filling in a list Garo
+## chemistry teaching already carries, not inventing one.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Ong·gijagipa rasayonik chinho
+chemistry-invalid-ionic-compound = Ong·gijagipa ayonik jougik
+
+## Inputs embedded in math
+
+math-embedded-input-blank = khali
+
+math-embedded-input-blank-ordinal = { $total }-oni khali { $ordinal }

--- a/packages/i18n/locales/grt/diagnostics.ftl
+++ b/packages/i18n/locales/grt/diagnostics.ftl
@@ -1,0 +1,672 @@
+# Garo (A·chik ku·rang) diagnostics: the warnings and errors the worker raises,
+# addressed to whoever is looking at the screen and so selected by `uiLocale`
+# rather than by `documentLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to fix it.
+#
+# **Script: Latin.** ICU maximizes a bare `grt` to `grt-Beng`; this catalog
+# writes Latin anyway, because Latin is what a Garo reader in Meghalaya reads.
+# `chrome.ftl` carries the full argument, and a conversion to Bengali letters
+# is a conversion of all four files at once. The raka is the middle dot «·».
+#
+# **Every DoenetML name in these messages stays in English exactly as
+# written** — `through`, `endpoint`, `midpointOffset`, `numDimensions`,
+# `selectFromSequence`, `sectionWideCheckWork`, `WCAG AA`, the `[deprecation]`
+# marker, and every tag, attribute and attribute value beside them. They are
+# part of the language, not prose.
+#
+# **Most of the remaining technical vocabulary is an English loan too, and
+# that is stated rather than hidden.** Meghalaya teaches mathematics and
+# secondary science in English, so circle, point, function, sequence, matrix,
+# domain, interval, index, format and their neighbours are written here as
+# English: those are the words the classroom uses. The Garo in this file is
+# the frame, and it is used consistently: «man·ja» cannot, «man·jaha» could
+# not, «nanga» must, «ra·gija» is ignored, «baha·a» use, «man·aha» found,
+# «dongja» there is none, «mikkang ka·ja» does not match, «maina» because,
+# «indiba» but, «ba» or, «aro» and, «uni gimin» so, «-oni» ablative, «-chi»
+# instrumental, «-ko» accusative, «-o» locative, «-rang» plural, «-gipa» the
+# attributive. A third, smaller group is Assamese- or Bengali-derived and is
+# the register Garo prose already carries: «bhul», «sabdanani», «khali»,
+# «somadan», «nirbhor», «bhagyo».
+#
+# **Nothing in this file selects on a count.** A Garo noun is unmarked after a
+# numeral, and CLDR has no plural data for `grt`, so every English plural
+# select is collapsed to its `*[other]` wording, keeping the placeables that
+# wording uses. The one numeric literal is `[1]` in
+# `field-function-wrong-num-outputs`, which is a count of outputs rather than
+# a plural category, and it stays exactly where English has it.
+#
+# Words a reviewer should check first here: «sabdanani» for a warning,
+# «ong·gijagipa» for *invalid* — a transparent "not being so" rather than a
+# word — and «bang·ani» for *number of*.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = gni endpoint on·ahani gimin { $attributes }-ko ra·gija
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = sa endpoint aro sa midpoint gnianibaba on·ahani gimin { $attributes }-ko ra·gija
+
+line-segment-midpoint-offset-without-midpoint = midpoint dongjaode midpointOffset kam ka·ja
+
+## `<line>`
+
+line-points-undetermined-dimensions = Dimension-rangko sikna man·gija point-rangchi re·gipa lain.
+
+line-points-too-few-dimensions = Lain kamsa gni dimension gnanggipa point-rangchi re·na nanga.
+
+line-points-depend-on-variables = Lain ia variable-rango nirbhor ka·gipa point-rangchi re·a: { $variables }.
+
+line-equation-invalid-format = { $variable1 } aro { $variable2 } variable-rango lain-ni equation-ni gimin ong·gijagipa format.
+
+## `<ray>`
+
+ray-overprescribed-through = Ray-ko through, endpoint aro direction-chi songaha.  On·ahagipa through-ko ra·gija.
+
+ray-dimension-mismatch = Ray-o numDimensions mikkang ka·ja.
+
+## `<vector>`
+
+vector-overprescribed-head = Vector-ko head, tail aro displacement-chi songaha.  On·ahagipa head-ko ra·gija.
+
+vector-dimension-mismatch = Vector-o numDimensions mikkang ka·ja.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>`-chi attract ka·na man·ja, maina uo nearestPoint state variable dongja.
+
+constrain-to-without-nearest-point = `<{ $component }>`-chi constrain ka·na man·ja, maina uo nearestPoint state variable dongja.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>`-ni bitcho constrain ka·na man·ja, maina uo nearestPoint state variable dongja.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline ong·gija choiceInput-ni gimin labelPosition-ko ra·gija
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-ni gimin on·ahagipa indices-ko ra·gija, maina indices-ni bang·ani choice bi·sarangni bang·anichi mikkang ka·ja.
+
+pretzel-indices-count-mismatch = problem-ni gimin on·ahagipa indices-ko ra·gija, maina indices-ni bang·ani problem bi·sarangni bang·anichi mikkang ka·ja.
+
+shuffle-indices-count-mismatch = shuffle-ni gimin on·ahagipa indices-ko ra·gija, maina indices-ni bang·ani component-rangni bang·anichi mikkang ka·ja.
+
+indices-ignored-out-of-range = { $component }-ni gimin on·ahagipa indices-ko ra·gija, maina maisa indices range-ni gisepo dongja.
+
+pretzel-indices-repeated = pretzel-ni gimin on·ahagipa indices-ko ra·gija, maina maisa indices sa·bsa re·baha.
+
+pretzel-circuit-first-index = circuit mode-o pretzel-ni gimin on·ahagipa indices-ko ra·gija, maina skanggipa index 1 ong·na nanga.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` string bi·sarangchi kam ka·na `type` attribute-ko on·na nanga.
+
+invalid-type-defaulting-to-math = { $component } component-ni gimin ong·gijagipa type { $type }. Ua math, text, number ba boolean-ni giseponi sa ong·na nanga. math-ko bahaenga.
+
+string-not-valid-component-to-arrange = "{ $value }" string { $component } ka·na kamgipa component ong·ja. Ra·gija.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Ong·gijagipa type { $type }, type-ko number ka·enga.
+
+invalid-variable-value = Variable-ni ong·gijagipa man: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant index { $index } number ong·na nanga
+
+variant-index-must-be-integer = Variant index { $index } integer ong·na nanga
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` absolute maprangni gimin dakahani dongja. Width-rangko relative ka·enga.
+
+side-by-side-absolute-margins = `<{ $component }>` absolute maprangni gimin dakahani dongja. Margin-rangko relative ka·enga.
+
+side-by-side-no-block-child = Ong·gijagipa `<{ $component }>`: iao kamsa sa block bi·sa dongna nanga.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Graphical `<label>`-o `for` attribute-ko ra·gija.
+
+label-for-must-resolve-to-one = `<label>`-o `for` attribute kamsa sa component-onosa sokna nanga.
+
+label-for-unresolved = `<label>`-o `for` attribute-ko component-o sokatna man·jaha.
+
+label-for-answer-with-authored-inputs = `<label>`-o `for` attribute author-ni an·tangon seahagipa input gnanggipa `<answer>`-ko sikpiengaha; input-onosa reference ka·bo.
+
+label-for-answer-without-input = `<label>`-o `for` attribute label ka·na input gnanggija `<answer>`-ko sikpiengaha.
+
+label-for-must-reference-input-or-answer = `<label>`-o `for` attribute input ba answer-ko reference ka·na nanga.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Sokna man·anini gimin, `<{ $component }>`-o chon·gipa bewalani dongna nanga ba uako decorative gita songna nanga.
+
+accessibility-video-short-description = Sokna man·anini gimin, `<video>`-o chon·gipa bewalani dongna nanga.
+
+accessibility-input-short-description-or-label = Sokna man·anini gimin, `<{ $component }>`-o chon·gipa bewalani ba label dongna nanga.
+
+accessibility-answer-input-short-description-or-label = Sokna man·anini gimin, input dakgipa `<answer>`-o chon·gipa bewalani ba label dongna nanga.
+
+accessibility-short-description-contains-math = Chon·gipa bewalanirango `<{ $component }>` gita math component-rang dongna nangja. Math-ko ku·rangchi segatbo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName }-ni contrast bibag-ni khoro ku·rani gimin man·gija (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kamsa { $threshold }:1 nanga).
+       *[other] { $colorName }-ni contrast bibag-ni khoro ku·rani gimin man·gija ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kamsa { $threshold }:1 nanga).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Point-rango numerical man dongjaode `<circle>`-ko { $count } point-rangchi dakahani dongja.
+
+circle-too-many-through-points = 3-oni bang·bata point-rangchi re·gipa circle-ko hisap ka·na man·ja.
+
+circle-overprescribed-radius-center-points = On·ahagipa radius, center aro through point-rangchi circle-ko hisap ka·na man·ja.
+
+circle-center-with-multiple-points = On·ahagipa center-chi 1-oni bang·bata point-rangchi re·gipa circle-ko hisap ka·na man·ja.
+
+circle-radius-too-small = Circle-ko hisap ka·na man·ja: gni point-rangni gisepni distance { $distance } ong·ani gimin, on·ahagipa radius { $radius } buktuk chon·a.
+
+circle-radius-with-many-points = On·ahagipa radius-chi gni-oni bang·bata point-rangchi re·gipa circle-ko dakna man·ja.
+
+circle-invalid-center-or-through-points = Circle-ni ong·gijagipa center ba through point-rang.
+
+circle-radius-center-with-multiple-points = On·ahagipa center-chi 1-oni bang·bata point-rangchi re·gipa circle-ni radius-ko hisap ka·na man·ja.
+
+circle-change-radius-non-numerical = Numerical ong·gija through point-rang gnanggipa circle-ni radius-ko salna man·ja
+
+circle-radius-with-points-non-numerical = Numerical man dongjaode on·ahagipa radius-chi sa-oni bang·bata point-rangchi re·gipa circle-ko dakna man·ja.
+
+circle-change-center-non-numerical = Numerical ong·gija point-rangchi re·gipa circle-ni center-ko salani da·o dakahani dongja.
+
+## `<function>`
+
+# No count select: a Garo noun is unmarked after a numeral, so English's two
+# nested plurals collapse to one wording that keeps both placeables.
+function-domain-insufficient-dimensions = Function-ni domain-ni gimin dimension-rang man·gija. Domain-o { $intervals } interval donga indiba function-o { $inputs } input donga.
+
+function-domain-invalid-format = Function-ni domain-ni gimin ong·gijagipa format.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Function-ni numerical ong·gija maximum-ko ra·gija.
+        [minimum] Function-ni numerical ong·gija minimum-ko ra·gija.
+        [extremum] Function-ni numerical ong·gija extremum-ko ra·gija.
+        [point] Function-ni numerical ong·gija point-ko ra·gija.
+        [slope] Function-ni numerical ong·gija slope-ko ra·gija.
+       *[other] Function-ni numerical ong·gija { $type }-ko ra·gija.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Function-ni khaligipa maximum-ko ra·gija.
+        [minimum] Function-ni khaligipa minimum-ko ra·gija.
+        [extremum] Function-ni khaligipa extremum-ko ra·gija.
+        [point] Function-ni khaligipa point-ko ra·gija.
+       *[other] Function-ni khaligipa { $type }-ko ra·gija.
+    }
+
+function-points-too-close = Function-o buktuk bak·bakgija bakon donggipa gni point donga. Function-ko songna man·ja.
+
+function-iterates-input-output-mismatch = Function iterate-rang function-ni input-rangni bang·ani output-rangni bang·anichi sakkise ong·ode-sa man·gen. Ia function-o { $inputs } input aro { $outputs } output donga.
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence-ni ong·gijagipa length.  Ua 0-oni chon·gija integer ong·na nanga.
+
+sequence-invalid-step = Sequence-ni ong·gijagipa step.  { $type } type-ni sequence-ni gimin ua number ong·na nanga.
+
+sequence-invalid-endpoint-number = Number sequence-ni ong·gijagipa "{ $attribute }".  Ua number ong·na nanga.
+
+sequence-invalid-endpoint-letters = Letters sequence-ni ong·gijagipa "{ $attribute }".  Ua akkor-rangni songjotani ong·na nanga.
+
+sequence-invalid-endpoint = Sequence-ni ong·gijagipa "{ $attribute }".
+
+select-from-sequence-coprime-not-numbers = number-rangko sikgija ong·ani gimin coprime-ko ra·gija
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations-ko songahani gimin coprime-ko ra·gija
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>`-ni gimin ong·gijagipa target: target-ko nikna man·ja.
+
+target-state-variable-not-found = `<{ $source }>`-ni gimin ong·gijagipa target: `<{ $component }>`-o "{ $property }" bimung gnanggipa state variable-ko nikna man·ja.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`-ni variable-rang independent variable-chi dingtang ong·na nanga.
+
+ode-system-duplicate-variable-names = Sa·gita dependent variable bimung gnanggipa ODE RHS function-rangko songna man·ja.
+
+ode-system-rhs-function-error = ODE RHS function-ko songna man·ja.  mathjs function dakengon bhul ong·aha.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } lain-rangni gisepo angle-ko songna man·ja
+
+angle-invalid-through-point = `<angle>`-ni through-o ong·gijagipa point
+
+parabola-vertex-too-many-points = Vertex-chi 1-oni bang·bata point-rangchi re·gipa parabola-ni dakahani dongja.
+
+parabola-too-many-points = 3-oni bang·bata point-rangchi re·gipa parabola-ni dakahani dongja.
+
+intersection-too-many-items = Gni-oni bang·bata jinis-rangni gimin intersection-ni dakahani dongja
+
+## Other math components
+
+ionic-compound-not-two-ions = Gni ion-ko cha·gija gipin jinis-rangni gimin ionic compound-ni dakahani dongja.
+
+ionic-compound-needs-cation-and-anion = Ionic compound sa cation aro sa anion-ni gimin-sa dakaha.
+
+solve-equations-cannot-evaluate = Equation-ko hisap ka·na man·jani gimin equation-ko somadan ka·na man·ja: { $equation }
+
+math-operators-operand-number-required = Math operand-ko ra·katengon operandNumber-ko songna nanga.
+
+eigen-decomposition-failed = Matrix-ni eigenvalue-rangko hisap ka·na man·jaha
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: { $parameters } parameter pattern-o dongja, uni gimin ua somoy pilakon khali jinis-chisa mikkang ka·gen.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }"-ko bujina man·ja. Ua none, medium, dense, ba space-chi bak·ahagipa gni positive number ong·na nanga, dakko grid="1 0.5". Maiba grid-ko seja.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>`-na { $expected ->
+        [1] sa output — point sa·sao slope y', dakko `y - x` — gnanggipa
+       *[other] gni output — point sa·sao vector, dakko `(y, -x)` — gnanggipa
+    } function nanga, indiba on·ahagipa function-o { $found } output donga. { $alternative ->
+        [none] Maiba seja.
+       *[other] Ua function-ni gimin `<{ $alternative }>` ong·gipa component. Maiba seja.
+    }
+
+field-function-attribute-ignored-with-child = `function` attribute-ko ra·gija maina function-ko component-ni bitchoba on·aha; bitchogipako bahaenga. Function-ko gni dakni giseponi sa·chisa on·bo.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` attribute component-ni bitcho seahagipa expression-ni variable-rangko bimung on·a. { $reason ->
+        [function-child] Iao function-ko `<function>` bi·sa gita on·aha, aro ua an·tangni variable-rangko bimung on·a, uni gimin `variables`-ko ra·gija.
+       *[no-expression] Iao ua gita expression on·gija, uni gimin `variables`-ko ra·gija.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure renderer-o xLabelPosition="left"-ko ra·na man·ja; right-position dakanikon bahaenga.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure renderer-o yLabelPosition="bottom"-ko ra·na man·ja; top-position dakanikon bahaenga.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure-o salatna ong·gijagipa axis bound-rang; skanggipa bbox (-10,-10,10,10)-ko bahaenga.
+
+prefigure-invalid-width = `<graph>`: prefigure-o salatna ong·gijagipa width; skanggipa diagram width 425-ko bahaenga.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure-o salatna ong·gijagipa aspectRatio; skanggipa aspect ratio 1-ko bahaenga.
+
+prefigure-grid-spacing-too-fine = `<graph>`: axis-ni seng·rangni gimin grid-ni gisepni bak buktuk chon·a; prefigure renderer-o grid-ko ra·gija.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure renderer-ko bahagijaode annotation-rangko seja.
+
+multiple-annotations-children = `<graph>`-o bang·gipa `<annotations>` bi·sarangko man·aha; ja·mangipa sa·kosa ra·aha, gipin pilakko ra·gija.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Sikna man·gija component type-ko extend ba copy ka·na man·ja: { $type }.
+
+copy-prop-not-found = { $component } type-ni component-o { $property } prop-ko nikna man·jaha
+
+collect-no-source = collect-ni gimin source man·jaha.
+
+collect-invalid-component-type = `<{ $component }>` type-ni component-rangko collect ka·na man·ja, maina ua ong·gijagipa component type.
+
+reference-index-unavailable = `{ $reference }` index-ko reference ka·na man·ja
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` component-o { $action }-ko call ka·na man·ja
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data-ni shape ong·gija.  Row-rangni length sakkise ong·ja. componentIdx :{ $componentIdx }-o man·aha
+
+data-frame-duplicate-column-names = Data-o sa·gita column bimung-rang donga.  componentIdx :{ $componentIdx }-o man·aha
+
+data-frame-missing-column-name = Data-o column-ni bimung dongja.  componentIdx :{ $componentIdx }-o man·aha
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ia answer-ni award an·tangni answer tag-ni on·ahagipa aganchakanio nirbhor ka·a, aro ua ni·gija dakanikon dakatgen.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` gnanggipa container-ni bitcho donggipa `<answer>`-o `maxNumAttempts`-ko songani kam ka·ja, maina chesotani-ni bang·anikon container-a nianga. `maxNumAttempts`-ko container-osa songbo.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` gnanggipa gipin container-ni bitcho donggipa `sectionWideCheckWork` gnanggipa container-o `maxNumAttempts`-ko songani kam ka·ja, maina chesotani-ni bang·anikon agalgipa container-a nianga. `maxNumAttempts`-ko agalgipa container-osa songbo.
+
+answer-attributes-need-symbolic-equality = symbolicEquality-ko songgijaode { $attributes } attribute kam ka·ja.
+
+answer-invalid-type = Answer-ni gimin ong·gijagipa type: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` component-o bimung dongjani gimin, uako module-ni attribute gita bahana man·ja
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` component-ko module-ni attribute gita bahana man·ja, maina `<module>` component type-o "{ $name }" attribute skangonba songaha.
+
+conditional-content-condition-ignored = case ba else bi·sarang gnanggipa `<conditionalContent>` component-o `condition` attribute-ko ra·gija.
+
+slider-markers-type-mismatch = Marker-rangni type slider-ni type-chi mikkang ka·ja.
+
+pretzel-problem-needs-statement-and-answer = Ong·gijagipa pretzel: `<problem>` sa·sao sa `<statement>` aro sa `<answer>` dongna nanga.
+
+pretzel-circuit-first-problem-distractor = Ong·gijagipa pretzel: mode="circuit"-o skanggipa `<problem>` distractor ong·na man·ja.
+
+## Attribute values
+
+attribute-invalid-values = `{ $attribute }` attribute-ni gimin ong·gijagipa man { $values }; ra·gija.
+
+attribute-must-be-references = `{ $attribute }` attribute-ni gimin ong·gijagipa man `{ $value }`. Attribute `$`-chi ja·rikatgipa reference-rangchi songa ong·na nanga.
+
+math-input-invalid-function-names = <mathInput>: { $attribute }-o ong·gijagipa function bimung-rangko ra·gija: { $names }. Bimung sa·sani pinigipa bak kamsa gni akkor (letter ba dash) ong·na nanga; uni ja·mano `|<mathspeak alternative>` re·baba man·gen.
+
+## Building components from the source
+
+component-type-invalid = Ong·gijagipa component type: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } attribute-ko sa·bsa seana man·ja.
+
+attribute-invalid-for-component = `<{ $componentType }>` type-ni component-ni gimin ong·gijagipa attribute "{ $attribute }".
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Style definition { $styleNumber }-o { $context ->
+        [text-on-background] background-ni rong-chi text-ni rong
+        [high-contrast] canvas-chi high-contrast rong
+        [line] canvas-chi lain-ni rong
+        [marker] canvas-chi marker-ni rong
+       *[text-on-canvas] canvas-chi text-ni rong
+    }-ni contrast man·gija{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kamsa { $threshold }:1 nanga).
+
+style-definition-dark-mode-text-background-contrast =
+    Style definition { $styleNumber }-o light mode-ni gimin man·gipa contrast gnanggipa rong-rangko songahaba, ia man-rangoni ra·ahagipa dark-mode rong-rango background-ni rong-chi text-ni rong-ni contrast man·gija ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kamsa { $threshold }:1 nanga). { $suggestion ->
+        [available] Dark mode-o contrast man·china, ba light-mode-ni contrast-ko bang·atbo (dakko { $lightAttribute }="{ $lightColor }" songbo) ba dark-mode-ni rong-ko salatbo (dakko { $darkAttribute }="{ $darkColor }" songbo).
+       *[none] Dark mode-o contrast man·china, light-mode-ni contrast-ko bang·atbo ba ra·ahagipa rong-rangko textColorDarkMode aro/ba backgroundColorDarkMode-chi salatbo.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Style definition { $styleNumber }-o light mode-ni gimin man·gipa contrast gnanggipa text-ni rong-ko songahaba, ia man-oni ra·ahagipa dark-mode text-ni rong-ni contrast canvas-chi man·gija ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kamsa { $threshold }:1 nanga). { $suggestion ->
+        [available] Dark mode-o contrast man·china, ba light-mode-ni contrast-ko bang·atbo (dakko textColor="{ $lightColor }" songbo) ba dark-mode-ni rong-ko salatbo (dakko textColorDarkMode="{ $darkColor }" songbo).
+       *[none] Dark mode-o contrast man·china, light-mode-ni contrast-ko bang·atbo ba ra·ahagipa rong-ko textColorDarkMode-chi salatbo.
+    }
+
+section-multiple-style-palettes = Bibag sa <stylePalette>-kosa sikna man·a; ja·mangipa sa·kosa bahaenga.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina numToSelect 0-oni chon·gija integer ong·ja.
+
+variant-num-to-select-not-constant-number = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina numToSelect sasa donggipa number ong·ja.
+
+variant-with-replacement-not-constant-boolean = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina withReplacement sasa donggipa boolean ong·ja.
+
+variant-select-weight-disables-unique = selectWeight ba selectForVariants gnanggipa option dongode select-ni dingtanggipa variant-rangko bondho ka·a
+
+variant-coprime-undetermined = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina coprime somoy pilakon ong·ja ong·anikon sikna man·ja.
+
+variant-attribute-not-constant = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina { $attribute } sasa donggipa ong·ja.
+
+variant-attribute-not-number = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina { $attribute } number ong·ja.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } type-ni { $component }-ni dingtanggipa variant-rangko sikna man·ja maina { $attribute } { $expected ->
+        [letters-combination] akkor-rangni songjotani
+        [math-expression] kamgipa math expression
+        [integer] integer
+       *[number] number
+    } ong·ja.
+
+variant-length-not-integer = { $component }-ni dingtanggipa variant-rangko sikna man·ja maina length integer ong·ja.
+
+variant-sort-not-implemented = sort gnanggipa { $component }-ni dingtanggipa variant-rangni dakahani dongja
+
+variant-exclude-combinations-not-implemented = excludeCombinations gnanggipa { $component }-ni dingtanggipa variant-rangni dakahani dongja
+
+variant-math-exclude-not-implemented = exclude gnanggipa math type-ni { $component }-ni dingtanggipa variant-rangni dakahani dongja
+
+variant-non-constant-exclude-not-implemented = sasa donggija exclude gnanggipa { $component }-ni dingtanggipa variant-rangni dakahani dongja
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure renderer-o ra·na man·ja; bi·sako ra·gija.
+
+prefigure-descendant-invalid-geometry = { $subject }: sakkigija ba chinggija geometry; bi·sako ra·gija.
+
+prefigure-curve-label-omitted = { $subject }: salatahagipa curve element-rango label-rangko ra·na man·ja; label-ko ra·gija.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ra·na man·gija curve function definition type '{ $definitionType }'; bi·sako ra·gija.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-o ra·na man·gija flipFunctions attribute; bi·sako ra·gija.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-o formula type-ni bi·sa function-rangkosa ra·na man·a; bi·sako ra·gija.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] lain-ni bakni label
+       *[point] point-ni label
+    }-ni gimin ra·na man·gija labelPosition '{ $labelPosition }'; skanggipa PreFigure alignment-ko bahaaha.
+
+prefigure-fill-style-unsupported = { $subject }: fill style '{ $fillStyle }'-ko PreFigure ra·na man·ja; solid fill-chi salaha.
+
+prefigure-line-style-unknown = { $subject }: sikna man·gija line style '{ $lineStyle }'-ko PreFigure output-oni ra·gija.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }'-ko PreFigure-ni 'diamond' style-chi salataha.
+
+prefigure-marker-style-unsupported = { $subject }: marker style '{ $markerStyle }'-ko PreFigure ra·na man·ja; skanggipa style-ko bahaaha.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ong·gijagipa `ref`; target-ko sokatna man·ja. Annotation-ko ra·gija.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` bang·gipa target-rango sokaha; skanggipa target-kosa bahaenga.
+
+annotation-ref-outside-graph = `<annotation>`: ong·gijagipa `ref`; target graph-ni agalo donga. Annotation-ko ra·gija.
+
+annotation-ref-unsupported-target = `<annotation>`: ong·gijagipa `ref`; prefigure salatanio target ra·na man·gija graphical jinis ong·a. Annotation-ko ra·gija.
+
+annotation-text-missing = `<annotation>`: `text` dongja ba khali; khali text-ko on·enga.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Girikgipa nirbhoranikon man·aha.
+       *[other] `<{ $componentType }>` component-ko cha·gipa girikgipa nirbhoranikon man·aha.
+    }
+
+reference-no-referent = Ia reference-ni gimin maiba man·jaha: `{ $reference }`
+
+reference-multiple-referents = Ia reference-ni gimin bang·gipa jinis man·aha: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>`-ni { $attribute } attribute-ni gimin ong·gijagipa format.
+
+children-invalid = `<{ $componentType }>`-ni gimin ong·gijagipa bi·sarang: Ong·gijagipa bi·sarangko man·aha: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` attribute-ni gimin ong·gijagipa man `{ $value }`, `{ $default }` man-ko bahaenga
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML version { $version } man·jaha.
+       *[other] DoenetML version { $version } man·jaha. Version { $fallback }-ko bahaenga
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Ong·gijagipa DoenetML: { $content }
+
+parse-tag-missing-close-tag = Ong·gijagipa DoenetML: `{ $tag }` tag-o bondho ka·gipa tag dongja. An·tangon bondho ong·gipa tag ba `</{ $tagName }>` tag nangaha.
+
+parse-tag-error = Ong·gijagipa DoenetML: `<{ $tagName }>` tag-o bhul
+
+parse-attribute-missing-value = Ong·gijagipa DoenetML: Ong·gijagipa attribute `{ $attribute }`-o man dongja gita nika.
+
+parse-attribute-invalid = Ong·gijagipa DoenetML: Ong·gijagipa attribute `{ $attribute }`
+
+parse-attribute-value-invalid = Ong·gijagipa DoenetML: Ong·gijagipa attribute-ni man `{ $value }`
+
+parse-attribute-value-quote-mismatch = Ong·gijagipa DoenetML: Ong·gijagipa attribute-ni man `{ $value }`. Quote chinho-rang mikkang ka·ja. Na·a `{ $quote }`-ko sea·gija gita nika
+
+parse-open-tag-name-missing = Ong·gijagipa DoenetML: Bimung gnanggija tag-ko man·aha, dakko `<`
+
+parse-tag-not-closed = Ong·gijagipa DoenetML: `{ $tag }` tag-ko bondho ka·jaha (`>` dongja gita nika).
+
+parse-self-closing-tag-name-missing = Ong·gijagipa DoenetML: Bimung gnanggija tag-ko man·aha `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Ong·gijagipa DoenetML: `{ $tag }` tag-ko bondho ka·jaha (`/>` dongja gita nika).
+
+parse-tag-invalid-attributes = Ong·gijagipa DoenetML: `{ $tag }` tag kamgija. Uni attribute-rang bhul ong·na man·gen.
+
+parse-close-tag-name-missing = Ong·gijagipa DoenetML: Bimung gnanggija bondho ka·gipa tag-ko man·aha, dakko `</`
+
+parse-attribute-value-unquoted = Attribute-ni man-rangko quote-ni bitcho dongatna nanga: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Ong·gijagipa DoenetML: Bondho ka·gipa tag `{ $tag }`-ko man·aha, indiba uni khegipa tag dongja
+
+parse-close-tag-mismatched = Ong·gijagipa DoenetML: Bondho ka·gipa tag mikkang ka·ja. `</{ $expected }>` nangaha. `{ $found }`-ko man·aha
+
+parser-node-unconvertible = { $node } node-ko Dast node-chi salatna man·jaha.
+
+## Names
+
+name-attribute-invalid =
+    Ong·gijagipa attribute name='{ $name }'. { $reason ->
+        [characters] Bimung-rango akkor, number, underscore ba hyphen-kosa dongna man·a.
+       *[start] Bimung-rang akkor-chi ja·rikatna nanga.
+    }
+
+component-name-invalid-start = Ong·gijagipa component-ni bimung "{ $name }". Bimung-rang akkor-chi ja·rikatna nanga.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched type gnanggipa answer-o video attribute dongna nanga
+
+answer-video-watched-video-not-reference = videoWatched type gnanggipa answer-ni video attribute reference ong·na nanga
+
+answer-name-not-single-text = Answer-ni name attribute-o sa text bi·sa dongna nanga
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Bang·gipa laboro girikaniko cha·ani gimin agalgipa DoenetML-ko ra·na man·jaha. Girikgipa reference donga ma?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }"-oni DoenetML-ko ra·na man·jaha
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }"-oni ra·ahagipa DoenetML ong·gija: ua "{ $componentType }" component type-chi mikkang ka·jaha
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` attribute-ko da·o ra·gija; uni bakon `{ $to }`-ko bahabo.
+       *[other] [deprecation] `<{ $component }>`-o `{ $from }` attribute-ko da·o ra·gija; uni bakon `{ $to }`-ko bahabo.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }`-koba songahani gimin `{ $from }` attribute-ko da·o ra·gija.
+       *[other] [deprecation] `{ $to }`-koba songahani gimin `<{ $component }>`-o `{ $from }` attribute-ko da·o ra·gija.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-o `{ $attribute }` attribute-ko da·o ra·gija.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-o `{ $attribute }` attribute-ko da·o ra·gija; uni bakon `<{ $child }>` bi·sako bahabo.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-o `{ $attribute }` attribute-ni `{ $value }` man-ko da·o ra·gija; uni bakon `{ $to }`-ko bahabo.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` English-kosa plural ka·na man·a, uni gimin { $locale }-o seahagipa dokumento uni text-ko salgija donga. Plural form-ko an·tangon seabo, ba `pluralForm` attribute-chi songbo.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` element sikna man·gipa Doenet element ong·ja.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` element-ko dokumento-ni ja·rikatani laboro dongatna man·ja.
+
+schema-element-not-allowed-inside = `<{ $tag }>` element-ko `<{ $parent }>`-ni bitcho dongatna man·ja.
+
+schema-attribute-unrecognized = `<{ $tag }>` element-o `{ $attribute }` bimung gnanggipa attribute dongja.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` element-ni `{ $attribute }` attribute list ong·na nanga, aro uni jinis sa·sa iarangni giseponi sa ong·na nanga: { $allowed }
+       *[other] `<{ $tag }>` element-ni `{ $attribute }` attribute iarangni giseponi sa ong·na nanga: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select-ni gimin ong·gijagipa variant bimung.  { $variantName } variant bimung { $numOptions } option-rango donga indiba sikna nanggipa bang·ani { $numToSelect }.
+
+select-variant-name-without-options = Select-ni gimin maisa variant-rangko songaha indiba ia man·na man·gipa variant bimung-ni gimin option dongja: { $variantName }.
+
+select-variant-name-not-possible = Select-ni gimin songahagipa { $variantName } variant bimung man·na man·gipa variant bimung ong·ja.
+
+select-too-few-options = { $numOptions }-onisa { $numToSelect } component-rangko sikna man·ja.
+
+select-from-sequence-too-few-values = { $length } length gnanggipa sequence-oni { $numToSelect } man-rangko sikna man·ja.
+
+select-from-sequence-indices-count-mismatch = Select-ni gimin songahagipa indices-ni bang·ani sikna nanggipa bang·anichi mikkang ka·na nanga
+
+select-from-sequence-indices-not-integers = Select-ni gimin songahagipa indices pilak integer ong·na nanga
+
+select-from-sequence-index-excluded = Ra·gijagipa selectfromsequence-ni index-ko songaha
+
+select-from-sequence-indices-excluded-combination = Ra·gijagipa songjotani ong·gipa selectfromsequence-ni indices-ko songaha
+
+select-from-sequence-coprime-not-positive-integers = Positive integer-rangko sikgija ong·ani gimin coprime songjotani-rangko sikna man·ja.
+
+select-from-sequence-coprime-common-factor = Coprime number-rangko sikna man·ja. Man·na man·gipa man pilako sa·gipa factor donga. ("from" ba "to"-ni songahagipa man-rang "step"-chi coprime ong·na nanga.)
+
+select-from-sequence-coprime-single-number = 1 ong·gija sa number-oni coprime songjotani-rangko sikna man·ja.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-o songjotani-rangni 70%-oni bang·bata ra·gija
+
+select-from-sequence-coprime-none-found = Coprime number-rangko sikna man·jaha. Man·na man·gipa man pilako sa·gipa factor donga.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } length gnanggipa sequence-oni { $numToSelect } dingtanggipa man-rangko sikna man·ja
+
+select-prime-numbers-too-few-values = { $numValues } length gnanggipa prime-rangni list-oni { $numToSelect } man-rangko sikna man·ja
+
+select-prime-numbers-values-count-mismatch = Select-ni gimin songahagipa man-rangni bang·ani sikna nanggipa bang·anichi mikkang ka·na nanga
+
+select-prime-numbers-values-not-prime = Select prime number-ni gimin songahagipa man pilak prime-rangni list-o dongna nanga
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers-ni songahagipa man-rang ra·gijagipa songjotani ong·aha
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-o songjotani-rangni 70%-oni bang·bata ra·gija
+
+select-random-combination-fluke = Buktuk ong·na man·gija bhagyo-ni gimin, random man-rangni songjotanikon sikna man·jaha
+
+select-random-value-fluke = Buktuk ong·na man·gija bhagyo-ni gimin, random man-ko sikna man·jaha
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Ia `<{ $component }>`-ko pinija maina ua math-ni bitcho donga aro `inline` ong·ja. `inline`-ko dongatbo, uni gimin ua drop-down list ong·gen, aro ua expression-ni bitcho cha·gen.
+        [expanded] Ia `<{ $component }>`-ko pinija maina ua math-ni bitcho donga aro `expanded` ong·a. `expanded`-ko ra·katbo; bang·gipa lain gnanggipa boks expression-ni bitcho cha·ja.
+        [on-graph] Ia `<{ $component }>`-ko pinija maina ua graph-o segipa math-ni bitcho donga, aro uo input-ni gimin bak dongja.
+       *[relative-width] Ia `<{ $component }>`-ko pinija maina ua math-ni bitcho donga aro uni width relative ong·a. Width-ko `px` gita absolute unit-chi on·bo.
+    }

--- a/packages/i18n/locales/grt/diagnostics.ftl
+++ b/packages/i18n/locales/grt/diagnostics.ftl
@@ -23,7 +23,7 @@
 # domain, interval, index, format and their neighbours are written here as
 # English: those are the words the classroom uses. The Garo in this file is
 # the frame, and it is used consistently: «man·ja» cannot, «man·jaha» could
-# not, «nanga» must, «ra·gija» is ignored, «baha·a» use, «man·aha» found,
+# not, «nanga» must, «ra·gija» is ignored, «baha» use, «man·aha» found,
 # «dongja» there is none, «mikkang ka·ja» does not match, «maina» because,
 # «indiba» but, «ba» or, «aro» and, «uni gimin» so, «-oni» ablative, «-chi»
 # instrumental, «-ko» accusative, «-o» locative, «-rang» plural, «-gipa» the

--- a/packages/i18n/locales/grt/diagnostics.ftl
+++ b/packages/i18n/locales/grt/diagnostics.ftl
@@ -36,7 +36,8 @@
 # select is collapsed to its `*[other]` wording, keeping the placeables that
 # wording uses. The one numeric literal is `[1]` in
 # `field-function-wrong-num-outputs`, which is a count of outputs rather than
-# a plural category, and it stays exactly where English has it.
+# a plural category: it stands where English selects the category `[one]`,
+# and Fluent matches it against the number itself.
 #
 # Words a reviewer should check first here: «sabdanani» for a warning,
 # «ong·gijagipa» for *invalid* — a transparent "not being so" rather than a

--- a/packages/i18n/locales/grt/editor.ftl
+++ b/packages/i18n/locales/grt/editor.ftl
@@ -1,0 +1,224 @@
+# Garo (A·chik ku·rang) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to fix it.
+#
+# **Script: Latin.** ICU maximizes a bare `grt` to `grt-Beng`; this catalog
+# writes Latin anyway, because Latin is what a Garo reader in Meghalaya reads.
+# `chrome.ftl` carries the full argument, and a conversion to Bengali letters
+# is a conversion of all four files at once. The raka is the middle dot «·».
+#
+# **The editor's vocabulary is mostly an English loan, and that is stated
+# rather than hidden.** An author editing DoenetML in Meghalaya is working in
+# English-medium terms — element, attribute, reference, snippet, variant,
+# filter, format, style — so those words are written as English here. The Garo
+# in this file is the frame around them: «man·ja» cannot, «nanga» must,
+# «man·aha» found, «dongja» there is none, «pinibo» show, «-ko» accusative,
+# «-ni» genitive, «-o» locative, «-rang» plural.
+#
+# **Nothing selects on a count.** CLDR has no plural data for `grt`, and a Garo
+# noun is unmarked after a numeral, so English's two count selects are
+# collapsed: `editor-accessibility-label` keeps `{ $count }` and writes one
+# wording for it, and `help-coordinates` drops the placeable English used only
+# to pick a plural.
+#
+# Words a reviewer should check first here: «sabdanani» for *warning*,
+# «sokna man·ani» for *accessibility*, and «dakchakani» for *help*.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Aro Songbo
+       *[update] Gitalbo
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Viewer-ko { $word }
+       *[other] Viewer-ko { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+
+editor-variant-filter = Bakbo...
+
+editor-variant-next = Ja·mangipa variant-ko sikbo
+
+editor-variant-previous = Skanggipa variant-ko sikbo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA sokna man·anini bhulko man·aha. Sokna man·anini ripot-ko { $action ->
+            [close] bondho ka·na
+           *[open] khena
+        } klik ka·bo.
+        [advisories] Sokna man·anini ripot-ko { $action ->
+            [close] bondho ka·na
+           *[open] khena
+        } klik ka·bo. WCAG AA bhulrang man·jaha, indiba gipin sokna man·anini ku·rachakanirang donga.
+       *[clean] Sokna man·anini ripot-ko { $action ->
+            [close] bondho ka·na
+           *[open] khena
+        } klik ka·bo. Sokna man·anini jinggani dongja.
+    }
+
+# No count select: a Garo noun is unmarked after a numeral.
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA sokna man·anini bhulko man·aha. { $count } WCAG AA bhulko man·aha. Sokna man·anini ripot-ko { $action ->
+            [close] bondho ka·na
+           *[open] khena
+        } klik ka·bo.
+        [advisories] WCAG AA bhulrang man·jaha. { $count } gipin sokna man·anini ku·rachakanikon man·aha. Sokna man·anini ripot-ko { $action ->
+            [close] bondho ka·na
+           *[open] khena
+        } klik ka·bo.
+       *[clean] WCAG AA bhulrang man·jaha. Sokna man·anini ripot-ko { $action ->
+            [close] bondho ka·na
+           *[open] khena
+        } klik ka·bo.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = Jaepon nanggipa dakchakani
+editor-tab-help-short = Jaepon
+editor-tab-errors = Bhulrang
+editor-tab-warnings = Sabdanani
+editor-tab-info = Khobor
+editor-tab-accessibility = Sokna man·ani
+editor-tab-responses = On·ahagipa aganchakanirang
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editor-ni opsonrang
+editor-format-as-doenetml = DoenetML gita format ka·bo
+editor-format-as-xml = XML gita format ka·bo
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = Bhul Dongja
+editor-no-warnings = Sabdanani Dongja
+editor-no-info = Khobor-ni jinggani dongja
+
+editor-show-info-annotations = Editor-o khobor-ni jingganirangko pinibo
+editor-show-accessibility-annotations = Editor-o sokna man·anini jingganirangko pinibo
+
+editor-accessibility-learn-more = Doenet sokna man·anikon maigita ra·ia, uako skibo
+
+editor-accessibility-violations-heading = Sokna man·anini bhulrang ({ $standard })
+
+editor-accessibility-other-heading = Sokna man·anini gipin jingganirang
+editor-none-found = Maiba man·jaha
+
+
+## Submitted responses
+
+editor-no-responses = Da·o on·ahagipa aganchakani dongja
+editor-response-answer-id = Aganchakani Id
+editor-response-response = Aganchakani
+editor-response-credit = Kredit
+editor-response-submitted = On·ahaha
+
+
+## The context-help panel
+
+help-placeholder = Dokumentesan-ni gimin tag-ni bimung, attribute, ba { $ref }-o kursorko dongatbo.
+
+help-unsupported-ref-chain = { $example } gita bang·gipa bak-ni reference-ni gimin dakchakani da·o dongja.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ia reference-ni gimin maiba man·jaha: { $ref }.
+        [multiple] Ia reference-ni gimin bang·gipa jinis man·aha: { $ref }.
+       *[indeterminate] { $ref }-ni gimin maiko sikna man·jaha.
+    }
+
+help-learn-about-references = Reference-rang-ni gimin skibo →
+help-reference-page = Reference-ni pata →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element }-ni bitcho
+       *[top] Chagitchamgipa laboro
+    }{ $allowed ->
+        [none] { " — iao maiba dongja." }
+        [text] { " — iao text-ko sokbo." }
+        [text-and-components] { " — iao text-ko sokbo, ba iarangko chesotbo:" }
+       *[components] { " — chesotna man·gipa jinisrang:" }
+    }
+
+help-suggestions-footer = { $total } component-rang pilakko nikna { $shortcut }-ko nappitbo.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ong·gipa { $target }-ni reference.
+       *[other] { $ref } ong·gipa { $target }-ni reference (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner }-chi { $role } gita dongataha.
+       *[other] { $owner }-chi lain { $line }-o { $role } gita dongataha.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ong·gipa { $element }-ni { $property } property-ni reference.
+       *[other] { $ref } ong·gipa { $element }-ni { $property } property-ni reference (lain { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array-ni entry
+
+help-default = Skanggipa man:
+help-active-default = Kam ka·gipa skanggipa man:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ra·na man·gipa manrang (sakgitalsa jinisni gimin sa·sa):
+       *[other] Ra·na man·gipa manrang:
+    }
+
+help-suggested-values = Ku·rachakgipa manrang:
+
+help-inserts = Nappitgipa:
+
+# English selects on a count here only to pick a plural. Garo does not mark
+# one, so the placeable is dropped and one wording stands for both.
+help-coordinates = Coordinate-rang:
+
+help-type = Type:
+
+help-resolved-style = Man·ahagipa style (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Man·ahagipa function-ni bimungrang:
+help-reset-list = Ia input-o list-ko aro songbo:
+help-added-on-input = Ia input-o dongataha:
+help-removed-on-input = Ia input-o ra·kataha:
+
+help-reset-overrides = { $reset } { $additional } aro { $removed }-ko salgen.

--- a/packages/i18n/locales/hif/chrome.ftl
+++ b/packages/i18n/locales/hif/chrome.ftl
@@ -43,7 +43,7 @@
 # before it consults any plural rule, so that branch is reachable whatever the
 # locale.
 #
-# **Register.** The `-o` imperative («karo», «dekho», «chuno»), which is the
+# **Register.** The `-o` imperative («karo», «dekhao», «chuno»), which is the
 # ordinary polite form and the only one that is safe not knowing who is being
 # addressed.
 #

--- a/packages/i18n/locales/hif/chrome.ftl
+++ b/packages/i18n/locales/hif/chrome.ftl
@@ -1,0 +1,154 @@
+# Fiji Hindi (Fiji Baat) viewer chrome: the buttons, panel headings and status
+# words the reader interacts with. Translated from `locales/en/chrome.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, not Devanagari — and ICU disagrees.** `Intl.Locale("hif")`
+# maximizes to `hif-Deva-FJ`, so anything reading the maximization believes
+# this language is written in Devanagari. Its speakers do not write it that
+# way. Fiji Hindi is written in the **Latin alphabet** wherever Fiji Hindi
+# itself is written — the Fiji Hindi Wikipedia, the Fiji Hindi New Testament,
+# the Fiji Hindi–English dictionaries, and the everyday writing of Indo-Fijians
+# in Fiji, New Zealand and Australia. Devanagari in Fiji is the script of
+# *Standard Hindi*, which is taught in school, read in the temple, and is a
+# different language from the one people speak at home. Seeding this catalog in
+# Devanagari would have produced a Standard Hindi catalog under a Fiji Hindi
+# tag, which is the one thing this seed must not be.
+#
+# **Direction is unaffected, and that is why nothing had to change.** Both
+# scripts run left to right, so `directionOf("hif")` answers `ltr` through the
+# maximization and answers it correctly. `src/direction.ts` needs no entry for
+# `hif`: the tag reaches the right answer by the wrong route, and here the
+# wrong route costs nothing. It would not be free for a tag whose two candidate
+# scripts ran in different directions, which is worth recording beside
+# `locales/skr` and `locales/brh` in this same batch — those two are
+# Perso-Arabic and *do* need the fallback list.
+#
+# **Spelling.** This catalog follows the conventional Latin orthography: `aa`
+# for the long vowel where it is contrastive («kaam», «naam», «laal»), plain
+# `a` elsewhere, `ch` and `chh`, `jaawe`/`hoe` for the imperfective, and no
+# diacritics at all — Fiji Hindi is typed on an English keyboard and its
+# writing reflects that. Retroflexes are not distinguished from dentals in
+# writing, as they are not in the sources this follows.
+#
+# **No plural categories.** CLDR has no plural data for `hif`, so nothing here
+# selects on a category and `lint:i18n` would reject one if it did. Nothing is
+# lost: a Fiji Hindi noun after a numeral stays unmarked. `[0]` is kept where
+# English has it — Fluent matches a numeric literal against the number itself
+# before it consults any plural rule, so that branch is reachable whatever the
+# locale.
+#
+# **Register.** The `-o` imperative («karo», «dekho», «chuno»), which is the
+# ordinary polite form and the only one that is safe not knowing who is being
+# addressed.
+#
+# **English loans kept rather than replaced.** Schooling in Fiji is in English,
+# and Fiji Hindi borrows from it freely and without apology: `keyboard`,
+# `matrix`, `column`, `percent`, `orbital`, `WCAG`, `preview` are what a
+# Fiji Hindi speaker actually says. Coining Hindi-Sanskrit replacements for
+# them would produce Standard Hindi, not Fiji Hindi. Where Fiji Hindi has its
+# own word it is used.
+
+
+## Answer submission
+
+answer-checking = Jaanch hoy rahaa hai...
+answer-submitting = Bhej rahaa hai...
+answer-checking-status = Jawaab ke jaanch hoy rahaa hai
+answer-submitting-status = Jawaab bhej rahaa hai
+answer-correct = Sahi
+answer-incorrect = Galat
+answer-response-saved = Jawaab save hoy gais
+answer-percent-credit = { $percent }% marks
+answer-percent-correct = { $percent }% sahi
+answer-percent-short = { $percent } %
+max-credit-available = Sab se jaada marks: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] Koi mauka nai bachaa hai
+       *[other] { $count } mauka bachaa hai
+    }
+validation-correct = (Sahi)
+validation-incorrect = (Galat)
+validation-partially-correct = (Thora sahi)
+# «ke» is a postposition and stands as its own word, so nothing is joined to
+# the placeable.
+answer-show-responses = { $answerId } ke { $count } jawaab dekhao
+
+## Disclosure panels
+
+feedback-heading = Raay
+collapsible-click-to-open = (kholne ke liye click karo)
+collapsible-click-to-close = (band karne ke liye click karo)
+collapsible-initializing = Taiyaar hoy rahaa hai...
+footnote-show = Footnote dekhao
+footnote-hide = Footnote chhupao
+description-more-information = aur jaankaari
+
+## Controls
+
+slider-previous = Pichhla
+slider-next = Agla
+keyboard-open = Keyboard kholo
+keyboard-close = Keyboard band karo
+choice-input-remove-choice = { $choice } hatao
+matrix-remove-row = Row hatao
+matrix-add-row = Row jorho
+matrix-remove-column = Column hatao
+matrix-add-column = Column jorho
+subset-add-remove-points = Point jorho/hatao
+subset-toggle-points-intervals = Point aur interval ke beech badlo
+subset-move-points = Point hilao
+subset-clear = Saaf karo
+orbital-add-row = Row jorho
+orbital-remove-row = Row hatao
+orbital-add-box = Box jorho
+orbital-remove-box = Box hatao
+orbital-add-up-arrow = Uupar ke arrow jorho
+orbital-add-down-arrow = Niche ke arrow jorho
+orbital-remove-arrow = Arrow hatao
+orbital-row-label = Row { $row } ke naam
+pretzel-answer = Jawaab
+# «column» names what `$column` is, so the postposition falls behind a word
+# this catalog writes rather than behind the value.
+summary-statistics-caption = Column { $column } ke statistics ke saaraansh
+
+## Math input
+
+math-input-preview-region = Math expression ke preview
+math-input-preview = Preview
+math-input-invalid-expression = Galat expression:
+
+## Document status
+
+viewer-initializing = Taiyaar hoy rahaa hai...
+
+## Errors
+
+error-heading = Galti
+error-found-at =
+    { $span ->
+        [line] Line { $startLine } pe milaa.
+       *[lines] Line { $startLine }–{ $endLine } pe milaa.
+    }
+document-contains-errors = Ii document me galti hai!
+diagnostic-heading-error = Galti
+diagnostic-heading-warning = Chetaawni
+diagnostic-heading-information = Jaankaari
+diagnostic-heading-hint = Ishaara
+# `WCAG AA` is the standard's own name and is not translated.
+accessibility-heading-level-1 = WCAG AA accessibility ke ulanghan
+accessibility-heading-level-2 = Accessibility ke chetaawni
+something-went-wrong = Kuchhu galat hoy gais.
+renderer-load-failed = Ek renderer load nai hoy sakaa. Kirpa kare ke page ke phir se load karo.
+core-start-failed = Ii document chaalu nai hoy sakaa. Kirpa kare ke page ke phir se load karo.
+core-start-failed-busy = Ii document chaalu nai hoy sakaa. Bahut document ek hi time pe chaalu hoy rahaa rahin, aur dhiimaa device pe iske jaada time lage hai. Dusra document khatam hoy jaay ke baad page ke phir se load kare se madad mil sake hai.
+core-start-failed-retry = Ii document chaalu nai hoy sakaa.
+core-start-failed-busy-retry = Ii document chaalu nai hoy sakaa. Bahut document ek hi time pe chaalu hoy rahaa rahin, aur dhiimaa device pe iske jaada time lage hai.
+core-start-retry = Phir se koshish karo
+saved-state-unavailable = Tumhaar save karaa kaam load nai hoy sakaa.

--- a/packages/i18n/locales/hif/content.ftl
+++ b/packages/i18n/locales/hif/content.ftl
@@ -1,0 +1,318 @@
+# Fiji Hindi (Fiji Baat) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in, not the reader's interface language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, not the Devanagari ICU maximizes `hif` to.** `chrome.ftl`
+# states the case in full — Fiji Hindi is written in the Latin alphabet by its
+# own speakers, and Devanagari in Fiji is the script of Standard Hindi, which
+# is a different language. Direction is unaffected: both scripts run left to
+# right, so `directionOf("hif")` answers `ltr` through the maximization and
+# answers it correctly, and `src/direction.ts` needs no entry.
+#
+# ## Word order
+#
+# **Every modifier comes before the noun**, in English's own order: «mota laal
+# lakiir» is *thick red line*, width first, then the dash pattern, then the
+# colour. Fiji Hindi is Indo-Aryan and head-final, so `style-stroke`,
+# `style-with-noun` and `style-filled-with-noun` all keep English's sequence of
+# placeables rather than reversing it. What does move is the preposition: Fiji
+# Hindi is postpositional, so «ke saath» (*with*) and «pe» (*on*) follow their
+# object and the composition messages below put them after the placeable.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } side waala regular polygon» and leaves `tail` empty, as
+# English does: the side count sits in front of the noun here too. The `-tail`
+# variants of the two composition messages are still written out, because that
+# is what a partly-translated locale falls back to.
+#
+# ## Gender and role — neither forks, and that is the interesting part
+#
+# **Fiji Hindi has levelled away Standard Hindi's agreement, and this catalog
+# records that rather than working around it.** In Standard Hindi «kaalaa»
+# becomes «kaalii» before a feminine noun and «kaale» before a postposition;
+# in Fiji Hindi the `-a` form stands in every position, for a noun of either
+# gender, in the direct case and the oblique alike. Gender survives in the
+# lexicon — a speaker still knows «lakiir» is the sort of word that would have
+# been feminine — but it does not reach the adjective. So `noun-gender` answers
+# the single token `neuter`, **no adjective selects on `$gender`**, and the
+# four `$role` positions render identically because there is no oblique for a
+# position to govern.
+#
+# That is worth reading beside the two catalogs seeded in the same batch.
+# `locales/skr` is Indo-Aryan too, is a close relative, and **does** fork on
+# both arguments, because Saraiki kept the marked/unmarked adjective classes
+# whole. `locales/brh` is Dravidian and forks on neither because it never had
+# gender at all. Fiji Hindi is the third answer: it *had* the agreement and
+# lost it. Three catalogs, three routes to three different shapes, and the
+# family tree predicts none of them.
+#
+# **Nothing selects on a count either.** A Fiji Hindi noun after a numeral
+# stays unmarked — «tiin lakiir», not «tiin lakiiren» — and CLDR has no plural
+# data for `hif` in any case, so a category branch would be one `lint:i18n`
+# rejects.
+#
+# ## The chemistry tables are deliberately absent
+#
+# `element-name` and `element-anion-name` are the only English keys this file
+# does not cover. **Fiji Hindi is nobody's medium of instruction**: schooling
+# in Fiji is in English, and a Fiji Hindi speaker meets the periodic table in
+# English and nowhere else. There is no settled Fiji Hindi list of the hundred
+# and eighteen elements to check a translation against, and the two candidates
+# — respelling the English names in this orthography, or importing Standard
+# Hindi's Devanagari nomenclature in transliteration — would each produce a
+# nomenclature nobody uses. Recording the gap is the honest answer.
+# `lint:i18n` reports the two keys as missing coverage and that report is
+# correct. `ion-name-oxidation-state` and the two invalid-symbol messages
+# **are** covered: they are frames and punctuation, not vocabulary.
+#
+# ## What is English here, and why that is not a failure
+#
+# A great deal. `vector`, `function`, `parabola`, `polygon`, `polyline`,
+# `curve`, `rectangle`, `diamond`, `cross`, `regular polygon`, `table`,
+# `paragraph` and the six colour words `grey`, `orange`, `cyan`, `purple`,
+# `pink`, `brown` are written as English, because Fiji Hindi genuinely borrows
+# them: mathematics is learnt in English in Fiji, and an Indo-Fijian speaker
+# describing a shape says «circle» as readily as «gol». Replacing them with
+# Sanskritic coinages would produce Standard Hindi under this tag, which is
+# precisely the failure this catalog is written to avoid. Where Fiji Hindi has
+# its own word it is used and is Bhojpuri-derived rather than Khari Boli:
+# «lakiir», «kiran», «tikon», «gol», «chaukor», «bindu», «hariyar» for green,
+# «patar» for thin, «kaam» for a task, «sahi» and «galat» for the booleans,
+# «nai to» for *otherwise*, «kaahe ki» for *because*.
+
+
+## Style vocabulary
+##
+## Every word here is invariable, and that is a fact about Fiji Hindi rather
+## than a choice about which words to write: its adjectives do not agree.
+
+color =
+    .black = kaala
+    .white = safed
+    .gray = grey
+    .red = laal
+    .orange = orange
+    .yellow = piyar
+    .green = hariyar
+    .cyan = cyan
+    .blue = niila
+    .purple = purple
+    .pink = pink
+    .brown = brown
+line-width =
+    .thick = mota
+    .thin = patar
+line-style =
+    .dashed = dash waala
+    .dotted = dot waala
+# Noun phrases rather than adjectives: every place a fill pattern is put, it
+# stands in front of «ke saath», so these are written as they are wanted there.
+fill-style =
+    .horizontal = horizontal lakiir
+    .vertical = vertical lakiir
+    .diagonal = tirchha lakiir
+    .backdiagonal = ulta tirchha lakiir
+    .dots = dot
+    .diamonds = diamond
+noun =
+    .line = lakiir
+    .line-segment = lakiir ke tukra
+    .ray = kiran
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = tikon
+    .rectangle = rectangle
+    .circle = gol
+    .region = ilaaka
+    .point = bindu
+    .square = chaukor
+    .diamond = diamond
+    .cross = cross
+    .plus = plus ke nishaan
+# «side waala» is invariable, like everything else in front of a Fiji Hindi
+# noun, so the side count stands with the other modifiers and there is nothing
+# to split off into a tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } side waala regular polygon
+    }
+# Fiji Hindi does not agree an adjective for gender. The token is defined
+# anyway rather than left to fall back, so that this catalog says so on
+# purpose. See the header.
+noun-gender = neuter
+
+
+## Style composition
+##
+## English's own order of placeables, kept rather than reversed — Fiji Hindi
+## puts its modifiers in front of the noun as well. What moves is the
+## preposition: Fiji Hindi is postpositional, so «ke saath» and «pe» follow
+## what they govern.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# Invariable in Fiji Hindi — in Standard Hindi this word would have to agree —
+# so it is written once and takes no branch. Its opposite is `style-unfilled`
+# below.
+style-filled-word = bharaa
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } { $pattern } ke saath
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } { $pattern } ke saath
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } ke saath
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «ke saath» follows what it governs, so the border and its modifiers come
+# first. Fiji Hindi has no article, so the two `-article` branches read as
+# their plain counterparts do; they are kept apart because the distinction
+# belongs to the English message rather than to this one.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } border ke saath
+        [and] aur { $border } border ke saath
+        [and-article] aur { $border } border ke saath
+       *[with] { $border } border ke saath
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = khaali
+style-text =
+    { $parts ->
+        [background] { $background } background pe { $color }
+       *[plain] { $color }
+    }
+style-background-none = kuchhu nai
+
+
+## Boolean words
+##
+## What a `<boolean>` displays. `true` and `false` as an author writes them in
+## the source stay English; only these two move.
+
+boolean-true = sahi
+boolean-false = galat
+
+
+## Answer buttons
+
+answer-submit-label = Kaam jaancho
+answer-submit-label-no-correctness = Jawaab bhejo
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kaam-kaaj
+    .aside = Alag baat
+    .cascade = Cascade
+    .definition = Paribhaasha
+    .example = Misaal
+    .exercise = Abhyaas
+    .exercises = Abhyaas
+    .given-answer = Jawaab
+    .note = Note
+    .objectives = Lakshya
+    .paragraphs = Paragraph
+    .part = Hissa
+    .problem = Samasya
+    .problems = Samasya
+    .proof = Saboot
+    .question = Sawaal
+    .section = Bhaag
+    .solution = Hal
+    .task = Kaam
+    .theorem = Siddhaant
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = Ishaara
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Table { $enumeration }
+        [numbered-title] Table { $enumeration }{ ": " }
+        [unnumbered-title] Table{ ": " }
+       *[unnumbered] Table
+    }
+figure-name =
+    { $parts ->
+        [numbered] Chitra { $enumeration }
+        [numbered-caption] Chitra { $enumeration }{ ": " }
+        [unnumbered-caption] Chitra{ ": " }
+       *[unnumbered] Chitra
+    }
+
+
+## Paginator controls
+##
+## «me se» — *out of* — is a postposition, so the total comes first and the
+## page label and its number follow. That is the reverse of English's order and
+## a fact about Fiji Hindi rather than a slip.
+
+paginator-previous = Pichhla
+paginator-next = Agla
+paginator-page = Panna
+paginator-page-status = { $numPages } me se { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ya
+piecewise-condition-if = agar
+piecewise-condition-otherwise = nai to
+
+
+## Chemistry
+##
+## The element tables are absent on purpose; see the header. What is here is
+## the frames around a name, which need no nomenclature.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = Galat chemical symbol
+chemistry-invalid-ionic-compound = Galat ionic compound
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = khaali
+math-embedded-input-blank-ordinal = { $total } me se khaali { $ordinal }

--- a/packages/i18n/locales/hif/diagnostics.ftl
+++ b/packages/i18n/locales/hif/diagnostics.ftl
@@ -1,0 +1,710 @@
+# Fiji Hindi (Fiji Baat) diagnostics: the errors and warnings the core and the
+# language server put in front of whoever is looking at the screen. Translated
+# from `locales/en/diagnostics.ftl`, which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Latin script, left to right, the conventional Fiji Hindi orthography —
+# the same convention the other three files of this locale state, and
+# `chrome.ftl` sets out why it is Latin rather than the Devanagari ICU
+# maximizes `hif` to.
+#
+# **Element names, attribute names and values are not words.** `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text`, `boolean`,
+# `coprime`, `selectFromSequence` and every `<tag>` written into these
+# sentences are DoenetML identifiers and stay in English exactly as they are.
+# The backticks and angle brackets around them are this catalog's punctuation.
+#
+# **This file is where the Latin script earns its keep and also where it is
+# hardest to read.** A DoenetML identifier is English written in Latin letters,
+# and so is the prose around it, so there is no visual boundary between the two
+# the way there is in `locales/skr` and `locales/brh`. The backticks are the
+# only marker, which is a reason to leave them exactly where they are.
+#
+# **No message here selects on a count.** CLDR has no plural data for `hif`, so
+# a category branch would be one nothing could select and `lint:i18n` would
+# reject; and a Fiji Hindi noun after a numeral stays unmarked in any case.
+# Each such message is written once as `*[other]`, with the count kept in the
+# selector so that nothing is lost from the message's shape. The `[1]` in
+# `field-function-wrong-num-outputs` is a numeric literal rather than a
+# category — Fluent matches it against the number itself — so it stays where
+# English has it. The symbolic selectors — `$reason`, `$type`, `$mode`,
+# `$suggestion`, `$isList`, `$context`, `$expected` and the rest — keep every
+# branch English has, because those keys are compared letter for letter and a
+# renamed one is a branch nothing can reach.
+#
+# **A small set of frames, chosen once and used throughout**, so that a
+# correction is one search:
+#
+#   «… ignore karaa jaawe hai»   is ignored
+#   «… set karaa hai»            is specified
+#   «… galat hai»                is invalid
+#   «… nai milaa»                was not found
+#   «… nai hoy sake»             cannot be done
+#   «… hona chaahi»              must be
+#   «kaahe ki …»                 because
+#
+# **The technical vocabulary is English, deliberately.** `component`,
+# `attribute`, `value`, `index`, `variant`, `reference`, `matrix`, `function`,
+# `vector`, `type`, `list`, `contrast`, `renderer` are what a Fiji Hindi
+# speaker says, because everything they were taught about computers and
+# mathematics was taught in English. Coining Sanskritic replacements would
+# produce Standard Hindi under this tag.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] Jab dui endpoint set karaa hai, tab { $attributes } ignore karaa jaawe hai
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] Jab ek endpoint aur ek midpoint dunu set karaa hai, tab { $attributes } ignore karaa jaawe hai
+    }
+
+line-segment-midpoint-offset-without-midpoint = Midpoint ke bina midpointOffset ke koi asar nai hai
+
+## `<line>`
+
+line-points-undetermined-dimensions = Lakiir uu point se jaawe hai jiske dimension pataa nai hai.
+
+line-points-too-few-dimensions = Lakiir ke uu point se jaana chaahi jiske kam se kam dui dimension hai.
+
+line-points-depend-on-variables = Lakiir uu point se jaawe hai jon ii variable pe nirbhar hai: { $variables }.
+
+line-equation-invalid-format = Variable { $variable1 } aur { $variable2 } me lakiir ke equation ke format galat hai.
+
+## `<ray>`
+
+ray-overprescribed-through = Kiran through, endpoint aur direction se set karaa hai.  Set karaa through ignore karaa jaawe hai.
+
+ray-dimension-mismatch = Kiran me numDimensions milaa nai.
+
+## `<vector>`
+
+vector-overprescribed-head = Vector head, tail aur displacement se set karaa hai.  Set karaa head ignore karaa jaawe hai.
+
+vector-dimension-mismatch = Vector me numDimensions milaa nai.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` pe attract nai hoy sake, kaahe ki uske nearestPoint state variable nai hai.
+
+constrain-to-without-nearest-point = `<{ $component }>` pe constrain nai hoy sake, kaahe ki uske nearestPoint state variable nai hai.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` ke andar constrain nai hoy sake, kaahe ki uske nearestPoint state variable nai hai.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Jaun choiceInput inline nai hai, uske liye labelPosition ignore karaa jaawe hai
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput ke liye set karaa index ignore karaa jaawe hai, kaahe ki index ke ginti aur choice ke bacchan ke ginti nai milaa.
+
+pretzel-indices-count-mismatch = problem ke liye set karaa index ignore karaa jaawe hai, kaahe ki index ke ginti aur problem ke bacchan ke ginti nai milaa.
+
+shuffle-indices-count-mismatch = shuffle ke liye set karaa index ignore karaa jaawe hai, kaahe ki index ke ginti aur component ke ginti nai milaa.
+
+indices-ignored-out-of-range = { $component } ke liye set karaa index ignore karaa jaawe hai, kaahe ki kuchhu index hadd se baahar hai.
+
+pretzel-indices-repeated = pretzel ke liye set karaa index ignore karaa jaawe hai, kaahe ki kuchhu index dohraais hai.
+
+pretzel-circuit-first-index = circuit mode me pretzel ke liye set karaa index ignore karaa jaawe hai, kaahe ki pahilaa index 1 hona chaahi.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ke string bacchan ke saath kaam karne ke liye `type` attribute set hona chaahi.
+
+invalid-type-defaulting-to-math = { $component } component ke liye type { $type } galat hai. Ii math, text, number ya boolean hona chaahi. Default math kaam me lawa jaawe hai.
+
+string-not-valid-component-to-arrange = String "{ $value }" { $component } ke liye sahi component nai hai. Ignore karaa jaawe hai.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } galat hai, type number set karaa jaawe hai.
+
+invalid-variable-value = Variable ke value galat hai: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant ke index { $index } ek number hona chaahi
+
+variant-index-must-be-integer = Variant ke index { $index } ek integer hona chaahi
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` absolute naap ke liye nai banaa hai. Width relative set karaa jaawe hai.
+
+side-by-side-absolute-margins = `<{ $component }>` absolute naap ke liye nai banaa hai. Margin relative set karaa jaawe hai.
+
+side-by-side-no-block-child = `<{ $component }>` galat hai: iske kam se kam ek block bacchaa hona chaahi.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Graphical `<label>` pe `for` attribute ignore karaa jaawe hai.
+
+label-for-must-resolve-to-one = `<label>` ke `for` attribute ke thiik ek component pe jaana chaahi.
+
+label-for-unresolved = `<label>` ke `for` attribute koi component pe nai jaay sakaa.
+
+label-for-answer-with-authored-inputs = `<label>` ke `for` attribute uu `<answer>` pe jaawe hai jiske input likhne waala khud likhis hai; siidhe input ke reference do.
+
+label-for-answer-without-input = `<label>` ke `for` attribute uu `<answer>` pe jaawe hai jiske naam dene ke liye koi input nai hai.
+
+label-for-must-reference-input-or-answer = `<label>` ke `for` attribute ke ek input ya ek answer pe reference dena chaahi.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Accessibility ke liye `<{ $component }>` ke ya to chhota description hona chaahi ya decorative set hona chaahi.
+
+accessibility-video-short-description = Accessibility ke liye `<video>` ke chhota description hona chaahi.
+
+accessibility-input-short-description-or-label = Accessibility ke liye `<{ $component }>` ke chhota description ya label hona chaahi.
+
+accessibility-answer-input-short-description-or-label = Accessibility ke liye uu `<answer>` ke, jaun ek input banaawe hai, chhota description ya label hona chaahi.
+
+accessibility-short-description-contains-math = Chhota description me `<{ $component }>` jaisan math component nai hona chaahi. Math ke shabd me likho.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } section ke heading ke text ke liye kaafi contrast nai dewe hai (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kam se kam { $threshold }:1 chaahi).
+       *[other] { $colorName } section ke heading ke text ke liye kaafi contrast nai dewe hai ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kam se kam { $threshold }:1 chaahi).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Jab point ke numerical value nai hai, tab { $count } point se jaay waala `<circle>` abhi tak nai banaa hai.
+
+circle-too-many-through-points = 3 se jaada point se jaay waala gol ke hisaab nai hoy sake.
+
+circle-overprescribed-radius-center-points = Set karaa radius, center aur point ke saath gol ke hisaab nai hoy sake.
+
+circle-center-with-multiple-points = Set karaa center ke saath 1 se jaada point se jaay waala gol ke hisaab nai hoy sake.
+
+circle-radius-too-small = Gol ke hisaab nai hoy sake: dui point ke beech ke duuri { $distance } hai, is liye set karaa radius { $radius } bahut chhota hai.
+
+circle-radius-with-many-points = Set karaa radius ke saath dui se jaada point se jaay waala gol nai ban sake.
+
+circle-invalid-center-or-through-points = Gol ke center ya point galat hai.
+
+circle-radius-center-with-multiple-points = Set karaa center ke saath 1 se jaada point se jaay waala gol ke radius ke hisaab nai hoy sake.
+
+circle-change-radius-non-numerical = Jaun point ke numerical value nai hai, uu se jaay waala gol ke radius nai badal sake
+
+circle-radius-with-points-non-numerical = Jab numerical value nai hai, tab set karaa radius ke saath ek se jaada point se jaay waala gol nai ban sake.
+
+circle-change-center-non-numerical = Jaun point ke numerical value nai hai, uu se jaay waala gol ke center badalne ke kaam abhi tak nai banaa hai.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] Function ke domain ke liye dimension kaafi nai hai. Domain me { $intervals } interval hai lekin function ke { $inputs ->
+           *[other] { $inputs } input
+        } hai.
+    }
+
+function-domain-invalid-format = Function ke domain ke format galat hai.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Function ke non-numerical maximum ignore karaa jaawe hai.
+        [minimum] Function ke non-numerical minimum ignore karaa jaawe hai.
+        [extremum] Function ke non-numerical extremum ignore karaa jaawe hai.
+        [point] Function ke non-numerical point ignore karaa jaawe hai.
+        [slope] Function ke non-numerical slope ignore karaa jaawe hai.
+       *[other] Function ke non-numerical { $type } ignore karaa jaawe hai.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Function ke khaali maximum ignore karaa jaawe hai.
+        [minimum] Function ke khaali minimum ignore karaa jaawe hai.
+        [extremum] Function ke khaali extremum ignore karaa jaawe hai.
+        [point] Function ke khaali point ignore karaa jaawe hai.
+       *[other] Function ke khaali { $type } ignore karaa jaawe hai.
+    }
+
+function-points-too-close = Function me dui point hai jiske jagah ek dusra ke bahut najdiik hai. Function ke paribhaasha nai hoy sake.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] Function iterate tabhi hoy sake hai jab function ke input ke ginti aur output ke ginti baraabar hoe. Ii function ke { $inputs } input aur { $outputs ->
+           *[other] { $outputs } output
+        } hai.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence ke length galat hai.  Ii non-negative integer hona chaahi.
+
+sequence-invalid-step = Sequence ke step galat hai.  { $type } type ke sequence ke liye ii ek number hona chaahi.
+
+sequence-invalid-endpoint-number = Number sequence ke "{ $attribute }" galat hai.  Ii ek number hona chaahi.
+
+sequence-invalid-endpoint-letters = Letters sequence ke "{ $attribute }" galat hai.  Ii akshar ke ek jorha hona chaahi.
+
+sequence-invalid-endpoint = Sequence ke "{ $attribute }" galat hai.
+
+select-from-sequence-coprime-not-numbers = Number nai chunaa jaay rahaa hai, is liye coprime ignore karaa jaawe hai
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations set karaa hai, is liye coprime ignore karaa jaawe hai
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` ke liye target galat hai: target nai milaa.
+
+target-state-variable-not-found = `<{ $source }>` ke liye target galat hai: `<{ $component }>` pe "{ $property }" naam ke state variable nai milaa.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` ke variable independent variable se alag hona chaahi.
+
+ode-system-duplicate-variable-names = Dohraais dependent variable ke naam ke saath ODE RHS function ke paribhaasha nai hoy sake.
+
+ode-system-rhs-function-error = ODE RHS function ke paribhaasha nai hoy sake.  mathjs function banaawe me galti.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } lakiir ke beech me angle ke paribhaasha nai hoy sake
+
+angle-invalid-through-point = `<angle>` ke through me galat point
+
+parabola-vertex-too-many-points = Vertex ke saath 1 se jaada point se jaay waala parabola abhi tak nai banaa hai.
+
+parabola-too-many-points = 3 se jaada point se jaay waala parabola abhi tak nai banaa hai.
+
+intersection-too-many-items = Dui se jaada chiij ke liye intersection abhi tak nai banaa hai
+
+## Other math components
+
+ionic-compound-not-two-ions = Dui ion ke alaawa kuchhu aur ke liye ionic compound abhi tak nai banaa hai.
+
+ionic-compound-needs-cation-and-anion = Ionic compound sirf ek cation aur ek anion ke liye banaa hai.
+
+solve-equations-cannot-evaluate = Equation ke hisaab nai hoy sakaa, is liye equation hal nai hoy sake: { $equation }
+
+math-operators-operand-number-required = Math ke operand nikaalte time operandNumber set hona chaahi.
+
+eigen-decomposition-failed = Matrix ke eigenvalue ke hisaab nai hoy sakaa
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: parameter { $parameters } pattern me nai hai, is liye ii hamesha khaali se match kari.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ke matlab samajh me nai aais. Ii none, medium, dense ya dui positive number hona chaahi jaun ek space se alag hai, jaise grid="1 0.5". Koi grid nai banaawa jaawe hai.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` ke uu function chaahi jaun { $expected ->
+        [1] ek output dewe, matlab har point pe slope y', jaise `y - x`
+       *[other] dui output dewe, matlab har point pe vector, jaise `(y, -x)`
+    }, lekin jaun function diyaa gais hai uu { $found ->
+       *[other] { $found } output
+    } dewe hai. { $alternative ->
+        [none] Kuchhu nai banaawa jaawe hai.
+       *[other] Ii function ke liye `<{ $alternative }>` sahi component hai. Kuchhu nai banaawa jaawe hai.
+    }
+
+field-function-attribute-ignored-with-child = `function` attribute ignore karaa jaawe hai kaahe ki function component ke andar bhi diyaa gais hai; andar waala kaam me lawa jaawe hai. Function ke sirf ek tarah se do.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` attribute uu expression ke variable ke naam dewe hai jaun siidhe component ke andar likhaa hai. { $reason ->
+        [function-child] Iihaan function ek `<function>` bacchaa ke roop me diyaa gais hai, aur uu apnaa variable ke naam khud dewe hai, is liye `variables` ignore karaa jaawe hai.
+       *[no-expression] Iihaan aisan koi expression nai hai, is liye `variables` ignore karaa jaawe hai.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure renderer me xLabelPosition="left" nai chale hai; daahine waala vyavhaar kaam me lawa jaawe hai.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure renderer me yLabelPosition="bottom" nai chale hai; uupar waala vyavhaar kaam me lawa jaawe hai.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure me badalne ke liye axis ke hadd galat hai; default bbox (-10,-10,10,10) kaam me lawa jaawe hai.
+
+prefigure-invalid-width = `<graph>`: prefigure me badalne ke liye width galat hai; default diagram width 425 kaam me lawa jaawe hai.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure me badalne ke liye aspectRatio galat hai; default aspect ratio 1 kaam me lawa jaawe hai.
+
+prefigure-grid-spacing-too-fine = `<graph>`: axis ke hadd ke liye grid ke duuri bahut chhota hai; prefigure renderer me grid chhor diyaa jaawe hai.
+
+prefigure-annotations-not-rendered = `<graph>`: jab PreFigure renderer kaam me nai lawa jaawe hai, tab annotation nai banaawa jaawe hai.
+
+multiple-annotations-children = `<graph>` me bahut `<annotations>` bacchaa milaa; aakhri ke chhor ke sab ignore karaa jaawe hai.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Anjaan component type ke extend ya copy nai hoy sake: { $type }.
+
+copy-prop-not-found = { $component } type ke component pe { $property } prop nai milaa
+
+collect-no-source = collect ke liye koi source nai milaa.
+
+collect-invalid-component-type = `<{ $component }>` type ke component collect nai hoy sake, kaahe ki ii type galat hai.
+
+reference-index-unavailable = Index `{ $reference }` ke reference nai diyaa jaay sake
+
+## `<callAction>`
+
+component-action-unavailable = Component `{ $reference }` pe { $action } nai bulaawa jaay sake
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data ke shakl galat hai.  Row ke length ek jaisan nai hai. componentIdx me milaa :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data me column ke naam dohraais hai.  componentIdx me milaa :{ $componentIdx }
+
+data-frame-missing-column-name = Data me ek column ke naam nai hai.  componentIdx me milaa :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ii answer ke ek award apne bhejaa gais jawaab pe nirbhar hai, aur is se anokha vyavhaar hoi.
+
+answer-max-num-attempts-in-section-wide-check-work = Jaun container me sectionWideCheckWork hai, uske andar `<answer>` pe `maxNumAttempts` set kare ke koi asar nai hai, kaahe ki mauka ke ginti container se control hoy hai. `maxNumAttempts` ke container pe set karo.
+
+nested-section-wide-check-work-max-num-attempts = Jaun sectionWideCheckWork waala container dusra sectionWideCheckWork waala container ke andar hai, uske uupar `maxNumAttempts` set kare ke koi asar nai hai, kaahe ki mauka ke ginti baahar waala container se control hoy hai. `maxNumAttempts` ke baahar waala container pe set karo.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality set kare bina { $attributes } attribute ke koi asar nai hoi.
+    }
+
+answer-invalid-type = Answer ke liye type galat hai: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` component ke koi naam nai hai, is liye uu module ke attribute ke roop me kaam me nai lawa jaay sake
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` component module ke attribute ke roop me kaam me nai lawa jaay sake, kaahe ki `<module>` component type me "{ $name }" naam ke attribute pahile se hai.
+
+conditional-content-condition-ignored = Jaun `<conditionalContent>` component me case ya else bacchaa hai, uske uupar `condition` attribute ignore karaa jaawe hai.
+
+slider-markers-type-mismatch = Marker ke type slider ke type se nai milaa.
+
+pretzel-problem-needs-statement-and-answer = Pretzel galat hai: har `<problem>` me ek `<statement>` aur ek `<answer>` hona chaahi.
+
+pretzel-circuit-first-problem-distractor = Pretzel galat hai: mode="circuit" me pahilaa `<problem>` distractor nai hoy sake.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] Attribute `{ $attribute }` ke liye galat value { $values }; ignore karaa jaawe hai.
+    }
+
+attribute-must-be-references = Attribute `{ $attribute }` ke liye value `{ $value }` galat hai. Attribute uu reference se banaa hona chaahi jaun `$` se shuru hoe.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } me galat function ke naam ignore karaa gais: { $names }. Har naam ke dekhaawe waala hissa kam se kam 2 akshar hona chaahi (akshar ya dash); uske baad ek `|<mathspeak alternative>` bhi aay sake hai.
+
+## Building components from the source
+
+component-type-invalid = Component type galat hai: `<{ $componentType }>`
+
+attribute-repeated = Attribute { $attribute } dohraawa nai jaay sake.
+
+attribute-invalid-for-component = `<{ $componentType }>` type ke component ke liye attribute "{ $attribute }" galat hai.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Style definition { $styleNumber } me { $context ->
+        [text-on-background] background ke saamne text ke colour
+        [high-contrast] canvas ke saamne high-contrast colour
+        [line] canvas ke saamne line ke colour
+        [marker] canvas ke saamne marker ke colour
+       *[text-on-canvas] canvas ke saamne text ke colour
+    } ke liye kaafi contrast nai hai{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kam se kam { $threshold }:1 chaahi).
+
+style-definition-dark-mode-text-background-contrast =
+    Style definition { $styleNumber } me set karaa colour light mode ke liye kaafi contrast dewe hai, lekin unse nikaalaa gais dark mode ke colour me background ke saamne text ke colour ke contrast kaafi nai hai ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kam se kam { $threshold }:1 chaahi). { $suggestion ->
+        [available] Dark mode me kaafi contrast ke liye ya to light mode ke contrast barhao (jaise { $lightAttribute }="{ $lightColor }" set karo) ya dark mode ke colour khud set karo (jaise { $darkAttribute }="{ $darkColor }" set karo).
+       *[none] Dark mode me kaafi contrast ke liye light mode ke contrast barhao ya nikaalaa gais colour ke textColorDarkMode aur/ya backgroundColorDarkMode se badlo.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Style definition { $styleNumber } me set karaa text ke colour light mode ke liye kaafi contrast dewe hai, lekin us se nikaalaa gais dark mode ke text ke colour canvas ke saamne kaafi contrast nai dewe hai ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kam se kam { $threshold }:1 chaahi). { $suggestion ->
+        [available] Dark mode me kaafi contrast ke liye ya to light mode ke contrast barhao (jaise textColor="{ $lightColor }" set karo) ya dark mode ke colour khud set karo (textColorDarkMode="{ $darkColor }" set karo).
+       *[none] Dark mode me kaafi contrast ke liye light mode ke contrast barhao ya nikaalaa gais colour ke textColorDarkMode se badlo.
+    }
+
+section-multiple-style-palettes = Ek section sirf ek <stylePalette> chun sake hai; aakhri waala kaam me lawa jaawe hai.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } ke unique variant pataa nai chal sake, kaahe ki numToSelect non-negative integer nai hai.
+
+variant-num-to-select-not-constant-number = { $component } ke unique variant pataa nai chal sake, kaahe ki numToSelect constant number nai hai.
+
+variant-with-replacement-not-constant-boolean = { $component } ke unique variant pataa nai chal sake, kaahe ki withReplacement constant boolean nai hai.
+
+variant-select-weight-disables-unique = Agar kono option pe selectWeight ya selectForVariants set hai to select ke liye unique variant band hoy jaawe hai
+
+variant-coprime-undetermined = { $component } ke unique variant pataa nai chal sake, kaahe ki ii pataa nai chale hai ki coprime hamesha galat hai.
+
+variant-attribute-not-constant = { $component } ke unique variant pataa nai chal sake, kaahe ki { $attribute } constant nai hai.
+
+variant-attribute-not-number = { $component } ke unique variant pataa nai chal sake, kaahe ki { $attribute } number nai hai.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } type ke { $component } ke unique variant pataa nai chal sake, kaahe ki { $attribute } { $expected ->
+        [letters-combination] akshar ke ek jorha
+        [math-expression] ek sahi math expression
+        [integer] ek integer
+       *[number] ek number
+    } nai hai.
+
+variant-length-not-integer = { $component } ke unique variant pataa nai chal sake, kaahe ki length integer nai hai.
+
+variant-sort-not-implemented = sort waala { $component } ke unique variant abhi tak nai banaa hai
+
+variant-exclude-combinations-not-implemented = excludeCombinations waala { $component } ke unique variant abhi tak nai banaa hai
+
+variant-math-exclude-not-implemented = exclude waala math type ke { $component } ke unique variant abhi tak nai banaa hai
+
+variant-non-constant-exclude-not-implemented = non-constant exclude waala { $component } ke unique variant abhi tak nai banaa hai
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph ke prefigure renderer me ii nai chale hai; descendant chhor diyaa gais.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometry adhuura ya non-finite hai; descendant chhor diyaa gais.
+
+prefigure-curve-label-omitted = { $subject }: badlaa gais curve element pe label nai chale hai; label chhor diyaa gais.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve ke function definition type '{ $definitionType }' nai chale hai; descendant chhor diyaa gais.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves pe flipFunctions attribute nai chale hai; descendant chhor diyaa gais.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves pe sirf formula type ke child function chale hai; descendant chhor diyaa gais.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] line-family ke label
+       *[point] point ke label
+    } ke liye labelPosition '{ $labelPosition }' nai chale hai; PreFigure ke default alignment kaam me lawa gais.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure me fill style '{ $fillStyle }' nai chale hai; saadaa fill kaam me lawa jaawe hai.
+
+prefigure-line-style-unknown = { $subject }: anjaan line style '{ $lineStyle }' PreFigure ke output se chhor diyaa gais.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }' PreFigure ke 'diamond' style me badlaa gais.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure me marker style '{ $markerStyle }' nai chale hai; default style kaam me lawa gais.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` galat hai; target nai milaa. Annotation chhor diyaa gais.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` bahut target pe gais; pahilaa target kaam me lawa jaawe hai.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` galat hai; target apne graph ke baahar hai. Annotation chhor diyaa gais.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` galat hai; prefigure me badalte time target koi chalne waala graphical chiij nai hai. Annotation chhor diyaa gais.
+
+annotation-text-missing = `<annotation>`: `text` nai hai ya khaali hai; khaali text diyaa jaawe hai.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Gol dependency milaa.
+       *[other] `<{ $componentType }>` component ke saath gol dependency milaa.
+    }
+
+reference-no-referent = Reference `{ $reference }` ke liye koi referent nai milaa
+
+reference-multiple-referents = Reference `{ $reference }` ke liye bahut referent milaa
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` ke attribute { $attribute } ke format galat hai.
+
+children-invalid = `<{ $componentType }>` ke liye galat bacchaa: galat bacchaa milaa: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Attribute `{ $attribute }` ke liye value `{ $value }` galat hai, value `{ $default }` kaam me lawa jaawe hai
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML version { $version } nai milaa.
+       *[other] DoenetML version { $version } nai milaa. Version { $fallback } kaam me lawa jaawe hai
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Galat DoenetML: { $content }
+
+parse-tag-missing-close-tag = Galat DoenetML: Tag `{ $tag }` ke koi closing tag nai hai. Ya to ek self-closing tag ya ek `</{ $tagName }>` tag chaahi.
+
+parse-tag-error = Galat DoenetML: Tag `<{ $tagName }>` me galti
+
+parse-attribute-missing-value = Galat DoenetML: Galat attribute `{ $attribute }` ke dekh ke lage hai ki iske value nai hai.
+
+parse-attribute-invalid = Galat DoenetML: Galat attribute `{ $attribute }`
+
+parse-attribute-value-invalid = Galat DoenetML: Galat attribute value `{ $value }`
+
+parse-attribute-value-quote-mismatch = Galat DoenetML: Galat attribute value `{ $value }`. Quote ke jorha nai milaa. Lage hai ki tumhaar ek `{ $quote }` chhut gais hai
+
+parse-open-tag-name-missing = Galat DoenetML: Bina naam ke ek tag milaa, jaise `<`
+
+parse-tag-not-closed = Galat DoenetML: Tag `{ $tag }` band nai hoy sakaa (lage hai ki ek `>` chhut gais hai).
+
+parse-self-closing-tag-name-missing = Galat DoenetML: Bina naam ke ek tag milaa `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Galat DoenetML: Tag `{ $tag }` band nai hoy sakaa (lage hai ki `/>` chhut gais hai).
+
+parse-tag-invalid-attributes = Galat DoenetML: Tag `{ $tag }` sahi nai hai. Lage hai ki iske attribute galat hai.
+
+parse-close-tag-name-missing = Galat DoenetML: Bina naam ke ek closing tag milaa, jaise `</`
+
+parse-attribute-value-unquoted = Attribute ke value quote ke andar hona chaahi: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Galat DoenetML: Closing tag `{ $tag }` milaa, lekin uske opening tag nai hai
+
+parse-close-tag-mismatched = Galat DoenetML: Closing tag nai milaa. `</{ $expected }>` chaahi rahaa. `{ $found }` milaa
+
+parser-node-unconvertible = Node { $node } ke Dast node me nai badlaa jaay sakaa.
+
+## Names
+
+name-attribute-invalid =
+    Galat attribute name='{ $name }'. { $reason ->
+        [characters] Naam me sirf akshar, number, underscore ya dash hoy sake hai.
+       *[start] Naam ek akshar se shuru hona chaahi.
+    }
+
+component-name-invalid-start = Galat component naam "{ $name }". Naam ek akshar se shuru hona chaahi.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched type ke answer me ek video attribute hona chaahi
+
+answer-video-watched-video-not-reference = videoWatched type ke answer ke video attribute ek reference hona chaahi
+
+answer-name-not-single-text = Answer ke name attribute me sirf ek text bacchaa hona chaahi
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Bahut jaada tah ke kaaran baahar ke DoenetML nai lawa jaay sakaa. Kahin koi gol reference to nai hai?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" se DoenetML nai lawa jaay sakaa
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" se lawa gais DoenetML galat hai: uu "{ $componentType }" component type se nai milaa
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` puraana hoy gais hai; iske jagah `{ $to }` kaam me lao.
+       *[other] [deprecation] `<{ $component }>` pe attribute `{ $from }` puraana hoy gais hai; iske jagah `{ $to }` kaam me lao.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` puraana hoy gais hai aur ignore karaa jaawe hai, kaahe ki `{ $to }` bhi set karaa hai.
+       *[other] [deprecation] `<{ $component }>` pe attribute `{ $from }` puraana hoy gais hai aur ignore karaa jaawe hai, kaahe ki `{ $to }` bhi set karaa hai.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` pe attribute `{ $attribute }` puraana hoy gais hai aur ignore karaa jaawe hai.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` pe attribute `{ $attribute }` puraana hoy gais hai; iske jagah ek `<{ $child }>` bacchaa kaam me lao.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` pe attribute `{ $attribute }` ke value `{ $value }` puraana hoy gais hai; iske jagah `{ $to }` kaam me lao.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` sirf English ke plural banaay sake hai, is liye { $locale } me likhaa document me uske text jaisan ke taisan rahe hai. Plural ke roop siidhe likho, ya `pluralForm` attribute se set karo.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Element `<{ $tag }>` Doenet ke pahchaanaa gais element nai hai.
+
+schema-element-not-allowed-at-root = Element `<{ $tag }>` document ke jarh pe nai aay sake.
+
+schema-element-not-allowed-inside = Element `<{ $tag }>` `<{ $parent }>` ke andar nai aay sake.
+
+schema-attribute-unrecognized = Element `<{ $tag }>` me `{ $attribute }` naam ke koi attribute nai hai.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Element `<{ $tag }>` ke attribute `{ $attribute }` ek aisan list hona chaahi jiske har chiij inme se ek hoe: { $allowed }
+       *[other] Element `<{ $tag }>` ke attribute `{ $attribute }` inme se ek hona chaahi: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select ke liye variant ke naam galat hai.  Variant ke naam { $variantName } { $numOptions } option me aawe hai, lekin chunne ke ginti { $numToSelect } hai.
+
+select-variant-name-without-options = select ke liye kuchhu variant set karaa hai, lekin sambhav variant naam { $variantName } ke liye koi option set nai hai.
+
+select-variant-name-not-possible = select ke liye set karaa variant naam { $variantName } sambhav variant naam nai hai.
+
+select-too-few-options = Sirf { $numOptions } me se { $numToSelect } component nai chunaa jaay sake.
+
+select-from-sequence-too-few-values = { $length } length ke sequence me se { $numToSelect } value nai chunaa jaay sake.
+
+select-from-sequence-indices-count-mismatch = select ke liye set karaa index ke ginti chunne ke ginti se milna chaahi
+
+select-from-sequence-indices-not-integers = select ke liye set karaa sab index integer hona chaahi
+
+select-from-sequence-index-excluded = selectfromsequence ke set karaa index nikaalaa gais rahaa
+
+select-from-sequence-indices-excluded-combination = selectfromsequence ke set karaa index ek nikaalaa gais jorha rahaa
+
+select-from-sequence-coprime-not-positive-integers = Positive integer nai chunaa jaay rahaa hai, is liye coprime jorha nai chunaa jaay sake.
+
+select-from-sequence-coprime-common-factor = Coprime number nai chunaa jaay sake. Sab sambhav value ke ek common factor hai. (Set karaa "from" ya "to" ke value "step" ke saath coprime hona chaahi.)
+
+select-from-sequence-coprime-single-number = Aisan ek hi number me se jaun 1 nai hai, coprime jorha nai chunaa jaay sake.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence me 70% se jaada jorha nikaalaa gais
+
+select-from-sequence-coprime-none-found = Coprime number nai chunaa jaay sakaa. Sab sambhav value ke ek common factor hai.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } length ke sequence me se { $numToSelect } unique value nai chunaa jaay sake
+
+select-prime-numbers-too-few-values = { $numValues } length ke prime number ke list me se { $numToSelect } value nai chunaa jaay sake
+
+select-prime-numbers-values-count-mismatch = select ke liye set karaa value ke ginti chunne ke ginti se milna chaahi
+
+select-prime-numbers-values-not-prime = Prime number chunne ke liye set karaa sab value prime number ke list me hona chaahi
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers ke set karaa value ek nikaalaa gais jorha rahaa
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers me 70% se jaada jorha nikaalaa gais
+
+select-random-combination-fluke = Bahut anokha sanjog se, random value ke jorha nai chunaa jaay sakaa
+
+select-random-value-fluke = Bahut anokha sanjog se, random value nai chunaa jaay sakaa
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Ii `<{ $component }>` nai dekhaawa jaawe hai kaahe ki ii math ke andar hai aur `inline` nai hai. `inline` jorho, taaki ii ek drop-down list ban jaay, jaun expression ke andar sama jaawe hai.
+        [expanded] Ii `<{ $component }>` nai dekhaawa jaawe hai kaahe ki ii math ke andar hai aur `expanded` hai. `expanded` hatao; bahut line waala box expression ke andar nai samaay sake.
+        [on-graph] Ii `<{ $component }>` nai dekhaawa jaawe hai kaahe ki ii graph pe banaawa gais math ke andar hai, aur uhaan input ke liye jagah nai hai.
+       *[relative-width] Ii `<{ $component }>` nai dekhaawa jaawe hai kaahe ki ii math ke andar hai aur iske width relative hai. Width ke absolute unit me do, jaise `px`.
+    }

--- a/packages/i18n/locales/hif/diagnostics.ftl
+++ b/packages/i18n/locales/hif/diagnostics.ftl
@@ -30,8 +30,8 @@
 # Each such message is written once as `*[other]`, with the count kept in the
 # selector so that nothing is lost from the message's shape. The `[1]` in
 # `field-function-wrong-num-outputs` is a numeric literal rather than a
-# category — Fluent matches it against the number itself — so it stays where
-# English has it. The symbolic selectors — `$reason`, `$type`, `$mode`,
+# category — Fluent matches it against the number itself — and it stands
+# where English selects the category `[one]`. The symbolic selectors — `$reason`, `$type`, `$mode`,
 # `$suggestion`, `$isList`, `$context`, `$expected` and the rest — keep every
 # branch English has, because those keys are compared letter for letter and a
 # renamed one is a branch nothing can reach.

--- a/packages/i18n/locales/hif/editor.ftl
+++ b/packages/i18n/locales/hif/editor.ftl
@@ -1,0 +1,227 @@
+# Fiji Hindi (Fiji Baat) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel beside them. Translated from `locales/en/editor.ftl`,
+# which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Latin script, left to right, the conventional Fiji Hindi orthography — the
+# same convention `chrome.ftl` states, and the four files of this locale must
+# not be split between two scripts.
+#
+# Fiji Hindi is verb-final, so where English drops a bare verb into the middle
+# of a sentence — "Click to { $action } accessibility report" — the whole
+# sentence sits inside the selector instead. Fluent does not care where a
+# select falls in a pattern.
+#
+# No message here selects on a plural category: CLDR has none for `hif`, and a
+# Fiji Hindi noun after a numeral stays unmarked in any case, so every count
+# message is a single `*[other]` with the count kept in the selector.
+#
+# `WCAG`, `DoenetML`, `XML`, `styleNumber` and every element or attribute name
+# are identifiers rather than words and stay exactly as written.
+#
+# **This is the thinnest of the four files, and the reason is not shyness.**
+# The context-help panel talks about references, properties, arrays and
+# resolved types, and the only words Fiji Hindi has for any of that are the
+# English ones — `reference`, `property`, `array`, `type`, `style`,
+# `coordinate` — because that is the language every Fiji Hindi speaker met
+# these ideas in. They are kept rather than replaced with Sanskritic coinages,
+# which would produce Standard Hindi under this tag. What is Fiji Hindi here is
+# the frame around them: the postpositions, the verb-final order, and the `-o`
+# imperative on every control.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reset
+       *[update] Update
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Viewer ke { $word } karo
+       *[other] Viewer ke { $word } karo { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = Chhaano...
+editor-variant-next = Agla variant chuno
+editor-variant-previous = Pichhla variant chuno
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA accessibility ke ulanghan milaa. { $action ->
+            [close] Accessibility report band kare ke liye click karo.
+           *[open] Accessibility report kholne ke liye click karo.
+        }
+        [advisories] { $action ->
+            [close] Accessibility report band kare ke liye click karo.
+           *[open] Accessibility report kholne ke liye click karo.
+        } WCAG AA ke koi ulanghan nai milaa, lekin accessibility ke kuchhu aur salaah hai.
+       *[clean] { $action ->
+            [close] Accessibility report band kare ke liye click karo.
+           *[open] Accessibility report kholne ke liye click karo.
+        } Accessibility ke koi samasya nai milaa.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA accessibility ke ulanghan milaa. { $count } WCAG AA ulanghan milaa. { $action ->
+            [close] Accessibility report band kare ke liye click karo.
+           *[open] Accessibility report kholne ke liye click karo.
+        }
+        [advisories] WCAG AA ke koi ulanghan nai milaa. Accessibility ke { $count } aur salaah milaa. { $action ->
+            [close] Accessibility report band kare ke liye click karo.
+           *[open] Accessibility report kholne ke liye click karo.
+        }
+       *[clean] WCAG AA ke koi ulanghan nai milaa. { $action ->
+            [close] Accessibility report band kare ke liye click karo.
+           *[open] Accessibility report kholne ke liye click karo.
+        }
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = Jagah ke hisaab se madad
+editor-tab-help-short = Jagah
+editor-tab-errors = Galti
+editor-tab-warnings = Chetaawni
+editor-tab-info = Jaankaari
+editor-tab-accessibility = Accessibility
+editor-tab-responses = Bhejaa gais jawaab
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editor ke setting
+editor-format-as-doenetml = DoenetML jaisan format karo
+editor-format-as-xml = XML jaisan format karo
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Line #{ $line }
+
+editor-no-errors = Koi galti nai
+editor-no-warnings = Koi chetaawni nai
+editor-no-info = Koi info diagnostic nai
+
+editor-show-info-annotations = Editor me info diagnostic dekhao
+editor-show-accessibility-annotations = Editor me accessibility diagnostic dekhao
+
+editor-accessibility-learn-more = Jaano ki Doenet accessibility ke kaise dekhe hai →
+
+editor-accessibility-violations-heading = Accessibility ke ulanghan ({ $standard })
+
+editor-accessibility-other-heading = Accessibility ke dusra samasya
+editor-none-found = Kuchhu nai milaa
+
+
+## Submitted responses
+
+editor-no-responses = Abhi tak koi jawaab nai bhejaa gais
+editor-response-answer-id = Answer ke id
+editor-response-response = Jawaab
+editor-response-credit = Marks
+editor-response-submitted = Bhejne ke time
+
+
+## The context-help panel
+
+help-placeholder = Documentation ke liye cursor ke kono tag ke naam, attribute ya { $ref } pe rakho.
+
+help-unsupported-ref-chain = { $example } jaisan bahut hissa waala reference ke liye madad abhi tak nai hai.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Reference { $ref } ke liye koi referent nai milaa.
+        [multiple] Reference { $ref } ke liye bahut referent milaa.
+       *[indeterminate] { $ref } ke referent pataa nai chal sakaa.
+    }
+
+help-learn-about-references = Reference ke baare me jaano →
+help-reference-page = Reference ke panna →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ke andar
+       *[top] Sab se uupar ke level pe
+    }{ $allowed ->
+        [none] { " — iihaan kuchhu nai aawe hai." }
+        [text] { " — iihaan text likho." }
+        [text-and-components] { " — iihaan text likho, ya ii koshish karo:" }
+       *[components] { " — koshish kare ke chiij:" }
+    }
+
+help-suggestions-footer = Sab { $total } component dekhne ke liye { $shortcut } dabao.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } { $target } ke ek reference hai.
+       *[other] { $ref } { $target } ke ek reference hai (line { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } iske { $role } ke roop me laais hai.
+       *[other] { $owner } iske line { $line } pe { $role } ke roop me laais hai.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } { $element } ke { $property } property ke ek reference hai.
+       *[other] { $ref } { $element } ke { $property } property ke ek reference hai (line { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array ke entry
+
+help-default = Default:
+help-active-default = Chaalu default:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Chalne waala value (har chiij ke liye ek):
+       *[other] Chalne waala value:
+    }
+
+help-suggested-values = Salaah diyaa gais value:
+
+help-inserts = Jorhe hai:
+
+help-coordinates =
+    { $count ->
+       *[other] Coordinate:
+    }
+
+help-type = Type:
+
+help-resolved-style = Nikaalaa gais style (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nikaalaa gais function ke naam:
+help-reset-list = Ii input pe list reset karo:
+help-added-on-input = Ii input pe jorhaa gais:
+help-removed-on-input = Ii input se hataawa gais:
+
+help-reset-overrides = { $reset } { $additional } aur { $removed } ke uupar chale hai.

--- a/packages/i18n/locales/hne/chrome.ftl
+++ b/packages/i18n/locales/hne/chrome.ftl
@@ -29,14 +29,16 @@
 # rather than disguised.** «कीबोर्ड», «पंक्ति», «स्तंभ», «व्यंजक», «त्रुटि»,
 # «सुगम्यता», «पूर्वावलोकन» are the words a Chhattisgarhi speaker has met in
 # school and on a screen, in Hindi. Where the language's own everyday word is
-# the one a reader would use, it is used instead: «जवाब», «गलत», «करिया»,
-# «पंडरा», «पींयर», «हरियर», «बाँचे».
+# the one a reader would use, it is used instead — across the catalog, not
+# only in this file: «जवाब», «गलत» and «बाँचे» here, «करिया», «पंडरा»,
+# «पींयर», «हरियर» among `content.ftl`'s colours.
 #
 # **Counts.** CLDR has no plural data for `hne`, so `Intl.PluralRules` would
 # resolve it against the runtime's own locale and any `[one]` branch would be
-# selected by somebody else's rules. Both counted messages collapse to a
-# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
-# Fluent matches against the number itself. A Chhattisgarhi noun is unmarked
+# selected by somebody else's rules. `answer-show-responses` therefore drops
+# the selector entirely and writes one form, and the only branch on a number
+# left in this file is `attempts-remaining`'s explicit `[0]`, which Fluent
+# matches against the number itself rather than against a category. A Chhattisgarhi noun is unmarked
 # after a numeral in any case — «मन» marks plurality, not counting — so one
 # form is right.
 

--- a/packages/i18n/locales/hne/chrome.ftl
+++ b/packages/i18n/locales/hne/chrome.ftl
@@ -1,0 +1,141 @@
+# Chhattisgarhi (छत्तीसगढ़ी) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Chhattisgarhi is written
+# in — it is a scheduled state language of Chhattisgarh with a Devanagari
+# print tradition and no competing script. Digits are **Latin** (`1`, `2`,
+# `1,234`), not Devanagari, because that is what DoenetML pins for every
+# locale in `src/intl.ts`; the grouping separator is the locale's own.
+#
+# **What is Chhattisgarhi here is the frame, and it is used consistently.**
+# The copula is «हे» / «हें», the negator «नइ», the dative and purposive is
+# **«बर»** — *for* — which is the single most visible Chhattisgarhi word in
+# this catalog and the quickest way to tell these files from Hindi at a
+# glance. Beside it: «अउ» for *and*, «काबर के» for *because*, «तेकर सेती» for
+# *therefore*, «कहूँ» for *if*, «नइते» for *otherwise*, «ले» for *from / out
+# of*, «ला» for the accusative, «ए» for *this*, «कोनो» for *any*, and the
+# plural marker **«मन»** written as a separate word after the noun («बिंदु
+# मन», «रेखा मन»). Buttons carry the honorific imperative in **-व** —
+# «खोलव», «हटावव», «जोड़व», «देखावव».
+#
+# **The technical vocabulary is Hindi and Sanskrit, and that is declared
+# rather than disguised.** «कीबोर्ड», «पंक्ति», «स्तंभ», «व्यंजक», «त्रुटि»,
+# «सुगम्यता», «पूर्वावलोकन» are the words a Chhattisgarhi speaker has met in
+# school and on a screen, in Hindi. Where the language's own everyday word is
+# the one a reader would use, it is used instead: «जवाब», «गलत», «करिया»,
+# «पंडरा», «पींयर», «हरियर», «बाँचे».
+#
+# **Counts.** CLDR has no plural data for `hne`, so `Intl.PluralRules` would
+# resolve it against the runtime's own locale and any `[one]` branch would be
+# selected by somebody else's rules. Both counted messages collapse to a
+# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
+# Fluent matches against the number itself. A Chhattisgarhi noun is unmarked
+# after a numeral in any case — «मन» marks plurality, not counting — so one
+# form is right.
+
+
+## Answer submission
+
+answer-checking = जाँचल जावत हे...
+answer-submitting = पठावल जावत हे...
+answer-checking-status = जवाब जाँचल जावत हे
+answer-submitting-status = जवाब पठावल जावत हे
+answer-correct = सही
+answer-incorrect = गलत
+answer-response-saved = जवाब सहेजल गिस
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+max-credit-available = सबसे जादा मिले वाला अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] कोनो मौका नइ बचा
+       *[other] { $count } मौका बाँचे हे
+    }
+validation-correct = (सही)
+validation-incorrect = (गलत)
+validation-partially-correct = (कुछ हद तक सही)
+answer-show-responses = { $answerId } के { $count } जवाब देखावव
+
+
+## Disclosure panels
+
+feedback-heading = राय
+collapsible-click-to-open = (खोले बर क्लिक करव)
+collapsible-click-to-close = (बंद करे बर क्लिक करव)
+collapsible-initializing = सुरू करे जावत हे...
+footnote-show = पादटिप्पणी देखावव
+footnote-hide = पादटिप्पणी छिपावव
+description-more-information = अउ जानकारी
+
+
+## Controls
+
+slider-previous = पहिली
+slider-next = आगे
+keyboard-open = कीबोर्ड खोलव
+keyboard-close = कीबोर्ड बंद करव
+choice-input-remove-choice = { $choice } हटावव
+matrix-remove-row = पंक्ति हटावव
+matrix-add-row = पंक्ति जोड़व
+matrix-remove-column = स्तंभ हटावव
+matrix-add-column = स्तंभ जोड़व
+subset-add-remove-points = बिंदु जोड़व/हटावव
+subset-toggle-points-intervals = बिंदु अउ अंतराल के बीच बदलव
+subset-move-points = बिंदु सरकावव
+subset-clear = साफ करव
+# A `box` here is one orbital, drawn as a square: खाँचा.
+orbital-add-row = पंक्ति जोड़व
+orbital-remove-row = पंक्ति हटावव
+orbital-add-box = खाँचा जोड़व
+orbital-remove-box = खाँचा हटावव
+orbital-add-up-arrow = ऊपर के तीर जोड़व
+orbital-add-down-arrow = नीचे के तीर जोड़व
+orbital-remove-arrow = तीर हटावव
+orbital-row-label = पंक्ति { $row } के लेबल
+pretzel-answer = जवाब
+summary-statistics-caption = { $column } के सारांश सांख्यिकी
+
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक के पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+
+## Document status
+
+viewer-initializing = सुरू करे जावत हे...
+
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } म मिलिस।
+       *[lines] पंक्ति { $startLine }–{ $endLine } म मिलिस।
+    }
+document-contains-errors = ए दस्तावेज म त्रुटि हें!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+something-went-wrong = कुछ गलत होइ गिस।
+renderer-load-failed = एक रेंडरर लोड नइ हो सकिस। कृपया पन्ना फेर लोड करव।
+core-start-failed = ए दस्तावेज सुरू नइ हो सकिस। कृपया पन्ना फेर लोड करव।
+core-start-failed-busy = ए दस्तावेज सुरू नइ हो सकिस। एके संग कई दस्तावेज सुरू होवत रिहिन, अउ धीमे यंत्र पर ए म जादा समय लागथे। दूसर दस्तावेज पूरा होइ जाँय तब पन्ना फेर लोड करे ले काम बन सकथे।
+core-start-failed-retry = ए दस्तावेज सुरू नइ हो सकिस।
+core-start-failed-busy-retry = ए दस्तावेज सुरू नइ हो सकिस। एके संग कई दस्तावेज सुरू होवत रिहिन, अउ धीमे यंत्र पर ए म जादा समय लागथे।
+core-start-retry = फेर कोसिस करव
+saved-state-unavailable = तोर सहेजल काम लोड नइ हो सकिस।

--- a/packages/i18n/locales/hne/content.ftl
+++ b/packages/i18n/locales/hne/content.ftl
@@ -32,12 +32,13 @@
 # once, and `noun-gender` answers the single token `neuter` because nothing
 # downstream needs to select on it.
 #
-# The gap: three words in this file **are** marked in Chhattisgarhi and are
+# The gap: four words in this file **are** marked in Chhattisgarhi and are
 # written here in their direct-masculine form regardless — the colour loans
 # «नीला» and «भूरा», the participle «भरा» in `style-filled-word`, and «वाला»
 # in `style-filled`. «बिंदु मन वाला रेखा» should be «बिंदु मन वाली रेखा». A
 # reviewer who wants that fixed has to reintroduce the `$gender` fork on
-# those spots and a `$role` fork for the oblique that `border-clause` wants,
+# those spots and a `$role` fork for the oblique that `style-border-clause`
+# wants,
 # and give `noun-gender` a real table — रेखा, किरण and बहुरेखा are feminine,
 # and so is पृष्ठभूमि. This is the largest single defect in the file.
 #
@@ -58,7 +59,7 @@
 # noun, which is what the fill patterns carry.
 #
 # **The two chemistry tables are absent.** `element-name` and
-# `element-anion-name` — 128 messages between them — are not translated in
+# `element-anion-name` — 130 messages between them — are not translated in
 # this batch, so this catalog sits at 445/575 keys with every other file in
 # it. The element names a Chhattisgarhi reader would use are the Hindi ones,
 # and a seed that copied them over would be claiming a review it has not had;
@@ -171,7 +172,7 @@ style-filled-with-noun =
     }
 # «के संग» is postpositional, so «किनारा» stands in the oblique «किनारे». The
 # adjective in front of it should go oblique too, and does not: that is the
-# `$role` gap the header names. Awadhi has no article, so the `-article`
+# `$role` gap the header names. Chhattisgarhi has no article, so the `-article`
 # branches read the same as the ones without.
 style-border-clause =
     { $parts ->

--- a/packages/i18n/locales/hne/content.ftl
+++ b/packages/i18n/locales/hne/content.ftl
@@ -1,0 +1,292 @@
+# Chhattisgarhi (छत्तीसगढ़ी) content catalog: the prose the core computes into
+# the document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, as in every file of this catalog, and the only
+# script Chhattisgarhi is written in. Digits are Latin and a number is grouped
+# by the locale's own rules (`1,000`), which is what DoenetML pins for every
+# locale in `src/intl.ts`.
+#
+# ## Word order
+#
+# **The description comes first and the noun last**, as in English and as in
+# Hindi: «मोट खंडित लाल रेखा» is *thick dashed red line*. So `style-with-noun`
+# and `style-filled-with-noun` keep English's order of placeables, and
+# `style-stroke` keeps English's internal order of width, dash pattern and
+# colour, because that is Chhattisgarhi's order too.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } भुजा वाला सम बहुभुज» and leaves `tail` empty, as English
+# does: the side count goes in front of the noun here, so nothing has to be
+# split around the adjectives.
+#
+# ## Gender, role and number
+#
+# **Neither `$gender` nor `$role` forks, and that is half a claim about the
+# language and half a gap.** The claim: the colour and width words this file
+# uses are invariant — «करिया», «पंडरा», «पींयर», «हरियर», «मोट», «पातर» —
+# so where `locales/hi` forks काला / काली / काले this file writes «करिया»
+# once, and `noun-gender` answers the single token `neuter` because nothing
+# downstream needs to select on it.
+#
+# The gap: three words in this file **are** marked in Chhattisgarhi and are
+# written here in their direct-masculine form regardless — the colour loans
+# «नीला» and «भूरा», the participle «भरा» in `style-filled-word`, and «वाला»
+# in `style-filled`. «बिंदु मन वाला रेखा» should be «बिंदु मन वाली रेखा». A
+# reviewer who wants that fixed has to reintroduce the `$gender` fork on
+# those spots and a `$role` fork for the oblique that `border-clause` wants,
+# and give `noun-gender` a real table — रेखा, किरण and बहुरेखा are feminine,
+# and so is पृष्ठभूमि. This is the largest single defect in the file.
+#
+# **Nothing selects on a count.** CLDR has no plural data for `hne`, and a
+# Chhattisgarhi noun is unmarked after a numeral: «मन» marks plurality, not
+# counting, and does not appear after a numeral.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry and chemistry register is Hindi and Sanskrit, declared as
+# such**: «रेखा», «रेखाखंड», «किरण», «सदिश», «वक्र», «फलन», «परवलय»,
+# «बहुभुज», «त्रिभुज», «आयत», «वृत्त», «समचतुर्भुज». Chhattisgarhi-medium
+# mathematics teaching barely exists above the primary years, so these are
+# the words a Chhattisgarhi student has actually met, and inventing coinages
+# would put words in front of a reader nobody uses. What is Chhattisgarhi
+# here is everything around them: «जवाब», «सवाल», «कहूँ», «नइते», «के» for
+# the genitive, «अउ», «बर», «ले», and the plural **«मन»** written after the
+# noun, which is what the fill patterns carry.
+#
+# **The two chemistry tables are absent.** `element-name` and
+# `element-anion-name` — 128 messages between them — are not translated in
+# this batch, so this catalog sits at 445/575 keys with every other file in
+# it. The element names a Chhattisgarhi reader would use are the Hindi ones,
+# and a seed that copied them over would be claiming a review it has not had;
+# the renderer already falls back to English for a missing key.
+
+
+## Style vocabulary
+
+color =
+    .black = करिया
+    .white = पंडरा
+    .gray = सलेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow = पींयर
+    .green = हरियर
+    .cyan = फिरोजी
+    .blue = नीला
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown = भूरा
+# Both are invariant in Chhattisgarhi, so neither takes a fork.
+line-width =
+    .thick = मोट
+    .thin = पातर
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+# Each carries the plural «मन» after the noun, because their other use is in
+# front of «वाला». They agree with nothing, so `style-fill` gives them a noun
+# to hang off rather than printing them bare.
+fill-style =
+    .horizontal = आड़ी रेखा मन
+    .vertical = खड़ी रेखा मन
+    .diagonal = विकर्ण रेखा मन
+    .backdiagonal = उलटी विकर्ण रेखा मन
+    .dots = बिंदु मन
+    .diamonds = समचतुर्भुज मन
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = प्रवणता क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = जोड़ चिह्न
+# The side count goes in front of the noun, so the whole phrase is one head
+# and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजा वाला सम बहुभुज
+    }
+# A single token: nothing in this file selects on gender, so there is no
+# table to fill in. Chhattisgarhi does have gender — रेखा, किरण, बहुरेखा and
+# पृष्ठभूमि are feminine, किनारा, भराव and पाठ masculine — and a reviewer who
+# reinstates agreement has to write that table here first.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# Adjectives precede the noun, as in English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# Said only of the shape itself, so it is standalone everywhere. «भरा» is a
+# marked adjective in Chhattisgarhi and ought to agree with the shape; the seed
+# writes the masculine throughout. See the header.
+style-filled-word = भरा
+# «वाला» belongs to the shape rather than to the pattern in front of it, and
+# in Chhattisgarhi it agrees with the shape — «बिंदु मन वाली रेखा», «बिंदु मन वाला
+# वर्ग». The seed writes «वाला» unagreed; see the header.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वाला { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «के संग» is postpositional, so «किनारा» stands in the oblique «किनारे». The
+# adjective in front of it should go oblique too, and does not: that is the
+# `$role` gap the header names. Awadhi has no article, so the `-article`
+# branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारे के संग
+        [and] अउ { $border } किनारे के संग
+        [and-article] अउ { $border } किनारे के संग
+       *[with] { $border } किनारे के संग
+    }
+# The fill-pattern words end in the plural «मन», so this message supplies a
+# noun for them to hang off — «भराव» — rather than printing them bare.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } भराव
+       *[plain] { $color } भराव
+    }
+style-unfilled = बिना भराव
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि पर { $color }
+       *[plain] { $color }
+    }
+style-background-none = कोनो नइ
+
+
+## Boolean words
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## Answer buttons
+
+answer-submit-label = जाँचव
+answer-submit-label-no-correctness = जवाब पठावव
+
+
+## Sectional blocks
+
+section-name =
+    .activity = गतिविधि
+    .aside = बगल के बात
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = जवाब
+    .note = टिप्पणी
+    .objectives = उद्देस
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = सवाल
+    .problems = सवाल
+    .proof = प्रमाण
+    .question = परसन
+    .section = अनुभाग
+    .solution = हल
+    .task = काम
+    .theorem = प्रमेय
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = संकेत
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = पहिली
+paginator-next = आगे
+paginator-page = पन्ना
+paginator-page-status = { $numPages } म ले { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = या
+piecewise-condition-if = कहूँ
+piecewise-condition-otherwise = नइते
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header. What is left is the prose around them.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = खाली जगह
+math-embedded-input-blank-ordinal = { $total } म ले { $ordinal } खाली जगह

--- a/packages/i18n/locales/hne/diagnostics.ftl
+++ b/packages/i18n/locales/hne/diagnostics.ftl
@@ -1,0 +1,677 @@
+# Chhattisgarhi (छत्तीसगढ़ी) diagnostics: the warnings and errors the worker
+# raises and the reader is shown. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth. Selected by
+# `uiLocale`, not by the language the document was written in.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# Neither are the DoenetML identifiers quoted inside these sentences:
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence` and every tag and attribute name like them are part of
+# the language an author writes, not prose, and stay in English exactly as
+# written. So does the `[deprecation]` marker, which is a label rather than a
+# word, and anything quoted back from the author's own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari with Latin digits**, as in every file of this catalog.
+#
+# **The technical vocabulary is Hindi and Sanskrit and is declared as such** —
+# घटक, विशेषता, चर, विमा, आव्यूह, संदर्भ, फलन, समीकरण, अनुक्रम, वैषम्य.
+# These are the words a Chhattisgarhi reader has met; inventing equivalents
+# would put words in front of a reader that nobody uses.
+#
+# **What is Chhattisgarhi is the frame**, and it carries the whole file:
+#
+#   «हे» / «हें»              the copula
+#   «नइ»                      the negator
+#   «नइ करे जा सकय»           *cannot be done*
+#   «छोड़े जावत हे»           *ignoring*
+#   «धियान नइ दिए जाय»        *is ignored*
+#   «होना चाही»               *must be*
+#   «काबर के»                 *because*
+#   «तेकर सेती»               *therefore*
+#   «अभी उपलब्ध नइ हे»        *has not been implemented*
+#   «बर»                      *for* — the dative, and the file's signature
+#   «ले»                      *from / out of*; «ला» the accusative
+#   «अउ» / «या» / «कहूँ»      *and* / *or* / *if*
+#   «मन»                      the plural, written after the noun
+#
+# A sentence that has slipped back into «है», «नहीं», «क्योंकि» or «के लिए»
+# is a mistake to fix rather than a stylistic choice. This is a **framed**
+# catalog: the sentences are Chhattisgarhi, the nouns inside them are declared
+# Hindi, and a speaker should expect to correct the sentences as often as the
+# words.
+#
+# **No plural branches.** CLDR has no plural data for `hne`, so every
+# `[one]`/`[other]` fork English writes over a count is collapsed here; most
+# become a plain message, since a Chhattisgarhi noun is unmarked after a
+# numeral. The one exception is `field-function-wrong-num-outputs`, where
+# English is not counting but distinguishing a one-output field from a
+# two-output one; that fork is kept as the numeric literal `[1]`, which Fluent
+# matches against the number itself rather than against a plural category.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दू सिरा दे जाय पर { $attributes } पर धियान नइ दिए जाय
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा अउ मध्यबिंदु दूनों दे जाय पर { $attributes } पर धियान नइ दिए जाय
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु के बिना midpointOffset के कोनो असर नइ होवय
+
+## `<line>`
+
+line-points-undetermined-dimensions = अइसन बिंदु मन से होके जाय वाली रेखा जेकर विमा तय नइ हे।
+
+line-points-too-few-dimensions = रेखा ला कम से कम दू विमा वाले बिंदु मन से होके जाना चाही।
+
+line-points-depend-on-variables = रेखा ओ बिंदु मन से होके जावत हे जउन चर मन पर निर्भर हें: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } अउ { $variable2 } म रेखा के समीकरण के प्रारूप अमान्य हे।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एके संग through, endpoint अउ direction से तय हे। दे गे through छोड़े जावत हे।
+
+ray-dimension-mismatch = किरण म numDimensions मेल नइ खावय।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एके संग head, tail अउ displacement से तय हे। दे गे head छोड़े जावत हे।
+
+vector-dimension-mismatch = सदिश म numDimensions मेल नइ खावय।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` के ओर खींचा नइ जा सकय, काबर के ओ म nearestPoint अवस्था चर नइ हे।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित नइ करे जा सकय, काबर के ओ म nearestPoint अवस्था चर नइ हे।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` के भीतरी भाग तक सीमित नइ करे जा सकय, काबर के ओ म nearestPoint अवस्था चर नइ हे।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होय वाले choiceInput बर labelPosition पर धियान नइ दिए जाय
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput बर दे गे indices छोड़े जावत हे, काबर के indices के संख्या choice संतान मन के संख्या से मेल नइ खावय।
+
+pretzel-indices-count-mismatch = problem बर दे गे indices छोड़े जावत हे, काबर के indices के संख्या problem संतान मन के संख्या से मेल नइ खावय।
+
+shuffle-indices-count-mismatch = shuffle बर दे गे indices छोड़े जावत हे, काबर के indices के संख्या घटक मन के संख्या से मेल नइ खावय।
+
+indices-ignored-out-of-range = { $component } बर दे गे indices छोड़े जावत हे, काबर के कुछ अनुक्रमांक परिसर से बाहर हें।
+
+pretzel-indices-repeated = pretzel बर दे गे indices छोड़े जावत हे, काबर के कुछ अनुक्रमांक दोहरावल गे हें।
+
+pretzel-circuit-first-index = circuit विधा म pretzel बर दे गे indices छोड़े जावत हे, काबर के पहिली अनुक्रमांक 1 होना चाही।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ला पाठ संतान मन के संग काम करे बर `type` विशेषता देना चाही।
+
+invalid-type-defaulting-to-math = { $component } घटक बर प्रकार { $type } अमान्य हे। ए math, text, number या boolean म ले एक होना चाही। math के उपयोग करे जावत हे।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } बर मान्य घटक नइ हे। छोड़े जावत हे।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य हे; प्रकार number करे जावत हे।
+
+invalid-variable-value = चर के मान अमान्य हे: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } संख्या होना चाही
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } पूर्णांक होना चाही
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष माप बर अभी उपलब्ध नइ हे। चौड़ाई सापेक्ष करे जावत हे।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष माप बर अभी उपलब्ध नइ हे। हाशिया सापेक्ष करे जावत हे।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: ए म कम से कम एक खंड संतान होना चाही।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर धियान नइ दिए जाय।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एके घटक तक पहुँचना चाही।
+
+label-for-unresolved = `<label>` पर `for` विशेषता कोनो घटक तक नइ पहुँच सकिस।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता अइसन `<answer>` के संदर्भ देथे जेमा इनपुट खुद लिखा गिस हे; सीधे ओहि इनपुट के संदर्भ देव।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता अइसन `<answer>` के संदर्भ देथे जेमा लेबल लगावे लायक इनपुट नइ हे।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता कोनो इनपुट या कोनो जवाब के संदर्भ देना चाही।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता बर `<{ $component }>` के या त संछिप्त विवरण होना चाही या ओला सजावटी बतावा जाना चाही।
+
+accessibility-video-short-description = सुगम्यता बर `<video>` के संछिप्त विवरण होना चाही।
+
+accessibility-input-short-description-or-label = सुगम्यता बर `<{ $component }>` के संछिप्त विवरण या लेबल होना चाही।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता बर इनपुट बनावे वाले `<answer>` के संछिप्त विवरण या लेबल होना चाही।
+
+accessibility-short-description-contains-math = संछिप्त विवरण म `<{ $component }>` जइसे गणितीय घटक नइ होना चाही। गणित ला सब्द मन म लिखव।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } के खंड सीर्षक के पाठ बर वैषम्य अपर्याप्त हे (गाढ़ विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+       *[other] { $colorName } के खंड सीर्षक के पाठ बर वैषम्य अपर्याप्त हे ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदु मन के संख्यात्मक मान न होंय, तब { $count } बिंदु मन से होके जाय वाला `<circle>` अभी उपलब्ध नइ हे।
+
+circle-too-many-through-points = 3 से जादा बिंदु मन से होके जाय वाला वृत्त नइ निकाला जा सकय।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र अउ गुजरे वाले बिंदु एके संग दे जाय पर वृत्त नइ निकाला जा सकय।
+
+circle-center-with-multiple-points = दे गे केंद्र के संग 1 से जादा बिंदु से होके जाय वाला वृत्त नइ निकाला जा सकय।
+
+circle-radius-too-small = वृत्त नइ निकाला जा सकय: दूनों बिंदु मन के बीच के दूरी { $distance } हे, तेकर सेती दे गे त्रिज्या { $radius } बहुत छोट हे।
+
+circle-radius-with-many-points = दे गे त्रिज्या के संग दू से जादा बिंदु मन से होके जाय वाला वृत्त नइ बनावा जा सकय।
+
+circle-invalid-center-or-through-points = वृत्त के केंद्र या गुजरे वाले बिंदु अमान्य हें।
+
+circle-radius-center-with-multiple-points = दे गे केंद्र के संग 1 से जादा बिंदु से होके जाय वाले वृत्त के त्रिज्या नइ निकाली जा सकय।
+
+circle-change-radius-non-numerical = जौन वृत्त के गुजरे वाले बिंदु संख्यात्मक नइ हें, ओकर त्रिज्या नइ बदली जा सकय
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होय पर, दे गे त्रिज्या के संग एक से जादा बिंदु से होके जाय वाला वृत्त नइ बनावा जा सकय।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदु मन से होके जाय वाले वृत्त के केंद्र बदलब अभी उपलब्ध नइ हे।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन के प्रांत के विमा अपर्याप्त हें। प्रांत म { $intervals } अंतराल हें, पर फलन म { $inputs } इनपुट हें।
+
+function-domain-invalid-format = फलन के प्रांत के प्रारूप अमान्य हे।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन के असंख्यात्मक उच्चिष्ठ छोड़े जावत हे।
+        [minimum] फलन के असंख्यात्मक निम्निष्ठ छोड़े जावत हे।
+        [extremum] फलन के असंख्यात्मक चरम मान छोड़े जावत हे।
+        [point] फलन के असंख्यात्मक बिंदु छोड़े जावत हे।
+        [slope] फलन के असंख्यात्मक प्रवणता छोड़े जावत हे।
+       *[other] फलन के असंख्यात्मक { $type } छोड़े जावत हे।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन के खाली उच्चिष्ठ छोड़े जावत हे।
+        [minimum] फलन के खाली निम्निष्ठ छोड़े जावत हे।
+        [extremum] फलन के खाली चरम मान छोड़े जावत हे।
+        [point] फलन के खाली बिंदु छोड़े जावत हे।
+       *[other] फलन के खाली { $type } छोड़े जावत हे।
+    }
+
+function-points-too-close = फलन म दू बिंदु बहुत पास-पास हें। फलन परिभाषित नइ करे जा सकय।
+
+function-iterates-input-output-mismatch = फलन के पुनरावर्तन तबहीं संभव हे जब इनपुट के संख्या आउटपुट के संख्या के बराबर होय। ए फलन म { $inputs } इनपुट अउ { $outputs } आउटपुट हें।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम के लंबाई अमान्य हे। ए ऋणेतर पूर्णांक होना चाही।
+
+sequence-invalid-step = अनुक्रम के चरण अमान्य हे। { $type } प्रकार के अनुक्रम बर ए संख्या होना चाही।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम के "{ $attribute }" अमान्य हे। ए संख्या होना चाही।
+
+sequence-invalid-endpoint-letters = अछर अनुक्रम के "{ $attribute }" अमान्य हे। ए अछर मन के संयोजन होना चाही।
+
+sequence-invalid-endpoint = अनुक्रम के "{ $attribute }" अमान्य हे।
+
+select-from-sequence-coprime-not-numbers = संख्या नइ चुनी जात, तेकर सेती coprime छोड़ा गिस
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations दे गे हे, तेकर सेती coprime छोड़ा गिस
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` बर target अमान्य हे: लक्ष्य नइ मिलिस।
+
+target-state-variable-not-found = `<{ $source }>` बर target अमान्य हे: `<{ $component }>` पर "{ $property }" नाम के अवस्था चर नइ मिलिस।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` के चर स्वतंत्र चर से अलग होना चाही।
+
+ode-system-duplicate-variable-names = दोहरावल गे आश्रित चर नाम मन के संग ODE के दाहिन पच्छ के फलन परिभाषित नइ करे जा सकय।
+
+ode-system-rhs-function-error = ODE के दाहिन पच्छ के फलन परिभाषित नइ करे जा सकय। mathjs फलन बनावत समय त्रुटि होइस।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखा मन के बीच के कोण परिभाषित नइ करे जा सकय
+
+angle-invalid-through-point = `<angle>` के through म अमान्य बिंदु हे
+
+parabola-vertex-too-many-points = दे गे सीर्ष के संग 1 से जादा बिंदु से होके जाय वाला परवलय अभी उपलब्ध नइ हे।
+
+parabola-too-many-points = 3 से जादा बिंदु मन से होके जाय वाला परवलय अभी उपलब्ध नइ हे।
+
+intersection-too-many-items = दू से जादा वस्तु मन के प्रतिच्छेदन अभी उपलब्ध नइ हे
+
+## Other math components
+
+ionic-compound-not-two-ions = दू आयन मन के अलावा कोनो अउ हालत बर आयनिक यौगिक अभी उपलब्ध नइ हे।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक खाली एक धनायन अउ एक ऋणायन बर उपलब्ध हे।
+
+solve-equations-cannot-evaluate = समीकरण के मान नइ निकाला जा सकिस, तेकर सेती ऊ हल नइ करे जा सकय: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालत समय operandNumber देब जरूरी हे।
+
+eigen-decomposition-failed = आव्यूह के अभिलच्छनिक मान नइ निकाले जा सकिन
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न म नइ आवय, तेकर सेती ऊ सदा खाली से मेल खाई।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" समझा नइ जा सकिस। ए none, medium, dense, या खाली जगह से अलगावल दू धनात्मक संख्या होना चाही, जइसे grid="1 0.5"। कोनो ग्रिड नइ खींचा जाई।
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` ला अइसन फलन चाही जेमा { $expected ->
+        [1] एक आउटपुट होय, हर बिंदु पर प्रवणता y', जइसे `y - x`
+       *[other] दू आउटपुट होंय, हर बिंदु पर सदिश, जइसे `(y, -x)`
+    }, पर जौन फलन दे गे ओ म { $found } आउटपुट हें। { $alternative ->
+        [none] कुछ नइ खींचा जाई।
+       *[other] ओ फलन बर `<{ $alternative }>` घटक हे। कुछ नइ खींचा जाई।
+    }
+
+field-function-attribute-ignored-with-child = `function` विशेषता पर धियान नइ दिए जाय, काबर के फलन घटक के भीतर भी दे गे हे; भीतर वाला लेय जावत हे। फलन दूनों म ले खाली एके तरह से देव।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषता ओ व्यंजक के चर मन के नाम देथे जौन सीधे घटक के भीतर लिखा गिस हे। { $reason ->
+        [function-child] इहाँ फलन `<function>` संतान के रूप म दे गे हे, जौन आपन चर खुद बतावत हे, तेकर सेती `variables` छोड़े जावत हे।
+       *[no-expression] इहाँ अइसन कोनो व्यंजक नइ दे गे, तेकर सेती `variables` छोड़े जावत हे।
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर म xLabelPosition="left" समर्थित नइ हे; दाहिन ओर वाला बरताव लेय जावत हे।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर म yLabelPosition="bottom" समर्थित नइ हे; ऊपर वाला बरताव लेय जावत हे।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण बर अच्छ सीमा अमान्य हे; पूर्वनिर्धारित bbox (-10,-10,10,10) लेय जावत हे।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण बर चौड़ाई अमान्य हे; पूर्वनिर्धारित आरेख चौड़ाई 425 लेय जावत हे।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण बर aspectRatio अमान्य हे; पूर्वनिर्धारित अनुपात 1 लेय जावत हे।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अच्छ सीमा के हिसाब से ग्रिड के अंतराल बहुत महीन हे; prefigure रेंडरर म ग्रिड छोड़े जावत हे।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर के उपयोग न होय पर टीका नइ खींची जाई।
+
+multiple-annotations-children = `<graph>` म एक से जादा `<annotations>` संतान मिलिसं; अंतिम ला छोड़िके सब पर धियान नइ दिए जाय।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार ला बढ़ावा या नकल नइ करे जा सकय: { $type }।
+
+copy-prop-not-found = { $component } प्रकार के घटक पर { $property } गुण नइ मिलिस
+
+collect-no-source = collect बर कोनो स्रोत नइ मिलिस।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार के घटक बटोरे नइ जा सकय, काबर के ए मान्य घटक प्रकार नइ हे।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` के संदर्भ नइ दे जा सकय
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } नइ बुलावा जा सकय
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़ा मन के आकार अमान्य हे। पंक्ति मन के लंबाई असंगत हे। componentIdx :{ $componentIdx } म मिलिस
+
+data-frame-duplicate-column-names = आँकड़ा मन म स्तंभ नाम दोहरावल गे हें। componentIdx :{ $componentIdx } म मिलिस
+
+data-frame-missing-column-name = आँकड़ा मन म एक स्तंभ नाम नइ हे। componentIdx :{ $componentIdx } म मिलिस
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ए जवाब के एक award खुद answer टैग के पठावल जवाब पर टिका हे, जेह से अनचाहा बरताव होई।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र के भीतर के `<answer>` पर `maxNumAttempts` राखे के कोनो असर नइ होवय, काबर के मौका मन के संख्या पात्र तय करथे। `maxNumAttempts` पात्र पर राखव।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले कोनो अउ पात्र के भीतर बैठे `sectionWideCheckWork` पात्र पर `maxNumAttempts` राखे के कोनो असर नइ होवय, काबर के मौका मन के संख्या बाहरी पात्र तय करथे। `maxNumAttempts` बाहरी पात्र पर राखव।
+
+answer-attributes-need-symbolic-equality = symbolicEquality राखे बिना { $attributes } विशेषता के कोनो असर नइ होई।
+
+answer-invalid-type = answer बर प्रकार अमान्य हे: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = काबर के घटक `<{ $component }>` के नाम नइ हे, एला मॉड्यूल के विशेषता के रूप म नइ लीन जा सकय
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` ला मॉड्यूल के विशेषता के रूप म नइ लीन जा सकय, काबर के घटक प्रकार `<module>` म "{ $name }" विशेषता पहिलिच ले परिभाषित हे।
+
+conditional-content-condition-ignored = case या else संतान मन वाले `<conditionalContent>` घटक पर `condition` विशेषता पर धियान नइ दिए जाय।
+
+slider-markers-type-mismatch = चिह्नक मन के प्रकार स्लाइडर के प्रकार से मेल नइ खावय।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: हर `<problem>` म एक `<statement>` अउ एक `<answer>` होना चाही।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" म पहिली `<problem>` भरमावे वाला विकल्प नइ हो सकय।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` बर मान { $values } अमान्य हे; छोड़े जावत हे।
+
+attribute-must-be-references = विशेषता `{ $attribute }` बर मान `{ $value }` अमान्य हे। विशेषता `$` से सुरू होय वाले संदर्भ मन से बनी होना चाही।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } म अमान्य फलन नाम छोड़े गए: { $names }। हर नाम के दिखे वाले भाग म कम से कम 2 वर्ण (अछर या योजक चिह्न) होना चाही; ओकर बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आइ सकत हे।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य हे: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहरावी नइ जा सकय।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार के घटक बर विशेषता "{ $attribute }" अमान्य हे।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } म { $context ->
+        [text-on-background] पृष्ठभूमि के रंग के आगे पाठ के रंग
+        [high-contrast] कैनवास के आगे उच्च वैषम्य के रंग
+        [line] कैनवास के आगे रेखा के रंग
+        [marker] कैनवास के आगे चिह्नक के रंग
+       *[text-on-canvas] कैनवास के आगे पाठ के रंग
+    } बर वैषम्य अपर्याप्त हे{ $mode ->
+        [dark] { " (गाढ़ विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+
+style-definition-dark-mode-text-background-contrast =
+    भले शैली परिभाषा { $styleNumber } हल्की विधा बर पर्याप्त वैषम्य वाले रंग देथे, ए मान मन से निकले गाढ़ विधा के रंग मन म पाठ के रंग अउ पृष्ठभूमि के रंग के बीच वैषम्य अपर्याप्त हे ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)। { $suggestion ->
+        [available] गाढ़ विधा म पर्याप्त वैषम्य पावे बर या त हल्की विधा के वैषम्य बढ़ावव (जइसे { $lightAttribute }="{ $lightColor }" राखव) या गाढ़ विधा के रंग बदलि देव (जइसे { $darkAttribute }="{ $darkColor }" राखव)।
+       *[none] गाढ़ विधा म पर्याप्त वैषम्य पावे बर हल्की विधा के वैषम्य बढ़ावव या निकले रंग मन ला textColorDarkMode अउ/या backgroundColorDarkMode से बदलि देव।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    भले शैली परिभाषा { $styleNumber } हल्की विधा बर पर्याप्त वैषम्य वाला पाठ रंग देथे, ए मान से निकला गाढ़ विधा के पाठ रंग कैनवास के आगे अपर्याप्त वैषम्य रखथे ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)। { $suggestion ->
+        [available] गाढ़ विधा म पर्याप्त वैषम्य पावे बर या त हल्की विधा के वैषम्य बढ़ावव (जइसे textColor="{ $lightColor }" राखव) या गाढ़ विधा के रंग बदलि देव (जइसे textColorDarkMode="{ $darkColor }" राखव)।
+       *[none] गाढ़ विधा म पर्याप्त वैषम्य पावे बर हल्की विधा के वैषम्य बढ़ावव या निकले रंग ला textColorDarkMode से बदलि देव।
+    }
+
+section-multiple-style-palettes = एक खंड खाली एक <stylePalette> चुनि सकत हे; अंतिम लेय जावत हे।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के numToSelect ऋणेतर पूर्णांक नइ हे।
+
+variant-num-to-select-not-constant-number = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के numToSelect अचर संख्या नइ हे।
+
+variant-with-replacement-not-constant-boolean = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के withReplacement अचर बूलीय मान नइ हे।
+
+variant-select-weight-disables-unique = कहूँ कोनो विकल्प selectWeight या selectForVariants देथे त select के अनोखा संस्करण बंद होइ जावत हें
+
+variant-coprime-undetermined = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के ए तय नइ हो सकिस कि coprime सदा असत्य हे।
+
+variant-attribute-not-constant = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के { $attribute } अचर नइ हे।
+
+variant-attribute-not-number = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के { $attribute } संख्या नइ हे।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार के { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के { $attribute } { $expected ->
+        [letters-combination] अछर मन के संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } नइ हे।
+
+variant-length-not-integer = { $component } के अनोखा संस्करण तय नइ करे जा सकय, काबर के length पूर्णांक नइ हे।
+
+variant-sort-not-implemented = sort वाले { $component } के अनोखा संस्करण अभी उपलब्ध नइ हें
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } के अनोखा संस्करण अभी उपलब्ध नइ हें
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार के { $component } के अनोखा संस्करण अभी उपलब्ध नइ हें
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } के अनोखा संस्करण अभी उपलब्ध नइ हें
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख के prefigure रेंडरर म समर्थित नइ; वंसज छोड़ा गिस।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित या अधूरी हे; वंसज छोड़ा गिस।
+
+prefigure-curve-label-omitted = { $subject }: बदले गे वक्र तत्व मन पर लेबल समर्थित नइ; लेबल छोड़ा गिस।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित नइ; वंसज छोड़ा गिस।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित नइ; वंसज छोड़ा गिस।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves खाली सूत्र प्रकार के संतान फलन मन ला मानथे; वंसज छोड़ा गिस।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल के लेबल
+       *[point] बिंदु के लेबल
+    } बर labelPosition '{ $labelPosition }' समर्थित नइ; PreFigure के पूर्वनिर्धारित संरेखण लेय जावत हे।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure म समर्थित नइ; ठोस भराव लेय जावत हे।
+
+prefigure-line-style-unknown = { $subject }: अनजान रेखा शैली '{ $lineStyle }' PreFigure के आउटपुट से छोड़ी गई।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure के 'diamond' शैली पर मानचित्रित करे गिस।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure म समर्थित नइ; पूर्वनिर्धारित शैली लेय जावत हे।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य तय नइ हो सकिस। टीका छोड़ी गई।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` से कई लक्ष्य निकले; पहिली लक्ष्य लेय जावत हे।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य ओला समेटे आलेख के बाहर हे। टीका छोड़ी गई।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण म लक्ष्य समर्थित आलेखीय वस्तु नइ हे। टीका छोड़ी गई।
+
+annotation-text-missing = `<annotation>`: `text` नइ हे या खाली हे; खाली पाठ दे जावत हे।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता के पता चला।
+       *[other] `<{ $componentType }>` घटक से जुड़ी चक्रीय निर्भरता के पता चला।
+    }
+
+reference-no-referent = ए संदर्भ के कोनो लक्ष्य नइ मिलिस: `{ $reference }`
+
+reference-multiple-referents = ए संदर्भ के कई लक्ष्य मिलिन: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` के विशेषता { $attribute } के प्रारूप अमान्य हे।
+
+children-invalid = `<{ $componentType }>` के संतान अमान्य हें: अमान्य संतान मिलिसं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` बर मान `{ $value }` अमान्य हे; मान `{ $default }` लेय जावत हे
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } नइ मिलिस।
+       *[other] DoenetML संस्करण { $version } नइ मिलिस। संस्करण { $fallback } पर लौटा जावत हे
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` के समापन टैग नइ हे। खुद बंद होय वाला टैग या `</{ $tagName }>` टैग चाही रिहिस।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` म त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` के मान नइ लागथे।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य हे
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता के मान `{ $value }` अमान्य हे
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता के मान `{ $value }` अमान्य हे। उद्धरण चिह्न मेल नइ खावय। एक `{ $quote }` छूटा लागथे
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम के टैग मिलिस, जइसे `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नइ होइस (एक `>` छूटा लागथे)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम के टैग मिलिस `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नइ होइस (`/>` छूटा लागथे)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य नइ हे। एकर विशेषता गलत हो सकय हें।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम के समापन टैग मिलिस, जइसे `</`
+
+parse-attribute-value-unquoted = विशेषता के मान उद्धरण चिह्न मन म होना चाही: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिलिस, पर ओहसे मेल खात आरंभ टैग नइ हे
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल नइ खावय। `</{ $expected }>` चाही रिहिस। `{ $found }` मिलिस
+
+parser-node-unconvertible = नोड { $node } ला Dast नोड म नइ बदला जा सकिस।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य हे। { $reason ->
+        [characters] नाम मन म खाली अछर, अंक, अधोरेखा या योजक चिह्न हो सकय हें।
+       *[start] नाम अछर से सुरू होना चाही।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य हे। नाम अछर से सुरू होना चाही।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार के answer म video विशेषता होना चाही
+
+answer-video-watched-video-not-reference = videoWatched प्रकार के answer के video विशेषता एक संदर्भ होना चाही
+
+answer-name-not-single-text = answer के name विशेषता म खाली एक पाठ संतान होना चाही
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन के बहुत जादा स्तर मन के कारन बाहरी DoenetML नइ मिल सका। कहूँ चक्रीय संदर्भ त नइ?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" से DoenetML नइ मिल सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" से मिलिस DoenetML अमान्य हे: ए घटक प्रकार "{ $componentType }" से मेल नइ खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित हे; एकर बदले `{ $to }` के उपयोग करव।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित हे; एकर बदले `{ $to }` के उपयोग करव।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित हे अउ छोड़ी गई, काबर के `{ $to }` भी दे गे हे।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित हे अउ छोड़ी गई, काबर के `{ $to }` भी दे गे हे।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित हे अउ छोड़ी गई।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित हे; एकर बदले `<{ $child }>` संतान लिखव।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` के मान `{ $value }` अप्रचलित हे; एकर बदले `{ $to }` के उपयोग करव।
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` खाली अंग्रेजी के बहुवचन बनाइ सकत हे, तेकर सेती { $locale } म लिखे दस्तावेज म ओकर पाठ जस के तस रहिथे। बहुवचन रूप सीधे लिखव, या `pluralForm` विशेषता से देव।
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कोनो परिचित Doenet तत्व नइ हे।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज के मूल म मान्य नइ हे।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` के भीतर मान्य नइ हे।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` म `{ $attribute }` नाम के कोनो विशेषता नइ हे।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` के विशेषता `{ $attribute }` अइसन सूची होना चाही जेकर हर मद इनमन ले एक होय: { $allowed }
+       *[other] तत्व `<{ $tag }>` के विशेषता `{ $attribute }` इनमन ले एक होना चाही: { $allowed }
+    }
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select बर संस्करण नाम अमान्य हे। संस्करण नाम { $variantName } { $numOptions } विकल्प मन म आथे, पर चुने के संख्या { $numToSelect } हे।
+
+select-variant-name-without-options = select बर संस्करण दे गे हें, पर संभव संस्करण नाम बर कोनो विकल्प नइ हे: { $variantName }।
+
+select-variant-name-not-possible = select बर दे गे संस्करण नाम { $variantName } संभव संस्करण नाम नइ हे।
+
+select-too-few-options = खाली { $numOptions } घटक मन म ले { $numToSelect } नइ चुने जा सकय।
+
+select-from-sequence-too-few-values = { $length } लंबाई के अनुक्रम से { $numToSelect } मान नइ चुने जा सकय।
+
+select-from-sequence-indices-count-mismatch = select बर दे गे अनुक्रमांक मन के संख्या चुने के संख्या से मेल खाना चाही
+
+select-from-sequence-indices-not-integers = select बर दे गे सब अनुक्रमांक पूर्णांक होना चाही
+
+select-from-sequence-index-excluded = selectfromsequence बर दे गे अनुक्रमांक बाहर करे गिस रिहिस
+
+select-from-sequence-indices-excluded-combination = selectfromsequence बर दे गे अनुक्रमांक बाहर करे गिस संयोजन रिहिन
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक नइ चुने जात, तेकर सेती सहअभाज्य संयोजन नइ चुने जा सकय।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्या नइ चुनी जा सकय। सब संभव मान मन म एक उभयनिष्ठ गुणनखंड हे। (दे गे "from" या "to" मान "step" के सहअभाज्य होना चाही।)
+
+select-from-sequence-coprime-single-number = 1 से अलग कोनो एके संख्या से सहअभाज्य संयोजन नइ चुने जा सकय।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence म 70% से जादा संयोजन बाहर करे गिस
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्या नइ चुनी जा सकिस। सब संभव मान मन म एक उभयनिष्ठ गुणनखंड हे।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई के अनुक्रम से { $numToSelect } अलग मान नइ चुने जा सकय
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई के अभाज्य सूची से { $numToSelect } मान नइ चुने जा सकय
+
+select-prime-numbers-values-count-mismatch = select बर दे गे मान मन के संख्या चुने के संख्या से मेल खाना चाही
+
+select-prime-numbers-values-not-prime = select prime number बर दे गे सब मान अभाज्य सूची म होना चाही
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers बर दे गे मान बाहर करे गिस संयोजन रिहिन
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers म 70% से जादा संयोजन बाहर करे गिस
+
+select-random-combination-fluke = बहुते अनहोनी संजोग से यादृच्छिक मान मन के संयोजन नइ चुना जा सकिस
+
+select-random-value-fluke = बहुते अनहोनी संजोग से यादृच्छिक मान नइ चुना जा सकिस
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] ए `<{ $component }>` नइ देखाए जावय, काबर के ए गणित के भीतर हे अउ `inline` नइ हे। `inline` जोड़व, जेह से ए ड्रॉप-डाउन सूची बनि जाय, जौन व्यंजक के भीतर समाइ जावत हे।
+        [expanded] ए `<{ $component }>` नइ देखाए जावय, काबर के ए गणित के भीतर हे अउ `expanded` हे। `expanded` हटावव; कई पंक्ति वाला डिब्बा व्यंजक के भीतर नइ समावय।
+        [on-graph] ए `<{ $component }>` नइ देखाए जावय, काबर के ए आलेख पर खींचे गे गणित के भीतर हे, जहाँ इनपुट बर जगह नइ हे।
+       *[relative-width] ए `<{ $component }>` नइ देखाए जावय, काबर के ए गणित के भीतर हे अउ एकर चौड़ाई सापेक्ष हे। चौड़ाई निरपेक्ष इकाई म देव, जइसे `px`।
+    }

--- a/packages/i18n/locales/hne/editor.ftl
+++ b/packages/i18n/locales/hne/editor.ftl
@@ -15,8 +15,10 @@
 # name stay in English.** They are identifiers an author types, not words.
 #
 # **The counts do not fork.** `editor-accessibility-label` and
-# `help-coordinates` write a single `*[other]` where English writes `[one]`
-# and `[other]`: CLDR has no plural data for `hne`, so an English-selected
+# `help-coordinates` drop the `$count` selector English writes and give one
+# form outright — `help-coordinates` is a plain message, and
+# `editor-accessibility-label` interpolates `{ $count }` without selecting
+# on it: CLDR has no plural data for `hne`, so an English-selected
 # branch would be worse than none, and a Chhattisgarhi noun is unmarked after
 # a numeral in any case.
 #

--- a/packages/i18n/locales/hne/editor.ftl
+++ b/packages/i18n/locales/hne/editor.ftl
@@ -1,0 +1,214 @@
+# Chhattisgarhi (छत्तीसगढ़ी) editor and language-server surfaces: the footer,
+# the diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script, frame and register** are `chrome.ftl`'s: Devanagari with Latin
+# digits; a Chhattisgarhi frame — «हे», «नइ», «के», «अउ», «बर», «काबर के»,
+# «तेकर सेती», «ले», «ला», «ए», «कोनो», «मन» — around a Hindi and Sanskrit
+# technical vocabulary that is declared rather than disguised. Buttons carry
+# the honorific imperative in **-व** («देखावव», «दबावव», «राखव», «चुनव»).
+#
+# **`WCAG`, `DoenetML`, `XML`, `styleNumber` and every element and attribute
+# name stay in English.** They are identifiers an author types, not words.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `hne`, so an English-selected
+# branch would be worse than none, and a Chhattisgarhi noun is unmarked after
+# a numeral in any case.
+#
+# **`help-name-summary` is punctuation.** It renders with `{ $name }` empty
+# for a suggestion the panel has already named, so the em dash and its spaces
+# have to read on their own.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करव
+       *[update] अद्यतन करव
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्सक { $word }
+       *[other] दर्सक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = रूपांतर
+editor-variant-filter = छानव...
+editor-variant-next = अगला रूपांतर चुनव
+editor-variant-previous = पहिली वाला रूपांतर चुनव
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन मिलिस। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } बर क्लिक करव।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } बर क्लिक करव। कोनो WCAG AA उल्लंघन नइ मिलिस, पर सुगम्यता के अउ सुझाव हें।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } बर क्लिक करव। कोनो सुगम्यता के समस्या नइ मिलिस।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन मिलिस। { $count } WCAG AA उल्लंघन मिलिन। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } बर क्लिक करव।
+        [advisories] कोनो WCAG AA उल्लंघन नइ मिलिस। सुगम्यता के { $count } अउ सुझाव मिलिन। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } बर क्लिक करव।
+       *[clean] कोनो WCAG AA उल्लंघन नइ मिलिस। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } बर क्लिक करव।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग के हिसाब से मदद
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटि
+editor-tab-warnings = चेतावनी
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = पठावल गे जवाब
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक के विकल्प
+editor-format-as-doenetml = DoenetML के रूप म सजावव
+editor-format-as-xml = XML के रूप म सजावव
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कोनो त्रुटि नइ
+editor-no-warnings = कोनो चेतावनी नइ
+editor-no-info = कोनो सूचनात्मक निदान नइ
+
+editor-show-info-annotations = संपादक म सूचनात्मक निदान देखावव
+editor-show-accessibility-annotations = संपादक म सुगम्यता के निदान देखावव
+
+editor-accessibility-learn-more = जानव कि Doenet सुगम्यता ला कइसे देखथे
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = सुगम्यता के अउ समस्या
+editor-none-found = कुछ नइ मिलिस
+
+
+## Submitted responses
+
+editor-no-responses = अभी तक कोनो जवाब नइ पठावल गिस
+editor-response-answer-id = जवाब के आईडी
+editor-response-response = जवाब
+editor-response-credit = अंक
+editor-response-submitted = पठावल गिस
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेजीकरण देखे बर कर्सर ला कोनो टैग नाम, विशेषता या { $ref } पर राखव।
+
+help-unsupported-ref-chain = { $example } जइसे बहु-भागी संदर्भ के मदद अभी नइ हे।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ए संदर्भ के कोनो लक्ष्य नइ मिलिस: { $ref }।
+        [multiple] ए संदर्भ के कई लक्ष्य मिलिन: { $ref }।
+       *[indeterminate] { $ref } के लक्ष्य तय नइ करे जा सकिस।
+    }
+
+help-learn-about-references = संदर्भ के बारे म जानव →
+help-reference-page = संदर्भ के पन्ना →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } के भीतर
+       *[top] सबसे ऊपर के स्तर पर
+    }{ $allowed ->
+        [none] { " — इहाँ कुछ नइ राखा जा सकय।" }
+        [text] { " — इहाँ पाठ लिखा जा सकय हे।" }
+        [text-and-components] { " — इहाँ पाठ लिखव, या ए आजमावव:" }
+       *[components] { " — ए आजमावव:" }
+    }
+
+help-suggestions-footer = सब { $total } घटक देखे बर { $shortcut } दबावव।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } के संदर्भ हे।
+       *[other] { $ref }, { $target } के संदर्भ हे (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } { $role } के रूप म एला लावा।
+       *[other] { $owner } पंक्ति { $line } म { $role } के रूप म एला लावा।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } के { $property } गुण के संदर्भ हे।
+       *[other] { $ref }, { $element } के { $property } गुण के संदर्भ हे (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड के टुकड़ा
+help-kind-array-entry = सरणी के प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = चालू पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] मान्य मान (हर मद बर एक):
+       *[other] मान्य मान:
+    }
+
+help-suggested-values = सुझावल मान:
+
+help-inserts = जोड़थे:
+
+help-coordinates = निर्देशांक:
+
+help-type = प्रकार:
+
+help-resolved-style = तय शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = तय फलन नाम:
+help-reset-list = ए इनपुट के रीसेट सूची:
+help-added-on-input = ए इनपुट पर जोड़ा गिस:
+help-removed-on-input = ए इनपुट पर हटावा गिस:
+
+help-reset-overrides = { $reset }, { $additional } अउ { $removed } पर भारी परथे।

--- a/packages/i18n/locales/kfy/chrome.ftl
+++ b/packages/i18n/locales/kfy/chrome.ftl
@@ -1,0 +1,131 @@
+# Kumaoni (कुमाऊँनी) viewer chrome: the buttons, panel headers and status words the
+# reader interacts with. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Kumaoni is written in.
+#
+# **Method, stated plainly.** Kumaoni has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Kumaoni
+# speaker meets in an Uttarakhand classroom, which teaches out of Hindi
+# textbooks. What is Kumaoni here is the grammatical layer written over it:
+# the genitive क / की / का rather than Hindi का / की / के, the object marker
+# कैं, the copula छ (plural छन), the negative नि, बटि for *from*, दगाड़ for
+# *with*, अर for *and*, बान for *for*, किलैकि for *because*, and the -ओ
+# imperative (करो, दिखाओ, हटाओ) Kumaoni puts on a button. A reviewer should
+# read this as Kumaoni grammar over Hindi terminology and is free to replace
+# the terminology wherever Kumaoni has its own word.
+#
+# Numbers render as 1,234.5 in **Latin digits**, never in Devanagari
+# numerals: that is what CLDR gives for the Devanagari-writing languages of
+# India, and it is what DoenetML pins for every locale (`src/intl.ts`).
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `kfy`, so `lint:i18n` would reject a `[one]` branch outright. Every count
+# in this file goes through a single `*[other]`, keeping only
+# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
+# number itself rather than against a category.
+
+## Answer submission
+
+answer-checking = जाँचा जा रौ छ...
+answer-submitting = भेजा जा रौ छ...
+answer-checking-status = उत्तर जाँचा जा रौ छ
+answer-submitting-status = उत्तर भेजा जा रौ छ
+answer-correct = सही
+answer-incorrect = ग़लत
+answer-response-saved = उत्तर सहेजा गया
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+max-credit-available = अधिकतम संभव अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] कोई प्रयास शेष नि छन
+       *[other] { $count } प्रयास शेष
+    }
+validation-correct = (सही)
+validation-incorrect = (ग़लत)
+validation-partially-correct = (आंशिक रूप से सही)
+answer-show-responses = { $answerId } का { $count } उत्तर दिखाओ
+
+## Disclosure panels
+
+feedback-heading = प्रतिक्रिया
+collapsible-click-to-open = (खोलण बान क्लिक करो)
+collapsible-click-to-close = (बंद करण बान क्लिक करो)
+collapsible-initializing = आरंभ किया जा रौ छ...
+footnote-show = पादटिप्पणी दिखाओ
+footnote-hide = पादटिप्पणी छिपाओ
+description-more-information = अधिक जानकारी
+
+## Controls
+
+slider-previous = पिछलो
+slider-next = अगलो
+keyboard-open = कीबोर्ड खोलो
+keyboard-close = कीबोर्ड बंद करो
+choice-input-remove-choice = { $choice } हटाओ
+matrix-remove-row = पंक्ति हटाओ
+matrix-add-row = पंक्ति जोड़ो
+matrix-remove-column = स्तंभ हटाओ
+matrix-add-column = स्तंभ जोड़ो
+subset-add-remove-points = बिंदु जोड़ो/हटाओ
+subset-toggle-points-intervals = बिंदुओं अर अंतरालों क बीच बदलें
+subset-move-points = बिंदु खसकाओ
+subset-clear = साफ़ करो
+orbital-add-row = पंक्ति जोड़ो
+orbital-remove-row = पंक्ति हटाओ
+orbital-add-box = खाँचा जोड़ो
+orbital-remove-box = खाँचा हटाओ
+orbital-add-up-arrow = ऊपर क तीर जोड़ो
+orbital-add-down-arrow = नीचे क तीर जोड़ो
+orbital-remove-arrow = तीर हटाओ
+orbital-row-label = पंक्ति { $row } क लेबल
+pretzel-answer = उत्तर
+summary-statistics-caption = { $column } का वर्णनात्मक सांख्यिकी
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक क पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+## Document status
+
+viewer-initializing = आरंभ किया जा रौ छ...
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } में मिली।
+       *[lines] पंक्तियों { $startLine }–{ $endLine } में मिली।
+    }
+document-contains-errors = ये दस्तावेज़ में त्रुटियाँ छन!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+something-went-wrong = कुछ ग़लत हो गया।
+renderer-load-failed = एक रेंडरर लोड नि हो सका। किरपा करिबेर पृष्ठ फिर बटि लोड करो।
+core-start-failed = यो दस्तावेज़ शुरू नि किया जा सका। किरपा करिबेर पृष्ठ फिर बटि लोड करो।
+
+core-start-failed-busy = यो दस्तावेज़ शुरू नि किया जा सका। एक साथ कई दस्तावेज़ शुरू हो रईं छी, जै में धीमे उपकरण पर अधिक समय लगता छ। बाकी दस्तावेज़ों का पूरा होण पर पृष्ठ फिर बटि लोड करण बटि बात बन सकन छ।
+
+core-start-failed-retry = यो दस्तावेज़ शुरू नि किया जा सका।
+
+core-start-failed-busy-retry = यो दस्तावेज़ शुरू नि किया जा सका। एक साथ कई दस्तावेज़ शुरू हो रईं छी, जै में धीमे उपकरण पर अधिक समय लगता छ।
+
+core-start-retry = फिर बटि कोशिश करो
+
+saved-state-unavailable = आपका सहेजा गया काम लोड नि किया जा सका।

--- a/packages/i18n/locales/kfy/content.ftl
+++ b/packages/i18n/locales/kfy/content.ftl
@@ -1,0 +1,308 @@
+# Kumaoni (कुमाऊँनी) content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Kumaoni is written in.
+#
+# ## Method, and what this file can only say in Hindi
+#
+# कुमाऊँनी is spoken in the Kumaon division of Uttarakhand and schooled in Hindi: it has no settled
+# register for mathematics, and the geometry words here — रेखा, रेखाखंड,
+# किरण, सदिश, वक्र, फलन, परवलय, बहुभुज, त्रिभुज, आयत, वृत्त, समचतुर्भुज — are
+# the Hindi terms a student meets in class, written as they stand. The same is
+# true of सारणी, चित्र, पृष्ठभूमि, भराव and the whole of `section-name`. What
+# is कुमाऊँनी here is the grammar written over that vocabulary:
+# the genitive क / की / का, the object marker कैं, the copula छ
+# (plural छन), the negative नि, बटि for *from*, दगाड़ for *with*, अर for
+# *and*, and जदि for *if*
+# — together with the adjective forms below. **A reviewer should start with
+# the adjectives and the section words**: those are the places where a
+# कुमाऊँनी word may exist and the seed has used the Hindi one.
+#
+# ## Word order
+#
+# **The adjectives precede the noun**, exactly as they do in English and in
+# Hindi: «मोटो लाल रेखा» is *thick red line*. So
+# `style-with-noun` and `style-filled-with-noun` keep English's order of
+# `{ $description }` and `{ $noun }`, and `style-stroke` keeps English's
+# internal order of width, dash pattern and colour, because that is this
+# language's order too. What does move is everything governed by a
+# postposition: a postposition follows its noun, so the border clause and the
+# background clause come out reversed from English.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` puts the side count in
+# front of the noun — «{ $numSides } भुजाओं वाल सम बहुभुज» — so the whole of it is
+# one `head` and `tail` is empty, as in English and in Hindi. The
+# `-tail` variants of `style-with-noun` and `style-filled-with-noun` are still
+# written out, because they are what a partly-translated locale falls back to.
+#
+# ## Gender and role: the fork is deliberately not taken
+#
+# कुमाऊँनी **does** inflect a marked adjective for gender and for the
+# direct/oblique distinction, the way Hindi does — the -ओ/-उ masculine here has
+# a feminine in -ी and an oblique in -ा — so English's `$gender` and `$role`
+# arguments are not idle in this language, and the shape Hindi's catalog uses
+# would be the right shape here.
+#
+# **This seed does not fork on either, and writes the masculine singular
+# direct form throughout.** That is a decision about what a seed can honestly
+# claim, not a claim that the language has no agreement. Forking would require
+# a trustworthy gender for every noun in `noun` in *this* language rather than
+# in Hindi, plus an oblique paradigm the seed is sure of for each of the three
+# clause positions; the seed has neither, and a confidently wrong agreement
+# table is harder for a reviewer to repair than a uniformly unagreed one.
+# **This is the single largest gap in the file.** A reviewer who supplies the
+# genders can lift Hindi's `{ $role -> … { $gender -> … } }` shape verbatim.
+#
+# For the same reason `noun-gender` answers the bare token `neuter` that
+# English answers: no adjective in this file selects on it, so a gender table
+# here would be inert until the fork above is taken.
+#
+# ## Number
+#
+# **Nothing selects on a count.** CLDR has no plural data for `kfy`, so
+# `lint:i18n` would reject a plural category outright — and nothing in this
+# file counts in any case. Numbers render in Latin digits, never in Devanagari
+# numerals, which is what DoenetML pins for every locale (`src/intl.ts`).
+#
+# ## Chemistry
+#
+# `element-name` and `element-anion-name` are **deliberately absent**, so
+# those 130 keys fall back to English. Chemistry is taught here out of Hindi
+# textbooks, so the element names a कुमाऊँनी student meets are the Hindi
+# ones, and a table under this tag would be a claim about spelling rather than
+# about the language. Hindi's own table is in `locales/hi/content.ftl` for
+# anyone who wants to start from it.
+
+## Style vocabulary
+
+color =
+    .black = कालो
+    .white = सफ़ेद
+    .gray = स्लेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow = पीलो
+    .green = हरो
+    .cyan = फ़िरोज़ी
+    .blue = नीलो
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown = भूरो
+
+line-width =
+    .thick = मोटो
+    .thin = पातलो
+
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+
+# Oblique plural noun phrases, because their other use is in front of «वाल»
+# in `style-filled` and `style-fill`. They are the Hindi forms: the seed has
+# no कुमाऊँनी oblique plural for them that it trusts.
+fill-style =
+    .horizontal = क्षैतिज रेखाओं
+    .vertical = ऊर्ध्वाधर रेखाओं
+    .diagonal = विकर्ण रेखाओं
+    .backdiagonal = विपरीत विकर्ण रेखाओं
+    .dots = बिंदुओं
+    .diamonds = समचतुर्भुजों
+
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = प्रवणता क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = धन चिह्न
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजाओं वाल सम बहुभुज
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = भरी
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वाल { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वाल { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वाल { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# The postposition follows its noun, so the whole clause comes out after the
+# adjective and English's preposition-first order is reversed. There is no
+# article, so the `-article` branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनार दगाड़
+        [and] अर { $border } किनार दगाड़
+        [and-article] अर { $border } किनार दगाड़
+       *[with] { $border } किनार दगाड़
+    }
+
+# The fill-pattern words are oblique plurals, so this message supplies «भराव»
+# for them to hang off rather than printing them bare.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } वाल { $color } भराव
+       *[plain] { $color } भराव
+    }
+
+style-unfilled = बिना भराव
+
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि में { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = कुछ नि
+
+
+## Boolean words
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## Answer buttons
+
+answer-submit-label = जाँचो
+answer-submit-label-no-correctness = उत्तर भेजो
+
+
+## Sectional blocks
+
+section-name =
+    .activity = गतिविधि
+    .aside = पार्श्व टिप्पणी
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = उत्तर
+    .note = टिप्पणी
+    .objectives = उद्देश्य
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = प्रश्न
+    .problems = प्रश्न
+    .proof = प्रमाण
+    .question = सवाल
+    .section = अनुभाग
+    .solution = हल
+    .task = काम
+    .theorem = प्रमेय
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = संकेत
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = पिछलो
+paginator-next = अगलो
+paginator-page = पृष्ठ
+
+paginator-page-status = { $numPages } में बटि { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = या
+
+piecewise-condition-if = जदि
+
+piecewise-condition-otherwise = नतर
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = रिक्त
+
+math-embedded-input-blank-ordinal = { $total } में बटि रिक्त { $ordinal }

--- a/packages/i18n/locales/kfy/content.ftl
+++ b/packages/i18n/locales/kfy/content.ftl
@@ -63,8 +63,9 @@
 # ## Number
 #
 # **Nothing selects on a count.** CLDR has no plural data for `kfy`, so
-# `lint:i18n` would reject a plural category outright — and nothing in this
-# file counts in any case. Numbers render in Latin digits, never in Devanagari
+# `lint:i18n` would reject a plural category outright. Counts are still
+# interpolated here — `{ $numSides }`, `{ $currentPage }`, `{ $total }` — but
+# nothing branches on one. Numbers render in Latin digits, never in Devanagari
 # numerals, which is what DoenetML pins for every locale (`src/intl.ts`).
 #
 # ## Chemistry

--- a/packages/i18n/locales/kfy/diagnostics.ftl
+++ b/packages/i18n/locales/kfy/diagnostics.ftl
@@ -1,0 +1,658 @@
+# Kumaoni (कुमाऊँनी) diagnostics: the errors and warnings shown to whoever is looking
+# at the screen. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Kumaoni is written in.
+#
+# **Method, stated plainly.** Kumaoni has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Kumaoni
+# speaker meets in an Uttarakhand classroom, which teaches out of Hindi
+# textbooks. What is Kumaoni here is the grammatical layer written over it:
+# the genitive क / की / का rather than Hindi का / की / के, the object marker
+# कैं, the copula छ (plural छन), the negative नि, बटि for *from*, दगाड़ for
+# *with*, अर for *and*, बान for *for*, किलैकि for *because*, and the -ओ
+# imperative (करो, दिखाओ, हटाओ) Kumaoni puts on a button. A reviewer should
+# read this as Kumaoni grammar over Hindi terminology and is free to replace
+# the terminology wherever Kumaoni has its own word.
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `kfy`, so every count in this file goes through a single `*[other]`. The
+# one exception is `field-function-wrong-num-outputs`, where English is not
+# counting but distinguishing a one-output field from a two-output one; that
+# fork is kept as the numeric literal `[1]`, which Fluent matches against the
+# number itself rather than against a plural category.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दो सिरे दिए जाण पर { $attributes } पर ध्यान नि दिया जान
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा अर मध्यबिंदु दोनों दिए जाण पर { $attributes } पर ध्यान नि दिया जान
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु का बिना midpointOffset क कोई प्रभाव नि हुन
+
+## `<line>`
+
+line-points-undetermined-dimensions = ऐसे बिंदुओं बटि होकर जाण वाली रेखा जिनकी विमा अनिश्चित छ।
+
+line-points-too-few-dimensions = रेखा कैं कम बटि कम द्विविमीय बिंदुओं बटि होकर जाना चैंछ।
+
+line-points-depend-on-variables = रेखा उन बिंदुओं बटि होकर जानि छ जो चरों पर निर्भर छन: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } अर { $variable2 } में रेखा का समीकरण क प्रारूप अमान्य छ।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एक साथ through, endpoint अर direction बटि निर्धारित छ। दिए गए through कैं छोड़ा जा रौ छ।
+
+ray-dimension-mismatch = किरण में numDimensions मेल नि खाते।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एक साथ head, tail अर displacement बटि निर्धारित छ। दिए गए head कैं छोड़ा जा रौ छ।
+
+vector-dimension-mismatch = सदिश में numDimensions मेल नि खाते।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` की तरफ आकर्षित नि किया जा सकन, किलैकि वी में nearestPoint अवस्था चर नि छ।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित नि किया जा सकन, किलैकि वी में nearestPoint अवस्था चर नि छ।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` का भीतरी भाग तक सीमित नि किया जा सकन, किलैकि वी में nearestPoint अवस्था चर नि छ।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होण वाले choiceInput बान labelPosition पर ध्यान नि दिया जान
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput बान दिए गए indices कैं छोड़ा जा रौ छ, किलैकि indices की संख्या choice संतानों की संख्या बटि मेल नि खाती।
+
+pretzel-indices-count-mismatch = problem बान दिए गए indices कैं छोड़ा जा रौ छ, किलैकि indices की संख्या problem संतानों की संख्या बटि मेल नि खाती।
+
+shuffle-indices-count-mismatch = shuffle बान दिए गए indices कैं छोड़ा जा रौ छ, किलैकि indices की संख्या घटकों की संख्या बटि मेल नि खाती।
+
+indices-ignored-out-of-range = { $component } बान दिए गए indices कैं छोड़ा जा रौ छ, किलैकि कुछ अनुक्रमांक परिसर बटि बाहर छन।
+
+pretzel-indices-repeated = pretzel बान दिए गए indices कैं छोड़ा जा रौ छ, किलैकि कुछ अनुक्रमांक दोहराए गए छन।
+
+pretzel-circuit-first-index = circuit विधा में pretzel बान दिए गए indices कैं छोड़ा जा रौ छ, किलैकि पैलो अनुक्रमांक 1 होण चैंछ।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` कैं पाठ संतानों दगाड़ काम करण बान `type` विशेषता देनी होलि।
+
+invalid-type-defaulting-to-math = { $component } घटक बान प्रकार { $type } अमान्य छ। यो math, text, number या boolean में बटि एक होण चैंछ। math क उपयोग किया जा रौ छ।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } बान मान्य घटक नि छ। छोड़ा जा रौ छ।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य छ; प्रकार number पर सेट किया जा रौ छ।
+
+invalid-variable-value = चर क मान अमान्य छ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } एक संख्या होणि चैंछ
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } एक पूर्णांक होण चैंछ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष मापों बान उपलब्ध नि छ। चौड़ाइयाँ सापेक्ष की जा रैं छन।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष मापों बान उपलब्ध नि छ। हाशिये सापेक्ष किए जा रईं छन।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: ये में कम बटि कम एक खंड संतान होणि चैंछ।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर ध्यान नि दिया जान।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एक घटक तक पहुँचनी चैंछ।
+
+label-for-unresolved = `<label>` पर `for` विशेषता किसी घटक तक नि पहुँच सकी।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता ऐसे `<answer>` क संदर्भ देती छ जै में इनपुट स्पष्ट रूप से लिखे गए छन; सीधे उसी इनपुट क संदर्भ दियो।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता ऐसे `<answer>` क संदर्भ देती छ जै में लेबल लगाण योग्य इनपुट नि छ।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता किसी इनपुट या किसी उत्तर क संदर्भ देनी चैंछ।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता बान `<{ $component }>` क या तो संक्षिप्त विवरण होण चैंछ या उसे सजावटी बताया जाना चैंछ।
+
+accessibility-video-short-description = सुगम्यता बान `<video>` क संक्षिप्त विवरण होण चैंछ।
+
+accessibility-input-short-description-or-label = सुगम्यता बान `<{ $component }>` क संक्षिप्त विवरण या लेबल होण चैंछ।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता बान इनपुट बनाण वाले `<answer>` क संक्षिप्त विवरण या लेबल होण चैंछ।
+
+accessibility-short-description-contains-math = संक्षिप्त विवरणों में `<{ $component }>` जस गणितीय घटक नि होण चैंछ। गणित कैं शब्दों में लेखो।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } क खंड शीर्षक पाठ बान वैषम्य अपर्याप्त छ (गहरी विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंछ)।
+       *[other] { $colorName } क खंड शीर्षक पाठ बान वैषम्य अपर्याप्त छ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंछ)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदुओं का संख्यात्मक मान न हों, तब { $count } बिंदुओं बटि होकर जाण वाला `<circle>` अभी उपलब्ध नि छ।
+
+circle-too-many-through-points = 3 बटि अधिक बिंदुओं बटि होकर जाण वाला वृत्त परिकलित नि किया जा सकन।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र अर गुज़रने वाले बिंदु एक साथ दिए जाण पर वृत्त परिकलित नि किया जा सकन।
+
+circle-center-with-multiple-points = दिए गए केंद्र दगाड़ 1 बटि अधिक बिंदु बटि होकर जाण वाला वृत्त परिकलित नि किया जा सकन।
+
+circle-radius-too-small = वृत्त परिकलित नि किया जा सकन: दोनों बिंदुओं क बीच की दूरी { $distance } छ, इसलिए दी गई त्रिज्या { $radius } बहुत छोटी छ।
+
+circle-radius-with-many-points = दी गई त्रिज्या दगाड़ दो बटि अधिक बिंदुओं बटि होकर जाण वाला वृत्त नि बनाया जा सकन।
+
+circle-invalid-center-or-through-points = वृत्त क केंद्र या गुज़रने वाले बिंदु अमान्य छन।
+
+circle-radius-center-with-multiple-points = दिए गए केंद्र दगाड़ 1 बटि अधिक बिंदु बटि होकर जाण वाले वृत्त की त्रिज्या परिकलित नि की जा सकन।
+
+circle-change-radius-non-numerical = जै वृत्त का गुज़रने वाले बिंदु संख्यात्मक नि छन, वीकी त्रिज्या नि बदली जा सकन
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होण पर, दी गई त्रिज्या दगाड़ एक बटि अधिक बिंदु बटि होकर जाण वाला वृत्त नि बनाया जा सकन।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदुओं बटि होकर जाण वाले वृत्त क केंद्र बदलना अभी उपलब्ध नि छ।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन का प्रांत की विमाएँ अपर्याप्त छन। प्रांत में { $intervals } अंतराल छन, पर फलन में { $inputs } इनपुट छन।
+
+function-domain-invalid-format = फलन का प्रांत क प्रारूप अमान्य छ।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन क असंख्यात्मक उच्चिष्ठ छोड़ा जा रौ छ।
+        [minimum] फलन क असंख्यात्मक निम्निष्ठ छोड़ा जा रौ छ।
+        [extremum] फलन क असंख्यात्मक चरम मान छोड़ा जा रौ छ।
+        [point] फलन क असंख्यात्मक बिंदु छोड़ा जा रौ छ।
+        [slope] फलन की असंख्यात्मक प्रवणता छोड़ी जा रैं छ।
+       *[other] फलन क असंख्यात्मक { $type } छोड़ा जा रौ छ।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन क रिक्त उच्चिष्ठ छोड़ा जा रौ छ।
+        [minimum] फलन क रिक्त निम्निष्ठ छोड़ा जा रौ छ।
+        [extremum] फलन क रिक्त चरम मान छोड़ा जा रौ छ।
+        [point] फलन क रिक्त बिंदु छोड़ा जा रौ छ।
+       *[other] फलन क रिक्त { $type } छोड़ा जा रौ छ।
+    }
+
+function-points-too-close = फलन में दो बिंदु बहुत पास-पास छन। फलन परिभाषित नि किया जा सकन।
+
+function-iterates-input-output-mismatch = फलन क पुनरावर्तन तभी संभव छ जब इनपुट की संख्या आउटपुट की संख्या का बराबर हो। ये फलन में { $inputs } इनपुट अर { $outputs } आउटपुट छन।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम की लंबाई अमान्य छ। यो ऋणेतर पूर्णांक होणि चैंछ।
+
+sequence-invalid-step = अनुक्रम क चरण अमान्य छ। { $type } प्रकार का अनुक्रम बान यो एक संख्या होणि चैंछ।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम क "{ $attribute }" अमान्य छ। यो एक संख्या होणि चैंछ।
+
+sequence-invalid-endpoint-letters = अक्षर अनुक्रम क "{ $attribute }" अमान्य छ। यो अक्षरों क संयोजन होण चैंछ।
+
+sequence-invalid-endpoint = अनुक्रम क "{ $attribute }" अमान्य छ।
+
+select-from-sequence-coprime-not-numbers = संख्याएँ नि चुनी जा रहीं, इसलिए coprime छोड़ा गया
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations दिया गया छ, इसलिए coprime छोड़ा गया
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` बान target अमान्य छ: लक्ष्य नि मिला।
+
+target-state-variable-not-found = `<{ $source }>` बान target अमान्य छ: `<{ $component }>` पर "{ $property }" नाम क अवस्था चर नि मिला।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` का चर स्वतंत्र चर बटि भिन्न होण चैंछ।
+
+ode-system-duplicate-variable-names = दोहराए गए आश्रित चर नामों दगाड़ ODE का दाएँ पक्ष का फलन परिभाषित नि किए जा सकन।
+
+ode-system-rhs-function-error = ODE का दाएँ पक्ष क फलन परिभाषित नि किया जा सकन। mathjs फलन बनाते समय त्रुटि हुई।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखाओं क बीच क कोण परिभाषित नि किया जा सकन
+
+angle-invalid-through-point = `<angle>` का through में अमान्य बिंदु छ
+
+parabola-vertex-too-many-points = दिए गए शीर्ष दगाड़ 1 बटि अधिक बिंदु बटि होकर जाण वाला परवलय अभी उपलब्ध नि छ।
+
+parabola-too-many-points = 3 बटि अधिक बिंदुओं बटि होकर जाण वाला परवलय अभी उपलब्ध नि छ।
+
+intersection-too-many-items = दो बटि अधिक वस्तुओं क प्रतिच्छेदन अभी उपलब्ध नि छ
+
+## Other math components
+
+ionic-compound-not-two-ions = दो आयनों क अलावा किसी अर स्थिति बान आयनिक यौगिक अभी उपलब्ध नि छ।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक केवल एक धनायन अर एक ऋणायन बान उपलब्ध छ।
+
+solve-equations-cannot-evaluate = समीकरण क मान नि निकाला जा सका, इसलिए वो हल नि किया जा सकन: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालते समय operandNumber देना आवश्यक छ।
+
+eigen-decomposition-failed = आव्यूह का अभिलक्षणिक मान परिकलित नि किए जा सके
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न में नि आते, इसलिए वे सदा रिक्त बटि मेल खाएँगे।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" कैं समझा नि जा सका। यो none, medium, dense, या रिक्त स्थान बटि अलग की गई दो धनात्मक संख्याएँ होणि चैंछ, जस grid="1 0.5"। कोई ग्रिड नि खींचा जाएगा।
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर में xLabelPosition="left" समर्थित नि छ; दाईं स्थिति वाला व्यवहार अपनाया जा रौ छ।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर में yLabelPosition="bottom" समर्थित नि छ; ऊपरी स्थिति वाला व्यवहार अपनाया जा रौ छ।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण बान अक्ष सीमाएँ अमान्य छन; पूर्वनिर्धारित bbox (-10,-10,10,10) अपनाया जा रौ छ।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण बान चौड़ाई अमान्य छ; पूर्वनिर्धारित आरेख चौड़ाई 425 अपनाई जा रैं छ।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण बान aspectRatio अमान्य छ; पूर्वनिर्धारित अनुपात 1 अपनाया जा रौ छ।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अक्ष सीमाओं की तुलना में ग्रिड क अंतराल बहुत महीन छ; prefigure रेंडरर में ग्रिड छोड़ा जा रौ छ।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर क उपयोग न होण पर टीकाएँ नि खींची जाएँगी।
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` कैं ऐसा फलन चैंछ जै में { $expected ->
+        [1] एक आउटपुट हो, यानी हर बिंदु पर प्रवणता y', जस `y - x`
+       *[other] दो आउटपुट हों, यानी हर बिंदु पर सदिश, जस `(y, -x)`
+    }, पर दिए गए फलन में { $found } आउटपुट छन। { $alternative ->
+        [none] कुछ नि खींचा जाएगा।
+       *[other] वी फलन बान `<{ $alternative }>` घटक छ। कुछ नि खींचा जाएगा।
+    }
+
+field-function-attribute-ignored-with-child = `function` विशेषता पर ध्यान नि दिया जान, किलैकि फलन घटक क भितर भी दिया गया छ; भीतर वाला ही लिया जान छ। फलन दोनों में बटि केवल एक तरह बटि दियो।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषता वी व्यंजक का चर बताती छ जो घटक क भितर सीधे लिखा गया हो। { $reason ->
+        [function-child] यहाँ फलन `<function>` संतान क रूप में दिया गया छ, जो अपने चर स्वयं बताती छ, इसलिए `variables` पर ध्यान नि दिया जान।
+       *[no-expression] यहाँ ऐसा कोई व्यंजक नि दिया गया, इसलिए `variables` पर ध्यान नि दिया जान।
+    }
+
+multiple-annotations-children = `<graph>` में एक बटि अधिक `<annotations>` संतानें मिलीं; अंतिम कैं छोड़कर सभी पर ध्यान नि दिया जाएगा।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार कैं विस्तारित या प्रतिलिपित नि किया जा सकन: { $type }।
+
+copy-prop-not-found = { $component } प्रकार का घटक पर { $property } गुण नि मिला
+
+collect-no-source = collect बान कोई स्रोत नि मिला।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार का घटक एकत्र नि किए जा सकन, किलैकि यो मान्य घटक प्रकार नि छ।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` क संदर्भ नि दिया जा सकन
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } नि बुलाया जा सकन
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़ों क आकार अमान्य छ। पंक्तियों की लंबाई असंगत छ। componentIdx :{ $componentIdx } में मिला
+
+data-frame-duplicate-column-names = आँकड़ों में स्तंभ नाम दोहराए गए छन। componentIdx :{ $componentIdx } में मिला
+
+data-frame-missing-column-name = आँकड़ों में एक स्तंभ नाम अनुपस्थित छ। componentIdx :{ $componentIdx } में मिला
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ये उत्तर क एक award स्वयं answer टैग द्वारा भेजे गए उत्तर पर आधारित छ, जिससे अप्रत्याशित व्यवहार होल।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र क भितर का `<answer>` पर `maxNumAttempts` सेट करण क कोई प्रभाव नि हुन, किलैकि प्रयासों की संख्या पात्र नियंत्रित करन छ। `maxNumAttempts` पात्र पर सेट करो।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले किसी अन्य पात्र क भितर स्थित `sectionWideCheckWork` पात्र पर `maxNumAttempts` सेट करण क कोई प्रभाव नि हुन, किलैकि प्रयासों की संख्या बाहरी पात्र नियंत्रित करन छ। `maxNumAttempts` बाहरी पात्र पर सेट करो।
+
+answer-attributes-need-symbolic-equality = symbolicEquality सेट किए बिना { $attributes } विशेषताओं क कोई प्रभाव नि होल।
+
+answer-invalid-type = answer बान प्रकार अमान्य छ: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = किलैकि घटक `<{ $component }>` क नाम नि छ, इसे मॉड्यूल विशेषता क रूप में उपयोग नि किया जा सकन
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` कैं मॉड्यूल की विशेषता क रूप में उपयोग नि किया जा सकन, किलैकि घटक प्रकार `<module>` में "{ $name }" विशेषता पहले बटि परिभाषित छ।
+
+conditional-content-condition-ignored = case या else संतानों वाले `<conditionalContent>` घटक पर `condition` विशेषता पर ध्यान नि दिया जान।
+
+slider-markers-type-mismatch = चिह्नकों क प्रकार स्लाइडर का प्रकार बटि मेल नि खाता।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: प्रत्येक `<problem>` में एक `<statement>` अर एक `<answer>` होण चैंछ।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" में पैलो `<problem>` भ्रामक विकल्प नि हो सकन।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` बान मान { $values } अमान्य छन; छोड़ा जा रौ छ।
+
+attribute-must-be-references = विशेषता `{ $attribute }` बान मान `{ $value }` अमान्य छ। विशेषता `$` बटि आरंभ होण वाले संदर्भों बटि बनी होणि चैंछ।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } में अमान्य फलन नाम छोड़े गए: { $names }। प्रत्येक नाम का दृश्य भाग में कम बटि कम 2 वर्ण (अक्षर या योजक चिह्न) होण चैंछ; उसके बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आ सकन छ।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य छ: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहराई नि जा सकन।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार का घटक बान विशेषता "{ $attribute }" अमान्य छ।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } में { $context ->
+        [text-on-background] पृष्ठभूमि रंग की तुलना में पाठ रंग
+        [high-contrast] कैनवास की तुलना में उच्च वैषम्य रंग
+        [line] कैनवास की तुलना में रेखा रंग
+        [marker] कैनवास की तुलना में चिह्नक रंग
+       *[text-on-canvas] कैनवास की तुलना में पाठ रंग
+    } बान वैषम्य अपर्याप्त छ{ $mode ->
+        [dark] { " (गहरी विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंछ)।
+
+style-definition-dark-mode-text-background-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा बान पर्याप्त वैषम्य वाले रंग दिए छन, इन मानों बटि व्युत्पन्न गहरी विधा का रंगों में पाठ रंग अर पृष्ठभूमि रंग क बीच वैषम्य अपर्याप्त छ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंछ)। { $suggestion ->
+        [available] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करण बान या तो हल्की विधा क वैषम्य बढ़ाओ (जस { $lightAttribute }="{ $lightColor }" सेट करो) या गहरी विधा क रंग अधिरोहित करो (जस { $darkAttribute }="{ $darkColor }" सेट करो)।
+       *[none] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करण बान हल्की विधा क वैषम्य बढ़ाओ या व्युत्पन्न रंगों कैं textColorDarkMode अर/या backgroundColorDarkMode बटि अधिरोहित करो।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा बान पर्याप्त वैषम्य वाला पाठ रंग दिया छ, ये मान बटि व्युत्पन्न गहरी विधा का पाठ रंग क कैनवास की तुलना में वैषम्य अपर्याप्त छ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम बटि कम { $threshold }:1 चैंछ)। { $suggestion ->
+        [available] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करण बान या तो हल्की विधा क वैषम्य बढ़ाओ (जस textColor="{ $lightColor }" सेट करो) या गहरी विधा क रंग अधिरोहित करो (जस textColorDarkMode="{ $darkColor }" सेट करो)।
+       *[none] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करण बान हल्की विधा क वैषम्य बढ़ाओ या व्युत्पन्न रंग कैं textColorDarkMode बटि अधिरोहित करो।
+    }
+
+section-multiple-style-palettes = एक खंड केवल एक <stylePalette> चुन सकन छ; अंतिम क उपयोग किया जा रौ छ।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि numToSelect ऋणेतर पूर्णांक नि छ।
+
+variant-num-to-select-not-constant-number = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि numToSelect अचर नि छ।
+
+variant-with-replacement-not-constant-boolean = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि withReplacement अचर बूलीय मान नि छ।
+
+variant-select-weight-disables-unique = जदि कोई विकल्प selectWeight या selectForVariants देता छ तो select का अद्वितीय संस्करण निष्क्रिय हो जाना छन
+
+variant-coprime-undetermined = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि यो तय नि हो सका कि coprime सदा असत्य छ।
+
+variant-attribute-not-constant = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि { $attribute } अचर नि छ।
+
+variant-attribute-not-number = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि { $attribute } संख्या नि छ।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार का { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि { $attribute } { $expected ->
+        [letters-combination] अक्षरों क संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } नि छ।
+
+variant-length-not-integer = { $component } का अद्वितीय संस्करण निर्धारित नि किए जा सकन, किलैकि length पूर्णांक नि छ।
+
+variant-sort-not-implemented = sort वाले { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार का { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } का अद्वितीय संस्करण अभी उपलब्ध नि छन
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख का prefigure रेंडरर में समर्थित नि; वंशज छोड़ा गया।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित या अपूर्ण छ; वंशज छोड़ा गया।
+
+prefigure-curve-label-omitted = { $subject }: रूपांतरित वक्र तत्वों पर लेबल समर्थित नि; लेबल छोड़ा गया।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित नि; वंशज छोड़ा गया।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित नि; वंशज छोड़ा गया।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves केवल सूत्र प्रकार का संतान फलनों क समर्थन करन छ; वंशज छोड़ा गया।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल का लेबल
+       *[point] बिंदु लेबल
+    } बान labelPosition '{ $labelPosition }' समर्थित नि; PreFigure की पूर्वनिर्धारित संरेखण अपनाई जा रैं छ।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure में समर्थित नि; ठोस भराव अपनाया जा रौ छ।
+
+prefigure-line-style-unknown = { $subject }: अज्ञात रेखा शैली '{ $lineStyle }' PreFigure का आउटपुट बटि छोड़ी गई।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure की 'diamond' शैली पर मानचित्रित की गई।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure में समर्थित नि; पूर्वनिर्धारित शैली अपनाई जा रैं छ।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य निर्धारित नि हो सका। टीका छोड़ी गई।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` बटि कई लक्ष्य निकले; पैलो लक्ष्य लिया जा रौ छ।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य उसे समेटे आलेख का बाहर छ। टीका छोड़ी गई।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण में लक्ष्य समर्थित आलेखीय वस्तु नि छ। टीका छोड़ी गई।
+
+annotation-text-missing = `<annotation>`: `text` अनुपस्थित या रिक्त; रिक्त पाठ दिया जा रौ छ।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता क पता चला।
+       *[other] `<{ $componentType }>` घटक बटि जुड़ी चक्रीय निर्भरता क पता चला।
+    }
+
+reference-no-referent = ये संदर्भ क कोई लक्ष्य नि मिला: `{ $reference }`
+
+reference-multiple-referents = ये संदर्भ का कई लक्ष्य मिले: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` की विशेषता { $attribute } क प्रारूप अमान्य छ।
+
+children-invalid = `<{ $componentType }>` की संतानें अमान्य छन: अमान्य संतानें मिलीं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` बान मान `{ $value }` अमान्य छ; मान `{ $default }` क उपयोग किया जा रौ छ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } नि मिला।
+       *[other] DoenetML संस्करण { $version } नि मिला। संस्करण { $fallback } पर लौटा जा रौ छ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` क समापन टैग नि छ। स्वतः बंद होण वाला टैग या `</{ $tagName }>` टैग अपेक्षित छी।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` में त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` क मान अनुपस्थित प्रतीत हुन छ।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य छ
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य छ
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य छ। उद्धरण चिह्न मेल नि खाते। एक `{ $quote }` अनुपस्थित प्रतीत हुन छ
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम क टैग मिला, जस `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नि हुआ (एक `>` अनुपस्थित प्रतीत हुन छ)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम क टैग मिला `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नि हुआ (`/>` अनुपस्थित प्रतीत हुन छ)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य नि छ। येकी विशेषताएँ ग़लत हो सकन छन।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम क समापन टैग मिला, जस `</`
+
+parse-attribute-value-unquoted = विशेषता मान उद्धरण चिह्नों में होण चैंछ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिला, पर वी बटि मेल खाता आरंभ टैग नि छ
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल नि खाता। `</{ $expected }>` अपेक्षित छी। `{ $found }` मिला
+
+parser-node-unconvertible = नोड { $node } कैं Dast नोड में परिवर्तित नि किया जा सका।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य छ। { $reason ->
+        [characters] नामों में केवल अक्षर, अंक, अधोरेखा या योजक चिह्न हो सकन छन।
+       *[start] नाम अक्षर बटि आरंभ होण चैंछ।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य छ। नाम अक्षर बटि आरंभ होण चैंछ।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार का answer में video विशेषता होणि चैंछ
+
+answer-video-watched-video-not-reference = videoWatched प्रकार का answer की video विशेषता एक संदर्भ होणि चैंछ
+
+answer-name-not-single-text = answer की name विशेषता में केवल एक पाठ संतान होणि चैंछ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन का बहुत अधिक स्तरों का कारण बाहरी DoenetML प्राप्त नि किया जा सका। कहीं चक्रीय संदर्भ तो नि?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" बटि DoenetML प्राप्त नि किया जा सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" बटि प्राप्त DoenetML अमान्य छ: यो घटक प्रकार "{ $componentType }" बटि मेल नि खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित छ; येक बदल `{ $to }` क उपयोग करो।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित छ; येक बदल `{ $to }` क उपयोग करो।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित छ अर छोड़ दी गई, किलैकि `{ $to }` भी दिया गया छ।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित छ अर छोड़ दी गई, किलैकि `{ $to }` भी दिया गया छ।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित छ अर छोड़ दी गई।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित छ; येक बदल `<{ $child }>` संतान लेखो।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` क मान `{ $value }` अप्रचलित छ; येक बदल `{ $to }` क उपयोग करो।
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` केवल अंग्रेज़ी क बहुवचन बना सकन छ, इसलिए { $locale } में लिखे दस्तावेज़ में वीक पाठ अपरिवर्तित रहता छ। बहुवचन रूप सीधे लेखो, या `pluralForm` विशेषता बटि दियो।
+
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कोई परिचित Doenet तत्व नि छ।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज़ का मूल में मान्य नि छ।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` क भितर मान्य नि छ।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` में `{ $attribute }` नाम की कोई विशेषता नि छ।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` की विशेषता `{ $attribute }` एक सूची होणि चैंछ जिसकी हर मद इनमें बटि एक हो: { $allowed }
+       *[other] तत्व `<{ $tag }>` की विशेषता `{ $attribute }` इनमें बटि एक होणि चैंछ: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select बान संस्करण नाम अमान्य छ। संस्करण नाम { $variantName } { $numOptions } विकल्पों में आता छ, पर चुनण की संख्या { $numToSelect } छ।
+
+select-variant-name-without-options = select बान संस्करण दिए गए छन, पर संभावित संस्करण नाम बान कोई विकल्प नि छ: { $variantName }।
+
+select-variant-name-not-possible = select बान दिया गया संस्करण नाम { $variantName } संभावित संस्करण नाम नि छ।
+
+select-too-few-options = केवल { $numOptions } घटकों में बटि { $numToSelect } नि चुने जा सकन।
+
+select-from-sequence-too-few-values = { $length } लंबाई का अनुक्रम बटि { $numToSelect } मान नि चुने जा सकन।
+
+select-from-sequence-indices-count-mismatch = select बान दिए गए अनुक्रमांकों की संख्या चुनण की संख्या बटि मेल खानी चैंछ
+
+select-from-sequence-indices-not-integers = select बान दिए गए सभी अनुक्रमांक पूर्णांक होण चैंछ
+
+select-from-sequence-index-excluded = selectfromsequence बान दिया गया अनुक्रमांक बहिष्कृत छी
+
+select-from-sequence-indices-excluded-combination = selectfromsequence बान दिए गए अनुक्रमांक बहिष्कृत संयोजन बनाते छी
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक नि चुने जा रईं, इसलिए सहअभाज्य संयोजन नि चुने जा सकन।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्याएँ नि चुनी जा सकन। सभी संभावित मानों में एक उभयनिष्ठ गुणनखंड छ। (दिए गए "from" या "to" मान "step" का सहअभाज्य होण चैंछ।)
+
+select-from-sequence-coprime-single-number = 1 बटि भिन्न किसी एकल संख्या बटि सहअभाज्य संयोजन नि चुने जा सकन।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence में 70% बटि अधिक संयोजन बहिष्कृत किए गए
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्याएँ नि चुनी जा सकीं। सभी संभावित मानों में एक उभयनिष्ठ गुणनखंड छ।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई का अनुक्रम बटि { $numToSelect } भिन्न मान नि चुने जा सकन
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई की अभाज्य सूची बटि { $numToSelect } मान नि चुने जा सकन
+
+select-prime-numbers-values-count-mismatch = select बान दिए गए मानों की संख्या चुनण की संख्या बटि मेल खानी चैंछ
+
+select-prime-numbers-values-not-prime = select prime number बान दिए गए सभी मान अभाज्य सूची में होण चैंछ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers बान दिए गए मान बहिष्कृत संयोजन बनाते छी
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers में 70% बटि अधिक संयोजन बहिष्कृत किए गए
+
+select-random-combination-fluke = अत्यंत असंभव संयोग बटि यादृच्छिक मानों क संयोजन नि चुना जा सका
+
+select-random-value-fluke = अत्यंत असंभव संयोग बटि यादृच्छिक मान नि चुना जा सका
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] यो `<{ $component }>` नि दिखाया जा रौ, किलैकि यो गणित क भितर छ अर `inline` नि छ। `inline` जोड़ो, ताकि यो ड्रॉप-डाउन सूची बन जाए, जो व्यंजक क भितर समा जानि छ।
+        [expanded] यो `<{ $component }>` नि दिखाया जा रौ, किलैकि यो गणित क भितर छ अर `expanded` छ। `expanded` हटाओ; बहु-पंक्ति बक्सा व्यंजक क भितर नि समाता।
+        [on-graph] यो `<{ $component }>` नि दिखाया जा रौ, किलैकि यो आलेख पर खींचे गए गणित क भितर छ, जै में इनपुट बान जगह नि छ।
+       *[relative-width] यो `<{ $component }>` नि दिखाया जा रौ, किलैकि यो गणित क भितर छ अर येकी चौड़ाई सापेक्ष छ। चौड़ाई निरपेक्ष इकाइयों में दियो, जस `px`।
+    }

--- a/packages/i18n/locales/kfy/editor.ftl
+++ b/packages/i18n/locales/kfy/editor.ftl
@@ -1,0 +1,217 @@
+# Kumaoni (कुमाऊँनी) editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker and the context-help panel beside them. Translated
+# from `locales/en/editor.ftl`, which is the source of truth.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, which is the only script Kumaoni is written in.
+#
+# **Method, stated plainly.** Kumaoni has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Kumaoni
+# speaker meets in an Uttarakhand classroom, which teaches out of Hindi
+# textbooks. What is Kumaoni here is the grammatical layer written over it:
+# the genitive क / की / का rather than Hindi का / की / के, the object marker
+# कैं, the copula छ (plural छन), the negative नि, बटि for *from*, दगाड़ for
+# *with*, अर for *and*, बान for *for*, किलैकि for *because*, and the -ओ
+# imperative (करो, दिखाओ, हटाओ) Kumaoni puts on a button. A reviewer should
+# read this as Kumaoni grammar over Hindi terminology and is free to replace
+# the terminology wherever Kumaoni has its own word.
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `kfy`, so `lint:i18n` would reject a `[one]` branch outright. Every count
+# in this file goes through a single `*[other]`, keeping only
+# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
+# number itself rather than against a category.
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करो
+       *[update] अद्यतन करो
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्शक { $word }
+       *[other] दर्शक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = रूपांतर
+editor-variant-filter = फ़िल्टर...
+editor-variant-next = अगलो रूपांतर छांटो
+editor-variant-previous = पिछलो रूपांतर छांटो
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पाया गया। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } बान क्लिक करो।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } बान क्लिक करो। कोई WCAG AA उल्लंघन नि मिला, पर सुगम्यता संबंधी अन्य सुझाव छन।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } बान क्लिक करो। कोई सुगम्यता समस्या नि मिली।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पाया गया। { $count } WCAG AA उल्लंघन मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } बान क्लिक करो।
+        [advisories] कोई WCAG AA उल्लंघन नि मिला। सुगम्यता संबंधी { $count } अन्य सुझाव मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } बान क्लिक करो।
+       *[clean] कोई WCAG AA उल्लंघन नि मिला। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } बान क्लिक करो।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग अनुसार सहायता
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटियाँ
+editor-tab-warnings = चेतावनियाँ
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = भेजे गए उत्तर
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक विकल्प
+editor-format-as-doenetml = DoenetML रूप में स्वरूपित करो
+editor-format-as-xml = XML रूप में स्वरूपित करो
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कोई त्रुटि नि
+editor-no-warnings = कोई चेतावनी नि
+editor-no-info = कोई सूचनात्मक निदान नि
+
+editor-show-info-annotations = संपादक में सूचनात्मक निदान दिखाओ
+editor-show-accessibility-annotations = संपादक में सुगम्यता निदान दिखाओ
+
+editor-accessibility-learn-more = जाणो कि Doenet सुगम्यता कैं किस तरह देखता छ
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = अन्य सुगम्यता समस्याएँ
+editor-none-found = कुछ नि मिला
+
+
+## Submitted responses
+
+editor-no-responses = अभी तक कोई उत्तर नि भेजा गया
+editor-response-answer-id = उत्तर आईडी
+editor-response-response = उत्तर
+editor-response-credit = अंक
+editor-response-submitted = भेजा गया
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेज़ीकरण देखण बान कर्सर कैं टैग नाम, विशेषता या { $ref } पर धरो।
+
+help-unsupported-ref-chain = { $example } जस बहु-भागीय संदर्भों की सहायता अभी उपलब्ध नि छ।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ये संदर्भ क कोई लक्ष्य नि मिला: { $ref }।
+        [multiple] ये संदर्भ का कई लक्ष्य मिले: { $ref }।
+       *[indeterminate] { $ref } क लक्ष्य निर्धारित नि किया जा सका।
+    }
+
+help-learn-about-references = संदर्भों क बारा में जाणो →
+help-reference-page = संदर्भ पृष्ठ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } क भितर
+       *[top] शीर्ष स्तर पर
+    }{ $allowed ->
+        [none] { " — यहाँ कुछ नि रखा जा सकन।" }
+        [text] { " — यहाँ पाठ लिखा जा सकन छ।" }
+        [text-and-components] { " — यहाँ पाठ लेखो, या ये अजमाओ:" }
+       *[components] { " — ये अजमाओ:" }
+    }
+
+help-suggestions-footer = सभी { $total } घटक देखण बान { $shortcut } दबाओ।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } क संदर्भ छ।
+       *[other] { $ref }, { $target } क संदर्भ छ (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } द्वारा { $role } क रूप में लाया गया।
+       *[other] { $owner } द्वारा पंक्ति { $line } में { $role } क रूप में लाया गया।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } का { $property } गुण क संदर्भ छ।
+       *[other] { $ref }, { $element } का { $property } गुण क संदर्भ छ (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड अंश
+help-kind-array-entry = सरणी प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = प्रभावी पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] अनुमत मान (प्रति मद एक):
+       *[other] अनुमत मान:
+    }
+
+help-suggested-values = सुझाए गए मान:
+
+help-inserts = जोड़ता छ:
+
+help-coordinates = निर्देशांक:
+
+help-type = प्रकार:
+
+help-resolved-style = निर्धारित शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = निर्धारित फलन नाम:
+help-reset-list = ये इनपुट की रीसेट सूची:
+help-added-on-input = ये इनपुट पर जोड़ा गया:
+help-removed-on-input = ये इनपुट पर हटाया गया:
+
+help-reset-overrides = { $reset }, { $additional } अर { $removed } पर वरीयता रखता छ।

--- a/packages/i18n/locales/kfy/editor.ftl
+++ b/packages/i18n/locales/kfy/editor.ftl
@@ -24,9 +24,10 @@
 #
 # **Nothing selects on a plural category.** CLDR has no plural data for
 # `kfy`, so `lint:i18n` would reject a `[one]` branch outright. Every count
-# in this file goes through a single `*[other]`, keeping only
-# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
-# number itself rather than against a category.
+# in this file is written with one form and no selector at all — `$count` is
+# plain interpolation here. The catalog's one branch on a number is
+# `attempts-remaining`'s explicit `[0]` in `chrome.ftl`, which Fluent matches
+# against the number itself rather than against a category.
 
 ## The viewer's controls
 

--- a/packages/i18n/locales/kha/chrome.ftl
+++ b/packages/i18n/locales/kha/chrome.ftl
@@ -16,7 +16,8 @@
 # other script is at issue for it — there is no rival orthography a reviewer
 # might have expected. What the seed does have to be consistent about is the
 # three marks that alphabet carries: `ï` (U+00EF) for the syllabic i in «ïa»
-# and «ïaid», `ñ` (U+00F1) in «kñi» and its relatives, and the ASCII
+# and «ïaid», `ñ` (U+00F1) in «kñi» and its relatives, which this catalog happens never
+# to need, and the ASCII
 # apostrophe `'` (U+0027) for the glottal stop in «ka'», never the typographic
 # U+2019. A search for `'` finds every glottal in all four files.
 #

--- a/packages/i18n/locales/kha/chrome.ftl
+++ b/packages/i18n/locales/kha/chrome.ftl
@@ -1,0 +1,176 @@
+# Khasi (Ka Ktien Khasi) viewer chrome: the buttons, panel headings and status
+# words the reader interacts with. Selected by `uiLocale`. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids, `.attribute` names, select variant keys and placeable names are
+# never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to change a word.
+#
+# **Orthography: Roman, with its diacritics.** Khasi has been written in the
+# Roman alphabet since the Welsh Presbyterian mission of the 1840s, and no
+# other script is at issue for it — there is no rival orthography a reviewer
+# might have expected. What the seed does have to be consistent about is the
+# three marks that alphabet carries: `ï` (U+00EF) for the syllabic i in «ïa»
+# and «ïaid», `ñ` (U+00F1) in «kñi» and its relatives, and the ASCII
+# apostrophe `'` (U+0027) for the glottal stop in «ka'», never the typographic
+# U+2019. A search for `'` finds every glottal in all four files.
+#
+# **Much of the technical vocabulary is an English loan, and that is declared
+# rather than disguised.** Meghalaya teaches mathematics and secondary science
+# in English, and Khasi has a long English-medium tradition beside its
+# missionary orthography, so the words a Khasi classroom actually uses for a
+# matrix, a percentage, a keyboard, a column or a diagram are the English ones.
+# They are written here in their English spelling. What is Khasi is the frame:
+# «ïa» as the object marker, «ban» for the infinitive, «na» for *from/of*,
+# «bad» for *with/and*, «ym» for the negative, «lah» for *can*, «don» for
+# *there is*, «ym don» for *none*, «sngewbha» for *please*, «beit» for
+# *correct* and «ym beit» for *incorrect*, «shem» for *found*, «plie»/«khang»
+# for *open*/*close*, «pynpaw»/«pynjah» for *show*/*hide*, and «dang …» for the
+# progressive.
+#
+# **Weakest words here, to check first:** «error» is left as the English loan
+# because the seed found no Khasi noun it was confident of (contrast
+# «jingsneng» for *warning*, from «sneng» *to advise*, which it is confident
+# of); «Jingong Phai» for *feedback* is a coinage; and «futnot», «kibod», «ro»,
+# «kolom», «bax» and «peij» are loans a speaker may well replace.
+#
+# No message here selects on a plural category: CLDR has no plural data for
+# `kha`, and a Khasi noun is not marked for number after a numeral in any case.
+# The `[0]` in `attempts-remaining` is matched against the number itself and is
+# not a plural rule, so it stays exactly where English has it.
+
+
+## Answer submission
+
+answer-checking = Dang peit...
+answer-submitting = Dang ai...
+
+answer-checking-status = Dang peit ïa ka jingjubab
+answer-submitting-status = Dang ai ïa ka jingjubab
+
+answer-correct = Beit
+answer-incorrect = Ym Beit
+
+answer-response-saved = La Buh ïa ka Jingjubab
+
+answer-percent-credit = { $percent }% Kredit
+answer-percent-correct = { $percent }% Beit
+answer-percent-short = { $percent } %
+
+max-credit-available = Kredit bakhraw tam ba don: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] ym don shuh ka jingpyrshang
+       *[other] { $count } tylli ki jingpyrshang ba don shuh
+    }
+
+validation-correct = (Beit)
+validation-incorrect = (Ym Beit)
+validation-partially-correct = (Beit bynta)
+
+answer-show-responses = Pynpaw ïa ki { $count } jingjubab sha { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Jingong Phai
+
+collapsible-click-to-open = (klik ban plie)
+collapsible-click-to-close = (klik ban khang)
+
+collapsible-initializing = Dang sdang...
+
+footnote-show = Pynpaw ïa ka futnot
+footnote-hide = Pynjah ïa ka futnot
+
+description-more-information = kham bun jingtip
+
+
+## Controls
+
+slider-previous = Mynshuwa
+slider-next = Shaphrang
+
+keyboard-open = Plie ïa ka Kibod
+keyboard-close = Khang ïa ka Kibod
+
+choice-input-remove-choice = Rah noh ïa { $choice }
+
+matrix-remove-row = Rah noh ïa ka ro
+matrix-add-row = Buh ïa ka ro
+matrix-remove-column = Rah noh ïa ka kolom
+matrix-add-column = Buh ïa ka kolom
+
+subset-add-remove-points = Buh/Rah noh ki point
+subset-toggle-points-intervals = Kylla ki point bad ki interval
+subset-move-points = Pynïaid ki point
+subset-clear = Sait Noh
+
+orbital-add-row = Buh Ro
+orbital-remove-row = Rah noh Ro
+orbital-add-box = Buh Bax
+orbital-remove-box = Rah noh Bax
+orbital-add-up-arrow = Buh Khnam Sha Khlieh
+orbital-add-down-arrow = Buh Khnam Sha Khyndew
+orbital-remove-arrow = Rah noh Khnam
+
+orbital-row-label = Kyrteng ka ro { $row }
+
+pretzel-answer = Jingjubab
+
+summary-statistics-caption = Ka jingbatai statistik jong { $column }
+
+
+## Math input
+
+math-input-preview-region = jingpeit lypa ïa ka jingthoh math
+math-input-preview = Peit Lypa
+math-input-invalid-expression = Jingthoh ba ym beit:
+
+
+## Document status
+
+viewer-initializing = Dang sdang...
+
+
+## Errors
+
+error-heading = Error
+
+error-found-at =
+    { $span ->
+        [line] La shem ha ka lain { $startLine }.
+       *[lines] La shem ha ki lain { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Kane ka dokumen ka don ki error!
+
+diagnostic-heading-error = Error
+diagnostic-heading-warning = Jingsneng
+diagnostic-heading-information = Jingtip
+diagnostic-heading-hint = Jingiarap
+
+accessibility-heading-level-1 = Jingpudong ïa ka WCAG AA Aksesibiliti
+accessibility-heading-level-2 = Jingsneng shaphang ka aksesibiliti
+
+something-went-wrong = Don kaei kaei kaba ym beit.
+
+renderer-load-failed = ym lah ban pynmih ïa ka renderer. Sngewbha pynthymmai ïa ka peij.
+
+core-start-failed = Ym lah ban sdang ïa kane ka dokumen. Sngewbha pynthymmai ïa ka peij.
+
+core-start-failed-busy = Ym lah ban sdang ïa kane ka dokumen. Bun ki dokumen ki la sdang lang ha kajuh ka por, kaba lah ban bat kham bun por ha ka dyrbon babym bakla. Ka jingpynthymmai ïa ka peij ka lah ban iarap haba ki dokumen kiwei ki la dep.
+
+core-start-failed-retry = Ym lah ban sdang ïa kane ka dokumen.
+
+core-start-failed-busy-retry = Ym lah ban sdang ïa kane ka dokumen. Bun ki dokumen ki la sdang lang ha kajuh ka por, kaba lah ban bat kham bun por ha ka dyrbon babym bakla.
+
+core-start-retry = Pyrshang biang
+
+saved-state-unavailable = Ym lah ban pynmih ïa ka kam jong phi kaba la buh.

--- a/packages/i18n/locales/kha/content.ftl
+++ b/packages/i18n/locales/kha/content.ftl
@@ -1,0 +1,336 @@
+# Khasi (Ka Ktien Khasi) content catalog: the prose the core computes into the
+# document — style descriptions, boolean words, section names, the words a
+# piecewise function is read with. Selected by `documentLocale`, which follows
+# the language the activity was written in rather than the reader's UI
+# language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to change a word.
+#
+# **Orthography: Roman, with its diacritics.** Khasi has been written in the
+# Roman alphabet since the Welsh Presbyterian mission, and no other script is
+# at issue for it. The three marks that alphabet carries are used consistently:
+# `ï` (U+00EF) in «ïa» and «ïaid», `ñ` (U+00F1) in «kñi» and its relatives, and
+# the ASCII apostrophe `'` (U+0027) for the glottal stop in «ka'», never the
+# typographic U+2019.
+#
+# **Word order: postnominal.** A Khasi attributive adjective follows its noun.
+# So `style-with-noun` and `style-filled-with-noun` put `{ $noun }` *before*
+# `{ $description }` — the reverse of English's sequence of placeables — and
+# `style-fill` puts the pattern before its colour: "diamonds blue", not "blue
+# diamonds". Inside `style-stroke` the internal order of width, dash pattern
+# and colour is left as English has it, since all three are adjectives and none
+# of them outranks the others in Khasi.
+#
+# **The attributive «ba-» prefix is written into the catalog's own words, not
+# welded onto a placeable.** This is the interesting thing about this file. A
+# Khasi adjective in attributive position carries «ba-» — «balieh» *white*,
+# «basaw» *red*, «bathiang» *green*, «bakhraw» *big* — and the README's rule
+# that an affix cannot be attached to a placeable would bite hard if the
+# catalog tried to add it at composition time. It does not have to: `color`,
+# `line-width` and `line-style` are the catalog's own words, so each of them is
+# spelled with its «ba-» already on it and every composition message is a plain
+# juxtaposition of finished words. Nothing here runs into the affix constraint.
+#
+# **No `$gender` fork and no `$role` fork — and Khasi's is a near miss worth
+# writing down.** Khasi does have grammatical gender, four ways: «u»
+# masculine, «ka» feminine, «i» diminutive, «ki» plural. But the gender falls
+# on the *article or pronoun that precedes the noun*, not on the adjective.
+# The messages that meet the noun — `style-with-noun`, `style-filled-with-noun`
+# — are never handed `$gender`; only the adjectives are, and a Khasi adjective
+# does not agree with anything. So no article is placed anywhere in this file,
+# `noun-gender` answers the single token `neuter`, and every adjective ignores
+# the argument it is given. This is a fact about *where* the agreement sits, not
+# about whether the language has one.
+#
+# **Nothing selects on a count.** A Khasi noun is not marked for number after a
+# numeral, and CLDR has no plural data for `kha` in any case. There is no
+# one/other plural branch anywhere in these four files.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` and leaves
+# `tail` empty, exactly as English does: the side count sits with the noun in
+# Khasi too, in front of it, so nothing is left over to follow the adjectives.
+# The `-tail` variants are kept because they are what a partly-translated
+# locale falls back to.
+#
+# **`piecewise-condition-if` is «lada»**, which is clause-initial in Khasi. The
+# renderer places the mathematics after this word, and «lada» is exactly where
+# a Khasi reader expects the conditional marker to be — so unlike some catalogs
+# in this batch, the word and the notation need no reordering to read right.
+#
+# **Vocabulary: a large part of it is an English loan, and that is declared
+# rather than disguised.** Meghalaya teaches mathematics and secondary science
+# in English, so the geometry and computing words a Khasi classroom uses are
+# the English ones, written here in their English spelling: `line`, `vector`,
+# `function`, `polygon`, `circle`, `interval`, `matrix`, `statistik`,
+# `paragraf`, `seksan`, `tebul`, `peij`. What is genuinely Khasi is the
+# ordinary vocabulary around them — the colour terms «lieh», «iong», «saw»,
+# «thiang», the size words «khraw» and «rit», «dur» *picture*, «bynta» *part*,
+# «nuksa» *example*, «jingkylli» *question*, «jingjubab» *answer*,
+# «jingpyrshang» *exercise*, «jingbatai» *explanation*, «kyrteng» *name*,
+# «shaphang» *about*, «hok» *true*, «bakhlem hok» *false*, «ym don» *none*,
+# «kam» *work/task*, «lada» *if*, «ne» *or*, «lymne» *otherwise*.
+#
+# **Words to check first:** «bathiang» for *green* (the seed also considered
+# «bastem», which some speakers use for the same band of colour, and a reviewer
+# should pick one and apply it consistently); «bakhraw»/«barit» for a stroke's
+# *thick* and *thin*, which are the ordinary words for big and small and may be
+# wrong for a line; «Jingpynbeit» for *solution*, which is a coinage; «kyrdan»
+# for a shape's *border*; and «blank», left as a loan because the seed found no
+# Khasi word it was confident of for the gap an input fills inside typeset
+# mathematics.
+#
+# **`element-name` and `element-anion-name` are deliberately absent**, so all
+# 130 of those keys fall back to English and `lint:i18n` reports the gap. This
+# is not an oversight and should not be "fixed" by transliteration. Meghalaya
+# teaches secondary chemistry in English, out of English textbooks, so the
+# element names a Khasi student actually meets are Hydrogen, Oxygen, Iron —
+# and falling back to English gives them exactly that. A Khasi table would be a
+# claim about how to spell those words in Khasi letters rather than a fact
+# about the language, and no such convention exists to seed from.
+
+
+## Style vocabulary
+
+# The four colours Khasi names with its own words carry the attributive «ba-»
+# («balieh», «baiong», «basaw», «bathiang»); the rest are loans, written as
+# «rong X» — *colour X* — because a loan does not take «ba-» comfortably.
+color =
+    .black = baiong
+    .white = balieh
+    .gray = rong gre
+    .red = basaw
+    .orange = rong orenj
+    .yellow = rong yelo
+    .green = bathiang
+    .cyan = rong sayan
+    .blue = rong blu
+    .purple = rong parpul
+    .pink = rong pink
+    .brown = rong brawn
+
+# Khasi names a stroke's width with its ordinary words for big and small.
+line-width =
+    .thick = bakhraw
+    .thin = barit
+
+line-style =
+    .dashed = badash
+    .dotted = badot
+
+fill-style =
+    .horizontal = ki lain ba iaid mynrei
+    .vertical = ki lain ba iaid jrong
+    .diagonal = ki lain ba iaid kynthup
+    .backdiagonal = ki lain ba iaid kynthup ba kylla
+    .dots = ki dot
+    .diamonds = ki dayamon
+
+noun =
+    .line = lain
+    .line-segment = bynta lain
+    .ray = ray
+    .vector = vektor
+    .curve = lain bakhon
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polylain
+    .polygon = polygon
+    .triangle = trayangul
+    .rectangle = rektangul
+    .circle = jyrong
+    .region = jaka
+    .point = point
+    .square = skwer
+    .diamond = dayamon
+    .cross = kruh
+    .plus = plas
+
+# The side count stands in front of the noun in Khasi, as it does in English,
+# so the head carries all of it and the tail is empty.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] polygon ba beit bad { $numSides } tylli ki bynta
+    }
+
+# Khasi gender sits on the article, not on the adjective, so nothing here
+# selects on it. See the header.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun comes first and the adjectives follow it. The trailing complement,
+# which Khasi never asks for, is kept last so that a fallback still renders.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = badap
+
+# «da» is the instrumental preposition and stands in front of what it governs,
+# as English's "with" does.
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } da { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } da { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } da { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Khasi places no article here — see the header — so the two `-article`
+# branches read like their neighbours. «bad» is *with*, «bad ruh» *and also*.
+style-border-clause =
+    { $parts ->
+        [with-article] bad kyrdan { $border }
+        [and] bad ruh kyrdan { $border }
+        [and-article] bad ruh kyrdan { $border }
+       *[with] bad kyrdan { $border }
+    }
+
+# The pattern is the noun and the colour the adjective, so they change places.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ym badap
+
+style-text =
+    { $parts ->
+        [background] { $color } bad bakgrawnd { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ym don
+
+
+## Boolean words
+
+boolean-true = hok
+boolean-false = bakhlem hok
+
+
+## Answer buttons
+
+answer-submit-label = Peit ïa ka Kam
+answer-submit-label-no-correctness = Ai ïa ka Jingjubab
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Jingtrei
+    .aside = Jingong Bynta
+    .cascade = Kaskad
+    .definition = Jingbatai Ktien
+    .example = Nuksa
+    .exercise = Jingpyrshang
+    .exercises = Ki Jingpyrshang
+    .given-answer = Jingjubab
+    .note = Jingkynmaw
+    .objectives = Ki Jingmut
+    .paragraphs = Ki Paragraf
+    .part = Bynta
+    .problem = Jingeh
+    .problems = Ki Jingeh
+    .proof = Jingpynshisha
+    .question = Jingkylli
+    .section = Seksan
+    .solution = Jingpynbeit
+    .task = Kam
+    .theorem = Thiorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Jingiarap
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tebul { $enumeration }
+        [numbered-title] Tebul { $enumeration }{ ": " }
+        [unnumbered-title] Tebul{ ": " }
+       *[unnumbered] Tebul
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Dur { $enumeration }
+        [numbered-caption] Dur { $enumeration }{ ": " }
+        [unnumbered-caption] Dur{ ": " }
+       *[unnumbered] Dur
+    }
+
+
+## Paginator controls
+
+paginator-previous = Mynshuwa
+paginator-next = Shaphrang
+paginator-page = Peij
+
+# «na» is *from/out of* and keeps English's order of the two counts.
+paginator-page-status = { $pageLabel } { $currentPage } na { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ne
+
+# «lada» is clause-initial in Khasi, so it sits correctly in front of the
+# mathematics the renderer places after it.
+piecewise-condition-if = lada
+
+piecewise-condition-otherwise = lymne
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent — see the
+## paragraph in the header. All 130 of those keys fall back to English, which
+## is the nomenclature a Khasi student is taught in.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simbol Kemikal Ba Ym Beit
+chemistry-invalid-ionic-compound = Kompawnd Ayonik Ba Ym Beit
+
+## Inputs embedded in math
+
+math-embedded-input-blank = blank
+
+math-embedded-input-blank-ordinal = blank { $ordinal } na { $total }

--- a/packages/i18n/locales/kha/content.ftl
+++ b/packages/i18n/locales/kha/content.ftl
@@ -11,7 +11,8 @@
 # **Orthography: Roman, with its diacritics.** Khasi has been written in the
 # Roman alphabet since the Welsh Presbyterian mission, and no other script is
 # at issue for it. The three marks that alphabet carries are used consistently:
-# `ï` (U+00EF) in «ïa» and «ïaid», `ñ` (U+00F1) in «kñi» and its relatives, and
+# `ï` (U+00EF) in «ïa» and «ïaid», `ñ` (U+00F1) in «kñi» and its relatives, which this catalog happens never
+# to need, and
 # the ASCII apostrophe `'` (U+0027) for the glottal stop in «ka'», never the
 # typographic U+2019.
 #
@@ -28,10 +29,13 @@
 # Khasi adjective in attributive position carries «ba-» — «balieh» *white*,
 # «basaw» *red*, «bathiang» *green*, «bakhraw» *big* — and the README's rule
 # that an affix cannot be attached to a placeable would bite hard if the
-# catalog tried to add it at composition time. It does not have to: `color`,
-# `line-width` and `line-style` are the catalog's own words, so each of them is
-# spelled with its «ba-» already on it and every composition message is a plain
-# juxtaposition of finished words. Nothing here runs into the affix constraint.
+# catalog tried to add it at composition time. It does not have to: every
+# `color`, `line-width` and `line-style` attribute is written out finished —
+# with «ba-» already on it where the word is Khasi's own («bathiang»,
+# «bakhraw», «badash»), and as a «rong»-prefixed loan where it is not
+# («rong blu», «rong orenj»; see the section comment below) — so every
+# composition message is a plain juxtaposition of finished words. Nothing
+# here runs into the affix constraint.
 #
 # **No `$gender` fork and no `$role` fork — and Khasi's is a near miss worth
 # writing down.** Khasi does have grammatical gender, four ways: «u»
@@ -39,7 +43,10 @@
 # on the *article or pronoun that precedes the noun*, not on the adjective.
 # The messages that meet the noun — `style-with-noun`, `style-filled-with-noun`
 # — are never handed `$gender`; only the adjectives are, and a Khasi adjective
-# does not agree with anything. So no article is placed anywhere in this file,
+# does not agree with anything. So no message in this file places an article
+# around a placeable — the «ki» and «ka» that do appear (in `fill-style`, in
+# `noun-regular-polygon`'s «tylli ki bynta», and in the button labels) are
+# lexicalized inside a single written value, not chosen at composition time.
 # `noun-gender` answers the single token `neuter`, and every adjective ignores
 # the argument it is given. This is a fact about *where* the agreement sits, not
 # about whether the language has one.
@@ -120,10 +127,10 @@ line-style =
     .dotted = badot
 
 fill-style =
-    .horizontal = ki lain ba iaid mynrei
-    .vertical = ki lain ba iaid jrong
-    .diagonal = ki lain ba iaid kynthup
-    .backdiagonal = ki lain ba iaid kynthup ba kylla
+    .horizontal = ki lain ba ïaid mynrei
+    .vertical = ki lain ba ïaid jrong
+    .diagonal = ki lain ba ïaid kynthup
+    .backdiagonal = ki lain ba ïaid kynthup ba kylla
     .dots = ki dot
     .diamonds = ki dayamon
 

--- a/packages/i18n/locales/kha/diagnostics.ftl
+++ b/packages/i18n/locales/kha/diagnostics.ftl
@@ -45,9 +45,10 @@
 # No message here selects on a plural category: CLDR has no plural data for
 # `kha`, and a Khasi noun is not marked for number after a numeral, so every
 # English count fork is collapsed to its `*[other]` wording with its placeables
-# kept. The `[1]` in `field-function-wrong-num-outputs` is matched against the
-# number itself rather than against a plural rule, so it stays exactly where
-# English has it.
+# kept. `field-function-wrong-num-outputs` keeps its fork, in the one form
+# that survives having no plural rules: English selects `$expected` on the
+# category `[one]`, and this catalog writes the numeric literal `[1]` in its
+# place, which Fluent matches against the number itself.
 
 ## `<lineSegment>`
 

--- a/packages/i18n/locales/kha/diagnostics.ftl
+++ b/packages/i18n/locales/kha/diagnostics.ftl
@@ -1,0 +1,677 @@
+# Khasi (Ka Ktien Khasi) diagnostics catalog: the warnings and errors the
+# worker, the parser and the schema checker raise. Produced by the worker but
+# addressed to whoever is looking at the screen, so these are selected by
+# `uiLocale`, not `documentLocale`.
+#
+# Translated from `locales/en/diagnostics.ftl`, which is the source of truth.
+# Message ids, `.attribute` names, select variant keys, placeable names and
+# `NUMBER()` are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to change a word.
+#
+# **Orthography: Roman, with its diacritics.** Khasi has been written in the
+# Roman alphabet since the Welsh Presbyterian mission, and no other script is
+# at issue for it. `ï` (U+00EF), `ñ` (U+00F1) and the ASCII apostrophe `'`
+# (U+0027) for the glottal stop are used consistently; the typographic
+# apostrophe U+2019 appears nowhere.
+#
+# **DoenetML's own words stay in English.** `through`, `endpoint`,
+# `midpointOffset`, `numDimensions`, `selectFromSequence`,
+# `sectionWideCheckWork`, `WCAG AA`, the `[deprecation]` marker and every tag,
+# attribute and attribute value written into these messages are part of the
+# language an author types, not prose. They are left exactly as written.
+#
+# **Beyond those, much of the technical vocabulary is an English loan, and that
+# is declared rather than disguised.** Meghalaya teaches mathematics and
+# computing in English, so `component`, `attribute`, `reference`, `function`,
+# `matrix`, `variant`, `index`, `interval`, `sequence` and their neighbours are
+# written here as English. What is Khasi is the frame that carries them: «ïa»
+# the object marker, «ban» the infinitive, «na» *from*, «jong» *of*, «bad»
+# *with/and*, «ne» *or*, «lada» *if*, «namar» *because*, «hynrei» *but*, «ym»
+# the negative, «ym lah ban» *cannot*, «ym don» *there is none*, «la shem»
+# *was found*, «ym la shem» *was not found*, «ym pdiang» *not accepted* for
+# English's *ignoring*, «leit lyngba» *passed over* for a skipped descendant,
+# «donkam» *needed*, «dei» *is/belongs*, «beit» *correct* and «ba ym beit»
+# *invalid*.
+#
+# **Words to check first:** «error» is left as the English loan throughout, for
+# want of a Khasi noun the seed was confident of; «ym pdiang» for *ignoring* is
+# built from «pdiang» *to accept* and a reviewer may prefer a different verb;
+# «duna kyrpad» for *deprecated* is a coinage; and «dienshohnud» for a quote
+# mark is the seed's least confident word in the file.
+#
+# No message here selects on a plural category: CLDR has no plural data for
+# `kha`, and a Khasi noun is not marked for number after a numeral, so every
+# English count fork is collapsed to its `*[other]` wording with its placeables
+# kept. The `[1]` in `field-function-wrong-num-outputs` is matched against the
+# number itself rather than against a plural rule, so it stays exactly where
+# English has it.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } ym pdiang haba la pyni ar tylli ki endpoint
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } ym pdiang haba la pyni baroh ar ka endpoint bad ka midpoint
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset kam trei khlem ka midpoint
+
+## `<line>`
+
+line-points-undetermined-dimensions = Ka lain ka leit lyngba ki point kiba ym tip ki dimension.
+
+line-points-too-few-dimensions = Ka lain ka dei ban leit lyngba ki point kiba don ar tylli ki dimension halor.
+
+line-points-depend-on-variables = Ka lain ka leit lyngba ki point kiba iadei bad ki variable: { $variables }.
+
+line-equation-invalid-format = Format ba ym beit ïa ka equation jong ka lain ha ki variable { $variable1 } bad { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ka ray ka la pyni da through, endpoint, bad direction.  Ym pdiang ïa ka through ba la pyni.
+
+ray-dimension-mismatch = numDimensions ym iaseng ha ka ray.
+
+## `<vector>`
+
+vector-overprescribed-head = Ka vector ka la pyni da head, tail, bad displacement.  Ym pdiang ïa ka head ba la pyni.
+
+vector-dimension-mismatch = numDimensions ym iaseng ha ka vector.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ym lah ban attract sha ka `<{ $component }>` namar kam don ka state variable nearestPoint.
+
+constrain-to-without-nearest-point = Ym lah ban constrain sha ka `<{ $component }>` namar kam don ka state variable nearestPoint.
+
+constrain-to-interior-without-nearest-point = Ym lah ban constrain sha ka bynta khlaw jong ka `<{ $component }>` namar kam don ka state variable nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ym pdiang ïa ka choiceInput babym inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ym pdiang ki index ba la pyni ïa ka choiceInput namar ka rukom ki index kam iaseng bad ka rukom ki khun choice.
+
+pretzel-indices-count-mismatch = Ym pdiang ki index ba la pyni ïa ka problem namar ka rukom ki index kam iaseng bad ka rukom ki khun problem.
+
+shuffle-indices-count-mismatch = Ym pdiang ki index ba la pyni ïa ka shuffle namar ka rukom ki index kam iaseng bad ka rukom ki component.
+
+indices-ignored-out-of-range = Ym pdiang ki index ba la pyni ïa { $component } namar don ki index kiba mih na ka jaka.
+
+pretzel-indices-repeated = Ym pdiang ki index ba la pyni ïa ka pretzel namar don ki index kiba la thoh biang.
+
+pretzel-circuit-first-index = Ym pdiang ki index ba la pyni ïa ka pretzel ha ka circuit mode namar ka index banyngkong ka dei ban long 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ban ka `<{ $component }>` ka trei bad ki khun string, ka attribute `type` ka donkam ban la pyni.
+
+invalid-type-defaulting-to-math = Type { $type } ba ym beit ïa ka component { $component }. Ka dei ban long math, text, number, ne boolean. Da ka default ka long math.
+
+string-not-valid-component-to-arrange = Ka string "{ $value }" kam dei ka component babeit ban { $component }. Ym pdiang.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } ba ym beit, ka type ka long number.
+
+invalid-variable-value = Bynta ba ym beit jong ka variable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Ka variant index { $index } ka dei ban long ka number
+
+variant-index-must-be-integer = Ka variant index { $index } ka dei ban long ka integer
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Ka `<{ $component }>` kam la pynlong ïa ki jingthik absolute. Ki width ki long relative.
+
+side-by-side-absolute-margins = Ka `<{ $component }>` kam la pynlong ïa ki jingthik absolute. Ki margin ki long relative.
+
+side-by-side-no-block-child = Ka `<{ $component }>` ba ym beit: ka donkam ban don shisien ka khun block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ka attribute `for` halor ka `<label>` graphical ym pdiang.
+
+label-for-must-resolve-to-one = Ka attribute `for` halor ka `<label>` ka dei ban dei shisien ka component.
+
+label-for-unresolved = Ym lah ban pynbeit ïa ka attribute `for` halor ka `<label>` sha kano kano ka component.
+
+label-for-answer-with-authored-inputs = Ka attribute `for` halor ka `<label>` ka iadei bad ka `<answer>` kaba don ki input ba la thoh da u nongthoh; iadei bad ka input hi.
+
+label-for-answer-without-input = Ka attribute `for` halor ka `<label>` ka iadei bad ka `<answer>` kaba ym don ka input ban ai kyrteng.
+
+label-for-must-reference-input-or-answer = Ka attribute `for` halor ka `<label>` ka dei ban iadei bad ka input ne ka answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ïa ka aksesibiliti, ka `<{ $component }>` ka dei ban don ka jingbatai bakhyndiat ne ban la pyni kum ka decorative.
+
+accessibility-video-short-description = Ïa ka aksesibiliti, ka `<video>` ka dei ban don ka jingbatai bakhyndiat.
+
+accessibility-input-short-description-or-label = Ïa ka aksesibiliti, ka `<{ $component }>` ka dei ban don ka jingbatai bakhyndiat ne ka label.
+
+accessibility-answer-input-short-description-or-label = Ïa ka aksesibiliti, ka `<answer>` kaba pynlong ka input ka dei ban don ka jingbatai bakhyndiat ne ka label.
+
+accessibility-short-description-contains-math = Ki jingbatai bakhyndiat kim dei ban don ki component math kum ka `<{ $component }>`. Batai ïa ka math da ki ktien.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kam don ka contrast bakhraw biang ïa ka ktien khlieh jong ka section (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; donkam halor { $threshold }:1).
+       *[other] { $colorName } kam don ka contrast bakhraw biang ïa ka ktien khlieh jong ka section ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; donkam halor { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Ym la pynlong ïa ka `<circle>` ba leit lyngba { $count } ki point haba ki point kim don ki bynta number.
+
+circle-too-many-through-points = Ym lah ban pynkhreh ïa ka circle ba leit lyngba kham bun ban 3 ki point.
+
+circle-overprescribed-radius-center-points = Ym lah ban pynkhreh ïa ka circle bad ka radius, ka center bad ki through point baroh ba la pyni.
+
+circle-center-with-multiple-points = Ym lah ban pynkhreh ïa ka circle bad ka center ba la pyni ba leit lyngba kham bun ban 1 ka point.
+
+circle-radius-too-small = Ym lah ban pynkhreh ïa ka circle: namar ka jinglong jngai hapdeng ki ar tylli ki point ka long { $distance }, ka radius { $radius } ba la pyni ka rit eh.
+
+circle-radius-with-many-points = Ym lah ban pynlong ïa ka circle ba leit lyngba kham bun ban ar tylli ki point bad ka radius ba la pyni.
+
+circle-invalid-center-or-through-points = Ka center ne ki through point jong ka circle ki ym beit.
+
+circle-radius-center-with-multiple-points = Ym lah ban pynkhreh ïa ka radius jong ka circle bad ka center ba la pyni ba leit lyngba kham bun ban 1 ka point.
+
+circle-change-radius-non-numerical = Ym lah ban pynkylla ïa ka radius jong ka circle ba don ki through point kiba ym number
+
+circle-radius-with-points-non-numerical = Ym lah ban pynlong ïa ka circle ba leit lyngba kham bun ban shi tylli ka point bad ka radius ba la pyni haba ym don ki bynta number.
+
+circle-change-center-non-numerical = Ym la pynlong ïa ka jingpynkylla ka center jong ka circle ba leit lyngba ki point kiba ym number.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Ym don ki dimension biang ïa ka domain jong ka function. Ka domain ka don { $intervals } ki interval hynrei ka function ka don { $inputs } ki input.
+
+function-domain-invalid-format = Format ba ym beit ïa ka domain jong ka function.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ym pdiang ïa ka maximum babym number jong ka function.
+        [minimum] Ym pdiang ïa ka minimum babym number jong ka function.
+        [extremum] Ym pdiang ïa ka extremum babym number jong ka function.
+        [point] Ym pdiang ïa ka point babym number jong ka function.
+        [slope] Ym pdiang ïa ka slope babym number jong ka function.
+       *[other] Ym pdiang ïa ka { $type } babym number jong ka function.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ym pdiang ïa ka maximum bathang jong ka function.
+        [minimum] Ym pdiang ïa ka minimum bathang jong ka function.
+        [extremum] Ym pdiang ïa ka extremum bathang jong ka function.
+        [point] Ym pdiang ïa ka point bathang jong ka function.
+       *[other] Ym pdiang ïa ka { $type } bathang jong ka function.
+    }
+
+function-points-too-close = Ka function ka don ar tylli ki point kiba shong marjan eh. Ym lah ban pynlong ïa ka function.
+
+function-iterates-input-output-mismatch = Ki function iterate ki lah tang lada ka rukom ki input jong ka function ka iaseng bad ka rukom ki output. Kane ka function ka don { $inputs } ki input bad { $outputs } ki output.
+
+## `<sequence>`
+
+sequence-invalid-length = Ka jinglong jrong jong ka sequence ka ym beit.  Ka dei ban long ka integer babym duna ban 0.
+
+sequence-invalid-step = Ka step jong ka sequence ka ym beit.  Ka dei ban long ka number ïa ka sequence jong ka type { $type }.
+
+sequence-invalid-endpoint-number = Ka "{ $attribute }" jong ka number sequence ka ym beit.  Ka dei ban long ka number.
+
+sequence-invalid-endpoint-letters = Ka "{ $attribute }" jong ka letters sequence ka ym beit.  Ka dei ban long ka jingiasoh ki lettar.
+
+sequence-invalid-endpoint = Ka "{ $attribute }" jong ka sequence ka ym beit.
+
+select-from-sequence-coprime-not-numbers = coprime ym pdiang namar ym jied ki number
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ym pdiang namar la pyni excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Ka target ba ym beit ïa ka `<{ $source }>`: ym lah ban shem ïa ka target.
+
+target-state-variable-not-found = Ka target ba ym beit ïa ka `<{ $source }>`: ym lah ban shem ka state variable kaba kyrteng "{ $property }" halor ka `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ki variable jong ka `<odeSystem>` ki dei ban pher na ka independent variable.
+
+ode-system-duplicate-variable-names = Ym lah ban pynlong ki ODE RHS function bad ki kyrteng dependent variable kiba iaman.
+
+ode-system-rhs-function-error = Ym lah ban pynlong ïa ka ODE RHS function.  Don ka error ha ka jingpynlong function mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ym lah ban pynlong ka angle hapdeng { $count } ki lain
+
+angle-invalid-through-point = Ka point ba ym beit ha ka through jong ka `<angle>`
+
+parabola-vertex-too-many-points = Ym la pynlong ïa ka parabola bad ka vertex ba leit lyngba kham bun ban 1 ka point.
+
+parabola-too-many-points = Ym la pynlong ïa ka parabola ba leit lyngba kham bun ban 3 ki point.
+
+intersection-too-many-items = Ym la pynlong ïa ka intersection ïa kham bun ban ar tylli ki jingei
+
+## Other math components
+
+ionic-compound-not-two-ions = Ym la pynlong ïa ka ionic compound ïa kaei kaei bakwah na ki ar tylli ki ion.
+
+ionic-compound-needs-cation-and-anion = Ka ionic compound ka la pynlong tang ïa shi tylli ka cation bad shi tylli ka anion.
+
+solve-equations-cannot-evaluate = Ym lah ban solve ïa ka equation namar ym lah ban pynkhreh ïa ka equation: { $equation }
+
+math-operators-operand-number-required = Ka donkam ban pyni ka operandNumber haba mih ka math operand.
+
+eigen-decomposition-failed = Ym lah ban pynkhreh ki eigenvalue jong ka matrix
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: ki parameter { $parameters } kim mih ha ka pattern, kumta ki'n ïaseng bad ka jaka thang baroh ka por.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ym lah ban sngewthuh ïa ka grid="{ $grid }". Ka dei ban long none, medium, dense, ne ar tylli ki number babym duna kiba iasuh da ka jaka thang, kum ka grid="1 0.5". Ym la thoh ka grid.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    Ka `<{ $component }>` ka donkam ka function bad { $expected ->
+        [1] shi tylli ka output, ka slope y' ha man la ka point, kum ka `y - x`
+       *[other] ar tylli ki output, ka vector ha man la ka point, kum ka `(y, -x)`
+    }, hynrei ka function ba la ai ka don { $found } ki output. { $alternative ->
+        [none] Ym la thoh ei ei.
+       *[other] Ka `<{ $alternative }>` ka dei ka component ïa kata ka function. Ym la thoh ei ei.
+    }
+
+field-function-attribute-ignored-with-child = Ka attribute `function` ym pdiang namar ka function ka la ai ruh ha ka bynta khlaw jong ka component; kaba ha khlaw ka trei. Ai ïa ka function tang da shi arasi.
+
+field-variables-ignored =
+    `<{ $component }>`: ka attribute `variables` ka ai kyrteng ïa ki variable jong ka expression ba la thoh hi ha ka bynta khlaw jong ka component. { $reason ->
+        [function-child] Ka function hangne ka la ai kum ka khun `<function>`, kaba ai kyrteng ïa ki variable jong ka lade, kumta `variables` ym pdiang.
+       *[no-expression] Ym don kata ka expression hangne, kumta `variables` ym pdiang.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" kam trei ha ka prefigure renderer; ka rukom right-position ka trei.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" kam trei ha ka prefigure renderer; ka rukom top-position ka trei.
+
+prefigure-invalid-axis-bounds = `<graph>`: ki axis bound ki ym beit ïa ka jingkylla prefigure; da ka default ka bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: ka width ka ym beit ïa ka jingkylla prefigure; da ka default ka diagram width 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: ka aspectRatio ka ym beit ïa ka jingkylla prefigure; da ka default ka aspect ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ka jaka thang hapdeng ki lain jong ka grid ka rit eh ïa ki axis limit; ka grid ka mihnoh ha ka prefigure renderer.
+
+prefigure-annotations-not-rendered = `<graph>`: ki annotation kim mih lada ym pyndonkam ïa ka PreFigure renderer.
+
+multiple-annotations-children = La shem bun ki khun `<annotations>` ha ka `<graph>`; ym pdiang baroh hynrei tang kaba khadduh.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ym lah ban extend ne copy ïa ka component type babym tip: { $type }.
+
+copy-prop-not-found = Ym lah ban shem ka prop { $property } halor ka component jong ka type { $component }
+
+collect-no-source = Ym la shem ka source ïa ka collect.
+
+collect-invalid-component-type = Ym lah ban collect ki component jong ka type `<{ $component }>` namar ka dei ka component type ba ym beit.
+
+reference-index-unavailable = Ym lah ban iadei bad ka index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ym lah ban khot { $action } halor ka component `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Ka data ka don ka jinglong ba ym beit.  Ki ro ki don ki jinglong jrong kiba pher. La shem ha ka componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Ka data ka don ki kyrteng kolom kiba iaman.  La shem ha ka componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Ka data kam don ka kyrteng kolom.  La shem ha ka componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ka award ïa kane ka answer ka iadei bad ka jingjubab jong ka answer tag hi, kaba'n pynmih ki jingjia babym kwah.
+
+answer-max-num-attempts-in-section-wide-check-work = Ka jingbuh `maxNumAttempts` halor ka `<answer>` ha ka bynta ba don `sectionWideCheckWork` kam trei, namar ka rukom ki jingpyrshang ka la buh da ka bynta bakhraw. Buh ïa ka `maxNumAttempts` halor ka bynta bakhraw hi.
+
+nested-section-wide-check-work-max-num-attempts = Ka jingbuh `maxNumAttempts` halor ka bynta ba don `sectionWideCheckWork` kaba shong ha ka bynta kawei pat ba don `sectionWideCheckWork` kam trei, namar ka rukom ki jingpyrshang ka la buh da ka bynta ba shabar. Buh ïa ka `maxNumAttempts` halor ka bynta ba shabar.
+
+answer-attributes-need-symbolic-equality = Ki attribute { $attributes } kim trei khlem ka symbolicEquality ba la buh.
+
+answer-invalid-type = Ka type ba ym beit ïa ka answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Namar ka component `<{ $component }>` kam don ka kyrteng, kam lah ban pyndonkam kum ka attribute jong ka module
+
+module-attribute-name-already-defined = Ka component `<{ $component } name="{ $name }">` kam lah ban pyndonkam kum ka attribute jong ka module namar ka component type `<module>` ka la don ka attribute "{ $name }" mynta.
+
+conditional-content-condition-ignored = Ka attribute `condition` ym pdiang halor ka component `<conditionalContent>` kaba don ki khun case ne else.
+
+slider-markers-type-mismatch = Ka type ki marker kam iaseng bad ka type jong ka slider.
+
+pretzel-problem-needs-statement-and-answer = Ka pretzel ba ym beit: man la ka `<problem>` ka dei ban don shi tylli ka `<statement>` bad shi tylli ka `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Ka pretzel ba ym beit: ha ka mode="circuit", ka `<problem>` banyngkong kam lah ban long ka distractor.
+
+## Attribute values
+
+attribute-invalid-values = Ki bynta { $values } ki ym beit ïa ka attribute `{ $attribute }`; ym pdiang.
+
+attribute-must-be-references = Ka bynta `{ $value }` ka ym beit ïa ka attribute `{ $attribute }`. Ka attribute ka dei ban long ki reference kiba sdang da ka `$`.
+
+math-input-invalid-function-names = <mathInput>: ym pdiang ki kyrteng function kiba ym beit ha { $attribute }: { $names }. Man la ka kyrteng ka dei ban don halor 2 ki lettar (ki lettar ne ki hyphen) ha ka bynta ba paw; ka lah ban bud ka `|<mathspeak alternative>` lada kwah.
+
+## Building components from the source
+
+component-type-invalid = Ka component type ba ym beit: `<{ $componentType }>`
+
+attribute-repeated = Ym lah ban thoh biang ïa ka attribute { $attribute }.
+
+attribute-invalid-for-component = Ka attribute "{ $attribute }" ka ym beit ïa ka component jong ka type `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Ka style definition { $styleNumber } kam don ka contrast bakhraw biang ïa { $context ->
+        [text-on-background] ka rong ktien halor ka rong bakgrawnd
+        [high-contrast] ka rong high-contrast halor ka canvas
+        [line] ka rong lain halor ka canvas
+        [marker] ka rong marker halor ka canvas
+       *[text-on-canvas] ka rong ktien halor ka canvas
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; donkam halor { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Lehse ka style definition { $styleNumber } ka la pyni ki rong kiba ai ka contrast bakhraw biang ïa ka light mode, ki rong dark mode kiba mih na kine ki bynta kim don ka contrast bakhraw biang ïa ka rong ktien halor ka rong bakgrawnd ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; donkam halor { $threshold }:1). { $suggestion ->
+        [available] Ban ai ka contrast bakhraw biang ha ka dark mode, pynkhraw ïa ka contrast jong ka light mode (kum ka { $lightAttribute }="{ $lightColor }") ne pynkylla ïa ka rong dark mode (kum ka { $darkAttribute }="{ $darkColor }").
+       *[none] Ban ai ka contrast bakhraw biang ha ka dark mode, pynkhraw ïa ka contrast jong ka light mode ne pynkylla ïa ki rong ba mih da ka textColorDarkMode bad/ne ka backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Lehse ka style definition { $styleNumber } ka la pyni ka rong ktien kaba ai ka contrast bakhraw biang ïa ka light mode, ka rong ktien dark mode kaba mih na kane ka bynta kam don ka contrast bakhraw biang halor ka canvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; donkam halor { $threshold }:1). { $suggestion ->
+        [available] Ban ai ka contrast bakhraw biang ha ka dark mode, pynkhraw ïa ka contrast jong ka light mode (kum ka textColor="{ $lightColor }") ne pynkylla ïa ka rong dark mode (kum ka textColorDarkMode="{ $darkColor }").
+       *[none] Ban ai ka contrast bakhraw biang ha ka dark mode, pynkhraw ïa ka contrast jong ka light mode ne pynkylla ïa ka rong ba mih da ka textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Ka section ka lah ban jied tang shi tylli ka <stylePalette>; kaba khadduh ka trei.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ym lah ban tip ki unique variant jong { $component } namar ka numToSelect kam dei ka integer babym duna ban 0.
+
+variant-num-to-select-not-constant-number = ym lah ban tip ki unique variant jong { $component } namar ka numToSelect kam dei ka number babym kylla.
+
+variant-with-replacement-not-constant-boolean = ym lah ban tip ki unique variant jong { $component } namar ka withReplacement kam dei ka boolean babym kylla.
+
+variant-select-weight-disables-unique = Ki unique variant ïa ka select ki ym trei lada don ka option bad ka selectWeight ne ka selectForVariants ba la pyni
+
+variant-coprime-undetermined = ym lah ban tip ki unique variant jong { $component } namar ym lah ban tip ba ka coprime ka long bakhlem hok baroh ka por.
+
+variant-attribute-not-constant = ym lah ban tip ki unique variant jong { $component } namar ka { $attribute } kam dei kaba ym kylla.
+
+variant-attribute-not-number = ym lah ban tip ki unique variant jong { $component } namar ka { $attribute } kam dei ka number.
+
+variant-attribute-wrong-type-for-sequence =
+    ym lah ban tip ki unique variant jong { $component } jong ka type { $type } namar ka { $attribute } kam dei { $expected ->
+        [letters-combination] ka jingiasoh ki lettar
+        [math-expression] ka math expression babeit
+        [integer] ka integer
+       *[number] ka number
+    }.
+
+variant-length-not-integer = ym lah ban tip ki unique variant jong { $component } namar ka length kam dei ka integer.
+
+variant-sort-not-implemented = ym la pynlong ki unique variant jong ka { $component } bad ka sort
+
+variant-exclude-combinations-not-implemented = ym la pynlong ki unique variant jong ka { $component } bad ka excludeCombinations
+
+variant-math-exclude-not-implemented = ym la pynlong ki unique variant jong ka { $component } jong ka type math bad ka exclude
+
+variant-non-constant-exclude-not-implemented = ym la pynlong ki unique variant jong ka { $component } bad ka exclude kaba kylla
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: kam trei ha ka graph prefigure renderer; la leit lyngba ïa ka khun.
+
+prefigure-descendant-invalid-geometry = { $subject }: ka geometry ka ym dep ne kam don ka jinglong; la leit lyngba ïa ka khun.
+
+prefigure-curve-label-omitted = { $subject }: ki label kim trei halor ki curve element ba la pynkylla; la mihnoh ïa ka label.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ka curve function definition type '{ $definitionType }' kam trei; la leit lyngba ïa ka khun.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ka attribute flipFunctions halor ka regionBetweenCurves kam trei; la leit lyngba ïa ka khun.
+
+prefigure-region-non-formula-child = { $subject }: tang ki khun function jong ka type formula ki trei halor ka regionBetweenCurves; la leit lyngba ïa ka khun.
+
+prefigure-label-position-unsupported =
+    { $subject }: ka labelPosition '{ $labelPosition }' kam trei ïa ka { $labelKind ->
+        [line-family] label jong ka rukom lain
+       *[point] label jong ka point
+    }; da ka default ka jingiaseng PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: ka fill style '{ $fillStyle }' kam trei ha ka PreFigure; da ka fill ba dap ka trei.
+
+prefigure-line-style-unknown = { $subject }: ka line style '{ $lineStyle }' babym tip la mihnoh na ka output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ka marker style '{ $markerStyle }' la pynkylla sha ka style PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: ka marker style '{ $markerStyle }' kam trei ha ka PreFigure; da ka default ka style ka trei.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ka `ref` ka ym beit; ym lah ban shem ïa ka target. La mihnoh ïa ka annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: ka `ref` ka poi sha bun ki target; kaba nyngkong ka trei.
+
+annotation-ref-outside-graph = `<annotation>`: ka `ref` ka ym beit; ka target ka shong shabar ka graph. La mihnoh ïa ka annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: ka `ref` ka ym beit; ka target kam dei ka jingei graphical kaba trei ha ka jingkylla prefigure. La mihnoh ïa ka annotation.
+
+annotation-text-missing = `<annotation>`: ka `text` ka duh ne ka thang; la ai ka ktien bathang.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] La shem ka circular dependency.
+       *[other] La shem ka circular dependency kaba iadei bad ka component `<{ $componentType }>`.
+    }
+
+reference-no-referent = Ym la shem ei ei ba dei ka reference: `{ $reference }`
+
+reference-multiple-referents = La shem bun ki jingdei ïa ka reference: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format ba ym beit ïa ka attribute { $attribute } jong ka `<{ $componentType }>`.
+
+children-invalid = Ki khun ki ym beit ïa ka `<{ $componentType }>`: La shem ki khun kiba ym beit: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ka bynta `{ $value }` ka ym beit ïa ka attribute `{ $attribute }`, da ka bynta `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ym la shem ka DoenetML version { $version }.
+       *[other] Ym la shem ka DoenetML version { $version }. Da ka version { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Ka DoenetML ka ym beit: { $content }
+
+parse-tag-missing-close-tag = Ka DoenetML ka ym beit: Ka tag `{ $tag }` kam don ka tag ba khang. Ka donkam ka tag ba khang lade ne ka tag `</{ $tagName }>`.
+
+parse-tag-error = Ka DoenetML ka ym beit: Don ka error ha ka tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Ka DoenetML ka ym beit: Ka attribute `{ $attribute }` ba ym beit ka lang kum ba kam don ka bynta.
+
+parse-attribute-invalid = Ka DoenetML ka ym beit: Ka attribute `{ $attribute }` ka ym beit
+
+parse-attribute-value-invalid = Ka DoenetML ka ym beit: Ka bynta attribute `{ $value }` ka ym beit
+
+parse-attribute-value-quote-mismatch = Ka DoenetML ka ym beit: Ka bynta attribute `{ $value }` ka ym beit. Ki dienshohnud quote kim iaseng. Ka lang kum ba duh ka `{ $quote }`
+
+parse-open-tag-name-missing = Ka DoenetML ka ym beit: La shem ka tag khlem kyrteng tag, kum ka `<`
+
+parse-tag-not-closed = Ka DoenetML ka ym beit: Ka tag `{ $tag }` ka ym la khang (ka lang kum ba duh ka `>`).
+
+parse-self-closing-tag-name-missing = Ka DoenetML ka ym beit: La shem ka tag khlem kyrteng tag `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Ka DoenetML ka ym beit: Ka tag `{ $tag }` ka ym la khang (ka lang kum ba duh ka `/>`).
+
+parse-tag-invalid-attributes = Ka DoenetML ka ym beit: Ka tag `{ $tag }` ka ym beit. Ki attribute jong ka ki lah ban ym beit.
+
+parse-close-tag-name-missing = Ka DoenetML ka ym beit: La shem ka tag ba khang khlem kyrteng tag, kum ka `</`
+
+parse-attribute-value-unquoted = Ki bynta attribute ki dei ban shong ha ki dienshohnud quote: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Ka DoenetML ka ym beit: La shem ka tag ba khang `{ $tag }`, hynrei ym don ka tag ba plie kaba iaseng
+
+parse-close-tag-mismatched = Ka DoenetML ka ym beit: Ka tag ba khang kam iaseng. Ka donkam ka `</{ $expected }>`. La shem ka `{ $found }`
+
+parser-node-unconvertible = Ym lah ban pynkylla ïa ka node { $node } sha ka Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Ka kyrteng attribute name='{ $name }' ka ym beit. { $reason ->
+        [characters] Ki kyrteng ki lah ban don tang ki lettar, ki number, ki underscore ne ki hyphen.
+       *[start] Ki kyrteng ki dei ban sdang da ka lettar.
+    }
+
+component-name-invalid-start = Ka kyrteng component "{ $name }" ka ym beit. Ki kyrteng ki dei ban sdang da ka lettar.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Ka answer jong ka type videoWatched ka dei ban don ka attribute video
+
+answer-video-watched-video-not-reference = Ka answer jong ka type videoWatched ka dei ban don ka attribute video kaba dei ka reference
+
+answer-name-not-single-text = Ka attribute name jong ka answer ka dei ban don shi tylli ka khun text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ym lah ban shem ïa ka DoenetML ba shabar namar bun eh ki daw jong ka recursion. Don ka circular reference?
+
+external-doenetml-unavailable = Ym lah ban shem ïa ka DoenetML na { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Ka DoenetML ba la shem na { $attribute }="{ $uri }" ka ym beit: kam iaseng bad ka component type "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Ka attribute `{ $from }` ka la duna kyrpad; pyndonkam ïa ka `{ $to }` hi.
+       *[other] [deprecation] Ka attribute `{ $from }` halor ka `<{ $component }>` ka la duna kyrpad; pyndonkam ïa ka `{ $to }` hi.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Ka attribute `{ $from }` ka la duna kyrpad bad ym pdiang namar la pyni ruh ka `{ $to }`.
+       *[other] [deprecation] Ka attribute `{ $from }` halor ka `<{ $component }>` ka la duna kyrpad bad ym pdiang namar la pyni ruh ka `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Ka attribute `{ $attribute }` halor ka `<{ $component }>` ka la duna kyrpad bad ym pdiang.
+
+deprecated-attribute-to-child = [deprecation] Ka attribute `{ $attribute }` halor ka `<{ $component }>` ka la duna kyrpad; pyndonkam ïa ka khun `<{ $child }>` hi.
+
+deprecated-attribute-value-renamed = [deprecation] Ka bynta `{ $value }` jong ka attribute `{ $attribute }` halor ka `<{ $component }>` ka la duna kyrpad; pyndonkam ïa ka `{ $to }` hi.
+
+
+## Language coverage
+
+pluralize-english-only = Ka `<pluralize>` ka lah ban pynbun tang ïa ka ktien Anglisa, kumta ka ktien jong ka ka sah kumba la thoh ha ka dokumen ba la thoh ha ka { $locale }. Thoh ïa ka rukom babun hi, ne buh ïa ka da ka attribute `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ka element `<{ $tag }>` kam dei ka element Doenet babym tip.
+
+schema-element-not-allowed-at-root = Ka element `<{ $tag }>` kam lah ban shong ha ka jaka bakhraw tam jong ka dokumen.
+
+schema-element-not-allowed-inside = Ka element `<{ $tag }>` kam lah ban shong ha ka bynta khlaw jong ka `<{ $parent }>`.
+
+schema-attribute-unrecognized = Ka element `<{ $tag }>` kam don ka attribute kaba kyrteng `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Ka attribute `{ $attribute }` jong ka element `<{ $tag }>` ka dei ban long ka list kaba man la ka bynta jong ka ka dei shi tylli na kine: { $allowed }
+       *[other] Ka attribute `{ $attribute }` jong ka element `<{ $tag }>` ka dei ban long shi tylli na kine: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Ka kyrteng variant ka ym beit ïa ka select.  Ka kyrteng variant { $variantName } ka mih ha { $numOptions } ki option hynrei ka rukom ban jied ka long { $numToSelect }.
+
+select-variant-name-without-options = La pyni ki variant ïa ka select hynrei ym la pyni ki option ïa ka kyrteng variant kaba lah: { $variantName }.
+
+select-variant-name-not-possible = Ka kyrteng variant { $variantName } ba la pyni ïa ka select kam dei ka kyrteng variant kaba lah.
+
+select-too-few-options = Ym lah ban jied { $numToSelect } ki component tang na { $numOptions }.
+
+select-from-sequence-too-few-values = Ym lah ban jied { $numToSelect } ki bynta na ka sequence kaba jrong { $length }.
+
+select-from-sequence-indices-count-mismatch = Ka rukom ki index ba la pyni ïa ka select ka dei ban iaseng bad ka rukom ban jied
+
+select-from-sequence-indices-not-integers = Baroh ki index ba la pyni ïa ka select ki dei ban long ki integer
+
+select-from-sequence-index-excluded = La pyni ka index jong ka selectfromsequence kaba la mihnoh
+
+select-from-sequence-indices-excluded-combination = La pyni ki index jong ka selectfromsequence kiba dei ka jingiasoh ba la mihnoh
+
+select-from-sequence-coprime-not-positive-integers = Ym lah ban jied ki jingiasoh coprime namar ym jied ki integer babym duna.
+
+select-from-sequence-coprime-common-factor = Ym lah ban jied ki number coprime. Baroh ki bynta kiba lah ki don ka factor ba iaman. (Ki bynta ba la pyni jong ka "from" ne ka "to" ki dei ban long coprime bad ka "step".)
+
+select-from-sequence-coprime-single-number = Ym lah ban jied ki jingiasoh coprime na shi tylli ka number kaba ym long 1.
+
+select-from-sequence-excluded-too-many-combinations = La mihnoh halor 70% ki jingiasoh ha ka selectFromSequence
+
+select-from-sequence-coprime-none-found = Ym lah ban jied ki number coprime. Baroh ki bynta kiba lah ki don ka factor ba iaman.
+
+select-from-sequence-too-few-unique-values = Ym lah ban jied { $numToSelect } ki bynta unique na ka sequence kaba jrong { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ym lah ban jied { $numToSelect } ki bynta na ka list ki prime kaba jrong { $numValues }
+
+select-prime-numbers-values-count-mismatch = Ka rukom ki bynta ba la pyni ïa ka select ka dei ban iaseng bad ka rukom ban jied
+
+select-prime-numbers-values-not-prime = Baroh ki bynta ba la pyni ïa ka select prime number ki dei ban shong ha ka list ki prime
+
+select-prime-numbers-values-excluded-combination = Ki bynta ba la pyni jong ka selectPrimeNumbers ki dei ka jingiasoh ba la mihnoh
+
+select-prime-numbers-excluded-too-many-combinations = La mihnoh halor 70% ki jingiasoh ha ka selectPrimeNumbers
+
+select-random-combination-fluke = Da ka jingjia babym kwah eh, ym lah ban jied ka jingiasoh ki bynta random
+
+select-random-value-fluke = Da ka jingjia babym kwah eh, ym lah ban jied ka bynta random
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] Kane ka `<{ $component }>` kam paw namar ka shong ha ka math bad kam dei `inline`. Buh ïa ka `inline` khnang ba ka'n long ka drop-down list, kaba shong ha ka expression.
+        [expanded] Kane ka `<{ $component }>` kam paw namar ka shong ha ka math bad ka dei `expanded`. Rah noh ïa ka `expanded`; ka box bunlain kam shong ha ka expression.
+        [on-graph] Kane ka `<{ $component }>` kam paw namar ka shong ha ka math kaba la thoh halor ka graph, kaba ym don ka jaka ïa ka input.
+       *[relative-width] Kane ka `<{ $component }>` kam paw namar ka shong ha ka math bad ka don ka width relative. Ai ïa ka width da ki jingthik absolute, kum ka `px`.
+    }

--- a/packages/i18n/locales/kha/editor.ftl
+++ b/packages/i18n/locales/kha/editor.ftl
@@ -1,0 +1,234 @@
+# Khasi (Ka Ktien Khasi) editor catalog: the editor's own surfaces and the
+# language server's — the footer, the diagnostics panel, the variant picker,
+# the accessibility button and the context-help panel beside them. Selected by
+# `uiLocale`.
+#
+# Translated from `locales/en/editor.ftl`, which is the source of truth.
+# Message ids, `.attribute` names, select variant keys and placeable names are
+# never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator, and
+# no permission is needed to change a word.
+#
+# **Orthography: Roman, with its diacritics.** Khasi has been written in the
+# Roman alphabet since the Welsh Presbyterian mission, and no other script is
+# at issue for it. `ï` (U+00EF), `ñ` (U+00F1) and the ASCII apostrophe `'`
+# (U+0027) for the glottal stop are used consistently; the typographic
+# apostrophe U+2019 appears nowhere.
+#
+# **The editor's vocabulary is the most heavily borrowed of the four files, and
+# that is declared rather than disguised.** Meghalaya's computing instruction
+# is in English, so `editor`, `variant`, `filter`, `format`, `XML`,
+# `DoenetML`, `attribute`, `snippet`, `array`, `default`, `WCAG` and the rest
+# are written here as English. What is Khasi is the frame around them: «ïa»,
+# «ban», «na», «bad», «ym», «shaphang» *about*, «kyrteng» *name*, «jingtip»
+# *information*, «jingsneng» *warning*, «jingiarap» *help*, «pynpaw» *show*,
+# «shem» *find*, «ym don» *none*, «lah» *can*, «buh» *put*.
+#
+# **Words to check first:** «error» is left as an English loan throughout, for
+# want of a Khasi noun the seed was confident of; «Jingpynthymmai» for *update*
+# and «Pynphai» for *reset* are both built from ordinary verbs and may be
+# longer than a toolbar button wants; and «jingpynkylla» for *variant* is a
+# coinage a speaker should replace or confirm.
+#
+# No message here selects on a plural category: CLDR has no plural data for
+# `kha`, and a Khasi noun is not marked for number after a numeral. Where
+# English forked on a count — the two accessibility labels and
+# `help-coordinates` — this catalog keeps English's `*[other]` wording and its
+# placeables, and the count simply stands in front of an unmarked noun.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Pynphai
+       *[update] Pynthymmai
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } ïa ka Viewer
+       *[other] { $word } ïa ka Viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Jingpynkylla
+
+editor-variant-filter = Filter...
+
+editor-variant-next = Jied ïa ka jingpynkylla ba shaphrang
+
+editor-variant-previous = Jied ïa ka jingpynkylla ba mynshuwa
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] La shem ka jingpudong ïa ka WCAG AA aksesibiliti. Klik ban { $action ->
+            [close] khang
+           *[open] plie
+        } ïa ka ripot aksesibiliti.
+        [advisories] Klik ban { $action ->
+            [close] khang
+           *[open] plie
+        } ïa ka ripot aksesibiliti. Ym la shem ki jingpudong ïa ka WCAG AA, hynrei don ki jingsneng aksesibiliti kiwei de.
+       *[clean] Klik ban { $action ->
+            [close] khang
+           *[open] plie
+        } ïa ka ripot aksesibiliti. Ym la shem ei ei ba ym beit ha ka aksesibiliti.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] La shem ka jingpudong ïa ka WCAG AA aksesibiliti. La shem { $count } ki jingpudong ïa ka WCAG AA. Klik ban { $action ->
+            [close] khang
+           *[open] plie
+        } ïa ka ripot aksesibiliti.
+        [advisories] Ym la shem ki jingpudong ïa ka WCAG AA. La shem { $count } ki jingsneng aksesibiliti kiwei de. Klik ban { $action ->
+            [close] khang
+           *[open] plie
+        } ïa ka ripot aksesibiliti.
+       *[clean] Ym la shem ki jingpudong ïa ka WCAG AA. Klik ban { $action ->
+            [close] khang
+           *[open] plie
+        } ïa ka ripot aksesibiliti.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = Jingiarap ba iadei bad ka jaka
+editor-tab-help-short = Jaka
+editor-tab-errors = Ki Error
+editor-tab-warnings = Ki Jingsneng
+editor-tab-info = Jingtip
+editor-tab-accessibility = Aksesibiliti
+editor-tab-responses = Ki jingjubab ba la ai
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ki jingjied jong ka editor
+editor-format-as-doenetml = Format kum ka DoenetML
+editor-format-as-xml = Format kum ka XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = Ym Don Error
+editor-no-warnings = Ym Don Jingsneng
+editor-no-info = Ym Don Jingtip
+
+editor-show-info-annotations = Pynpaw ki jingtip ha ka editor
+editor-show-accessibility-annotations = Pynpaw ki jingsneng aksesibiliti ha ka editor
+
+editor-accessibility-learn-more = Pule shaphang ka lynti jong ka Doenet sha ka aksesibiliti
+
+editor-accessibility-violations-heading = Ki jingpudong aksesibiliti ({ $standard })
+
+editor-accessibility-other-heading = Kiwei ki jingeh aksesibiliti
+editor-none-found = Ym la shem ei ei
+
+
+## Submitted responses
+
+editor-no-responses = Ym don shuh ka jingjubab ba la ai
+editor-response-answer-id = Answer Id
+editor-response-response = Jingjubab
+editor-response-credit = Kredit
+editor-response-submitted = La ai
+
+
+## The context-help panel
+
+help-placeholder = Buh ïa ka kursor halor ka kyrteng tag, ka attribute, ne { $ref } ban shem ka dokumentesan.
+
+help-unsupported-ref-chain = Ka jingiarap ïa ki reference bunbynta kum { $example } kam don shuh mynta.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ym la shem ei ei ba dei ka reference: { $ref }.
+        [multiple] La shem bun ki jingdei ïa ka reference: { $ref }.
+       *[indeterminate] Ym lah ban tip ïa kaba dei { $ref }.
+    }
+
+help-learn-about-references = Pule shaphang ki reference →
+help-reference-page = Peij reference →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ha ka bynta jong { $element }
+       *[top] Ha ka jaka bakhraw tam
+    }{ $allowed ->
+        [none] { " — ym don ei ei ba wan hangne." }
+        [text] { " — thoh ïa ka ktien hangne." }
+        [text-and-components] { " — thoh ïa ka ktien hangne, ne pyrshang ïa kine:" }
+       *[components] { " — ki jingpyrshang:" }
+    }
+
+help-suggestions-footer = Nget ïa { $shortcut } ban peit baroh ki { $total } component.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ka dei ka reference sha { $target }.
+       *[other] { $ref } ka dei ka reference sha { $target } (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] La pyni da { $owner } kum { $role }.
+       *[other] La pyni da { $owner } ha ka lain { $line } kum { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ka dei ka reference sha ka property { $property } jong { $element }.
+       *[other] { $ref } ka dei ka reference sha ka property { $property } jong { $element } (lain { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = Default:
+help-active-default = Default ba trei:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ki bynta ba lah (wei wei ha man la ka bynta):
+       *[other] Ki bynta ba lah:
+    }
+
+help-suggested-values = Ki bynta ba la pyni:
+
+help-inserts = Buh:
+
+help-coordinates =
+    { $count ->
+       *[other] Ki koordinet:
+    }
+
+help-type = Rukom:
+
+help-resolved-style = Style ba la pynbeit (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Ki kyrteng function ba la pynbeit:
+help-reset-list = Pynphai ïa ka list ha kane ka input:
+help-added-on-input = La buh ha kane ka input:
+help-removed-on-input = La rah noh ha kane ka input:
+
+help-reset-overrides = { $reset } ka palat ïa { $additional } bad { $removed }.

--- a/packages/i18n/locales/lus/chrome.ftl
+++ b/packages/i18n/locales/lus/chrome.ftl
@@ -1,0 +1,167 @@
+# Mizo (Mizo ṭawng) viewer chrome. Translated from `locales/en/chrome.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin, in the Roman orthography the Welsh mission fixed in 1894**
+# and Mizoram has used ever since. Mizo has never had another script, so
+# nothing is at issue here that is at issue in `locales/mni` or `locales/brx`:
+# the only orthographic decisions are diacritic ones. This catalog writes the
+# circumflex on the long vowels (â ê î ô û) and the **subscript-dotted ṭ**
+# (U+1E6D / U+1E6C) that distinguishes «ṭawng» from «tawng», because that is
+# the spelling Mizo print uses. A reviewer who prefers the undotted `t` that
+# plain-ASCII Mizo typing falls back to should respell rather than retranslate,
+# and must convert **all four files at once**.
+#
+# **Much of the vocabulary here is an English loan, and that is what the
+# classroom uses.** Mizoram schools teach mathematics, science and computing
+# in English; «click», «keyboard», «row», «column», «point», «interval»,
+# «box», «arrow», «document», «reload», «credit» and «mark» are the words a
+# Mizo student and a Mizo teacher actually say, and writing a coinage in their
+# place would put a word in this catalog that no reader has met. Where Mizo has
+# its own word the seed is confident of, it is used: «dik» and «dik lo» for
+# right and wrong, «hawn» and «khâr» for open and close, «belh» and «paih» for
+# add and remove, «entîr» and «thup» for show and hide, «buatsaih» for
+# preparing, «vaukhânna» for a warning, «chhânna» for an answer, «zawhna» for a
+# question, «phêk» for a page, «hming» for a name.
+#
+# Numbers render in Latin digits (#1615).
+
+
+## Answer submission
+
+answer-checking = Enfiah mêk...
+answer-submitting = Thawn mêk...
+
+answer-checking-status = Chhânna enfiah mêk
+answer-submitting-status = Chhânna thawn mêk
+
+answer-correct = A dik
+answer-incorrect = A dik lo
+
+answer-response-saved = Chhânna Vawng A Ni
+
+answer-percent-credit = Credit { $percent }%
+answer-percent-correct = A dik { $percent }%
+answer-percent-short = { $percent } %
+
+max-credit-available = Credit dawn theih tam ber: { $percent }%
+
+# CLDR has no plural data for `lus`, and a Mizo noun is not marked for number
+# after a numeral in any case, so the count branch is gone. The `[0]` branch
+# stays: Fluent matches that against the number itself, not against a plural
+# rule.
+attempts-remaining =
+    { $count ->
+        [0] tumna a awm tawh lo
+       *[other] tumna { $count } a la awm
+    }
+
+validation-correct = (A dik)
+validation-incorrect = (A dik lo)
+validation-partially-correct = (Chhehvêl thenkhat a dik)
+
+answer-show-responses = { $answerId } chhânna { $count } entîr
+
+
+## Disclosure panels
+
+feedback-heading = Chhânlêtna
+
+collapsible-click-to-open = (hawn tûrin click rawh)
+collapsible-click-to-close = (khâr tûrin click rawh)
+
+collapsible-initializing = Buatsaih mêk...
+
+footnote-show = Hnuai ziak entîr
+footnote-hide = Hnuai ziak thup
+
+description-more-information = thu belhchhah
+
+
+## Controls
+
+slider-previous = Hmasa
+slider-next = Dawt
+
+keyboard-open = Keyboard Hawn
+keyboard-close = Keyboard Khâr
+
+choice-input-remove-choice = { $choice } paih
+
+matrix-remove-row = Row paih
+matrix-add-row = Row belh
+matrix-remove-column = Column paih
+matrix-add-column = Column belh
+
+subset-add-remove-points = Point belh/paih
+subset-toggle-points-intervals = Point leh interval inthlâk
+subset-move-points = Point Sawn
+subset-clear = Tihfai
+
+orbital-add-row = Row Belh
+orbital-remove-row = Row Paih
+orbital-add-box = Box Belh
+orbital-remove-box = Box Paih
+orbital-add-up-arrow = Chungkâwn Arrow Belh
+orbital-add-down-arrow = Hnuailam Arrow Belh
+orbital-remove-arrow = Arrow Paih
+
+orbital-row-label = Row { $row } hming
+
+pretzel-answer = Chhânna
+
+summary-statistics-caption = { $column } statistics tlângpui
+
+
+## Math input
+
+math-input-preview-region = math ziahna en lâwkna
+math-input-preview = En lâwk
+math-input-invalid-expression = Ziahna dik lo:
+
+
+## Document status
+
+viewer-initializing = Buatsaih mêk...
+
+
+## Errors
+
+error-heading = Thil Dik Lo
+
+error-found-at =
+    { $span ->
+        [line] Line { $startLine }-ah hmuh a ni.
+       *[lines] Line { $startLine }–{ $endLine }-ah hmuh a ni.
+    }
+
+document-contains-errors = He document-ah hian thil dik lo a awm!
+
+diagnostic-heading-error = Thil Dik Lo
+diagnostic-heading-warning = Vaukhânna
+diagnostic-heading-information = Thu
+diagnostic-heading-hint = Kaihhruaina
+
+accessibility-heading-level-1 = WCAG AA Accessibility Bawhchhiatna
+accessibility-heading-level-2 = Accessibility vaukhânna
+
+something-went-wrong = Engemaw a kal dik lo.
+
+renderer-load-failed = renderer pakhat a chhuak thei lo. Phêk hi reload leh rawh le.
+
+core-start-failed = He document hi tan theih a ni lo. Phêk hi reload leh rawh le.
+
+core-start-failed-busy = He document hi tan theih a ni lo. Document tam tak a inkhat lai tea tan an ni a, chu chu tha lo zawk device-ah chuan a rei zâwk thei. Document dangte an zawh hnu chuan phêk reload leh chuan a ṭanpui thei.
+
+core-start-failed-retry = He document hi tan theih a ni lo.
+
+core-start-failed-busy-retry = He document hi tan theih a ni lo. Document tam tak a inkhat lai tea tan an ni a, chu chu tha lo zawk device-ah chuan a rei zâwk thei.
+
+core-start-retry = Tum leh rawh
+
+saved-state-unavailable = I hnathawh vawn chu chhuah theih a ni lo.

--- a/packages/i18n/locales/lus/content.ftl
+++ b/packages/i18n/locales/lus/content.ftl
@@ -1,0 +1,325 @@
+# Mizo (Mizo ṭawng) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin**, in the Roman orthography the Welsh mission fixed in 1894.
+# Mizo has never been written in anything else, so unlike `locales/mni` and
+# `locales/brx` there is no script question here at all — only diacritics. The
+# circumflex marks the long vowels (â ê î ô û) and **ṭ** is the subscript-dotted
+# letter (U+1E6D), as `chrome.ftl`'s header sets out in full.
+#
+# ## Word order
+#
+# **The noun comes first and every modifier follows it.** A Mizo attributive
+# adjective is postnominal — «lehkhabu sen» is *a red book*, never «sen
+# lehkhabu» — so `style-with-noun` and `style-filled-with-noun` put
+# `{ $noun }` in front of `{ $description }`, the reverse of English's
+# sequence of placeables. `style-stroke` keeps English's internal order of the
+# three adjectives, because that is Mizo's order too.
+#
+# **The three catalogs of this batch do not agree with each other about this,
+# and the disagreement is real rather than an artefact of the seed.** Mizo and
+# Khasi are postnominal and Garo is prenominal, following `locales/brx`, its
+# closest relative in the roster — three languages of one region, two families
+# between them, and the split does not follow the family line.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «polygon kil { $numSides } nei» — *a polygon having N corners* — and leaves
+# `tail` empty, as English does: the side count sits inside the noun phrase
+# here as well, so nothing has to be split around the adjectives.
+#
+# ## Gender, role and number
+#
+# **No `$gender` fork and no `$role` fork.** Mizo has no grammatical gender, so
+# `noun-gender` answers the single token `neuter` and no adjective selects on
+# it; nor does Mizo inflect a modifier for the clause position its phrase is
+# going into, so `standalone`, `border-clause`, `background-clause` and
+# `text-clause` are written identically. Both are claims about the language
+# rather than gaps in the seed. Where a relation has to be spelled at all it is
+# spelled by a **postposition** — «nen» for accompaniment, «zînga» for
+# partition — and both have one shape whatever precedes them, so putting one
+# after a placeable is sound.
+#
+# **Nothing selects on a count.** A Mizo noun is unmarked after a numeral, and
+# CLDR has no plural data for `lus` in any case.
+#
+# ## The one place the frame and the grammar disagree
+#
+# **`piecewise-condition-if` reads out of position, and a speaker should know
+# that before reading it as a typo.** The renderer puts this word in front of
+# the inequality it introduces; Mizo's conditional marker «a nih chuan» is
+# **clause-final** — the mathematics comes first and the marker closes it. So
+# «a nih chuan 1 < x < 2» is the right word in the wrong place. That is
+# `locales/miq`'s defect rather than a new one: a fault in the composition, not
+# in the vocabulary, and fixing it means changing what the piecewise renderer
+# is handed rather than changing this string. `piecewise-condition-otherwise`
+# («a nih loh chuan») stands alone and is unaffected.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry is English, declared as such.** Mizoram teaches mathematics
+# and science in English from the primary grades up, so «line», «ray»,
+# «vector», «curve», «function», «polygon», «parabola», «rectangle», «square»,
+# «point» and «diamond» are the words a Mizo student has met, and a coinage in
+# their place would be a word no reader has read. Where Mizo has its own term
+# the seed is confident of, it is used: «kilthum» for the triangle (*three
+# corners*), «kualvêl» for the circle, «hmun» for a region, «milem» for a
+# figure, «bung» for a section, «phêk» for a page, «zawhna» for a question,
+# «chhânna» for an answer, «finfiahna» for a proof, «awmzia» for a definition,
+# «entîrna» for an example, «dik» and «dik lo» for true and false, «emaw» for
+# *or*.
+#
+# **The colours are the weakest part of this file and a reviewer should start
+# there.** Five are Mizo — «dum», «var», «sen», «eng», «hring» — and the other
+# seven are written as plain English loans, because the seed has no Mizo term
+# for them that it trusts. Nothing was invented to fill the gap. `line-style`
+# is the same admission: «dash-nei» and «dot-nei» are the Mizo possessive
+# «-nei» on an English root, which is how Mizo does build such words, but they
+# are a construction of this seed rather than a phrase anyone has verified.
+#
+# **`line-width` is a guess.** «lian» and «te» are Mizo's ordinary words for
+# big and small pressed into service for thick and thin — the same guess
+# `locales/brx` and `locales/mni` make — and a speaker may well have a proper
+# pair for the width of a drawn stroke.
+#
+# ## Chemistry
+#
+# `element-name` and `element-anion-name` are **deliberately absent**, so those
+# 130 keys fall back to English. Mizoram teaches secondary chemistry in
+# English, out of English textbooks, so the element names a Mizo student meets
+# are the English ones; a Mizo table would be a claim about spelling rather
+# than about the language.
+#
+# Numbers render in Latin digits (#1615).
+
+
+## Style vocabulary
+
+color =
+    .black = dum
+    .white = var
+    .gray = grey
+    .red = sen
+    .orange = orange
+    .yellow = eng
+    .green = hring
+    .cyan = cyan
+    .blue = blue
+    .purple = purple
+    .pink = pink
+    .brown = brown
+
+line-width =
+    .thick = lian
+    .thin = te
+
+line-style =
+    .dashed = dash-nei
+    .dotted = dot-nei
+
+fill-style =
+    .horizontal = horizontal line
+    .vertical = vertical line
+    .diagonal = diagonal line
+    .backdiagonal = diagonal line letling
+    .dots = dot
+    .diamonds = diamond
+
+noun =
+    .line = line
+    .line-segment = line segment
+    .ray = ray
+    .vector = vector
+    .curve = curve
+    .function = function
+    .slope-field = slope field
+    .vector-field = vector field
+    .parabola = parabola
+    .polyline = polyline
+    .polygon = polygon
+    .triangle = kilthum
+    .rectangle = rectangle
+    .circle = kualvêl
+    .region = hmun
+    .point = point
+    .square = square
+    .diamond = diamond
+    .cross = cross
+    .plus = plus
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] polygon kil { $numSides } nei
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $nounTail } { $description }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = khat
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled }, { $pattern } nen
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled }, { $pattern } nen
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled }, { $pattern } nen
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+style-border-clause =
+    { $parts ->
+        [with-article] border { $border } nen
+        [and] leh border { $border }
+        [and-article] leh border { $border }
+       *[with] border { $border } nen
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = khat lo
+
+style-text =
+    { $parts ->
+        [background] { $color }, background { $background } nen
+       *[plain] { $color }
+    }
+
+style-background-none = engmah lo
+
+
+## Boolean words
+
+boolean-true = dik
+boolean-false = dik lo
+
+
+## Answer buttons
+
+answer-submit-label = Enfiah Rawh
+answer-submit-label-no-correctness = Chhânna Thawn
+
+## Sectional blocks
+
+section-name =
+    .activity = Thiltih
+    .aside = Belhchhah
+    .cascade = Cascade
+    .definition = Awmzia
+    .example = Entîrna
+    .exercise = Zirbing
+    .exercises = Zirbing
+    .given-answer = Chhânna
+    .note = Hriattîrna
+    .objectives = Thiltum
+    .paragraphs = Paragraph
+    .part = Ṭhen
+    .problem = Zawhna
+    .problems = Zawhna
+    .proof = Finfiahna
+    .question = Zawhna
+    .section = Bung
+    .solution = Chhânna
+    .task = Hnathawh
+    .theorem = Theorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Kaihhruaina
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Table { $enumeration }
+        [numbered-title] Table { $enumeration }{ ": " }
+        [unnumbered-title] Table{ ": " }
+       *[unnumbered] Table
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Milem { $enumeration }
+        [numbered-caption] Milem { $enumeration }{ ": " }
+        [unnumbered-caption] Milem{ ": " }
+       *[unnumbered] Milem
+    }
+
+
+## Paginator controls
+
+paginator-previous = Hmasa
+paginator-next = Dawt
+paginator-page = Phêk
+
+paginator-page-status = { $pageLabel } { $numPages } zînga { $currentPage }-na
+
+
+## Piecewise functions
+
+piecewise-condition-or = emaw
+
+piecewise-condition-if = a nih chuan
+
+piecewise-condition-otherwise = a nih loh chuan
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so those
+## 130 keys fall back to English. Mizoram teaches secondary chemistry in
+## English, out of English textbooks, so the element names a Mizo student meets
+## are the English ones and a Mizo table would be a claim about spelling rather
+## than about the language.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Chemical Symbol Dik Lo
+chemistry-invalid-ionic-compound = Ionic Compound Dik Lo
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = ruak
+
+math-embedded-input-blank-ordinal = ruak { $total } zînga { $ordinal }-na

--- a/packages/i18n/locales/lus/diagnostics.ftl
+++ b/packages/i18n/locales/lus/diagnostics.ftl
@@ -1,0 +1,660 @@
+# Mizo (Mizo ṭawng) diagnostics: the warnings and errors surfaced to whoever is
+# looking at the screen. Produced by the worker but addressed to the reader, so
+# these follow `uiLocale` rather than `documentLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin**, in the 1894 Roman orthography, with the circumflex on the
+# long vowels and the subscript-dotted **ṭ**, as `chrome.ftl`'s header sets out.
+#
+# **Every DoenetML identifier in this file stays in English.** `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `selectFromSequence`,
+# `sectionWideCheckWork`, `maxNumAttempts`, `coprime`, the tag names inside
+# `<…>`, everything inside backticks and the literal `[deprecation]` marker are
+# part of the language an author types, not prose, and a translated one names
+# nothing. Only the sentence around them is Mizo.
+#
+# **The technical nouns are English too, and that is what the classroom uses.**
+# «component», «attribute», «value», «type», «reference», «line», «index»,
+# «variant», «pattern», «graph», «matrix», «function», «domain», «interval» —
+# Mizoram teaches mathematics, science and computing in English, so these are
+# the words a Mizo author reads in their own textbook. What this file
+# translates is the frame: «... theih a ni lo» for *cannot*, «... dik lo» for
+# *invalid*, «hnâwl a ni» for *ignored*, «... a ni tûr a ni» for *must be*,
+# «siam a la ni lo» for *have not implemented*, «hmuh a ni» for *found*,
+# «a aiin» for *instead*.
+#
+# **No plural branches.** CLDR has no plural data for `lus`, and a Mizo noun is
+# unmarked after a numeral, so every English one/other count select is
+# collapsed to one wording with the count standing beside it. The **`[1]` in
+# `field-function-wrong-num-outputs` stays**: it forks on how many outputs a
+# component *needs*, which Fluent matches against the number itself rather than
+# through a plural rule, and it is the only bracketed digit in this file.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = Endpoint pahnih sawi lan a nih chuan { $attributes } chu hnâwl a ni.
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Endpoint leh midpoint sawi lan tel a nih chuan { $attributes } chu hnâwl a ni.
+
+line-segment-midpoint-offset-without-midpoint = midpoint awm lo chuan midpointOffset hian nghawng a nei lo
+
+## `<line>`
+
+line-points-undetermined-dimensions = Dimension hriat chian loh point-ate zawha kal line.
+
+line-points-too-few-dimensions = Line chu a tlêm berah dimension hnih nei point-ate zawha kal a ni tûr a ni.
+
+line-points-depend-on-variables = Line chu variable-ah innghat point-ate zawha kal a ni: { $variables }.
+
+line-equation-invalid-format = Variable { $variable1 } leh { $variable2 } hmanga line equation format dik lo.
+
+## `<ray>`
+
+ray-overprescribed-through = Ray chu through, endpoint leh direction hmangin sawi lan a ni. Sawi lan through chu hnâwl a ni.
+
+ray-dimension-mismatch = Ray-ah numDimensions a inmil lo.
+
+## `<vector>`
+
+vector-overprescribed-head = Vector chu head, tail leh displacement hmangin sawi lan a ni. Sawi lan head chu hnâwl a ni.
+
+vector-dimension-mismatch = Vector-ah numDimensions a inmil lo.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` lamah attract theih a ni lo, nearestPoint state variable a nei lo si a.
+
+constrain-to-without-nearest-point = `<{ $component }>` lamah constrain theih a ni lo, nearestPoint state variable a nei lo si a.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` chhûng lamah constrain theih a ni lo, nearestPoint state variable a nei lo si a.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Inline ni lo choiceInput tân labelPosition chu hnâwl a ni
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = ChoiceInput tâna sawi lan indices chu hnâwl a ni, indices zât leh choice fa zât a inmil lo si a.
+
+pretzel-indices-count-mismatch = Problem tâna sawi lan indices chu hnâwl a ni, indices zât leh problem fa zât a inmil lo si a.
+
+shuffle-indices-count-mismatch = Shuffle tâna sawi lan indices chu hnâwl a ni, indices zât leh component zât a inmil lo si a.
+
+indices-ignored-out-of-range = { $component } tâna sawi lan indices chu hnâwl a ni, indices ṭhenkhat chu chin ram pêl a ni si a.
+
+pretzel-indices-repeated = Pretzel tâna sawi lan indices chu hnâwl a ni, indices ṭhenkhat a inang leh si a.
+
+pretzel-circuit-first-index = Circuit mode-a pretzel tâna sawi lan indices chu hnâwl a ni, index hmasa ber chu 1 a ni tûr a ni si a.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` chu string fa nena hna a thawh theih nân `type` attribute sawi lan a ngai.
+
+invalid-type-defaulting-to-math = { $component } component tân type { $type } chu a dik lo. Math, text, number, emaw boolean zînga pakhat a ni tûr a ni. Math-ah dah a ni.
+
+string-not-valid-component-to-arrange = String "{ $value }" chu { $component } tûra component dik a ni lo. Hnâwl a ni.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } a dik lo, type chu number-ah dah a ni.
+
+invalid-variable-value = Variable value dik lo: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant index { $index } chu number a ni tûr a ni
+
+variant-index-must-be-integer = Variant index { $index } chu integer a ni tûr a ni
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` chu absolute tehna tân siam a la ni lo. Width-te chu relative-ah dah a ni.
+
+side-by-side-absolute-margins = `<{ $component }>` chu absolute tehna tân siam a la ni lo. Margin-te chu relative-ah dah a ni.
+
+side-by-side-no-block-child = `<{ $component }>` dik lo: a tlêm berah block fa pakhat a nei tûr a ni.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Graphical `<label>` chunga `for` attribute chu hnâwl a ni.
+
+label-for-must-resolve-to-one = `<label>` chunga `for` attribute chuan component pakhat chiah a kâwk tûr a ni.
+
+label-for-unresolved = `<label>` chunga `for` attribute chuan component a kâwk chhuak thei lo.
+
+label-for-answer-with-authored-inputs = `<label>` chunga `for` attribute chuan input ziak nei `<answer>` a kâwk; input ngei chu kâwk zâwk rawh.
+
+label-for-answer-without-input = `<label>` chunga `for` attribute chuan label tûr input nei lo `<answer>` a kâwk.
+
+label-for-must-reference-input-or-answer = `<label>` chunga `for` attribute chuan input emaw answer emaw a kâwk tûr a ni.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Accessibility avângin `<{ $component }>` chuan short description a nei tûr a ni a, a nih loh chuan decorative angin sawi lan a ni tûr a ni.
+
+accessibility-video-short-description = Accessibility avângin `<video>` chuan short description a nei tûr a ni.
+
+accessibility-input-short-description-or-label = Accessibility avângin `<{ $component }>` chuan short description emaw label emaw a nei tûr a ni.
+
+accessibility-answer-input-short-description-or-label = Accessibility avângin input siamtu `<answer>` chuan short description emaw label emaw a nei tûr a ni.
+
+accessibility-short-description-contains-math = Short description-ah `<{ $component }>` ang math component a awm tûr a ni lo. Math zawng zawng chu ṭawngkam hmangin sawi rawh.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } chuan section heading thu tân contrast a tâwk lo (dark mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a tlêm berah { $threshold }:1 a ngai).
+       *[other] { $colorName } chuan section heading thu tân contrast a tâwk lo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a tlêm berah { $threshold }:1 a ngai).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Point-te chuan number value an neih loh hunah `<circle>` chu point { $count } zawha kal siam a la ni lo.
+
+circle-too-many-through-points = Point 3 aia tam zawha kal circle chhût theih a ni lo.
+
+circle-overprescribed-radius-center-points = Radius, center leh through point sawi lan tel nena circle chhût theih a ni lo.
+
+circle-center-with-multiple-points = Center sawi lan nena point 1 aia tam zawha kal circle chhût theih a ni lo.
+
+circle-radius-too-small = Circle chhût theih a ni lo: point pahnih inkâr hla zawng chu { $distance } a nih avângin, radius sawi lan { $radius } chu a tê lutuk.
+
+circle-radius-with-many-points = Radius sawi lan nena point pahnih aia tam zawha kal circle siam theih a ni lo.
+
+circle-invalid-center-or-through-points = Circle center emaw through point emaw a dik lo.
+
+circle-radius-center-with-multiple-points = Center sawi lan nena point 1 aia tam zawha kal circle radius chhût theih a ni lo.
+
+circle-change-radius-non-numerical = Number value nei lo through point nena circle radius thlâk theih a ni lo
+
+circle-radius-with-points-non-numerical = Number value an awm loh hunah radius sawi lan nena point pakhat aia tam zawha kal circle siam theih a ni lo.
+
+circle-change-center-non-numerical = Number value nei lo point zawha kal circle center thlâk chu siam a la ni lo.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Function domain tân dimension a tâwk lo. Domain-ah interval { $intervals } a awm a, function-ah erawh input { $inputs } a awm.
+
+function-domain-invalid-format = Function domain format a dik lo.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Function-a number ni lo maximum chu hnâwl a ni.
+        [minimum] Function-a number ni lo minimum chu hnâwl a ni.
+        [extremum] Function-a number ni lo extremum chu hnâwl a ni.
+        [point] Function-a number ni lo point chu hnâwl a ni.
+        [slope] Function-a number ni lo slope chu hnâwl a ni.
+       *[other] Function-a number ni lo { $type } chu hnâwl a ni.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Function-a maximum ruak chu hnâwl a ni.
+        [minimum] Function-a minimum ruak chu hnâwl a ni.
+        [extremum] Function-a extremum ruak chu hnâwl a ni.
+        [point] Function-a point ruak chu hnâwl a ni.
+       *[other] Function-a { $type } ruak chu hnâwl a ni.
+    }
+
+function-points-too-close = Function-ah hian a hmun inhnaih lutuk point pahnih a awm. Function siam theih a ni lo.
+
+function-iterates-input-output-mismatch = Function iterate chu function input zât leh output zât a inan a nih chauhvin a theih a ni. He function-ah hian input { $inputs } leh output { $outputs } a awm.
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence length a dik lo. Integer chhia ni lo a ni tûr a ni.
+
+sequence-invalid-step = Sequence step a dik lo. Type { $type } sequence tân number a ni tûr a ni.
+
+sequence-invalid-endpoint-number = Number sequence "{ $attribute }" a dik lo. Number a ni tûr a ni.
+
+sequence-invalid-endpoint-letters = Letters sequence "{ $attribute }" a dik lo. Hawrawp inzawmkhâwm a ni tûr a ni.
+
+sequence-invalid-endpoint = Sequence "{ $attribute }" a dik lo.
+
+select-from-sequence-coprime-not-numbers = Number thlan a nih loh avângin coprime chu hnâwl a ni
+
+select-from-sequence-coprime-with-exclude-combinations = ExcludeCombinations sawi lan a nih avângin coprime chu hnâwl a ni
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` tân target a dik lo: target hmuh theih a ni lo.
+
+target-state-variable-not-found = `<{ $source }>` tân target a dik lo: `<{ $component }>` chungah "{ $property }" tia hriat state variable hmuh theih a ni lo.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` variable-te chu independent variable nên an inang lo tûr a ni.
+
+ode-system-duplicate-variable-names = Dependent variable hming inang nena ODE RHS function siam theih a ni lo.
+
+ode-system-rhs-function-error = ODE RHS function siam theih a ni lo. Mathjs function siamnaah thil dik lo a awm.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Line { $count } inkârah angle siam theih a ni lo
+
+angle-invalid-through-point = `<angle>` through-ah point dik lo
+
+parabola-vertex-too-many-points = Vertex nena point 1 aia tam zawha kal parabola chu siam a la ni lo.
+
+parabola-too-many-points = Point 3 aia tam zawha kal parabola chu siam a la ni lo.
+
+intersection-too-many-items = Thil pahnih aia tam tâna intersection chu siam a la ni lo
+
+## Other math components
+
+ionic-compound-not-two-ions = Ion pahnih ni lo tân ionic compound chu siam a la ni lo.
+
+ionic-compound-needs-cation-and-anion = Ionic compound chu cation pakhat leh anion pakhat tân chauh siam a ni.
+
+solve-equations-cannot-evaluate = Equation chhût theih a ni loh avângin equation chhâng theih a ni lo: { $equation }
+
+math-operators-operand-number-required = Math operand la chhuah tûrin operandNumber sawi lan a ngai.
+
+eigen-decomposition-failed = Matrix eigenvalue chhût theih a ni lo
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } chu pattern-ah a awm lo, chuvângin blank chu a inmil reng ang.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" hriatthiam theih a ni lo. None, medium, dense, emaw hnâr hmanga ṭhen number pahnih chhia ni lo, entîr nân grid="1 0.5", a ni tûr a ni. Grid siam a ni lo.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` chuan { $expected ->
+        [1] output pakhat, point tin ah slope y', entîr nân `y - x`
+       *[other] output pahnih, point tin ah vector, entîr nân `(y, -x)`
+    } nei function a mamawh a, mahse function pêk chu output { $found } a nei. { $alternative ->
+        [none] Engmah siam a ni lo.
+       *[other] Chu function tân chuan `<{ $alternative }>` chu a component a ni. Engmah siam a ni lo.
+    }
+
+field-function-attribute-ignored-with-child = Function chu component chhûngah pêk a nih avângin `function` attribute chu hnâwl a ni; a chhûnga awm chu hman a ni. Function chu kawng pakhat chauh hmangin pe rawh.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` attribute chuan component chhûnga ziak ngei expression variable-te a kâwk. { $reason ->
+        [function-child] Hetah hian function chu `<function>` fa angin pêk a ni a, chuan a variable ngei a kâwk tawh, chuvângin `variables` chu hnâwl a ni.
+       *[no-expression] Hetah hian chutiang expression pêk a awm lo, chuvângin `variables` chu hnâwl a ni.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure renderer-ah xLabelPosition="left" hman theih a ni lo; right-position dân hman a ni.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure renderer-ah yLabelPosition="bottom" hman theih a ni lo; top-position dân hman a ni.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure lehlin nân axis bound a dik lo; bbox pângngai (-10,-10,10,10) hman a ni.
+
+prefigure-invalid-width = `<graph>`: prefigure lehlin nân width a dik lo; diagram width pângngai 425 hman a ni.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure lehlin nân aspectRatio a dik lo; aspect ratio pângngai 1 hman a ni.
+
+prefigure-grid-spacing-too-fine = `<graph>`: axis chin ram tân grid inkâr a tê lutuk; prefigure renderer-ah grid siam a ni lo.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure renderer hman a nih loh chuan annotation-te siam a ni lo.
+
+multiple-annotations-children = `<graph>`-ah `<annotations>` fa tam tak hmuh a ni; a hnuhnung ber lo chu zawng zawng hnâwl a ni.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Component type hriat loh { $type } chu extend emaw copy emaw theih a ni lo.
+
+copy-prop-not-found = Type { $component } component chungah prop { $property } hmuh theih a ni lo
+
+collect-no-source = Collect tân source hmuh a ni lo.
+
+collect-invalid-component-type = Component type `<{ $component }>` chu a dik loh avângin collect theih a ni lo.
+
+reference-index-unavailable = Index `{ $reference }` kâwk theih a ni lo
+
+## `<callAction>`
+
+component-action-unavailable = Component `{ $reference }` chungah { $action } ko theih a ni lo
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data shape a dik lo. Row-te chu an inang lo. componentIdx :{ $componentIdx } ah hmuh a ni
+
+data-frame-duplicate-column-names = Data-ah column hming inang a awm. componentIdx :{ $componentIdx } ah hmuh a ni
+
+data-frame-missing-column-name = Data-ah column hming a tlachham. componentIdx :{ $componentIdx } ah hmuh a ni
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = He answer tâna award chu answer tag ngeia chhânna thawn chungah innghat a ni a, chuan beisei loh thil a thlen ang.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` nei container chhûnga `<answer>` chungah `maxNumAttempts` dah hian nghawng a nei lo, tumna zât chu container-in a enkawl si a. `maxNumAttempts` chu container chungah dah zâwk rawh.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` nei container dang chhûnga `sectionWideCheckWork` nei container chungah `maxNumAttempts` dah hian nghawng a nei lo, tumna zât chu container pawn lam berin a enkawl si a. `maxNumAttempts` chu container pawn lam ber chungah dah zâwk rawh.
+
+answer-attributes-need-symbolic-equality = symbolicEquality dah loh chuan { $attributes } attribute hian nghawng a nei lo vang.
+
+answer-invalid-type = Answer tân type a dik lo: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Component `<{ $component }>` hian hming a neih loh avângin module attribute atân hman theih a ni lo
+
+module-attribute-name-already-defined = Component `<{ $component } name="{ $name }">` chu module attribute atân hman theih a ni lo, `<module>` component type chuan "{ $name }" attribute a nei tawh si a.
+
+conditional-content-condition-ignored = Case emaw else fa nei `<conditionalContent>` component chungah attribute `condition` chu hnâwl a ni.
+
+slider-markers-type-mismatch = Marker type leh slider type a inmil lo.
+
+pretzel-problem-needs-statement-and-answer = Pretzel a dik lo: `<problem>` tin hian `<statement>` pakhat leh `<answer>` pakhat a keng tûr a ni.
+
+pretzel-circuit-first-problem-distractor = Pretzel a dik lo: mode="circuit" ah chuan `<problem>` hmasa ber chu distractor a ni thei lo.
+
+## Attribute values
+
+attribute-invalid-values = Attribute `{ $attribute }` tân value { $values } a dik lo; hnâwl a ni.
+
+attribute-must-be-references = Attribute `{ $attribute }` tân value `{ $value }` a dik lo. Attribute chu `$` hmanga inṭan reference-te hmanga siam a ni tûr a ni.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ah function hming dik lo hnâwl a ni: { $names }. Hming tin a lan dân chu a tlêm berah hawrawp 2 (hawrawp emaw hnâr emaw) a ni tûr a ni; a hnuah `|<mathspeak alternative>` a zui thei.
+
+## Building components from the source
+
+component-type-invalid = Component type a dik lo: `<{ $componentType }>`
+
+attribute-repeated = Attribute { $attribute } hi tihnawn theih a ni lo.
+
+attribute-invalid-for-component = Type `<{ $componentType }>` component tân attribute "{ $attribute }" a dik lo.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Style definition { $styleNumber } chuan { $context ->
+        [text-on-background] background color hmaa text color
+        [high-contrast] canvas hmaa high-contrast color
+        [line] canvas hmaa line color
+        [marker] canvas hmaa marker color
+       *[text-on-canvas] canvas hmaa text color
+    } tân contrast a tâwk lo{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a tlêm berah { $threshold }:1 a ngai).
+
+style-definition-dark-mode-text-background-contrast =
+    Style definition { $styleNumber } chuan light mode tân contrast tâwk pêk color a sawi lan nâ chung pawhin, chûng value aṭanga chhuak dark-mode color-te chuan background color hmaa text color tân contrast an tâwk lo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a tlêm berah { $threshold }:1 a ngai). { $suggestion ->
+        [available] Dark mode-a contrast a tâwk nân, light-mode contrast chu tibelh rawh (entîr nân { $lightAttribute }="{ $lightColor }" dah rawh), a nih loh chuan dark-mode color chu thlâk rawh (entîr nân { $darkAttribute }="{ $darkColor }" dah rawh).
+       *[none] Dark mode-a contrast a tâwk nân, light-mode contrast chu tibelh rawh, a nih loh chuan chhuak color-te chu textColorDarkMode leh/emaw backgroundColorDarkMode hmangin thlâk rawh.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Style definition { $styleNumber } chuan light mode tân contrast tâwk pêk text color a sawi lan nâ chung pawhin, he value aṭanga chhuak dark-mode text color chuan canvas hmaah contrast a tâwk lo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a tlêm berah { $threshold }:1 a ngai). { $suggestion ->
+        [available] Dark mode-a contrast a tâwk nân, light-mode contrast chu tibelh rawh (entîr nân textColor="{ $lightColor }" dah rawh), a nih loh chuan dark-mode color chu thlâk rawh (entîr nân textColorDarkMode="{ $darkColor }" dah rawh).
+       *[none] Dark mode-a contrast a tâwk nân, light-mode contrast chu tibelh rawh, a nih loh chuan chhuak color chu textColorDarkMode hmangin thlâk rawh.
+    }
+
+section-multiple-style-palettes = Section pakhatin <stylePalette> pakhat chauh a thlang thei; a hnuhnung ber hman a ni.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } unique variant hriat chian theih a ni lo, numToSelect chu integer chhia ni lo a ni lo si a.
+
+variant-num-to-select-not-constant-number = { $component } unique variant hriat chian theih a ni lo, numToSelect chu number inthlâk thin lo a ni lo si a.
+
+variant-with-replacement-not-constant-boolean = { $component } unique variant hriat chian theih a ni lo, withReplacement chu boolean inthlâk thin lo a ni lo si a.
+
+variant-select-weight-disables-unique = SelectWeight emaw selectForVariants emaw sawi lan option a awm a nih chuan select tân unique variant chu tibo a ni
+
+variant-coprime-undetermined = { $component } unique variant hriat chian theih a ni lo, coprime chu a dik lo reng tih hriat chian theih a ni lo si a.
+
+variant-attribute-not-constant = { $component } unique variant hriat chian theih a ni lo, { $attribute } chu inthlâk thin lo a ni lo si a.
+
+variant-attribute-not-number = { $component } unique variant hriat chian theih a ni lo, { $attribute } chu number a ni lo si a.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } type { $component } unique variant hriat chian theih a ni lo, { $attribute } chu { $expected ->
+        [letters-combination] hawrawp inzawmkhâwm
+        [math-expression] math expression dik
+        [integer] integer
+       *[number] number
+    } a ni lo si a.
+
+variant-length-not-integer = { $component } unique variant hriat chian theih a ni lo, length chu integer a ni lo si a.
+
+variant-sort-not-implemented = Sort nei { $component } unique variant chu siam a la ni lo
+
+variant-exclude-combinations-not-implemented = ExcludeCombinations nei { $component } unique variant chu siam a la ni lo
+
+variant-math-exclude-not-implemented = Exclude nei math type { $component } unique variant chu siam a la ni lo
+
+variant-non-constant-exclude-not-implemented = Inthlâk thin exclude nei { $component } unique variant chu siam a la ni lo
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure renderer-ah hman theih a ni lo; fa chu hnâwl a ni.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometry a tâwk lo emaw a tâwp lo emaw; fa chu hnâwl a ni.
+
+prefigure-curve-label-omitted = { $subject }: lehlin curve element-ah label hman theih a ni lo; label chu hnâwl a ni.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve function definition type '{ $definitionType }' hman theih a ni lo; fa chu hnâwl a ni.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves chungah flipFunctions attribute hman theih a ni lo; fa chu hnâwl a ni.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves chungah formula type function fa chauh hman theih a ni; fa chu hnâwl a ni.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] line-family label
+       *[point] point label
+    } tân labelPosition '{ $labelPosition }' hman theih a ni lo; PreFigure alignment pângngai hman a ni.
+
+prefigure-fill-style-unsupported = { $subject }: fill style '{ $fillStyle }' chu PreFigure-in a hmang thei lo; fill kim a lo kîr leh.
+
+prefigure-line-style-unknown = { $subject }: line style hriat loh '{ $lineStyle }' chu PreFigure output aṭangin hnâwl a ni.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker style '{ $markerStyle }' chu PreFigure style 'diamond' ah thlâk a ni.
+
+prefigure-marker-style-unsupported = { $subject }: marker style '{ $markerStyle }' chu PreFigure-in a hmang thei lo; style pângngai hman a ni.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` a dik lo; target kâwk chhuah theih a ni lo. Annotation chu hnâwl a ni.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` chuan target tam tak a kâwk; target hmasa ber hman a ni.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` a dik lo; target chu graph pawn lamah a awm. Annotation chu hnâwl a ni.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` a dik lo; target chu prefigure lehlinnaah graphical object hman theih a ni lo. Annotation chu hnâwl a ni.
+
+annotation-text-missing = `<annotation>`: `text` a tlachham emaw a ruak emaw; text ruak chhuah a ni.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Circular dependency hmuh a ni.
+       *[other] `<{ $componentType }>` component tel circular dependency hmuh a ni.
+    }
+
+reference-no-referent = Reference tân referent hmuh a ni lo: `{ $reference }`
+
+reference-multiple-referents = Reference tân referent tam tak hmuh a ni: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` attribute { $attribute } format a dik lo.
+
+children-invalid = `<{ $componentType }>` tân fa a dik lo: fa dik lo hmuh a ni: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Attribute `{ $attribute }` tân value `{ $value }` a dik lo, value `{ $default }` hman a ni
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML version { $version } hmuh a ni lo.
+       *[other] DoenetML version { $version } hmuh a ni lo. Version { $fallback } lamah a kîr leh
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML dik lo: { $content }
+
+parse-tag-missing-close-tag = DoenetML dik lo: Tag `{ $tag }` hian khârna tag a nei lo. Amah khârtu tag emaw `</{ $tagName }>` tag emaw a ngai.
+
+parse-tag-error = DoenetML dik lo: Tag `<{ $tagName }>` ah thil dik lo
+
+parse-attribute-missing-value = DoenetML dik lo: Attribute `{ $attribute }` a dik lo, value a tlachham anga lang.
+
+parse-attribute-invalid = DoenetML dik lo: Attribute `{ $attribute }` a dik lo
+
+parse-attribute-value-invalid = DoenetML dik lo: Attribute value `{ $value }` a dik lo
+
+parse-attribute-value-quote-mismatch = DoenetML dik lo: Attribute value `{ $value }` a dik lo. Quote mark-te a inmil lo. `{ $quote }` a tlachham anga lang
+
+parse-open-tag-name-missing = DoenetML dik lo: Tag hming nei lo tag hmuh a ni, entîr nân `<`
+
+parse-tag-not-closed = DoenetML dik lo: Tag `{ $tag }` khâr a ni lo (`>` a tlachham anga lang).
+
+parse-self-closing-tag-name-missing = DoenetML dik lo: Tag hming nei lo tag hmuh a ni `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML dik lo: Tag `{ $tag }` khâr a ni lo (`/>` a tlachham anga lang).
+
+parse-tag-invalid-attributes = DoenetML dik lo: Tag `{ $tag }` a dik lo. Attribute dik lo a nei mai thei.
+
+parse-close-tag-name-missing = DoenetML dik lo: Tag hming nei lo khârna tag hmuh a ni, entîr nân `</`
+
+parse-attribute-value-unquoted = Attribute value-te chu quote chhûngah dah tûr a ni: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML dik lo: Khârna tag `{ $tag }` hmuh a ni, mahse a hawnna tag a awm lo
+
+parse-close-tag-mismatched = DoenetML dik lo: Khârna tag a inmil lo. `</{ $expected }>` beisei a ni. `{ $found }` hmuh a ni
+
+parser-node-unconvertible = Node { $node } chu Dast node-ah lehlin theih a ni lo.
+
+## Names
+
+name-attribute-invalid =
+    Attribute name='{ $name }' a dik lo. { $reason ->
+        [characters] Hming-ah hawrawp, number, underscore emaw hyphen emaw chauh a awm thei.
+       *[start] Hming chu hawrawp hmangin a inṭan tûr a ni.
+    }
+
+component-name-invalid-start = Component hming "{ $name }" a dik lo. Hming chu hawrawp hmangin a inṭan tûr a ni.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Type videoWatched nei answer chuan video attribute a nei tûr a ni
+
+answer-video-watched-video-not-reference = Type videoWatched nei answer chuan reference ni video attribute a nei tûr a ni
+
+answer-name-not-single-text = Answer name attribute chuan text fa pakhat a nei tûr a ni
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Recursion a lêt tam lutuk avângin pawn lam DoenetML la chhuah theih a ni lo. Circular reference a awm em ni?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" aṭangin DoenetML la chhuah theih a ni lo
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" aṭanga la chhuah DoenetML a dik lo: component type "{ $componentType }" nên a inmil lo
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` chu hman tawh loh tûr a ni; a aiin `{ $to }` hmang rawh.
+       *[other] [deprecation] `<{ $component }>` chunga attribute `{ $from }` chu hman tawh loh tûr a ni; a aiin `{ $to }` hmang rawh.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }` pawh sawi lan a nih avângin attribute `{ $from }` chu hman tawh loh tûr a ni a, hnâwl a ni.
+       *[other] [deprecation] `{ $to }` pawh sawi lan a nih avângin `<{ $component }>` chunga attribute `{ $from }` chu hman tawh loh tûr a ni a, hnâwl a ni.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` chunga attribute `{ $attribute }` chu hman tawh loh tûr a ni a, hnâwl a ni.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` chunga attribute `{ $attribute }` chu hman tawh loh tûr a ni; a aiin `<{ $child }>` fa hmang rawh.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` chunga attribute `{ $attribute }` value `{ $value }` chu hman tawh loh tûr a ni; a aiin `{ $to }` hmang rawh.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` hian English chauh a tipung thei a, chuvângin { $locale } hmanga ziak document-ah chuan a thu chu thlâk loh a ni. Pung tak chu ziak ngei rawh, a nih loh chuan `pluralForm` attribute hmangin dah rawh.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Element `<{ $tag }>` chu Doenet element hriat a ni lo.
+
+schema-element-not-allowed-at-root = Element `<{ $tag }>` chu document bul beraah phal a ni lo.
+
+schema-element-not-allowed-inside = Element `<{ $tag }>` chu `<{ $parent }>` chhûngah phal a ni lo.
+
+schema-attribute-unrecognized = Element `<{ $tag }>` chuan `{ $attribute }` tia hriat attribute a nei lo.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Element `<{ $tag }>` attribute `{ $attribute }` chu a item tin heng zînga pakhat ni list a ni tûr a ni: { $allowed }
+       *[other] Element `<{ $tag }>` attribute `{ $attribute }` chu heng zînga pakhat a ni tûr a ni: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select tân variant hming a dik lo. Variant hming { $variantName } chu option { $numOptions } ah a lang a, thlan tûr zât erawh { $numToSelect } a ni.
+
+select-variant-name-without-options = Select tân variant ṭhenkhat sawi lan a ni, mahse variant hming theih tûr { $variantName } tân option sawi lan a awm lo.
+
+select-variant-name-not-possible = Select tâna sawi lan variant hming { $variantName } chu variant hming theih tûr a ni lo.
+
+select-too-few-options = { $numOptions } chauh zînga component { $numToSelect } thlang theih a ni lo.
+
+select-from-sequence-too-few-values = Length { $length } sequence aṭangin value { $numToSelect } thlang theih a ni lo.
+
+select-from-sequence-indices-count-mismatch = Select tâna sawi lan indices zât leh thlan tûr zât a inmil tûr a ni
+
+select-from-sequence-indices-not-integers = Select tâna sawi lan indices zawng zawng chu integer a ni tûr a ni
+
+select-from-sequence-index-excluded = Hnâwl tawh selectfromsequence index sawi lan a ni
+
+select-from-sequence-indices-excluded-combination = Hnâwl tawh inzawmkhâwm ni selectfromsequence indices sawi lan a ni
+
+select-from-sequence-coprime-not-positive-integers = Integer ṭha thlan a nih loh avângin coprime inzawmkhâwm thlang theih a ni lo.
+
+select-from-sequence-coprime-common-factor = Coprime number thlang theih a ni lo. Value theih tûr zawng zawngin factor an nei pawlh. ("from" emaw "to" emaw value sawi lan chu "step" nên coprime a ni tûr a ni.)
+
+select-from-sequence-coprime-single-number = 1 ni lo number pakhat aṭangin coprime inzawmkhâwm thlang theih a ni lo.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-ah inzawmkhâwm 70% aia tam hnâwl a ni
+
+select-from-sequence-coprime-none-found = Coprime number thlang theih a ni lo. Value theih tûr zawng zawngin factor an nei pawlh.
+
+select-from-sequence-too-few-unique-values = Length { $numPossibleValues } sequence aṭangin unique value { $numToSelect } thlang theih a ni lo
+
+select-prime-numbers-too-few-values = Length { $numValues } prime number list aṭangin value { $numToSelect } thlang theih a ni lo
+
+select-prime-numbers-values-count-mismatch = Select tâna sawi lan value zât leh thlan tûr zât a inmil tûr a ni
+
+select-prime-numbers-values-not-prime = Select prime number tâna sawi lan value zawng zawng chu prime number list-ah a awm tûr a ni
+
+select-prime-numbers-values-excluded-combination = Hnâwl tawh inzawmkhâwm ni selectPrimeNumbers value sawi lan a ni
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-ah inzawmkhâwm 70% aia tam hnâwl a ni
+
+select-random-combination-fluke = Thleng ngai lo tak angin, random value inzawmkhâwm thlang theih a ni lo
+
+select-random-value-fluke = Thleng ngai lo tak angin, random value thlang theih a ni lo
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] He `<{ $component }>` hi entîr a ni lo, math chhûngah a awm a, `inline` a ni lo si a. Expression chhûnga inhûm thei drop-down list a nih theih nân `inline` belh rawh.
+        [expanded] He `<{ $component }>` hi entîr a ni lo, math chhûngah a awm a, `expanded` a ni si a. `expanded` chu paih rawh; box lem tam chu expression chhûngah a inhûm lo.
+        [on-graph] He `<{ $component }>` hi entîr a ni lo, graph chunga siam math chhûngah a awm a, chuan input tân hmun a awm lo.
+       *[relative-width] He `<{ $component }>` hi entîr a ni lo, math chhûngah a awm a, width relative a nei si a. A aiin `px` ang chi absolute unit hmangin width pe rawh.
+    }

--- a/packages/i18n/locales/lus/editor.ftl
+++ b/packages/i18n/locales/lus/editor.ftl
@@ -1,0 +1,215 @@
+# Mizo (Mizo ṭawng) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Latin**, in the 1894 Roman orthography, with the circumflex on the
+# long vowels and the subscript-dotted **ṭ**, as `chrome.ftl`'s header sets out.
+#
+# **This is the file with the most English in it, and that is deliberate.** An
+# editor is a computing surface, and Mizoram's computing vocabulary is English:
+# «editor», «format», «variant», «filter», «line», «tag», «attribute»,
+# «reference», «snippet», «array entry», «default», «coordinates», «type» and
+# the standard's own name «WCAG AA» are what a Mizo user of an editor reads and
+# says. What is translated here is the prose around them — the verbs, the
+# negations, the headings — and where Mizo has a word the seed is confident of
+# it is used: «thil dik lo» for an error, «vaukhânna» for a warning, «entîr»
+# for show, «dahluh» for insert, «hmuh a ni lo» for none found.
+#
+# **No plural branches.** CLDR has no plural data for `lus`, and a Mizo noun is
+# unmarked after a numeral in any case, so `editor-accessibility-label` and
+# `help-coordinates` write one form and let the count stand beside it.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Let
+       *[update] Thar
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Viewer { $word }
+       *[other] Viewer { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+
+editor-variant-filter = Thliar...
+
+editor-variant-next = Variant dawt thlang
+
+editor-variant-previous = Variant hmasa thlang
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA accessibility bawhchhiatna hmuh a ni. Accessibility report { $action ->
+            [close] khâr
+           *[open] hawn
+        } tûrin click rawh.
+        [advisories] Accessibility report { $action ->
+            [close] khâr
+           *[open] hawn
+        } tûrin click rawh. WCAG AA bawhchhiatna hmuh a ni lo, mahse accessibility ngaihdân belhchhah a awm.
+       *[clean] Accessibility report { $action ->
+            [close] khâr
+           *[open] hawn
+        } tûrin click rawh. Accessibility harsatna engmah hmuh a ni lo.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA accessibility bawhchhiatna hmuh a ni. WCAG AA bawhchhiatna { $count } hmuh a ni. Accessibility report { $action ->
+            [close] khâr
+           *[open] hawn
+        } tûrin click rawh.
+        [advisories] WCAG AA bawhchhiatna hmuh a ni lo. Accessibility ngaihdân belhchhah { $count } hmuh a ni. Accessibility report { $action ->
+            [close] khâr
+           *[open] hawn
+        } tûrin click rawh.
+       *[clean] WCAG AA bawhchhiatna hmuh a ni lo. Accessibility report { $action ->
+            [close] khâr
+           *[open] hawn
+        } tûrin click rawh.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = Hmun mila ṭanpuina
+editor-tab-help-short = Hmun
+editor-tab-errors = Thil Dik Lo
+editor-tab-warnings = Vaukhânna
+editor-tab-info = Thu
+editor-tab-accessibility = Accessibility
+editor-tab-responses = Chhânna thawn tawhte
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editor thlan theihte
+editor-format-as-doenetml = DoenetML angin format rawh
+editor-format-as-xml = XML angin format rawh
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Line #{ $line }
+
+editor-no-errors = Thil Dik Lo A Awm Lo
+editor-no-warnings = Vaukhânna A Awm Lo
+editor-no-info = Info Diagnostic A Awm Lo
+
+editor-show-info-annotations = Editor-ah info diagnostic entîr
+editor-show-accessibility-annotations = Editor-ah accessibility diagnostic entîr
+
+editor-accessibility-learn-more = Doenet-in accessibility a enkawl dân zir rawh
+
+editor-accessibility-violations-heading = Accessibility bawhchhiatna ({ $standard })
+
+editor-accessibility-other-heading = Accessibility harsatna dangte
+editor-none-found = Engmah hmuh a ni lo
+
+
+## Submitted responses
+
+editor-no-responses = Chhânna thawn a la awm lo
+editor-response-answer-id = Answer Id
+editor-response-response = Chhânna
+editor-response-credit = Credit
+editor-response-submitted = Thawn hun
+
+
+## The context-help panel
+
+help-placeholder = Documentation dawn nân tag hming, attribute, emaw { $ref } chungah cursor dah rawh.
+
+help-unsupported-ref-chain = { $example } ang reference ṭhen tam tân ṭanpuina a la awm lo.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Reference { $ref } tân referent hmuh a ni lo.
+        [multiple] Reference { $ref } tân referent tam tak hmuh a ni.
+       *[indeterminate] { $ref } tân referent chu hriat chian theih a ni lo.
+    }
+
+help-learn-about-references = Reference chungchâng zir rawh →
+help-reference-page = Reference phêk →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } chhûngah
+       *[top] A chung ber ah
+    }{ $allowed ->
+        [none] { " — hetah hian engmah a awm thei lo." }
+        [text] { " — hetah hian thu ziak rawh." }
+        [text-and-components] { " — hetah hian thu ziak rawh, a nih loh leh:" }
+       *[components] { " — tum theih te:" }
+    }
+
+help-suggestions-footer = Component { $total } zawng zawng hmuh nân { $shortcut } hmang rawh.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } chu { $target } lam reference a ni.
+       *[other] { $ref } chu { $target } lam reference a ni (line { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner }-in { $role } angin a hnuaia dah a ni.
+       *[other] { $owner }-in line { $line }-ah { $role } angin a hnuaia dah a ni.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } chu { $element } property { $property } lam reference a ni.
+       *[other] { $ref } chu { $element } property { $property } lam reference a ni (line { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = Default:
+help-active-default = Default hman mêk:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Value phalte (item tinah pakhat):
+       *[other] Value phalte:
+    }
+
+help-suggested-values = Value sawi lâwkte:
+
+help-inserts = A dahluh:
+
+help-coordinates = Coordinates:
+
+help-type = Type:
+
+help-resolved-style = Style chhuina (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Function hming chhuinate:
+help-reset-list = He input-a reset list:
+help-added-on-input = He input-a belh:
+help-removed-on-input = He input-a paih:
+
+help-reset-overrides = { $reset }-in { $additional } leh { $removed } a thlâk.

--- a/packages/i18n/locales/lus/editor.ftl
+++ b/packages/i18n/locales/lus/editor.ftl
@@ -19,8 +19,9 @@
 # for show, «dahluh» for insert, «hmuh a ni lo» for none found.
 #
 # **No plural branches.** CLDR has no plural data for `lus`, and a Mizo noun is
-# unmarked after a numeral in any case, so `editor-accessibility-label` and
-# `help-coordinates` write one form and let the count stand beside it.
+# unmarked after a numeral in any case, so `editor-accessibility-label` writes
+# one form and lets the count stand beside it, and `help-coordinates` drops
+# the count English selects on and writes one form outright.
 
 
 ## The viewer's controls

--- a/packages/i18n/locales/mag/chrome.ftl
+++ b/packages/i18n/locales/mag/chrome.ftl
@@ -30,14 +30,16 @@
 # rather than disguised.** «कीबोर्ड», «पंक्ति», «स्तंभ», «व्यंजक», «त्रुटि»,
 # «सुगम्यता», «पूर्वावलोकन» are the words a Magahi speaker has met in school
 # and on a screen, in Hindi. Where Magahi's own everyday word is the one a
-# reader would use, it is used instead: «जवाब», «गलत», «करिया», «उज्जर»,
-# «पीयर», «हरियर», «धेयान».
+# reader would use, it is used instead — across the catalog, not only in this
+# file: «जवाब» and «गलत» here, «करिया», «उज्जर», «पीयर», «हरियर» among
+# `content.ftl`'s colours, «धेयान» in `diagnostics.ftl`.
 #
 # **Counts.** CLDR has no plural data for `mag`, so `Intl.PluralRules` would
 # resolve it against the runtime's own locale and any `[one]` branch would be
-# selected by somebody else's rules. Both counted messages collapse to a
-# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
-# Fluent matches against the number itself. A Magahi noun is unmarked after a
+# selected by somebody else's rules. `answer-show-responses` therefore drops
+# the selector entirely and writes one form, and the only branch on a number
+# left in this file is `attempts-remaining`'s explicit `[0]`, which Fluent
+# matches against the number itself rather than against a category. A Magahi noun is unmarked after a
 # numeral in any case — «सब» marks plurality, not counting — so one form is
 # right.
 

--- a/packages/i18n/locales/mag/chrome.ftl
+++ b/packages/i18n/locales/mag/chrome.ftl
@@ -1,0 +1,142 @@
+# Magahi (मगही) viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari.** Magahi's historical script is Kaithi, and printed
+# Magahi has used Devanagari for a century; Kaithi is not used here and a
+# conversion to it would be a research project, not a transliteration. Digits
+# are **Latin** (`1`, `2`, `1,234`), not Devanagari, because that is what
+# DoenetML pins for every locale in `src/intl.ts`.
+#
+# **What is Magahi here is the frame, and it is used consistently.** The
+# copula is «हइ», the negator «ना», the dative and purposive **«लेल»** —
+# *for* — which is the quickest way to tell these files from Hindi at a
+# glance, and from `locales/hne`, which writes «बर» in the same slot.
+# Beside it: «आउ» for *and*, «काहेकि» for *because*, «तेकरा लेल» for
+# *therefore*, «अगर» for *if*, «ना त» for *otherwise*, «में» for the
+# locative, «ई» for *this*, «कोनो» for *any*, «जे» for the relative
+# pronoun, and the plural word **«सब»** after the noun («बिंदु सब», «रेखा
+# सब»). Verbs are the eastern **-ल** participle — «देल», «कएल», «मिलल»,
+# «छोड़ल», «लिखल» — where Awadhi in the same batch writes «दीन», «कीन»,
+# «मिला». Buttons carry the honorific imperative in **-ू** — «खोलू»,
+# «हटावू», «जोड़ू», «देखावू».
+#
+# **The technical vocabulary is Hindi and Sanskrit, and that is declared
+# rather than disguised.** «कीबोर्ड», «पंक्ति», «स्तंभ», «व्यंजक», «त्रुटि»,
+# «सुगम्यता», «पूर्वावलोकन» are the words a Magahi speaker has met in school
+# and on a screen, in Hindi. Where Magahi's own everyday word is the one a
+# reader would use, it is used instead: «जवाब», «गलत», «करिया», «उज्जर»,
+# «पीयर», «हरियर», «धेयान».
+#
+# **Counts.** CLDR has no plural data for `mag`, so `Intl.PluralRules` would
+# resolve it against the runtime's own locale and any `[one]` branch would be
+# selected by somebody else's rules. Both counted messages collapse to a
+# single `*[other]`, keeping only `attempts-remaining`'s explicit `[0]`, which
+# Fluent matches against the number itself. A Magahi noun is unmarked after a
+# numeral in any case — «सब» marks plurality, not counting — so one form is
+# right.
+
+
+## Answer submission
+
+answer-checking = जाँचल जा रहल हइ...
+answer-submitting = पठावल जा रहल हइ...
+answer-checking-status = जवाब जाँचल जा रहल हइ
+answer-submitting-status = जवाब पठावल जा रहल हइ
+answer-correct = सही
+answer-incorrect = गलत
+answer-response-saved = जवाब सहेजल गेल
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+max-credit-available = सबसे जादा मिले वाला अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] कोनो मौका ना बचा
+       *[other] { $count } मौका बाँचल हइ
+    }
+validation-correct = (सही)
+validation-incorrect = (गलत)
+validation-partially-correct = (कुछ हद तक सही)
+answer-show-responses = { $answerId } के { $count } जवाब देखावू
+
+
+## Disclosure panels
+
+feedback-heading = राय
+collapsible-click-to-open = (खोले लेल क्लिक करू)
+collapsible-click-to-close = (बंद करे लेल क्लिक करू)
+collapsible-initializing = सुरू कएल जा रहल हइ...
+footnote-show = पादटिप्पणी देखावू
+footnote-hide = पादटिप्पणी छिपावू
+description-more-information = आउ जानकारी
+
+
+## Controls
+
+slider-previous = पहिले
+slider-next = आगे
+keyboard-open = कीबोर्ड खोलू
+keyboard-close = कीबोर्ड बंद करू
+choice-input-remove-choice = { $choice } हटावू
+matrix-remove-row = पंक्ति हटावू
+matrix-add-row = पंक्ति जोड़ू
+matrix-remove-column = स्तंभ हटावू
+matrix-add-column = स्तंभ जोड़ू
+subset-add-remove-points = बिंदु जोड़ू/हटावू
+subset-toggle-points-intervals = बिंदु आउ अंतराल के बीच बदलू
+subset-move-points = बिंदु सरकावू
+subset-clear = साफ करू
+# A `box` here is one orbital, drawn as a square: खाँचा.
+orbital-add-row = पंक्ति जोड़ू
+orbital-remove-row = पंक्ति हटावू
+orbital-add-box = खाँचा जोड़ू
+orbital-remove-box = खाँचा हटावू
+orbital-add-up-arrow = ऊपर के तीर जोड़ू
+orbital-add-down-arrow = नीचे के तीर जोड़ू
+orbital-remove-arrow = तीर हटावू
+orbital-row-label = पंक्ति { $row } के लेबल
+pretzel-answer = जवाब
+summary-statistics-caption = { $column } के सारांश सांख्यिकी
+
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक के पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+
+## Document status
+
+viewer-initializing = सुरू कएल जा रहल हइ...
+
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } में मिलल।
+       *[lines] पंक्ति { $startLine }–{ $endLine } में मिलल।
+    }
+document-contains-errors = ई दस्तावेज में त्रुटि हइ!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+something-went-wrong = कुछ गलत होइ गेल।
+renderer-load-failed = एक रेंडरर लोड ना हो सकल। कृपया पन्ना फेर लोड करू।
+core-start-failed = ई दस्तावेज सुरू ना हो सकल। कृपया पन्ना फेर लोड करू।
+core-start-failed-busy = ई दस्तावेज सुरू ना हो सकल। एके संग कई दस्तावेज सुरू होवऽ हल, आउ धीमे यंत्र पर ई में जादा समय लगऽ हइ। दूसर दस्तावेज पूरा होइ जाँय तब पन्ना फेर लोड करे से काम बन सकऽ हइ।
+core-start-failed-retry = ई दस्तावेज सुरू ना हो सकल।
+core-start-failed-busy-retry = ई दस्तावेज सुरू ना हो सकल। एके संग कई दस्तावेज सुरू होवऽ हल, आउ धीमे यंत्र पर ई में जादा समय लगऽ हइ।
+core-start-retry = फेर कोसिस करू
+saved-state-unavailable = तोहर सहेजल काम लोड ना हो सकल।

--- a/packages/i18n/locales/mag/chrome.ftl
+++ b/packages/i18n/locales/mag/chrome.ftl
@@ -22,7 +22,7 @@
 # locative, «ई» for *this*, «कोनो» for *any*, «जे» for the relative
 # pronoun, and the plural word **«सब»** after the noun («बिंदु सब», «रेखा
 # सब»). Verbs are the eastern **-ल** participle — «देल», «कएल», «मिलल»,
-# «छोड़ल», «लिखल» — where Awadhi in the same batch writes «दीन», «कीन»,
+# «छोड़ल», «रहल» — where Awadhi in the same batch writes «दीन», «कीन»,
 # «मिला». Buttons carry the honorific imperative in **-ू** — «खोलू»,
 # «हटावू», «जोड़ू», «देखावू».
 #

--- a/packages/i18n/locales/mag/content.ftl
+++ b/packages/i18n/locales/mag/content.ftl
@@ -1,0 +1,289 @@
+# Magahi (मगही) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, as in every file of this catalog; Kaithi is
+# historical and is not used. Digits are Latin and a number is grouped by the
+# locale's own rules (`1,000`), which is what DoenetML pins for every locale
+# in `src/intl.ts`.
+#
+# ## Word order
+#
+# **The description comes first and the noun last**, as in English and as in
+# Hindi: «मोट खंडित लाल रेखा» is *thick dashed red line*. So `style-with-noun`
+# and `style-filled-with-noun` keep English's order of placeables, and
+# `style-stroke` keeps English's internal order of width, dash pattern and
+# colour, because that is Magahi's order too.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } भुजा वाला सम बहुभुज» and leaves `tail` empty, as English
+# does: the side count goes in front of the noun here, so nothing has to be
+# split around the adjectives.
+#
+# ## Gender, role and number
+#
+# **Neither `$gender` nor `$role` forks, and here that is very nearly a claim
+# about the language rather than a gap.** Magahi has no productive
+# adjective–noun gender agreement of the Hindi kind: the participles are the
+# invariant eastern **-ल** forms, and the colour and width words this file
+# uses are invariant too — «करिया», «उज्जर», «पीयर», «हरियर», «मोट»,
+# «पातर». `noun-gender` therefore answers the single token `neuter`, and
+# nothing downstream selects on it. Of the three catalogs in this batch this
+# is the one where that decision is on the firmest ground.
+#
+# What is left over is the two Hindi colour loans «नीला» and «भूर» and the
+# borrowed «वाला», which a Hindi-influenced speaker may still want to agree
+# («नीली रेखा»), and the oblique before a postposition that
+# `style-border-clause` would want. A reviewer who reinstates either has to
+# add the `$gender` / `$role` forks and fill in `noun-gender` first.
+#
+# **Nothing selects on a count.** CLDR has no plural data for `mag`, and a
+# Magahi noun is unmarked after a numeral: «सब» marks plurality, not counting.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry and chemistry register is Hindi and Sanskrit, declared as
+# such**: «रेखा», «रेखाखंड», «किरण», «सदिश», «वक्र», «फलन», «परवलय»,
+# «बहुभुज», «त्रिभुज», «आयत», «वृत्त», «समचतुर्भुज». Magahi is not a medium
+# of instruction, so these are the words a Magahi student has actually met,
+# and inventing coinages would put words in front of a reader nobody uses.
+# What is Magahi here is everything around them: «जवाब», «सवाल», «अगर», «ना
+# त», «के» for the genitive, «आउ», «लेल», «में», the **-ल** participles, and
+# the plural **«सब»** after the noun, which is what the fill patterns carry.
+#
+# **The two chemistry tables are absent.** `element-name` and
+# `element-anion-name` — 128 messages between them — are not translated in
+# this batch, so this catalog sits at 445/575 keys with every other file in
+# it. The element names a Magahi reader would use are the Hindi ones, and a
+# seed that copied them over would be claiming a review it has not had; the
+# renderer already falls back to English for a missing key.
+
+
+## Style vocabulary
+
+color =
+    .black = करिया
+    .white = उज्जर
+    .gray = सलेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow = पीयर
+    .green = हरियर
+    .cyan = फिरोजी
+    .blue = नीला
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown = भूर
+# Both are invariant in Magahi, so neither takes a fork.
+line-width =
+    .thick = मोट
+    .thin = पातर
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+# Each carries the plural «सब» after the noun, because their other use is in
+# front of «वाला». They agree with nothing, so `style-fill` gives them a noun
+# to hang off rather than printing them bare.
+fill-style =
+    .horizontal = आड़ी रेखा सब
+    .vertical = खड़ी रेखा सब
+    .diagonal = विकर्ण रेखा सब
+    .backdiagonal = उलटी विकर्ण रेखा सब
+    .dots = बिंदु सब
+    .diamonds = समचतुर्भुज सब
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = प्रवणता क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = जोड़ चिह्न
+# The side count goes in front of the noun, so the whole phrase is one head
+# and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजा वाला सम बहुभुज
+    }
+# A single token: nothing in this file selects on gender, so there is no
+# table to fill in. Magahi does have gender — रेखा, किरण, बहुरेखा and
+# पृष्ठभूमि are feminine, किनारा, भराव and पाठ masculine — and a reviewer who
+# reinstates agreement has to write that table here first.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+# Adjectives precede the noun, as in English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# Said only of the shape itself, so it is standalone everywhere. «भरा» is a
+# marked adjective in Magahi and ought to agree with the shape; the seed
+# writes the masculine throughout. See the header.
+style-filled-word = भरा
+# «वाला» belongs to the shape rather than to the pattern in front of it, and
+# in Magahi it agrees with the shape — «बिंदु सब वाली रेखा», «बिंदु सब वाला
+# वर्ग». The seed writes «वाला» unagreed; see the header.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वाला { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+# «के संग» is postpositional, so «किनारा» stands in the oblique «किनारे». The
+# adjective in front of it should go oblique too, and does not: that is the
+# `$role` gap the header names. Awadhi has no article, so the `-article`
+# branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारे के संग
+        [and] आउ { $border } किनारे के संग
+        [and-article] आउ { $border } किनारे के संग
+       *[with] { $border } किनारे के संग
+    }
+# The fill-pattern words end in the plural «सब», so this message supplies a
+# noun for them to hang off — «भराव» — rather than printing them bare.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } भराव
+       *[plain] { $color } भराव
+    }
+style-unfilled = बिना भराव
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि पर { $color }
+       *[plain] { $color }
+    }
+style-background-none = कोनो ना
+
+
+## Boolean words
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## Answer buttons
+
+answer-submit-label = जाँचू
+answer-submit-label-no-correctness = जवाब पठावू
+
+
+## Sectional blocks
+
+section-name =
+    .activity = गतिविधि
+    .aside = बगल के बात
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = जवाब
+    .note = टिप्पणी
+    .objectives = उद्देस
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = सवाल
+    .problems = सवाल
+    .proof = प्रमाण
+    .question = परसन
+    .section = अनुभाग
+    .solution = हल
+    .task = काम
+    .theorem = प्रमेय
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = संकेत
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = पहिले
+paginator-next = आगे
+paginator-page = पन्ना
+paginator-page-status = { $numPages } में से { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = या
+piecewise-condition-if = अगर
+piecewise-condition-otherwise = ना त
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; see the
+## header. What is left is the prose around them.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = खाली जगह
+math-embedded-input-blank-ordinal = { $total } में से { $ordinal } खाली जगह

--- a/packages/i18n/locales/mag/content.ftl
+++ b/packages/i18n/locales/mag/content.ftl
@@ -55,7 +55,7 @@
 # the plural **«सब»** after the noun, which is what the fill patterns carry.
 #
 # **The two chemistry tables are absent.** `element-name` and
-# `element-anion-name` — 128 messages between them — are not translated in
+# `element-anion-name` — 130 messages between them — are not translated in
 # this batch, so this catalog sits at 445/575 keys with every other file in
 # it. The element names a Magahi reader would use are the Hindi ones, and a
 # seed that copied them over would be claiming a review it has not had; the
@@ -168,7 +168,7 @@ style-filled-with-noun =
     }
 # «के संग» is postpositional, so «किनारा» stands in the oblique «किनारे». The
 # adjective in front of it should go oblique too, and does not: that is the
-# `$role` gap the header names. Awadhi has no article, so the `-article`
+# `$role` gap the header names. Magahi has no article, so the `-article`
 # branches read the same as the ones without.
 style-border-clause =
     { $parts ->

--- a/packages/i18n/locales/mag/diagnostics.ftl
+++ b/packages/i18n/locales/mag/diagnostics.ftl
@@ -1,0 +1,683 @@
+# Magahi (मगही) diagnostics: the warnings and errors the worker raises and the
+# reader is shown. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth. Selected by `uiLocale`, not by the language the document
+# was written in.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# Neither are the DoenetML identifiers quoted inside these sentences:
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence` and every tag and attribute name like them are part of
+# the language an author writes, not prose, and stay in English exactly as
+# written. So does the `[deprecation]` marker, which is a label rather than a
+# word, and anything quoted back from the author's own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari with Latin digits**, as in every file of this catalog.
+#
+# **The technical vocabulary is Hindi and Sanskrit and is declared as such** —
+# घटक, विशेषता, चर, विमा, आव्यूह, संदर्भ, फलन, समीकरण, अनुक्रम, वैषम्य.
+# These are the words a Magahi reader has met; inventing equivalents would put
+# words in front of a reader that nobody uses.
+#
+# **What is Magahi is the frame**, and it carries the whole file:
+#
+#   «हइ»                      the copula
+#   «ना»                      the negator
+#   «ना कएल जा सकऽ हइ»        *cannot be done*
+#   «छोड़ल जा रहल हइ»         *ignoring*
+#   «धेयान ना देल जा हइ»      *is ignored*
+#   «होवे के चाही»            *must be*
+#   «काहेकि»                  *because*; «तेकरा लेल» *therefore*
+#   «अखने उपलब्ध ना हइ»       *has not been implemented*
+#   «लेल»                     *for* — the dative, and the file's signature
+#   «में»                     the locative; «के» the genitive and accusative
+#   «आउ» / «या» / «अगर»       *and* / *or* / *if*
+#   «जे» / «जेकर»             the relative pronoun and its genitive
+#   «सब»                      the plural, written after the noun
+#   -ल                        the participle: देल, कएल, मिलल, छोड़ल, लिखल
+#
+# A sentence that has slipped back into «है», «नहीं», «क्योंकि» or «के लिए»
+# is a mistake to fix rather than a stylistic choice. This is a **framed**
+# catalog: the sentences are Magahi, the nouns inside them are declared Hindi,
+# and a speaker should expect to correct the sentences as often as the words.
+#
+# **The present habitual «-ऽ हइ» is the seed's least certain choice.** It
+# writes «होवऽ हइ», «देवऽ हइ», «करऽ हइ» with an avagraha for the lengthened
+# stem vowel, which is one of several conventions in printed Magahi; a
+# reviewer who prefers «होबऽ हइ», «होवे हइ» or a plain «होवइ» should change
+# all four files at once rather than message by message.
+#
+# **No plural branches.** CLDR has no plural data for `mag`, so every
+# `[one]`/`[other]` fork English writes over a count is collapsed here; most
+# become a plain message, since a Magahi noun is unmarked after a numeral. The
+# one exception is `field-function-wrong-num-outputs`, where English is not
+# counting but distinguishing a one-output field from a two-output one; that
+# fork is kept as the numeric literal `[1]`, which Fluent matches against the
+# number itself rather than against a plural category.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दू सिरा देल जाय पर { $attributes } पर धेयान ना देल जा हइ
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा आउ मध्यबिंदु दूनू देल जाय पर { $attributes } पर धेयान ना देल जा हइ
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु के बिना midpointOffset के कोनो असर ना होवऽ हइ
+
+## `<line>`
+
+line-points-undetermined-dimensions = अइसन बिंदु सब से होके जाय वाली रेखा जेकर विमा तय ना हइ।
+
+line-points-too-few-dimensions = रेखा के कम से कम दू विमा वाले बिंदु सब से होके जाय के चाही।
+
+line-points-depend-on-variables = रेखा ओह बिंदु सब से होके जा रहल हइ जे चर सब पर निर्भर हइ: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } आउ { $variable2 } में रेखा के समीकरण के प्रारूप अमान्य हइ।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एके संग through, endpoint आउ direction से तय हइ। देल गेल through छोड़ल जा रहल हइ।
+
+ray-dimension-mismatch = किरण में numDimensions मेल ना खाय हइ।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एके संग head, tail आउ displacement से तय हइ। देल गेल head छोड़ल जा रहल हइ।
+
+vector-dimension-mismatch = सदिश में numDimensions मेल ना खाय हइ।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` के ओर खींचा ना जा सकऽ हइ, काहेकि ओह में nearestPoint अवस्था चर ना हइ।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित ना कएल जा सकऽ हइ, काहेकि ओह में nearestPoint अवस्था चर ना हइ।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` के भीतरी भाग तक सीमित ना कएल जा सकऽ हइ, काहेकि ओह में nearestPoint अवस्था चर ना हइ।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होय वाले choiceInput लेल labelPosition पर धेयान ना देल जा हइ
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput लेल देल गेल indices छोड़ल जा रहल हइ, काहेकि indices के संख्या choice संतान सब के संख्या से मेल ना खाय हइ।
+
+pretzel-indices-count-mismatch = problem लेल देल गेल indices छोड़ल जा रहल हइ, काहेकि indices के संख्या problem संतान सब के संख्या से मेल ना खाय हइ।
+
+shuffle-indices-count-mismatch = shuffle लेल देल गेल indices छोड़ल जा रहल हइ, काहेकि indices के संख्या घटक सब के संख्या से मेल ना खाय हइ।
+
+indices-ignored-out-of-range = { $component } लेल देल गेल indices छोड़ल जा रहल हइ, काहेकि कुछ अनुक्रमांक परिसर से बाहर हइ।
+
+pretzel-indices-repeated = pretzel लेल देल गेल indices छोड़ल जा रहल हइ, काहेकि कुछ अनुक्रमांक दोहरावल गेल हइ।
+
+pretzel-circuit-first-index = circuit विधा में pretzel लेल देल गेल indices छोड़ल जा रहल हइ, काहेकि पहिलका अनुक्रमांक 1 होवे के चाही।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` के पाठ संतान सब के संग काम करे लेल `type` विशेषता देवे के चाही।
+
+invalid-type-defaulting-to-math = { $component } घटक लेल प्रकार { $type } अमान्य हइ। ई math, text, number या boolean में से एक होवे के चाही। math के उपयोग कएल जा रहल हइ।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } लेल मान्य घटक ना हइ। छोड़ल जा रहल हइ।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य हइ; प्रकार number कएल जा रहल हइ।
+
+invalid-variable-value = चर के मान अमान्य हइ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } संख्या होवे के चाही
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } पूर्णांक होवे के चाही
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष माप लेल अखने उपलब्ध ना हइ। चौड़ाई सापेक्ष कएल जा रहल हइ।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष माप लेल अखने उपलब्ध ना हइ। हाशिया सापेक्ष कएल जा रहल हइ।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: ई में कम से कम एक खंड संतान होवे के चाही।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर धेयान ना देल जा हइ।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एके घटक तक पहुँचे के चाही।
+
+label-for-unresolved = `<label>` पर `for` विशेषता कोनो घटक तक ना पहुँच सकल।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता अइसन `<answer>` के संदर्भ देवऽ हइ जेकरा में इनपुट खुद लिखा गेल हइ; सीधे ओहि इनपुट के संदर्भ दऽ।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता अइसन `<answer>` के संदर्भ देवऽ हइ जेकरा में लेबल लगावे लायक इनपुट ना हइ।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता कोनो इनपुट या कोनो जवाब के संदर्भ देवे के चाही।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता लेल `<{ $component }>` के या त संछिप्त विवरण होवे के चाही या ओकरा सजावटी बतावा जाय के चाही।
+
+accessibility-video-short-description = सुगम्यता लेल `<video>` के संछिप्त विवरण होवे के चाही।
+
+accessibility-input-short-description-or-label = सुगम्यता लेल `<{ $component }>` के संछिप्त विवरण या लेबल होवे के चाही।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता लेल इनपुट बनावे वाले `<answer>` के संछिप्त विवरण या लेबल होवे के चाही।
+
+accessibility-short-description-contains-math = संछिप्त विवरण में `<{ $component }>` जइसे गणितीय घटक ना होवे के चाही। गणित के सब्द सब में लिखू।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } के खंड सीर्षक के पाठ लेल वैषम्य अपर्याप्त हइ (गाढ़ विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+       *[other] { $colorName } के खंड सीर्षक के पाठ लेल वैषम्य अपर्याप्त हइ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदु सब के संख्यात्मक मान न होंय, तब { $count } बिंदु सब से होके जाय वाला `<circle>` अखने उपलब्ध ना हइ।
+
+circle-too-many-through-points = 3 से जादा बिंदु सब से होके जाय वाला वृत्त ना निकाला जा सकऽ हइ।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र आउ गुजरे वाले बिंदु एके संग देल जाय पर वृत्त ना निकाला जा सकऽ हइ।
+
+circle-center-with-multiple-points = देल गेल केंद्र के संग 1 से जादा बिंदु से होके जाय वाला वृत्त ना निकाला जा सकऽ हइ।
+
+circle-radius-too-small = वृत्त ना निकाला जा सकऽ हइ: दूनू बिंदु सब के बीच के दूरी { $distance } हइ, तेकरा लेल देल गेल त्रिज्या { $radius } बहुत छोट हइ।
+
+circle-radius-with-many-points = देल गेल त्रिज्या के संग दू से जादा बिंदु सब से होके जाय वाला वृत्त ना बनावा जा सकऽ हइ।
+
+circle-invalid-center-or-through-points = वृत्त के केंद्र या गुजरे वाले बिंदु अमान्य हइ।
+
+circle-radius-center-with-multiple-points = देल गेल केंद्र के संग 1 से जादा बिंदु से होके जाय वाले वृत्त के त्रिज्या ना निकाली जा सकऽ हइ।
+
+circle-change-radius-non-numerical = जौन वृत्त के गुजरे वाले बिंदु संख्यात्मक ना हइ, ओकर त्रिज्या ना बदली जा सकऽ हइ
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होय पर, देल गेल त्रिज्या के संग एक से जादा बिंदु से होके जाय वाला वृत्त ना बनावा जा सकऽ हइ।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदु सब से होके जाय वाले वृत्त के केंद्र बदलब अखने उपलब्ध ना हइ।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन के प्रांत के विमा अपर्याप्त हइ। प्रांत में { $intervals } अंतराल हइ, बाकिर फलन में { $inputs } इनपुट हइ।
+
+function-domain-invalid-format = फलन के प्रांत के प्रारूप अमान्य हइ।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन के असंख्यात्मक उच्चिष्ठ छोड़ल जा रहल हइ।
+        [minimum] फलन के असंख्यात्मक निम्निष्ठ छोड़ल जा रहल हइ।
+        [extremum] फलन के असंख्यात्मक चरम मान छोड़ल जा रहल हइ।
+        [point] फलन के असंख्यात्मक बिंदु छोड़ल जा रहल हइ।
+        [slope] फलन के असंख्यात्मक प्रवणता छोड़ल जा रहल हइ।
+       *[other] फलन के असंख्यात्मक { $type } छोड़ल जा रहल हइ।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन के खाली उच्चिष्ठ छोड़ल जा रहल हइ।
+        [minimum] फलन के खाली निम्निष्ठ छोड़ल जा रहल हइ।
+        [extremum] फलन के खाली चरम मान छोड़ल जा रहल हइ।
+        [point] फलन के खाली बिंदु छोड़ल जा रहल हइ।
+       *[other] फलन के खाली { $type } छोड़ल जा रहल हइ।
+    }
+
+function-points-too-close = फलन में दू बिंदु बहुत पास-पास हइ। फलन परिभाषित ना कएल जा सकऽ हइ।
+
+function-iterates-input-output-mismatch = फलन के पुनरावर्तन तबहीं संभव हइ जब इनपुट के संख्या आउटपुट के संख्या के बराबर होय। ई फलन में { $inputs } इनपुट आउ { $outputs } आउटपुट हइ।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम के लंबाई अमान्य हइ। ई ऋणेतर पूर्णांक होवे के चाही।
+
+sequence-invalid-step = अनुक्रम के चरण अमान्य हइ। { $type } प्रकार के अनुक्रम लेल ई संख्या होवे के चाही।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम के "{ $attribute }" अमान्य हइ। ई संख्या होवे के चाही।
+
+sequence-invalid-endpoint-letters = अच्छर अनुक्रम के "{ $attribute }" अमान्य हइ। ई अच्छर सब के संयोजन होवे के चाही।
+
+sequence-invalid-endpoint = अनुक्रम के "{ $attribute }" अमान्य हइ।
+
+select-from-sequence-coprime-not-numbers = संख्या ना चुनी जात, तेकरा लेल coprime छोड़ा गेल
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations देल गेल हइ, तेकरा लेल coprime छोड़ा गेल
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` लेल target अमान्य हइ: लक्ष्य ना मिलल।
+
+target-state-variable-not-found = `<{ $source }>` लेल target अमान्य हइ: `<{ $component }>` पर "{ $property }" नाम के अवस्था चर ना मिलल।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` के चर स्वतंत्र चर से अलग होवे के चाही।
+
+ode-system-duplicate-variable-names = दोहरावल गेल आश्रित चर नाम सब के संग ODE के दाहिन पच्छ के फलन परिभाषित ना कएल जा सकऽ हइ।
+
+ode-system-rhs-function-error = ODE के दाहिन पच्छ के फलन परिभाषित ना कएल जा सकऽ हइ। mathjs फलन बनावत समय त्रुटि भेल।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखा सब के बीच के कोण परिभाषित ना कएल जा सकऽ हइ
+
+angle-invalid-through-point = `<angle>` के through में अमान्य बिंदु हइ
+
+parabola-vertex-too-many-points = देल गेल सीर्ष के संग 1 से जादा बिंदु से होके जाय वाला परवलय अखने उपलब्ध ना हइ।
+
+parabola-too-many-points = 3 से जादा बिंदु सब से होके जाय वाला परवलय अखने उपलब्ध ना हइ।
+
+intersection-too-many-items = दू से जादा वस्तु सब के प्रतिच्छेदन अखने उपलब्ध ना हइ
+
+## Other math components
+
+ionic-compound-not-two-ions = दू आयन सब के अलावा कोनो आउ हालत लेल आयनिक यौगिक अखने उपलब्ध ना हइ।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक खाली एक धनायन आउ एक ऋणायन लेल उपलब्ध हइ।
+
+solve-equations-cannot-evaluate = समीकरण के मान ना निकाला जा सकल, तेकरा लेल ऊ हल ना कएल जा सकऽ हइ: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालत समय operandNumber देब जरूरी हइ।
+
+eigen-decomposition-failed = आव्यूह के अभिलच्छनिक मान ना निकाले जा सकल
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न में ना आवऽ हइ, तेकरा लेल ऊ सदा खाली से मेल खाई।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" समझा ना जा सकल। ई none, medium, dense, या खाली जगह से अलगावल दू धनात्मक संख्या होवे के चाही, जइसे grid="1 0.5"। कोनो ग्रिड ना खींचा जाई।
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` के अइसन फलन चाही जेकरा में { $expected ->
+        [1] एक आउटपुट होय, हर बिंदु पर प्रवणता y', जइसे `y - x`
+       *[other] दू आउटपुट होंय, हर बिंदु पर सदिश, जइसे `(y, -x)`
+    }, बाकिर जौन फलन देल गेल ओह में { $found } आउटपुट हइ। { $alternative ->
+        [none] कुछ ना खींचा जाई।
+       *[other] ओह फलन लेल `<{ $alternative }>` घटक हइ। कुछ ना खींचा जाई।
+    }
+
+field-function-attribute-ignored-with-child = `function` विशेषता पर धेयान ना देल जा हइ, काहेकि फलन घटक के भीतर भी देल गेल हइ; भीतर वाला लेल जा रहल हइ। फलन दूनू में से खाली एके तरह से दऽ।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषता ओह व्यंजक के चर सब के नाम देवऽ हइ जौन सीधे घटक के भीतर लिखा गेल हइ। { $reason ->
+        [function-child] इहाँ फलन `<function>` संतान के रूप में देल गेल हइ, जौन आपन चर खुद बतावत हइ, तेकरा लेल `variables` छोड़ल जा रहल हइ।
+       *[no-expression] इहाँ अइसन कोनो व्यंजक ना देल गेल, तेकरा लेल `variables` छोड़ल जा रहल हइ।
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर में xLabelPosition="left" समर्थित ना हइ; दाहिन ओर वाला बरताव लेल जा रहल हइ।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर में yLabelPosition="bottom" समर्थित ना हइ; ऊपर वाला बरताव लेल जा रहल हइ।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण लेल अच्छ सीमा अमान्य हइ; पूर्वनिर्धारित bbox (-10,-10,10,10) लेल जा रहल हइ।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण लेल चौड़ाई अमान्य हइ; पूर्वनिर्धारित आरेख चौड़ाई 425 लेल जा रहल हइ।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण लेल aspectRatio अमान्य हइ; पूर्वनिर्धारित अनुपात 1 लेल जा रहल हइ।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अच्छ सीमा के हिसाब से ग्रिड के अंतराल बहुत महीन हइ; prefigure रेंडरर में ग्रिड छोड़ल जा रहल हइ।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर के उपयोग न होय पर टीका ना खींची जाई।
+
+multiple-annotations-children = `<graph>` में एक से जादा `<annotations>` संतान मिललं; अंतिम के छोड़िके सब पर धेयान ना देल जइतइ।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार के बढ़ावा या नकल ना कएल जा सकऽ हइ: { $type }।
+
+copy-prop-not-found = { $component } प्रकार के घटक पर { $property } गुण ना मिलल
+
+collect-no-source = collect लेल कोनो स्रोत ना मिलल।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार के घटक बटोरे ना जा सकऽ हइ, काहेकि ई मान्य घटक प्रकार ना हइ।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` के संदर्भ ना देल जा सकऽ हइ
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } ना बुलावा जा सकऽ हइ
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़ा सब के आकार अमान्य हइ। पंक्ति सब के लंबाई असंगत हइ। componentIdx :{ $componentIdx } में मिलल
+
+data-frame-duplicate-column-names = आँकड़ा सब में स्तंभ नाम दोहरावल गेल हइ। componentIdx :{ $componentIdx } में मिलल
+
+data-frame-missing-column-name = आँकड़ा सब में एक स्तंभ नाम ना हइ। componentIdx :{ $componentIdx } में मिलल
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ई जवाब के एक award खुद answer टैग के पठावल जवाब पर टिका हइ, जेह से अनचाहा बरताव होई।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र के भीतर के `<answer>` पर `maxNumAttempts` राखे के कोनो असर ना होवऽ हइ, काहेकि मौका सब के संख्या पात्र तय करऽ हइ। `maxNumAttempts` पात्र पर राखू।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले कोनो आउ पात्र के भीतर बैठे `sectionWideCheckWork` पात्र पर `maxNumAttempts` राखे के कोनो असर ना होवऽ हइ, काहेकि मौका सब के संख्या बाहरी पात्र तय करऽ हइ। `maxNumAttempts` बाहरी पात्र पर राखू।
+
+answer-attributes-need-symbolic-equality = symbolicEquality राखे बिना { $attributes } विशेषता के कोनो असर ना होई।
+
+answer-invalid-type = answer लेल प्रकार अमान्य हइ: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = काहेकि घटक `<{ $component }>` के नाम ना हइ, एकरा मॉड्यूल के विशेषता के रूप में ना लीन जा सकऽ हइ
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` के मॉड्यूल के विशेषता के रूप में ना लीन जा सकऽ हइ, काहेकि घटक प्रकार `<module>` में "{ $name }" विशेषता पहिलहीं से परिभाषित हइ।
+
+conditional-content-condition-ignored = case या else संतान सब वाले `<conditionalContent>` घटक पर `condition` विशेषता पर धेयान ना देल जा हइ।
+
+slider-markers-type-mismatch = चिह्नक सब के प्रकार स्लाइडर के प्रकार से मेल ना खाय हइ।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: हर `<problem>` में एक `<statement>` आउ एक `<answer>` होवे के चाही।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" में पहिलका `<problem>` भरमावे वाला विकल्प ना हो सकऽ हइ।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` लेल मान { $values } अमान्य हइ; छोड़ल जा रहल हइ।
+
+attribute-must-be-references = विशेषता `{ $attribute }` लेल मान `{ $value }` अमान्य हइ। विशेषता `$` से सुरू होय वाले संदर्भ सब से बनी होवे के चाही।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } में अमान्य फलन नाम छोड़े गए: { $names }। हर नाम के दिखे वाले भाग में कम से कम 2 वर्ण (अच्छर या योजक चिह्न) होवे के चाही; ओकर बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आइ सकत हइ।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य हइ: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहरावी ना जा सकऽ हइ।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार के घटक लेल विशेषता "{ $attribute }" अमान्य हइ।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } में { $context ->
+        [text-on-background] पृष्ठभूमि के रंग के आगे पाठ के रंग
+        [high-contrast] कैनवास के आगे उच्च वैषम्य के रंग
+        [line] कैनवास के आगे रेखा के रंग
+        [marker] कैनवास के आगे चिह्नक के रंग
+       *[text-on-canvas] कैनवास के आगे पाठ के रंग
+    } लेल वैषम्य अपर्याप्त हइ{ $mode ->
+        [dark] { " (गाढ़ विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)।
+
+style-definition-dark-mode-text-background-contrast =
+    जदपि शैली परिभाषा { $styleNumber } हल्की विधा लेल पर्याप्त वैषम्य वाले रंग देवऽ हइ, ई मान सब से निकले गाढ़ विधा के रंग सब में पाठ के रंग आउ पृष्ठभूमि के रंग के बीच वैषम्य अपर्याप्त हइ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)। { $suggestion ->
+        [available] गाढ़ विधा में पर्याप्त वैषम्य पावे लेल या त हल्की विधा के वैषम्य बढ़ावू (जइसे { $lightAttribute }="{ $lightColor }" राखू) या गाढ़ विधा के रंग बदलि दऽ (जइसे { $darkAttribute }="{ $darkColor }" राखू)।
+       *[none] गाढ़ विधा में पर्याप्त वैषम्य पावे लेल हल्की विधा के वैषम्य बढ़ावू या निकले रंग सब के textColorDarkMode आउ/या backgroundColorDarkMode से बदलि दऽ।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    जदपि शैली परिभाषा { $styleNumber } हल्की विधा लेल पर्याप्त वैषम्य वाला पाठ रंग देवऽ हइ, ई मान से निकला गाढ़ विधा के पाठ रंग कैनवास के आगे अपर्याप्त वैषम्य रखऽ हइ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाही)। { $suggestion ->
+        [available] गाढ़ विधा में पर्याप्त वैषम्य पावे लेल या त हल्की विधा के वैषम्य बढ़ावू (जइसे textColor="{ $lightColor }" राखू) या गाढ़ विधा के रंग बदलि दऽ (जइसे textColorDarkMode="{ $darkColor }" राखू)।
+       *[none] गाढ़ विधा में पर्याप्त वैषम्य पावे लेल हल्की विधा के वैषम्य बढ़ावू या निकले रंग के textColorDarkMode से बदलि दऽ।
+    }
+
+section-multiple-style-palettes = एक खंड खाली एक <stylePalette> चुनि सकत हइ; अंतिम लेल जा रहल हइ।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि numToSelect ऋणेतर पूर्णांक ना हइ।
+
+variant-num-to-select-not-constant-number = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि numToSelect अचर संख्या ना हइ।
+
+variant-with-replacement-not-constant-boolean = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि withReplacement अचर बूलीय मान ना हइ।
+
+variant-select-weight-disables-unique = अगर कोनो विकल्प selectWeight या selectForVariants देवऽ हइ त select के अनोखा संस्करण बंद होइ जा रहल हइ
+
+variant-coprime-undetermined = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि ई तय ना हो सकल कि coprime सदा असत्य हइ।
+
+variant-attribute-not-constant = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि { $attribute } अचर ना हइ।
+
+variant-attribute-not-number = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि { $attribute } संख्या ना हइ।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार के { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि { $attribute } { $expected ->
+        [letters-combination] अच्छर सब के संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } ना हइ।
+
+variant-length-not-integer = { $component } के अनोखा संस्करण तय ना कएल जा सकऽ हइ, काहेकि length पूर्णांक ना हइ।
+
+variant-sort-not-implemented = sort वाले { $component } के अनोखा संस्करण अखने उपलब्ध ना हइ
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } के अनोखा संस्करण अखने उपलब्ध ना हइ
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार के { $component } के अनोखा संस्करण अखने उपलब्ध ना हइ
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } के अनोखा संस्करण अखने उपलब्ध ना हइ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख के prefigure रेंडरर में समर्थित ना; वंसज छोड़ा गेल।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित या अधूरी हइ; वंसज छोड़ा गेल।
+
+prefigure-curve-label-omitted = { $subject }: बदले गेल वक्र तत्व सब पर लेबल समर्थित ना; लेबल छोड़ा गेल।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित ना; वंसज छोड़ा गेल।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित ना; वंसज छोड़ा गेल।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves खाली सूत्र प्रकार के संतान फलन सब के मानऽ हइ; वंसज छोड़ा गेल।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल के लेबल
+       *[point] बिंदु के लेबल
+    } लेल labelPosition '{ $labelPosition }' समर्थित ना; PreFigure के पूर्वनिर्धारित संरेखण लेल जा रहल हइ।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure में समर्थित ना; ठोस भराव लेल जा रहल हइ।
+
+prefigure-line-style-unknown = { $subject }: अनजान रेखा शैली '{ $lineStyle }' PreFigure के आउटपुट से छोड़ी गई।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure के 'diamond' शैली पर मानचित्रित कएल गेल।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure में समर्थित ना; पूर्वनिर्धारित शैली लेल जा रहल हइ।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य तय ना हो सकल। टीका छोड़ी गई।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` से कई लक्ष्य निकले; पहिलका लक्ष्य लेल जा रहल हइ।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य ओकरा समेटे आलेख के बाहर हइ। टीका छोड़ी गई।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण में लक्ष्य समर्थित आलेखीय वस्तु ना हइ। टीका छोड़ी गई।
+
+annotation-text-missing = `<annotation>`: `text` ना हइ या खाली हइ; खाली पाठ देल जा रहल हइ।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता के पता चला।
+       *[other] `<{ $componentType }>` घटक से जुड़ी चक्रीय निर्भरता के पता चला।
+    }
+
+reference-no-referent = ई संदर्भ के कोनो लक्ष्य ना मिलल: `{ $reference }`
+
+reference-multiple-referents = ई संदर्भ के कई लक्ष्य मिलल: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` के विशेषता { $attribute } के प्रारूप अमान्य हइ।
+
+children-invalid = `<{ $componentType }>` के संतान अमान्य हइ: अमान्य संतान मिललं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` लेल मान `{ $value }` अमान्य हइ; मान `{ $default }` लेल जा रहल हइ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } ना मिलल।
+       *[other] DoenetML संस्करण { $version } ना मिलल। संस्करण { $fallback } पर लौटा जा रहल हइ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` के समापन टैग ना हइ। खुद बंद होय वाला टैग या `</{ $tagName }>` टैग चाही हल।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` में त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` के मान ना लगऽ हइ।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य हइ
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता के मान `{ $value }` अमान्य हइ
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता के मान `{ $value }` अमान्य हइ। उद्धरण चिह्न मेल ना खाय हइ। एक `{ $quote }` छूटा लगऽ हइ
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम के टैग मिलल, जइसे `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद ना भेल (एक `>` छूटा लगऽ हइ)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम के टैग मिलल `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद ना भेल (`/>` छूटा लगऽ हइ)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य ना हइ। एकर विशेषता गलत हो सकऽ हइ हइ।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम के समापन टैग मिलल, जइसे `</`
+
+parse-attribute-value-unquoted = विशेषता के मान उद्धरण चिह्न सब में होवे के चाही: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिलल, बाकिर ओहसे मेल खात आरंभ टैग ना हइ
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल ना खाय हइ। `</{ $expected }>` चाही हल। `{ $found }` मिलल
+
+parser-node-unconvertible = नोड { $node } के Dast नोड में ना बदला जा सकल।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य हइ। { $reason ->
+        [characters] नाम सब में खाली अच्छर, अंक, अधोरेखा या योजक चिह्न हो सकऽ हइ हइ।
+       *[start] नाम अच्छर से सुरू होवे के चाही।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य हइ। नाम अच्छर से सुरू होवे के चाही।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार के answer में video विशेषता होवे के चाही
+
+answer-video-watched-video-not-reference = videoWatched प्रकार के answer के video विशेषता एक संदर्भ होवे के चाही
+
+answer-name-not-single-text = answer के name विशेषता में खाली एक पाठ संतान होवे के चाही
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन के बहुत जादा स्तर सब के कारन बाहरी DoenetML ना मिल सका। कहूँ चक्रीय संदर्भ त ना?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" से DoenetML ना मिल सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" से मिलल DoenetML अमान्य हइ: ई घटक प्रकार "{ $componentType }" से मेल ना खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित हइ; एकर बदले `{ $to }` के उपयोग करू।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित हइ; एकर बदले `{ $to }` के उपयोग करू।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित हइ आउ छोड़ी गई, काहेकि `{ $to }` भी देल गेल हइ।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित हइ आउ छोड़ी गई, काहेकि `{ $to }` भी देल गेल हइ।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित हइ आउ छोड़ी गई।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित हइ; एकर बदले `<{ $child }>` संतान लिखू।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` के मान `{ $value }` अप्रचलित हइ; एकर बदले `{ $to }` के उपयोग करू।
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` खाली अंग्रेजी के बहुवचन बनाइ सकत हइ, तेकरा लेल { $locale } में लिखे दस्तावेज में ओकर पाठ जस के तस रहऽ हइ। बहुवचन रूप सीधे लिखू, या `pluralForm` विशेषता से दऽ।
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कोनो परिचित Doenet तत्व ना हइ।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज के मूल में मान्य ना हइ।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` के भीतर मान्य ना हइ।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` में `{ $attribute }` नाम के कोनो विशेषता ना हइ।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` के विशेषता `{ $attribute }` अइसन सूची होवे के चाही जेकर हर मद इनमें से एक होय: { $allowed }
+       *[other] तत्व `<{ $tag }>` के विशेषता `{ $attribute }` इनमें से एक होवे के चाही: { $allowed }
+    }
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select लेल संस्करण नाम अमान्य हइ। संस्करण नाम { $variantName } { $numOptions } विकल्प सब में आवऽ हइ, बाकिर चुने के संख्या { $numToSelect } हइ।
+
+select-variant-name-without-options = select लेल संस्करण देल गेल हइ, बाकिर संभव संस्करण नाम लेल कोनो विकल्प ना हइ: { $variantName }।
+
+select-variant-name-not-possible = select लेल देल गेल संस्करण नाम { $variantName } संभव संस्करण नाम ना हइ।
+
+select-too-few-options = खाली { $numOptions } घटक सब में से { $numToSelect } ना चुने जा सकऽ हइ।
+
+select-from-sequence-too-few-values = { $length } लंबाई के अनुक्रम से { $numToSelect } मान ना चुने जा सकऽ हइ।
+
+select-from-sequence-indices-count-mismatch = select लेल देल गेल अनुक्रमांक सब के संख्या चुने के संख्या से मेल खाय के चाही
+
+select-from-sequence-indices-not-integers = select लेल देल गेल सब अनुक्रमांक पूर्णांक होवे के चाही
+
+select-from-sequence-index-excluded = selectfromsequence लेल देल गेल अनुक्रमांक बाहर कएल गेल रहल
+
+select-from-sequence-indices-excluded-combination = selectfromsequence लेल देल गेल अनुक्रमांक बाहर कएल गेल संयोजन रहल
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक ना चुने जात, तेकरा लेल सहअभाज्य संयोजन ना चुने जा सकऽ हइ।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्या ना चुनी जा सकऽ हइ। सब संभव मान सब में एक उभयनिष्ठ गुणनखंड हइ। (देल गेल "from" या "to" मान "step" के सहअभाज्य होवे के चाही।)
+
+select-from-sequence-coprime-single-number = 1 से अलग कोनो एके संख्या से सहअभाज्य संयोजन ना चुने जा सकऽ हइ।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence में 70% से जादा संयोजन बाहर कएल गेल
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्या ना चुनी जा सकल। सब संभव मान सब में एक उभयनिष्ठ गुणनखंड हइ।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई के अनुक्रम से { $numToSelect } अलग मान ना चुने जा सकऽ हइ
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई के अभाज्य सूची से { $numToSelect } मान ना चुने जा सकऽ हइ
+
+select-prime-numbers-values-count-mismatch = select लेल देल गेल मान सब के संख्या चुने के संख्या से मेल खाय के चाही
+
+select-prime-numbers-values-not-prime = select prime number लेल देल गेल सब मान अभाज्य सूची में होवे के चाही
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers लेल देल गेल मान बाहर कएल गेल संयोजन रहल
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers में 70% से जादा संयोजन बाहर कएल गेल
+
+select-random-combination-fluke = बहुते अनहोनी संजोग से यादृच्छिक मान सब के संयोजन ना चुना जा सकल
+
+select-random-value-fluke = बहुते अनहोनी संजोग से यादृच्छिक मान ना चुना जा सकल
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] ई `<{ $component }>` ना देखाओल जा हइ, काहेकि ई गणित के भीतर हइ आउ `inline` ना हइ। `inline` जोड़ू, जेह से ई ड्रॉप-डाउन सूची बनि जाय, जौन व्यंजक के भीतर समाइ जा रहल हइ।
+        [expanded] ई `<{ $component }>` ना देखाओल जा हइ, काहेकि ई गणित के भीतर हइ आउ `expanded` हइ। `expanded` हटावू; कई पंक्ति वाला डिब्बा व्यंजक के भीतर ना समाय हइ।
+        [on-graph] ई `<{ $component }>` ना देखाओल जा हइ, काहेकि ई आलेख पर खींचे गेल गणित के भीतर हइ, जहाँ इनपुट लेल जगह ना हइ।
+       *[relative-width] ई `<{ $component }>` ना देखाओल जा हइ, काहेकि ई गणित के भीतर हइ आउ एकर चौड़ाई सापेक्ष हइ। चौड़ाई निरपेक्ष इकाई में दऽ, जइसे `px`।
+    }

--- a/packages/i18n/locales/mag/diagnostics.ftl
+++ b/packages/i18n/locales/mag/diagnostics.ftl
@@ -36,7 +36,7 @@
 #   «आउ» / «या» / «अगर»       *and* / *or* / *if*
 #   «जे» / «जेकर»             the relative pronoun and its genitive
 #   «सब»                      the plural, written after the noun
-#   -ल                        the participle: देल, कएल, मिलल, छोड़ल, लिखल
+#   -ल                        the participle: देल, कएल, मिलल, छोड़ल, रहल
 #
 # A sentence that has slipped back into «है», «नहीं», «क्योंकि» or «के लिए»
 # is a mistake to fix rather than a stylistic choice. This is a **framed**

--- a/packages/i18n/locales/mag/editor.ftl
+++ b/packages/i18n/locales/mag/editor.ftl
@@ -1,0 +1,215 @@
+# Magahi (मगही) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script, frame and register** are `chrome.ftl`'s: Devanagari with Latin
+# digits; a Magahi frame — «हइ», «ना», «के», «आउ», «लेल», «काहेकि», «तेकरा
+# लेल», «में», «ई», «कोनो», «जे», «सब» and the **-ल** participles — around a
+# Hindi and Sanskrit technical vocabulary that is declared rather than
+# disguised. Buttons carry the honorific imperative in **-ू** («देखावू»,
+# «दबावू», «राखू», «चुनू»).
+#
+# **`WCAG`, `DoenetML`, `XML`, `styleNumber` and every element and attribute
+# name stay in English.** They are identifiers an author types, not words.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `mag`, so an English-selected
+# branch would be worse than none, and a Magahi noun is unmarked after a
+# numeral in any case.
+#
+# **`help-name-summary` is punctuation.** It renders with `{ $name }` empty
+# for a suggestion the panel has already named, so the em dash and its spaces
+# have to read on their own.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करू
+       *[update] अद्यतन करू
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्सक { $word }
+       *[other] दर्सक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = रूपांतर
+editor-variant-filter = छानू...
+editor-variant-next = अगला रूपांतर चुनू
+editor-variant-previous = पहिले वाला रूपांतर चुनू
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन मिलल। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } लेल क्लिक करू।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } लेल क्लिक करू। कोनो WCAG AA उल्लंघन ना मिलल, बाकिर सुगम्यता के आउ सुझाव हइ।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } लेल क्लिक करू। कोनो सुगम्यता के समस्या ना मिलल।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन मिलल। { $count } WCAG AA उल्लंघन मिलल। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } लेल क्लिक करू।
+        [advisories] कोनो WCAG AA उल्लंघन ना मिलल। सुगम्यता के { $count } आउ सुझाव मिलल। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } लेल क्लिक करू।
+       *[clean] कोनो WCAG AA उल्लंघन ना मिलल। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करे
+           *[open] खोले
+        } लेल क्लिक करू।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग के हिसाब से मदद
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटि
+editor-tab-warnings = चेतावनी
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = पठावल गेल जवाब
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक के विकल्प
+editor-format-as-doenetml = DoenetML के रूप में सजावू
+editor-format-as-xml = XML के रूप में सजावू
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कोनो त्रुटि ना
+editor-no-warnings = कोनो चेतावनी ना
+editor-no-info = कोनो सूचनात्मक निदान ना
+
+editor-show-info-annotations = संपादक में सूचनात्मक निदान देखावू
+editor-show-accessibility-annotations = संपादक में सुगम्यता के निदान देखावू
+
+editor-accessibility-learn-more = जानू कि Doenet सुगम्यता के कइसे देखऽ हइ
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = सुगम्यता के आउ समस्या
+editor-none-found = कुछ ना मिलल
+
+
+## Submitted responses
+
+editor-no-responses = अखने तक कोनो जवाब ना पठावल गेल
+editor-response-answer-id = जवाब के आईडी
+editor-response-response = जवाब
+editor-response-credit = अंक
+editor-response-submitted = पठावल गेल
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेजीकरण देखे लेल कर्सर के कोनो टैग नाम, विशेषता या { $ref } पर राखू।
+
+help-unsupported-ref-chain = { $example } जइसे बहु-भागी संदर्भ के मदद अखने ना हइ।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ई संदर्भ के कोनो लक्ष्य ना मिलल: { $ref }।
+        [multiple] ई संदर्भ के कई लक्ष्य मिलल: { $ref }।
+       *[indeterminate] { $ref } के लक्ष्य तय ना कएल जा सकल।
+    }
+
+help-learn-about-references = संदर्भ के बारे में जानू →
+help-reference-page = संदर्भ के पन्ना →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } के भीतर
+       *[top] सबसे ऊपर के स्तर पर
+    }{ $allowed ->
+        [none] { " — इहाँ कुछ ना राखा जा सकऽ हइ।" }
+        [text] { " — इहाँ पाठ लिखा जा सकऽ हइ हइ।" }
+        [text-and-components] { " — इहाँ पाठ लिखू, या ई आजमावू:" }
+       *[components] { " — ई आजमावू:" }
+    }
+
+help-suggestions-footer = सब { $total } घटक देखे लेल { $shortcut } दबावू।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } के संदर्भ हइ।
+       *[other] { $ref }, { $target } के संदर्भ हइ (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } { $role } के रूप में एकरा लावा।
+       *[other] { $owner } पंक्ति { $line } में { $role } के रूप में एकरा लावा।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } के { $property } गुण के संदर्भ हइ।
+       *[other] { $ref }, { $element } के { $property } गुण के संदर्भ हइ (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड के टुकड़ा
+help-kind-array-entry = सरणी के प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = चालू पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] मान्य मान (हर मद लेल एक):
+       *[other] मान्य मान:
+    }
+
+help-suggested-values = सुझावल मान:
+
+help-inserts = जोड़ऽ हइ:
+
+help-coordinates = निर्देशांक:
+
+help-type = प्रकार:
+
+help-resolved-style = तय शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = तय फलन नाम:
+help-reset-list = ई इनपुट के रीसेट सूची:
+help-added-on-input = ई इनपुट पर जोड़ा गेल:
+help-removed-on-input = ई इनपुट पर हटावा गेल:
+
+help-reset-overrides = { $reset }, { $additional } आउ { $removed } पर भारी परऽ हइ।

--- a/packages/i18n/locales/mag/editor.ftl
+++ b/packages/i18n/locales/mag/editor.ftl
@@ -16,8 +16,10 @@
 # name stay in English.** They are identifiers an author types, not words.
 #
 # **The counts do not fork.** `editor-accessibility-label` and
-# `help-coordinates` write a single `*[other]` where English writes `[one]`
-# and `[other]`: CLDR has no plural data for `mag`, so an English-selected
+# `help-coordinates` drop the `$count` selector English writes and give one
+# form outright — `help-coordinates` is a plain message, and
+# `editor-accessibility-label` interpolates `{ $count }` without selecting
+# on it: CLDR has no plural data for `mag`, so an English-selected
 # branch would be worse than none, and a Magahi noun is unmarked after a
 # numeral in any case.
 #

--- a/packages/i18n/locales/mwr/chrome.ftl
+++ b/packages/i18n/locales/mwr/chrome.ftl
@@ -1,0 +1,133 @@
+# Marwari (मारवाड़ी) viewer chrome: the buttons, panel headers and status words the
+# reader interacts with. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari.** Marwari is written in Devanagari today, in print
+# and online; the Mahajani script it once used for accounts is not a running
+# script for prose and is not attempted here.
+#
+# **Method, stated plainly.** Marwari has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Marwari
+# speaker meets in a Rajasthani classroom, which teaches out of Hindi
+# textbooks. What is Marwari here is the grammatical layer written over it:
+# the genitive रो / री / रा rather than Hindi का / की / के, the object marker
+# नै, the copula छै, the negative कोनी, मांय for *in*, सूं for *from*, अर for
+# *and*, कै for *or*, जे for *if*, रै वास्ते for *for*, and the -ओ imperative
+# (करो, दिखावो, हटावो) that Marwari puts on a button. A reviewer should read
+# this as Marwari grammar over Hindi terminology and is free to replace the
+# terminology wherever Marwari has its own word.
+#
+# Numbers render as 1,234.5 in **Latin digits**, never in Devanagari
+# numerals: that is what CLDR gives for the Devanagari-writing languages of
+# India, and it is what DoenetML pins for every locale (`src/intl.ts`).
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `mwr`, so `lint:i18n` would reject a `[one]` branch outright. Every count
+# in this file goes through a single `*[other]`, keeping only
+# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
+# number itself rather than against a category.
+
+## Answer submission
+
+answer-checking = जाँच्यो जा रैयो छै...
+answer-submitting = भेज्यो जा रैयो छै...
+answer-checking-status = उत्तर जाँच्यो जा रैयो छै
+answer-submitting-status = उत्तर भेज्यो जा रैयो छै
+answer-correct = सही
+answer-incorrect = ग़लत
+answer-response-saved = उत्तर सहेज्यो गयो
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+max-credit-available = अधिकतम संभव अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] कोई प्रयास शेष कोनी
+       *[other] { $count } प्रयास शेष
+    }
+validation-correct = (सही)
+validation-incorrect = (ग़लत)
+validation-partially-correct = (आंशिक रूप सूं सही)
+answer-show-responses = { $answerId } रा { $count } उत्तर दिखावो
+
+## Disclosure panels
+
+feedback-heading = प्रतिक्रिया
+collapsible-click-to-open = (खोलण रै वास्ते क्लिक करो)
+collapsible-click-to-close = (बंद करण रै वास्ते क्लिक करो)
+collapsible-initializing = आरंभ करियो जा रैयो छै...
+footnote-show = पादटिप्पणी दिखावो
+footnote-hide = पादटिप्पणी छिपावो
+description-more-information = अधिक जानकारी
+
+## Controls
+
+slider-previous = पिछलो
+slider-next = अगलो
+keyboard-open = कीबोर्ड खोलो
+keyboard-close = कीबोर्ड बंद करो
+choice-input-remove-choice = { $choice } हटावो
+matrix-remove-row = पंक्ति हटावो
+matrix-add-row = पंक्ति जोड़ो
+matrix-remove-column = स्तंभ हटावो
+matrix-add-column = स्तंभ जोड़ो
+subset-add-remove-points = बिंदु जोड़ो/हटावो
+subset-toggle-points-intervals = बिंदुओं अर अंतरालों रै बिचाळै बदलें
+subset-move-points = बिंदु खिसकावो
+subset-clear = साफ़ करो
+orbital-add-row = पंक्ति जोड़ो
+orbital-remove-row = पंक्ति हटावो
+orbital-add-box = खाँचा जोड़ो
+orbital-remove-box = खाँचा हटावो
+orbital-add-up-arrow = ऊपर रो तीर जोड़ो
+orbital-add-down-arrow = नीचे रो तीर जोड़ो
+orbital-remove-arrow = तीर हटावो
+orbital-row-label = पंक्ति { $row } रो लेबल
+pretzel-answer = उत्तर
+summary-statistics-caption = { $column } रा वर्णनात्मक सांख्यिकी
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक रो पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+## Document status
+
+viewer-initializing = आरंभ करियो जा रैयो छै...
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } मांय मिली।
+       *[lines] पंक्तियों { $startLine }–{ $endLine } मांय मिली।
+    }
+document-contains-errors = इण दस्तावेज़ मांय त्रुटियाँ छै!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+something-went-wrong = कुछ ग़लत हो गयो।
+renderer-load-failed = एक रेंडरर लोड कोनी हो सका। किरपा कर'र पृष्ठ फेरूं लोड करो।
+core-start-failed = आ दस्तावेज़ शुरू कोनी करियो जा सका। किरपा कर'र पृष्ठ फेरूं लोड करो।
+
+core-start-failed-busy = आ दस्तावेज़ शुरू कोनी करियो जा सका। एक साथ कई दस्तावेज़ शुरू हो रैया हा, जिण मांय धीमे उपकरण पर अधिक समय लगता छै। बाकी दस्तावेज़ों रा पूरा होण पर पृष्ठ फेरूं लोड करण सूं बात बन सकै छै।
+
+core-start-failed-retry = आ दस्तावेज़ शुरू कोनी करियो जा सका।
+
+core-start-failed-busy-retry = आ दस्तावेज़ शुरू कोनी करियो जा सका। एक साथ कई दस्तावेज़ शुरू हो रैया हा, जिण मांय धीमे उपकरण पर अधिक समय लगता छै।
+
+core-start-retry = फेरूं कोशिश करो
+
+saved-state-unavailable = आपका सहेज्यो गयो काम लोड कोनी करियो जा सका।

--- a/packages/i18n/locales/mwr/content.ftl
+++ b/packages/i18n/locales/mwr/content.ftl
@@ -1,0 +1,310 @@
+# Marwari (मारवाड़ी) content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari**, as `chrome.ftl`'s header sets out: Marwari is
+# written in Devanagari in print and online, and the Mahajani script it once
+# used for accounts is not a running script for prose.
+#
+# ## Method, and what this file can only say in Hindi
+#
+# मारवाड़ी is spoken in Rajasthan and schooled in Hindi: it has no settled
+# register for mathematics, and the geometry words here — रेखा, रेखाखंड,
+# किरण, सदिश, वक्र, फलन, परवलय, बहुभुज, त्रिभुज, आयत, वृत्त, समचतुर्भुज — are
+# the Hindi terms a student meets in class, written as they stand. The same is
+# true of सारणी, चित्र, पृष्ठभूमि, भराव and the whole of `section-name`. What
+# is मारवाड़ी here is the grammar written over that vocabulary:
+# the genitive रो / री / रा, the object marker नै, the copula छै, the
+# negative कोनी, मांय for *in*, सूं for *from*, माथै for *on*, अर for *and*,
+# कै for *or*, जे for *if*, and रै साथै for *with*
+# — together with the adjective forms below. **A reviewer should start with
+# the adjectives and the section words**: those are the places where a
+# मारवाड़ी word may exist and the seed has used the Hindi one.
+#
+# ## Word order
+#
+# **The adjectives precede the noun**, exactly as they do in English and in
+# Hindi: «मोटो लाल रेखा» is *thick red line*. So
+# `style-with-noun` and `style-filled-with-noun` keep English's order of
+# `{ $description }` and `{ $noun }`, and `style-stroke` keeps English's
+# internal order of width, dash pattern and colour, because that is this
+# language's order too. What does move is everything governed by a
+# postposition: a postposition follows its noun, so the border clause and the
+# background clause come out reversed from English.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` puts the side count in
+# front of the noun — «{ $numSides } भुजावां वाळो सम बहुभुज» — so the whole of it is
+# one `head` and `tail` is empty, as in English and in Hindi. The
+# `-tail` variants of `style-with-noun` and `style-filled-with-noun` are still
+# written out, because they are what a partly-translated locale falls back to.
+#
+# ## Gender and role: the fork is deliberately not taken
+#
+# मारवाड़ी **does** inflect a marked adjective for gender and for the
+# direct/oblique distinction, the way Hindi does — the -ओ/-उ masculine here has
+# a feminine in -ी and an oblique in -ा — so English's `$gender` and `$role`
+# arguments are not idle in this language, and the shape Hindi's catalog uses
+# would be the right shape here.
+#
+# **This seed does not fork on either, and writes the masculine singular
+# direct form throughout.** That is a decision about what a seed can honestly
+# claim, not a claim that the language has no agreement. Forking would require
+# a trustworthy gender for every noun in `noun` in *this* language rather than
+# in Hindi, plus an oblique paradigm the seed is sure of for each of the three
+# clause positions; the seed has neither, and a confidently wrong agreement
+# table is harder for a reviewer to repair than a uniformly unagreed one.
+# **This is the single largest gap in the file.** A reviewer who supplies the
+# genders can lift Hindi's `{ $role -> … { $gender -> … } }` shape verbatim.
+#
+# For the same reason `noun-gender` answers the bare token `neuter` that
+# English answers: no adjective in this file selects on it, so a gender table
+# here would be inert until the fork above is taken.
+#
+# ## Number
+#
+# **Nothing selects on a count.** CLDR has no plural data for `mwr`, so
+# `lint:i18n` would reject a plural category outright — and nothing in this
+# file counts in any case. Numbers render in Latin digits, never in Devanagari
+# numerals, which is what DoenetML pins for every locale (`src/intl.ts`).
+#
+# ## Chemistry
+#
+# `element-name` and `element-anion-name` are **deliberately absent**, so
+# those 130 keys fall back to English. Chemistry is taught here out of Hindi
+# textbooks, so the element names a मारवाड़ी student meets are the Hindi
+# ones, and a table under this tag would be a claim about spelling rather than
+# about the language. Hindi's own table is in `locales/hi/content.ftl` for
+# anyone who wants to start from it.
+
+## Style vocabulary
+
+color =
+    .black = कालो
+    .white = सफ़ेद
+    .gray = स्लेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow = पीळो
+    .green = हरियो
+    .cyan = फ़िरोज़ी
+    .blue = नीलो
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown = भूरो
+
+line-width =
+    .thick = मोटो
+    .thin = पातळो
+
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+
+# Oblique plural noun phrases, because their other use is in front of «वाळो»
+# in `style-filled` and `style-fill`. They are the Hindi forms: the seed has
+# no मारवाड़ी oblique plural for them that it trusts.
+fill-style =
+    .horizontal = क्षैतिज रेखाओं
+    .vertical = ऊर्ध्वाधर रेखाओं
+    .diagonal = विकर्ण रेखाओं
+    .backdiagonal = विपरीत विकर्ण रेखाओं
+    .dots = बिंदुओं
+    .diamonds = समचतुर्भुजों
+
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = प्रवणता क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = धन चिह्न
+
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजावां वाळो सम बहुभुज
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = भरियो
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वाळो { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वाळो { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वाळो { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# The postposition follows its noun, so the whole clause comes out after the
+# adjective and English's preposition-first order is reversed. There is no
+# article, so the `-article` branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारै रै साथै
+        [and] अर { $border } किनारै रै साथै
+        [and-article] अर { $border } किनारै रै साथै
+       *[with] { $border } किनारै रै साथै
+    }
+
+# The fill-pattern words are oblique plurals, so this message supplies «भराव»
+# for them to hang off rather than printing them bare.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } वाळो { $color } भराव
+       *[plain] { $color } भराव
+    }
+
+style-unfilled = बिना भराव
+
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि माथै { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = कोई कोनी
+
+
+## Boolean words
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## Answer buttons
+
+answer-submit-label = जाँचो
+answer-submit-label-no-correctness = उत्तर भेजो
+
+
+## Sectional blocks
+
+section-name =
+    .activity = गतिविधि
+    .aside = पार्श्व टिप्पणी
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = उत्तर
+    .note = टिप्पणी
+    .objectives = उद्देश्य
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = प्रश्न
+    .problems = प्रश्न
+    .proof = प्रमाण
+    .question = सवाल
+    .section = अनुभाग
+    .solution = हल
+    .task = काम
+    .theorem = प्रमेय
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = संकेत
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = पिछलो
+paginator-next = अगलो
+paginator-page = पृष्ठ
+
+paginator-page-status = { $numPages } मांय सूं { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = कै
+
+piecewise-condition-if = जे
+
+piecewise-condition-otherwise = नीं तो
+
+
+## Chemistry
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = रिक्त
+
+math-embedded-input-blank-ordinal = { $total } मांय सूं रिक्त { $ordinal }

--- a/packages/i18n/locales/mwr/diagnostics.ftl
+++ b/packages/i18n/locales/mwr/diagnostics.ftl
@@ -1,0 +1,660 @@
+# Marwari (मारवाड़ी) diagnostics: the errors and warnings shown to whoever is looking
+# at the screen. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari.** Marwari is written in Devanagari today, in print
+# and online; the Mahajani script it once used for accounts is not a running
+# script for prose and is not attempted here.
+#
+# **Method, stated plainly.** Marwari has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Marwari
+# speaker meets in a Rajasthani classroom, which teaches out of Hindi
+# textbooks. What is Marwari here is the grammatical layer written over it:
+# the genitive रो / री / रा rather than Hindi का / की / के, the object marker
+# नै, the copula छै, the negative कोनी, मांय for *in*, सूं for *from*, अर for
+# *and*, कै for *or*, जे for *if*, रै वास्ते for *for*, and the -ओ imperative
+# (करो, दिखावो, हटावो) that Marwari puts on a button. A reviewer should read
+# this as Marwari grammar over Hindi terminology and is free to replace the
+# terminology wherever Marwari has its own word.
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `mwr`, so every count in this file goes through a single `*[other]`. The
+# one exception is `field-function-wrong-num-outputs`, where English is not
+# counting but distinguishing a one-output field from a two-output one; that
+# fork is kept as the numeric literal `[1]`, which Fluent matches against the
+# number itself rather than against a plural category.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दो सिरे दिए जाण पर { $attributes } पर ध्यान कोनी दिया जावै
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा अर मध्यबिंदु दोनों दिए जाण पर { $attributes } पर ध्यान कोनी दिया जावै
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु रै बिना midpointOffset रो कोई प्रभाव कोनी होवै
+
+## `<line>`
+
+line-points-undetermined-dimensions = ऐसे बिंदुओं सूं होकर जाण वाली रेखा जिनकी विमा अनिश्चित छै।
+
+line-points-too-few-dimensions = रेखा नै कम सूं कम द्विविमीय बिंदुओं सूं होकर जाना चाहीजै।
+
+line-points-depend-on-variables = रेखा उन बिंदुओं सूं होकर जावै छै जो चरों पर निर्भर छै: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } अर { $variable2 } मांय रेखा रा समीकरण रो प्रारूप अमान्य छै।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एक साथ through, endpoint अर direction सूं निर्धारित छै। दिए गिया through नै छोड़्यो जा रैयो छै।
+
+ray-dimension-mismatch = किरण मांय numDimensions मेल कोनी खाते।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एक साथ head, tail अर displacement सूं निर्धारित छै। दिए गिया head नै छोड़्यो जा रैयो छै।
+
+vector-dimension-mismatch = सदिश मांय numDimensions मेल कोनी खाते।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` री ओर आकर्षित कोनी करियो जा सकै, क्यूंकै बीं मांय nearestPoint अवस्था चर कोनी।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित कोनी करियो जा सकै, क्यूंकै बीं मांय nearestPoint अवस्था चर कोनी।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` रा भीतरी भाग तक सीमित कोनी करियो जा सकै, क्यूंकै बीं मांय nearestPoint अवस्था चर कोनी।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होण वाले choiceInput रै वास्ते labelPosition पर ध्यान कोनी दिया जावै
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput रै वास्ते दिए गिया indices नै छोड़्यो जा रैयो छै, क्यूंकै indices री संख्या choice संतानों री संख्या सूं मेल कोनी खाती।
+
+pretzel-indices-count-mismatch = problem रै वास्ते दिए गिया indices नै छोड़्यो जा रैयो छै, क्यूंकै indices री संख्या problem संतानों री संख्या सूं मेल कोनी खाती।
+
+shuffle-indices-count-mismatch = shuffle रै वास्ते दिए गिया indices नै छोड़्यो जा रैयो छै, क्यूंकै indices री संख्या घटकों री संख्या सूं मेल कोनी खाती।
+
+indices-ignored-out-of-range = { $component } रै वास्ते दिए गिया indices नै छोड़्यो जा रैयो छै, क्यूंकै कुछ अनुक्रमांक परिसर सूं बाहर छै।
+
+pretzel-indices-repeated = pretzel रै वास्ते दिए गिया indices नै छोड़्यो जा रैयो छै, क्यूंकै कुछ अनुक्रमांक दोहराए गिया छै।
+
+pretzel-circuit-first-index = circuit विधा मांय pretzel रै वास्ते दिए गिया indices नै छोड़्यो जा रैयो छै, क्यूंकै पहलो अनुक्रमांक 1 होणो चाहीजै।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` नै पाठ संतानों रै साथै काम करण रै वास्ते `type` विशेषता देनी होवैली।
+
+invalid-type-defaulting-to-math = { $component } घटक रै वास्ते प्रकार { $type } अमान्य छै। आ math, text, number कै boolean मांय सूं एक होणो चाहीजै। math रो उपयोग करियो जा रैयो छै।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } रै वास्ते मान्य घटक कोनी। छोड़्यो जा रैयो छै।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य छै; प्रकार number पर सेट करियो जा रैयो छै।
+
+invalid-variable-value = चर रो मान अमान्य छै: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } एक संख्या होणी चाहीजै
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } एक पूर्णांक होणो चाहीजै
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष मापों रै वास्ते उपलब्ध कोनी। चौड़ाइयाँ सापेक्ष री जा रैयी छै।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष मापों रै वास्ते उपलब्ध कोनी। हाशिये सापेक्ष किए जा रैया छै।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: इण मांय कम सूं कम एक खंड संतान होणी चाहीजै।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर ध्यान कोनी दिया जावै।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एक घटक तक पहुँचनी चाहीजै।
+
+label-for-unresolved = `<label>` पर `for` विशेषता किसी घटक तक कोनी पहुँच सकी।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता ऐसे `<answer>` रो संदर्भ देती छै जिण मांय इनपुट स्पष्ट रूप सूं लिखे गिया छै; सीधे उसी इनपुट रो संदर्भ द्यो।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता ऐसे `<answer>` रो संदर्भ देती छै जिण मांय लेबल लगाण योग्य इनपुट कोनी।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता किसी इनपुट कै किसी उत्तर रो संदर्भ देनी चाहीजै।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता रै वास्ते `<{ $component }>` रो कै तो संक्षिप्त विवरण होणो चाहीजै कै उसे सजावटी बताया जाना चाहीजै।
+
+accessibility-video-short-description = सुगम्यता रै वास्ते `<video>` रो संक्षिप्त विवरण होणो चाहीजै।
+
+accessibility-input-short-description-or-label = सुगम्यता रै वास्ते `<{ $component }>` रो संक्षिप्त विवरण कै लेबल होणो चाहीजै।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता रै वास्ते इनपुट बनाण वाले `<answer>` रो संक्षिप्त विवरण कै लेबल होणो चाहीजै।
+
+accessibility-short-description-contains-math = संक्षिप्त विवरणों मांय `<{ $component }>` जियां गणितीय घटक कोनी होण चाहीजै। गणित नै शब्दों मांय लिखो।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } रो खंड शीर्षक पाठ रै वास्ते वैषम्य अपर्याप्त छै (गहरी विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम सूं कम { $threshold }:1 चाहीजै)।
+       *[other] { $colorName } रो खंड शीर्षक पाठ रै वास्ते वैषम्य अपर्याप्त छै ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम सूं कम { $threshold }:1 चाहीजै)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदुओं रा संख्यात्मक मान न हों, तब { $count } बिंदुओं सूं होकर जाण वाला `<circle>` अभी उपलब्ध कोनी।
+
+circle-too-many-through-points = 3 सूं अधिक बिंदुओं सूं होकर जाण वाला वृत्त परिकलित कोनी करियो जा सकै।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र अर गुज़रने वाले बिंदु एक साथ दिए जाण पर वृत्त परिकलित कोनी करियो जा सकै।
+
+circle-center-with-multiple-points = दिए गिया केंद्र रै साथै 1 सूं अधिक बिंदु सूं होकर जाण वाला वृत्त परिकलित कोनी करियो जा सकै।
+
+circle-radius-too-small = वृत्त परिकलित कोनी करियो जा सकै: दोनों बिंदुओं रै बिचाळै री दूरी { $distance } छै, इसलिए दी गी त्रिज्या { $radius } बहुत छोटी छै।
+
+circle-radius-with-many-points = दी गी त्रिज्या रै साथै दो सूं अधिक बिंदुओं सूं होकर जाण वाला वृत्त कोनी बनाया जा सकै।
+
+circle-invalid-center-or-through-points = वृत्त रो केंद्र कै गुज़रने वाले बिंदु अमान्य छै।
+
+circle-radius-center-with-multiple-points = दिए गिया केंद्र रै साथै 1 सूं अधिक बिंदु सूं होकर जाण वाले वृत्त री त्रिज्या परिकलित कोनी री जा सकै।
+
+circle-change-radius-non-numerical = जिण वृत्त रा गुज़रने वाले बिंदु संख्यात्मक कोनी, बींरी त्रिज्या कोनी बदली जा सकै
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होण पर, दी गी त्रिज्या रै साथै एक सूं अधिक बिंदु सूं होकर जाण वाला वृत्त कोनी बनाया जा सकै।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदुओं सूं होकर जाण वाले वृत्त रो केंद्र बदलना अभी उपलब्ध कोनी।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन रा प्रांत री विमाएँ अपर्याप्त छै। प्रांत मांय { $intervals } अंतराल छै, पर फलन मांय { $inputs } इनपुट छै।
+
+function-domain-invalid-format = फलन रा प्रांत रो प्रारूप अमान्य छै।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन रो असंख्यात्मक उच्चिष्ठ छोड़्यो जा रैयो छै।
+        [minimum] फलन रो असंख्यात्मक निम्निष्ठ छोड़्यो जा रैयो छै।
+        [extremum] फलन रो असंख्यात्मक चरम मान छोड़्यो जा रैयो छै।
+        [point] फलन रो असंख्यात्मक बिंदु छोड़्यो जा रैयो छै।
+        [slope] फलन री असंख्यात्मक प्रवणता छोड़ी जा रैयी छै।
+       *[other] फलन रो असंख्यात्मक { $type } छोड़्यो जा रैयो छै।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन रो रिक्त उच्चिष्ठ छोड़्यो जा रैयो छै।
+        [minimum] फलन रो रिक्त निम्निष्ठ छोड़्यो जा रैयो छै।
+        [extremum] फलन रो रिक्त चरम मान छोड़्यो जा रैयो छै।
+        [point] फलन रो रिक्त बिंदु छोड़्यो जा रैयो छै।
+       *[other] फलन रो रिक्त { $type } छोड़्यो जा रैयो छै।
+    }
+
+function-points-too-close = फलन मांय दो बिंदु बहुत पास-पास छै। फलन परिभाषित कोनी करियो जा सकै।
+
+function-iterates-input-output-mismatch = फलन रो पुनरावर्तन तभी संभव छै जब इनपुट री संख्या आउटपुट री संख्या रा बराबर हो। इण फलन मांय { $inputs } इनपुट अर { $outputs } आउटपुट छै।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम री लंबाई अमान्य छै। आ ऋणेतर पूर्णांक होणी चाहीजै।
+
+sequence-invalid-step = अनुक्रम रो चरण अमान्य छै। { $type } प्रकार रा अनुक्रम रै वास्ते आ एक संख्या होणी चाहीजै।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम रो "{ $attribute }" अमान्य छै। आ एक संख्या होणी चाहीजै।
+
+sequence-invalid-endpoint-letters = अक्षर अनुक्रम रो "{ $attribute }" अमान्य छै। आ अक्षरों रो संयोजन होणो चाहीजै।
+
+sequence-invalid-endpoint = अनुक्रम रो "{ $attribute }" अमान्य छै।
+
+select-from-sequence-coprime-not-numbers = संख्याएँ कोनी चुनी जा रहीं, इसलिए coprime छोड़्यो गयो
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations दिया गयो छै, इसलिए coprime छोड़्यो गयो
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` रै वास्ते target अमान्य छै: लक्ष्य कोनी मिल्यो।
+
+target-state-variable-not-found = `<{ $source }>` रै वास्ते target अमान्य छै: `<{ $component }>` पर "{ $property }" नाम रो अवस्था चर कोनी मिल्यो।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` रा चर स्वतंत्र चर सूं भिन्न होण चाहीजै।
+
+ode-system-duplicate-variable-names = दोहराए गिया आश्रित चर नामों रै साथै ODE रा दाएँ पक्ष रा फलन परिभाषित कोनी किए जा सकै।
+
+ode-system-rhs-function-error = ODE रा दाएँ पक्ष रो फलन परिभाषित कोनी करियो जा सकै। mathjs फलन बनाते समय त्रुटि हुई।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखाओं रै बिचाळै रो कोण परिभाषित कोनी करियो जा सकै
+
+angle-invalid-through-point = `<angle>` रा through मांय अमान्य बिंदु छै
+
+parabola-vertex-too-many-points = दिए गिया शीर्ष रै साथै 1 सूं अधिक बिंदु सूं होकर जाण वाला परवलय अभी उपलब्ध कोनी।
+
+parabola-too-many-points = 3 सूं अधिक बिंदुओं सूं होकर जाण वाला परवलय अभी उपलब्ध कोनी।
+
+intersection-too-many-items = दो सूं अधिक वस्तुओं रो प्रतिच्छेदन अभी उपलब्ध कोनी
+
+## Other math components
+
+ionic-compound-not-two-ions = दो आयनों रै अलावा किसी अर स्थिति रै वास्ते आयनिक यौगिक अभी उपलब्ध कोनी।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक केवल एक धनायन अर एक ऋणायन रै वास्ते उपलब्ध छै।
+
+solve-equations-cannot-evaluate = समीकरण रो मान कोनी निकाला जा सका, इसलिए बो हल कोनी करियो जा सकै: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालते समय operandNumber देना आवश्यक छै।
+
+eigen-decomposition-failed = आव्यूह रा अभिलक्षणिक मान परिकलित कोनी किए जा सके
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न मांय कोनी आते, इसलिए वे सदा रिक्त सूं मेल खाएँगे।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" नै समझा कोनी जा सका। आ none, medium, dense, कै रिक्त स्थान सूं अलग री गी दो धनात्मक संख्याएँ होणी चाहीजै, जियां grid="1 0.5"। कोई ग्रिड कोनी खींचा जाएगा।
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर मांय xLabelPosition="left" समर्थित कोनी; दाईं स्थिति वाला व्यवहार अपणायो जा रैयो छै।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर मांय yLabelPosition="bottom" समर्थित कोनी; ऊपरी स्थिति वाला व्यवहार अपणायो जा रैयो छै।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण रै वास्ते अक्ष सीमाएँ अमान्य छै; पूर्वनिर्धारित bbox (-10,-10,10,10) अपणायो जा रैयो छै।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण रै वास्ते चौड़ाई अमान्य छै; पूर्वनिर्धारित आरेख चौड़ाई 425 अपनाई जा रैयी छै।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण रै वास्ते aspectRatio अमान्य छै; पूर्वनिर्धारित अनुपात 1 अपणायो जा रैयो छै।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अक्ष सीमाओं री तुलना मांय ग्रिड रो अंतराल बहुत महीन छै; prefigure रेंडरर मांय ग्रिड छोड़्यो जा रैयो छै।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर रो उपयोग न होण पर टीकाएँ कोनी खींची जाएँगी।
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` नै ऐसा फलन चाहीजै जिण मांय { $expected ->
+        [1] एक आउटपुट हो, यानी हर बिंदु पर प्रवणता y', जियां `y - x`
+       *[other] दो आउटपुट हों, यानी हर बिंदु पर सदिश, जियां `(y, -x)`
+    }, पर दिए गिया फलन मांय { $found } आउटपुट छै। { $alternative ->
+        [none] कुछ कोनी खींचा जाएगा।
+       *[other] बीं फलन रै वास्ते `<{ $alternative }>` घटक छै। कुछ कोनी खींचा जाएगा।
+    }
+
+field-function-attribute-ignored-with-child = `function` विशेषता पर ध्यान कोनी दिया जावै, क्यूंकै फलन घटक रै भीतर भी दिया गयो छै; भीतर वाला ही लियो जावै छै। फलन दोनों मांय सूं केवल एक तरह सूं द्यो।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषता बीं व्यंजक रा चर बताती छै जो घटक रै भीतर सीधे लिखा गयो हो। { $reason ->
+        [function-child] यहाँ फलन `<function>` संतान रै रूप मांय दिया गयो छै, जो अपने चर स्वयं बताती छै, इसलिए `variables` पर ध्यान कोनी दिया जावै।
+       *[no-expression] यहाँ ऐसा कोई व्यंजक कोनी दिया गयो, इसलिए `variables` पर ध्यान कोनी दिया जावै।
+    }
+
+multiple-annotations-children = `<graph>` मांय एक सूं अधिक `<annotations>` संतानें मिलीं; अंतिम नै छोड़कर सभी पर ध्यान कोनी दिया जाएगा।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार नै विस्तारित कै प्रतिलिपित कोनी करियो जा सकै: { $type }।
+
+copy-prop-not-found = { $component } प्रकार रा घटक पर { $property } गुण कोनी मिल्यो
+
+collect-no-source = collect रै वास्ते कोई स्रोत कोनी मिल्यो।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार रा घटक एकत्र कोनी किए जा सकै, क्यूंकै आ मान्य घटक प्रकार कोनी।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` रो संदर्भ कोनी दिया जा सकै
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } कोनी बुलाया जा सकै
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़ों रो आकार अमान्य छै। पंक्तियों री लंबाई असंगत छै। componentIdx :{ $componentIdx } मांय मिल्यो
+
+data-frame-duplicate-column-names = आँकड़ों मांय स्तंभ नाम दोहराए गिया छै। componentIdx :{ $componentIdx } मांय मिल्यो
+
+data-frame-missing-column-name = आँकड़ों मांय एक स्तंभ नाम अनुपस्थित छै। componentIdx :{ $componentIdx } मांय मिल्यो
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = इण उत्तर रो एक award स्वयं answer टैग द्वारा भेजे गिया उत्तर पर आधारित छै, जिससे अप्रत्याशित व्यवहार होवैला।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र रै भीतर रा `<answer>` पर `maxNumAttempts` सेट करण रो कोई प्रभाव कोनी होवै, क्यूंकै प्रयासों री संख्या पात्र नियंत्रित करै छै। `maxNumAttempts` पात्र पर सेट करो।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले किसी अन्य पात्र रै भीतर स्थित `sectionWideCheckWork` पात्र पर `maxNumAttempts` सेट करण रो कोई प्रभाव कोनी होवै, क्यूंकै प्रयासों री संख्या बाहरी पात्र नियंत्रित करै छै। `maxNumAttempts` बाहरी पात्र पर सेट करो।
+
+answer-attributes-need-symbolic-equality = symbolicEquality सेट किए बिना { $attributes } विशेषताओं रो कोई प्रभाव कोनी होवैला।
+
+answer-invalid-type = answer रै वास्ते प्रकार अमान्य छै: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = क्यूंकै घटक `<{ $component }>` रो नाम कोनी, इसे मॉड्यूल विशेषता रै रूप मांय उपयोग कोनी करियो जा सकै
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` नै मॉड्यूल री विशेषता रै रूप मांय उपयोग कोनी करियो जा सकै, क्यूंकै घटक प्रकार `<module>` मांय "{ $name }" विशेषता पहले सूं परिभाषित छै।
+
+conditional-content-condition-ignored = case कै else संतानों वाले `<conditionalContent>` घटक पर `condition` विशेषता पर ध्यान कोनी दिया जावै।
+
+slider-markers-type-mismatch = चिह्नकों रो प्रकार स्लाइडर रा प्रकार सूं मेल कोनी खाता।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: प्रत्येक `<problem>` मांय एक `<statement>` अर एक `<answer>` होणो चाहीजै।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" मांय पहलो `<problem>` भ्रामक विकल्प कोनी हो सकै।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` रै वास्ते मान { $values } अमान्य छै; छोड़्यो जा रैयो छै।
+
+attribute-must-be-references = विशेषता `{ $attribute }` रै वास्ते मान `{ $value }` अमान्य छै। विशेषता `$` सूं आरंभ होण वाले संदर्भों सूं बनी होणी चाहीजै।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } मांय अमान्य फलन नाम छोड़े गिया: { $names }। प्रत्येक नाम रा दृश्य भाग मांय कम सूं कम 2 वर्ण (अक्षर कै योजक चिह्न) होण चाहीजै; उसके बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आ सकै छै।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य छै: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहराई कोनी जा सकै।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार रा घटक रै वास्ते विशेषता "{ $attribute }" अमान्य छै।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } मांय { $context ->
+        [text-on-background] पृष्ठभूमि रंग री तुलना मांय पाठ रंग
+        [high-contrast] कैनवास री तुलना मांय उच्च वैषम्य रंग
+        [line] कैनवास री तुलना मांय रेखा रंग
+        [marker] कैनवास री तुलना मांय चिह्नक रंग
+       *[text-on-canvas] कैनवास री तुलना मांय पाठ रंग
+    } रै वास्ते वैषम्य अपर्याप्त छै{ $mode ->
+        [dark] { " (गहरी विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम सूं कम { $threshold }:1 चाहीजै)।
+
+style-definition-dark-mode-text-background-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा रै वास्ते पर्याप्त वैषम्य वाले रंग दिए छै, इन मानों सूं व्युत्पन्न गहरी विधा रा रंगों मांय पाठ रंग अर पृष्ठभूमि रंग रै बिचाळै वैषम्य अपर्याप्त छै ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम सूं कम { $threshold }:1 चाहीजै)। { $suggestion ->
+        [available] गहरी विधा मांय पर्याप्त वैषम्य सुनिश्चित करण रै वास्ते कै तो हल्की विधा रो वैषम्य बढ़ावो (जियां { $lightAttribute }="{ $lightColor }" सेट करो) कै गहरी विधा रो रंग अधिरोहित करो (जियां { $darkAttribute }="{ $darkColor }" सेट करो)।
+       *[none] गहरी विधा मांय पर्याप्त वैषम्य सुनिश्चित करण रै वास्ते हल्की विधा रो वैषम्य बढ़ावो कै व्युत्पन्न रंगों नै textColorDarkMode अर/कै backgroundColorDarkMode सूं अधिरोहित करो।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा रै वास्ते पर्याप्त वैषम्य वाला पाठ रंग दिया छै, इण मान सूं व्युत्पन्न गहरी विधा रा पाठ रंग रो कैनवास री तुलना मांय वैषम्य अपर्याप्त छै ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम सूं कम { $threshold }:1 चाहीजै)। { $suggestion ->
+        [available] गहरी विधा मांय पर्याप्त वैषम्य सुनिश्चित करण रै वास्ते कै तो हल्की विधा रो वैषम्य बढ़ावो (जियां textColor="{ $lightColor }" सेट करो) कै गहरी विधा रो रंग अधिरोहित करो (जियां textColorDarkMode="{ $darkColor }" सेट करो)।
+       *[none] गहरी विधा मांय पर्याप्त वैषम्य सुनिश्चित करण रै वास्ते हल्की विधा रो वैषम्य बढ़ावो कै व्युत्पन्न रंग नै textColorDarkMode सूं अधिरोहित करो।
+    }
+
+section-multiple-style-palettes = एक खंड केवल एक <stylePalette> चुन सकै छै; अंतिम रो उपयोग करियो जा रैयो छै।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै numToSelect ऋणेतर पूर्णांक कोनी।
+
+variant-num-to-select-not-constant-number = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै numToSelect अचर कोनी।
+
+variant-with-replacement-not-constant-boolean = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै withReplacement अचर बूलीय मान कोनी।
+
+variant-select-weight-disables-unique = जे कोई विकल्प selectWeight कै selectForVariants देता छै तो select रा अद्वितीय संस्करण निष्क्रिय हो जावै छै
+
+variant-coprime-undetermined = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै आ तय कोनी हो सका कि coprime सदा असत्य छै।
+
+variant-attribute-not-constant = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै { $attribute } अचर कोनी।
+
+variant-attribute-not-number = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै { $attribute } संख्या कोनी।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार रा { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै { $attribute } { $expected ->
+        [letters-combination] अक्षरों रो संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } कोनी।
+
+variant-length-not-integer = { $component } रा अद्वितीय संस्करण निर्धारित कोनी किए जा सकै, क्यूंकै length पूर्णांक कोनी।
+
+variant-sort-not-implemented = sort वाले { $component } रा अद्वितीय संस्करण अभी उपलब्ध कोनी
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } रा अद्वितीय संस्करण अभी उपलब्ध कोनी
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार रा { $component } रा अद्वितीय संस्करण अभी उपलब्ध कोनी
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } रा अद्वितीय संस्करण अभी उपलब्ध कोनी
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख रा prefigure रेंडरर मांय समर्थित कोनी; वंशज छोड़्यो गयो।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित कै अपूर्ण छै; वंशज छोड़्यो गयो।
+
+prefigure-curve-label-omitted = { $subject }: रूपांतरित वक्र तत्वों पर लेबल समर्थित कोनी; लेबल छोड़्यो गयो।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित कोनी; वंशज छोड़्यो गयो।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित कोनी; वंशज छोड़्यो गयो।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves केवल सूत्र प्रकार रा संतान फलनों रो समर्थन करै छै; वंशज छोड़्यो गयो।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल रा लेबल
+       *[point] बिंदु लेबल
+    } रै वास्ते labelPosition '{ $labelPosition }' समर्थित कोनी; PreFigure री पूर्वनिर्धारित संरेखण अपनाई जा रैयी छै।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure मांय समर्थित कोनी; ठोस भराव अपणायो जा रैयो छै।
+
+prefigure-line-style-unknown = { $subject }: अज्ञात रेखा शैली '{ $lineStyle }' PreFigure रा आउटपुट सूं छोड़ी गी।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure री 'diamond' शैली पर मानचित्रित री गी।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure मांय समर्थित कोनी; पूर्वनिर्धारित शैली अपनाई जा रैयी छै।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य निर्धारित कोनी हो सका। टीका छोड़ी गी।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` सूं कई लक्ष्य निकले; पहलो लक्ष्य लियो जा रैयो छै।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य उसे समेटे आलेख रा बाहर छै। टीका छोड़ी गी।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण मांय लक्ष्य समर्थित आलेखीय वस्तु कोनी। टीका छोड़ी गी।
+
+annotation-text-missing = `<annotation>`: `text` अनुपस्थित कै रिक्त; रिक्त पाठ दिया जा रैयो छै।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता रो पता चला।
+       *[other] `<{ $componentType }>` घटक सूं जुड़ी चक्रीय निर्भरता रो पता चला।
+    }
+
+reference-no-referent = इण संदर्भ रो कोई लक्ष्य कोनी मिल्यो: `{ $reference }`
+
+reference-multiple-referents = इण संदर्भ रा कई लक्ष्य मिल्या: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` री विशेषता { $attribute } रो प्रारूप अमान्य छै।
+
+children-invalid = `<{ $componentType }>` री संतानें अमान्य छै: अमान्य संतानें मिलीं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` रै वास्ते मान `{ $value }` अमान्य छै; मान `{ $default }` रो उपयोग करियो जा रैयो छै
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } कोनी मिल्यो।
+       *[other] DoenetML संस्करण { $version } कोनी मिल्यो। संस्करण { $fallback } पर लौटा जा रैयो छै
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` रो समापन टैग कोनी। स्वतः बंद होण वाला टैग कै `</{ $tagName }>` टैग अपेक्षित हो।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` मांय त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` रो मान अनुपस्थित प्रतीत होवै छै।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य छै
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य छै
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य छै। उद्धरण चिह्न मेल कोनी खाते। एक `{ $quote }` अनुपस्थित प्रतीत होवै छै
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम रो टैग मिल्यो, जियां `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद कोनी हुआ (एक `>` अनुपस्थित प्रतीत होवै छै)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम रो टैग मिल्यो `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद कोनी हुआ (`/>` अनुपस्थित प्रतीत होवै छै)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य कोनी। इणरी विशेषताएँ ग़लत हो सकै छै।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम रो समापन टैग मिल्यो, जियां `</`
+
+parse-attribute-value-unquoted = विशेषता मान उद्धरण चिह्नों मांय होण चाहीजै: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिल्यो, पर बीं सूं मेल खाता आरंभ टैग कोनी
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल कोनी खाता। `</{ $expected }>` अपेक्षित हो। `{ $found }` मिल्यो
+
+parser-node-unconvertible = नोड { $node } नै Dast नोड मांय परिवर्तित कोनी करियो जा सका।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य छै। { $reason ->
+        [characters] नामों मांय केवल अक्षर, अंक, अधोरेखा कै योजक चिह्न हो सकै छै।
+       *[start] नाम अक्षर सूं आरंभ होण चाहीजै।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य छै। नाम अक्षर सूं आरंभ होण चाहीजै।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार रा answer मांय video विशेषता होणी चाहीजै
+
+answer-video-watched-video-not-reference = videoWatched प्रकार रा answer री video विशेषता एक संदर्भ होणी चाहीजै
+
+answer-name-not-single-text = answer री name विशेषता मांय केवल एक पाठ संतान होणी चाहीजै
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन रा बहुत अधिक स्तरों रा कारण बाहरी DoenetML प्राप्त कोनी करियो जा सका। कहीं चक्रीय संदर्भ तो कोनी?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" सूं DoenetML प्राप्त कोनी करियो जा सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" सूं प्राप्त DoenetML अमान्य छै: आ घटक प्रकार "{ $componentType }" सूं मेल कोनी खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित छै; इणरै ठोड़ `{ $to }` रो उपयोग करो।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित छै; इणरै ठोड़ `{ $to }` रो उपयोग करो।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित छै अर छोड़ दी गी, क्यूंकै `{ $to }` भी दिया गयो छै।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित छै अर छोड़ दी गी, क्यूंकै `{ $to }` भी दिया गयो छै।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित छै अर छोड़ दी गी।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित छै; इणरै ठोड़ `<{ $child }>` संतान लिखो।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` रो मान `{ $value }` अप्रचलित छै; इणरै ठोड़ `{ $to }` रो उपयोग करो।
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` केवल अंग्रेज़ी रो बहुवचन बना सकै छै, इसलिए { $locale } मांय लिखे दस्तावेज़ मांय बींरो पाठ अपरिवर्तित रहता छै। बहुवचन रूप सीधे लिखो, कै `pluralForm` विशेषता सूं द्यो।
+
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कोई परिचित Doenet तत्व कोनी।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज़ रा मूल मांय मान्य कोनी।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` रै भीतर मान्य कोनी।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` मांय `{ $attribute }` नाम री कोई विशेषता कोनी।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` री विशेषता `{ $attribute }` एक सूची होणी चाहीजै जिसकी हर मद इनमें सूं एक हो: { $allowed }
+       *[other] तत्व `<{ $tag }>` री विशेषता `{ $attribute }` इनमें सूं एक होणी चाहीजै: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select रै वास्ते संस्करण नाम अमान्य छै। संस्करण नाम { $variantName } { $numOptions } विकल्पों मांय आता छै, पर चुनण री संख्या { $numToSelect } छै।
+
+select-variant-name-without-options = select रै वास्ते संस्करण दिए गिया छै, पर संभावित संस्करण नाम रै वास्ते कोई विकल्प कोनी: { $variantName }।
+
+select-variant-name-not-possible = select रै वास्ते दिया गयो संस्करण नाम { $variantName } संभावित संस्करण नाम कोनी।
+
+select-too-few-options = केवल { $numOptions } घटकों मांय सूं { $numToSelect } कोनी चुने जा सकै।
+
+select-from-sequence-too-few-values = { $length } लंबाई रा अनुक्रम सूं { $numToSelect } मान कोनी चुने जा सकै।
+
+select-from-sequence-indices-count-mismatch = select रै वास्ते दिए गिया अनुक्रमांकों री संख्या चुनण री संख्या सूं मेल खानी चाहीजै
+
+select-from-sequence-indices-not-integers = select रै वास्ते दिए गिया सभी अनुक्रमांक पूर्णांक होण चाहीजै
+
+select-from-sequence-index-excluded = selectfromsequence रै वास्ते दिया गयो अनुक्रमांक बहिष्कृत हो
+
+select-from-sequence-indices-excluded-combination = selectfromsequence रै वास्ते दिए गिया अनुक्रमांक बहिष्कृत संयोजन बनाते हा
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक कोनी चुने जा रैया, इसलिए सहअभाज्य संयोजन कोनी चुने जा सकै।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्याएँ कोनी चुनी जा सकै। सभी संभावित मानों मांय एक उभयनिष्ठ गुणनखंड छै। (दिए गिया "from" कै "to" मान "step" रा सहअभाज्य होण चाहीजै।)
+
+select-from-sequence-coprime-single-number = 1 सूं भिन्न किसी एकल संख्या सूं सहअभाज्य संयोजन कोनी चुने जा सकै।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence मांय 70% सूं अधिक संयोजन बहिष्कृत किए गिया
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्याएँ कोनी चुनी जा सकी। सभी संभावित मानों मांय एक उभयनिष्ठ गुणनखंड छै।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई रा अनुक्रम सूं { $numToSelect } भिन्न मान कोनी चुने जा सकै
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई री अभाज्य सूची सूं { $numToSelect } मान कोनी चुने जा सकै
+
+select-prime-numbers-values-count-mismatch = select रै वास्ते दिए गिया मानों री संख्या चुनण री संख्या सूं मेल खानी चाहीजै
+
+select-prime-numbers-values-not-prime = select prime number रै वास्ते दिए गिया सभी मान अभाज्य सूची मांय होण चाहीजै
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers रै वास्ते दिए गिया मान बहिष्कृत संयोजन बनाते हा
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers मांय 70% सूं अधिक संयोजन बहिष्कृत किए गिया
+
+select-random-combination-fluke = अत्यंत असंभव संयोग सूं यादृच्छिक मानों रो संयोजन कोनी चुना जा सका
+
+select-random-value-fluke = अत्यंत असंभव संयोग सूं यादृच्छिक मान कोनी चुना जा सका
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] आ `<{ $component }>` कोनी दिखाया जा रैयो, क्यूंकै आ गणित रै भीतर छै अर `inline` कोनी। `inline` जोड़ो, ताकि आ ड्रॉप-डाउन सूची बन जाए, जो व्यंजक रै भीतर समा जावै छै।
+        [expanded] आ `<{ $component }>` कोनी दिखाया जा रैयो, क्यूंकै आ गणित रै भीतर छै अर `expanded` छै। `expanded` हटावो; बहु-पंक्ति बक्सा व्यंजक रै भीतर कोनी समाता।
+        [on-graph] आ `<{ $component }>` कोनी दिखाया जा रैयो, क्यूंकै आ आलेख पर खींचे गिया गणित रै भीतर छै, जिण मांय इनपुट रै वास्ते जगह कोनी।
+       *[relative-width] आ `<{ $component }>` कोनी दिखाया जा रैयो, क्यूंकै आ गणित रै भीतर छै अर इणरी चौड़ाई सापेक्ष छै। चौड़ाई निरपेक्ष इकाइयों मांय द्यो, जियां `px`।
+    }

--- a/packages/i18n/locales/mwr/editor.ftl
+++ b/packages/i18n/locales/mwr/editor.ftl
@@ -26,9 +26,10 @@
 #
 # **Nothing selects on a plural category.** CLDR has no plural data for
 # `mwr`, so `lint:i18n` would reject a `[one]` branch outright. Every count
-# in this file goes through a single `*[other]`, keeping only
-# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
-# number itself rather than against a category.
+# in this file is written with one form and no selector at all. The
+# catalog's one branch on a number is `attempts-remaining`'s explicit `[0]`
+# in `chrome.ftl`, which Fluent matches against the number itself rather
+# than against a category.
 
 ## The viewer's controls
 

--- a/packages/i18n/locales/mwr/editor.ftl
+++ b/packages/i18n/locales/mwr/editor.ftl
@@ -1,0 +1,219 @@
+# Marwari (मारवाड़ी) editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker and the context-help panel beside them. Translated
+# from `locales/en/editor.ftl`, which is the source of truth.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari.** Marwari is written in Devanagari today, in print
+# and online; the Mahajani script it once used for accounts is not a running
+# script for prose and is not attempted here.
+#
+# **Method, stated plainly.** Marwari has no established register for
+# mathematics or for software, so the technical vocabulary of this catalog is
+# Hindi — रेखा, बहुभुज, फलन, विशेषता, घटक, संस्करण — the words a Marwari
+# speaker meets in a Rajasthani classroom, which teaches out of Hindi
+# textbooks. What is Marwari here is the grammatical layer written over it:
+# the genitive रो / री / रा rather than Hindi का / की / के, the object marker
+# नै, the copula छै, the negative कोनी, मांय for *in*, सूं for *from*, अर for
+# *and*, कै for *or*, जे for *if*, रै वास्ते for *for*, and the -ओ imperative
+# (करो, दिखावो, हटावो) that Marwari puts on a button. A reviewer should read
+# this as Marwari grammar over Hindi terminology and is free to replace the
+# terminology wherever Marwari has its own word.
+#
+# **Nothing selects on a plural category.** CLDR has no plural data for
+# `mwr`, so `lint:i18n` would reject a `[one]` branch outright. Every count
+# in this file goes through a single `*[other]`, keeping only
+# `attempts-remaining`'s explicit `[0]`, which Fluent matches against the
+# number itself rather than against a category.
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करो
+       *[update] अद्यतन करो
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्शक { $word }
+       *[other] दर्शक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = रूपांतर
+editor-variant-filter = फ़िल्टर...
+editor-variant-next = अगलो रूपांतर चुणो
+editor-variant-previous = पिछलो रूपांतर चुणो
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पायो गयो। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } रै वास्ते क्लिक करो।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } रै वास्ते क्लिक करो। कोई WCAG AA उल्लंघन कोनी मिल्यो, पर सुगम्यता संबंधी अन्य सुझाव छै।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } रै वास्ते क्लिक करो। कोई सुगम्यता समस्या कोनी मिली।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पायो गयो। { $count } WCAG AA उल्लंघन मिल्या। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } रै वास्ते क्लिक करो।
+        [advisories] कोई WCAG AA उल्लंघन कोनी मिल्यो। सुगम्यता संबंधी { $count } अन्य सुझाव मिल्या। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } रै वास्ते क्लिक करो।
+       *[clean] कोई WCAG AA उल्लंघन कोनी मिल्यो। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करण
+           *[open] खोलण
+        } रै वास्ते क्लिक करो।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग अनुसार सहायता
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटियाँ
+editor-tab-warnings = चेतावनियाँ
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = भेजे गिया उत्तर
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक विकल्प
+editor-format-as-doenetml = DoenetML रूप मांय स्वरूपित करो
+editor-format-as-xml = XML रूप मांय स्वरूपित करो
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कोई त्रुटि कोनी
+editor-no-warnings = कोई चेतावनी कोनी
+editor-no-info = कोई सूचनात्मक निदान कोनी
+
+editor-show-info-annotations = संपादक मांय सूचनात्मक निदान दिखावो
+editor-show-accessibility-annotations = संपादक मांय सुगम्यता निदान दिखावो
+
+editor-accessibility-learn-more = जाणो कि Doenet सुगम्यता नै किस तरह देखता छै
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = अन्य सुगम्यता समस्याएँ
+editor-none-found = कुछ कोनी मिल्यो
+
+
+## Submitted responses
+
+editor-no-responses = अभी तक कोई उत्तर कोनी भेज्यो गयो
+editor-response-answer-id = उत्तर आईडी
+editor-response-response = उत्तर
+editor-response-credit = अंक
+editor-response-submitted = भेज्यो गयो
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेज़ीकरण देखण रै वास्ते कर्सर नै टैग नाम, विशेषता कै { $ref } पर राखो।
+
+help-unsupported-ref-chain = { $example } जियां बहु-भागीय संदर्भों री सहायता अभी उपलब्ध कोनी।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] इण संदर्भ रो कोई लक्ष्य कोनी मिल्यो: { $ref }।
+        [multiple] इण संदर्भ रा कई लक्ष्य मिल्या: { $ref }।
+       *[indeterminate] { $ref } रो लक्ष्य निर्धारित कोनी करियो जा सका।
+    }
+
+help-learn-about-references = संदर्भों रै बारै मांय जाणो →
+help-reference-page = संदर्भ पृष्ठ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } रै भीतर
+       *[top] शीर्ष स्तर पर
+    }{ $allowed ->
+        [none] { " — यहाँ कुछ कोनी रखा जा सकै।" }
+        [text] { " — यहाँ पाठ लिखा जा सकै छै।" }
+        [text-and-components] { " — यहाँ पाठ लिखो, कै ये आजमावो:" }
+       *[components] { " — ये आजमावो:" }
+    }
+
+help-suggestions-footer = सभी { $total } घटक देखण रै वास्ते { $shortcut } दबावो।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } रो संदर्भ छै।
+       *[other] { $ref }, { $target } रो संदर्भ छै (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } द्वारा { $role } रै रूप मांय लाया गयो।
+       *[other] { $owner } द्वारा पंक्ति { $line } मांय { $role } रै रूप मांय लाया गयो।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } रा { $property } गुण रो संदर्भ छै।
+       *[other] { $ref }, { $element } रा { $property } गुण रो संदर्भ छै (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड अंश
+help-kind-array-entry = सरणी प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = प्रभावी पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] अनुमत मान (प्रति मद एक):
+       *[other] अनुमत मान:
+    }
+
+help-suggested-values = सुझाए गिया मान:
+
+help-inserts = जोड़ता छै:
+
+help-coordinates = निर्देशांक:
+
+help-type = प्रकार:
+
+help-resolved-style = निर्धारित शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = निर्धारित फलन नाम:
+help-reset-list = इण इनपुट री रीसेट सूची:
+help-added-on-input = इण इनपुट पर जोड़ा गयो:
+help-removed-on-input = इण इनपुट पर हटाया गयो:
+
+help-reset-overrides = { $reset }, { $additional } अर { $removed } पर वरीयता रखता छै।

--- a/packages/i18n/locales/new/chrome.ftl
+++ b/packages/i18n/locales/new/chrome.ftl
@@ -9,7 +9,7 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # **Script: Devanagari, not Ranjana.** Newar has one of the richest script
-# histories in South Asia — Ranjana (𑈰𑈴𑈜𑈰), Bhujimol, Prachalit and their
+# histories in South Asia — Ranjana, Bhujimol, Prachalit and their
 # relatives are Newar scripts in a way Devanagari is not, and Ranjana in
 # particular is a living emblem of the language: it is carved on temples,
 # painted on shopfronts, taught in classes and used for titles and headings
@@ -20,8 +20,9 @@
 # dictionaries, school materials, government notices, everything published
 # since the twentieth century — is set in Devanagari; Ranjana is used for
 # display, not for paragraphs, and a reader who reads Newar fluently reads it
-# in these letters. There is a second, mechanical reason: Ranjana's Unicode
-# block is young, font coverage in a browser is thin and inconsistent, and a
+# in these letters. There is a second, mechanical reason: the Newar script is
+# encoded as **Newa** (U+11400–U+1147F), a young block whose font coverage in
+# a browser is thin and inconsistent, and a
 # catalog that renders as boxes on most machines helps nobody. Converting this
 # catalog to Ranjana means converting **all four files at once**, never a
 # mixture inside one catalog, and it is a real conversion rather than a

--- a/packages/i18n/locales/new/chrome.ftl
+++ b/packages/i18n/locales/new/chrome.ftl
@@ -1,0 +1,155 @@
+# Newar / Nepal Bhasa (नेपाल भाषा, नेवाः भाय्) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari, not Ranjana.** Newar has one of the richest script
+# histories in South Asia — Ranjana (𑈰𑈴𑈜𑈰), Bhujimol, Prachalit and their
+# relatives are Newar scripts in a way Devanagari is not, and Ranjana in
+# particular is a living emblem of the language: it is carved on temples,
+# painted on shopfronts, taught in classes and used for titles and headings
+# throughout the Kathmandu Valley. A reviewer may reasonably have expected it
+# here. This catalog nevertheless writes **Devanagari**, and the reason is
+# about what a reader reads rather than about which script is the language's
+# own. Continuous Newar prose — newspapers, the Nepal Bhasa Wikipedia,
+# dictionaries, school materials, government notices, everything published
+# since the twentieth century — is set in Devanagari; Ranjana is used for
+# display, not for paragraphs, and a reader who reads Newar fluently reads it
+# in these letters. There is a second, mechanical reason: Ranjana's Unicode
+# block is young, font coverage in a browser is thin and inconsistent, and a
+# catalog that renders as boxes on most machines helps nobody. Converting this
+# catalog to Ranjana means converting **all four files at once**, never a
+# mixture inside one catalog, and it is a real conversion rather than a
+# transliteration — the conjunct repertoire and the orthographic conventions
+# would have to be settled by someone who writes the script.
+#
+# **This seed leans on Nepali.** Newar and Nepali have shared the same valley,
+# the same schoolrooms and the same Devanagari letters for a long time, and
+# the technical vocabulary in these files — त्रुटि, चेतावनी, जानकारी, पंक्ति,
+# स्तम्भ, अन्तराल, दस्तावेज — is the Sanskrit-and-Nepali register a Newar
+# reader meets in Nepali schooling, not a Newar coinage. What is Newar here is
+# the **frame**: मदु and मखु for the negations, दु for the existential, याये /
+# यानादिसँ for the verb, नापं and निंतिं for the postpositions, लिसः for an
+# answer, ल्यंगु for what remains. A message where that frame has slipped back
+# into Nepali — where छ, छैन, गर्नुहोस् or को has appeared — is a defect rather
+# than a variant, and is the single easiest thing to check in this catalog.
+#
+# **Controls take the honorific -दिसँ imperative** where they instruct the
+# reader, and the -गु verbal noun where they name an action, which is what
+# Newar software convention does.
+#
+# **Numbers render in Latin digits** rather than in Devanagari numerals, which
+# is the digit policy in the package README (#1615). The grouping is the
+# locale's; the ten characters are not.
+#
+# **No plural branches.** CLDR has no plural data for `new`, so a `one` or
+# `few` category here would be text selected by somebody else's rules. The
+# numeric literal `[0]` in `attempts-remaining` stays, because Fluent matches
+# it against the number itself before any plural rule is consulted.
+
+
+## Answer submission
+
+answer-checking = जाँच यानाच्वंगु...
+answer-submitting = छ्वयाच्वंगु...
+answer-checking-status = लिसः जाँच यानाच्वंगु दु
+answer-submitting-status = लिसः छ्वयाच्वंगु दु
+answer-correct = ठीक
+answer-incorrect = ठीक मखु
+answer-response-saved = लिसः सुरक्षित जुल
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% ठीक
+answer-percent-short = { $percent } %
+max-credit-available = तःधंगु अंक: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] छुं नं प्रयास ल्यंगु मदु
+       *[other] { $count } प्रयास ल्यंगु दु
+    }
+validation-correct = (ठीक)
+validation-incorrect = (ठीक मखु)
+validation-partially-correct = (छगू भाग ठीक)
+answer-show-responses =
+    { $count ->
+       *[other] { $answerId } या { $count } लिसः क्यनेगु
+    }
+
+
+## Disclosure panels
+
+feedback-heading = प्रतिक्रिया
+collapsible-click-to-open = (खुल्ला यायेत क्लिक यानादिसँ)
+collapsible-click-to-close = (बन्द यायेत क्लिक यानादिसँ)
+collapsible-initializing = शुरु यानाच्वंगु...
+footnote-show = पादटिप्पणी क्यनेगु
+footnote-hide = पादटिप्पणी लुकायेगु
+description-more-information = अप्व जानकारी
+
+
+## Controls
+
+slider-previous = न्ह्यः
+slider-next = लिपा
+keyboard-open = किबोर्ड खुल्ला यायेगु
+keyboard-close = किबोर्ड बन्द यायेगु
+choice-input-remove-choice = { $choice } पिकायेगु
+matrix-remove-row = पंक्ति पिकायेगु
+matrix-add-row = पंक्ति तयेगु
+matrix-remove-column = स्तम्भ पिकायेगु
+matrix-add-column = स्तम्भ तयेगु
+subset-add-remove-points = बिन्दु तयेगु/पिकायेगु
+subset-toggle-points-intervals = बिन्दु व अन्तराल बदलेगु
+subset-move-points = बिन्दु न्ह्याकेगु
+subset-clear = सफा यायेगु
+orbital-add-row = पंक्ति तयेगु
+orbital-remove-row = पंक्ति पिकायेगु
+orbital-add-box = बाकस तयेगु
+orbital-remove-box = बाकस पिकायेगु
+orbital-add-up-arrow = च्वय् ल्हाःगु तीर तयेगु
+orbital-add-down-arrow = क्वय् ल्हाःगु तीर तयेगु
+orbital-remove-arrow = तीर पिकायेगु
+orbital-row-label = पंक्ति { $row } या नां
+pretzel-answer = लिसः
+summary-statistics-caption = { $column } या सारांश तथ्याङ्क
+
+
+## Math input
+
+math-input-preview-region = गणितीय अभिव्यक्तिया झलक
+math-input-preview = झलक
+math-input-invalid-expression = अवैध अभिव्यक्ति:
+
+
+## Document status
+
+viewer-initializing = शुरु यानाच्वंगु...
+
+
+## Errors
+
+error-heading = त्रुटि
+error-found-at =
+    { $span ->
+        [line] { $startLine } लाइनय् लुत।
+       *[lines] { $startLine }–{ $endLine } लाइनय् लुत।
+    }
+document-contains-errors = थ्व दस्तावेजय् त्रुटि दु!
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = इशारा
+accessibility-heading-level-1 = WCAG AA पहुँचयोग्यता उल्लङ्घन
+accessibility-heading-level-2 = पहुँचयोग्यता सूचना
+something-went-wrong = छुं गल्ती जुल।
+renderer-load-failed = छगू रेन्डरर लोड जुइ मफुत। कृपया पेज हानं लोड यानादिसँ।
+core-start-failed = थ्व दस्तावेज शुरु याये मफुत। कृपया पेज हानं लोड यानादिसँ।
+core-start-failed-busy = थ्व दस्तावेज शुरु याये मफुत। छगू इलय् दक्व दस्तावेज शुरु जुयाच्वंगु खनाः, कम्ज्या याइगु उपकरणय् थ्व अप्व इलं काइ। मेमेगु दस्तावेज सिधयेधुंकाः पेज हानं लोड यात धाःसा ग्वाहालि जुइ फु।
+core-start-failed-retry = थ्व दस्तावेज शुरु याये मफुत।
+core-start-failed-busy-retry = थ्व दस्तावेज शुरु याये मफुत। छगू इलय् दक्व दस्तावेज शुरु जुयाच्वंगु खनाः, कम्ज्या याइगु उपकरणय् थ्व अप्व इलं काइ।
+core-start-retry = हानं कुतः यानादिसँ
+saved-state-unavailable = छिगु सुरक्षित ज्या लोड याये मफुत।

--- a/packages/i18n/locales/new/content.ftl
+++ b/packages/i18n/locales/new/content.ftl
@@ -29,7 +29,8 @@
 # «{ $numSides } पाखे दुगु नियमित बहुभुज» and leaves `tail` empty, exactly as
 # English does: the side count is a modifier and modifiers go in front, so
 # there is nothing to place after the adjectives and no reason to split the
-# noun. The `[noun-tail]` branches in the two composition messages are kept
+# noun. `style-with-noun`'s `[noun-tail]` branch, and the `[plain-tail]` and
+# `[pattern-tail]` branches `style-filled-with-noun` uses in its place, are kept
 # because a partly-translated locale falls back through them, not because
 # anything in this file selects them.
 #

--- a/packages/i18n/locales/new/content.ftl
+++ b/packages/i18n/locales/new/content.ftl
@@ -1,0 +1,322 @@
+# Newar / Nepal Bhasa (नेपाल भाषा, नेवाः भाय्) content catalog: the prose the
+# core computes into the document. Selected by `documentLocale` — the language
+# the activity was written in, not the language of the reader's chrome.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Devanagari, not Ranjana**, for the reasons `chrome.ftl`'s header
+# sets out in full — running Newar prose is published in Devanagari and has
+# been for a century, Ranjana is a display script rather than a paragraph
+# script, and its browser font coverage is thin. A conversion is a conversion
+# of all four files at once, and a real conversion rather than a
+# transliteration.
+#
+# ## Word order
+#
+# **Modifiers precede the noun and postpositions follow it.** Newar is
+# verb-final and left-branching, so `style-with-noun` and
+# `style-filled-with-noun` keep English's order of `{ $description }` before
+# `{ $noun }`, and `style-stroke` keeps English's internal sequence of width,
+# dash pattern, colour. What does move is every one of English's prepositions:
+# `with` becomes the postposition नापं and `on`/`in` the locative -य्, so
+# `style-border-clause`, `style-filled` and `style-text` all put the value in
+# front of the word English puts it behind. That reordering is the whole of
+# the difference between this file and a word-for-word rendering, and it is a
+# fact about Newar rather than a liberty.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } पाखे दुगु नियमित बहुभुज» and leaves `tail` empty, exactly as
+# English does: the side count is a modifier and modifiers go in front, so
+# there is nothing to place after the adjectives and no reason to split the
+# noun. The `[noun-tail]` branches in the two composition messages are kept
+# because a partly-translated locale falls back through them, not because
+# anything in this file selects them.
+#
+# ## Gender, role and number
+#
+# **Neither `$gender` nor `$role` is selected on.** Newar has no grammatical
+# gender at all — it does not even have Nepali's animate -ी feminine — so
+# `noun-gender` answers the single token `neuter` and every adjective is
+# written once. And a Newar modifier does not change shape for the position
+# its phrase is going into: the -गु attributive ending stands unaltered before
+# a postposition, so बाक्लो ह्याउँ reads the same standing alone as it does
+# behind नापं. Both are claims about the language, not gaps in the seed.
+#
+# **Nothing selects on a count.** A Newar noun is not marked for number after
+# a numeral — «निगू रेखा», not a pluralized noun — and CLDR has no plural data
+# for `new` in any case, so a `one` or `few` branch here would be text chosen
+# by another language's rules. There are no plural branches anywhere in this
+# catalog.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry and style words are largely Nepali and Sanskrit, declared as
+# such.** Newar-medium mathematics teaching does not run to the grades where
+# these terms are needed, and रेखा, बिन्दु, वक्र, बहुभुज, सदिश, परवलय, फलन
+# are the words a Newar reader has met — in Nepali. Inventing Newar
+# equivalents would put words in front of a reader that no Newar reader has
+# seen.
+#
+# **The colours are the one place this file is genuinely Newar, and only
+# half of it.** हाकु, तुयु, ह्याउँ, म्हासु and वाउँ — black, white, red,
+# yellow and green — are Newar words. The other seven (grey, orange, cyan,
+# blue, purple, pink, brown) are Nepali or English loans, and cyan is a
+# transliteration. वाउँ is the harder case and is flagged rather than hidden:
+# it covers a green-and-blue range in Newar, so writing it for `green` and a
+# loan for `blue` is the seed splitting a range it does not know how to split.
+# A speaker should expect to correct that pair together.
+#
+# **`line-width` and `line-style` are Nepali loans throughout** — बाक्लो,
+# पातलो, धर्के, थोप्ले — and so is every `fill-style` entry. The seed does not
+# know the Newar words for thick and thin with enough confidence to write
+# them, and guessing at a word that appears in every second style description
+# would be worse than declaring the loan. This is the first thing in this file
+# a speaker should replace.
+#
+# **What *is* Newar here is the grammar**: दु and मदु for the existential and
+# its negation, ख: and मखु for the copula and its negation — which is why
+# `boolean-true` and `boolean-false` are those two words and not a
+# transliteration — जाःगु and मजाःगु for filled and unfilled, न्ह्यसः for a
+# question, लिसः for an answer, and the -गु attributive throughout. A message
+# where छ, छैन, हो or होइन has crept in is a Nepali leak and a defect.
+#
+# **The chemistry tables are absent.** `element-name` and `element-anion-name`
+# are not translated here, and the reason is the school-system one: chemistry
+# in Nepal is taught in Nepali and English, the periodic table a Newar pupil
+# meets is one of those two, and there is no Newar nomenclature for 118
+# elements to reproduce. Coining one would invent names no reader has met and
+# would hide the fact that the reader already has a language for them. The
+# three messages that are *frames* rather than names —
+# `ion-name-oxidation-state`, `chemistry-invalid-symbol` and
+# `chemistry-invalid-ionic-compound` — are translated, on the standing ground
+# that a frame is the catalog's business whether or not the names in it are.
+#
+# **Numbers render in Latin digits** under Newar's own grouping, which is the
+# digit policy in the package README (#1615).
+
+
+## Style vocabulary
+
+color =
+    .black = हाकु
+    .white = तुयु
+    .gray = फुस्रो
+    .red = ह्याउँ
+    .orange = सुन्तला
+    .yellow = म्हासु
+    .green = वाउँ
+    .cyan = सायन
+    .blue = नील
+    .purple = बैजनी
+    .pink = गुलाबी
+    .brown = खैरो
+line-width =
+    .thick = बाक्लो
+    .thin = पातलो
+line-style =
+    .dashed = धर्के
+    .dotted = थोप्ले
+# Noun phrases rather than adjectives: they stand in front of the postposition
+# नापं that the composition messages supply, and modify nothing.
+fill-style =
+    .horizontal = तेर्सा रेखा
+    .vertical = ठाडा रेखा
+    .diagonal = विकर्ण रेखा
+    .backdiagonal = उल्टो विकर्ण रेखा
+    .dots = थोप्ला
+    .diamonds = समचतुर्भुज
+noun =
+    .line = रेखा
+    .line-segment = रेखाखण्ड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .slope-field = ढलान क्षेत्र
+    .vector-field = सदिश क्षेत्र
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिन्दु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रस चिन्ह
+    .plus = जोड चिन्ह
+# दुगु ("having") attaches the side count to the noun that follows it, so the
+# whole phrase is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } पाखे दुगु नियमित बहुभुज
+    }
+# Newar has no grammatical gender, so every noun answers the same and the
+# answer goes unused — as in English.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = जाःगु
+# नापं is a postposition, so the pattern comes to the front of the clause
+# English appends at the end.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } नापं { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } नापं { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } नापं { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# नापं follows किनारा rather than preceding it as English's `with` does, and व
+# opens the further clause. Newar has no article, which leaves the two
+# `-article` branches reading exactly like the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारा नापं
+        [and] व { $border } किनारा नापं
+        [and-article] व { $border } किनारा नापं
+       *[with] { $border } किनारा नापं
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = मजाःगु
+# The locative -य् marks पृष्ठभूमि, so the background leads and the text
+# colour follows it.
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमिय् { $color }
+       *[plain] { $color }
+    }
+style-background-none = मदु
+
+
+## Boolean words
+
+# ख: and मखु are Newar's own copula and its negation, which is exactly what a
+# boolean displays. The DoenetML values `true` and `false` an author writes
+# are untouched by this.
+boolean-true = ख:
+boolean-false = मखु
+
+
+## Answer buttons
+
+answer-submit-label = ज्या जाँच यानादिसँ
+answer-submit-label-no-correctness = लिसः छ्वयादिसँ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = क्रियाकलाप
+    .aside = पाखेटिप्पणी
+    .cascade = क्यास्केड
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = लिसः
+    .note = टिप्पणी
+    .objectives = उद्देश्य
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = समस्या
+    .problems = समस्या
+    .proof = प्रमाण
+    .question = न्ह्यसः
+    .section = खण्ड
+    .solution = समाधान
+    .task = ज्या
+    .theorem = प्रमेय
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = इशारा
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] तालिका { $enumeration }
+        [numbered-title] तालिका { $enumeration }{ ": " }
+        [unnumbered-title] तालिका{ ": " }
+       *[unnumbered] तालिका
+    }
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## Paginator controls
+
+paginator-previous = न्ह्यःगु
+paginator-next = लिपांगु
+paginator-page = पेज
+# «of» is not a word here: the total precedes and या links it, which is the
+# genitive Newar builds this phrase with.
+paginator-page-status = { $numPages } या { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = वा
+# Newar's own conditional is clause-final (-सा), and the renderer places this
+# word *before* the mathematics it introduces, so the native construction
+# cannot be reached from inside the catalog. यदि is the Sanskrit-register
+# clause-initial conditional, which is grammatical here and lands correctly.
+piecewise-condition-if = यदि
+piecewise-condition-otherwise = अन्यथा
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; the header
+## says why. Only the frames are here.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = अवैध रासायनिक चिन्ह
+chemistry-invalid-ionic-compound = अवैध आयनिक यौगिक
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = खालि
+math-embedded-input-blank-ordinal = { $total } मध्ये खालि { $ordinal }

--- a/packages/i18n/locales/new/diagnostics.ftl
+++ b/packages/i18n/locales/new/diagnostics.ftl
@@ -22,14 +22,16 @@
 # Newar readers meet these words in Nepali schooling; coining Newar
 # equivalents would put unfamiliar words in front of a reader who already has
 # familiar ones. What is Newar is the frame around them: मफु and मफुत for the
-# inabilities, मदु for absence, मखु for the negated copula, याये / यानातःगु
-# for the verb, and नापं, निंतिं, स्वयां for the postpositions.
+# inabilities, मदु for absence, मखु for the negated copula, याये and its
+# inflections for the verb, and नापं, निंतिं, स्वयां for the postpositions.
 #
 # **One paraphrase is declared and used everywhere so that one search replaces
 # it.** English's *is ignored* is written «उपेक्षा याइ» throughout — literally
 # *is disregarded*. It is a Sanskrit-register word rather than a Newar one,
-# and it appears in something like thirty messages, so it is the first thing a
-# speaker should replace and replacing it is a single search.
+# and it appears in thirty-six messages, so it is the first thing a speaker
+# should replace. One message inflects it differently —
+# `math-input-invalid-function-names` writes «उपेक्षा यानाच्वन» — so a search
+# for «उपेक्षा» rather than for the whole phrase catches all of them.
 #
 # **No plural branches anywhere.** CLDR has no plural data for `new`, so
 # `line-segment-attributes-ignored-with-endpoints` and its relatives write a
@@ -486,7 +488,7 @@ prefigure-label-position-unsupported =
 
 prefigure-fill-style-unsupported = { $subject }: भरणया शैली '{ $fillStyle }' PreFigure य् लागू जुइ मफु; ठोस भरण छ्यलाच्वन।
 
-prefigure-line-style-unknown = { $subject }: मस्युगु रेखा शैली '{ $lineStyle }' PreFigure नितिं त्वःताच्वन।
+prefigure-line-style-unknown = { $subject }: मस्युगु रेखा शैली '{ $lineStyle }' PreFigure निंतिं त्वःताच्वन।
 
 prefigure-marker-style-mapped-to-diamond = { $subject }: marker शैली '{ $markerStyle }' PreFigure या 'diamond' शैलीय् बदलाच्वन।
 

--- a/packages/i18n/locales/new/diagnostics.ftl
+++ b/packages/i18n/locales/new/diagnostics.ftl
@@ -1,0 +1,696 @@
+# Newar / Nepal Bhasa (नेपाल भाषा) diagnostics: the warnings and errors the
+# worker raises and the reader is shown. Translated from
+# `locales/en/diagnostics.ftl`, which is the source of truth. Selected by
+# `uiLocale`, not by the language the document was written in.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# Neither are the DoenetML identifiers quoted inside these sentences:
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence`, `styleNumber` and every tag and attribute name like
+# them are part of the language an author writes, not prose, and stay in
+# English exactly as written. So does the `[deprecation]` marker, which is a
+# label rather than a word, and so do `WCAG AA` and `PreFigure`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script** is `chrome.ftl`'s: Devanagari rather than Ranjana, for the
+# reasons that file's header gives in full.
+#
+# **The technical vocabulary is Nepali and Sanskrit, declared as such** —
+# अवैध, त्रुटि, चेतावनी, घटक, विशेषता, चर, आयाम, सन्दर्भ, अनुक्रम, संयोजन.
+# Newar readers meet these words in Nepali schooling; coining Newar
+# equivalents would put unfamiliar words in front of a reader who already has
+# familiar ones. What is Newar is the frame around them: मफु and मफुत for the
+# inabilities, मदु for absence, मखु for the negated copula, याये / यानातःगु
+# for the verb, and नापं, निंतिं, स्वयां for the postpositions.
+#
+# **One paraphrase is declared and used everywhere so that one search replaces
+# it.** English's *is ignored* is written «उपेक्षा याइ» throughout — literally
+# *is disregarded*. It is a Sanskrit-register word rather than a Newar one,
+# and it appears in something like thirty messages, so it is the first thing a
+# speaker should replace and replacing it is a single search.
+#
+# **No plural branches anywhere.** CLDR has no plural data for `new`, so
+# `line-segment-attributes-ignored-with-endpoints` and its relatives write a
+# single `*[other]` where English writes `[one]` and `[other]`. The one
+# numeric literal that survives is `[1]` in
+# `field-function-wrong-num-outputs`, which forks on how many outputs a
+# component *needs* rather than on a count the reader is looking at; Fluent
+# matches it against the number itself before any plural rule is consulted.
+#
+# **Numbers render in Latin digits** (#1615).
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] निगू endpoint तयातःबले { $attributes } या उपेक्षा याइ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] endpoint व midpoint निगूं तयातःबले { $attributes } या उपेक्षा याइ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpoint मदुसा midpointOffset या छुं असर मदु
+
+## `<line>`
+
+line-points-undetermined-dimensions = आयाम मस्युगु बिन्दु द्वारा रेखा।
+
+line-points-too-few-dimensions = रेखा उकिं न्ह्यथनागु बिन्दुत कम्तीमं निगू आयामया जुइमाः।
+
+line-points-depend-on-variables = रेखा उकिं न्ह्यथनागु बिन्दुत चरय् आधारित दु: { $variables }।
+
+line-equation-invalid-format = { $variable1 } व { $variable2 } चरय् रेखाया समीकरणया अवैध ढाँचा।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण through, endpoint व direction स्वंलिसें तयातःगु दु।  तयातःगु through या उपेक्षा याइ।
+
+ray-dimension-mismatch = किरणय् numDimensions मिले जुइ मफुत।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश head, tail व displacement स्वंलिसें तयातःगु दु।  तयातःगु head या उपेक्षा याइ।
+
+vector-dimension-mismatch = सदिशय् numDimensions मिले जुइ मफुत।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` य् nearestPoint स्थिति चर मदुगुलिं उकियात आकर्षित याये मफु।
+
+constrain-to-without-nearest-point = `<{ $component }>` य् nearestPoint स्थिति चर मदुगुलिं उकियात सीमित याये मफु।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` य् nearestPoint स्थिति चर मदुगुलिं उकिया दुनेयात सीमित याये मफु।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline मजूगु choiceInput या निंतिं labelPosition या उपेक्षा याइ
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput या निंतिं तयातःगु indices या संख्या choice कापंत या संख्या नापं मिले मजूगुलिं उकिया उपेक्षा याइ।
+
+pretzel-indices-count-mismatch = problem या निंतिं तयातःगु indices या संख्या problem कापंत या संख्या नापं मिले मजूगुलिं उकिया उपेक्षा याइ।
+
+shuffle-indices-count-mismatch = shuffle या निंतिं तयातःगु indices या संख्या घटकत या संख्या नापं मिले मजूगुलिं उकिया उपेक्षा याइ।
+
+indices-ignored-out-of-range = { $component } या निंतिं तयातःगु indices मध्ये छुं सीमा पिने जूगुलिं उकिया उपेक्षा याइ।
+
+pretzel-indices-repeated = pretzel या निंतिं तयातःगु indices मध्ये छुं दुबारा जूगुलिं उकिया उपेक्षा याइ।
+
+pretzel-circuit-first-index = circuit मोडय् pretzel या निंतिं न्हापांगु index 1 जुइमाःगुलिं तयातःगु indices या उपेक्षा याइ।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` स्ट्रिङ कापंत नापं ज्या यायेत `type` विशेषता तयेमाः।
+
+invalid-type-defaulting-to-math = { $component } घटकया निंतिं अवैध type { $type }। math, text, number वा boolean मध्ये छगू जुइमाः। math कथं तयाच्वन।
+
+string-not-valid-component-to-arrange = स्ट्रिङ "{ $value }" { $component } यायेत वैध घटक मखु। उपेक्षा याइ।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = अवैध type { $type }, type number कथं तयाच्वन।
+
+invalid-variable-value = चरया अवैध मान: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant index { $index } संख्या जुइमाः
+
+variant-index-must-be-integer = Variant index { $index } पूर्णांक जुइमाः
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष नापया निंतिं लागू जुयाच्वंगु मदु। चाकलत सापेक्ष कथं तयाच्वन।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष नापया निंतिं लागू जुयाच्वंगु मदु। किनारात सापेक्ष कथं तयाच्वन।
+
+side-by-side-no-block-child = अवैध `<{ $component }>`: उकिइ कम्तीमं छगू ब्लक काय जुइमाः।
+
+## `<label>`
+
+label-for-ignored-on-graphical = चित्रात्मक `<label>` य् दुगु `for` विशेषताया उपेक्षा याइ।
+
+label-for-must-resolve-to-one = `<label>` या `for` विशेषता ठीक छगू घटकय् मात्र लाइमाः।
+
+label-for-unresolved = `<label>` या `for` विशेषता छुं नं घटकय् लाके मफुत।
+
+label-for-answer-with-authored-inputs = `<label>` या `for` विशेषतां च्वमिं थःम्हं तयातःगु input दुगु `<answer>` न्ह्यथनाच्वंगु दु; input यात हे सीधा न्ह्यथनादिसँ।
+
+label-for-answer-without-input = `<label>` या `for` विशेषतां label याये त्वःगु input मदुगु `<answer>` न्ह्यथनाच्वंगु दु।
+
+label-for-must-reference-input-or-answer = `<label>` या `for` विशेषतां छगू input वा छगू answer न्ह्यथनेमाः।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = पहुँचयोग्यताया निंतिं `<{ $component }>` या छगू छोटो विवरण दयेमाः वा उकियात decorative कथं तयेमाः।
+
+accessibility-video-short-description = पहुँचयोग्यताया निंतिं `<video>` या छगू छोटो विवरण दयेमाः।
+
+accessibility-input-short-description-or-label = पहुँचयोग्यताया निंतिं `<{ $component }>` या छगू छोटो विवरण वा छगू label दयेमाः।
+
+accessibility-answer-input-short-description-or-label = पहुँचयोग्यताया निंतिं input दयेकीगु `<answer>` या छगू छोटो विवरण वा छगू label दयेमाः।
+
+accessibility-short-description-contains-math = छोटो विवरणय् `<{ $component }>` थें ज्याःगु गणित घटक मदयेमाः। गणित खँग्वलं हे च्वयादिसँ।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] खण्डया शीर्षक अक्षरया निंतिं { $colorName } या विपरीतता तताः (हाकु मोड) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम्तीमं { $threshold }:1 मालि)।
+       *[other] खण्डया शीर्षक अक्षरया निंतिं { $colorName } या विपरीतता तताः ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम्तीमं { $threshold }:1 मालि)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = बिन्दुतय्गु संख्यात्मक मान मदुबले { $count } बिन्दु द्वारा `<circle>` लागू यायेधुंकूगु मदु।
+
+circle-too-many-through-points = स्वंगू स्वयां अप्व बिन्दु द्वारा वृत्त गणना याये मफु।
+
+circle-overprescribed-radius-center-points = तयातःगु radius, center व through बिन्दु स्वंलिसें दुगु वृत्त गणना याये मफु।
+
+circle-center-with-multiple-points = तयातःगु center नापं छगू स्वयां अप्व बिन्दु द्वारा वृत्त गणना याये मफु।
+
+circle-radius-too-small = वृत्त गणना याये मफु: निगू बिन्दुया दथुइ दूरी { $distance } जूगुलिं, तयातःगु radius { $radius } तताः चिधिकः।
+
+circle-radius-with-many-points = तयातःगु radius नापं निगू स्वयां अप्व बिन्दु द्वारा वृत्त दयेके मफु।
+
+circle-invalid-center-or-through-points = वृत्तया अवैध center वा through बिन्दु।
+
+circle-radius-center-with-multiple-points = तयातःगु center नापं छगू स्वयां अप्व बिन्दु द्वारा वृत्तया radius गणना याये मफु।
+
+circle-change-radius-non-numerical = संख्यात्मक मान मदुगु through बिन्दु दुगु वृत्तया radius बदले मफु
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान मदुबले तयातःगु radius नापं छगू स्वयां अप्व बिन्दु द्वारा वृत्त दयेके मफु।
+
+circle-change-center-non-numerical = संख्यात्मक मान मदुगु बिन्दु द्वारा दयेकूगु वृत्तया center बदलेगु लागू यायेधुंकूगु मदु।
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] फलनया domain या निंतिं आयाम तताः। domain य् { $intervals } अन्तराल दु तर फलनय् { $inputs ->
+           *[other] { $inputs } input
+        } दु।
+    }
+
+function-domain-invalid-format = फलनया domain या अवैध ढाँचा।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलनया संख्यात्मक मजूगु अधिकतमया उपेक्षा याइ।
+        [minimum] फलनया संख्यात्मक मजूगु न्यूनतमया उपेक्षा याइ।
+        [extremum] फलनया संख्यात्मक मजूगु चरम मानया उपेक्षा याइ।
+        [point] फलनया संख्यात्मक मजूगु बिन्दुया उपेक्षा याइ।
+        [slope] फलनया संख्यात्मक मजूगु ढलानया उपेक्षा याइ।
+       *[other] फलनया संख्यात्मक मजूगु { $type } या उपेक्षा याइ।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलनया खालि अधिकतमया उपेक्षा याइ।
+        [minimum] फलनया खालि न्यूनतमया उपेक्षा याइ।
+        [extremum] फलनया खालि चरम मानया उपेक्षा याइ।
+        [point] फलनया खालि बिन्दुया उपेक्षा याइ।
+       *[other] फलनया खालि { $type } या उपेक्षा याइ।
+    }
+
+function-points-too-close = फलनय् तताः चकंचकं दुगु निगू बिन्दु दु। फलन परिभाषित याये मफु।
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] फलनया input या संख्या व output या संख्या समान जूसा मात्र फलन दोहोर्याये फु। थ्व फलनय् { $inputs } input व { $outputs ->
+           *[other] { $outputs } output
+        } दु।
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रमया अवैध ल्याः।  ऋणात्मक मजूगु पूर्णांक जुइमाः।
+
+sequence-invalid-step = अनुक्रमया अवैध step।  { $type } प्रकारया अनुक्रमया निंतिं संख्या जुइमाः।
+
+sequence-invalid-endpoint-number = number अनुक्रमया अवैध "{ $attribute }"।  संख्या जुइमाः।
+
+sequence-invalid-endpoint-letters = letters अनुक्रमया अवैध "{ $attribute }"।  अक्षरया संयोजन जुइमाः।
+
+sequence-invalid-endpoint = अनुक्रमया अवैध "{ $attribute }"।
+
+select-from-sequence-coprime-not-numbers = संख्या ल्ययाच्वंगु मजूगुलिं coprime या उपेक्षा याइ
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations तयातःगुलिं coprime या उपेक्षा याइ
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` या निंतिं अवैध target: target लुइ मफुत।
+
+target-state-variable-not-found = `<{ $source }>` या निंतिं अवैध target: `<{ $component }>` य् "{ $property }" नांगु स्थिति चर लुइ मफुत।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` या चरत स्वतन्त्र चर स्वयां पाइमाः।
+
+ode-system-duplicate-variable-names = दुबारा जूगु आश्रित चरया नां नापं ODE RHS फलन परिभाषित याये मफु।
+
+ode-system-rhs-function-error = ODE RHS फलन परिभाषित याये मफु।  mathjs फलन दयेकेगुली त्रुटि।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखाया दथुइ कोण परिभाषित याये मफु
+
+angle-invalid-through-point = `<angle>` या through य् अवैध बिन्दु
+
+parabola-vertex-too-many-points = vertex नापं छगू स्वयां अप्व बिन्दु द्वारा परवलय लागू यायेधुंकूगु मदु।
+
+parabola-too-many-points = स्वंगू स्वयां अप्व बिन्दु द्वारा परवलय लागू यायेधुंकूगु मदु।
+
+intersection-too-many-items = निगू स्वयां अप्व वस्तुया निंतिं प्रतिच्छेदन लागू यायेधुंकूगु मदु
+
+## Other math components
+
+ionic-compound-not-two-ions = निगू आयन मखुगु मेगु छुं नं निंतिं आयनिक यौगिक लागू यायेधुंकूगु मदु।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक छगू क्याटायन व छगू आयनया निंतिं मात्र लागू जुयाच्वंगु दु।
+
+solve-equations-cannot-evaluate = समीकरण मूल्याङ्कन याये मफुगुलिं उकियात हल याये मफु: { $equation }
+
+math-operators-operand-number-required = गणितीय operand पिकायेबले operandNumber तयेमाः।
+
+eigen-decomposition-failed = मेट्रिक्सया eigenvalue गणना याये मफुत
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: { $parameters } parameter pattern य् मदुगुलिं उकिं सदां खालि हे मिले जुइ।
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" बुझे याये मफु। थ्व none, medium, dense, वा खालि ठाउँलिसें पाःगु निगू धनात्मक संख्या जुइमाः, जस्तै grid="1 0.5"। छुं नं grid क्यनाच्वंगु मदु।
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` यात { $expected ->
+        [1] छगू output दुगु फलन मालि, ब्वबिं ब्वबिं ढलान y', जस्तै `y - x`
+       *[other] निगू output दुगु फलन मालि, ब्वबिं ब्वबिं सदिश, जस्तै `(y, -x)`
+    }, तर बियातःगु फलनय् { $found ->
+       *[other] { $found } output
+    } दु। { $alternative ->
+        [none] छुं नं क्यनाच्वंगु मदु।
+       *[other] उगु फलनया निंतिं `<{ $alternative }>` घटक ख:। छुं नं क्यनाच्वंगु मदु।
+    }
+
+field-function-attribute-ignored-with-child = फलन घटकया दुने नं बियातःगुलिं `function` विशेषताया उपेक्षा याइ; दुनेयागु हे छ्यलाच्वंगु दु। फलन निगू उपाय मध्ये छगू कथं मात्र बियादिसँ।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` विशेषतां घटकया दुने सीधा च्वयातःगु अभिव्यक्तिया चरतय्गु नां न्ह्यथनी। { $reason ->
+        [function-child] थन फलन छगू `<function>` काय कथं बियातःगु दु, गुगुं थःगु चर थःम्हं हे न्ह्यथनी, अले `variables` या उपेक्षा याइ।
+       *[no-expression] थन अथे छुं नं अभिव्यक्ति बियातःगु मदु, अले `variables` या उपेक्षा याइ।
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेन्डररय् xLabelPosition="left" लागू जुइ मफु; right-position या व्यवहार छ्यलाच्वन।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेन्डररय् yLabelPosition="bottom" लागू जुइ मफु; top-position या व्यवहार छ्यलाच्वन।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपान्तरणया निंतिं अवैध अक्ष सीमा; पूर्वनिर्धारित bbox (-10,-10,10,10) छ्यलाच्वन।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपान्तरणया निंतिं अवैध चाकल; पूर्वनिर्धारित रेखाचित्र चाकल 425 छ्यलाच्वन।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपान्तरणया निंतिं अवैध aspectRatio; पूर्वनिर्धारित अनुपात 1 छ्यलाच्वन।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अक्षया सीमाया निंतिं ग्रिडया दूरी तताः चिधिकः; prefigure रेन्डररय् ग्रिड त्वःताच्वन।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेन्डरर मछ्यःसा टिप्पणीत क्यनाच्वंगु मदु।
+
+multiple-annotations-children = `<graph>` य् अप्व `<annotations>` कापंत लुत; लिपांगु छगू बाहेक दक्वया उपेक्षा याइ।
+
+## Referring to other components
+
+copy-unrecognized-component-type = मस्युगु घटक प्रकार विस्तार वा प्रतिलिपि याये मफु: { $type }।
+
+copy-prop-not-found = { $component } प्रकारया घटकय् { $property } prop लुइ मफुत
+
+collect-no-source = collect या निंतिं छुं नं स्रोत लुइ मफुत।
+
+collect-invalid-component-type = `<{ $component }>` अवैध घटक प्रकार जूगुलिं उगु प्रकारया घटकत collect याये मफु।
+
+reference-index-unavailable = index `{ $reference }` न्ह्यथने मफु
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` घटकय् { $action } बोले याये मफु
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = डाटाया आकार अवैध दु।  पंक्तितय्गु ल्याः फरक फरक दु। componentIdx :{ $componentIdx } य् लुत
+
+data-frame-duplicate-column-names = डाटाय् दुबारा जूगु स्तम्भया नां दु।  componentIdx :{ $componentIdx } य् लुत
+
+data-frame-missing-column-name = डाटाय् छगू स्तम्भया नां मदु।  componentIdx :{ $componentIdx } य् लुत
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = थ्व लिसःया छगू award थ्व answer ट्यागं हे छ्वयातःगु लिसःय् आधारित दु, गुकिं अनपेक्षित व्यवहार जुइ।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` दुगु कन्टेनरया दुने दुगु `<answer>` य् `maxNumAttempts` तयेगुया छुं असर मदु, छाय्धाःसा प्रयासया संख्या कन्टेनरं हे नियन्त्रण याइ। `maxNumAttempts` कन्टेनरय् हे तयादिसँ।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` दुगु मेगु कन्टेनरया दुने दुगु `sectionWideCheckWork` कन्टेनरय् `maxNumAttempts` तयेगुया छुं असर मदु, छाय्धाःसा प्रयासया संख्या पिनेयागु कन्टेनरं हे नियन्त्रण याइ। `maxNumAttempts` पिनेयागु कन्टेनरय् हे तयादिसँ।
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality मतःसा { $attributes } विशेषताया छुं नं असर मदइ।
+    }
+
+answer-invalid-type = लिसःया निंतिं अवैध type: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` घटकया नां मदुगुलिं उकियात module या विशेषता कथं छ्यले मफु
+
+module-attribute-name-already-defined = `<module>` घटक प्रकारय् "{ $name }" विशेषता न्हापां हे परिभाषित जुइधुंकूगुलिं `<{ $component } name="{ $name }">` घटकयात module या विशेषता कथं छ्यले मफु।
+
+conditional-content-condition-ignored = case वा else कापंत दुगु `<conditionalContent>` घटकय् `condition` विशेषताया उपेक्षा याइ।
+
+slider-markers-type-mismatch = Marker या प्रकार slider या प्रकार नापं मिले जुइ मफुत।
+
+pretzel-problem-needs-statement-and-answer = अवैध pretzel: दक्व `<problem>` य् छगू `<statement>` व छगू `<answer>` जुइमाः।
+
+pretzel-circuit-first-problem-distractor = अवैध pretzel: mode="circuit" य् न्हापांगु `<problem>` distractor जुइ मफु।
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] `{ $attribute }` विशेषताया निंतिं अवैध मान { $values }; उपेक्षा याइ।
+    }
+
+attribute-must-be-references = `{ $attribute }` विशेषताया निंतिं अवैध मान `{ $value }`। विशेषता `$` नं शुरु जुइगु सन्दर्भं दयेकेमाः।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } य् दुगु अवैध फलनया नांया उपेक्षा यानाच्वन: { $names }। दक्व नांया प्रदर्शन खण्ड कम्तीमं 2 अक्षर (अक्षर वा ड्यास) जुइमाः; लिपा वैकल्पिक `|<mathspeak alternative>` प्रत्यय वये फु।
+
+## Building components from the source
+
+component-type-invalid = अवैध घटक प्रकार: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } विशेषता दुबारा तये मफु।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकारया घटकया निंतिं अवैध विशेषता "{ $attribute }"।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } य् { $context ->
+        [text-on-background] पृष्ठभूमिया रङ नापं अक्षरया रङया
+        [high-contrast] क्यानभास नापं उच्च-विपरीतता रङया
+        [line] क्यानभास नापं रेखाया रङया
+        [marker] क्यानभास नापं marker या रङया
+       *[text-on-canvas] क्यानभास नापं अक्षरया रङया
+    } विपरीतता तताः{ $mode ->
+        [dark] { " (हाकु मोड)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम्तीमं { $threshold }:1 मालि)।
+
+style-definition-dark-mode-text-background-contrast =
+    शैली परिभाषा { $styleNumber } य् तयातःगु रङं तुयु मोडया निंतिं ल्यंकः विपरीतता बिइ धाःसां, उगु मानं दयेकूगु हाकु मोडया रङय् पृष्ठभूमिया रङ नापं अक्षरया रङया विपरीतता तताः ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम्तीमं { $threshold }:1 मालि)। { $suggestion ->
+        [available] हाकु मोडय् ल्यंकः विपरीतता दयेकेत तुयु मोडया विपरीतता अप्व यानादिसँ (जस्तै { $lightAttribute }="{ $lightColor }" तयादिसँ) वा हाकु मोडया रङ थःम्हं तयादिसँ (जस्तै { $darkAttribute }="{ $darkColor }")।
+       *[none] हाकु मोडय् ल्यंकः विपरीतता दयेकेत तुयु मोडया विपरीतता अप्व यानादिसँ वा दयेकूगु रङतयेत textColorDarkMode व/वा backgroundColorDarkMode नं बदलेयानादिसँ।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    शैली परिभाषा { $styleNumber } य् तयातःगु अक्षरया रङं तुयु मोडया निंतिं ल्यंकः विपरीतता बिइ धाःसां, उगु मानं दयेकूगु हाकु मोडया अक्षरया रङया क्यानभास नापं विपरीतता तताः ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम्तीमं { $threshold }:1 मालि)। { $suggestion ->
+        [available] हाकु मोडय् ल्यंकः विपरीतता दयेकेत तुयु मोडया विपरीतता अप्व यानादिसँ (जस्तै textColor="{ $lightColor }" तयादिसँ) वा हाकु मोडया रङ थःम्हं तयादिसँ (जस्तै textColorDarkMode="{ $darkColor }")।
+       *[none] हाकु मोडय् ल्यंकः विपरीतता दयेकेत तुयु मोडया विपरीतता अप्व यानादिसँ वा दयेकूगु रङ textColorDarkMode नं बदलेयानादिसँ।
+    }
+
+section-multiple-style-palettes = छगू खण्डं छगू <stylePalette> मात्र ल्यये फु; लिपांगु छगू छ्यलाच्वन।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect ऋणात्मक मजूगु पूर्णांक मजूगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-num-to-select-not-constant-number = numToSelect स्थिर संख्या मजूगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-with-replacement-not-constant-boolean = withReplacement स्थिर boolean मजूगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-select-weight-disables-unique = selectWeight वा selectForVariants तयातःगु विकल्प दुसा select या अद्वितीय variant बन्द जुइ
+
+variant-coprime-undetermined = coprime सदां असत्य ख: धकाः निर्धारण याये मफुगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-attribute-not-constant = { $attribute } स्थिर मजूगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-attribute-not-number = { $attribute } संख्या मजूगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } { $expected ->
+        [letters-combination] अक्षरया संयोजन
+        [math-expression] वैध गणितीय अभिव्यक्ति
+        [integer] पूर्णांक
+       *[number] संख्या
+    } मजूगुलिं { $type } प्रकारया { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-length-not-integer = length पूर्णांक मजूगुलिं { $component } या अद्वितीय variant निर्धारण याये मफु।
+
+variant-sort-not-implemented = sort दुगु { $component } या अद्वितीय variant लागू यायेधुंकूगु मदु
+
+variant-exclude-combinations-not-implemented = excludeCombinations दुगु { $component } या अद्वितीय variant लागू यायेधुंकूगु मदु
+
+variant-math-exclude-not-implemented = exclude दुगु math प्रकारया { $component } या अद्वितीय variant लागू यायेधुंकूगु मदु
+
+variant-non-constant-exclude-not-implemented = स्थिर मजूगु exclude दुगु { $component } या अद्वितीय variant लागू यायेधुंकूगु मदु
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure रेन्डररय् लागू जुइ मफु; सन्तति त्वःताच्वन।
+
+prefigure-descendant-invalid-geometry = { $subject }: अपूर्ण वा सीमित मजूगु ज्यामिति; सन्तति त्वःताच्वन।
+
+prefigure-curve-label-omitted = { $subject }: रूपान्तरण जूगु वक्र तत्वय् label लागू जुइ मफु; label त्वःताच्वन।
+
+prefigure-curve-unsupported-definition-type = { $subject }: लागू जुइ मफुगु वक्र फलन परिभाषा प्रकार '{ $definitionType }'; सन्तति त्वःताच्वन।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves य् लागू जुइ मफुगु flipFunctions विशेषता; सन्तति त्वःताच्वन।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves य् formula प्रकारया काय फलन मात्र लागू जुइ फु; सन्तति त्वःताच्वन।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा-परिवारया label
+       *[point] बिन्दुया label
+    } या निंतिं लागू जुइ मफुगु labelPosition '{ $labelPosition }'; पूर्वनिर्धारित PreFigure पङ्क्तिबद्धता छ्यलाच्वन।
+
+prefigure-fill-style-unsupported = { $subject }: भरणया शैली '{ $fillStyle }' PreFigure य् लागू जुइ मफु; ठोस भरण छ्यलाच्वन।
+
+prefigure-line-style-unknown = { $subject }: मस्युगु रेखा शैली '{ $lineStyle }' PreFigure नितिं त्वःताच्वन।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker शैली '{ $markerStyle }' PreFigure या 'diamond' शैलीय् बदलाच्वन।
+
+prefigure-marker-style-unsupported = { $subject }: marker शैली '{ $markerStyle }' PreFigure य् लागू जुइ मफु; पूर्वनिर्धारित शैली छ्यलाच्वन।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: अवैध `ref`; target लाके मफु। टिप्पणी त्वःताच्वन।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` अप्व target य् लात; न्हापांगु target छ्यलाच्वन।
+
+annotation-ref-outside-graph = `<annotation>`: अवैध `ref`; target दुगु graph या पिने दु। टिप्पणी त्वःताच्वन।
+
+annotation-ref-unsupported-target = `<annotation>`: अवैध `ref`; prefigure रूपान्तरणय् target लागू जुइफुगु चित्रात्मक वस्तु मखु। टिप्पणी त्वःताच्वन।
+
+annotation-text-missing = `<annotation>`: `text` मदु वा खालि दु; खालि अक्षर पिकयाच्वन।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता लुत।
+       *[other] `<{ $componentType }>` घटक नापं जुड्यागु चक्रीय निर्भरता लुत।
+    }
+
+reference-no-referent = सन्दर्भया निंतिं छुं नं लक्ष्य लुइ मफुत: `{ $reference }`
+
+reference-multiple-referents = सन्दर्भया निंतिं अप्व लक्ष्य लुत: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` या { $attribute } विशेषताया अवैध ढाँचा।
+
+children-invalid = `<{ $componentType }>` या निंतिं अवैध कापंत: अवैध कापंत लुत: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` विशेषताया निंतिं अवैध मान `{ $value }`, `{ $default }` मान छ्यलाच्वन
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } लुइ मफुत।
+       *[other] DoenetML संस्करण { $version } लुइ मफुत। संस्करण { $fallback } य् लिहाँ वनाच्वन
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अवैध DoenetML: { $content }
+
+parse-tag-missing-close-tag = अवैध DoenetML: `{ $tag }` ट्यागया बन्द याइगु ट्याग मदु। थःम्हं बन्द जुइगु ट्याग वा छगू `</{ $tagName }>` ट्याग मालि।
+
+parse-tag-error = अवैध DoenetML: `<{ $tagName }>` ट्यागय् त्रुटि
+
+parse-attribute-missing-value = अवैध DoenetML: अवैध विशेषता `{ $attribute }` य् मान मदुथें ताः।
+
+parse-attribute-invalid = अवैध DoenetML: अवैध विशेषता `{ $attribute }`
+
+parse-attribute-value-invalid = अवैध DoenetML: अवैध विशेषता मान `{ $value }`
+
+parse-attribute-value-quote-mismatch = अवैध DoenetML: अवैध विशेषता मान `{ $value }`। उद्धरण चिन्ह मिले जुइ मफुत। छित छगू `{ $quote }` मदुथें ताः
+
+parse-open-tag-name-missing = अवैध DoenetML: नां मदुगु ट्याग लुत, जस्तै `<`
+
+parse-tag-not-closed = अवैध DoenetML: `{ $tag }` ट्याग बन्द जुइ मफुत (छगू `>` मदुथें ताः)।
+
+parse-self-closing-tag-name-missing = अवैध DoenetML: नां मदुगु ट्याग लुत `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अवैध DoenetML: `{ $tag }` ट्याग बन्द जुइ मफुत (`/>` मदुथें ताः)।
+
+parse-tag-invalid-attributes = अवैध DoenetML: `{ $tag }` ट्याग वैध मखु। उकिइ ठीक मजूगु विशेषता दयेफु।
+
+parse-close-tag-name-missing = अवैध DoenetML: नां मदुगु बन्द ट्याग लुत, जस्तै `</`
+
+parse-attribute-value-unquoted = विशेषताया मान उद्धरण चिन्ह दुने तयेमाः: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अवैध DoenetML: `{ $tag }` बन्द ट्याग लुत, तर उकिया निंतिं चायेकीगु ट्याग मदु
+
+parse-close-tag-mismatched = अवैध DoenetML: बन्द ट्याग मिले जुइ मफुत। `</{ $expected }>` मालि। `{ $found }` लुत
+
+parser-node-unconvertible = { $node } नोडयात Dast नोडय् बदले मफुत।
+
+## Names
+
+name-attribute-invalid =
+    अवैध विशेषता name='{ $name }'। { $reason ->
+        [characters] नांय् अक्षर, संख्या, अन्डरस्कोर वा हाइफन मात्र दयेफु।
+       *[start] नां अक्षरं शुरु जुइमाः।
+    }
+
+component-name-invalid-start = अवैध घटक नां "{ $name }"। नां अक्षरं शुरु जुइमाः।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकारया answer य् video विशेषता जुइमाः
+
+answer-video-watched-video-not-reference = videoWatched प्रकारया answer या video विशेषता छगू सन्दर्भ जुइमाः
+
+answer-name-not-single-text = Answer या name विशेषताय् छगू मात्र text काय जुइमाः
+
+## Referencing another document
+
+external-doenetml-recursion-limit = तताः अप्व तह पुनरावृत्ति जूगुलिं पिनेयागु DoenetML काये मफुत। चक्रीय सन्दर्भ दु ला?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" नं DoenetML काये मफुत
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" नं कयागु DoenetML अवैध दु: थ्व "{ $componentType }" घटक प्रकार नापं मिले जुइ मफुत
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` विशेषता पुलांगु जुइधुंकल; उकिया सट्टाय् `{ $to }` छ्यलादिसँ।
+       *[other] [deprecation] `<{ $component }>` य् दुगु `{ $from }` विशेषता पुलांगु जुइधुंकल; उकिया सट्टाय् `{ $to }` छ्यलादिसँ।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }` नं तयातःगुलिं `{ $from }` विशेषता पुलांगु जुइधुंकल व उकिया उपेक्षा याइ।
+       *[other] [deprecation] `<{ $component }>` य् दुगु `{ $from }` विशेषता `{ $to }` नं तयातःगुलिं पुलांगु जुइधुंकल व उकिया उपेक्षा याइ।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` य् दुगु `{ $attribute }` विशेषता पुलांगु जुइधुंकल व उकिया उपेक्षा याइ।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` य् दुगु `{ $attribute }` विशेषता पुलांगु जुइधुंकल; उकिया सट्टाय् छगू `<{ $child }>` काय छ्यलादिसँ।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` य् दुगु `{ $attribute }` विशेषताया `{ $value }` मान पुलांगु जुइधुंकल; उकिया सट्टाय् `{ $to }` छ्यलादिसँ।
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` अंग्रेजीया मात्र बहुवचन दयेके फु, अले { $locale } भाषाय् च्वयातःगु दस्तावेजय् उकिया अक्षर छुं नं मबदलिकं ल्यनी। बहुवचन रूप सीधा च्वयादिसँ, वा `pluralForm` विशेषतां तयादिसँ।
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` तत्व Doenet या स्युगु तत्व मखु।
+
+schema-element-not-allowed-at-root = `<{ $tag }>` तत्व दस्तावेजया मूलय् तये मज्यू।
+
+schema-element-not-allowed-inside = `<{ $tag }>` तत्व `<{ $parent }>` या दुने तये मज्यू।
+
+schema-attribute-unrecognized = `<{ $tag }>` तत्वय् `{ $attribute }` नांगु विशेषता मदु।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` तत्वया `{ $attribute }` विशेषता छगू सूची जुइमाः, गुकिया दक्व वस्तु थ्व मध्ये छगू जुइमाः: { $allowed }
+       *[other] `<{ $tag }>` तत्वया `{ $attribute }` विशेषता थ्व मध्ये छगू जुइमाः: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select या निंतिं अवैध variant नां।  Variant नां { $variantName } { $numOptions } विकल्पय् वयाच्वंगु दु तर ल्ययेत्वःगु संख्या { $numToSelect } ख:।
+
+select-variant-name-without-options = select या निंतिं छुं variant तयातःगु दु तर संभावित variant नां { $variantName } या निंतिं छुं नं विकल्प तयातःगु मदु।
+
+select-variant-name-not-possible = select या निंतिं तयातःगु variant नां { $variantName } संभावित variant नां मखु।
+
+select-too-few-options = { $numOptions } मात्र दुसा { $numToSelect } घटक ल्यये मफु।
+
+select-from-sequence-too-few-values = { $length } ल्याःया अनुक्रमं { $numToSelect } मान ल्यये मफु।
+
+select-from-sequence-indices-count-mismatch = select या निंतिं तयातःगु indices या संख्या ल्ययेत्वःगु संख्या नापं मिले जुइमाः
+
+select-from-sequence-indices-not-integers = select या निंतिं तयातःगु दक्व indices पूर्णांक जुइमाः
+
+select-from-sequence-index-excluded = selectfromsequence या तयातःगु index पिकयातःगु ख:
+
+select-from-sequence-indices-excluded-combination = selectfromsequence या तयातःगु indices पिकयातःगु संयोजन ख:
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक ल्ययाच्वंगु मजूगुलिं coprime संयोजन ल्यये मफु।
+
+select-from-sequence-coprime-common-factor = Coprime संख्या ल्यये मफु। दक्व संभावित मानय् छगू साझा गुणनखण्ड दु। ("from" वा "to" या तयातःगु मान "step" नापं coprime जुइमाः।)
+
+select-from-sequence-coprime-single-number = 1 मजूगु छगू मात्र संख्यां coprime संयोजन ल्यये मफु।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence य् संयोजनया 70% स्वयां अप्व पिकयातःगु दु
+
+select-from-sequence-coprime-none-found = Coprime संख्या ल्यये मफुत। दक्व संभावित मानय् छगू साझा गुणनखण्ड दु।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } ल्याःया अनुक्रमं { $numToSelect } अद्वितीय मान ल्यये मफु
+
+select-prime-numbers-too-few-values = { $numValues } ल्याःया अभाज्य संख्याया सूचीं { $numToSelect } मान ल्यये मफु
+
+select-prime-numbers-values-count-mismatch = select या निंतिं तयातःगु मानया संख्या ल्ययेत्वःगु संख्या नापं मिले जुइमाः
+
+select-prime-numbers-values-not-prime = select prime number या निंतिं तयातःगु दक्व मान अभाज्य संख्याया सूचीय् जुइमाः
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers या तयातःगु मान पिकयातःगु संयोजन ख:
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers य् संयोजनया 70% स्वयां अप्व पिकयातःगु दु
+
+select-random-combination-fluke = तताः असंभव संयोगं, अनियमित मानया संयोजन ल्यये मफुत
+
+select-random-value-fluke = तताः असंभव संयोगं, अनियमित मान ल्यये मफुत
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] थ्व `<{ $component }>` गणितया दुने दुसां `inline` मजूगुलिं क्यनाच्वंगु मदु। `inline` तयादिसँ, अले थ्व ड्रप-डाउन सूची जुइ, गुगु अभिव्यक्तिया दुने लाइ।
+        [expanded] थ्व `<{ $component }>` गणितया दुने दुसां `expanded` जूगुलिं क्यनाच्वंगु मदु। `expanded` पिकयादिसँ; अप्व लाइनया बाकस अभिव्यक्तिया दुने मलाः।
+        [on-graph] थ्व `<{ $component }>` graph य् क्यनातःगु गणितया दुने दूगुलिं क्यनाच्वंगु मदु, अन input या निंतिं ठाउँ मदु।
+       *[relative-width] थ्व `<{ $component }>` गणितया दुने दुसां सापेक्ष चाकल दूगुलिं क्यनाच्वंगु मदु। चाकल `px` थें ज्याःगु निरपेक्ष एककय् बियादिसँ।
+    }

--- a/packages/i18n/locales/new/editor.ftl
+++ b/packages/i18n/locales/new/editor.ftl
@@ -1,0 +1,225 @@
+# Newar / Nepal Bhasa (नेपाल भाषा) editor and language-server surfaces: the
+# footer, the diagnostics panel, the variant picker, the accessibility button,
+# and the context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and register** are `chrome.ftl`'s: Devanagari rather than Ranjana,
+# and a Nepali-and-Sanskrit technical vocabulary declared as a loan register
+# around a Newar frame — मदु, मखु, मफु, दु, याये, यानादिसँ, नापं, निंतिं, या,
+# ल्यंगु, लुत.
+#
+# **`WCAG`, `DoenetML`, `styleNumber` and every element and attribute name
+# stay in English.** They are identifiers an author types, not words. So does
+# `$shortcut`, which is a key combination, and `$version`, `$standard` and
+# `$ref`.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `new`, so an English-selected
+# branch here would be a category this locale cannot reach. A Newar noun is
+# unmarked for number after a numeral in any case, so the single form is also
+# the grammatical one.
+#
+# **The arrow `→` in the two link labels is direction rather than
+# punctuation** and is left where English puts it: Newar is written left to
+# right.
+#
+# **Numbers render in Latin digits** (#1615).
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रिसेट
+       *[update] अपडेट
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] भ्युअर { $word }
+       *[other] भ्युअर { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = छान्नेगु...
+editor-variant-next = लिपांगु variant ल्यनादिसँ
+editor-variant-previous = न्ह्यःगु variant ल्यनादिसँ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA पहुँचयोग्यता उल्लङ्घन लुत। पहुँचयोग्यता प्रतिवेदन { $action ->
+            [close] बन्द
+           *[open] खुल्ला
+        } यायेत क्लिक यानादिसँ।
+        [advisories] पहुँचयोग्यता प्रतिवेदन { $action ->
+            [close] बन्द
+           *[open] खुल्ला
+        } यायेत क्लिक यानादिसँ। छुं नं WCAG AA उल्लङ्घन लुइ मफुत, तर मेमेगु पहुँचयोग्यता सुझाव दु।
+       *[clean] पहुँचयोग्यता प्रतिवेदन { $action ->
+            [close] बन्द
+           *[open] खुल्ला
+        } यायेत क्लिक यानादिसँ। छुं नं पहुँचयोग्यता समस्या लुइ मफुत।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA पहुँचयोग्यता उल्लङ्घन लुत। { $count ->
+           *[other] { $count } WCAG AA उल्लङ्घन
+        } लुत। पहुँचयोग्यता प्रतिवेदन { $action ->
+            [close] बन्द
+           *[open] खुल्ला
+        } यायेत क्लिक यानादिसँ।
+        [advisories] छुं नं WCAG AA उल्लङ्घन लुइ मफुत। { $count ->
+           *[other] { $count } मेमेगु पहुँचयोग्यता सुझाव
+        } लुत। पहुँचयोग्यता प्रतिवेदन { $action ->
+            [close] बन्द
+           *[open] खुल्ला
+        } यायेत क्लिक यानादिसँ।
+       *[clean] छुं नं WCAG AA उल्लङ्घन लुइ मफुत। पहुँचयोग्यता प्रतिवेदन { $action ->
+            [close] बन्द
+           *[open] खुल्ला
+        } यायेत क्लिक यानादिसँ।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग अनुसारया ग्वाहालि
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटित
+editor-tab-warnings = चेतावनीत
+editor-tab-info = जानकारी
+editor-tab-accessibility = पहुँचयोग्यता
+editor-tab-responses = छ्वयातःगु लिसःत
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = सम्पादक विकल्प
+editor-format-as-doenetml = DoenetML कथं ढाँचाबद्ध यायेगु
+editor-format-as-xml = XML कथं ढाँचाबद्ध यायेगु
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = लाइन #{ $line }
+
+editor-no-errors = छुं त्रुटि मदु
+editor-no-warnings = छुं चेतावनी मदु
+editor-no-info = छुं जानकारी सूचना मदु
+
+editor-show-info-annotations = सम्पादकय् जानकारी सूचना क्यनादिसँ
+editor-show-accessibility-annotations = सम्पादकय् पहुँचयोग्यता सूचना क्यनादिसँ
+
+editor-accessibility-learn-more = Doenet न पहुँचयोग्यतायात गथे कयाच्वंगु दु स्यनादिसँ
+
+editor-accessibility-violations-heading = पहुँचयोग्यता उल्लङ्घन ({ $standard })
+
+editor-accessibility-other-heading = मेमेगु पहुँचयोग्यता समस्या
+editor-none-found = छुं नं लुइ मफुत
+
+
+## Submitted responses
+
+editor-no-responses = अजु छुं नं लिसः छ्वयातःगु मदु
+editor-response-answer-id = Answer Id
+editor-response-response = लिसः
+editor-response-credit = अंक
+editor-response-submitted = छ्वयाधुंकल
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेजया निंतिं कर्सर छगू ट्यागया नां, विशेषता वा { $ref } य् तयादिसँ।
+
+help-unsupported-ref-chain = { $example } थें ज्याःगु अप्व भागया सन्दर्भया निंतिं ग्वाहालि अजु लागू जुइ मफु।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] सन्दर्भया निंतिं छुं नं लक्ष्य लुइ मफुत: { $ref }।
+        [multiple] सन्दर्भया निंतिं अप्व लक्ष्य लुत: { $ref }।
+       *[indeterminate] { $ref } या लक्ष्य निर्धारण याये मफुत।
+    }
+
+help-learn-about-references = सन्दर्भया बारे स्यनादिसँ →
+help-reference-page = सन्दर्भ पेज →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } या दुने
+       *[top] च्वयागु तहय्
+    }{ $allowed ->
+        [none] { " — थन छुं नं तये मज्यू।" }
+        [text] { " — थन अक्षर च्वयादिसँ।" }
+        [text-and-components] { " — थन अक्षर च्वयादिसँ, वा थ्व कुतः यानादिसँ:" }
+       *[components] { " — कुतः यायेत्वःगु खँ:" }
+    }
+
+help-suggestions-footer = दक्व { $total } घटक स्वयेत { $shortcut } थिचादिसँ।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } { $target } या छगू सन्दर्भ ख:।
+       *[other] { $ref } { $target } या छगू सन्दर्भ ख: (लाइन { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } न { $role } कथं हयागु।
+       *[other] { $owner } न लाइन { $line } य् { $role } कथं हयागु।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } { $element } या { $property } गुणया छगू सन्दर्भ ख:।
+       *[other] { $ref } { $element } या { $property } गुणया छगू सन्दर्भ ख: (लाइन { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = स्निपेट
+help-kind-array-entry = सरणी प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = सक्रिय पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] मिले जुइगु मान (दक्व वस्तुया निंतिं छगू):
+       *[other] मिले जुइगु मान:
+    }
+
+help-suggested-values = सुझाव जूगु मान:
+
+help-inserts = दुथ्याकी:
+
+help-coordinates =
+    { $count ->
+       *[other] निर्देशाङ्क:
+    }
+
+help-type = प्रकार:
+
+help-resolved-style = निर्धारित शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = निर्धारित फलनया नां:
+help-reset-list = थ्व input य् रिसेट सूची:
+help-added-on-input = थ्व input य् तयागु:
+help-removed-on-input = थ्व input य् पिकयागु:
+
+help-reset-overrides = { $reset } न { $additional } व { $removed } यात लिकनी।

--- a/packages/i18n/locales/skr/chrome.ftl
+++ b/packages/i18n/locales/skr/chrome.ftl
@@ -1,0 +1,153 @@
+# Saraiki (سرائیکی) viewer chrome: the buttons, panel headings and status
+# words the reader interacts with. Translated from `locales/en/chrome.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and direction: Perso-Arabic, right to left.** Saraiki's alphabet is
+# Urdu's — `ٹ ڈ ڑ` for the retroflexes, `ے` for final *ē*, `ہ` rather than
+# `ه` — plus the four implosives that are the language's signature:
+# **ٻ ڄ ڋ ڳ**. They are written here wherever the word has one, so «اڳلا» is
+# *next* with ڳ and «ڋکھاؤ» is *show* with the implosive *ḍ*. The implosive *ḍ*
+# is encoded **U+068B ڋ** throughout; Saraiki text also circulates with
+# U+0759 (dal with two dots vertically below and small tah), which renders
+# almost identically and compares unequal, so a corrector converting to that
+# convention must convert all four files of this locale at once rather than
+# mix the two. The retroflex nasal is written **ݨ** (U+0768) — «کرݨ»,
+# «ڋکھاوݨ» — which is Saraiki's letter and not Urdu's, and is used here
+# wherever the word has one. `directionOf` learns `skr` from
+# `src/direction.ts`'s fallback list, since ICU does not maximize the tag to a
+# script on its own.
+#
+# Nothing about the file format changes for a right-to-left catalog. The text
+# is written in **logical order** — the order it is spoken — and no bidi
+# control characters are placed by hand: Fluent's own isolation puts the marks
+# around an interpolated value, and `dir` decides where each run is drawn.
+# Brackets and parentheses are written opening-first and the bidi algorithm
+# turns them around at render time.
+#
+# **Digits are Latin.** `{ $percent }`, `{ $count }` and `{ $row }` render as
+# `0`–`9` here as everywhere else in the repository, which is what keeps a
+# Saraiki sentence and the mathematics beside it counting in the same
+# characters. The separator is not pinned; only the ten characters are.
+#
+# **No plural categories.** CLDR has no plural data for `skr`, so nothing here
+# selects on a category and `lint:i18n` would reject one if it did. That costs
+# nothing: a Saraiki noun after a numeral stays unmarked, so one form counts
+# everything. `[0]` is kept where English has it — Fluent matches a numeric
+# literal against the number itself before it consults any plural rule, so
+# that branch is reachable whatever the locale.
+#
+# **Register.** The polite plural imperative in `-و` («کرو», «ڋکھاؤ»,
+# «کھولو»), which is what a Saraiki interface would use and the only form that
+# is safe not knowing who is being addressed. Sentences end in «۔» and separate
+# with «،».
+#
+# **Loans kept rather than coined.** Saraiki-medium schooling stops well short
+# of mathematics and computing, so the technical vocabulary here is the Urdu
+# one a Saraiki-speaking pupil actually meets — `کی بورڈ`, `میٹرکس`, `کالم`,
+# `شماریاتی`, `فیصد`, `آربیٹل`, `WCAG` — written in Saraiki spelling rather
+# than replaced with new words.
+
+
+## Answer submission
+
+answer-checking = پرکھ تھیندی پئی اے...
+answer-submitting = گھلی ویندی پئی اے...
+answer-checking-status = جواب پرکھیا ویندا پئے
+answer-submitting-status = جواب گھلیا ویندا پئے
+answer-correct = ٹھیک
+answer-incorrect = غلط
+answer-response-saved = جواب محفوظ تھی ڳیا
+answer-percent-credit = { $percent }% نمبر
+answer-percent-correct = { $percent }% ٹھیک
+answer-percent-short = { $percent } %
+max-credit-available = ودھ توں ودھ نمبر: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] کوئی کوشش باقی کائنی
+       *[other] { $count } کوششاں باقی ہن
+    }
+validation-correct = (ٹھیک)
+validation-incorrect = (غلط)
+validation-partially-correct = (جزوی طور تے ٹھیک)
+# «دے» is a postposition and stands as its own word, so nothing is joined to
+# the placeable.
+answer-show-responses = { $answerId } دے { $count } جواب ڋکھاؤ
+
+## Disclosure panels
+
+feedback-heading = رائے
+collapsible-click-to-open = (کھولݨ کیتے کلک کرو)
+collapsible-click-to-close = (بند کرݨ کیتے کلک کرو)
+collapsible-initializing = تیار تھیندا پئے...
+footnote-show = حاشیہ ڋکھاؤ
+footnote-hide = حاشیہ لکاؤ
+description-more-information = ودھیک معلومات
+
+## Controls
+
+slider-previous = پچھلا
+slider-next = اڳلا
+keyboard-open = کی بورڈ کھولو
+keyboard-close = کی بورڈ بند کرو
+choice-input-remove-choice = { $choice } ہٹاؤ
+matrix-remove-row = قطار ہٹاؤ
+matrix-add-row = قطار شامل کرو
+matrix-remove-column = کالم ہٹاؤ
+matrix-add-column = کالم شامل کرو
+subset-add-remove-points = نقطے شامل کرو/ہٹاؤ
+subset-toggle-points-intervals = نقطیاں تے وقفیاں وچ بدلو
+subset-move-points = نقطے ہلاؤ
+subset-clear = صاف کرو
+orbital-add-row = قطار شامل کرو
+orbital-remove-row = قطار ہٹاؤ
+orbital-add-box = خانہ شامل کرو
+orbital-remove-box = خانہ ہٹاؤ
+orbital-add-up-arrow = اُتلا تیر شامل کرو
+orbital-add-down-arrow = ہیٹھلا تیر شامل کرو
+orbital-remove-arrow = تیر ہٹاؤ
+orbital-row-label = قطار { $row } دا عنوان
+pretzel-answer = جواب
+# «کالم» names what `$column` is, so the genitive falls on a word this catalog
+# writes rather than on the value.
+summary-statistics-caption = کالم { $column } دا شماریاتی خلاصہ
+
+## Math input
+
+math-input-preview-region = ریاضی دے اظہار دا پیش نظارہ
+math-input-preview = پیش نظارہ
+math-input-invalid-expression = غلط اظہار:
+
+## Document status
+
+viewer-initializing = تیار تھیندا پئے...
+
+## Errors
+
+error-heading = خرابی
+error-found-at =
+    { $span ->
+        [line] سطر { $startLine } تے ملی۔
+       *[lines] سطر { $startLine }–{ $endLine } تے ملی۔
+    }
+document-contains-errors = ایں دستاویز وچ خرابیاں ہن!
+diagnostic-heading-error = خرابی
+diagnostic-heading-warning = تنبیہ
+diagnostic-heading-information = معلومات
+diagnostic-heading-hint = اشارہ
+# `WCAG AA` is the standard's own name and is not translated.
+accessibility-heading-level-1 = رسائی دی خلاف ورزی: WCAG AA
+accessibility-heading-level-2 = رسائی دی تنبیہ
+something-went-wrong = کجھ غلط تھی ڳیا۔
+renderer-load-failed = ہک رینڈرر لوڈ نہ تھی سڳیا۔ مہربانی کر کے صفحہ ولدا لوڈ کرو۔
+core-start-failed = ایہ دستاویز شروع نہ تھی سڳی۔ مہربانی کر کے صفحہ ولدا لوڈ کرو۔
+core-start-failed-busy = ایہ دستاویز شروع نہ تھی سڳی۔ کئی دستاویزاں ہکو ویلھے شروع تھیندیاں پئیاں ہن، تے ہیں ڳالھ نوں سست ڈیوائس تے ودھیک ویلا لڳدا اے۔ ٻیاں دستاویزاں دے مکݨ توں بعد صفحہ ولدا لوڈ کرݨ نال فائدہ تھی سڳدا اے۔
+core-start-failed-retry = ایہ دستاویز شروع نہ تھی سڳی۔
+core-start-failed-busy-retry = ایہ دستاویز شروع نہ تھی سڳی۔ کئی دستاویزاں ہکو ویلھے شروع تھیندیاں پئیاں ہن، تے ہیں ڳالھ نوں سست ڈیوائس تے ودھیک ویلا لڳدا اے۔
+core-start-retry = ولدا کوشش کرو
+saved-state-unavailable = تہاڋا محفوظ تھیا ہویا کم لوڈ نہ تھی سڳیا۔

--- a/packages/i18n/locales/skr/chrome.ftl
+++ b/packages/i18n/locales/skr/chrome.ftl
@@ -18,7 +18,7 @@
 # almost identically and compares unequal, so a corrector converting to that
 # convention must convert all four files of this locale at once rather than
 # mix the two. The retroflex nasal is written **ݨ** (U+0768) — «کرݨ»,
-# «ڋکھاوݨ» — which is Saraiki's letter and not Urdu's, and is used here
+# «کھولݨ» — which is Saraiki's letter and not Urdu's, and is used here
 # wherever the word has one. `directionOf` learns `skr` from
 # `src/direction.ts`'s fallback list, since ICU does not maximize the tag to a
 # script on its own.

--- a/packages/i18n/locales/skr/content.ftl
+++ b/packages/i18n/locales/skr/content.ftl
@@ -87,8 +87,10 @@
 # coined: Saraiki-medium schooling stops well short of geometry, and this is
 # what a Saraiki-speaking pupil actually reads. The **colour and width words
 # are not** — «کالا», «چٹا», «لال», «ساوا», «نیلا», «پیلا», «بھورا», «موٹا»,
-# «پتلا» are the everyday Saraiki words, and they are what make the `$gender`
-# fork above necessary. Elsewhere too, where Saraiki has its own word this file
+# «پتلا» are the everyday Saraiki words. The marked ones among them are what
+# make the `$gender` fork above necessary; «لال» is in the list because it is
+# Saraiki, not because it inflects — it is one of the eight unmarked
+# adjectives and takes no branch. Elsewhere too, where Saraiki has its own word this file
 # uses it: «لکیر» for a line, «نقطہ» for a point, «کم» for a task, «سچ» and
 # «جھوٹ» for the boolean words, «اڳلا» and «پچھلا» for next and previous, «جے»
 # for *if*, «وچوں» for *out of*.

--- a/packages/i18n/locales/skr/content.ftl
+++ b/packages/i18n/locales/skr/content.ftl
@@ -1,0 +1,430 @@
+# Saraiki (سرائیکی) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in, not the reader's interface language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and direction: Perso-Arabic, right to left**, on Urdu's letter
+# inventory plus Saraiki's four implosives **ٻ ڄ ڋ ڳ**, with the implosive *ḍ*
+# encoded U+068B ڋ throughout. `chrome.ftl` states the convention in full and
+# all four files of this locale must keep to the one convention. Nothing about
+# the file format changes for a right-to-left catalog: the text is written in
+# logical order, no bidi control characters are placed by hand, and digits stay
+# Latin.
+#
+# ## Word order
+#
+# **Every modifier comes before the noun**, in English's own order: «موٹی لال
+# لکیر» is *thick red line*, width first, then the dash pattern, then the
+# colour — and «موٹی» is feminine there because «لکیر» is. Saraiki is
+# Indo-Aryan and shares Urdu's and Hindi's shape here, so
+# `style-stroke`, `style-with-noun` and `style-filled-with-noun` all keep the
+# sequence of placeables English uses rather than reversing it. What Saraiki
+# does *not* share with English is the preposition: it is postpositional, so
+# «نال» (*with*) and «تے» (*on*) follow their object, and the composition
+# messages below put them after the placeable rather than in front of it.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } ضلعی باقاعدہ کثیر الاضلاع» and leaves `tail` empty, as English
+# does: the side count sits in front of the noun here too, so nothing has to be
+# split around the adjectives. The `-tail` variants of `style-with-noun` and
+# `style-filled-with-noun` are still written out, because that is what a
+# partly-translated locale falls back to.
+#
+# ## Gender and role — this catalog forks on both
+#
+# **Saraiki inflects an adjective for gender, and this catalog does too.** Its
+# adjectives fall into Urdu's and Hindi's two classes. *Marked* ones end in ا
+# and change — کالا / کالی / کالے, موٹا / موٹی / موٹے — while *unmarked* ones
+# never do: لال, سرمئی, نارنجی, فیروزی, بنفشی, گلابی, منقطع, نقطہ دار. Only
+# the marked ones select below, which is why some entries in `color` are a
+# single word and others are a two-level select.
+#
+# A marked adjective also takes the **oblique ے** in front of a noun governed
+# by a postposition, and that is what `$role` is for here:
+#
+#   standalone          direct, agreeing with the noun described
+#   border-clause       oblique, in front of «کنارے نال»
+#   background-clause   oblique, in front of «پس منظر تے»
+#   text-clause         direct masculine, agreeing with متن
+#
+# The middle two coincide — both nouns are masculine and both sit under a
+# postposition — and they are written out separately anyway: which case a
+# position governs is this catalog's business, and a later rewording may
+# separate them. This is `locales/ur`'s and `locales/hi`'s shape, which is the
+# right one to copy rather than a convenience: Saraiki's inflection *is*
+# theirs, and a correction to one of the three is usually a correction to all
+# three.
+#
+# **What this seed is unsure of is the gender assignments, not the
+# morphology.** `noun-gender` follows Urdu, on the ground that Saraiki and Urdu
+# are known to agree for the words it names; a speaker may well move one
+# between the classes. That is one line to change per word, and no message has
+# to move with it.
+#
+# **Nothing selects on a count.** A Saraiki noun after a numeral stays
+# unmarked, and CLDR has no plural data for `skr` in any case, so a category
+# branch would be one `lint:i18n` rejects.
+#
+# ## The chemistry tables are deliberately absent
+#
+# `element-name` and `element-anion-name` are the only English keys this file
+# does not cover. Saraiki is not a medium of instruction for science —
+# chemistry in Pakistan is taught in Urdu and English — so a Saraiki-speaking
+# pupil meets the periodic table in one of those two and there is no settled
+# Saraiki list of the hundred and eighteen elements to check a translation
+# against. Recording that is the honest answer; transliterating Urdu into
+# Saraiki spelling and calling it a nomenclature is not. `lint:i18n` reports
+# the two keys as missing coverage and that report is correct.
+# `ion-name-oxidation-state` and the two invalid-symbol messages **are**
+# covered: they are frames and punctuation, not vocabulary.
+#
+# ## Where else this seed leans on Urdu
+#
+# The geometry vocabulary — مثلث، مستطیل، مربع، دائرہ، شعاع، منحنی، معین،
+# کثیر الاضلاع، قطعہ خط — is the Urdu mathematical vocabulary, kept rather than
+# coined: Saraiki-medium schooling stops well short of geometry, and this is
+# what a Saraiki-speaking pupil actually reads. The **colour and width words
+# are not** — «کالا», «چٹا», «لال», «ساوا», «نیلا», «پیلا», «بھورا», «موٹا»,
+# «پتلا» are the everyday Saraiki words, and they are what make the `$gender`
+# fork above necessary. Elsewhere too, where Saraiki has its own word this file
+# uses it: «لکیر» for a line, «نقطہ» for a point, «کم» for a task, «سچ» and
+# «جھوٹ» for the boolean words, «اڳلا» and «پچھلا» for next and previous, «جے»
+# for *if*, «وچوں» for *out of*.
+
+
+## Style vocabulary
+##
+## A marked adjective is written as a two-level select: `$role` first, because
+## a postposition's oblique overrides gender agreement, and `$gender` only
+## inside the `standalone` branch. An unmarked adjective is one word and takes
+## no branch at all — writing one out four times would say Saraiki inflects it
+## when it does not.
+
+color =
+    .black =
+        { $role ->
+            [border-clause] کالے
+            [background-clause] کالے
+            [text-clause] کالا
+           *[standalone]
+                { $gender ->
+                    [f] کالی
+                   *[m] کالا
+                }
+        }
+    .white =
+        { $role ->
+            [border-clause] چٹے
+            [background-clause] چٹے
+            [text-clause] چٹا
+           *[standalone]
+                { $gender ->
+                    [f] چٹی
+                   *[m] چٹا
+                }
+        }
+    .gray = سرمئی
+    .red = لال
+    .orange = نارنجی
+    .yellow =
+        { $role ->
+            [border-clause] پیلے
+            [background-clause] پیلے
+            [text-clause] پیلا
+           *[standalone]
+                { $gender ->
+                    [f] پیلی
+                   *[m] پیلا
+                }
+        }
+    .green =
+        { $role ->
+            [border-clause] ساوے
+            [background-clause] ساوے
+            [text-clause] ساوا
+           *[standalone]
+                { $gender ->
+                    [f] ساوی
+                   *[m] ساوا
+                }
+        }
+    .cyan = فیروزی
+    .blue =
+        { $role ->
+            [border-clause] نیلے
+            [background-clause] نیلے
+            [text-clause] نیلا
+           *[standalone]
+                { $gender ->
+                    [f] نیلی
+                   *[m] نیلا
+                }
+        }
+    .purple = بنفشی
+    .pink = گلابی
+    .brown =
+        { $role ->
+            [border-clause] بھورے
+            [background-clause] بھورے
+            [text-clause] بھورا
+           *[standalone]
+                { $gender ->
+                    [f] بھوری
+                   *[m] بھورا
+                }
+        }
+# Both are marked, so both select.
+line-width =
+    .thick =
+        { $role ->
+            [border-clause] موٹے
+            [background-clause] موٹے
+            [text-clause] موٹا
+           *[standalone]
+                { $gender ->
+                    [f] موٹی
+                   *[m] موٹا
+                }
+        }
+    .thin =
+        { $role ->
+            [border-clause] پتلے
+            [background-clause] پتلے
+            [text-clause] پتلا
+           *[standalone]
+                { $gender ->
+                    [f] پتلی
+                   *[m] پتلا
+                }
+        }
+# Both are unmarked, so neither inflects.
+line-style =
+    .dashed = منقطع
+    .dotted = نقطہ دار
+# Noun phrases rather than adjectives: every place a fill pattern is put, it
+# stands in front of the postposition «نال», which governs the oblique — and
+# the oblique plural of these is the form written here, so nothing has to be
+# inflected at the point of use.
+fill-style =
+    .horizontal = افقی لکیراں
+    .vertical = عمودی لکیراں
+    .diagonal = ترچھیاں لکیراں
+    .backdiagonal = مخالف ترچھیاں لکیراں
+    .dots = نقطیاں
+    .diamonds = معیناں
+noun =
+    .line = لکیر
+    .line-segment = قطعہ خط
+    .ray = شعاع
+    .vector = ویکٹر
+    .curve = منحنی
+    .function = فنکشن
+    .slope-field = میلان دا میدان
+    .vector-field = ویکٹر دا میدان
+    .parabola = پیرابولا
+    .polyline = کثیر لکیر
+    .polygon = کثیر الاضلاع
+    .triangle = مثلث
+    .rectangle = مستطیل
+    .circle = دائرہ
+    .region = خطہ
+    .point = نقطہ
+    .square = مربع
+    .diamond = معین
+    .cross = کراس
+    .plus = جمع دا نشان
+# «ضلعی» is unmarked, so the side count sits in front of the noun with the
+# other modifiers and there is nothing to split off into a tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } ضلعی باقاعدہ کثیر الاضلاع
+    }
+# Besides the nouns above, `$noun` can be `regular-polygon` (کثیر الاضلاع, m)
+# or the head of a phrase the description never names: `border` (کنارہ, m),
+# `fill` (بھراؤ, m), `text` (متن, m), `background` (پس منظر, m). The masculine
+# پس منظر is what makes `background-clause` an oblique masculine above, and it
+# is where Saraiki and Urdu part company with Hindi, whose पृष्ठभूमि is
+# feminine. Anything not named here falls to the default, which is also what an
+# author's own `markerStyleWord` gets, since the catalog has never seen it.
+noun-gender =
+    { $noun ->
+        [line] f
+        [ray] f
+        [polyline] f
+       *[other] m
+    }
+
+
+## Style composition
+##
+## English's own order of placeables, kept rather than reversed — Saraiki puts
+## its modifiers in front of the noun as well. What moves is the preposition:
+## Saraiki is postpositional, so «نال» and «تے» follow the value they govern.
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+# A marked participle, so it agrees with the shape: «بھریا ہویا مربع»,
+# «بھری ہوئی لکیر». Only ever said of the shape itself, so it is standalone in
+# every description and takes no `$role` branch. Its opposite, `style-unfilled`
+# below, is the unmarked «خالی» and needs none.
+style-filled-word =
+    { $gender ->
+        [f] بھری ہوئی
+       *[m] بھریا ہویا
+    }
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } { $pattern } نال
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } { $pattern } نال
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } { $pattern } نال
+       *[plain] { $filled } { $color } { $noun }
+    }
+# «نال» is a postposition and governs the oblique, so «کنارہ» is written
+# «کنارے» and its adjectives take the oblique ے too — which is exactly what
+# `$role`'s `border-clause` supplies. Saraiki has no article, so the two
+# `-article` branches read as their plain counterparts do; they are kept apart
+# because the distinction belongs to the English message rather than to this
+# one.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } کنارے نال
+        [and] تے { $border } کنارے نال
+        [and-article] تے { $border } کنارے نال
+       *[with] { $border } کنارے نال
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = خالی
+style-text =
+    { $parts ->
+        [background] { $background } پس منظر تے { $color }
+       *[plain] { $color }
+    }
+style-background-none = کوئی نہیں
+
+
+## Boolean words
+##
+## What a `<boolean>` displays. `true` and `false` as an author writes them in
+## the source stay English; only these two move.
+
+boolean-true = سچ
+boolean-false = جھوٹ
+
+
+## Answer buttons
+
+answer-submit-label = جواب پرکھو
+answer-submit-label-no-correctness = جواب گھلو
+
+
+## Sectional blocks
+
+section-name =
+    .activity = سرگرمی
+    .aside = حاشیہ
+    .cascade = سلسلہ
+    .definition = تعریف
+    .example = مثال
+    .exercise = مشق
+    .exercises = مشقاں
+    .given-answer = جواب
+    .note = نوٹ
+    .objectives = مقصد
+    .paragraphs = پیراگراف
+    .part = حصہ
+    .problem = مسئلہ
+    .problems = مسئلے
+    .proof = ثبوت
+    .question = سوال
+    .section = باب
+    .solution = حل
+    .task = کم
+    .theorem = نظریہ
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ "۔ " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = اشارہ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] جدول { $enumeration }
+        [numbered-title] جدول { $enumeration }{ ": " }
+        [unnumbered-title] جدول{ ": " }
+       *[unnumbered] جدول
+    }
+figure-name =
+    { $parts ->
+        [numbered] شکل { $enumeration }
+        [numbered-caption] شکل { $enumeration }{ ": " }
+        [unnumbered-caption] شکل{ ": " }
+       *[unnumbered] شکل
+    }
+
+
+## Paginator controls
+##
+## «وچوں» — *out of* — is a postposition, so the total comes first and the page
+## label and its number follow, which is the reverse of English's order and a
+## fact about Saraiki rather than a slip.
+
+paginator-previous = پچھلا
+paginator-next = اڳلا
+paginator-page = صفحہ
+paginator-page-status = { $numPages } وچوں { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = یا
+piecewise-condition-if = جے
+piecewise-condition-otherwise = ورنہ
+
+
+## Chemistry
+##
+## The element tables are absent on purpose; see the header. What is here is
+## the frames around a name, which need no nomenclature.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = غلط کیمیائی نشان
+chemistry-invalid-ionic-compound = غلط آئنی مرکب
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = خالی
+math-embedded-input-blank-ordinal = { $total } وچوں خالی { $ordinal }

--- a/packages/i18n/locales/skr/diagnostics.ftl
+++ b/packages/i18n/locales/skr/diagnostics.ftl
@@ -1,0 +1,694 @@
+# Saraiki (سرائیکی) diagnostics: the errors and warnings the core and the
+# language server put in front of whoever is looking at the screen. Translated
+# from `locales/en/diagnostics.ftl`, which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Perso-Arabic on Urdu's letter inventory plus Saraiki's four implosives
+# ٻ ڄ ڋ ڳ, the implosive *ḍ* encoded U+068B, right to left — the same
+# convention the other three files of this locale state. Digits are Latin.
+#
+# **Element names, attribute names and values are not words.** `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text`, `boolean`,
+# `coprime`, `selectFromSequence` and every `<tag>` written into these
+# sentences are DoenetML identifiers and stay in English exactly as they are.
+# The backticks and angle brackets around them are this catalog's punctuation.
+#
+# **No message here selects on a count.** CLDR has no plural data for `skr`, so
+# a category branch would be one nothing could select and `lint:i18n` would
+# reject; and it would be pointless besides, since a Saraiki noun after a
+# numeral stays unmarked. Each such message is written once as `*[other]`, with
+# the count argument kept in the selector so that nothing is lost from the
+# message's shape. The `[1]` in `field-function-wrong-num-outputs` is a numeric
+# literal rather than a category — Fluent matches it against the number itself
+# — so it stays where English has it. The symbolic selectors — `$reason`,
+# `$type`, `$mode`, `$suggestion`, `$isList`, `$context`, `$expected` and the
+# rest — keep every branch English has, because those keys are compared letter
+# for letter and a renamed one is a branch nothing can reach.
+#
+# **Vocabulary chosen once and used throughout**, so a correction is one
+# search: «نظرانداز کیتا ویندے» for *is ignored*, «مقرر کیتا ڳیا» for
+# *specified*, «غلط» for *invalid*, «قیمت» for *value*, «ایٹریبیوٹ» for
+# *attribute*, «کمپوننٹ» for *component*, «لازمی» for *must*, «نہ ملیا» for
+# *not found*, «کیوں جو» for *because*. Those and `ریفرنس`, `میٹرکس`, `ٹائپ`,
+# `فنکشن`, `ویکٹر`, `انڈیکس`, `ورینٹ` are Urdu or English loans kept rather
+# than coined: Saraiki has no computing register of its own, and this file says
+# so rather than inventing one.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] جڈاں ڋو endpoint مقرر کیتے ون٘ڄن، تاں { $attributes } نظرانداز کیتا ویندے
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] جڈاں ہک endpoint تے ہک midpoint ڋوہیں مقرر کیتے ون٘ڄن، تاں { $attributes } نظرانداز کیتا ویندے
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpoint دے بغیر midpointOffset دا کوئی اثر کائنی
+
+## `<line>`
+
+line-points-undetermined-dimensions = خط اینہاں نقطیاں وچوں لنگھدے جینہاں دے ابعاد نامعلوم ہن۔
+
+line-points-too-few-dimensions = خط دا اینہاں نقطیاں وچوں لنگھݨا لازمی اے جیہڑے گھٹ توں گھٹ ڋو ابعاد رکھدے ہن۔
+
+line-points-depend-on-variables = خط اینہاں نقطیاں وچوں لنگھدے جیہڑے ایں متغیرات تے منحصر ہن: { $variables }۔
+
+line-equation-invalid-format = متغیرات { $variable1 } تے { $variable2 } وچ خط دی مساوات دا فارمیٹ غلط اے۔
+
+## `<ray>`
+
+ray-overprescribed-through = شعاع through، endpoint تے direction نال مقرر کیتی ڳئی اے۔  مقرر کیتا ڳیا through نظرانداز کیتا ویندے۔
+
+ray-dimension-mismatch = شعاع وچ numDimensions میل نہیں کھاندا۔
+
+## `<vector>`
+
+vector-overprescribed-head = ویکٹر head، tail تے displacement نال مقرر کیتا ڳیا اے۔  مقرر کیتا ڳیا head نظرانداز کیتا ویندے۔
+
+vector-dimension-mismatch = ویکٹر وچ numDimensions میل نہیں کھاندا۔
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` ول کھچ نہیں سڳدی، کیوں جو ایندے کول nearestPoint حالتی متغیر کائنی۔
+
+constrain-to-without-nearest-point = `<{ $component }>` تے پابندی نہیں لڳ سڳدی، کیوں جو ایندے کول nearestPoint حالتی متغیر کائنی۔
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` دے اندرونی حصے تے پابندی نہیں لڳ سڳدی، کیوں جو ایندے کول nearestPoint حالتی متغیر کائنی۔
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = جیہڑا choiceInput inline کائنی، اوندے کیتے labelPosition نظرانداز کیتا ویندے
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput کیتے مقرر کیتے ڳئے انڈیکس نظرانداز کیتے ویندن، کیوں جو انڈیکساں دی تعداد choice دے بچیاں دی تعداد نال میل نہیں کھاندی۔
+
+pretzel-indices-count-mismatch = problem کیتے مقرر کیتے ڳئے انڈیکس نظرانداز کیتے ویندن، کیوں جو انڈیکساں دی تعداد problem دے بچیاں دی تعداد نال میل نہیں کھاندی۔
+
+shuffle-indices-count-mismatch = shuffle کیتے مقرر کیتے ڳئے انڈیکس نظرانداز کیتے ویندن، کیوں جو انڈیکساں دی تعداد کمپوننٹاں دی تعداد نال میل نہیں کھاندی۔
+
+indices-ignored-out-of-range = { $component } کیتے مقرر کیتے ڳئے انڈیکس نظرانداز کیتے ویندن، کیوں جو کجھ انڈیکس حد توں ٻاہر ہن۔
+
+pretzel-indices-repeated = pretzel کیتے مقرر کیتے ڳئے انڈیکس نظرانداز کیتے ویندن، کیوں جو کجھ انڈیکس دُہرائے ڳئے ہن۔
+
+pretzel-circuit-first-index = circuit موڈ وچ pretzel کیتے مقرر کیتے ڳئے انڈیکس نظرانداز کیتے ویندن، کیوں جو پہلے انڈیکس دا 1 ہوݨ لازمی اے۔
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` نوں string بچیاں نال کم کرݨ کیتے `type` ایٹریبیوٹ دا مقرر ہوݨ لازمی اے۔
+
+invalid-type-defaulting-to-math = { $component } کمپوننٹ کیتے ٹائپ { $type } غلط اے۔ ایندا math، text، number یا boolean ہوݨ لازمی اے۔ پہلوں توں مقرر math ورتیا ویندے۔
+
+string-not-valid-component-to-arrange = String "{ $value }" { $component } کیتے درست کمپوننٹ کائنی۔ نظرانداز کیتا ویندے۔
+
+## Types and variables
+
+invalid-type-defaulting-to-number = ٹائپ { $type } غلط اے، ٹائپ number مقرر کیتا ویندے۔
+
+invalid-variable-value = متغیر دی قیمت غلط اے: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = ورینٹ دے انڈیکس { $index } دا عدد ہوݨ لازمی اے
+
+variant-index-must-be-integer = ورینٹ دے انڈیکس { $index } دا صحیح عدد ہوݨ لازمی اے
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` مطلق پیمائشاں کیتے نہیں بݨیا۔ چوڑائیاں نسبتی مقرر کیتیاں ویندن۔
+
+side-by-side-absolute-margins = `<{ $component }>` مطلق پیمائشاں کیتے نہیں بݨیا۔ حاشیے نسبتی مقرر کیتے ویندن۔
+
+side-by-side-no-block-child = `<{ $component }>` غلط اے: ایندے کول گھٹ توں گھٹ ہک بلاک بچہ ہوݨ لازمی اے۔
+
+## `<label>`
+
+label-for-ignored-on-graphical = گرافیکی `<label>` تے `for` ایٹریبیوٹ نظرانداز کیتا ویندے۔
+
+label-for-must-resolve-to-one = `<label>` تے `for` ایٹریبیوٹ دا ٹھیک ہک کمپوننٹ ول اشارہ کرݨ لازمی اے۔
+
+label-for-unresolved = `<label>` تے `for` ایٹریبیوٹ کیں کمپوننٹ ول اشارہ نہ کر سڳیا۔
+
+label-for-answer-with-authored-inputs = `<label>` تے `for` ایٹریبیوٹ ہک ہیجھے `<answer>` ول اشارہ کریندے جیندے ان پٹ مصنف نے آپ لکھے ہن؛ سیدھا ان پٹ ول ریفرنس ڋیو۔
+
+label-for-answer-without-input = `<label>` تے `for` ایٹریبیوٹ ہک ہیجھے `<answer>` ول اشارہ کریندے جیندے کول عنوان ڋیوݨ کیتے کوئی ان پٹ کائنی۔
+
+label-for-must-reference-input-or-answer = `<label>` تے `for` ایٹریبیوٹ دا کیں ان پٹ یا کیں answer ول ریفرنس ہوݨ لازمی اے۔
+
+## Accessibility
+
+accessibility-short-description-or-decorative = رسائی کیتے `<{ $component }>` دا یا تاں مختصر تفصیل رکھݨ یا decorative مقرر ہوݨ لازمی اے۔
+
+accessibility-video-short-description = رسائی کیتے `<video>` دا مختصر تفصیل رکھݨ لازمی اے۔
+
+accessibility-input-short-description-or-label = رسائی کیتے `<{ $component }>` دا مختصر تفصیل یا label رکھݨ لازمی اے۔
+
+accessibility-answer-input-short-description-or-label = رسائی کیتے ہیجھے `<answer>` دا، جیہڑا ہک ان پٹ بݨیندے، مختصر تفصیل یا label رکھݨ لازمی اے۔
+
+accessibility-short-description-contains-math = مختصر تفصیلاں وچ `<{ $component }>` ورڳے ریاضی دے کمپوننٹ نہیں ہوݨے چاہیدے۔ ریاضی نوں لفظاں وچ لکھو۔
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } باب دے عنوان دے متن کیتے کافی کنٹراسٹ نہیں ڋیندا (تاریک موڈ) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ گھٹ توں گھٹ { $threshold }:1 درکار اے)۔
+       *[other] { $colorName } باب دے عنوان دے متن کیتے کافی کنٹراسٹ نہیں ڋیندا ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ گھٹ توں گھٹ { $threshold }:1 درکار اے)۔
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = جڈاں نقطیاں دیاں عددی قیمتاں نہ ہوون، تاں { $count } نقطیاں وچوں لنگھݨ آلا `<circle>` ہالے تیک نہیں بݨیا۔
+
+circle-too-many-through-points = 3 توں ودھ نقطیاں وچوں لنگھݨ آلے دائرے دا حساب نہیں تھی سڳدا۔
+
+circle-overprescribed-radius-center-points = مقرر کیتے ڳئے رداس، مرکز تے نقطیاں نال دائرے دا حساب نہیں تھی سڳدا۔
+
+circle-center-with-multiple-points = مقرر کیتے ڳئے مرکز نال 1 توں ودھ نقطیاں وچوں لنگھݨ آلے دائرے دا حساب نہیں تھی سڳدا۔
+
+circle-radius-too-small = دائرے دا حساب نہیں تھی سڳدا: ڋوہاں نقطیاں وچکار فاصلہ { $distance } اے، ایں کیتے مقرر کیتا ڳیا رداس { $radius } ٻہوں گھٹ اے۔
+
+circle-radius-with-many-points = مقرر کیتے ڳئے رداس نال ڋو توں ودھ نقطیاں وچوں لنگھݨ آلا دائرہ نہیں بݨ سڳدا۔
+
+circle-invalid-center-or-through-points = دائرے دا مرکز یا نقطے غلط ہن۔
+
+circle-radius-center-with-multiple-points = مقرر کیتے ڳئے مرکز نال 1 توں ودھ نقطیاں وچوں لنگھݨ آلے دائرے دے رداس دا حساب نہیں تھی سڳدا۔
+
+circle-change-radius-non-numerical = جیہڑے نقطیاں دیاں عددی قیمتاں کائنی، اونہاں وچوں لنگھݨ آلے دائرے دا رداس نہیں بدل سڳدا
+
+circle-radius-with-points-non-numerical = جڈاں عددی قیمتاں نہ ہوون، تاں مقرر کیتے ڳئے رداس نال ہک توں ودھ نقطیاں وچوں لنگھݨ آلا دائرہ نہیں بݨ سڳدا۔
+
+circle-change-center-non-numerical = جیہڑے نقطیاں دیاں عددی قیمتاں کائنی، اونہاں وچوں لنگھݨ آلے دائرے دا مرکز بدلݨ ہالے تیک نہیں بݨیا۔
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] فنکشن دے ڈومین کیتے ابعاد کافی کائنی۔ ڈومین وچ { $intervals } وقفے ہن پر فنکشن کول { $inputs ->
+           *[other] { $inputs } ان پٹ
+        } ہن۔
+    }
+
+function-domain-invalid-format = فنکشن دے ڈومین دا فارمیٹ غلط اے۔
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] فنکشن دا غیر عددی maximum نظرانداز کیتا ویندے۔
+        [minimum] فنکشن دا غیر عددی minimum نظرانداز کیتا ویندے۔
+        [extremum] فنکشن دا غیر عددی extremum نظرانداز کیتا ویندے۔
+        [point] فنکشن دا غیر عددی نقطہ نظرانداز کیتا ویندے۔
+        [slope] فنکشن دا غیر عددی میلان نظرانداز کیتا ویندے۔
+       *[other] فنکشن دا غیر عددی { $type } نظرانداز کیتا ویندے۔
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] فنکشن دا خالی maximum نظرانداز کیتا ویندے۔
+        [minimum] فنکشن دا خالی minimum نظرانداز کیتا ویندے۔
+        [extremum] فنکشن دا خالی extremum نظرانداز کیتا ویندے۔
+        [point] فنکشن دا خالی نقطہ نظرانداز کیتا ویندے۔
+       *[other] فنکشن دا خالی { $type } نظرانداز کیتا ویندے۔
+    }
+
+function-points-too-close = فنکشن وچ ڋو ہیجھے نقطے ہن جیہڑے ہک ڋوجھے دے ٻہوں نزدیک ہن۔ فنکشن دی تعریف نہیں تھی سڳدی۔
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] فنکشن دے تکرار تڈاں ہی ممکن ہن جڈاں فنکشن دے ان پٹاں دی تعداد آؤٹ پٹاں دی تعداد دے برابر ہووے۔ ایں فنکشن کول { $inputs } ان پٹ تے { $outputs ->
+           *[other] { $outputs } آؤٹ پٹ
+        } ہن۔
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = ترتیب دی لمبائی غلط اے۔  ایندا غیر منفی صحیح عدد ہوݨ لازمی اے۔
+
+sequence-invalid-step = ترتیب دا قدم غلط اے۔  { $type } ٹائپ دی ترتیب کیتے ایندا عدد ہوݨ لازمی اے۔
+
+sequence-invalid-endpoint-number = عددی ترتیب دا "{ $attribute }" غلط اے۔  ایندا عدد ہوݨ لازمی اے۔
+
+sequence-invalid-endpoint-letters = حرفی ترتیب دا "{ $attribute }" غلط اے۔  ایندا حرفاں دا مجموعہ ہوݨ لازمی اے۔
+
+sequence-invalid-endpoint = ترتیب دا "{ $attribute }" غلط اے۔
+
+select-from-sequence-coprime-not-numbers = عدد نہیں چݨے ویندے، ایں کیتے coprime نظرانداز کیتا ویندے
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations مقرر کیتا ڳیا اے، ایں کیتے coprime نظرانداز کیتا ویندے
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` کیتے target غلط اے: target نہ ملیا۔
+
+target-state-variable-not-found = `<{ $source }>` کیتے target غلط اے: `<{ $component }>` تے "{ $property }" ناں دا حالتی متغیر نہ ملیا۔
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` دے متغیرات دا آزاد متغیر توں وکھرا ہوݨ لازمی اے۔
+
+ode-system-duplicate-variable-names = دُہرائے ڳئے تابع متغیراں دے ناواں نال ODE RHS فنکشناں دی تعریف نہیں تھی سڳدی۔
+
+ode-system-rhs-function-error = ODE RHS فنکشن دی تعریف نہیں تھی سڳدی۔  mathjs فنکشن بݨاوݨ وچ خرابی۔
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } خطاں وچکار زاویے دی تعریف نہیں تھی سڳدی
+
+angle-invalid-through-point = `<angle>` دے through وچ غلط نقطہ
+
+parabola-vertex-too-many-points = راس نال 1 توں ودھ نقطیاں وچوں لنگھݨ آلا پیرابولا ہالے تیک نہیں بݨیا۔
+
+parabola-too-many-points = 3 توں ودھ نقطیاں وچوں لنگھݨ آلا پیرابولا ہالے تیک نہیں بݨیا۔
+
+intersection-too-many-items = ڋو توں ودھ چیزاں دا تقاطع ہالے تیک نہیں بݨیا
+
+## Other math components
+
+ionic-compound-not-two-ions = ڋو آئناں توں علاوہ کیں ٻئی صورت وچ آئنی مرکب ہالے تیک نہیں بݨیا۔
+
+ionic-compound-needs-cation-and-anion = آئنی مرکب صرف ہک کیٹائن تے ہک اینائن کیتے بݨیا اے۔
+
+solve-equations-cannot-evaluate = مساوات دا حساب نہ تھی سڳیا، ایں کیتے مساوات حل نہیں تھیندی: { $equation }
+
+math-operators-operand-number-required = ریاضی دا کوئی عامل کڈھݨ ویلھے operandNumber دا مقرر ہوݨ لازمی اے۔
+
+eigen-decomposition-failed = میٹرکس دیاں آئگن قیمتاں دا حساب نہ تھی سڳیا
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: پیرامیٹر { $parameters } پیٹرن وچ کائنی، ایں کیتے ہمیشہ خالی نال میل کھاسی۔
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" دا مطلب سمجھ نہیں آندا۔ ایندا none، medium، dense یا ڋو مثبت عدد ہوݨ لازمی اے جیہڑے ہک خالی جاء نال وکھرے کیتے ڳئے ہوون، جیویں grid="1 0.5"۔ کوئی گرڈ نہیں وائھیا ویندا۔
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` نوں ہیجھا فنکشن گھرجدے جیہڑا { $expected ->
+        [1] ہک آؤٹ پٹ ڋیوے، یعنی ہر نقطے تے میلان y'، جیویں `y - x`
+       *[other] ڋو آؤٹ پٹ ڋیوے، یعنی ہر نقطے تے ویکٹر، جیویں `(y, -x)`
+    }، پر جیہڑا فنکشن ڋتا ڳیا اے او { $found ->
+       *[other] { $found } آؤٹ پٹ
+    } ڋیندے۔ { $alternative ->
+        [none] کجھ وی نہیں وائھیا ویندا۔
+       *[other] ایں فنکشن کیتے `<{ $alternative }>` ٹھیک کمپوننٹ اے۔ کجھ وی نہیں وائھیا ویندا۔
+    }
+
+field-function-attribute-ignored-with-child = `function` ایٹریبیوٹ نظرانداز کیتا ویندے کیوں جو فنکشن کمپوننٹ دے اندر وی ڋتا ڳیا اے؛ اندر آلا ورتیا ویندے۔ فنکشن ڋوہاں وچوں صرف ہک طریقے نال ڋیو۔
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` ایٹریبیوٹ ہیجھے اظہار دے متغیرات دے ناں ڋیندے جیہڑا سیدھا کمپوننٹ دے اندر لکھیا ڳیا ہووے۔ { $reason ->
+        [function-child] ایتھاں فنکشن `<function>` بچے دے طور تے ڋتا ڳیا اے، جیہڑا آپݨے متغیرات دے ناں آپ ڋیندے، ایں کیتے `variables` نظرانداز کیتا ویندے۔
+       *[no-expression] ایتھاں ہیجھا کوئی اظہار کائنی، ایں کیتے `variables` نظرانداز کیتا ویندے۔
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure رینڈرر وچ xLabelPosition="left" دی سہولت کائنی؛ سڄے پاسے آلا رویہ ورتیا ویندے۔
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure رینڈرر وچ yLabelPosition="bottom" دی سہولت کائنی؛ اُتلے پاسے آلا رویہ ورتیا ویندے۔
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure وچ بدلݨ کیتے محور دیاں حداں غلط ہن؛ پہلوں توں مقرر bbox (-10,-10,10,10) ورتیا ویندے۔
+
+prefigure-invalid-width = `<graph>`: prefigure وچ بدلݨ کیتے چوڑائی غلط اے؛ پہلوں توں مقرر خاکے دی چوڑائی 425 ورتی ویندی اے۔
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure وچ بدلݨ کیتے aspectRatio غلط اے؛ پہلوں توں مقرر تناسب 1 ورتیا ویندے۔
+
+prefigure-grid-spacing-too-fine = `<graph>`: محور دیاں حداں کیتے گرڈ دا فاصلہ ٻہوں باریک اے؛ prefigure رینڈرر وچ گرڈ چھوڑ ڋتا ویندے۔
+
+prefigure-annotations-not-rendered = `<graph>`: جڈاں PreFigure رینڈرر نہ ورتیا ون٘ڄے، تاں annotation نہیں وائھے ویندے۔
+
+multiple-annotations-children = `<graph>` وچ کئی `<annotations>` بچے ملے؛ آخری توں سوا باقی سارے نظرانداز کیتے ویندن۔
+
+## Referring to other components
+
+copy-unrecognized-component-type = ناشناختہ کمپوننٹ ٹائپ دی توسیع یا نقل نہیں تھی سڳدی: { $type }۔
+
+copy-prop-not-found = { $component } ٹائپ دے کمپوننٹ تے { $property } prop نہ ملیا
+
+collect-no-source = collect کیتے کوئی ماخذ نہ ملیا۔
+
+collect-invalid-component-type = `<{ $component }>` ٹائپ دے کمپوننٹ اکٹھے نہیں تھی سڳدے، کیوں جو ایہ ٹائپ غلط اے۔
+
+reference-index-unavailable = انڈیکس `{ $reference }` دا ریفرنس نہیں ڋتا ون٘ڄ سڳدا
+
+## `<callAction>`
+
+component-action-unavailable = کمپوننٹ `{ $reference }` تے { $action } نہیں سڋیا ون٘ڄ سڳدا
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ڈیٹے دی شکل غلط اے۔  قطاراں دیاں لمبائیاں ہک ورڳیاں کائنی۔ componentIdx وچ ملیا :{ $componentIdx }
+
+data-frame-duplicate-column-names = ڈیٹے وچ کالماں دے ناں دُہرائے ڳئے ہن۔  componentIdx وچ ملیا :{ $componentIdx }
+
+data-frame-missing-column-name = ڈیٹے وچ ہک کالم دا ناں کائنی۔  componentIdx وچ ملیا :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ایں جواب دا ہک award اوندے آپݨے بھیجے ڳئے جواب تے منحصر اے، تے ایں نال غیر متوقع رویہ سامݨے آسی۔
+
+answer-max-num-attempts-in-section-wide-check-work = ہیجھے کنٹینر دے اندر جیندے کول sectionWideCheckWork ہووے، `<answer>` تے `maxNumAttempts` مقرر کرݨ دا کوئی اثر کائنی، کیوں جو کوششاں دی تعداد کنٹینر کنٹرول کریندے۔ `maxNumAttempts` کنٹینر تے مقرر کرو۔
+
+nested-section-wide-check-work-max-num-attempts = ہیجھے کنٹینر تے جیندے کول sectionWideCheckWork ہووے تے جیہڑا کیں ٻئے sectionWideCheckWork آلے کنٹینر دے اندر ہووے، `maxNumAttempts` مقرر کرݨ دا کوئی اثر کائنی، کیوں جو کوششاں دی تعداد ٻاہرلا کنٹینر کنٹرول کریندے۔ `maxNumAttempts` ٻاہرلے کنٹینر تے مقرر کرو۔
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality مقرر کیتے بغیر { $attributes } ایٹریبیوٹ دا کوئی اثر نہیں تھیسی۔
+    }
+
+answer-invalid-type = جواب کیتے ٹائپ غلط اے: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` کمپوننٹ دا کوئی ناں کائنی، ایں کیتے او module دے ایٹریبیوٹ طور تے نہیں ورتیا ون٘ڄ سڳدا
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` کمپوننٹ module دے ایٹریبیوٹ طور تے نہیں ورتیا ون٘ڄ سڳدا، کیوں جو `<module>` کمپوننٹ ٹائپ وچ "{ $name }" ناں دا ایٹریبیوٹ پہلوں ای موجود اے۔
+
+conditional-content-condition-ignored = جیندے کول case یا else بچے ہوون، ایہو جیہے `<conditionalContent>` کمپوننٹ تے `condition` ایٹریبیوٹ نظرانداز کیتا ویندے۔
+
+slider-markers-type-mismatch = مارکراں دا ٹائپ slider دے ٹائپ نال میل نہیں کھاندا۔
+
+pretzel-problem-needs-statement-and-answer = pretzel غلط اے: ہر `<problem>` وچ ہک `<statement>` تے ہک `<answer>` ہوݨ لازمی اے۔
+
+pretzel-circuit-first-problem-distractor = pretzel غلط اے: mode="circuit" وچ پہلا `<problem>` distractor نہیں تھی سڳدا۔
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] ایٹریبیوٹ `{ $attribute }` کیتے غلط قیمت { $values }؛ نظرانداز کیتی ویندی اے۔
+    }
+
+attribute-must-be-references = ایٹریبیوٹ `{ $attribute }` کیتے قیمت `{ $value }` غلط اے۔ ایٹریبیوٹ ہیجھے ریفرنساں توں بݨیا ہوݨ لازمی اے جیہڑے `$` نال شروع تھیندن۔
+
+math-input-invalid-function-names = <mathInput>: { $attribute } وچ غلط فنکشن ناں نظرانداز کیتے ڳئے: { $names }۔ ہر ناں دا ڋکھاوے آلا حصہ گھٹ توں گھٹ 2 حرفاں دا ہوݨ لازمی اے (حرف یا ڈیش)؛ اوندے پچھوں مرضی نال `|<mathspeak alternative>` وی آ سڳدے۔
+
+## Building components from the source
+
+component-type-invalid = کمپوننٹ ٹائپ غلط اے: `<{ $componentType }>`
+
+attribute-repeated = ایٹریبیوٹ { $attribute } دُہرایا نہیں ون٘ڄ سڳدا۔
+
+attribute-invalid-for-component = `<{ $componentType }>` ٹائپ دے کمپوننٹ کیتے ایٹریبیوٹ "{ $attribute }" غلط اے۔
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    سٹائل دی تعریف { $styleNumber } وچ { $context ->
+        [text-on-background] پس منظر دے مقابلے متن دے رنگ
+        [high-contrast] کینوس دے مقابلے تیز کنٹراسٹ آلے رنگ
+        [line] کینوس دے مقابلے خط دے رنگ
+        [marker] کینوس دے مقابلے مارکر دے رنگ
+       *[text-on-canvas] کینوس دے مقابلے متن دے رنگ
+    } کیتے کافی کنٹراسٹ کائنی{ $mode ->
+        [dark] { " (تاریک موڈ)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ گھٹ توں گھٹ { $threshold }:1 درکار اے)۔
+
+style-definition-dark-mode-text-background-contrast =
+    سٹائل دی تعریف { $styleNumber } وچ مقرر کیتے ڳئے رنگ روشن موڈ کیتے کافی کنٹراسٹ ڋیندن، پر اونہاں توں کڈھے ڳئے تاریک موڈ دے رنگاں وچ پس منظر دے مقابلے متن دے رنگ دا کنٹراسٹ کافی کائنی ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ گھٹ توں گھٹ { $threshold }:1 درکار اے)۔ { $suggestion ->
+        [available] تاریک موڈ وچ کافی کنٹراسٹ یقینی بݨاوݨ کیتے یا تاں روشن موڈ دا کنٹراسٹ ودھاؤ (مثلاً { $lightAttribute }="{ $lightColor }" مقرر کرو) یا تاریک موڈ دا رنگ آپ مقرر کرو (مثلاً { $darkAttribute }="{ $darkColor }" مقرر کرو)۔
+       *[none] تاریک موڈ وچ کافی کنٹراسٹ یقینی بݨاوݨ کیتے روشن موڈ دا کنٹراسٹ ودھاؤ یا کڈھے ڳئے رنگاں نوں textColorDarkMode تے/یا backgroundColorDarkMode نال بدلو۔
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    سٹائل دی تعریف { $styleNumber } وچ مقرر کیتا ڳیا متن دا رنگ روشن موڈ کیتے کافی کنٹراسٹ ڋیندے، پر اوندے توں کڈھیا ڳیا تاریک موڈ دے متن دا رنگ کینوس دے مقابلے کافی کنٹراسٹ نہیں ڋیندا ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1؛ گھٹ توں گھٹ { $threshold }:1 درکار اے)۔ { $suggestion ->
+        [available] تاریک موڈ وچ کافی کنٹراسٹ یقینی بݨاوݨ کیتے یا تاں روشن موڈ دا کنٹراسٹ ودھاؤ (مثلاً textColor="{ $lightColor }" مقرر کرو) یا تاریک موڈ دا رنگ آپ مقرر کرو (textColorDarkMode="{ $darkColor }" مقرر کرو)۔
+       *[none] تاریک موڈ وچ کافی کنٹراسٹ یقینی بݨاوݨ کیتے روشن موڈ دا کنٹراسٹ ودھاؤ یا کڈھے ڳئے رنگ نوں textColorDarkMode نال بدلو۔
+    }
+
+section-multiple-style-palettes = ہک باب صرف ہک <stylePalette> چݨ سڳدے؛ آخری ورتیا ویندے۔
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو numToSelect غیر منفی صحیح عدد کائنی۔
+
+variant-num-to-select-not-constant-number = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو numToSelect ثابت عدد کائنی۔
+
+variant-with-replacement-not-constant-boolean = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو withReplacement ثابت boolean کائنی۔
+
+variant-select-weight-disables-unique = جے کیں آپشن تے selectWeight یا selectForVariants مقرر ہووے تاں select کیتے منفرد ورینٹ بند تھی ویندن
+
+variant-coprime-undetermined = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو ایہ معلوم نہیں تھیندا جو coprime ہمیشہ غلط اے۔
+
+variant-attribute-not-constant = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو { $attribute } ثابت کائنی۔
+
+variant-attribute-not-number = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو { $attribute } عدد کائنی۔
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } ٹائپ دے { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو { $attribute } { $expected ->
+        [letters-combination] حرفاں دا مجموعہ
+        [math-expression] درست ریاضیاتی اظہار
+        [integer] صحیح عدد
+       *[number] عدد
+    } کائنی۔
+
+variant-length-not-integer = { $component } دے منفرد ورینٹ معلوم نہیں تھی سڳدے، کیوں جو length صحیح عدد کائنی۔
+
+variant-sort-not-implemented = sort آلے { $component } دے منفرد ورینٹ ہالے تیک نہیں بݨے
+
+variant-exclude-combinations-not-implemented = excludeCombinations آلے { $component } دے منفرد ورینٹ ہالے تیک نہیں بݨے
+
+variant-math-exclude-not-implemented = exclude آلے math ٹائپ دے { $component } دے منفرد ورینٹ ہالے تیک نہیں بݨے
+
+variant-non-constant-exclude-not-implemented = غیر ثابت exclude آلے { $component } دے منفرد ورینٹ ہالے تیک نہیں بݨے
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: گراف دے prefigure رینڈرر وچ ایندی سہولت کائنی؛ اولاد چھوڑ ڋتی ڳئی۔
+
+prefigure-descendant-invalid-geometry = { $subject }: جیومیٹری غیر محدود یا ادھوری اے؛ اولاد چھوڑ ڋتی ڳئی۔
+
+prefigure-curve-label-omitted = { $subject }: بدلے ڳئے منحنی عناصر تے label دی سہولت کائنی؛ label چھوڑ ڋتا ڳیا۔
+
+prefigure-curve-unsupported-definition-type = { $subject }: منحنی دے فنکشن دی تعریف دے ٹائپ '{ $definitionType }' دی سہولت کائنی؛ اولاد چھوڑ ڋتی ڳئی۔
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves تے flipFunctions ایٹریبیوٹ دی سہولت کائنی؛ اولاد چھوڑ ڋتی ڳئی۔
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves تے صرف formula ٹائپ دے بچہ فنکشناں دی سہولت اے؛ اولاد چھوڑ ڋتی ڳئی۔
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] خط خاندان دے label
+       *[point] نقطے دے label
+    } کیتے labelPosition '{ $labelPosition }' دی سہولت کائنی؛ PreFigure دی پہلوں توں مقرر ترتیب ورتی ڳئی۔
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure وچ بھراوے دے سٹائل '{ $fillStyle }' دی سہولت کائنی؛ سادہ بھراوا ورتیا ویندے۔
+
+prefigure-line-style-unknown = { $subject }: ناشناختہ خط دا سٹائل '{ $lineStyle }' PreFigure دے آؤٹ پٹ وچوں چھوڑ ڋتا ڳیا۔
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: مارکر دا سٹائل '{ $markerStyle }' PreFigure دے 'diamond' سٹائل وچ بدلیا ڳیا۔
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure وچ مارکر دے سٹائل '{ $markerStyle }' دی سہولت کائنی؛ پہلوں توں مقرر سٹائل ورتیا ڳیا۔
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` غلط اے؛ ہدف نہیں لبھدا۔ annotation چھوڑ ڋتا ڳیا۔
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` کئی ہدفاں ول اشارہ کریندے؛ پہلا ہدف ورتیا ویندے۔
+
+annotation-ref-outside-graph = `<annotation>`: `ref` غلط اے؛ ہدف اپݨے گراف توں ٻاہر اے۔ annotation چھوڑ ڋتا ڳیا۔
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` غلط اے؛ prefigure وچ بدلݨ ویلھے ہدف کوئی سہولت آلی گرافیکی چیز کائنی۔ annotation چھوڑ ڋتا ڳیا۔
+
+annotation-text-missing = `<annotation>`: `text` غائب یا خالی اے؛ خالی متن ڋتا ویندے۔
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] گول انحصار لبھیا۔
+       *[other] `<{ $componentType }>` کمپوننٹ نال جڑیا گول انحصار لبھیا۔
+    }
+
+reference-no-referent = ریفرنس `{ $reference }` کیتے کوئی مرجع نہ ملیا
+
+reference-multiple-referents = ریفرنس `{ $reference }` کیتے کئی مرجع ملے
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` دے ایٹریبیوٹ { $attribute } دا فارمیٹ غلط اے۔
+
+children-invalid = `<{ $componentType }>` کیتے غلط بچے: غلط بچے ملے: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = ایٹریبیوٹ `{ $attribute }` کیتے قیمت `{ $value }` غلط اے، قیمت `{ $default }` ورتی ویندی اے
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML دا ورژن { $version } نہ ملیا۔
+       *[other] DoenetML دا ورژن { $version } نہ ملیا۔ ورژن { $fallback } ورتیا ویندے
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = غلط DoenetML: { $content }
+
+parse-tag-missing-close-tag = غلط DoenetML: ٹیگ `{ $tag }` دا بند کرݨ آلا ٹیگ کائنی۔ یا تاں آپ بند تھیوݨ آلا ٹیگ یا `</{ $tagName }>` ٹیگ درکار اے۔
+
+parse-tag-error = غلط DoenetML: ٹیگ `<{ $tagName }>` وچ خرابی
+
+parse-attribute-missing-value = غلط DoenetML: غلط ایٹریبیوٹ `{ $attribute }` توں لڳدے جو ایندی قیمت غائب اے۔
+
+parse-attribute-invalid = غلط DoenetML: غلط ایٹریبیوٹ `{ $attribute }`
+
+parse-attribute-value-invalid = غلط DoenetML: ایٹریبیوٹ دی غلط قیمت `{ $value }`
+
+parse-attribute-value-quote-mismatch = غلط DoenetML: ایٹریبیوٹ دی غلط قیمت `{ $value }`۔ واوین دا جوڑا میل نہیں کھاندا۔ لڳدے جو تہاڋے کول ہک `{ $quote }` گھٹ اے
+
+parse-open-tag-name-missing = غلط DoenetML: بغیر ناں دا ٹیگ ملیا، جیویں `<`
+
+parse-tag-not-closed = غلط DoenetML: ٹیگ `{ $tag }` بند نہ تھیا (لڳدے جو ہک `>` غائب اے)۔
+
+parse-self-closing-tag-name-missing = غلط DoenetML: بغیر ناں دا ٹیگ ملیا `<{ $content }>`
+
+parse-self-closing-tag-not-closed = غلط DoenetML: ٹیگ `{ $tag }` بند نہ تھیا (لڳدے جو `/>` غائب اے)۔
+
+parse-tag-invalid-attributes = غلط DoenetML: ٹیگ `{ $tag }` درست کائنی۔ لڳدے جو ایندے ایٹریبیوٹ غلط ہن۔
+
+parse-close-tag-name-missing = غلط DoenetML: بغیر ناں دا بند کرݨ آلا ٹیگ ملیا، جیویں `</`
+
+parse-attribute-value-unquoted = ایٹریبیوٹ دیاں قیمتاں دا واوین وچ ہوݨ لازمی اے: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = غلط DoenetML: بند کرݨ آلا ٹیگ `{ $tag }` ملیا، پر اوندا کھولݨ آلا ٹیگ کائنی
+
+parse-close-tag-mismatched = غلط DoenetML: بند کرݨ آلا ٹیگ میل نہیں کھاندا۔ `</{ $expected }>` درکار ہا۔ `{ $found }` ملیا
+
+parser-node-unconvertible = نوڈ { $node } نوں Dast نوڈ وچ نہ بدلیا ون٘ڄ سڳیا۔
+
+## Names
+
+name-attribute-invalid =
+    غلط ایٹریبیوٹ name='{ $name }'۔ { $reason ->
+        [characters] ناواں وچ صرف حرف، عدد، ہیٹھلی لکیر یا ڈیش آ سڳدن۔
+       *[start] ناواں دا کیں حرف نال شروع تھیوݨ لازمی اے۔
+    }
+
+component-name-invalid-start = غلط کمپوننٹ ناں "{ $name }"۔ ناواں دا کیں حرف نال شروع تھیوݨ لازمی اے۔
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched ٹائپ دے جواب کول video ایٹریبیوٹ ہوݨ لازمی اے
+
+answer-video-watched-video-not-reference = videoWatched ٹائپ دے جواب دا video ایٹریبیوٹ ہک ریفرنس ہوݨ لازمی اے
+
+answer-name-not-single-text = جواب دے name ایٹریبیوٹ وچ صرف ہک text بچہ ہوݨ لازمی اے
+
+## Referencing another document
+
+external-doenetml-recursion-limit = ٻہوں زیادہ تہاں دے سبب ٻاہرلا DoenetML نہ لیا ون٘ڄ سڳیا۔ کیا کوئی گول ریفرنس اے؟
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" توں DoenetML نہ لیا ون٘ڄ سڳیا
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" توں لیا ڳیا DoenetML غلط اے: او "{ $componentType }" کمپوننٹ ٹائپ نال میل نہ کھادا
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] ایٹریبیوٹ `{ $from }` متروک اے؛ اوندی جاء تے `{ $to }` ورتو۔
+       *[other] [deprecation] `<{ $component }>` تے ایٹریبیوٹ `{ $from }` متروک اے؛ اوندی جاء تے `{ $to }` ورتو۔
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] ایٹریبیوٹ `{ $from }` متروک اے تے نظرانداز کیتا ویندے، کیوں جو `{ $to }` وی مقرر کیتا ڳیا اے۔
+       *[other] [deprecation] `<{ $component }>` تے ایٹریبیوٹ `{ $from }` متروک اے تے نظرانداز کیتا ویندے، کیوں جو `{ $to }` وی مقرر کیتا ڳیا اے۔
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` تے ایٹریبیوٹ `{ $attribute }` متروک اے تے نظرانداز کیتا ویندے۔
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` تے ایٹریبیوٹ `{ $attribute }` متروک اے؛ اوندی جاء تے `<{ $child }>` بچہ ورتو۔
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` تے ایٹریبیوٹ `{ $attribute }` دی قیمت `{ $value }` متروک اے؛ اوندی جاء تے `{ $to }` ورتو۔
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` صرف انگریزی دی جمع بݨا سڳدے، ایں کیتے { $locale } وچ لکھی ڳئی دستاویز وچ اوندا متن جیویں ہا اوویں رہندے۔ جمع دی شکل سیدھی لکھو، یا `pluralForm` ایٹریبیوٹ نال مقرر کرو۔
+
+
+## Checking against the schema
+
+schema-element-unrecognized = عنصر `<{ $tag }>` Doenet دا پہچاݨیا ہویا عنصر کائنی۔
+
+schema-element-not-allowed-at-root = عنصر `<{ $tag }>` دستاویز دی جڑ تے نہیں آ سڳدا۔
+
+schema-element-not-allowed-inside = عنصر `<{ $tag }>` `<{ $parent }>` دے اندر نہیں آ سڳدا۔
+
+schema-attribute-unrecognized = عنصر `<{ $tag }>` کول `{ $attribute }` ناں دا کوئی ایٹریبیوٹ کائنی۔
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] عنصر `<{ $tag }>` دے ایٹریبیوٹ `{ $attribute }` دا ہیجھی فہرست ہوݨ لازمی اے جیندا ہر جز اینہاں وچوں ہک ہووے: { $allowed }
+       *[other] عنصر `<{ $tag }>` دے ایٹریبیوٹ `{ $attribute }` دا اینہاں وچوں ہک ہوݨ لازمی اے: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select کیتے ورینٹ دا ناں غلط اے۔  ورینٹ دا ناں { $variantName } { $numOptions } آپشناں وچ آندے، پر چݨݨ دی تعداد { $numToSelect } اے۔
+
+select-variant-name-without-options = select کیتے کجھ ورینٹ مقرر کیتے ڳئے ہن، پر ممکنہ ورینٹ ناں { $variantName } کیتے کوئی آپشن مقرر کائنی۔
+
+select-variant-name-not-possible = select کیتے مقرر کیتا ڳیا ورینٹ ناں { $variantName } ممکنہ ورینٹ ناں کائنی۔
+
+select-too-few-options = صرف { $numOptions } وچوں { $numToSelect } کمپوننٹ نہیں چݨے ون٘ڄ سڳدے۔
+
+select-from-sequence-too-few-values = { $length } لمبائی دی ترتیب وچوں { $numToSelect } قیمتاں نہیں چݨیاں ون٘ڄ سڳدیاں۔
+
+select-from-sequence-indices-count-mismatch = select کیتے مقرر کیتے ڳئے انڈیکساں دی تعداد دا چݨݨ دی تعداد نال میل کھاوݨ لازمی اے
+
+select-from-sequence-indices-not-integers = select کیتے مقرر کیتے ڳئے سارے انڈیکساں دا صحیح عدد ہوݨ لازمی اے
+
+select-from-sequence-index-excluded = selectfromsequence دا مقرر کیتا ڳیا انڈیکس خارج کیتا ڳیا ہا
+
+select-from-sequence-indices-excluded-combination = selectfromsequence دے مقرر کیتے ڳئے انڈیکس ہک خارج کیتا ڳیا مجموعہ ہن
+
+select-from-sequence-coprime-not-positive-integers = مثبت صحیح عدد نہیں چݨے ویندے، ایں کیتے coprime مجموعے نہیں چݨے ون٘ڄ سڳدے۔
+
+select-from-sequence-coprime-common-factor = coprime عدد نہیں چݨے ون٘ڄ سڳدے۔ ساریاں ممکنہ قیمتاں دا ہک سانجھا عامل اے۔ (مقرر کیتیاں ڳئیاں "from" یا "to" دیاں قیمتاں دا "step" نال coprime ہوݨ لازمی اے۔)
+
+select-from-sequence-coprime-single-number = ہیجھے اکلے عدد وچوں جیہڑا 1 کائنی، coprime مجموعے نہیں چݨے ون٘ڄ سڳدے۔
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence وچ 70% توں ودھ مجموعے خارج کیتے ڳئے
+
+select-from-sequence-coprime-none-found = coprime عدد نہ چݨے ون٘ڄ سڳے۔ ساریاں ممکنہ قیمتاں دا ہک سانجھا عامل اے۔
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } لمبائی دی ترتیب وچوں { $numToSelect } منفرد قیمتاں نہیں چݨیاں ون٘ڄ سڳدیاں
+
+select-prime-numbers-too-few-values = { $numValues } لمبائی دی مفرد عدداں دی فہرست وچوں { $numToSelect } قیمتاں نہیں چݨیاں ون٘ڄ سڳدیاں
+
+select-prime-numbers-values-count-mismatch = select کیتے مقرر کیتیاں ڳئیاں قیمتاں دی تعداد دا چݨݨ دی تعداد نال میل کھاوݨ لازمی اے
+
+select-prime-numbers-values-not-prime = مفرد عدد چݨݨ کیتے مقرر کیتیاں ڳئیاں ساریاں قیمتاں دا مفرد عدداں دی فہرست وچ ہوݨ لازمی اے
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers دیاں مقرر کیتیاں ڳئیاں قیمتاں ہک خارج کیتا ڳیا مجموعہ ہن
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers وچ 70% توں ودھ مجموعے خارج کیتے ڳئے
+
+select-random-combination-fluke = ٻہوں انوکھے اتفاق نال بے ترتیب قیمتاں دا مجموعہ نہ چݨیا ون٘ڄ سڳیا
+
+select-random-value-fluke = ٻہوں انوکھے اتفاق نال بے ترتیب قیمت نہ چݨی ون٘ڄ سڳی
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] ایہ `<{ $component }>` نہیں وائھیا ویندا کیوں جو ایہ ریاضی دے اندر اے تے `inline` کائنی۔ `inline` شامل کرو تاں جو ایہ ہک ڈراپ ڈاؤن فہرست بݨ ون٘ڄے، جیہڑی اظہار دے اندر سما ویندی اے۔
+        [expanded] ایہ `<{ $component }>` نہیں وائھیا ویندا کیوں جو ایہ ریاضی دے اندر اے تے `expanded` اے۔ `expanded` ہٹاؤ؛ کئی سطراں آلا ڈٻہ اظہار دے اندر نہیں سما سڳدا۔
+        [on-graph] ایہ `<{ $component }>` نہیں وائھیا ویندا کیوں جو ایہ گراف تے وائھے ڳئے ریاضی دے اندر اے، تے اوتھاں ان پٹ کیتے جاء کائنی۔
+       *[relative-width] ایہ `<{ $component }>` نہیں وائھیا ویندا کیوں جو ایہ ریاضی دے اندر اے تے ایندی چوڑائی نسبتی اے۔ چوڑائی مطلق اکائیاں وچ ڋیو، جیویں `px`۔
+    }

--- a/packages/i18n/locales/skr/diagnostics.ftl
+++ b/packages/i18n/locales/skr/diagnostics.ftl
@@ -23,8 +23,8 @@
 # numeral stays unmarked. Each such message is written once as `*[other]`, with
 # the count argument kept in the selector so that nothing is lost from the
 # message's shape. The `[1]` in `field-function-wrong-num-outputs` is a numeric
-# literal rather than a category — Fluent matches it against the number itself
-# — so it stays where English has it. The symbolic selectors — `$reason`,
+# literal rather than a category — Fluent matches it against the number
+# itself — and it stands where English selects the category `[one]`. The symbolic selectors — `$reason`,
 # `$type`, `$mode`, `$suggestion`, `$isList`, `$context`, `$expected` and the
 # rest — keep every branch English has, because those keys are compared letter
 # for letter and a renamed one is a branch nothing can reach.

--- a/packages/i18n/locales/skr/editor.ftl
+++ b/packages/i18n/locales/skr/editor.ftl
@@ -1,0 +1,226 @@
+# Saraiki (سرائیکی) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button and the
+# context-help panel beside them. Translated from `locales/en/editor.ftl`,
+# which is the source of truth.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Perso-Arabic on Urdu's letter inventory plus Saraiki's four implosives
+# ٻ ڄ ڋ ڳ, right to left — the same convention `chrome.ftl` states, and the
+# four files of this locale must not be split between two orthographies.
+#
+# Saraiki is verb-final, so where English drops a bare verb into the middle of
+# a sentence — "Click to { $action } accessibility report" — the whole sentence
+# sits inside the selector instead. Fluent does not care where a select falls
+# in a pattern.
+#
+# No message here selects on a plural category: CLDR has none for `skr`, and a
+# Saraiki noun after a numeral stays unmarked in any case, so every count
+# message is a single `*[other]` with the count kept in the selector.
+#
+# `WCAG`, `DoenetML`, `XML`, `styleNumber` and every element or attribute name
+# are identifiers rather than words and stay exactly as written.
+#
+# **This is the thinnest of the four files.** The context-help panel talks
+# about references, properties, arrays and resolved types, and Saraiki has no
+# settled words for any of that; what is written below keeps the Urdu and
+# English computing terms — `ریفرنس`, `پراپرٹی`, `اری`, `ٹائپ`, `سٹائل`,
+# `کوآرڈینیٹ` — rather than coining Saraiki ones. A speaker replacing them
+# needs no permission.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ری سیٹ
+       *[update] اپ ڈیٹ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] ناظر { $word } کرو
+       *[other] ناظر { $word } کرو { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = ورینٹ
+editor-variant-filter = چھاݨو...
+editor-variant-next = اڳلا ورینٹ چݨو
+editor-variant-previous = پچھلا ورینٹ چݨو
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA رسائی دی خلاف ورزی لبھی۔ { $action ->
+            [close] رسائی دی رپورٹ بند کرݨ کیتے کلک کرو۔
+           *[open] رسائی دی رپورٹ کھولݨ کیتے کلک کرو۔
+        }
+        [advisories] { $action ->
+            [close] رسائی دی رپورٹ بند کرݨ کیتے کلک کرو۔
+           *[open] رسائی دی رپورٹ کھولݨ کیتے کلک کرو۔
+        } WCAG AA دی کوئی خلاف ورزی نہ لبھی، پر رسائی دیاں کجھ ٻیاں سفارشاں موجود ہن۔
+       *[clean] { $action ->
+            [close] رسائی دی رپورٹ بند کرݨ کیتے کلک کرو۔
+           *[open] رسائی دی رپورٹ کھولݨ کیتے کلک کرو۔
+        } رسائی دا کوئی مسئلہ نہ لبھا۔
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA رسائی دی خلاف ورزی لبھی۔ { $count } WCAG AA خلاف ورزیاں لبھیاں۔ { $action ->
+            [close] رسائی دی رپورٹ بند کرݨ کیتے کلک کرو۔
+           *[open] رسائی دی رپورٹ کھولݨ کیتے کلک کرو۔
+        }
+        [advisories] WCAG AA دی کوئی خلاف ورزی نہ لبھی۔ رسائی دیاں { $count } ٻیاں سفارشاں لبھیاں۔ { $action ->
+            [close] رسائی دی رپورٹ بند کرݨ کیتے کلک کرو۔
+           *[open] رسائی دی رپورٹ کھولݨ کیتے کلک کرو۔
+        }
+       *[clean] WCAG AA دی کوئی خلاف ورزی نہ لبھی۔ { $action ->
+            [close] رسائی دی رپورٹ بند کرݨ کیتے کلک کرو۔
+           *[open] رسائی دی رپورٹ کھولݨ کیتے کلک کرو۔
+        }
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML ورژن { $version }
+
+editor-tab-help = موقعے دے مطابق مدد
+editor-tab-help-short = موقع
+editor-tab-errors = خرابیاں
+editor-tab-warnings = تنبیہاں
+editor-tab-info = معلومات
+editor-tab-accessibility = رسائی
+editor-tab-responses = بھیجے ڳئے جواب
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = ایڈیٹر دیاں ترتیباں
+editor-format-as-doenetml = DoenetML وانگوں ترتیب ڋیو
+editor-format-as-xml = XML وانگوں ترتیب ڋیو
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = سطر #{ $line }
+
+editor-no-errors = کوئی خرابی کائنی
+editor-no-warnings = کوئی تنبیہ کائنی
+editor-no-info = کوئی معلوماتی نشانی کائنی
+
+editor-show-info-annotations = ایڈیٹر وچ معلوماتی نشانیاں ڋکھاؤ
+editor-show-accessibility-annotations = ایڈیٹر وچ رسائی دیاں نشانیاں ڋکھاؤ
+
+editor-accessibility-learn-more = ڄاݨو جو Doenet رسائی نوں کیویں ڋیکھدے ←
+
+editor-accessibility-violations-heading = رسائی دیاں خلاف ورزیاں ({ $standard })
+
+editor-accessibility-other-heading = رسائی دے ٻئے مسئلے
+editor-none-found = کجھ نہ لبھا
+
+
+## Submitted responses
+
+editor-no-responses = ہالے تیک کوئی جواب نہیں بھیجیا ڳیا
+editor-response-answer-id = جواب دی شناخت
+editor-response-response = جواب
+editor-response-credit = نمبر
+editor-response-submitted = بھیجݨ دا ویلا
+
+
+## The context-help panel
+
+help-placeholder = دستاویزات کیتے کرسر کیں ٹیگ دے ناں، ایٹریبیوٹ یا { $ref } تے رکھو۔
+
+help-unsupported-ref-chain = { $example } ورڳے کئی حصیاں آلے ریفرنساں کیتے مدد ہالے تیک موجود کائنی۔
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ریفرنس { $ref } کیتے کوئی مرجع نہ ملیا۔
+        [multiple] ریفرنس { $ref } کیتے کئی مرجع ملے۔
+       *[indeterminate] { $ref } دا مرجع معلوم نہ تھی سڳیا۔
+    }
+
+# The arrow is direction rather than punctuation, and Saraiki runs the other
+# way, so it points where the reader is going.
+help-learn-about-references = ریفرنساں دے بارے ڄاݨو ←
+help-reference-page = ریفرنس دا صفحہ ←
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } دے اندر
+       *[top] سب توں اُتلی سطح تے
+    }{ $allowed ->
+        [none] { " — ایتھاں کجھ وی نہیں آندا۔" }
+        [text] { " — ایتھاں متن لکھو۔" }
+        [text-and-components] { " — ایتھاں متن لکھو، یا ایہ اڋمائو:" }
+       *[components] { " — اڋماوݨ آلیاں چیزاں:" }
+    }
+
+help-suggestions-footer = سارے { $total } کمپوننٹ ڋیکھݨ کیتے { $shortcut } دٻاؤ۔
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } { $target } دا ریفرنس اے۔
+       *[other] { $ref } { $target } دا ریفرنس اے (سطر { $line })۔
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } نے ایں نوں { $role } دے طور تے متعارف کرایا۔
+       *[other] { $owner } نے ایں نوں سطر { $line } تے { $role } دے طور تے متعارف کرایا۔
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } { $element } دی { $property } پراپرٹی دا ریفرنس اے۔
+       *[other] { $ref } { $element } دی { $property } پراپرٹی دا ریفرنس اے (سطر { $line })۔
+    }
+
+help-kind-attribute = ایٹریبیوٹ
+help-kind-snippet = ٹکڑا
+help-kind-array-entry = اری دا اندراج
+
+help-default = پہلوں توں مقرر:
+help-active-default = چالو پہلوں توں مقرر:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] جائز قیمتاں (ہر جز کیتے ہک):
+       *[other] جائز قیمتاں:
+    }
+
+help-suggested-values = تجویز کیتیاں ڳئیاں قیمتاں:
+
+help-inserts = شامل کریندے:
+
+help-coordinates =
+    { $count ->
+       *[other] کوآرڈینیٹ:
+    }
+
+help-type = ٹائپ:
+
+help-resolved-style = طے تھیا ہویا سٹائل (styleNumber { $styleNumber }):
+
+help-resolved-function-names = طے تھئے ہوئے فنکشن ناں:
+help-reset-list = ایں ان پٹ تے فہرست ری سیٹ کرو:
+help-added-on-input = ایں ان پٹ تے شامل کیتے ڳئے:
+help-removed-on-input = ایں ان پٹ توں ہٹائے ڳئے:
+
+help-reset-overrides = { $reset }، { $additional } تے { $removed } تے حاوی تھیندے۔

--- a/packages/i18n/locales/syl/chrome.ftl
+++ b/packages/i18n/locales/syl/chrome.ftl
@@ -1,0 +1,158 @@
+# Sylheti (ছিলটি, Sylheti Nagri ꠍꠤꠟꠐꠤ) viewer chrome. Translated from
+# `locales/en/chrome.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: the Bengali script, as Sylheti is normally printed today, not
+# Sylheti Nagri.** Sylheti has a script of its own — **Sylheti Nagri**
+# (ꠍꠤꠟꠐꠤ ꠘꠣꠉꠞꠤ, Unicode U+A800–U+A82F), a Brahmic script unrelated in shape to
+# Bengali, used for Sylheti manuscripts and printing from roughly the
+# fifteenth century into the twentieth, revived deliberately since the 1970s,
+# and taught today in community classes in Sylhet and in the British Sylheti
+# diaspora. A reviewer may reasonably have expected it here, and its absence
+# is not a judgement about which script belongs to the language.
+#
+# This catalog writes the **Bengali script**, for three reasons. The first is
+# what a Sylheti reader reads: virtually everything published in or about
+# Sylheti in the last century — newspapers, songbooks, dictionaries, social
+# media, the Sylheti material on the Bangladeshi web — is set in Bengali
+# letters, because that is the script every Sylheti speaker is schooled in.
+# The second is mechanical: Sylheti Nagri font coverage in a browser is thin
+# and inconsistent, and a catalog that renders as boxes on most machines helps
+# nobody. The third is that Sylheti Nagri has a **smaller inventory** than
+# Bengali — it writes no distinct ড়/ঢ়/য়, no independent vowel series of the
+# same size, and no conjunct repertoire of the same depth — so a Nagri seed
+# would collapse distinctions this seed cannot restore, and a reviewer could
+# not tell a correction from a spelling convention. Converting this catalog to
+# Sylheti Nagri means converting **all four files at once**, never a mixture
+# inside one catalog, and it is a real conversion rather than a
+# transliteration.
+#
+# **This seed leans heavily on Bengali, and says so.** Sylheti and Bengali
+# share most of their written lexicon, and every technical word in these files
+# — ত্রুটি, সতর্কতা, উপাদান, বৈশিষ্ট্য, চলক, মাত্রা, সারি, স্তম্ভ — is
+# Bengali, because Sylheti-medium education does not exist and a Sylheti
+# reader met these words in Bengali. What is Sylheti here is the **grammar and
+# the function words**: নায় for verbal negation, নাই for absence, আছে for
+# presence, অউ for *this*, ইতা for *these*, লাগি for *for*, দিয়া for *with*,
+# লগে for *along with*, আর for *and*, মিছা for *false*, and the honorific
+# imperative in -ইন — করইন, দেখইন, লেখইন — which is what a Sylheti reader
+# expects a button to say. A message where বাংলা's করুন, এই, এগুলি, জন্য or
+# নেই has crept back in is a defect rather than a variant, and is the easiest
+# thing in this catalog to check.
+#
+# **Numbers render in Latin digits** rather than in Bengali numerals, which is
+# the digit policy in the package README (#1615). The grouping is the
+# locale's; the ten characters are not.
+#
+# **No plural branches.** CLDR has no plural data for `syl`, so a `one` branch
+# here would be text selected by Bengali's rules rather than by this locale's.
+# The numeric literal `[0]` in `attempts-remaining` stays, because Fluent
+# matches it against the number itself before any plural rule is consulted.
+
+
+## Answer submission
+
+answer-checking = দেখরাম...
+answer-submitting = পাঠাইরাম...
+answer-checking-status = জুয়াপ দেখরাম
+answer-submitting-status = জুয়াপ পাঠাইরাম
+answer-correct = ঠিক
+answer-incorrect = ঠিক নায়
+answer-response-saved = জুয়াপ রাখা অইছে
+answer-percent-credit = { $percent }% নম্বর
+answer-percent-correct = { $percent }% ঠিক
+answer-percent-short = { $percent } %
+max-credit-available = সবতে বেশি নম্বর: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] আর কোনো সুযোগ নাই
+       *[other] আরো { $count } সুযোগ আছে
+    }
+validation-correct = (ঠিক)
+validation-incorrect = (ঠিক নায়)
+validation-partially-correct = (কিছু অংশ ঠিক)
+answer-show-responses =
+    { $count ->
+       *[other] { $answerId }-র { $count } জুয়াপ দেখাইন
+    }
+
+
+## Disclosure panels
+
+feedback-heading = মতামত
+collapsible-click-to-open = (খুলতে ক্লিক করইন)
+collapsible-click-to-close = (বন্ধ করতে ক্লিক করইন)
+collapsible-initializing = শুরু অইরার...
+footnote-show = পাদটীকা দেখাইন
+footnote-hide = পাদটীকা লুকাইন
+description-more-information = আরো খবর
+
+
+## Controls
+
+slider-previous = আগের
+slider-next = পরের
+keyboard-open = কিবোর্ড খুলইন
+keyboard-close = কিবোর্ড বন্ধ করইন
+choice-input-remove-choice = { $choice } সরাইন
+matrix-remove-row = সারি সরাইন
+matrix-add-row = সারি বাড়াইন
+matrix-remove-column = স্তম্ভ সরাইন
+matrix-add-column = স্তম্ভ বাড়াইন
+subset-add-remove-points = বিন্দু বাড়ানি/সরানি
+subset-toggle-points-intervals = বিন্দু আর ব্যবধান বদলাইন
+subset-move-points = বিন্দু নাড়াইন
+subset-clear = সাফ করইন
+orbital-add-row = সারি বাড়াইন
+orbital-remove-row = সারি সরাইন
+orbital-add-box = বাকসো বাড়াইন
+orbital-remove-box = বাকসো সরাইন
+orbital-add-up-arrow = উপরের তীর বাড়াইন
+orbital-add-down-arrow = নিচের তীর বাড়াইন
+orbital-remove-arrow = তীর সরাইন
+orbital-row-label = { $row } নম্বর সারির নাম
+pretzel-answer = জুয়াপ
+summary-statistics-caption = { $column }-র সারসংক্ষেপ পরিসংখ্যান
+
+
+## Math input
+
+math-input-preview-region = গণিত রাশির ঝলক
+math-input-preview = ঝলক
+math-input-invalid-expression = ভুল রাশি:
+
+
+## Document status
+
+viewer-initializing = শুরু অইরার...
+
+
+## Errors
+
+error-heading = ত্রুটি
+error-found-at =
+    { $span ->
+        [line] { $startLine } নম্বর লাইনো পাওয়া গেছে।
+       *[lines] { $startLine }–{ $endLine } নম্বর লাইনো পাওয়া গেছে।
+    }
+document-contains-errors = অউ দলিলো ত্রুটি আছে!
+diagnostic-heading-error = ত্রুটি
+diagnostic-heading-warning = সতর্কতা
+diagnostic-heading-information = খবর
+diagnostic-heading-hint = ইশারা
+accessibility-heading-level-1 = WCAG AA প্রবেশগম্যতা লঙ্ঘন
+accessibility-heading-level-2 = প্রবেশগম্যতা সতর্কতা
+something-went-wrong = কিছু একটা ভুল অইছে।
+renderer-load-failed = একটা রেন্ডারার লোড অইছে নায়। দয়া করি পাতাটা আবার লোড করইন।
+core-start-failed = অউ দলিল চালু করা গেছে নায়। দয়া করি পাতাটা আবার লোড করইন।
+core-start-failed-busy = অউ দলিল চালু করা গেছে নায়। একলগে অনেক দলিল চালু অইরাছিল, ধীর যন্ত্রো ইতাত আরো বেশি সময় লাগে। বাকি দলিল শেষ অইলে পাতাটা আবার লোড করলে কাম অইতে পারে।
+core-start-failed-retry = অউ দলিল চালু করা গেছে নায়।
+core-start-failed-busy-retry = অউ দলিল চালু করা গেছে নায়। একলগে অনেক দলিল চালু অইরাছিল, ধীর যন্ত্রো ইতাত আরো বেশি সময় লাগে।
+core-start-retry = আবার চেষ্টা করইন
+saved-state-unavailable = আপনার রাখা কাম লোড করা গেছে নায়।

--- a/packages/i18n/locales/syl/chrome.ftl
+++ b/packages/i18n/locales/syl/chrome.ftl
@@ -39,8 +39,8 @@
 # Bengali, because Sylheti-medium education does not exist and a Sylheti
 # reader met these words in Bengali. What is Sylheti here is the **grammar and
 # the function words**: নায় for verbal negation, নাই for absence, আছে for
-# presence, অউ for *this*, ইতা for *these*, লাগি for *for*, দিয়া for *with*,
-# লগে for *along with*, আর for *and*, মিছা for *false*, and the honorific
+# presence, অউ for *this*, ইতা for *these*, লাগি for *for*, লগে for *with*
+# and *along with*, আর for *and*, মিছা for *false*, and the honorific
 # imperative in -ইন — করইন, দেখইন, লেখইন — which is what a Sylheti reader
 # expects a button to say. A message where বাংলা's করুন, এই, এগুলি, জন্য or
 # নেই has crept back in is a defect rather than a variant, and is the easiest

--- a/packages/i18n/locales/syl/content.ftl
+++ b/packages/i18n/locales/syl/content.ftl
@@ -28,7 +28,9 @@
 # «{ $numSides } বাউয়ালা সমবহুভুজ» and leaves `tail` empty, exactly as English
 # does: the side count is a modifier and modifiers go in front, so there is
 # nothing to place after the adjectives and no reason to split the noun. The
-# `[noun-tail]` branches in the two composition messages are kept because a
+# `[noun-tail]` branch of `style-with-noun`, and the `[plain-tail]` and
+# `[pattern-tail]` branches `style-filled-with-noun` uses in its place, are
+# kept because a
 # partly-translated locale falls back through them, not because anything here
 # selects them.
 #
@@ -62,9 +64,9 @@
 # **The colours are where Sylheti shows.** কালা, ধলা and অইল্দা — black,
 # white and yellow — are Sylheti rather than Bengali (কালো, সাদা, হলুদ), and
 # লাল is shared. The remaining eight are Bengali or English loans, and সায়ান
-# is a transliteration. That five-to-eight split is a fact about the seed's
+# is a transliteration. That four-to-eight split is a fact about the seed's
 # knowledge, not about the language: Sylheti certainly has more of its own
-# colour words than five, and supplying them is a bigger improvement to this
+# colour words than four, and supplying them is a bigger improvement to this
 # file than anything else in it.
 #
 # **The grammar is where the rest of the Sylheti is**: নায় for verbal

--- a/packages/i18n/locales/syl/content.ftl
+++ b/packages/i18n/locales/syl/content.ftl
@@ -1,0 +1,317 @@
+# Sylheti (ছিলটি) content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in, not the language of the reader's chrome.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: the Bengali script, as Sylheti is normally printed today, not
+# Sylheti Nagri** (ꠍꠤꠟꠐꠤ ꠘꠣꠉꠞꠤ). `chrome.ftl`'s header sets out the three
+# reasons in full — what a Sylheti reader actually reads, browser font
+# coverage, and Nagri's smaller inventory, which would collapse distinctions
+# this seed cannot restore. A conversion is a conversion of all four files at
+# once, and a real conversion rather than a transliteration.
+#
+# ## Word order
+#
+# **Modifiers precede the noun and postpositions follow it.** Sylheti is
+# verb-final and left-branching like Bengali, so `style-with-noun` and
+# `style-filled-with-noun` keep English's order of `{ $description }` before
+# `{ $noun }`, and `style-stroke` keeps English's internal sequence of width,
+# dash pattern, colour. What moves is every one of English's prepositions:
+# `with` becomes the postposition দিয়া or লগে and `on`/`in` the locative -ও,
+# so `style-border-clause`, `style-filled` and `style-text` all put the value
+# in front of the word English puts it behind. That reordering is the whole of
+# the difference between this file and a word-for-word rendering.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } বাউয়ালা সমবহুভুজ» and leaves `tail` empty, exactly as English
+# does: the side count is a modifier and modifiers go in front, so there is
+# nothing to place after the adjectives and no reason to split the noun. The
+# `[noun-tail]` branches in the two composition messages are kept because a
+# partly-translated locale falls back through them, not because anything here
+# selects them.
+#
+# ## Gender, role and number
+#
+# **Neither `$gender` nor `$role` is selected on.** Sylheti has no
+# grammatical gender — an adjective does not agree with anything — so
+# `noun-gender` answers the single token `neuter` and every style word is
+# written once. Nor does a Sylheti modifier change shape for the position its
+# phrase is going into: the case marking a clause position wants lands on the
+# *noun* at the end of the phrase, never on the adjective in front of it, so
+# মোটা লাল reads the same standing alone as it does before দিয়া. Both are
+# claims about the language, not gaps in the seed. That is the same reason
+# `locales/eu` gives from a completely different family.
+#
+# **Nothing selects on a count.** A Sylheti noun is not marked for number
+# after a numeral — «দুই রেখা», not a pluralized noun — and CLDR has no plural
+# data for `syl` in any case, so a `one` branch here would be text selected by
+# Bengali's rules. There are no plural branches anywhere in this catalog.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry and style words are Bengali, declared as such.** There is no
+# Sylheti-medium schooling, so রেখা, বিন্দু, বক্ররেখা, বহুভুজ, ভেক্টর,
+# পরাবৃত্ত and ফাংশন are the words a Sylheti reader has met — in Bengali —
+# and coining Sylheti equivalents would put unfamiliar words in front of a
+# reader who already has familiar ones. This file is a **Sylheti frame around
+# a declared Bengali technical register**, which is the honest description of
+# it.
+#
+# **The colours are where Sylheti shows.** কালা, ধলা and অইল্দা — black,
+# white and yellow — are Sylheti rather than Bengali (কালো, সাদা, হলুদ), and
+# লাল is shared. The remaining eight are Bengali or English loans, and সায়ান
+# is a transliteration. That five-to-eight split is a fact about the seed's
+# knowledge, not about the language: Sylheti certainly has more of its own
+# colour words than five, and supplying them is a bigger improvement to this
+# file than anything else in it.
+#
+# **The grammar is where the rest of the Sylheti is**: নায় for verbal
+# negation, নাই for absence, আছে for presence, অউ and ইতা for the
+# demonstratives, লাগি, দিয়া and লগে for the postpositions, and মিছা for
+# *false* — which is why `boolean-false` is that word and not Bengali's
+# মিথ্যা. A message where বাংলা's নেই, এই, এগুলি or জন্য has crept back in is
+# a defect.
+#
+# **The chemistry tables are absent.** `element-name` and `element-anion-name`
+# are not translated here, and the reason is the school-system one: chemistry
+# in Sylhet is taught in Bengali and English, the periodic table a Sylheti
+# pupil meets is one of those two, and there is no Sylheti nomenclature for
+# 118 elements to reproduce. Coining one would invent names no reader has met
+# and would hide the fact that the reader already has a language for them.
+# `locales/bn` carries the Bengali names for anyone who wants that list. The
+# three messages that are *frames* rather than names —
+# `ion-name-oxidation-state`, `chemistry-invalid-symbol` and
+# `chemistry-invalid-ionic-compound` — are translated, on the standing ground
+# that a frame is the catalog's business whether or not the names in it are.
+#
+# **Numbers render in Latin digits** under the locale's own grouping, which is
+# the digit policy in the package README (#1615). A side count reads `1,234`
+# here, not `১,২৩৪`.
+
+
+## Style vocabulary
+
+color =
+    .black = কালা
+    .white = ধলা
+    .gray = ধূসর
+    .red = লাল
+    .orange = কমলা
+    .yellow = অইল্দা
+    .green = সবুজ
+    .cyan = সায়ান
+    .blue = নীল
+    .purple = বেগুনি
+    .pink = গুলাপি
+    .brown = বাদামি
+line-width =
+    .thick = মোটা
+    .thin = চিকন
+line-style =
+    .dashed = দাগ-দাগ
+    .dotted = ফুটকি-ফুটকি
+# Noun phrases rather than adjectives: they stand in front of the postposition
+# দিয়া that the composition messages supply, and modify nothing.
+fill-style =
+    .horizontal = আড়াআড়ি রেখা
+    .vertical = খাড়া রেখা
+    .diagonal = কর্ণ রেখা
+    .backdiagonal = উল্টা কর্ণ রেখা
+    .dots = ফুটকি
+    .diamonds = রম্বস
+noun =
+    .line = রেখা
+    .line-segment = রেখাংশ
+    .ray = রশ্মি
+    .vector = ভেক্টর
+    .curve = বক্ররেখা
+    .function = ফাংশন
+    .slope-field = ঢাল ক্ষেত্র
+    .vector-field = ভেক্টর ক্ষেত্র
+    .parabola = পরাবৃত্ত
+    .polyline = বহুরেখা
+    .polygon = বহুভুজ
+    .triangle = তিনকোণা
+    .rectangle = আয়তক্ষেত্র
+    .circle = বৃত্ত
+    .region = অঞ্চল
+    .point = বিন্দু
+    .square = চতুষ্কোণ
+    .diamond = রম্বস
+    .cross = আড়ি চিহ্ন
+    .plus = যোগ চিহ্ন
+# বাউয়ালা ("having sides") attaches the count to the noun that follows it, so
+# the whole phrase is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } বাউয়ালা সমবহুভুজ
+    }
+# Sylheti has no grammatical gender, so every noun answers the same and the
+# answer goes unused — as in English.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = ভরা
+# দিয়া is a postposition, so the pattern comes to the front of the clause
+# English appends at the end.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } দিয়া { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } দিয়া { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } দিয়া { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# লগে follows কিনার rather than preceding it as English's `with` does, and আর
+# opens the further clause. Sylheti has no article, which leaves the two
+# `-article` branches reading exactly like the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } কিনার লগে
+        [and] আর { $border } কিনার লগে
+        [and-article] আর { $border } কিনার লগে
+       *[with] { $border } কিনার লগে
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+style-unfilled = ভরা নায়
+# The locative -ও marks পটভূমি, so the background leads and the text colour
+# follows it.
+style-text =
+    { $parts ->
+        [background] { $background } পটভূমিও { $color }
+       *[plain] { $color }
+    }
+style-background-none = নাই
+
+
+## Boolean words
+
+# মিছা is Sylheti's own word for what is not so, where Bengali writes মিথ্যা.
+# The DoenetML values `true` and `false` an author writes are untouched by
+# this.
+boolean-true = সত্য
+boolean-false = মিছা
+
+
+## Answer buttons
+
+answer-submit-label = কাম দেখইন
+answer-submit-label-no-correctness = জুয়াপ পাঠাইন
+
+
+## Sectional blocks
+
+section-name =
+    .activity = কাম
+    .aside = পাশটীকা
+    .cascade = ক্যাসকেড
+    .definition = সংজ্ঞা
+    .example = উদাহরণ
+    .exercise = অনুশীলন
+    .exercises = অনুশীলন
+    .given-answer = জুয়াপ
+    .note = টীকা
+    .objectives = উদ্দেশ্য
+    .paragraphs = অনুচ্ছেদ
+    .part = অংশ
+    .problem = সমস্যা
+    .problems = সমস্যা
+    .proof = প্রমাণ
+    .question = প্রশ্ন
+    .section = বিভাগ
+    .solution = সমাধান
+    .task = কাজ
+    .theorem = উপপাদ্য
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = ইশারা
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] সারণি { $enumeration }
+        [numbered-title] সারণি { $enumeration }{ ": " }
+        [unnumbered-title] সারণি{ ": " }
+       *[unnumbered] সারণি
+    }
+figure-name =
+    { $parts ->
+        [numbered] ছবি { $enumeration }
+        [numbered-caption] ছবি { $enumeration }{ ": " }
+        [unnumbered-caption] ছবি{ ": " }
+       *[unnumbered] ছবি
+    }
+
+
+## Paginator controls
+
+paginator-previous = আগের
+paginator-next = পরের
+paginator-page = পাতা
+# «of» is not a word here: the total precedes and the genitive -র links it,
+# which is how Sylheti builds this phrase.
+paginator-page-status = { $numPages }-র মাঝে { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = বা
+# Sylheti's own conditional is a clause-final -লে, and the renderer places
+# this word *before* the mathematics it introduces, so the native
+# construction cannot be reached from inside the catalog. যদি is the
+# clause-initial conditional, which is grammatical here and lands correctly.
+piecewise-condition-if = যদি
+piecewise-condition-otherwise = নাইলে
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; the header
+## says why. Only the frames are here.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = ভুল রাসায়নিক চিহ্ন
+chemistry-invalid-ionic-compound = ভুল আয়নিক যৌগ
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = খালি
+math-embedded-input-blank-ordinal = { $total }-র মাঝে { $ordinal } নম্বর খালি

--- a/packages/i18n/locales/syl/diagnostics.ftl
+++ b/packages/i18n/locales/syl/diagnostics.ftl
@@ -1,0 +1,698 @@
+# Sylheti (ছিলটি) diagnostics: the warnings and errors the worker raises and
+# the reader is shown. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth. Selected by `uiLocale`, not by the language the
+# document was written in.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# Neither are the DoenetML identifiers quoted inside these sentences:
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence`, `styleNumber` and every tag and attribute name like
+# them are part of the language an author writes, not prose, and stay in
+# English exactly as written. So does the `[deprecation]` marker, which is a
+# label rather than a word, and so do `WCAG AA` and `PreFigure`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script** is `chrome.ftl`'s: the Bengali script, as Sylheti is normally
+# printed today, rather than Sylheti Nagri, for the three reasons that file's
+# header gives in full.
+#
+# **The technical vocabulary is Bengali, declared as such** — ভুল, ত্রুটি,
+# সতর্কতা, উপাদান, বৈশিষ্ট্য, চলক, মাত্রা, সন্দর্ভ, অনুক্রম, সংমিশ্রণ.
+# Sylheti readers meet these words in Bengali schooling; coining Sylheti
+# equivalents would put unfamiliar words in front of a reader who already has
+# familiar ones. What is Sylheti is the frame around them: নায় for verbal
+# negation, নাই for absence, আছে for presence, অউ and ইতা for the
+# demonstratives, লাগি, দিয়া and লগে for the postpositions, and the honorific
+# imperative in -ইন.
+#
+# **One paraphrase is declared and used everywhere so that one search replaces
+# it.** English's *is ignored* is written «গণায় লওয়া অয় নায়» throughout —
+# literally *is not taken into account*. It appears in something like thirty
+# messages, so it is the first thing a speaker should replace, and replacing
+# it is a single search.
+#
+# **No plural branches anywhere.** CLDR has no plural data for `syl`, so
+# `line-segment-attributes-ignored-with-endpoints` and its relatives write a
+# single `*[other]` where English writes `[one]` and `[other]`. The one
+# numeric literal that survives is `[1]` in
+# `field-function-wrong-num-outputs`, which forks on how many outputs a
+# component *needs* rather than on a count the reader is looking at; Fluent
+# matches it against the number itself before any plural rule is consulted.
+#
+# **Numbers render in Latin digits** rather than in Bengali numerals (#1615).
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] দুইটা endpoint দেওয়া থাকলে { $attributes } গণায় লওয়া অয় নায়
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] endpoint আর midpoint দুইটাউ দেওয়া থাকলে { $attributes } গণায় লওয়া অয় নায়
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpoint নাই অইলে midpointOffset-র কোনো কাম নাই
+
+## `<line>`
+
+line-points-undetermined-dimensions = মাত্রা ঠিক অয় নাই এমন বিন্দু দিয়া রেখা।
+
+line-points-too-few-dimensions = রেখা যেসব বিন্দু দিয়া যাইব ইতার কমসেকম দুই মাত্রা অইতে অইব।
+
+line-points-depend-on-variables = রেখা যেসব বিন্দু দিয়া যাইব ইতা চলকের উপরে নির্ভর করে: { $variables }।
+
+line-equation-invalid-format = { $variable1 } আর { $variable2 } চলকো রেখার সমীকরণের ভুল ছাঁচ।
+
+## `<ray>`
+
+ray-overprescribed-through = রশ্মি through, endpoint আর direction তিনটা দিয়াউ ঠিক করা অইছে।  দেওয়া through গণায় লওয়া অয় নায়।
+
+ray-dimension-mismatch = রশ্মিও numDimensions মিলে নায়।
+
+## `<vector>`
+
+vector-overprescribed-head = ভেক্টর head, tail আর displacement তিনটা দিয়াউ ঠিক করা অইছে।  দেওয়া head গণায় লওয়া অয় নায়।
+
+vector-dimension-mismatch = ভেক্টরো numDimensions মিলে নায়।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>`-র nearestPoint অবস্থা-চলক নাই, তাইন ইতার দিকে টানা যায় নায়।
+
+constrain-to-without-nearest-point = `<{ $component }>`-র nearestPoint অবস্থা-চলক নাই, তাইন ইতার লগে বাঁধা যায় নায়।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>`-র nearestPoint অবস্থা-চলক নাই, তাইন ইতার ভিতরের লগে বাঁধা যায় নায়।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline নায় এমন choiceInput-র লাগি labelPosition গণায় লওয়া অয় নায়
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-র লাগি দেওয়া indices-র সংখ্যা choice সন্তানের সংখ্যার লগে মিলে নায়, তাইন ইতা গণায় লওয়া অয় নায়।
+
+pretzel-indices-count-mismatch = problem-র লাগি দেওয়া indices-র সংখ্যা problem সন্তানের সংখ্যার লগে মিলে নায়, তাইন ইতা গণায় লওয়া অয় নায়।
+
+shuffle-indices-count-mismatch = shuffle-র লাগি দেওয়া indices-র সংখ্যা উপাদানের সংখ্যার লগে মিলে নায়, তাইন ইতা গণায় লওয়া অয় নায়।
+
+indices-ignored-out-of-range = { $component }-র লাগি দেওয়া কিছু indices সীমার বাইরে, তাইন ইতা গণায় লওয়া অয় নায়।
+
+pretzel-indices-repeated = pretzel-র লাগি দেওয়া কিছু indices দুইবার আইছে, তাইন ইতা গণায় লওয়া অয় নায়।
+
+pretzel-circuit-first-index = circuit মোডো pretzel-র পয়লা index 1 অইতে অইব, তাইন দেওয়া indices গণায় লওয়া অয় নায়।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` স্ট্রিং সন্তান দিয়া কাম করতে অইলে একটা `type` বৈশিষ্ট্য দিতে অইব।
+
+invalid-type-defaulting-to-math = { $component } উপাদানের লাগি ভুল type { $type }। math, text, number বা boolean-র একটা অইতে অইব। math ধরা অইল।
+
+string-not-valid-component-to-arrange = স্ট্রিং "{ $value }" { $component } করার লাগি ঠিক উপাদান নায়। গণায় লওয়া অয় নায়।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = ভুল type { $type }, type number ধরা অইল।
+
+invalid-variable-value = চলকের ভুল মান: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant index { $index } সংখ্যা অইতে অইব
+
+variant-index-must-be-integer = Variant index { $index } পূর্ণসংখ্যা অইতে অইব
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` নিরপেক্ষ মাপের লাগি বানানো অয় নাই। চওড়া সাপেক্ষ ধরা অইল।
+
+side-by-side-absolute-margins = `<{ $component }>` নিরপেক্ষ মাপের লাগি বানানো অয় নাই। কিনার সাপেক্ষ ধরা অইল।
+
+side-by-side-no-block-child = ভুল `<{ $component }>`: ইতাত কমসেকম একটা ব্লক সন্তান থাকতে অইব।
+
+## `<label>`
+
+label-for-ignored-on-graphical = ছবিওয়ালা `<label>`-র উপরে `for` বৈশিষ্ট্য গণায় লওয়া অয় নায়।
+
+label-for-must-resolve-to-one = `<label>`-র `for` বৈশিষ্ট্য ঠিক একটা উপাদানো লাগতে অইব।
+
+label-for-unresolved = `<label>`-র `for` বৈশিষ্ট্য কোনো উপাদানো লাগানো গেছে নায়।
+
+label-for-answer-with-authored-inputs = `<label>`-র `for` বৈশিষ্ট্য এমন একটা `<answer>`-রে দেখাইরার যেটার input লেখক নিজে দিছইন; input-রেউ সোজা দেখাইন।
+
+label-for-answer-without-input = `<label>`-র `for` বৈশিষ্ট্য এমন একটা `<answer>`-রে দেখাইরার যেটার label দেওয়ার মতো কোনো input নাই।
+
+label-for-must-reference-input-or-answer = `<label>`-র `for` বৈশিষ্ট্য একটা input বা একটা answer দেখাইতে অইব।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = প্রবেশগম্যতার লাগি `<{ $component }>`-র একটা ছোট বিবরণ থাকতে অইব, নাইলে ইতারে decorative করতে অইব।
+
+accessibility-video-short-description = প্রবেশগম্যতার লাগি `<video>`-র একটা ছোট বিবরণ থাকতে অইব।
+
+accessibility-input-short-description-or-label = প্রবেশগম্যতার লাগি `<{ $component }>`-র একটা ছোট বিবরণ বা একটা label থাকতে অইব।
+
+accessibility-answer-input-short-description-or-label = প্রবেশগম্যতার লাগি input বানায় এমন `<answer>`-র একটা ছোট বিবরণ বা একটা label থাকতে অইব।
+
+accessibility-short-description-contains-math = ছোট বিবরণো `<{ $component }>`-র মতো গণিত উপাদান রাখা ঠিক নায়। গণিতটা কথা দিয়াউ লেখইন।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] বিভাগের শিরোনামের লেখার লাগি { $colorName }-র বৈসাদৃশ্য কম (কালা মোড) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; কমসেকম { $threshold }:1 লাগব)।
+       *[other] বিভাগের শিরোনামের লেখার লাগি { $colorName }-র বৈসাদৃশ্য কম ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; কমসেকম { $threshold }:1 লাগব)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = বিন্দুইনতার সংখ্যা-মান নাই অইলে { $count } বিন্দু দিয়া `<circle>` এখনো বানানো অয় নাই।
+
+circle-too-many-through-points = তিনটার বেশি বিন্দু দিয়া বৃত্ত হিসাব করা যায় নায়।
+
+circle-overprescribed-radius-center-points = দেওয়া radius, center আর through বিন্দু তিনটাউ দিয়া বৃত্ত হিসাব করা যায় নায়।
+
+circle-center-with-multiple-points = দেওয়া center-র লগে একটার বেশি বিন্দু দিয়া বৃত্ত হিসাব করা যায় নায়।
+
+circle-radius-too-small = বৃত্ত হিসাব করা যায় নায়: দুই বিন্দুর মাঝের দূরত্ব { $distance }, তাইন দেওয়া radius { $radius } বেশি ছোট।
+
+circle-radius-with-many-points = দেওয়া radius-র লগে দুইটার বেশি বিন্দু দিয়া বৃত্ত বানানো যায় নায়।
+
+circle-invalid-center-or-through-points = বৃত্তের ভুল center বা through বিন্দু।
+
+circle-radius-center-with-multiple-points = দেওয়া center-র লগে একটার বেশি বিন্দু দিয়া বৃত্তের radius হিসাব করা যায় নায়।
+
+circle-change-radius-non-numerical = সংখ্যা-মান নাই এমন through বিন্দুওয়ালা বৃত্তের radius বদলানো যায় নায়
+
+circle-radius-with-points-non-numerical = সংখ্যা-মান নাই অইলে দেওয়া radius-র লগে একটার বেশি বিন্দু দিয়া বৃত্ত বানানো যায় নায়।
+
+circle-change-center-non-numerical = সংখ্যা-মান নাই এমন বিন্দু দিয়া বানানো বৃত্তের center বদলানো এখনো করা অয় নাই।
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] ফাংশনের domain-র মাত্রা কম। domain-ও { $intervals } ব্যবধান আছে অথচ ফাংশনো { $inputs ->
+           *[other] { $inputs } input
+        } আছে।
+    }
+
+function-domain-invalid-format = ফাংশনের domain-র ভুল ছাঁচ।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] ফাংশনের সংখ্যা নায় এমন সর্বোচ্চ মান গণায় লওয়া অয় নায়।
+        [minimum] ফাংশনের সংখ্যা নায় এমন সর্বনিম্ন মান গণায় লওয়া অয় নায়।
+        [extremum] ফাংশনের সংখ্যা নায় এমন চরম মান গণায় লওয়া অয় নায়।
+        [point] ফাংশনের সংখ্যা নায় এমন বিন্দু গণায় লওয়া অয় নায়।
+        [slope] ফাংশনের সংখ্যা নায় এমন ঢাল গণায় লওয়া অয় নায়।
+       *[other] ফাংশনের সংখ্যা নায় এমন { $type } গণায় লওয়া অয় নায়।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] ফাংশনের খালি সর্বোচ্চ মান গণায় লওয়া অয় নায়।
+        [minimum] ফাংশনের খালি সর্বনিম্ন মান গণায় লওয়া অয় নায়।
+        [extremum] ফাংশনের খালি চরম মান গণায় লওয়া অয় নায়।
+        [point] ফাংশনের খালি বিন্দু গণায় লওয়া অয় নায়।
+       *[other] ফাংশনের খালি { $type } গণায় লওয়া অয় নায়।
+    }
+
+function-points-too-close = ফাংশনো এমন দুইটা বিন্দু আছে যেগুলি বেশি কাছাকাছি। ফাংশন ঠিক করা যায় নায়।
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] ফাংশনের input-র সংখ্যা আর output-র সংখ্যা সমান অইলেউ কেবল ফাংশন পুনরাবৃত্তি করা যায়। অউ ফাংশনো { $inputs } input আর { $outputs ->
+           *[other] { $outputs } output
+        } আছে।
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = অনুক্রমের ভুল দৈর্ঘ্য।  ঋণাত্মক নায় এমন পূর্ণসংখ্যা অইতে অইব।
+
+sequence-invalid-step = অনুক্রমের ভুল step।  { $type } ধরনের অনুক্রমের লাগি একটা সংখ্যা অইতে অইব।
+
+sequence-invalid-endpoint-number = number অনুক্রমের ভুল "{ $attribute }"।  একটা সংখ্যা অইতে অইব।
+
+sequence-invalid-endpoint-letters = letters অনুক্রমের ভুল "{ $attribute }"।  অক্ষরের সংমিশ্রণ অইতে অইব।
+
+sequence-invalid-endpoint = অনুক্রমের ভুল "{ $attribute }"।
+
+select-from-sequence-coprime-not-numbers = সংখ্যা বাছা অইরার নায়, তাইন coprime গণায় লওয়া অয় নায়
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations দেওয়া আছে, তাইন coprime গণায় লওয়া অয় নায়
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>`-র লাগি ভুল target: target পাওয়া গেছে নায়।
+
+target-state-variable-not-found = `<{ $source }>`-র লাগি ভুল target: `<{ $component }>`-ও "{ $property }" নামের কোনো অবস্থা-চলক পাওয়া গেছে নায়।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`-র চলক স্বাধীন চলক থাকি আলাদা অইতে অইব।
+
+ode-system-duplicate-variable-names = একউ নামের নির্ভরশীল চলক দিয়া ODE RHS ফাংশন ঠিক করা যায় নায়।
+
+ode-system-rhs-function-error = ODE RHS ফাংশন ঠিক করা যায় নায়।  mathjs ফাংশন বানাইতে ত্রুটি অইছে।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } রেখার মাঝে কোণ ঠিক করা যায় নায়
+
+angle-invalid-through-point = `<angle>`-র through-ও ভুল বিন্দু
+
+parabola-vertex-too-many-points = vertex-র লগে একটার বেশি বিন্দু দিয়া পরাবৃত্ত এখনো বানানো অয় নাই।
+
+parabola-too-many-points = তিনটার বেশি বিন্দু দিয়া পরাবৃত্ত এখনো বানানো অয় নাই।
+
+intersection-too-many-items = দুইটার বেশি জিনিসের ছেদ এখনো বানানো অয় নাই
+
+## Other math components
+
+ionic-compound-not-two-ions = দুইটা আয়ন ছাড়া আর কিছুর লাগি আয়নিক যৌগ এখনো বানানো অয় নাই।
+
+ionic-compound-needs-cation-and-anion = আয়নিক যৌগ খালি একটা ক্যাটায়ন আর একটা আয়নের লাগিউ বানানো অইছে।
+
+solve-equations-cannot-evaluate = সমীকরণের মান বাইর করা গেছে নায়, তাইন ইতা সমাধান করা যায় নায়: { $equation }
+
+math-operators-operand-number-required = গণিতের operand বাইর করার সময় একটা operandNumber দিতে অইব।
+
+eigen-decomposition-failed = ম্যাট্রিক্সের eigenvalue হিসাব করা গেছে নায়
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: { $parameters } parameter pattern-ও নাই, তাইন ইতা সবসময় খালিউ মিলাইব।
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" বুঝা যায় নায়। ইতা none, medium, dense, বা খালি জায়গা দিয়া আলাদা করা দুইটা ধনাত্মক সংখ্যা অইতে অইব, যেমন grid="1 0.5"। কোনো grid আঁকা অয় নাই।
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>`-র লাগি { $expected ->
+        [1] একটা output-অলা ফাংশন লাগে, মানে প্রতি বিন্দুর ঢাল y', যেমন `y - x`
+       *[other] দুইটা output-অলা ফাংশন লাগে, মানে প্রতি বিন্দুর ভেক্টর, যেমন `(y, -x)`
+    }, অথচ যেই ফাংশন দেওয়া অইছে ইতাত { $found ->
+       *[other] { $found } output
+    } আছে। { $alternative ->
+        [none] কিছুউ আঁকা অয় নাই।
+       *[other] অউ ফাংশনের লাগি `<{ $alternative }>` উপাদানটাউ ঠিক। কিছুউ আঁকা অয় নাই।
+    }
+
+field-function-attribute-ignored-with-child = ফাংশনটা উপাদানের ভিতরেউ দেওয়া আছে, তাইন `function` বৈশিষ্ট্য গণায় লওয়া অয় নায়; ভিতরেরটাউ কামে লাগে। ফাংশন দুই রকমের একটা রকমেউ দিইন।
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` বৈশিষ্ট্য উপাদানের ভিতরে সোজা লেখা রাশির চলকইনতার নাম কয়। { $reason ->
+        [function-child] এখানে ফাংশনটা একটা `<function>` সন্তান হিসাবে দেওয়া আছে, যেটা নিজের চলক নিজেউ কয়, তাইন `variables` গণায় লওয়া অয় নায়।
+       *[no-expression] এখানে এমন কোনো রাশি দেওয়া নাই, তাইন `variables` গণায় লওয়া অয় নায়।
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure রেন্ডারারো xLabelPosition="left" চলে নায়; right-position-র আচরণ কামে লাগানো অইল।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure রেন্ডারারো yLabelPosition="bottom" চলে নায়; top-position-র আচরণ কামে লাগানো অইল।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure রূপান্তরের লাগি ভুল অক্ষ-সীমা; আগে থাকি ঠিক করা bbox (-10,-10,10,10) কামে লাগানো অইল।
+
+prefigure-invalid-width = `<graph>`: prefigure রূপান্তরের লাগি ভুল চওড়া; আগে থাকি ঠিক করা নকশার চওড়া 425 কামে লাগানো অইল।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure রূপান্তরের লাগি ভুল aspectRatio; আগে থাকি ঠিক করা অনুপাত 1 কামে লাগানো অইল।
+
+prefigure-grid-spacing-too-fine = `<graph>`: অক্ষের সীমার তুলনায় গ্রিডের ফাঁক বেশি চিকন; prefigure রেন্ডারারো গ্রিড বাদ দেওয়া অইল।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure রেন্ডারার কামে না লাগাইলে টীকা আঁকা অয় নায়।
+
+multiple-annotations-children = `<graph>`-ও একের বেশি `<annotations>` সন্তান পাওয়া গেছে; শেষেরটা ছাড়া বাকি সবগুলি গণায় লওয়া অয় নায়।
+
+## Referring to other components
+
+copy-unrecognized-component-type = চিনা যায় নায় এমন উপাদান-ধরন বাড়ানো বা নকল করা যায় নায়: { $type }।
+
+copy-prop-not-found = { $component } ধরনের উপাদানো { $property } prop পাওয়া গেছে নায়
+
+collect-no-source = collect-র লাগি কোনো উৎস পাওয়া গেছে নায়।
+
+collect-invalid-component-type = `<{ $component }>` ঠিক উপাদান-ধরন নায়, তাইন অউ ধরনের উপাদান collect করা যায় নায়।
+
+reference-index-unavailable = index `{ $reference }` দেখানো যায় নায়
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` উপাদানো { $action } ডাকা যায় নায়
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ডেটার আকার ভুল।  সারিইনতার দৈর্ঘ্য একরকম নায়। componentIdx :{ $componentIdx }-ও পাওয়া গেছে
+
+data-frame-duplicate-column-names = ডেটাত একউ স্তম্ভের নাম দুইবার আছে।  componentIdx :{ $componentIdx }-ও পাওয়া গেছে
+
+data-frame-missing-column-name = ডেটাত একটা স্তম্ভের নাম নাই।  componentIdx :{ $componentIdx }-ও পাওয়া গেছে
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = অউ জুয়াপের একটা award অউ answer ট্যাগের নিজের পাঠানো জুয়াপের উপরে নির্ভর করে, ইতাত অপ্রত্যাশিত আচরণ অইব।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork`-ওয়ালা পাত্রের ভিতরের `<answer>`-ও `maxNumAttempts` দিলে কোনো কাম অয় নায়, কারণ সুযোগের সংখ্যা পাত্রটাউ ঠিক করে। `maxNumAttempts` পাত্রের উপরেউ দিইন।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork`-ওয়ালা আরেকটা পাত্রের ভিতরের `sectionWideCheckWork`-ওয়ালা পাত্রো `maxNumAttempts` দিলে কোনো কাম অয় নায়, কারণ সুযোগের সংখ্যা বাইরের পাত্রটাউ ঠিক করে। `maxNumAttempts` বাইরের পাত্রের উপরেউ দিইন।
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality দেওয়া না থাকলে { $attributes } বৈশিষ্ট্যের কোনো কাম অইত নায়।
+    }
+
+answer-invalid-type = জুয়াপের লাগি ভুল type: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` উপাদানের কোনো নাম নাই, তাইন ইতা module-র বৈশিষ্ট্য হিসাবে কামে লাগানো যায় নায়
+
+module-attribute-name-already-defined = `<module>` উপাদান-ধরনো "{ $name }" নামের বৈশিষ্ট্য আগেউ ঠিক করা আছে, তাইন `<{ $component } name="{ $name }">` উপাদানটা module-র বৈশিষ্ট্য হিসাবে কামে লাগানো যায় নায়।
+
+conditional-content-condition-ignored = case বা else সন্তানওয়ালা `<conditionalContent>` উপাদানো `condition` বৈশিষ্ট্য গণায় লওয়া অয় নায়।
+
+slider-markers-type-mismatch = Marker-র ধরন slider-র ধরনের লগে মিলে নায়।
+
+pretzel-problem-needs-statement-and-answer = ভুল pretzel: প্রতিটা `<problem>`-ও একটা `<statement>` আর একটা `<answer>` থাকতে অইব।
+
+pretzel-circuit-first-problem-distractor = ভুল pretzel: mode="circuit"-ও পয়লা `<problem>` distractor অইতে পারে নায়।
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] `{ $attribute }` বৈশিষ্ট্যের লাগি ভুল মান { $values }; গণায় লওয়া অয় নায়।
+    }
+
+attribute-must-be-references = `{ $attribute }` বৈশিষ্ট্যের লাগি ভুল মান `{ $value }`। বৈশিষ্ট্যটা `$` দিয়া শুরু অওয়া সন্দর্ভ দিয়া বানাইতে অইব।
+
+math-input-invalid-function-names = <mathInput>: { $attribute }-ও থাকা ভুল ফাংশন-নাম গণায় লওয়া অয় নায়: { $names }। প্রতিটা নামের দেখানোর অংশ কমসেকম 2 অক্ষরের (অক্ষর বা ড্যাশ) অইতে অইব; পিছে একটা `|<mathspeak alternative>` লাগানো যাইতে পারে।
+
+## Building components from the source
+
+component-type-invalid = ভুল উপাদান-ধরন: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } বৈশিষ্ট্য দুইবার দেওয়া যায় নায়।
+
+attribute-invalid-for-component = `<{ $componentType }>` ধরনের উপাদানের লাগি ভুল বৈশিষ্ট্য "{ $attribute }"।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    শৈলী-সংজ্ঞা { $styleNumber }-ও { $context ->
+        [text-on-background] পটভূমির রঙের লগে লেখার রঙের
+        [high-contrast] ক্যানভাসের লগে উচ্চ-বৈসাদৃশ্য রঙের
+        [line] ক্যানভাসের লগে রেখার রঙের
+        [marker] ক্যানভাসের লগে marker-র রঙের
+       *[text-on-canvas] ক্যানভাসের লগে লেখার রঙের
+    } বৈসাদৃশ্য কম{ $mode ->
+        [dark] { " (কালা মোড)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; কমসেকম { $threshold }:1 লাগব)।
+
+style-definition-dark-mode-text-background-contrast =
+    শৈলী-সংজ্ঞা { $styleNumber }-ও দেওয়া রঙ ধলা মোডের লাগি যথেষ্ট বৈসাদৃশ্য দেয় ঠিকউ, অথচ অউ মান থাকি বানানো কালা মোডের রঙো পটভূমির রঙের লগে লেখার রঙের বৈসাদৃশ্য কম ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; কমসেকম { $threshold }:1 লাগব)। { $suggestion ->
+        [available] কালা মোডো যথেষ্ট বৈসাদৃশ্য পাইতে অইলে ধলা মোডের বৈসাদৃশ্য বাড়াইন (যেমন { $lightAttribute }="{ $lightColor }" দিইন), নাইলে কালা মোডের রঙ নিজেউ ঠিক করইন (যেমন { $darkAttribute }="{ $darkColor }")।
+       *[none] কালা মোডো যথেষ্ট বৈসাদৃশ্য পাইতে অইলে ধলা মোডের বৈসাদৃশ্য বাড়াইন, নাইলে textColorDarkMode আর/বা backgroundColorDarkMode দিয়া বানানো রঙ নিজেউ ঠিক করইন।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    শৈলী-সংজ্ঞা { $styleNumber }-ও দেওয়া লেখার রঙ ধলা মোডের লাগি যথেষ্ট বৈসাদৃশ্য দেয় ঠিকউ, অথচ অউ মান থাকি বানানো কালা মোডের লেখার রঙের ক্যানভাসের লগে বৈসাদৃশ্য কম ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; কমসেকম { $threshold }:1 লাগব)। { $suggestion ->
+        [available] কালা মোডো যথেষ্ট বৈসাদৃশ্য পাইতে অইলে ধলা মোডের বৈসাদৃশ্য বাড়াইন (যেমন textColor="{ $lightColor }" দিইন), নাইলে কালা মোডের রঙ নিজেউ ঠিক করইন (যেমন textColorDarkMode="{ $darkColor }")।
+       *[none] কালা মোডো যথেষ্ট বৈসাদৃশ্য পাইতে অইলে ধলা মোডের বৈসাদৃশ্য বাড়াইন, নাইলে textColorDarkMode দিয়া বানানো রঙ নিজেউ ঠিক করইন।
+    }
+
+section-multiple-style-palettes = একটা বিভাগ খালি একটা <stylePalette> বাছতে পারে; শেষেরটা কামে লাগানো অইল।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect ঋণাত্মক নায় এমন পূর্ণসংখ্যা নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-num-to-select-not-constant-number = numToSelect ধ্রুব সংখ্যা নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-with-replacement-not-constant-boolean = withReplacement ধ্রুব boolean নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-select-weight-disables-unique = selectWeight বা selectForVariants দেওয়া কোনো option থাকলে select-র অনন্য variant বন্ধ অইযায়
+
+variant-coprime-undetermined = coprime সবসময় মিছা কি না ঠিক করা যায় নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-attribute-not-constant = { $attribute } ধ্রুব নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-attribute-not-number = { $attribute } সংখ্যা নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } { $expected ->
+        [letters-combination] অক্ষরের সংমিশ্রণ
+        [math-expression] ঠিক গণিত রাশি
+        [integer] পূর্ণসংখ্যা
+       *[number] সংখ্যা
+    } নায়, তাইন { $type } ধরনের { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-length-not-integer = length পূর্ণসংখ্যা নায়, তাইন { $component }-র অনন্য variant ঠিক করা যায় নায়।
+
+variant-sort-not-implemented = sort-ওয়ালা { $component }-র অনন্য variant এখনো বানানো অয় নাই
+
+variant-exclude-combinations-not-implemented = excludeCombinations-ওয়ালা { $component }-র অনন্য variant এখনো বানানো অয় নাই
+
+variant-math-exclude-not-implemented = exclude-ওয়ালা math ধরনের { $component }-র অনন্য variant এখনো বানানো অয় নাই
+
+variant-non-constant-exclude-not-implemented = ধ্রুব নায় এমন exclude-ওয়ালা { $component }-র অনন্য variant এখনো বানানো অয় নাই
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure রেন্ডারারো চলে নায়; বংশধর বাদ দেওয়া অইল।
+
+prefigure-descendant-invalid-geometry = { $subject }: সসীম নায় বা অসম্পূর্ণ জ্যামিতি; বংশধর বাদ দেওয়া অইল।
+
+prefigure-curve-label-omitted = { $subject }: রূপান্তর করা বক্র উপাদানো label চলে নায়; label বাদ দেওয়া অইল।
+
+prefigure-curve-unsupported-definition-type = { $subject }: চলে নায় এমন বক্র ফাংশন-সংজ্ঞার ধরন '{ $definitionType }'; বংশধর বাদ দেওয়া অইল।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves-ও চলে নায় এমন flipFunctions বৈশিষ্ট্য; বংশধর বাদ দেওয়া অইল।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves-ও খালি formula ধরনের সন্তান ফাংশনউ চলে; বংশধর বাদ দেওয়া অইল।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] রেখা-পরিবারের label
+       *[point] বিন্দুর label
+    }-র লাগি চলে নায় এমন labelPosition '{ $labelPosition }'; আগে থাকি ঠিক করা PreFigure সারিবদ্ধতা কামে লাগানো অইল।
+
+prefigure-fill-style-unsupported = { $subject }: ভরাটের শৈলী '{ $fillStyle }' PreFigure-ও চলে নায়; ঠাসা ভরাট কামে লাগানো অইল।
+
+prefigure-line-style-unknown = { $subject }: অচেনা রেখা-শৈলী '{ $lineStyle }' PreFigure-র লেখা থাকি বাদ দেওয়া অইল।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker শৈলী '{ $markerStyle }' PreFigure-র 'diamond' শৈলীও বদলানো অইল।
+
+prefigure-marker-style-unsupported = { $subject }: marker শৈলী '{ $markerStyle }' PreFigure-ও চলে নায়; আগে থাকি ঠিক করা শৈলী কামে লাগানো অইল।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ভুল `ref`; target ঠিক করা যায় নায়। টীকা বাদ দেওয়া অইল।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` একের বেশি target-ও লাগছে; পয়লা target কামে লাগানো অইল।
+
+annotation-ref-outside-graph = `<annotation>`: ভুল `ref`; target যেই graph-র ভিতরে থাকার কথা ইতার বাইরে। টীকা বাদ দেওয়া অইল।
+
+annotation-ref-unsupported-target = `<annotation>`: ভুল `ref`; prefigure রূপান্তরো target চলে এমন ছবির জিনিস নায়। টীকা বাদ দেওয়া অইল।
+
+annotation-text-missing = `<annotation>`: `text` নাই বা খালি; খালি লেখা বাইর করা অইল।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] চক্রাকার নির্ভরতা পাওয়া গেছে।
+       *[other] `<{ $componentType }>` উপাদানের লগে জড়িত চক্রাকার নির্ভরতা পাওয়া গেছে।
+    }
+
+reference-no-referent = সন্দর্ভের লাগি কোনো লক্ষ্য পাওয়া গেছে নায়: `{ $reference }`
+
+reference-multiple-referents = সন্দর্ভের লাগি একের বেশি লক্ষ্য পাওয়া গেছে: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>`-র { $attribute } বৈশিষ্ট্যের ভুল ছাঁচ।
+
+children-invalid = `<{ $componentType }>`-র লাগি ভুল সন্তান: ভুল সন্তান পাওয়া গেছে: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` বৈশিষ্ট্যের লাগি ভুল মান `{ $value }`, `{ $default }` মান কামে লাগানো অইল
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML সংস্করণ { $version } পাওয়া গেছে নায়।
+       *[other] DoenetML সংস্করণ { $version } পাওয়া গেছে নায়। সংস্করণ { $fallback }-ও ফিরা যাওয়া অইল
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = ভুল DoenetML: { $content }
+
+parse-tag-missing-close-tag = ভুল DoenetML: `{ $tag }` ট্যাগের কোনো বন্ধ ট্যাগ নাই। নিজেউ বন্ধ অওয়া ট্যাগ বা একটা `</{ $tagName }>` ট্যাগ লাগব।
+
+parse-tag-error = ভুল DoenetML: `<{ $tagName }>` ট্যাগো ত্রুটি
+
+parse-attribute-missing-value = ভুল DoenetML: ভুল বৈশিষ্ট্য `{ $attribute }`-র মান নাই বইলা মনে অইরার।
+
+parse-attribute-invalid = ভুল DoenetML: ভুল বৈশিষ্ট্য `{ $attribute }`
+
+parse-attribute-value-invalid = ভুল DoenetML: ভুল বৈশিষ্ট্যের মান `{ $value }`
+
+parse-attribute-value-quote-mismatch = ভুল DoenetML: ভুল বৈশিষ্ট্যের মান `{ $value }`। উদ্ধৃতি চিহ্ন মিলে নায়। একটা `{ $quote }` নাই বইলা মনে অইরার
+
+parse-open-tag-name-missing = ভুল DoenetML: নাম নাই এমন একটা ট্যাগ পাওয়া গেছে, যেমন `<`
+
+parse-tag-not-closed = ভুল DoenetML: `{ $tag }` ট্যাগ বন্ধ করা অয় নাই (একটা `>` নাই বইলা মনে অইরার)।
+
+parse-self-closing-tag-name-missing = ভুল DoenetML: নাম নাই এমন একটা ট্যাগ পাওয়া গেছে `<{ $content }>`
+
+parse-self-closing-tag-not-closed = ভুল DoenetML: `{ $tag }` ট্যাগ বন্ধ করা অয় নাই (`/>` নাই বইলা মনে অইরার)।
+
+parse-tag-invalid-attributes = ভুল DoenetML: `{ $tag }` ট্যাগ ঠিক নায়। ইতার বৈশিষ্ট্য ভুল অইতে পারে।
+
+parse-close-tag-name-missing = ভুল DoenetML: নাম নাই এমন একটা বন্ধ ট্যাগ পাওয়া গেছে, যেমন `</`
+
+parse-attribute-value-unquoted = বৈশিষ্ট্যের মান উদ্ধৃতি চিহ্নের ভিতরে রাখতে অইব: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = ভুল DoenetML: `{ $tag }` বন্ধ ট্যাগ পাওয়া গেছে, অথচ ইতার কোনো খোলা ট্যাগ নাই
+
+parse-close-tag-mismatched = ভুল DoenetML: বন্ধ ট্যাগ মিলে নায়। `</{ $expected }>` লাগব। `{ $found }` পাওয়া গেছে
+
+parser-node-unconvertible = { $node } নোডটা Dast নোডো বদলানো গেছে নায়।
+
+## Names
+
+name-attribute-invalid =
+    ভুল বৈশিষ্ট্য name='{ $name }'। { $reason ->
+        [characters] নামো খালি অক্ষর, সংখ্যা, আন্ডারস্কোর বা হাইফেন থাকতে পারে।
+       *[start] নাম অক্ষর দিয়া শুরু অইতে অইব।
+    }
+
+component-name-invalid-start = ভুল উপাদানের নাম "{ $name }"। নাম অক্ষর দিয়া শুরু অইতে অইব।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched ধরনের answer-র একটা video বৈশিষ্ট্য থাকতে অইব
+
+answer-video-watched-video-not-reference = videoWatched ধরনের answer-র video বৈশিষ্ট্য একটা সন্দর্ভ অইতে অইব
+
+answer-name-not-single-text = Answer-র name বৈশিষ্ট্যো খালি একটা text সন্তান থাকতে অইব
+
+## Referencing another document
+
+external-doenetml-recursion-limit = বেশি স্তরের পুনরাবৃত্তির লাগি বাইরের DoenetML আনা গেছে নায়। কোনো চক্রাকার সন্দর্ভ আছে নি?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" থাকি DoenetML আনা গেছে নায়
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" থাকি আনা DoenetML ভুল: ইতা "{ $componentType }" উপাদান-ধরনের লগে মিলে নায়
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` বৈশিষ্ট্য পুরানা অইগেছে; ইতার বদলে `{ $to }` কামে লাগাইন।
+       *[other] [deprecation] `<{ $component }>`-র `{ $from }` বৈশিষ্ট্য পুরানা অইগেছে; ইতার বদলে `{ $to }` কামে লাগাইন।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }`-ও দেওয়া আছে, তাইন `{ $from }` বৈশিষ্ট্য পুরানা অইগেছে আর গণায় লওয়া অয় নায়।
+       *[other] [deprecation] `<{ $component }>`-র `{ $from }` বৈশিষ্ট্য পুরানা অইগেছে আর `{ $to }`-ও দেওয়া আছে বইলা গণায় লওয়া অয় নায়।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`-র `{ $attribute }` বৈশিষ্ট্য পুরানা অইগেছে আর গণায় লওয়া অয় নায়।
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`-র `{ $attribute }` বৈশিষ্ট্য পুরানা অইগেছে; ইতার বদলে একটা `<{ $child }>` সন্তান কামে লাগাইন।
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`-র `{ $attribute }` বৈশিষ্ট্যের `{ $value }` মান পুরানা অইগেছে; ইতার বদলে `{ $to }` কামে লাগাইন।
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` খালি ইংরাজিরউ বহুবচন বানাইতে পারে, তাইন { $locale } ভাষায় লেখা দলিলো ইতার লেখা যেমন আছিল তেমনউ থাকে। বহুবচন রূপটা সোজা লেখইন, নাইলে `pluralForm` বৈশিষ্ট্য দিয়া দিইন।
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` উপাদান Doenet-র চিনা উপাদান নায়।
+
+schema-element-not-allowed-at-root = `<{ $tag }>` উপাদান দলিলের গোড়াত রাখা যায় নায়।
+
+schema-element-not-allowed-inside = `<{ $tag }>` উপাদান `<{ $parent }>`-র ভিতরে রাখা যায় নায়।
+
+schema-attribute-unrecognized = `<{ $tag }>` উপাদানের `{ $attribute }` নামের কোনো বৈশিষ্ট্য নাই।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` উপাদানের `{ $attribute }` বৈশিষ্ট্য এমন একটা তালিকা অইতে অইব যেটার প্রতিটা জিনিস ইতার একটা: { $allowed }
+       *[other] `<{ $tag }>` উপাদানের `{ $attribute }` বৈশিষ্ট্য ইতার একটা অইতে অইব: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select-র লাগি ভুল variant নাম।  Variant নাম { $variantName } { $numOptions } option-ও আছে অথচ বাছার সংখ্যা { $numToSelect }।
+
+select-variant-name-without-options = select-র লাগি কিছু variant দেওয়া আছে অথচ সম্ভব variant নাম { $variantName }-র লাগি কোনো option দেওয়া নাই।
+
+select-variant-name-not-possible = select-র লাগি দেওয়া variant নাম { $variantName } সম্ভব variant নাম নায়।
+
+select-too-few-options = খালি { $numOptions } থাকতে { $numToSelect } উপাদান বাছা যায় নায়।
+
+select-from-sequence-too-few-values = { $length } দৈর্ঘ্যের অনুক্রম থাকি { $numToSelect } মান বাছা যায় নায়।
+
+select-from-sequence-indices-count-mismatch = select-র লাগি দেওয়া indices-র সংখ্যা বাছার সংখ্যার লগে মিলতে অইব
+
+select-from-sequence-indices-not-integers = select-র লাগি দেওয়া সব indices পূর্ণসংখ্যা অইতে অইব
+
+select-from-sequence-index-excluded = selectfromsequence-র যেই index দেওয়া অইছে ইতা বাদ দেওয়া আছিল
+
+select-from-sequence-indices-excluded-combination = selectfromsequence-র যেই indices দেওয়া অইছে ইতা বাদ দেওয়া সংমিশ্রণ আছিল
+
+select-from-sequence-coprime-not-positive-integers = ধনাত্মক পূর্ণসংখ্যা বাছা অইরার নায়, তাইন coprime সংমিশ্রণ বাছা যায় নায়।
+
+select-from-sequence-coprime-common-factor = Coprime সংখ্যা বাছা যায় নায়। সব সম্ভব মানের একটা সাধারণ উৎপাদক আছে। ("from" বা "to"-র দেওয়া মান "step"-র লগে coprime অইতে অইব।)
+
+select-from-sequence-coprime-single-number = 1 নায় এমন একটাউ সংখ্যা থাকি coprime সংমিশ্রণ বাছা যায় নায়।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence-ও সংমিশ্রণের 70%-র বেশি বাদ দেওয়া অইছে
+
+select-from-sequence-coprime-none-found = Coprime সংখ্যা বাছা গেছে নায়। সব সম্ভব মানের একটা সাধারণ উৎপাদক আছে।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } দৈর্ঘ্যের অনুক্রম থাকি { $numToSelect } অনন্য মান বাছা যায় নায়
+
+select-prime-numbers-too-few-values = { $numValues } দৈর্ঘ্যের মৌলিক সংখ্যার তালিকা থাকি { $numToSelect } মান বাছা যায় নায়
+
+select-prime-numbers-values-count-mismatch = select-র লাগি দেওয়া মানের সংখ্যা বাছার সংখ্যার লগে মিলতে অইব
+
+select-prime-numbers-values-not-prime = select prime number-র লাগি দেওয়া সব মান মৌলিক সংখ্যার তালিকাত থাকতে অইব
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers-র যেই মান দেওয়া অইছে ইতা বাদ দেওয়া সংমিশ্রণ আছিল
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers-ও সংমিশ্রণের 70%-র বেশি বাদ দেওয়া অইছে
+
+select-random-combination-fluke = খুবউ অসম্ভব একটা ঘটনায়, এলোমেলো মানের সংমিশ্রণ বাছা গেছে নায়
+
+select-random-value-fluke = খুবউ অসম্ভব একটা ঘটনায়, এলোমেলো মান বাছা গেছে নায়
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] অউ `<{ $component }>` গণিতের ভিতরে আছে অথচ `inline` নায়, তাইন ইতা দেখানো অয় নায়। `inline` দিইন, তাইলে ইতা ড্রপ-ডাউন তালিকা অইব, যেটা রাশির ভিতরে আঁটে।
+        [expanded] অউ `<{ $component }>` গণিতের ভিতরে আছে আর `expanded`, তাইন ইতা দেখানো অয় নায়। `expanded` সরাইন; অনেক লাইনের বাকসো রাশির ভিতরে আঁটে নায়।
+        [on-graph] অউ `<{ $component }>` graph-র উপরে আঁকা গণিতের ভিতরে আছে, ইতাত input-র জায়গা নাই, তাইন ইতা দেখানো অয় নায়।
+       *[relative-width] অউ `<{ $component }>` গণিতের ভিতরে আছে আর ইতার চওড়া সাপেক্ষ, তাইন ইতা দেখানো অয় নায়। চওড়াটা `px`-র মতো নিরপেক্ষ এককো দিইন।
+    }

--- a/packages/i18n/locales/syl/editor.ftl
+++ b/packages/i18n/locales/syl/editor.ftl
@@ -8,7 +8,7 @@
 # **Script and register** are `chrome.ftl`'s: the Bengali script, as Sylheti
 # is normally printed today, rather than Sylheti Nagri, and a Bengali
 # technical vocabulary declared as a loan register around a Sylheti frame —
-# নায়, নাই, আছে, অউ, ইতা, লাগি, দিয়া, লগে, আর, and the honorific imperative
+# নায়, নাই, আছে, অউ, ইতা, লাগি, লগে, আর, and the honorific imperative
 # in -ইন.
 #
 # **`WCAG`, `DoenetML`, `styleNumber` and every element and attribute name

--- a/packages/i18n/locales/syl/editor.ftl
+++ b/packages/i18n/locales/syl/editor.ftl
@@ -1,0 +1,226 @@
+# Sylheti (ছিলটি) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and register** are `chrome.ftl`'s: the Bengali script, as Sylheti
+# is normally printed today, rather than Sylheti Nagri, and a Bengali
+# technical vocabulary declared as a loan register around a Sylheti frame —
+# নায়, নাই, আছে, অউ, ইতা, লাগি, দিয়া, লগে, আর, and the honorific imperative
+# in -ইন.
+#
+# **`WCAG`, `DoenetML`, `styleNumber` and every element and attribute name
+# stay in English.** They are identifiers an author types, not words. So does
+# `$shortcut`, which is a key combination, and `$version`, `$standard` and
+# `$ref`.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `syl`, so an English-selected
+# branch here would be a category this locale cannot reach. A Sylheti noun is
+# unmarked for number after a numeral in any case, so the single form is also
+# the grammatical one.
+#
+# **The arrow `→` in the two link labels is direction rather than
+# punctuation** and is left where English puts it: Sylheti in the Bengali
+# script is written left to right.
+#
+# **Numbers render in Latin digits** rather than in Bengali numerals (#1615).
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] রিসেট
+       *[update] হালনাগাদ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] ভিউয়ার { $word }
+       *[other] ভিউয়ার { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = ছাঁকনি...
+editor-variant-next = পরের variant বাছইন
+editor-variant-previous = আগের variant বাছইন
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA প্রবেশগম্যতা লঙ্ঘন পাওয়া গেছে। প্রবেশগম্যতার প্রতিবেদন { $action ->
+            [close] বন্ধ
+           *[open] খুলতে
+        } ক্লিক করইন।
+        [advisories] প্রবেশগম্যতার প্রতিবেদন { $action ->
+            [close] বন্ধ
+           *[open] খুলতে
+        } ক্লিক করইন। কোনো WCAG AA লঙ্ঘন পাওয়া গেছে নায়, অথচ আরো কিছু প্রবেশগম্যতার পরামর্শ আছে।
+       *[clean] প্রবেশগম্যতার প্রতিবেদন { $action ->
+            [close] বন্ধ
+           *[open] খুলতে
+        } ক্লিক করইন। কোনো প্রবেশগম্যতার সমস্যা পাওয়া গেছে নায়।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA প্রবেশগম্যতা লঙ্ঘন পাওয়া গেছে। { $count ->
+           *[other] { $count } WCAG AA লঙ্ঘন
+        } পাওয়া গেছে। প্রবেশগম্যতার প্রতিবেদন { $action ->
+            [close] বন্ধ
+           *[open] খুলতে
+        } ক্লিক করইন।
+        [advisories] কোনো WCAG AA লঙ্ঘন পাওয়া গেছে নায়। { $count ->
+           *[other] { $count } বাড়তি প্রবেশগম্যতার পরামর্শ
+        } পাওয়া গেছে। প্রবেশগম্যতার প্রতিবেদন { $action ->
+            [close] বন্ধ
+           *[open] খুলতে
+        } ক্লিক করইন।
+       *[clean] কোনো WCAG AA লঙ্ঘন পাওয়া গেছে নায়। প্রবেশগম্যতার প্রতিবেদন { $action ->
+            [close] বন্ধ
+           *[open] খুলতে
+        } ক্লিক করইন।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML সংস্করণ { $version }
+
+editor-tab-help = প্রসঙ্গ অনুযায়ী সাহায্য
+editor-tab-help-short = প্রসঙ্গ
+editor-tab-errors = ত্রুটি
+editor-tab-warnings = সতর্কতা
+editor-tab-info = খবর
+editor-tab-accessibility = প্রবেশগম্যতা
+editor-tab-responses = পাঠানো জুয়াপ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = সম্পাদকের বিকল্প
+editor-format-as-doenetml = DoenetML হিসাবে সাজাইন
+editor-format-as-xml = XML হিসাবে সাজাইন
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = লাইন #{ $line }
+
+editor-no-errors = কোনো ত্রুটি নাই
+editor-no-warnings = কোনো সতর্কতা নাই
+editor-no-info = কোনো খবরের সূচনা নাই
+
+editor-show-info-annotations = সম্পাদকো খবরের সূচনা দেখাইন
+editor-show-accessibility-annotations = সম্পাদকো প্রবেশগম্যতার সূচনা দেখাইন
+
+editor-accessibility-learn-more = Doenet প্রবেশগম্যতারে কেমনে দেখে ইতা জানইন
+
+editor-accessibility-violations-heading = প্রবেশগম্যতা লঙ্ঘন ({ $standard })
+
+editor-accessibility-other-heading = আরো কিছু প্রবেশগম্যতার সমস্যা
+editor-none-found = কিছুউ পাওয়া গেছে নায়
+
+
+## Submitted responses
+
+editor-no-responses = এখনো কোনো জুয়াপ পাঠানো অয় নাই
+editor-response-answer-id = Answer Id
+editor-response-response = জুয়াপ
+editor-response-credit = নম্বর
+editor-response-submitted = পাঠানো অইছে
+
+
+## The context-help panel
+
+help-placeholder = দলিলের লাগি কার্সরটা একটা ট্যাগের নাম, বৈশিষ্ট্য বা { $ref }-র উপরে রাখইন।
+
+help-unsupported-ref-chain = { $example }-র মতো অনেক অংশের সন্দর্ভের লাগি সাহায্য এখনো চলে নায়।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] সন্দর্ভের লাগি কোনো লক্ষ্য পাওয়া গেছে নায়: { $ref }।
+        [multiple] সন্দর্ভের লাগি একের বেশি লক্ষ্য পাওয়া গেছে: { $ref }।
+       *[indeterminate] { $ref }-র লক্ষ্য ঠিক করা গেছে নায়।
+    }
+
+help-learn-about-references = সন্দর্ভের কথা জানইন →
+help-reference-page = সন্দর্ভের পাতা →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element }-র ভিতরে
+       *[top] সবার উপরের স্তরো
+    }{ $allowed ->
+        [none] { " — এখানে কিছুউ বসে নায়।" }
+        [text] { " — এখানে লেখা লেখইন।" }
+        [text-and-components] { " — এখানে লেখা লেখইন, নাইলে ইতা দেখইন:" }
+       *[components] { " — যেগুলি দেখতে পারইন:" }
+    }
+
+help-suggestions-footer = সব { $total } উপাদান দেখতে { $shortcut } চাপইন।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } অইল { $target }-র একটা সন্দর্ভ।
+       *[other] { $ref } অইল { $target }-র একটা সন্দর্ভ (লাইন { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ইতারে { $role } হিসাবে আনছে।
+       *[other] { $owner } ইতারে লাইন { $line }-ও { $role } হিসাবে আনছে।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } অইল { $element }-র { $property } বৈশিষ্ট্যের একটা সন্দর্ভ।
+       *[other] { $ref } অইল { $element }-র { $property } বৈশিষ্ট্যের একটা সন্দর্ভ (লাইন { $line })।
+    }
+
+help-kind-attribute = বৈশিষ্ট্য
+help-kind-snippet = স্নিপেট
+help-kind-array-entry = অ্যারের ঘর
+
+help-default = আগে থাকি ঠিক করা:
+help-active-default = এখনকার আগে থাকি ঠিক করা:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] চলে এমন মান (প্রতিটা জিনিসের লাগি একটা):
+       *[other] চলে এমন মান:
+    }
+
+help-suggested-values = পরামর্শ দেওয়া মান:
+
+help-inserts = বসায়:
+
+help-coordinates =
+    { $count ->
+       *[other] স্থানাঙ্ক:
+    }
+
+help-type = ধরন:
+
+help-resolved-style = ঠিক করা শৈলী (styleNumber { $styleNumber }):
+
+help-resolved-function-names = ঠিক করা ফাংশনের নাম:
+help-reset-list = অউ input-র রিসেট তালিকা:
+help-added-on-input = অউ input-ও বাড়ানো অইছে:
+help-removed-on-input = অউ input-ও সরানো অইছে:
+
+help-reset-overrides = { $reset } { $additional } আর { $removed }-র উপরে চলে।

--- a/packages/i18n/locales/tcy/chrome.ftl
+++ b/packages/i18n/locales/tcy/chrome.ftl
@@ -1,0 +1,157 @@
+# Tulu (ತುಳು) viewer chrome. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Kannada, not Tigalari.** Tulu has a historic script of its own —
+# **Tigalari**, also called Tulu-Tigalari or Tulu lipi, a Brahmic script
+# descended from the same Grantha stock as Malayalam's, in which the Tulu
+# palm-leaf literature (the Sri Bhagavato, the Kaveri) is written, encoded in
+# Unicode as of version 16.0 (U+11380–U+113FF). Its revival is active and
+# organized: it is taught in Mangaluru and Udupi, the Karnataka Tulu Sahitya
+# Academy promotes it, and there is a real argument that a Tulu catalog should
+# be written in it. A reviewer may reasonably have expected that, and its
+# absence here is not a judgement about which script belongs to the language.
+#
+# This catalog writes the **Kannada script**, for three reasons. The first is
+# what a Tulu reader reads: every Tulu book, magazine, film subtitle,
+# schoolbook, road sign and web page published in the last century and a half
+# is in Kannada letters, and a Tulu speaker is schooled in them. The second is
+# mechanical and, for a script encoded this recently, decisive: Tigalari font
+# coverage in a browser is close to nonexistent, and a catalog that renders as
+# boxes on almost every machine helps nobody. The third is that Tigalari
+# orthography for *modern* Tulu is not settled — the manuscripts are Sanskrit
+# and old Tulu, and how to write today's borrowings, its ಎ/ಏ and ಒ/ಓ
+# contrasts, and its final ಇ in that script is a question the revival is still
+# answering — so a Tigalari seed would be making orthographic decisions no
+# current practice supports. Converting this catalog to Tigalari means
+# converting **all four files at once**, never a mixture inside one catalog,
+# and it is a real conversion rather than a transliteration.
+#
+# **This seed leans on Kannada.** Tulu and Kannada are both Southern
+# Dravidian, they share the script and a great deal of the learned vocabulary,
+# and every technical word in these files — ದೋಷ, ಎಚ್ಚರಿಕೆ, ಘಟಕ, ಗುಣ, ಚರ,
+# ಆಯಾಮ, ಸಾಲು, ಕಂಬ — is Kannada, because Tulu-medium schooling does not exist
+# and a Tulu reader met these words in Kannada. What is Tulu here is the
+# **grammar**: ಇಜ್ಜಿ for negation and absence, ಉಂಡು for presence, the negative
+# verb in -ಜಿ (ತಿಕ್ಕುಜಿ, ಆಪುಜಿ, ಮಲ್ಪುಜಿ), ಬೊಕ್ಕ for *and*, ಅತ್ತ್ಂಡ for *or*,
+# ಒಟ್ಟುಗು for *with*, ಆವೊಡು for *must*, and the honorific imperative in -ಲೆ —
+# ಮಲ್ಪುಲೆ, ತೋಜಾಲೆ — which is what a Tulu reader expects a button to say. A
+# message where Kannada's ಇಲ್ಲ, ಮತ್ತು, ಅಥವಾ, ಮಾಡಿ or ಆಗಿದೆ has crept back in
+# is a defect rather than a variant, and is the easiest thing in this catalog
+# to check.
+#
+# **Numbers render in Latin digits** rather than in Kannada numerals, which is
+# the digit policy in the package README (#1615). The grouping is the
+# locale's; the ten characters are not.
+#
+# **No plural branches.** CLDR has no plural data for `tcy`, so a `one` branch
+# here would be text selected by Kannada's rules rather than by this locale's.
+# The numeric literal `[0]` in `attempts-remaining` stays, because Fluent
+# matches it against the number itself before any plural rule is consulted.
+
+
+## Answer submission
+
+answer-checking = ಪರಿಶೀಲನೆ ಆವೊಂದುಂಡು...
+answer-submitting = ಕಡಪುಡೊಂದುಂಡು...
+answer-checking-status = ಉತ್ತರೊದ ಪರಿಶೀಲನೆ ಆವೊಂದುಂಡು
+answer-submitting-status = ಉತ್ತರ ಕಡಪುಡೊಂದುಂಡು
+answer-correct = ಸರಿ
+answer-incorrect = ಸರಿ ಅತ್ತ್
+answer-response-saved = ಉತ್ತರ ದೀಪುನ ಆಂಡ್
+answer-percent-credit = { $percent }% ಅಂಕ
+answer-percent-correct = { $percent }% ಸರಿ
+answer-percent-short = { $percent } %
+max-credit-available = ಗರಿಷ್ಠ ಅಂಕ: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] ಇನಿ ಒವ್ವೇ ಪ್ರಯತ್ನ ಒರಿದ್‌ಜಿ
+       *[other] ಇನಿ { $count } ಪ್ರಯತ್ನ ಒರಿದ್ಂಡ್
+    }
+validation-correct = (ಸರಿ)
+validation-incorrect = (ಸರಿ ಅತ್ತ್)
+validation-partially-correct = (ಒಂತೆ ಸರಿ)
+answer-show-responses =
+    { $count ->
+       *[other] { $answerId }ಗ್ ಬತ್ತಿನ { $count } ಉತ್ತರ ತೋಜಾಲೆ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = ಅನಿಸಿಕೆ
+collapsible-click-to-open = (ದೆಪ್ಪರೆ ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ)
+collapsible-click-to-close = (ಮುಚ್ಚರೆ ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ)
+collapsible-initializing = ಸುರುವಾವೊಂದುಂಡು...
+footnote-show = ಅಡಿಟಿಪ್ಪಣಿ ತೋಜಾಲೆ
+footnote-hide = ಅಡಿಟಿಪ್ಪಣಿ ದೆಂಗಾಲೆ
+description-more-information = ಇನ್ನಷ್ಟು ವಿವರ
+
+
+## Controls
+
+slider-previous = ದುಂಬುದ
+slider-next = ಬೊಕ್ಕದ
+keyboard-open = ಕೀಬೋರ್ಡ್ ದೆಪ್ಪುಲೆ
+keyboard-close = ಕೀಬೋರ್ಡ್ ಮುಚ್ಚುಲೆ
+choice-input-remove-choice = { $choice } ದೆತ್ತ್ ಪಾಡ್ಲೆ
+matrix-remove-row = ಸಾಲು ದೆತ್ತ್ ಪಾಡ್ಲೆ
+matrix-add-row = ಸಾಲು ಸೇರಾಲೆ
+matrix-remove-column = ಕಂಬ ದೆತ್ತ್ ಪಾಡ್ಲೆ
+matrix-add-column = ಕಂಬ ಸೇರಾಲೆ
+subset-add-remove-points = ಬಿಂದು ಸೇರಾವುನ/ದೆಪ್ಪುನ
+subset-toggle-points-intervals = ಬಿಂದು ಬೊಕ್ಕ ಅಂತರ ಬದಲ್ ಮಲ್ಪುಲೆ
+subset-move-points = ಬಿಂದು ಜರಿಪಾಲೆ
+subset-clear = ಕ್ಲೀನ್ ಮಲ್ಪುಲೆ
+orbital-add-row = ಸಾಲು ಸೇರಾಲೆ
+orbital-remove-row = ಸಾಲು ದೆತ್ತ್ ಪಾಡ್ಲೆ
+orbital-add-box = ಪೆಟ್ಟಿಗೆ ಸೇರಾಲೆ
+orbital-remove-box = ಪೆಟ್ಟಿಗೆ ದೆತ್ತ್ ಪಾಡ್ಲೆ
+orbital-add-up-arrow = ಮಿತ್ತ್‌ದ ಬಾಣ ಸೇರಾಲೆ
+orbital-add-down-arrow = ತಿರ್ತ್‌ದ ಬಾಣ ಸೇರಾಲೆ
+orbital-remove-arrow = ಬಾಣ ದೆತ್ತ್ ಪಾಡ್ಲೆ
+orbital-row-label = { $row }ನೇ ಸಾಲುದ ಪುದರ್
+pretzel-answer = ಉತ್ತರ
+summary-statistics-caption = { $column }ದ ಸಾರಾಂಶ ಅಂಕಿಅಂಶ
+
+
+## Math input
+
+math-input-preview-region = ಗಣಿತ ಸೂತ್ರೊದ ಮುನ್ನೋಟ
+math-input-preview = ಮುನ್ನೋಟ
+math-input-invalid-expression = ತಪ್ಪು ಸೂತ್ರ:
+
+
+## Document status
+
+viewer-initializing = ಸುರುವಾವೊಂದುಂಡು...
+
+
+## Errors
+
+error-heading = ದೋಷ
+error-found-at =
+    { $span ->
+        [line] { $startLine }ನೇ ಸಾಲುಡ್ ತಿಕ್ಕ್‌ಂಡ್.
+       *[lines] { $startLine }–{ $endLine } ಸಾಲುಡ್ ತಿಕ್ಕ್‌ಂಡ್.
+    }
+document-contains-errors = ಈ ದಾಖಲೆಡ್ ದೋಷ ಉಂಡು!
+diagnostic-heading-error = ದೋಷ
+diagnostic-heading-warning = ಎಚ್ಚರಿಕೆ
+diagnostic-heading-information = ವಿವರ
+diagnostic-heading-hint = ಸುಳಿವು
+accessibility-heading-level-1 = WCAG AA ಸೌಲಭ್ಯ ಉಲ್ಲಂಘನೆ
+accessibility-heading-level-2 = ಸೌಲಭ್ಯ ಸೂಚನೆ
+something-went-wrong = ಒವ್ವೋ ತಪ್ಪಾಂಡ್.
+renderer-load-failed = ಒಂಜಿ ರೆಂಡರರ್ ಲೋಡ್ ಆಪುಜಿ. ದಯಮಲ್ತ್ ಪುಟೊನು ಪಿರ ಲೋಡ್ ಮಲ್ಪುಲೆ.
+core-start-failed = ಈ ದಾಖಲೆನ್ ಸುರು ಮಲ್ಪೆರೆ ಆಪುಜಿ. ದಯಮಲ್ತ್ ಪುಟೊನು ಪಿರ ಲೋಡ್ ಮಲ್ಪುಲೆ.
+core-start-failed-busy = ಈ ದಾಖಲೆನ್ ಸುರು ಮಲ್ಪೆರೆ ಆಪುಜಿ. ಒಟ್ಟುಗು ಮಸ್ತ್ ದಾಖಲೆಲು ಸುರುವಾವೊಂದಿತ್ತ, ಮೆಲ್ಲ ಸಾಗುನ ಸಾಧನೊಡು ಅವು ಜಾಸ್ತಿ ಪೊರ್ತು ದೆತೊನುಂಡು. ಬಾಕಿ ದಾಖಲೆಲು ಮುಗಿಯಿನ ಬುಕ್ಕ ಪುಟೊನು ಪಿರ ಲೋಡ್ ಮಲ್ತ್ಂಡ ಸಹಾಯ ಆವು.
+core-start-failed-retry = ಈ ದಾಖಲೆನ್ ಸುರು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+core-start-failed-busy-retry = ಈ ದಾಖಲೆನ್ ಸುರು ಮಲ್ಪೆರೆ ಆಪುಜಿ. ಒಟ್ಟುಗು ಮಸ್ತ್ ದಾಖಲೆಲು ಸುರುವಾವೊಂದಿತ್ತ, ಮೆಲ್ಲ ಸಾಗುನ ಸಾಧನೊಡು ಅವು ಜಾಸ್ತಿ ಪೊರ್ತು ದೆತೊನುಂಡು.
+core-start-retry = ಪಿರ ಪ್ರಯತ್ನ ಮಲ್ಪುಲೆ
+saved-state-unavailable = ಈರ್ ದೀತಿನ ಕೆಲಸೊನು ಲೋಡ್ ಮಲ್ಪೆರೆ ಆಪುಜಿ.

--- a/packages/i18n/locales/tcy/content.ftl
+++ b/packages/i18n/locales/tcy/content.ftl
@@ -28,7 +28,8 @@
 # «{ $numSides } ಬರಿತ ಸಮ ಬಹುಭುಜ» and leaves `tail` empty, exactly as English
 # does: the side count is a modifier and a Dravidian modifier goes in front,
 # so there is nothing to place after the adjectives and no reason to split the
-# noun. The `[noun-tail]` branches in the two composition messages are kept
+# noun. `style-with-noun`'s `[noun-tail]` branch, and the `[plain-tail]` and
+# `[pattern-tail]` branches `style-filled-with-noun` uses in its place, are kept
 # because a partly-translated locale falls back through them, not because
 # anything here selects them.
 #
@@ -72,9 +73,10 @@
 # absence, ಉಂಡು for presence, the negative verb in -ಜಿ, ಬೊಕ್ಕ for *and*,
 # ಅತ್ತ್ಂಡ for *or*, ಒಟ್ಟುಗು for *with*, the locative -ಡ್ and the genitive -ದ.
 # **ಬೊಕ್ಕ does double duty** — it is both *and* and *next/after* — so
-# `slider-next` and `piecewise-condition-or` in the sibling files share a root
-# on purpose rather than by mistake. A message where Kannada's ಮತ್ತು, ಅಥವಾ or
-# ಇಲ್ಲ has crept back in is a defect.
+# `chrome.ftl`'s `slider-next` (ಬೊಕ್ಕದ) is built on the same root as this
+# file's conjunction rather than on a separate word; *or* is unrelated to it
+# (`piecewise-condition-or` below is ಅತ್ತ್ಂಡ). A message where Kannada's
+# ಮತ್ತು, ಅಥವಾ or ಇಲ್ಲ has crept back in is a defect.
 #
 # **`style-filled-word` and `style-unfilled` are the Tulu participle pair**
 # ತುಂಬಿನ / ತುಂಬಂದಿನ, positive and negative of one verb, which is how Tulu

--- a/packages/i18n/locales/tcy/content.ftl
+++ b/packages/i18n/locales/tcy/content.ftl
@@ -1,0 +1,335 @@
+# Tulu (ತುಳು) content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in, not
+# the language of the reader's chrome.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script: Kannada, not Tigalari**, for the three reasons `chrome.ftl`'s
+# header sets out in full — what a Tulu reader actually reads, Tigalari's
+# near-absent browser font coverage, and the fact that Tigalari orthography
+# for modern Tulu is still being settled by the revival. A conversion is a
+# conversion of all four files at once, and a real conversion rather than a
+# transliteration.
+#
+# ## Word order
+#
+# **Modifiers precede the noun and postpositions follow it.** Tulu is
+# Dravidian, verb-final and strictly left-branching, so `style-with-noun` and
+# `style-filled-with-noun` keep English's order of `{ $description }` before
+# `{ $noun }`, and `style-stroke` keeps English's internal sequence of width,
+# dash pattern, colour. What moves is every one of English's prepositions:
+# `with` becomes the postposition ಒಟ್ಟುಗು and `on`/`in` the locative -ಡ್, so
+# `style-border-clause`, `style-filled` and `style-text` all put the value in
+# front of the word English puts it behind. That reordering is the whole of
+# the difference between this file and a word-for-word rendering.
+#
+# **`[noun-tail]` is unused.** `noun-regular-polygon` fills `head` with
+# «{ $numSides } ಬರಿತ ಸಮ ಬಹುಭುಜ» and leaves `tail` empty, exactly as English
+# does: the side count is a modifier and a Dravidian modifier goes in front,
+# so there is nothing to place after the adjectives and no reason to split the
+# noun. The `[noun-tail]` branches in the two composition messages are kept
+# because a partly-translated locale falls back through them, not because
+# anything here selects them.
+#
+# ## Gender, role and number
+#
+# **Neither `$gender` nor `$role` is selected on.** Tulu marks gender on
+# *verbs and pronouns*, in a three-way system it shares with Kannada and
+# Malayalam, and not on the adjectives in these phrases: an attributive word
+# in front of a noun does not agree with it in anything. So `noun-gender`
+# answers the single token `neuter` and every style word is written once. Nor
+# does a Tulu modifier change shape for the position its phrase is going into:
+# the case a clause position wants is a suffix on the *last word of the noun
+# phrase*, which is a word this catalog writes rather than one it receives, so
+# ದಪ್ಪ ಕೆಂಪು reads the same standing alone as it does before ಒಟ್ಟುಗು. That is
+# `locales/eu`'s reason arriving from Dravidian. Both are claims about the
+# language, not gaps in the seed.
+#
+# **Nothing selects on a count.** A Tulu noun is not marked for number after a
+# numeral — «ರಡ್ಡ್ ಗೆರೆ», not a pluralized noun — and CLDR has no plural data
+# for `tcy` in any case, so a `one` branch here would be text selected by
+# Kannada's rules. There are no plural branches anywhere in this catalog.
+#
+# ## Vocabulary, and what this file does not know
+#
+# **The geometry words are Kannada, declared as such.** There is no
+# Tulu-medium schooling, so ಗೆರೆ, ಬಿಂದು, ವಕ್ರರೇಖೆ, ಬಹುಭುಜ, ಸದಿಶ, ಪರವಲಯ and
+# ಉತ್ಪನ್ನ are the words a Tulu reader has met — in Kannada — and coining Tulu
+# equivalents would put unfamiliar words in front of a reader who already has
+# familiar ones. This file is a **Tulu frame around a declared Kannada
+# technical register**, which is the honest description of it.
+#
+# **The colours are where Tulu shows, and only partly.** ಬೊಲ್ದು (white),
+# ಮಂಜಲ್ (yellow), ಪಚ್ಚೆ (green) and ಕಪ್ಪು (black) are Tulu; ಕೆಂಪು (red) and
+# ನೀಲಿ (blue) are shared with Kannada; the remaining six are Kannada or
+# English loans, and ಸಯಾನ್ is a transliteration. Six of twelve is a fact about
+# the seed's knowledge rather than about the language: Tulu certainly has more
+# of its own colour words than six, and supplying them is a bigger improvement
+# to this file than anything else in it.
+#
+# **The grammar is where the rest of the Tulu is**: ಇಜ್ಜಿ for negation and
+# absence, ಉಂಡು for presence, the negative verb in -ಜಿ, ಬೊಕ್ಕ for *and*,
+# ಅತ್ತ್ಂಡ for *or*, ಒಟ್ಟುಗು for *with*, the locative -ಡ್ and the genitive -ದ.
+# **ಬೊಕ್ಕ does double duty** — it is both *and* and *next/after* — so
+# `slider-next` and `piecewise-condition-or` in the sibling files share a root
+# on purpose rather than by mistake. A message where Kannada's ಮತ್ತು, ಅಥವಾ or
+# ಇಲ್ಲ has crept back in is a defect.
+#
+# **`style-filled-word` and `style-unfilled` are the Tulu participle pair**
+# ತುಂಬಿನ / ತುಂಬಂದಿನ, positive and negative of one verb, which is how Tulu
+# builds an attributive out of a verb and is why they are not two unrelated
+# words as English's *filled* and *unfilled* are.
+#
+# **The chemistry tables are absent.** `element-name` and `element-anion-name`
+# are not translated here, and the reason is the school-system one: chemistry
+# in coastal Karnataka is taught in Kannada and English, the periodic table a
+# Tulu pupil meets is one of those two, and there is no Tulu nomenclature for
+# 118 elements to reproduce. Coining one would invent names no reader has met
+# and would hide the fact that the reader already has a language for them.
+# **The neighbour does not supply them either**, which is worth saying because
+# it would be the obvious place to look: `locales/kn` omits both tables too,
+# and for a different reason — Kannada has *two* nomenclatures, the native
+# coinages that reach a dozen elements and the transliterated international
+# names, and a seed cannot choose between them. So a Tulu reader who wants
+# the periodic table in Kannada does not get it from this roster at all; they
+# get it from a textbook. The three messages that are *frames* rather than names —
+# `ion-name-oxidation-state`, `chemistry-invalid-symbol` and
+# `chemistry-invalid-ionic-compound` — are translated, on the standing ground
+# that a frame is the catalog's business whether or not the names in it are.
+#
+# **Numbers render in Latin digits** under the locale's own grouping, which is
+# the digit policy in the package README (#1615).
+
+
+## Style vocabulary
+
+# Tulu uses the bare colour word attributively — «ಕೆಂಪು ಗೆರೆ» — so these need
+# no adjectival form of their own.
+color =
+    .black = ಕಪ್ಪು
+    .white = ಬೊಲ್ದು
+    .gray = ಬೂದು
+    .red = ಕೆಂಪು
+    .orange = ಕಿತ್ತಳೆ
+    .yellow = ಮಂಜಲ್
+    .green = ಪಚ್ಚೆ
+    .cyan = ಸಯಾನ್
+    .blue = ನೀಲಿ
+    .purple = ನೇರಳೆ
+    .pink = ಗುಲಾಬಿ
+    .brown = ಕಂದು
+line-width =
+    .thick = ದಪ್ಪ
+    .thin = ತೆಳ್ಳ
+line-style =
+    .dashed = ತುಂಡು ತುಂಡುದ
+    .dotted = ಚುಕ್ಕಿದ
+# Noun phrases rather than adjectives: they stand in front of the
+# postposition ಒಟ್ಟುಗು that the composition messages supply, and modify
+# nothing.
+fill-style =
+    .horizontal = ಅಡ್ಡ ಗೆರೆಲು
+    .vertical = ನಿಲುವು ಗೆರೆಲು
+    .diagonal = ಕರ್ಣ ಗೆರೆಲು
+    .backdiagonal = ಎದುರು ಕರ್ಣ ಗೆರೆಲು
+    .dots = ಚುಕ್ಕಿಲು
+    .diamonds = ವಜ್ರಾಕೃತಿಲು
+noun =
+    .line = ಗೆರೆ
+    .line-segment = ಗೆರೆತುಂಡು
+    .ray = ಕಿರಣ
+    .vector = ಸದಿಶ
+    .curve = ವಕ್ರರೇಖೆ
+    .function = ಉತ್ಪನ್ನ
+    .slope-field = ಇಳಿಜಾರು ಕ್ಷೇತ್ರ
+    .vector-field = ಸದಿಶ ಕ್ಷೇತ್ರ
+    .parabola = ಪರವಲಯ
+    .polyline = ಬಹುಗೆರೆ
+    .polygon = ಬಹುಭುಜ
+    .triangle = ಮೂಜಿಬರಿ
+    .rectangle = ಆಯತ
+    .circle = ವೃತ್ತ
+    .region = ಪ್ರದೇಶ
+    .point = ಬಿಂದು
+    .square = ಚೌಕ
+    .diamond = ವಜ್ರಾಕೃತಿ
+    .cross = ಅಡ್ಡಗುರುತು
+    .plus = ಕೂಡ್ಪುನ ಗುರುತು
+# ಬರಿತ ("of sides") attaches the count to the noun that follows it, so the
+# whole phrase is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } ಬರಿತ ಸಮ ಬಹುಭುಜ
+    }
+# Tulu marks gender on verbs and pronouns, not on the adjectives in these
+# phrases, so every noun answers the same and the answer goes unused — as in
+# English.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+style-filled-word = ತುಂಬಿನ
+# ಒಟ್ಟುಗು is a postposition, so the pattern comes to the front of the clause
+# English appends at the end.
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } ಒಟ್ಟುಗು { $filled } { $color }
+       *[plain] { $filled } { $color }
+    }
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } ಒಟ್ಟುಗು { $filled } { $color } { $noun }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } ಒಟ್ಟುಗು { $filled } { $color } { $noun } { $nounTail }
+       *[plain] { $filled } { $color } { $noun }
+    }
+# ಒಟ್ಟುಗು follows ಅಂಚಿ rather than preceding it as English's `with` does, and
+# ಬೊಕ್ಕ opens the further clause. Tulu has no article, which leaves the two
+# `-article` branches reading exactly like the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } ಅಂಚಿದ ಒಟ್ಟುಗು
+        [and] ಬೊಕ್ಕ { $border } ಅಂಚಿದ ಒಟ್ಟುಗು
+        [and-article] ಬೊಕ್ಕ { $border } ಅಂಚಿದ ಒಟ್ಟುಗು
+       *[with] { $border } ಅಂಚಿದ ಒಟ್ಟುಗು
+    }
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+# The negative participle of the same verb `style-filled-word` writes, which
+# is how Tulu forms this pair.
+style-unfilled = ತುಂಬಂದಿನ
+# The locative -ಡ್ marks ಹಿನ್ನೆಲೆ, so the background leads and the text colour
+# follows it.
+style-text =
+    { $parts ->
+        [background] { $background } ಹಿನ್ನೆಲೆಡ್ { $color }
+       *[plain] { $color }
+    }
+style-background-none = ಒವ್ವೂ ಇಜ್ಜಿ
+
+
+## Boolean words
+
+# ಸತ್ಯ and ಸುಳ್ಳು are the Kannada-register pair, declared as a loan: the seed
+# does not know a settled Tulu pair for a displayed boolean. The DoenetML
+# values `true` and `false` an author writes are untouched by this.
+boolean-true = ಸತ್ಯ
+boolean-false = ಸುಳ್ಳು
+
+
+## Answer buttons
+
+answer-submit-label = ಕೆಲಸ ಪರಿಶೀಲನೆ ಮಲ್ಪುಲೆ
+answer-submit-label-no-correctness = ಉತ್ತರ ಕಡಪುಡುಲೆ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ಚಟುವಟಿಕೆ
+    .aside = ಪಕ್ಕದ ಟಿಪ್ಪಣಿ
+    .cascade = ಸರಣಿ
+    .definition = ವ್ಯಾಖ್ಯೆ
+    .example = ಉದಾಹರಣೆ
+    .exercise = ಅಭ್ಯಾಸ
+    .exercises = ಅಭ್ಯಾಸೊಲು
+    .given-answer = ಉತ್ತರ
+    .note = ಟಿಪ್ಪಣಿ
+    .objectives = ಉದ್ದೇಶೊಲು
+    .paragraphs = ಪ್ಯಾರಾಲು
+    .part = ಭಾಗ
+    .problem = ಸಮಸ್ಯೆ
+    .problems = ಸಮಸ್ಯೆಲು
+    .proof = ಸಾಧನೆ
+    .question = ಪ್ರಶ್ನೆ
+    .section = ವಿಭಾಗ
+    .solution = ಪರಿಹಾರ
+    .task = ಕೆಲಸ
+    .theorem = ಪ್ರಮೇಯ
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+hint-title = ಸುಳಿವು
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] ಕೋಷ್ಟಕ { $enumeration }
+        [numbered-title] ಕೋಷ್ಟಕ { $enumeration }{ ": " }
+        [unnumbered-title] ಕೋಷ್ಟಕ{ ": " }
+       *[unnumbered] ಕೋಷ್ಟಕ
+    }
+figure-name =
+    { $parts ->
+        [numbered] ಚಿತ್ರ { $enumeration }
+        [numbered-caption] ಚಿತ್ರ { $enumeration }{ ": " }
+        [unnumbered-caption] ಚಿತ್ರ{ ": " }
+       *[unnumbered] ಚಿತ್ರ
+    }
+
+
+## Paginator controls
+
+paginator-previous = ದುಂಬುದ
+paginator-next = ಬೊಕ್ಕದ
+paginator-page = ಪುಟ
+# «of» is not a word here: the total precedes and the locative -ಡ್ links it,
+# which is how Tulu builds this phrase.
+paginator-page-status = { $numPages }ಡ್ { $pageLabel } { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ಅತ್ತ್ಂಡ
+# Tulu's own conditional is a clause-final suffix -ಂಡ, and the renderer places
+# this word *before* the mathematics it introduces, so the native construction
+# cannot be reached from inside the catalog. ಒಂದುವೇಳೆ is the clause-initial
+# Kannada-register conditional, which is grammatical here and lands correctly;
+# it is a declared loan, and the limit is recorded here rather than hidden.
+piecewise-condition-if = ಒಂದುವೇಳೆ
+piecewise-condition-otherwise = ಇಜ್ಜಾಂಡ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent; the header
+## says why. Only the frames are here.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+chemistry-invalid-symbol = ತಪ್ಪು ರಾಸಾಯನಿಕ ಚಿಹ್ನೆ
+chemistry-invalid-ionic-compound = ತಪ್ಪು ಅಯಾನಿಕ ಸಂಯುಕ್ತ
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = ಖಾಲಿ
+math-embedded-input-blank-ordinal = { $total }ಡ್ { $ordinal }ನೇ ಖಾಲಿ

--- a/packages/i18n/locales/tcy/diagnostics.ftl
+++ b/packages/i18n/locales/tcy/diagnostics.ftl
@@ -29,11 +29,12 @@
 # **One paraphrase is declared and used everywhere so that one search replaces
 # it.** English's *is ignored* is written «ಪರಿಗಣನೆ ಆಪುಜಿ» throughout —
 # literally *is not considered*. It is Kannada-register rather than Tulu, and
-# it appears in something like thirty messages, so it is the first thing a
+# it appears in thirty-seven messages, so it is the first thing a
 # speaker should replace, and replacing it is a single search. **ತಪ್ಪು** for
 # English's *invalid* is the second such choice: it means *wrong* rather than
 # *not permitted*, which is slightly weaker than the English, and it is used
-# in every one of the `parse-` and `schema-` messages a beginner meets first.
+# in most of the `parse-` and `schema-` messages a beginner meets first —
+# the handful that name a construct rather than judge one do without it.
 #
 # **No plural branches anywhere.** CLDR has no plural data for `tcy`, so
 # `line-segment-attributes-ignored-with-endpoints` and its relatives write a

--- a/packages/i18n/locales/tcy/diagnostics.ftl
+++ b/packages/i18n/locales/tcy/diagnostics.ftl
@@ -1,0 +1,700 @@
+# Tulu (ತುಳು) diagnostics: the warnings and errors the worker raises and the
+# reader is shown. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth. Selected by `uiLocale`, not by the language the document
+# was written in.
+#
+# Message ids are never translated — only the text to the right of `=`.
+# Neither are the DoenetML identifiers quoted inside these sentences:
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `maxNumAttempts`,
+# `selectFromSequence`, `styleNumber` and every tag and attribute name like
+# them are part of the language an author writes, not prose, and stay in
+# English exactly as written. So does the `[deprecation]` marker, which is a
+# label rather than a word, and so do `WCAG AA` and `PreFigure`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script** is `chrome.ftl`'s: Kannada rather than Tigalari, for the three
+# reasons that file's header gives in full.
+#
+# **The technical vocabulary is Kannada, declared as such** — ದೋಷ, ಎಚ್ಚರಿಕೆ,
+# ಘಟಕ, ಗುಣ, ಚರ, ಆಯಾಮ, ಉಲ್ಲೇಖ, ಅನುಕ್ರಮ, ಸಂಯೋಜನೆ. Tulu readers meet these
+# words in Kannada schooling; coining Tulu equivalents would put unfamiliar
+# words in front of a reader who already has familiar ones. What is Tulu is
+# the frame around them: ಇಜ್ಜಿ for negation and absence, ಉಂಡು for presence,
+# the negative verb in -ಜಿ (ಆಪುಜಿ, ತಿಕ್ಕುಜಿ), ಆವೊಡು for *must*, ಬೊಕ್ಕ for
+# *and*, ಅತ್ತ್ಂಡ for *or*, ಒಟ್ಟುಗು for *with*, ದಾಯೆಗ್ಂಡ for *because*, and
+# the honorific imperative in -ಲೆ.
+#
+# **One paraphrase is declared and used everywhere so that one search replaces
+# it.** English's *is ignored* is written «ಪರಿಗಣನೆ ಆಪುಜಿ» throughout —
+# literally *is not considered*. It is Kannada-register rather than Tulu, and
+# it appears in something like thirty messages, so it is the first thing a
+# speaker should replace, and replacing it is a single search. **ತಪ್ಪು** for
+# English's *invalid* is the second such choice: it means *wrong* rather than
+# *not permitted*, which is slightly weaker than the English, and it is used
+# in every one of the `parse-` and `schema-` messages a beginner meets first.
+#
+# **No plural branches anywhere.** CLDR has no plural data for `tcy`, so
+# `line-segment-attributes-ignored-with-endpoints` and its relatives write a
+# single `*[other]` where English writes `[one]` and `[other]`. The one
+# numeric literal that survives is `[1]` in
+# `field-function-wrong-num-outputs`, which forks on how many outputs a
+# component *needs* rather than on a count the reader is looking at; Fluent
+# matches it against the number itself before any plural rule is consulted.
+#
+# **Numbers render in Latin digits** rather than in Kannada numerals (#1615).
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+       *[other] ರಡ್ಡ್ endpoint ಕೊರ್ತ್ಂಡ { $attributes } ಪರಿಗಣನೆ ಆಪುಜಿ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+       *[other] endpoint ಬೊಕ್ಕ midpoint ರಡ್ಡ್‌ಲಾ ಕೊರ್ತ್ಂಡ { $attributes } ಪರಿಗಣನೆ ಆಪುಜಿ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpoint ಇಜ್ಜಂದೆ midpointOffset‌ದ ಒವ್ವೇ ಪರಿಣಾಮ ಇಜ್ಜಿ
+
+## `<line>`
+
+line-points-undetermined-dimensions = ಆಯಾಮ ಗೊತ್ತಾವಂದಿನ ಬಿಂದುಲೆ ಮುಖಾಂತರ ಗೆರೆ.
+
+line-points-too-few-dimensions = ಗೆರೆ ಪೋಪುನ ಬಿಂದುಲೆಗ್ ಕಡಿಮೆ ಪಂಡ ರಡ್ಡ್ ಆಯಾಮ ಆವೊಡು.
+
+line-points-depend-on-variables = ಗೆರೆ ಪೋಪುನ ಬಿಂದುಲು ಚರೊಲೆ ಮಿತ್ತ್ ನಿಂದ್‌ದ: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ಬೊಕ್ಕ { $variable2 } ಚರೊಲೆಡ್ ಗೆರೆದ ಸಮೀಕರಣೊದ ತಪ್ಪು ರೂಪ.
+
+## `<ray>`
+
+ray-overprescribed-through = ಕಿರಣ through, endpoint ಬೊಕ್ಕ direction ಮೂಜಿಲಾ ಮುಖಾಂತರ ಗೊತ್ತು ಮಲ್ತ್‌ದ್ಂಡ್.  ಕೊರ್ತಿನ through ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+ray-dimension-mismatch = ಕಿರಣೊಡು numDimensions ಸರಿ ಬರ್ಪುಜಿ.
+
+## `<vector>`
+
+vector-overprescribed-head = ಸದಿಶ head, tail ಬೊಕ್ಕ displacement ಮೂಜಿಲಾ ಮುಖಾಂತರ ಗೊತ್ತು ಮಲ್ತ್‌ದ್ಂಡ್.  ಕೊರ್ತಿನ head ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+vector-dimension-mismatch = ಸದಿಶೊಡು numDimensions ಸರಿ ಬರ್ಪುಜಿ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>`ಗ್ nearestPoint ಸ್ಥಿತಿ ಚರ ಇಜ್ಜಿ, ಅಂಚಾದ್ ಅವೆಟ್ಟ್ ಸೆಳೆಯೆರೆ ಆಪುಜಿ.
+
+constrain-to-without-nearest-point = `<{ $component }>`ಗ್ nearestPoint ಸ್ಥಿತಿ ಚರ ಇಜ್ಜಿ, ಅಂಚಾದ್ ಅವೆಗ್ ಕಟ್ಟ್ ಪಾಡೆರೆ ಆಪುಜಿ.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>`ಗ್ nearestPoint ಸ್ಥಿತಿ ಚರ ಇಜ್ಜಿ, ಅಂಚಾದ್ ಅವೆತ ಒಳಯಿಗ್ ಕಟ್ಟ್ ಪಾಡೆರೆ ಆಪುಜಿ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = inline ಅತ್ತಿನ choiceInput‌ಗ್ labelPosition ಪರಿಗಣನೆ ಆಪುಜಿ
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput‌ಗ್ ಕೊರ್ತಿನ indices‌ದ ಸಂಖ್ಯೆ choice ಮಗೆಲೆ ಸಂಖ್ಯೆಗ್ ಸರಿ ಬರ್ಪುಜಿ, ಅಂಚಾದ್ ಅವು ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+pretzel-indices-count-mismatch = problem‌ಗ್ ಕೊರ್ತಿನ indices‌ದ ಸಂಖ್ಯೆ problem ಮಗೆಲೆ ಸಂಖ್ಯೆಗ್ ಸರಿ ಬರ್ಪುಜಿ, ಅಂಚಾದ್ ಅವು ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+shuffle-indices-count-mismatch = shuffle‌ಗ್ ಕೊರ್ತಿನ indices‌ದ ಸಂಖ್ಯೆ ಘಟಕೊಲೆ ಸಂಖ್ಯೆಗ್ ಸರಿ ಬರ್ಪುಜಿ, ಅಂಚಾದ್ ಅವು ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+indices-ignored-out-of-range = { $component }ಗ್ ಕೊರ್ತಿನ ಕೆಲವು indices ಮಿತಿದ ಪಿದಯಿ ಉಂಡು, ಅಂಚಾದ್ ಅವು ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+pretzel-indices-repeated = pretzel‌ಗ್ ಕೊರ್ತಿನ ಕೆಲವು indices ರಡ್ಡ್ ಸರ್ತಿ ಬತ್ತ್‌ದ್ಂಡ್, ಅಂಚಾದ್ ಅವು ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+pretzel-circuit-first-index = circuit ಮೋಡ್‌ಡ್ pretzel‌ದ ಸುರುತ index 1 ಆವೊಡು, ಅಂಚಾದ್ ಕೊರ್ತಿನ indices ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ಸ್ಟ್ರಿಂಗ್ ಮಗೆಲೆ ಒಟ್ಟುಗು ಕೆಲಸ ಮಲ್ಪೆರೆ ಒಂಜಿ `type` ಗುಣ ಕೊರೊಡು.
+
+invalid-type-defaulting-to-math = { $component } ಘಟಕೊಗು ತಪ್ಪು type { $type }. math, text, number ಅತ್ತ್ಂಡ boolean‌ಡ್ ಒಂಜಿ ಆವೊಡು. math ಪಂಡ್‌ದ್ ದೀತ್‌ದ್ಂಡ್.
+
+string-not-valid-component-to-arrange = ಸ್ಟ್ರಿಂಗ್ "{ $value }" { $component } ಮಲ್ಪೆರೆ ಸರಿಯಾಯಿನ ಘಟಕ ಅತ್ತ್. ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = ತಪ್ಪು type { $type }, type number ಪಂಡ್‌ದ್ ದೀತ್‌ದ್ಂಡ್.
+
+invalid-variable-value = ಚರೊದ ತಪ್ಪು ಮೌಲ್ಯ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Variant index { $index } ಸಂಖ್ಯೆ ಆವೊಡು
+
+variant-index-must-be-integer = Variant index { $index } ಪೂರ್ಣಾಂಕ ಆವೊಡು
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ನಿರಪೇಕ್ಷ ಅಳತೆಗ್ ಮಲ್ತಿಜ್ಜಿ. ಅಗಲೊಲು ಸಾಪೇಕ್ಷ ಪಂಡ್‌ದ್ ದೀತ್‌ದ್ಂಡ್.
+
+side-by-side-absolute-margins = `<{ $component }>` ನಿರಪೇಕ್ಷ ಅಳತೆಗ್ ಮಲ್ತಿಜ್ಜಿ. ಅಂಚಿಲು ಸಾಪೇಕ್ಷ ಪಂಡ್‌ದ್ ದೀತ್‌ದ್ಂಡ್.
+
+side-by-side-no-block-child = ತಪ್ಪು `<{ $component }>`: ಅವೆಟ್ ಕಡಿಮೆ ಪಂಡ ಒಂಜಿ ಬ್ಲಾಕ್ ಮಗೆ ಇಪ್ಪೊಡು.
+
+## `<label>`
+
+label-for-ignored-on-graphical = ಚಿತ್ರೊದ `<label>`ದ ಮಿತ್ತ್‌ದ `for` ಗುಣ ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+label-for-must-resolve-to-one = `<label>`ದ `for` ಗುಣ ಸರಿಯಾದ್ ಒಂಜೇ ಘಟಕೊಗು ಸೇರೊಡು.
+
+label-for-unresolved = `<label>`ದ `for` ಗುಣೊನು ಒವ್ವೇ ಘಟಕೊಗು ಸೇರಾಯೆರೆ ಆತಿಜ್ಜಿ.
+
+label-for-answer-with-authored-inputs = `<label>`ದ `for` ಗುಣ, ಬರೆಪುನಾಯೆ ತಾನೇ ಕೊರ್ತಿನ input ಇತ್ತಿನ `<answer>`ನ್ ತೋಜಾವೊಂದುಂಡು; input‌ನೇ ನೇರವಾದ್ ತೋಜಾಲೆ.
+
+label-for-answer-without-input = `<label>`ದ `for` ಗುಣ, label ಕೊರೆರೆ ಒವ್ವೇ input ಇಜ್ಜಂದಿನ `<answer>`ನ್ ತೋಜಾವೊಂದುಂಡು.
+
+label-for-must-reference-input-or-answer = `<label>`ದ `for` ಗುಣ ಒಂಜಿ input ಅತ್ತ್ಂಡ ಒಂಜಿ answer‌ನ್ ತೋಜಾವೊಡು.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = ಸೌಲಭ್ಯೊಗಾದ್ `<{ $component }>`ಗ್ ಒಂಜಿ ಎಲ್ಯ ವಿವರ ಇಪ್ಪೊಡು, ಅತ್ತ್ಂಡ ಅವೆನ್ decorative ಪಂಡ್‌ದ್ ಗೊತ್ತು ಮಲ್ಪೊಡು.
+
+accessibility-video-short-description = ಸೌಲಭ್ಯೊಗಾದ್ `<video>`ಗ್ ಒಂಜಿ ಎಲ್ಯ ವಿವರ ಇಪ್ಪೊಡು.
+
+accessibility-input-short-description-or-label = ಸೌಲಭ್ಯೊಗಾದ್ `<{ $component }>`ಗ್ ಒಂಜಿ ಎಲ್ಯ ವಿವರ ಅತ್ತ್ಂಡ ಒಂಜಿ label ಇಪ್ಪೊಡು.
+
+accessibility-answer-input-short-description-or-label = ಸೌಲಭ್ಯೊಗಾದ್, input ಮಲ್ಪುನ `<answer>`ಗ್ ಒಂಜಿ ಎಲ್ಯ ವಿವರ ಅತ್ತ್ಂಡ ಒಂಜಿ label ಇಪ್ಪೊಡು.
+
+accessibility-short-description-contains-math = ಎಲ್ಯ ವಿವರೊಡು `<{ $component }>`ದ ಲೆಕ್ಕದ ಗಣಿತ ಘಟಕೊಲು ಇಪ್ಪೆರೆ ಬಲ್ಲಿ. ಗಣಿತೊನು ಪದೊಕುಲೆಡೇ ಬರೆಪುಲೆ.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] ವಿಭಾಗದ ಶೀರ್ಷಿಕೆದ ಬರವುಗು { $colorName }ದ ವ್ಯತ್ಯಾಸ ಸಾಲುಜಿ (ಕಪ್ಪು ಮೋಡ್) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ಕಡಿಮೆ ಪಂಡ { $threshold }:1 ಬೋಡು).
+       *[other] ವಿಭಾಗದ ಶೀರ್ಷಿಕೆದ ಬರವುಗು { $colorName }ದ ವ್ಯತ್ಯಾಸ ಸಾಲುಜಿ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ಕಡಿಮೆ ಪಂಡ { $threshold }:1 ಬೋಡು).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ಬಿಂದುಲೆಗ್ ಸಂಖ್ಯೆದ ಮೌಲ್ಯ ಇಜ್ಜಂದಿನ ಸಂದರ್ಭೊಡು { $count } ಬಿಂದುಲೆ ಮುಖಾಂತರ `<circle>` ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ.
+
+circle-too-many-through-points = ಮೂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದುಲೆ ಮುಖಾಂತರ ವೃತ್ತ ಲೆಕ್ಕ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+circle-overprescribed-radius-center-points = ಕೊರ್ತಿನ radius, center ಬೊಕ್ಕ through ಬಿಂದುಲು ಮೂಜಿಲಾ ಇತ್ತ್ಂಡ ವೃತ್ತ ಲೆಕ್ಕ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+circle-center-with-multiple-points = ಕೊರ್ತಿನ center‌ದ ಒಟ್ಟುಗು ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದು ಮುಖಾಂತರ ವೃತ್ತ ಲೆಕ್ಕ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+circle-radius-too-small = ವೃತ್ತ ಲೆಕ್ಕ ಮಲ್ಪೆರೆ ಆಪುಜಿ: ರಡ್ಡ್ ಬಿಂದುಲೆ ನಡುತ ದೂರ { $distance }, ಅಂಚಾದ್ ಕೊರ್ತಿನ radius { $radius } ಮಸ್ತ್ ಎಲ್ಯ.
+
+circle-radius-with-many-points = ಕೊರ್ತಿನ radius‌ದ ಒಟ್ಟುಗು ರಡ್ಡ್‌ಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದುಲೆ ಮುಖಾಂತರ ವೃತ್ತ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+circle-invalid-center-or-through-points = ವೃತ್ತೊದ ತಪ್ಪು center ಅತ್ತ್ಂಡ through ಬಿಂದುಲು.
+
+circle-radius-center-with-multiple-points = ಕೊರ್ತಿನ center‌ದ ಒಟ್ಟುಗು ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದು ಮುಖಾಂತರ ವೃತ್ತೊದ radius ಲೆಕ್ಕ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+circle-change-radius-non-numerical = ಸಂಖ್ಯೆದ ಮೌಲ್ಯ ಇಜ್ಜಂದಿನ through ಬಿಂದುಲು ಇತ್ತಿನ ವೃತ್ತೊದ radius ಬದಲ್ ಮಲ್ಪೆರೆ ಆಪುಜಿ
+
+circle-radius-with-points-non-numerical = ಸಂಖ್ಯೆದ ಮೌಲ್ಯ ಇಜ್ಜಂದಿನ ಸಂದರ್ಭೊಡು ಕೊರ್ತಿನ radius‌ದ ಒಟ್ಟುಗು ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದು ಮುಖಾಂತರ ವೃತ್ತ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+circle-change-center-non-numerical = ಸಂಖ್ಯೆದ ಮೌಲ್ಯ ಇಜ್ಜಂದಿನ ಬಿಂದುಲೆ ಮುಖಾಂತರ ಮಲ್ತಿನ ವೃತ್ತೊದ center ಬದಲ್ ಮಲ್ಪುನೆನ್ ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+       *[other] ಉತ್ಪನ್ನೊದ domain‌ಗ್ ಆಯಾಮ ಸಾಲುಜಿ. domain‌ಡ್ { $intervals } ಅಂತರ ಉಂಡು ಆಂಡ ಉತ್ಪನ್ನೊಡು { $inputs ->
+           *[other] { $inputs } input
+        } ಉಂಡು.
+    }
+
+function-domain-invalid-format = ಉತ್ಪನ್ನೊದ domain‌ದ ತಪ್ಪು ರೂಪ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] ಉತ್ಪನ್ನೊದ ಸಂಖ್ಯೆ ಅತ್ತಿನ ಗರಿಷ್ಠ ಮೌಲ್ಯ ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [minimum] ಉತ್ಪನ್ನೊದ ಸಂಖ್ಯೆ ಅತ್ತಿನ ಕನಿಷ್ಠ ಮೌಲ್ಯ ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [extremum] ಉತ್ಪನ್ನೊದ ಸಂಖ್ಯೆ ಅತ್ತಿನ ಚರಮ ಮೌಲ್ಯ ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [point] ಉತ್ಪನ್ನೊದ ಸಂಖ್ಯೆ ಅತ್ತಿನ ಬಿಂದು ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [slope] ಉತ್ಪನ್ನೊದ ಸಂಖ್ಯೆ ಅತ್ತಿನ ಇಳಿಜಾರು ಪರಿಗಣನೆ ಆಪುಜಿ.
+       *[other] ಉತ್ಪನ್ನೊದ ಸಂಖ್ಯೆ ಅತ್ತಿನ { $type } ಪರಿಗಣನೆ ಆಪುಜಿ.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] ಉತ್ಪನ್ನೊದ ಖಾಲಿ ಗರಿಷ್ಠ ಮೌಲ್ಯ ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [minimum] ಉತ್ಪನ್ನೊದ ಖಾಲಿ ಕನಿಷ್ಠ ಮೌಲ್ಯ ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [extremum] ಉತ್ಪನ್ನೊದ ಖಾಲಿ ಚರಮ ಮೌಲ್ಯ ಪರಿಗಣನೆ ಆಪುಜಿ.
+        [point] ಉತ್ಪನ್ನೊದ ಖಾಲಿ ಬಿಂದು ಪರಿಗಣನೆ ಆಪುಜಿ.
+       *[other] ಉತ್ಪನ್ನೊದ ಖಾಲಿ { $type } ಪರಿಗಣನೆ ಆಪುಜಿ.
+    }
+
+function-points-too-close = ಉತ್ಪನ್ನೊಡು ಮಸ್ತ್ ಕೈತಲ್ ಇತ್ತಿನ ರಡ್ಡ್ ಬಿಂದುಲು ಉಂಡು. ಉತ್ಪನ್ನ ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+       *[other] ಉತ್ಪನ್ನೊದ input‌ದ ಸಂಖ್ಯೆ ಬೊಕ್ಕ output‌ದ ಸಂಖ್ಯೆ ಸಮ ಆಂಡ ಮಾತ್ರ ಉತ್ಪನ್ನೊದ ಪುನರಾವರ್ತನೆ ಸಾಧ್ಯ. ಈ ಉತ್ಪನ್ನೊಡು { $inputs } input ಬೊಕ್ಕ { $outputs ->
+           *[other] { $outputs } output
+        } ಉಂಡು.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = ಅನುಕ್ರಮೊದ ತಪ್ಪು ಉದ್ದ.  ಋಣಾತ್ಮಕ ಅತ್ತಿನ ಪೂರ್ಣಾಂಕ ಆವೊಡು.
+
+sequence-invalid-step = ಅನುಕ್ರಮೊದ ತಪ್ಪು step.  { $type } ತರೊತ ಅನುಕ್ರಮೊಗು ಒಂಜಿ ಸಂಖ್ಯೆ ಆವೊಡು.
+
+sequence-invalid-endpoint-number = number ಅನುಕ್ರಮೊದ ತಪ್ಪು "{ $attribute }".  ಒಂಜಿ ಸಂಖ್ಯೆ ಆವೊಡು.
+
+sequence-invalid-endpoint-letters = letters ಅನುಕ್ರಮೊದ ತಪ್ಪು "{ $attribute }".  ಅಕ್ಷರೊಲೆ ಸಂಯೋಜನೆ ಆವೊಡು.
+
+sequence-invalid-endpoint = ಅನುಕ್ರಮೊದ ತಪ್ಪು "{ $attribute }".
+
+select-from-sequence-coprime-not-numbers = ಸಂಖ್ಯೆಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪುಜಿ, ಅಂಚಾದ್ coprime ಪರಿಗಣನೆ ಆಪುಜಿ
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations ಕೊರ್ತ್‌ದ್ಂಡ್, ಅಂಚಾದ್ coprime ಪರಿಗಣನೆ ಆಪುಜಿ
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>`ಗ್ ತಪ್ಪು target: target ತಿಕ್ಕುಜಿ.
+
+target-state-variable-not-found = `<{ $source }>`ಗ್ ತಪ್ಪು target: `<{ $component }>`ಡ್ "{ $property }" ಪುದರ್‌ದ ಸ್ಥಿತಿ ಚರ ತಿಕ್ಕುಜಿ.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`ದ ಚರೊಲು ಸ್ವತಂತ್ರ ಚರೊಡ್ದ್ ಬೇತೆ ಆವೊಡು.
+
+ode-system-duplicate-variable-names = ಒಂಜೇ ಪುದರ್‌ದ ಅವಲಂಬಿತ ಚರೊಲೆ ಒಟ್ಟುಗು ODE RHS ಉತ್ಪನ್ನ ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+ode-system-rhs-function-error = ODE RHS ಉತ್ಪನ್ನ ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.  mathjs ಉತ್ಪನ್ನ ಮಲ್ಪುನೆಡ್ ದೋಷ.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } ಗೆರೆಲೆ ನಡುತ ಕೋನ ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ
+
+angle-invalid-through-point = `<angle>`ದ through‌ಡ್ ತಪ್ಪು ಬಿಂದು
+
+parabola-vertex-too-many-points = vertex‌ದ ಒಟ್ಟುಗು ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದು ಮುಖಾಂತರ ಪರವಲಯ ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ.
+
+parabola-too-many-points = ಮೂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಬಿಂದುಲೆ ಮುಖಾಂತರ ಪರವಲಯ ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ.
+
+intersection-too-many-items = ರಡ್ಡ್‌ಡ್ದ್ ಜಾಸ್ತಿ ವಸ್ತುಲೆ ಛೇದನ ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ
+
+## Other math components
+
+ionic-compound-not-two-ions = ರಡ್ಡ್ ಅಯಾನ್ ಬುಡ್‌ದ್ ಬೇತೆ ಒವ್ವೆಗ್ಲಾ ಅಯಾನಿಕ ಸಂಯುಕ್ತ ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ.
+
+ionic-compound-needs-cation-and-anion = ಅಯಾನಿಕ ಸಂಯುಕ್ತ ಒಂಜಿ ಕ್ಯಾಟಯಾನ್ ಬೊಕ್ಕ ಒಂಜಿ ಅಯಾನ್‌ಗ್ ಮಾತ್ರ ಮಲ್ತ್‌ದ್ಂಡ್.
+
+solve-equations-cannot-evaluate = ಸಮೀಕರಣೊದ ಮೌಲ್ಯ ಕಂಡುಪತ್ತೆರೆ ಆತಿಜ್ಜಿ, ಅಂಚಾದ್ ಅವೆನ್ ಬಗೆಹರಿಪೆರೆ ಆಪುಜಿ: { $equation }
+
+math-operators-operand-number-required = ಗಣಿತೊದ operand ದೆಪ್ಪುನಗ ಒಂಜಿ operandNumber ಕೊರೊಡು.
+
+eigen-decomposition-failed = ಮ್ಯಾಟ್ರಿಕ್ಸ್‌ದ eigenvalue ಲೆಕ್ಕ ಮಲ್ಪೆರೆ ಆತಿಜ್ಜಿ
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+       *[other] `<matchesPattern>`: { $parameters } parameter pattern‌ಡ್ ಇಜ್ಜಿ, ಅಂಚಾದ್ ಅವು ಪೂರ ಸರ್ತಿಲಾ ಖಾಲಿನೇ ಸರಿ ಬರ್ಪುಂಡು.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ಅರ್ಥ ಆಪುಜಿ. ಅವು none, medium, dense, ಅತ್ತ್ಂಡ ಖಾಲಿ ಜಾಗೆಡ್ ಬೇತೆ ಮಲ್ತಿನ ರಡ್ಡ್ ಧನಾತ್ಮಕ ಸಂಖ್ಯೆ ಆವೊಡು, ಉದಾ. grid="1 0.5". ಒವ್ವೇ grid ಬರೆತಿಜ್ಜಿ.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>`ಗ್ { $expected ->
+        [1] ಒಂಜಿ output ಇತ್ತಿನ ಉತ್ಪನ್ನ ಬೋಡು, ಪಂಡ ಪ್ರತಿ ಬಿಂದುಡ್ದ ಇಳಿಜಾರು y', ಉದಾ. `y - x`
+       *[other] ರಡ್ಡ್ output ಇತ್ತಿನ ಉತ್ಪನ್ನ ಬೋಡು, ಪಂಡ ಪ್ರತಿ ಬಿಂದುಡ್ದ ಸದಿಶ, ಉದಾ. `(y, -x)`
+    }, ಆಂಡ ಕೊರ್ತಿನ ಉತ್ಪನ್ನೊಡು { $found ->
+       *[other] { $found } output
+    } ಉಂಡು. { $alternative ->
+        [none] ಒವ್ವೂ ಬರೆತಿಜ್ಜಿ.
+       *[other] ಆ ಉತ್ಪನ್ನೊಗು `<{ $alternative }>` ಘಟಕನೇ ಸರಿ. ಒವ್ವೂ ಬರೆತಿಜ್ಜಿ.
+    }
+
+field-function-attribute-ignored-with-child = ಉತ್ಪನ್ನೊನು ಘಟಕೊದ ಒಳಯಿಲಾ ಕೊರ್ತ್‌ದ್ಂಡ್, ಅಂಚಾದ್ `function` ಗುಣ ಪರಿಗಣನೆ ಆಪುಜಿ; ಒಳಯಿದನೇ ಬಳಕೆ ಆಪುಂಡು. ಉತ್ಪನ್ನೊನು ರಡ್ಡ್ ದಾರಿಡ್ ಒಂಜಿಡ್ ಮಾತ್ರ ಕೊರ್ಲೆ.
+
+field-variables-ignored =
+    `<{ $component }>`: `variables` ಗುಣ ಘಟಕೊದ ಒಳಯಿ ನೇರವಾದ್ ಬರೆತಿನ ಸೂತ್ರೊದ ಚರೊಲೆ ಪುದರ್ ಪಂಡುಂಡು. { $reason ->
+        [function-child] ಇಂಚಿ ಉತ್ಪನ್ನ ಒಂಜಿ `<function>` ಮಗೆ ಆದ್ ಕೊರ್ತ್‌ದ್ಂಡ್, ಅವು ತನ್ನ ಚರೊಲೆನ್ ತಾನೇ ಪಂಡುಂಡು, ಅಂಚಾದ್ `variables` ಪರಿಗಣನೆ ಆಪುಜಿ.
+       *[no-expression] ಇಂಚಿ ಅಂಚಿನ ಒವ್ವೇ ಸೂತ್ರ ಕೊರ್ತಿಜ್ಜಿ, ಅಂಚಾದ್ `variables` ಪರಿಗಣನೆ ಆಪುಜಿ.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure ರೆಂಡರರ್‌ಡ್ xLabelPosition="left" ನಡೆಪುಜಿ; right-position‌ದ ವರ್ತನೆ ಬಳಕೆ ಆಂಡ್.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure ರೆಂಡರರ್‌ಡ್ yLabelPosition="bottom" ನಡೆಪುಜಿ; top-position‌ದ ವರ್ತನೆ ಬಳಕೆ ಆಂಡ್.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure ಪರಿವರ್ತನೆಗ್ ತಪ್ಪು ಅಕ್ಷದ ಮಿತಿ; ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನ bbox (-10,-10,10,10) ಬಳಕೆ ಆಂಡ್.
+
+prefigure-invalid-width = `<graph>`: prefigure ಪರಿವರ್ತನೆಗ್ ತಪ್ಪು ಅಗಲ; ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನ ಚಿತ್ರೊದ ಅಗಲ 425 ಬಳಕೆ ಆಂಡ್.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure ಪರಿವರ್ತನೆಗ್ ತಪ್ಪು aspectRatio; ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನ ಅನುಪಾತ 1 ಬಳಕೆ ಆಂಡ್.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ಅಕ್ಷದ ಮಿತಿಗ್ ಹೋಲಿಸ್‌ದ್ grid‌ದ ಅಂತರ ಮಸ್ತ್ ಎಲ್ಯ; prefigure ರೆಂಡರರ್‌ಡ್ grid ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure ರೆಂಡರರ್ ಬಳಕೆ ಮಲ್ತಿಜ್ಜಂಡ ಟಿಪ್ಪಣಿಲು ಬರೆಪುಜಿ.
+
+multiple-annotations-children = `<graph>`ಡ್ ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ `<annotations>` ಮಗೆಲು ತಿಕ್ಕ್‌ಂಡ್; ಕಡೆತ ಒಂಜಿ ಬುಡ್‌ದ್ ಬಾಕಿ ಮಾತ ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+## Referring to other components
+
+copy-unrecognized-component-type = ಗೊತ್ತಾವಂದಿನ ಘಟಕೊದ ತರೊನು ವಿಸ್ತರಿಸೆರೆ ಅತ್ತ್ಂಡ ನಕಲ್ ಮಲ್ಪೆರೆ ಆಪುಜಿ: { $type }.
+
+copy-prop-not-found = { $component } ತರೊತ ಘಟಕೊಡು { $property } prop ತಿಕ್ಕುಜಿ
+
+collect-no-source = collect‌ಗ್ ಒವ್ವೇ ಮೂಲ ತಿಕ್ಕುಜಿ.
+
+collect-invalid-component-type = `<{ $component }>` ಸರಿಯಾಯಿನ ಘಟಕೊದ ತರ ಅತ್ತ್, ಅಂಚಾದ್ ಆ ತರೊತ ಘಟಕೊಲೆನ್ collect ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+reference-index-unavailable = index `{ $reference }`ನ್ ತೋಜಾಯೆರೆ ಆಪುಜಿ
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` ಘಟಕೊಡು { $action } ಲೆಪ್ಪೆರೆ ಆಪುಜಿ
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ದತ್ತಾಂಶೊದ ಆಕಾರ ತಪ್ಪು.  ಸಾಲುಲೆ ಉದ್ದ ಒಂಜೇ ಲೆಕ್ಕ ಇಜ್ಜಿ. componentIdx :{ $componentIdx }ಡ್ ತಿಕ್ಕ್‌ಂಡ್
+
+data-frame-duplicate-column-names = ದತ್ತಾಂಶೊಡು ಒಂಜೇ ಕಂಬೊದ ಪುದರ್ ರಡ್ಡ್ ಸರ್ತಿ ಉಂಡು.  componentIdx :{ $componentIdx }ಡ್ ತಿಕ್ಕ್‌ಂಡ್
+
+data-frame-missing-column-name = ದತ್ತಾಂಶೊಡು ಒಂಜಿ ಕಂಬೊದ ಪುದರ್ ಇಜ್ಜಿ.  componentIdx :{ $componentIdx }ಡ್ ತಿಕ್ಕ್‌ಂಡ್
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ಈ ಉತ್ತರೊದ ಒಂಜಿ award ಈ answer ಟ್ಯಾಗ್ ತಾನೇ ಕಡಪುಡಿನ ಉತ್ತರೊದ ಮಿತ್ತ್ ನಿಂದ್‌ದ, ಅವೆಟ್ಟ್ ನಿರೀಕ್ಷೆ ಮಲ್ತಿಜ್ಜಂದಿನ ವರ್ತನೆ ಬರ್ಪುಂಡು.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` ಇತ್ತಿನ ಪಾತ್ರೆದ ಒಳಯಿದ `<answer>`ಡ್ `maxNumAttempts` ದೀತ್ಂಡ ಒವ್ವೇ ಪ್ರಯೋಜನ ಇಜ್ಜಿ, ದಾಯೆಗ್ಂಡ ಪ್ರಯತ್ನೊದ ಸಂಖ್ಯೆನ್ ಪಾತ್ರೆನೇ ನಿಯಂತ್ರಣ ಮಲ್ಪುಂಡು. `maxNumAttempts`ನ್ ಪಾತ್ರೆದ ಮಿತ್ತೇ ದೀಲೆ.
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` ಇತ್ತಿನ ಬೇತೆ ಒಂಜಿ ಪಾತ್ರೆದ ಒಳಯಿದ `sectionWideCheckWork` ಪಾತ್ರೆಡ್ `maxNumAttempts` ದೀತ್ಂಡ ಒವ್ವೇ ಪ್ರಯೋಜನ ಇಜ್ಜಿ, ದಾಯೆಗ್ಂಡ ಪ್ರಯತ್ನೊದ ಸಂಖ್ಯೆನ್ ಪಿದಯಿದ ಪಾತ್ರೆನೇ ನಿಯಂತ್ರಣ ಮಲ್ಪುಂಡು. `maxNumAttempts`ನ್ ಪಿದಯಿದ ಪಾತ್ರೆದ ಮಿತ್ತೇ ದೀಲೆ.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+       *[other] symbolicEquality ದೀತಿಜ್ಜಂಡ { $attributes } ಗುಣೊಗು ಒವ್ವೇ ಪ್ರಯೋಜನ ಇಜ್ಜಿ.
+    }
+
+answer-invalid-type = ಉತ್ತರೊಗು ತಪ್ಪು type: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` ಘಟಕೊಗು ಪುದರ್ ಇಜ್ಜಿ, ಅಂಚಾದ್ ಅವೆನ್ module‌ದ ಗುಣ ಆದ್ ಬಳಸೆರೆ ಆಪುಜಿ
+
+module-attribute-name-already-defined = `<module>` ಘಟಕೊದ ತರೊಡು "{ $name }" ಪುದರ್‌ದ ಗುಣ ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತ್‌ದ್ಂಡ್, ಅಂಚಾದ್ `<{ $component } name="{ $name }">` ಘಟಕೊನು module‌ದ ಗುಣ ಆದ್ ಬಳಸೆರೆ ಆಪುಜಿ.
+
+conditional-content-condition-ignored = case ಅತ್ತ್ಂಡ else ಮಗೆಲು ಇತ್ತಿನ `<conditionalContent>` ಘಟಕೊಡು `condition` ಗುಣ ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+slider-markers-type-mismatch = Marker‌ದ ತರ slider‌ದ ತರೊಗು ಸರಿ ಬರ್ಪುಜಿ.
+
+pretzel-problem-needs-statement-and-answer = ತಪ್ಪು pretzel: ಪ್ರತಿ `<problem>`ಡ್ ಒಂಜಿ `<statement>` ಬೊಕ್ಕ ಒಂಜಿ `<answer>` ಇಪ್ಪೊಡು.
+
+pretzel-circuit-first-problem-distractor = ತಪ್ಪು pretzel: mode="circuit"ಡ್ ಸುರುತ `<problem>` distractor ಆಯೆರೆ ಆಪುಜಿ.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+       *[other] `{ $attribute }` ಗುಣೊಗು ತಪ್ಪು ಮೌಲ್ಯ { $values }; ಪರಿಗಣನೆ ಆಪುಜಿ.
+    }
+
+attribute-must-be-references = `{ $attribute }` ಗುಣೊಗು ತಪ್ಪು ಮೌಲ್ಯ `{ $value }`. ಗುಣೊನು `$`ಡ್ ಸುರುವಾಪುನ ಉಲ್ಲೇಖೊಲೆಡ್ ಮಲ್ಪೊಡು.
+
+math-input-invalid-function-names = <mathInput>: { $attribute }ಡ್ ಇತ್ತಿನ ತಪ್ಪು ಉತ್ಪನ್ನೊದ ಪುದರ್ ಪರಿಗಣನೆ ಆಪುಜಿ: { $names }. ಪ್ರತಿ ಪುದರ್‌ದ ತೋಜಾವುನ ಭಾಗ ಕಡಿಮೆ ಪಂಡ 2 ಅಕ್ಷರ (ಅಕ್ಷರ ಅತ್ತ್ಂಡ ಡ್ಯಾಶ್) ಆವೊಡು; ಬುಕ್ಕ ಒಂಜಿ `|<mathspeak alternative>` ಸೇರಾವೊಲಿ.
+
+## Building components from the source
+
+component-type-invalid = ತಪ್ಪು ಘಟಕೊದ ತರ: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } ಗುಣೊನು ರಡ್ಡ್ ಸರ್ತಿ ಕೊರೆರೆ ಆಪುಜಿ.
+
+attribute-invalid-for-component = `<{ $componentType }>` ತರೊತ ಘಟಕೊಗು ತಪ್ಪು ಗುಣ "{ $attribute }".
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    ಶೈಲಿ ವ್ಯಾಖ್ಯೆ { $styleNumber }ಡ್ { $context ->
+        [text-on-background] ಹಿನ್ನೆಲೆದ ಬಣ್ಣೊಗು ಎದುರು ಬರವುದ ಬಣ್ಣೊದ
+        [high-contrast] ಕ್ಯಾನ್ವಾಸ್‌ಗ್ ಎದುರು ಹೆಚ್ಚು-ವ್ಯತ್ಯಾಸೊದ ಬಣ್ಣೊದ
+        [line] ಕ್ಯಾನ್ವಾಸ್‌ಗ್ ಎದುರು ಗೆರೆದ ಬಣ್ಣೊದ
+        [marker] ಕ್ಯಾನ್ವಾಸ್‌ಗ್ ಎದುರು marker‌ದ ಬಣ್ಣೊದ
+       *[text-on-canvas] ಕ್ಯಾನ್ವಾಸ್‌ಗ್ ಎದುರು ಬರವುದ ಬಣ್ಣೊದ
+    } ವ್ಯತ್ಯಾಸ ಸಾಲುಜಿ{ $mode ->
+        [dark] { " (ಕಪ್ಪು ಮೋಡ್)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ಕಡಿಮೆ ಪಂಡ { $threshold }:1 ಬೋಡು).
+
+style-definition-dark-mode-text-background-contrast =
+    ಶೈಲಿ ವ್ಯಾಖ್ಯೆ { $styleNumber }ಡ್ ಕೊರ್ತಿನ ಬಣ್ಣೊಲು ಬೊಲ್ದು ಮೋಡ್‌ಗ್ ಸಾಕಾಪುನಷ್ಟು ವ್ಯತ್ಯಾಸ ಕೊರ್ಪುಂಡು ಆಂಡ, ಆ ಮೌಲ್ಯೊಡ್ದ್ ಮಲ್ತಿನ ಕಪ್ಪು ಮೋಡ್‌ದ ಬಣ್ಣೊಲೆಡ್ ಹಿನ್ನೆಲೆದ ಬಣ್ಣೊಗು ಎದುರು ಬರವುದ ಬಣ್ಣೊದ ವ್ಯತ್ಯಾಸ ಸಾಲುಜಿ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ಕಡಿಮೆ ಪಂಡ { $threshold }:1 ಬೋಡು). { $suggestion ->
+        [available] ಕಪ್ಪು ಮೋಡ್‌ಡ್ ಸಾಕಾಪುನಷ್ಟು ವ್ಯತ್ಯಾಸ ತಿಕ್ಕೆರೆ ಬೊಲ್ದು ಮೋಡ್‌ದ ವ್ಯತ್ಯಾಸೊನು ಜಾಸ್ತಿ ಮಲ್ಪುಲೆ (ಉದಾ. { $lightAttribute }="{ $lightColor }" ದೀಲೆ), ಅತ್ತ್ಂಡ ಕಪ್ಪು ಮೋಡ್‌ದ ಬಣ್ಣೊನು ಈರೇ ಗೊತ್ತು ಮಲ್ಪುಲೆ (ಉದಾ. { $darkAttribute }="{ $darkColor }").
+       *[none] ಕಪ್ಪು ಮೋಡ್‌ಡ್ ಸಾಕಾಪುನಷ್ಟು ವ್ಯತ್ಯಾಸ ತಿಕ್ಕೆರೆ ಬೊಲ್ದು ಮೋಡ್‌ದ ವ್ಯತ್ಯಾಸೊನು ಜಾಸ್ತಿ ಮಲ್ಪುಲೆ, ಅತ್ತ್ಂಡ textColorDarkMode ಬೊಕ್ಕ/ಅತ್ತ್ಂಡ backgroundColorDarkMode ಮುಖಾಂತರ ಮಲ್ತಿನ ಬಣ್ಣೊಲೆನ್ ಈರೇ ಗೊತ್ತು ಮಲ್ಪುಲೆ.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    ಶೈಲಿ ವ್ಯಾಖ್ಯೆ { $styleNumber }ಡ್ ಕೊರ್ತಿನ ಬರವುದ ಬಣ್ಣ ಬೊಲ್ದು ಮೋಡ್‌ಗ್ ಸಾಕಾಪುನಷ್ಟು ವ್ಯತ್ಯಾಸ ಕೊರ್ಪುಂಡು ಆಂಡ, ಆ ಮೌಲ್ಯೊಡ್ದ್ ಮಲ್ತಿನ ಕಪ್ಪು ಮೋಡ್‌ದ ಬರವುದ ಬಣ್ಣೊಗು ಕ್ಯಾನ್ವಾಸ್‌ಗ್ ಎದುರು ವ್ಯತ್ಯಾಸ ಸಾಲುಜಿ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ಕಡಿಮೆ ಪಂಡ { $threshold }:1 ಬೋಡು). { $suggestion ->
+        [available] ಕಪ್ಪು ಮೋಡ್‌ಡ್ ಸಾಕಾಪುನಷ್ಟು ವ್ಯತ್ಯಾಸ ತಿಕ್ಕೆರೆ ಬೊಲ್ದು ಮೋಡ್‌ದ ವ್ಯತ್ಯಾಸೊನು ಜಾಸ್ತಿ ಮಲ್ಪುಲೆ (ಉದಾ. textColor="{ $lightColor }" ದೀಲೆ), ಅತ್ತ್ಂಡ ಕಪ್ಪು ಮೋಡ್‌ದ ಬಣ್ಣೊನು ಈರೇ ಗೊತ್ತು ಮಲ್ಪುಲೆ (ಉದಾ. textColorDarkMode="{ $darkColor }").
+       *[none] ಕಪ್ಪು ಮೋಡ್‌ಡ್ ಸಾಕಾಪುನಷ್ಟು ವ್ಯತ್ಯಾಸ ತಿಕ್ಕೆರೆ ಬೊಲ್ದು ಮೋಡ್‌ದ ವ್ಯತ್ಯಾಸೊನು ಜಾಸ್ತಿ ಮಲ್ಪುಲೆ, ಅತ್ತ್ಂಡ textColorDarkMode ಮುಖಾಂತರ ಮಲ್ತಿನ ಬಣ್ಣೊನು ಈರೇ ಗೊತ್ತು ಮಲ್ಪುಲೆ.
+    }
+
+section-multiple-style-palettes = ಒಂಜಿ ವಿಭಾಗ ಒಂಜೇ <stylePalette>ನ್ ಆಯ್ಕೆ ಮಲ್ಪೊಲಿ; ಕಡೆತ ಒಂಜಿ ಬಳಕೆ ಆಂಡ್.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect ಋಣಾತ್ಮಕ ಅತ್ತಿನ ಪೂರ್ಣಾಂಕ ಅತ್ತ್, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-num-to-select-not-constant-number = numToSelect ಸ್ಥಿರ ಸಂಖ್ಯೆ ಅತ್ತ್, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-with-replacement-not-constant-boolean = withReplacement ಸ್ಥಿರ boolean ಅತ್ತ್, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-select-weight-disables-unique = selectWeight ಅತ್ತ್ಂಡ selectForVariants ಕೊರ್ತಿನ option ಇತ್ತ್ಂಡ select‌ದ ವಿಶಿಷ್ಟ variant ನಿಲ್ಲುಂಡು
+
+variant-coprime-undetermined = coprime ಪೂರ ಸರ್ತಿಲಾ ಸುಳ್ಳು ಪಂಡ್‌ದ್ ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-attribute-not-constant = { $attribute } ಸ್ಥಿರ ಅತ್ತ್, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-attribute-not-number = { $attribute } ಸಂಖ್ಯೆ ಅತ್ತ್, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } { $expected ->
+        [letters-combination] ಅಕ್ಷರೊಲೆ ಸಂಯೋಜನೆ
+        [math-expression] ಸರಿಯಾಯಿನ ಗಣಿತ ಸೂತ್ರ
+        [integer] ಪೂರ್ಣಾಂಕ
+       *[number] ಸಂಖ್ಯೆ
+    } ಅತ್ತ್, ಅಂಚಾದ್ { $type } ತರೊತ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-length-not-integer = length ಪೂರ್ಣಾಂಕ ಅತ್ತ್, ಅಂಚಾದ್ { $component }ದ ವಿಶಿಷ್ಟ variant ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+variant-sort-not-implemented = sort ಇತ್ತಿನ { $component }ದ ವಿಶಿಷ್ಟ variant ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ
+
+variant-exclude-combinations-not-implemented = excludeCombinations ಇತ್ತಿನ { $component }ದ ವಿಶಿಷ್ಟ variant ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ
+
+variant-math-exclude-not-implemented = exclude ಇತ್ತಿನ math ತರೊತ { $component }ದ ವಿಶಿಷ್ಟ variant ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ
+
+variant-non-constant-exclude-not-implemented = ಸ್ಥಿರ ಅತ್ತಿನ exclude ಇತ್ತಿನ { $component }ದ ವಿಶಿಷ್ಟ variant ಇನಿ ಮುಟ್ಟ ಮಲ್ತಿಜ್ಜಿ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure ರೆಂಡರರ್‌ಡ್ ನಡೆಪುಜಿ; ವಂಶಜೆ ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-descendant-invalid-geometry = { $subject }: ಅಪೂರ್ಣ ಅತ್ತ್ಂಡ ಮಿತಿ ಇಜ್ಜಂದಿನ ರೇಖಾಗಣಿತ; ವಂಶಜೆ ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-curve-label-omitted = { $subject }: ಪರಿವರ್ತನೆ ಆಯಿನ ವಕ್ರ ಘಟಕೊಲೆಡ್ label ನಡೆಪುಜಿ; label ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ನಡೆಪಂದಿನ ವಕ್ರ ಉತ್ಪನ್ನೊದ ವ್ಯಾಖ್ಯೆದ ತರ '{ $definitionType }'; ವಂಶಜೆ ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves‌ಡ್ ನಡೆಪಂದಿನ flipFunctions ಗುಣ; ವಂಶಜೆ ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves‌ಡ್ formula ತರೊತ ಮಗೆ ಉತ್ಪನ್ನೊಲು ಮಾತ್ರ ನಡೆಪುಂಡು; ವಂಶಜೆ ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] ಗೆರೆ-ಕುಟುಮೊದ label
+       *[point] ಬಿಂದುದ label
+    }ಗ್ ನಡೆಪಂದಿನ labelPosition '{ $labelPosition }'; ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನ PreFigure ಜೋಡಣೆ ಬಳಕೆ ಆಂಡ್.
+
+prefigure-fill-style-unsupported = { $subject }: ತುಂಬಾವುನ ಶೈಲಿ '{ $fillStyle }' PreFigure‌ಡ್ ನಡೆಪುಜಿ; ಗಟ್ಟಿ ತುಂಬಾವುನ ಬಳಕೆ ಆಂಡ್.
+
+prefigure-line-style-unknown = { $subject }: ಗೊತ್ತಿಜ್ಜಂದಿನ ಗೆರೆದ ಶೈಲಿ '{ $lineStyle }' PreFigure‌ದ ಫಲಿತಾಂಶೊಡ್ದ್ ಬುಡ್‌ದ್ಂಡ್.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: marker ಶೈಲಿ '{ $markerStyle }' PreFigure‌ದ 'diamond' ಶೈಲಿಗ್ ಬದಲಾಂಡ್.
+
+prefigure-marker-style-unsupported = { $subject }: marker ಶೈಲಿ '{ $markerStyle }' PreFigure‌ಡ್ ನಡೆಪುಜಿ; ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನ ಶೈಲಿ ಬಳಕೆ ಆಂಡ್.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ತಪ್ಪು `ref`; target ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆಪುಜಿ. ಟಿಪ್ಪಣಿ ಬುಡ್‌ದ್ಂಡ್.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ target‌ಗ್ ಸೇರ್‌ದ್ಂಡ್; ಸುರುತ target ಬಳಕೆ ಆಂಡ್.
+
+annotation-ref-outside-graph = `<annotation>`: ತಪ್ಪು `ref`; target ಸುತ್ತುದ graph‌ದ ಪಿದಯಿ ಉಂಡು. ಟಿಪ್ಪಣಿ ಬುಡ್‌ದ್ಂಡ್.
+
+annotation-ref-unsupported-target = `<annotation>`: ತಪ್ಪು `ref`; prefigure ಪರಿವರ್ತನೆಡ್ target ನಡೆಪುನ ಚಿತ್ರೊದ ವಸ್ತು ಅತ್ತ್. ಟಿಪ್ಪಣಿ ಬುಡ್‌ದ್ಂಡ್.
+
+annotation-text-missing = `<annotation>`: `text` ಇಜ್ಜಿ ಅತ್ತ್ಂಡ ಖಾಲಿ ಉಂಡು; ಖಾಲಿ ಬರವು ಕೊರ್ತ್‌ದ್ಂಡ್.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] ಸುತ್ತು ಅವಲಂಬನೆ ತಿಕ್ಕ್‌ಂಡ್.
+       *[other] `<{ $componentType }>` ಘಟಕೊಗು ಸಂಬಂಧಪಟ್ಟಿನ ಸುತ್ತು ಅವಲಂಬನೆ ತಿಕ್ಕ್‌ಂಡ್.
+    }
+
+reference-no-referent = ಉಲ್ಲೇಖೊಗು ಒವ್ವೇ ಗುರಿ ತಿಕ್ಕುಜಿ: `{ $reference }`
+
+reference-multiple-referents = ಉಲ್ಲೇಖೊಗು ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಗುರಿ ತಿಕ್ಕ್‌ಂಡ್: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>`ದ { $attribute } ಗುಣೊದ ತಪ್ಪು ರೂಪ.
+
+children-invalid = `<{ $componentType }>`ಗ್ ತಪ್ಪು ಮಗೆಲು: ತಪ್ಪು ಮಗೆಲು ತಿಕ್ಕ್‌ಂಡ್: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` ಗುಣೊಗು ತಪ್ಪು ಮೌಲ್ಯ `{ $value }`, `{ $default }` ಮೌಲ್ಯ ಬಳಕೆ ಆಂಡ್
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML ಆವೃತ್ತಿ { $version } ತಿಕ್ಕುಜಿ.
+       *[other] DoenetML ಆವೃತ್ತಿ { $version } ತಿಕ್ಕುಜಿ. ಆವೃತ್ತಿ { $fallback }ಗ್ ಪಿರ ಪೋತ್‌ದ್ಂಡ್
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = ತಪ್ಪು DoenetML: { $content }
+
+parse-tag-missing-close-tag = ತಪ್ಪು DoenetML: `{ $tag }` ಟ್ಯಾಗ್‌ಗ್ ಮುಚ್ಚುನ ಟ್ಯಾಗ್ ಇಜ್ಜಿ. ತನ್ನಂತಾನೇ ಮುಚ್ಚುನ ಟ್ಯಾಗ್ ಅತ್ತ್ಂಡ ಒಂಜಿ `</{ $tagName }>` ಟ್ಯಾಗ್ ಬೋಡು.
+
+parse-tag-error = ತಪ್ಪು DoenetML: `<{ $tagName }>` ಟ್ಯಾಗ್‌ಡ್ ದೋಷ
+
+parse-attribute-missing-value = ತಪ್ಪು DoenetML: ತಪ್ಪು ಗುಣ `{ $attribute }`ಗ್ ಮೌಲ್ಯ ಇಜ್ಜಿ ಪಂಡ್‌ದ್ ತೋಜುಂಡು.
+
+parse-attribute-invalid = ತಪ್ಪು DoenetML: ತಪ್ಪು ಗುಣ `{ $attribute }`
+
+parse-attribute-value-invalid = ತಪ್ಪು DoenetML: ತಪ್ಪು ಗುಣೊದ ಮೌಲ್ಯ `{ $value }`
+
+parse-attribute-value-quote-mismatch = ತಪ್ಪು DoenetML: ತಪ್ಪು ಗುಣೊದ ಮೌಲ್ಯ `{ $value }`. ಉದ್ಧರಣ ಚಿಹ್ನೆಲು ಸರಿ ಬರ್ಪುಜಿ. ಒಂಜಿ `{ $quote }` ಇಜ್ಜಿ ಪಂಡ್‌ದ್ ತೋಜುಂಡು
+
+parse-open-tag-name-missing = ತಪ್ಪು DoenetML: ಪುದರ್ ಇಜ್ಜಂದಿನ ಒಂಜಿ ಟ್ಯಾಗ್ ತಿಕ್ಕ್‌ಂಡ್, ಉದಾ. `<`
+
+parse-tag-not-closed = ತಪ್ಪು DoenetML: `{ $tag }` ಟ್ಯಾಗ್ ಮುಚ್ಚಿಜ್ಜಿ (ಒಂಜಿ `>` ಇಜ್ಜಿ ಪಂಡ್‌ದ್ ತೋಜುಂಡು).
+
+parse-self-closing-tag-name-missing = ತಪ್ಪು DoenetML: ಪುದರ್ ಇಜ್ಜಂದಿನ ಒಂಜಿ ಟ್ಯಾಗ್ ತಿಕ್ಕ್‌ಂಡ್ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = ತಪ್ಪು DoenetML: `{ $tag }` ಟ್ಯಾಗ್ ಮುಚ್ಚಿಜ್ಜಿ (`/>` ಇಜ್ಜಿ ಪಂಡ್‌ದ್ ತೋಜುಂಡು).
+
+parse-tag-invalid-attributes = ತಪ್ಪು DoenetML: `{ $tag }` ಟ್ಯಾಗ್ ಸರಿ ಅತ್ತ್. ಅವೆತ ಗುಣೊಲು ತಪ್ಪಾದಿಪ್ಪೊಲಿ.
+
+parse-close-tag-name-missing = ತಪ್ಪು DoenetML: ಪುದರ್ ಇಜ್ಜಂದಿನ ಒಂಜಿ ಮುಚ್ಚುನ ಟ್ಯಾಗ್ ತಿಕ್ಕ್‌ಂಡ್, ಉದಾ. `</`
+
+parse-attribute-value-unquoted = ಗುಣೊದ ಮೌಲ್ಯೊಲೆನ್ ಉದ್ಧರಣ ಚಿಹ್ನೆದ ಒಳಯಿ ದೀಯೊಡು: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = ತಪ್ಪು DoenetML: `{ $tag }` ಮುಚ್ಚುನ ಟ್ಯಾಗ್ ತಿಕ್ಕ್‌ಂಡ್, ಆಂಡ ಅವೆಗ್ ಸರಿಯಾಯಿನ ದೆಪ್ಪುನ ಟ್ಯಾಗ್ ಇಜ್ಜಿ
+
+parse-close-tag-mismatched = ತಪ್ಪು DoenetML: ಮುಚ್ಚುನ ಟ್ಯಾಗ್ ಸರಿ ಬರ್ಪುಜಿ. `</{ $expected }>` ಬೋಡು. `{ $found }` ತಿಕ್ಕ್‌ಂಡ್
+
+parser-node-unconvertible = { $node } ನೋಡ್‌ನ್ Dast ನೋಡ್‌ಗ್ ಬದಲಾಯೆರೆ ಆತಿಜ್ಜಿ.
+
+## Names
+
+name-attribute-invalid =
+    ತಪ್ಪು ಗುಣ name='{ $name }'. { $reason ->
+        [characters] ಪುದರುಲೆಡ್ ಅಕ್ಷರ, ಸಂಖ್ಯೆ, ಅಂಡರ್‌ಸ್ಕೋರ್ ಅತ್ತ್ಂಡ ಹೈಫನ್ ಮಾತ್ರ ಇಪ್ಪೊಲಿ.
+       *[start] ಪುದರ್ ಒಂಜಿ ಅಕ್ಷರೊಡ್ದ್ ಸುರುವಾವೊಡು.
+    }
+
+component-name-invalid-start = ತಪ್ಪು ಘಟಕೊದ ಪುದರ್ "{ $name }". ಪುದರ್ ಒಂಜಿ ಅಕ್ಷರೊಡ್ದ್ ಸುರುವಾವೊಡು.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched ತರೊತ answer‌ಗ್ ಒಂಜಿ video ಗುಣ ಇಪ್ಪೊಡು
+
+answer-video-watched-video-not-reference = videoWatched ತರೊತ answer‌ದ video ಗುಣ ಒಂಜಿ ಉಲ್ಲೇಖ ಆವೊಡು
+
+answer-name-not-single-text = Answer‌ದ name ಗುಣೊಡು ಒಂಜೇ text ಮಗೆ ಇಪ್ಪೊಡು
+
+## Referencing another document
+
+external-doenetml-recursion-limit = ಮಸ್ತ್ ಹಂತೊಲೆ ಪುನರಾವರ್ತನೆದ ಕಾರಣ ಪಿದಯಿದ DoenetML ದೆತೊನ್ಯೆರೆ ಆತಿಜ್ಜಿ. ಒವ್ವಾಂಡಲಾ ಸುತ್ತು ಉಲ್ಲೇಖ ಉಂಡಾ?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }"ಡ್ದ್ DoenetML ದೆತೊನ್ಯೆರೆ ಆತಿಜ್ಜಿ
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }"ಡ್ದ್ ದೆತೊಂಡಿನ DoenetML ತಪ್ಪು: ಅವು "{ $componentType }" ಘಟಕೊದ ತರೊಗು ಸರಿ ಬರ್ಪುಜಿ
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` ಗುಣ ಪರ್ತ್‌ದ್ಂಡ್; ಅವೆತ ಬದಲ್ `{ $to }` ಬಳಸುಲೆ.
+       *[other] [deprecation] `<{ $component }>`ದ `{ $from }` ಗುಣ ಪರ್ತ್‌ದ್ಂಡ್; ಅವೆತ ಬದಲ್ `{ $to }` ಬಳಸುಲೆ.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }`ಲಾ ಕೊರ್ತ್‌ದ್ಂಡ್, ಅಂಚಾದ್ `{ $from }` ಗುಣ ಪರ್ತ್‌ದ್ಂಡ್ ಬೊಕ್ಕ ಪರಿಗಣನೆ ಆಪುಜಿ.
+       *[other] [deprecation] `<{ $component }>`ದ `{ $from }` ಗುಣ ಪರ್ತ್‌ದ್ಂಡ್ ಬೊಕ್ಕ `{ $to }`ಲಾ ಕೊರ್ತಿನೆಡ್ದ್ ಪರಿಗಣನೆ ಆಪುಜಿ.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>`ದ `{ $attribute }` ಗುಣ ಪರ್ತ್‌ದ್ಂಡ್ ಬೊಕ್ಕ ಪರಿಗಣನೆ ಆಪುಜಿ.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>`ದ `{ $attribute }` ಗುಣ ಪರ್ತ್‌ದ್ಂಡ್; ಅವೆತ ಬದಲ್ ಒಂಜಿ `<{ $child }>` ಮಗೆನ್ ಬಳಸುಲೆ.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>`ದ `{ $attribute }` ಗುಣೊದ `{ $value }` ಮೌಲ್ಯ ಪರ್ತ್‌ದ್ಂಡ್; ಅವೆತ ಬದಲ್ `{ $to }` ಬಳಸುಲೆ.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ಇಂಗ್ಲಿಷ್‌ದ ಬಹುವಚನೊನು ಮಾತ್ರ ಮಲ್ಪೊಲಿ, ಅಂಚಾದ್ { $locale } ಭಾಷೆಡ್ ಬರೆತಿನ ದಾಖಲೆಡ್ ಅವೆತ ಬರವು ಇತ್ತಿನಂಚನೇ ಒರಿಪುಂಡು. ಬಹುವಚನೊದ ರೂಪೊನು ನೇರವಾದ್ ಬರೆಪುಲೆ, ಅತ್ತ್ಂಡ `pluralForm` ಗುಣೊಡು ಕೊರ್ಲೆ.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` ಘಟಕ Doenet‌ದ ಗೊತ್ತಿತ್ತಿನ ಘಟಕ ಅತ್ತ್.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` ಘಟಕೊನು ದಾಖಲೆದ ಬುಡೊಡು ದೀಯೆರೆ ಆಪುಜಿ.
+
+schema-element-not-allowed-inside = `<{ $tag }>` ಘಟಕೊನು `<{ $parent }>`ದ ಒಳಯಿ ದೀಯೆರೆ ಆಪುಜಿ.
+
+schema-attribute-unrecognized = `<{ $tag }>` ಘಟಕೊಗು `{ $attribute }` ಪುದರ್‌ದ ಒವ್ವೇ ಗುಣ ಇಜ್ಜಿ.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` ಘಟಕೊದ `{ $attribute }` ಗುಣ ಒಂಜಿ ಪಟ್ಟಿ ಆವೊಡು, ಅವೆತ ಪ್ರತಿ ವಸ್ತುಲಾ ಇಂದೆಟ್ಟ್ ಒಂಜಿ ಆವೊಡು: { $allowed }
+       *[other] `<{ $tag }>` ಘಟಕೊದ `{ $attribute }` ಗುಣ ಇಂದೆಟ್ಟ್ ಒಂಜಿ ಆವೊಡು: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select‌ಗ್ ತಪ್ಪು variant ಪುದರ್.  Variant ಪುದರ್ { $variantName } { $numOptions } option‌ಡ್ ಬರ್ಪುಂಡು ಆಂಡ ಆಯ್ಕೆ ಮಲ್ಪುನ ಸಂಖ್ಯೆ { $numToSelect }.
+
+select-variant-name-without-options = select‌ಗ್ ಕೆಲವು variant ಕೊರ್ತ್‌ದ್ಂಡ್ ಆಂಡ ಸಾಧ್ಯ ಇತ್ತಿನ variant ಪುದರ್ { $variantName }ಗ್ ಒವ್ವೇ option ಕೊರ್ತಿಜ್ಜಿ.
+
+select-variant-name-not-possible = select‌ಗ್ ಕೊರ್ತಿನ variant ಪುದರ್ { $variantName } ಸಾಧ್ಯ ಇತ್ತಿನ variant ಪುದರ್ ಅತ್ತ್.
+
+select-too-few-options = { $numOptions } ಮಾತ್ರ ಇತ್ತ್ಂಡ { $numToSelect } ಘಟಕೊಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+select-from-sequence-too-few-values = { $length } ಉದ್ದೊದ ಅನುಕ್ರಮೊಡ್ದ್ { $numToSelect } ಮೌಲ್ಯೊಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+select-from-sequence-indices-count-mismatch = select‌ಗ್ ಕೊರ್ತಿನ indices‌ದ ಸಂಖ್ಯೆ ಆಯ್ಕೆ ಮಲ್ಪುನ ಸಂಖ್ಯೆಗ್ ಸರಿ ಬರೊಡು
+
+select-from-sequence-indices-not-integers = select‌ಗ್ ಕೊರ್ತಿನ ಮಾತ indices ಪೂರ್ಣಾಂಕ ಆವೊಡು
+
+select-from-sequence-index-excluded = selectfromsequence‌ದ ಕೊರ್ತಿನ index ಬುಡ್‌ದಿನವು ಆದಿತ್ತ್ಂಡ್
+
+select-from-sequence-indices-excluded-combination = selectfromsequence‌ದ ಕೊರ್ತಿನ indices ಬುಡ್‌ದಿನ ಸಂಯೋಜನೆ ಆದಿತ್ತ್ಂಡ್
+
+select-from-sequence-coprime-not-positive-integers = ಧನಾತ್ಮಕ ಪೂರ್ಣಾಂಕೊಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪುಜಿ, ಅಂಚಾದ್ coprime ಸಂಯೋಜನೆ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+select-from-sequence-coprime-common-factor = Coprime ಸಂಖ್ಯೆಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ. ಮಾತ ಸಾಧ್ಯ ಮೌಲ್ಯೊಲೆಗ್ ಒಂಜಿ ಸಾಮಾನ್ಯ ಅಪವರ್ತನ ಉಂಡು. ("from" ಅತ್ತ್ಂಡ "to"ದ ಕೊರ್ತಿನ ಮೌಲ್ಯೊಲು "step"ಗ್ coprime ಆವೊಡು.)
+
+select-from-sequence-coprime-single-number = 1 ಅತ್ತಿನ ಒಂಜೇ ಸಂಖ್ಯೆಡ್ದ್ coprime ಸಂಯೋಜನೆ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence‌ಡ್ ಸಂಯೋಜನೆಲೆಡ್ 70%ಡ್ದ್ ಜಾಸ್ತಿ ಬುಡ್‌ದ್ಂಡ್
+
+select-from-sequence-coprime-none-found = Coprime ಸಂಖ್ಯೆಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆತಿಜ್ಜಿ. ಮಾತ ಸಾಧ್ಯ ಮೌಲ್ಯೊಲೆಗ್ ಒಂಜಿ ಸಾಮಾನ್ಯ ಅಪವರ್ತನ ಉಂಡು.
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } ಉದ್ದೊದ ಅನುಕ್ರಮೊಡ್ದ್ { $numToSelect } ವಿಶಿಷ್ಟ ಮೌಲ್ಯೊಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ
+
+select-prime-numbers-too-few-values = { $numValues } ಉದ್ದೊದ ಅವಿಭಾಜ್ಯ ಸಂಖ್ಯೆಲೆ ಪಟ್ಟಿಡ್ದ್ { $numToSelect } ಮೌಲ್ಯೊಲೆನ್ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆಪುಜಿ
+
+select-prime-numbers-values-count-mismatch = select‌ಗ್ ಕೊರ್ತಿನ ಮೌಲ್ಯೊಲೆ ಸಂಖ್ಯೆ ಆಯ್ಕೆ ಮಲ್ಪುನ ಸಂಖ್ಯೆಗ್ ಸರಿ ಬರೊಡು
+
+select-prime-numbers-values-not-prime = select prime number‌ಗ್ ಕೊರ್ತಿನ ಮಾತ ಮೌಲ್ಯೊಲು ಅವಿಭಾಜ್ಯ ಸಂಖ್ಯೆಲೆ ಪಟ್ಟಿಡ್ ಇಪ್ಪೊಡು
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers‌ದ ಕೊರ್ತಿನ ಮೌಲ್ಯೊಲು ಬುಡ್‌ದಿನ ಸಂಯೋಜನೆ ಆದಿತ್ತ್ಂಡ್
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers‌ಡ್ ಸಂಯೋಜನೆಲೆಡ್ 70%ಡ್ದ್ ಜಾಸ್ತಿ ಬುಡ್‌ದ್ಂಡ್
+
+select-random-combination-fluke = ಮಸ್ತ್ ಅಪರೂಪದ ಆಕಸ್ಮಿಕೊಡು, ಯಾದೃಚ್ಛಿಕ ಮೌಲ್ಯೊಲೆ ಸಂಯೋಜನೆ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆತಿಜ್ಜಿ
+
+select-random-value-fluke = ಮಸ್ತ್ ಅಪರೂಪದ ಆಕಸ್ಮಿಕೊಡು, ಯಾದೃಚ್ಛಿಕ ಮೌಲ್ಯ ಆಯ್ಕೆ ಮಲ್ಪೆರೆ ಆತಿಜ್ಜಿ
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] ಈ `<{ $component }>` ಗಣಿತೊದ ಒಳಯಿ ಉಂಡು ಆಂಡ `inline` ಅತ್ತ್, ಅಂಚಾದ್ ಅವು ತೋಜುಜಿ. `inline` ಸೇರಾಲೆ, ಅಂಚಾಂಡ ಅವು ಡ್ರಾಪ್-ಡೌನ್ ಪಟ್ಟಿ ಆಪುಂಡು, ಅವು ಸೂತ್ರೊದ ಒಳಯಿ ಸರಿಯಾಪುಂಡು.
+        [expanded] ಈ `<{ $component }>` ಗಣಿತೊದ ಒಳಯಿ ಉಂಡು ಬೊಕ್ಕ `expanded` ಆದುಂಡು, ಅಂಚಾದ್ ಅವು ತೋಜುಜಿ. `expanded` ದೆತ್ತ್ ಪಾಡ್ಲೆ; ಮಸ್ತ್ ಸಾಲುದ ಪೆಟ್ಟಿಗೆ ಸೂತ್ರೊದ ಒಳಯಿ ಸರಿಯಾಪುಜಿ.
+        [on-graph] ಈ `<{ $component }>` graph‌ದ ಮಿತ್ತ್ ಬರೆತಿನ ಗಣಿತೊದ ಒಳಯಿ ಉಂಡು, ಅವೆಟ್ input‌ಗ್ ಜಾಗೆ ಇಜ್ಜಿ, ಅಂಚಾದ್ ಅವು ತೋಜುಜಿ.
+       *[relative-width] ಈ `<{ $component }>` ಗಣಿತೊದ ಒಳಯಿ ಉಂಡು ಬೊಕ್ಕ ಅವೆತ ಅಗಲ ಸಾಪೇಕ್ಷ ಆದುಂಡು, ಅಂಚಾದ್ ಅವು ತೋಜುಜಿ. ಅಗಲೊನು `px` ಲೆಕ್ಕದ ನಿರಪೇಕ್ಷ ಏಕಮಾನೊಡು ಕೊರ್ಲೆ.
+    }

--- a/packages/i18n/locales/tcy/editor.ftl
+++ b/packages/i18n/locales/tcy/editor.ftl
@@ -1,0 +1,225 @@
+# Tulu (ತುಳು) editor and language-server surfaces: the footer, the diagnostics
+# panel, the variant picker, the accessibility button, and the context-help
+# panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and register** are `chrome.ftl`'s: Kannada rather than Tigalari,
+# and a Kannada technical vocabulary declared as a loan register around a Tulu
+# frame — ಇಜ್ಜಿ, ಉಂಡು, ಆಪುಜಿ, ತಿಕ್ಕುಜಿ, ಆವೊಡು, ಬೊಕ್ಕ, ಅತ್ತ್ಂಡ, ಒಟ್ಟುಗು, and
+# the honorific imperative in -ಲೆ.
+#
+# **`WCAG`, `DoenetML`, `styleNumber` and every element and attribute name
+# stay in English.** They are identifiers an author types, not words. So does
+# `$shortcut`, which is a key combination, and `$version`, `$standard` and
+# `$ref`.
+#
+# **The counts do not fork.** `editor-accessibility-label` and
+# `help-coordinates` write a single `*[other]` where English writes `[one]`
+# and `[other]`: CLDR has no plural data for `tcy`, so an English-selected
+# branch here would be a category this locale cannot reach. A Tulu noun is
+# unmarked for number after a numeral in any case, so the single form is also
+# the grammatical one.
+#
+# **The arrow `→` in the two link labels is direction rather than
+# punctuation** and is left where English puts it: the Kannada script is
+# written left to right.
+#
+# **Numbers render in Latin digits** rather than in Kannada numerals (#1615).
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ಪಿರ ದೀಲೆ
+       *[update] ನವೀಕರಣ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] ವೀಕ್ಷಕ { $word }
+       *[other] ವೀಕ್ಷಕ { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = ಸೋಸುನ...
+editor-variant-next = ಬೊಕ್ಕದ variant ಆಯ್ಕೆ ಮಲ್ಪುಲೆ
+editor-variant-previous = ದುಂಬುದ variant ಆಯ್ಕೆ ಮಲ್ಪುಲೆ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA ಸೌಲಭ್ಯ ಉಲ್ಲಂಘನೆ ತಿಕ್ಕ್‌ಂಡ್. ಸೌಲಭ್ಯದ ವರದಿನ್ { $action ->
+            [close] ಮುಚ್ಚೆರೆ
+           *[open] ದೆಪ್ಪೆರೆ
+        } ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ.
+        [advisories] ಸೌಲಭ್ಯದ ವರದಿನ್ { $action ->
+            [close] ಮುಚ್ಚೆರೆ
+           *[open] ದೆಪ್ಪೆರೆ
+        } ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ. ಒವ್ವೇ WCAG AA ಉಲ್ಲಂಘನೆ ತಿಕ್ಕುಜಿ, ಆಂಡ ಬೇತೆ ಕೆಲವು ಸೌಲಭ್ಯದ ಸಲಹೆಲು ಉಂಡು.
+       *[clean] ಸೌಲಭ್ಯದ ವರದಿನ್ { $action ->
+            [close] ಮುಚ್ಚೆರೆ
+           *[open] ದೆಪ್ಪೆರೆ
+        } ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ. ಒವ್ವೇ ಸೌಲಭ್ಯದ ಸಮಸ್ಯೆ ತಿಕ್ಕುಜಿ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA ಸೌಲಭ್ಯ ಉಲ್ಲಂಘನೆ ತಿಕ್ಕ್‌ಂಡ್. { $count ->
+           *[other] { $count } WCAG AA ಉಲ್ಲಂಘನೆ
+        } ತಿಕ್ಕ್‌ಂಡ್. ಸೌಲಭ್ಯದ ವರದಿನ್ { $action ->
+            [close] ಮುಚ್ಚೆರೆ
+           *[open] ದೆಪ್ಪೆರೆ
+        } ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ.
+        [advisories] ಒವ್ವೇ WCAG AA ಉಲ್ಲಂಘನೆ ತಿಕ್ಕುಜಿ. { $count ->
+           *[other] { $count } ಬೇತೆ ಸೌಲಭ್ಯದ ಸಲಹೆ
+        } ತಿಕ್ಕ್‌ಂಡ್. ಸೌಲಭ್ಯದ ವರದಿನ್ { $action ->
+            [close] ಮುಚ್ಚೆರೆ
+           *[open] ದೆಪ್ಪೆರೆ
+        } ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ.
+       *[clean] ಒವ್ವೇ WCAG AA ಉಲ್ಲಂಘನೆ ತಿಕ್ಕುಜಿ. ಸೌಲಭ್ಯದ ವರದಿನ್ { $action ->
+            [close] ಮುಚ್ಚೆರೆ
+           *[open] ದೆಪ್ಪೆರೆ
+        } ಕ್ಲಿಕ್ ಮಲ್ಪುಲೆ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML ಆವೃತ್ತಿ { $version }
+
+editor-tab-help = ಸಂದರ್ಭೊಗು ತಕ್ಕ ಸಹಾಯ
+editor-tab-help-short = ಸಂದರ್ಭ
+editor-tab-errors = ದೋಷೊಲು
+editor-tab-warnings = ಎಚ್ಚರಿಕೆಲು
+editor-tab-info = ವಿವರ
+editor-tab-accessibility = ಸೌಲಭ್ಯ
+editor-tab-responses = ಕಡಪುಡಿನ ಉತ್ತರೊಲು
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = ಸಂಪಾದಕದ ಆಯ್ಕೆಲು
+editor-format-as-doenetml = DoenetML ಆದ್ ಜೋಡಿಪುಲೆ
+editor-format-as-xml = XML ಆದ್ ಜೋಡಿಪುಲೆ
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = ಸಾಲು #{ $line }
+
+editor-no-errors = ಒವ್ವೇ ದೋಷ ಇಜ್ಜಿ
+editor-no-warnings = ಒವ್ವೇ ಎಚ್ಚರಿಕೆ ಇಜ್ಜಿ
+editor-no-info = ಒವ್ವೇ ವಿವರದ ಸೂಚನೆ ಇಜ್ಜಿ
+
+editor-show-info-annotations = ಸಂಪಾದಕೊಡು ವಿವರದ ಸೂಚನೆಲೆನ್ ತೋಜಾಲೆ
+editor-show-accessibility-annotations = ಸಂಪಾದಕೊಡು ಸೌಲಭ್ಯದ ಸೂಚನೆಲೆನ್ ತೋಜಾಲೆ
+
+editor-accessibility-learn-more = Doenet ಸೌಲಭ್ಯೊನು ಏತ್ ಲೆಕ್ಕ ತೂಪುಂಡು ಪಂಡ್‌ದ್ ಕಲ್ಪುಲೆ
+
+editor-accessibility-violations-heading = ಸೌಲಭ್ಯ ಉಲ್ಲಂಘನೆಲು ({ $standard })
+
+editor-accessibility-other-heading = ಬೇತೆ ಸೌಲಭ್ಯದ ಸಮಸ್ಯೆಲು
+editor-none-found = ಒವ್ವೂ ತಿಕ್ಕುಜಿ
+
+
+## Submitted responses
+
+editor-no-responses = ಇನಿ ಮುಟ್ಟ ಒವ್ವೇ ಉತ್ತರ ಕಡಪುಡ್‌ದಿಜ್ಜಿ
+editor-response-answer-id = Answer Id
+editor-response-response = ಉತ್ತರ
+editor-response-credit = ಅಂಕ
+editor-response-submitted = ಕಡಪುಡ್‌ದ್ಂಡ್
+
+
+## The context-help panel
+
+help-placeholder = ದಾಖಲೆಗ್ ಕರ್ಸರ್‌ನ್ ಒಂಜಿ ಟ್ಯಾಗ್‌ದ ಪುದರ್, ಗುಣ ಅತ್ತ್ಂಡ { $ref }ದ ಮಿತ್ತ್ ದೀಲೆ.
+
+help-unsupported-ref-chain = { $example }ದ ಲೆಕ್ಕದ ಮಸ್ತ್ ಭಾಗೊಲೆ ಉಲ್ಲೇಖೊಗು ಸಹಾಯ ಇನಿ ಮುಟ್ಟ ನಡೆಪುಜಿ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ಉಲ್ಲೇಖೊಗು ಒವ್ವೇ ಗುರಿ ತಿಕ್ಕುಜಿ: { $ref }.
+        [multiple] ಉಲ್ಲೇಖೊಗು ಒಂಜಿಡ್ದ್ ಜಾಸ್ತಿ ಗುರಿ ತಿಕ್ಕ್‌ಂಡ್: { $ref }.
+       *[indeterminate] { $ref }ದ ಗುರಿನ್ ಗೊತ್ತು ಮಲ್ಪೆರೆ ಆತಿಜ್ಜಿ.
+    }
+
+help-learn-about-references = ಉಲ್ಲೇಖೊಲೆ ಬಗೆಟ್ ಕಲ್ಪುಲೆ →
+help-reference-page = ಉಲ್ಲೇಖೊದ ಪುಟ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element }ದ ಒಳಯಿ
+       *[top] ಮಿತ್ತ್‌ದ ಹಂತೊಡು
+    }{ $allowed ->
+        [none] { " — ಇಂಚಿ ಒವ್ವೂ ಬರ್ಪುಜಿ." }
+        [text] { " — ಇಂಚಿ ಬರವು ಬರೆಪುಲೆ." }
+        [text-and-components] { " — ಇಂಚಿ ಬರವು ಬರೆಪುಲೆ, ಅತ್ತ್ಂಡ ಇಂದೆನ್ ತೂಲೆ:" }
+       *[components] { " — ತೂವೊಲಿನವು:" }
+    }
+
+help-suggestions-footer = ಮಾತ { $total } ಘಟಕೊಲೆನ್ ತೂಯೆರೆ { $shortcut } ಒತ್ತುಲೆ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ಪಂಡ { $target }ದ ಒಂಜಿ ಉಲ್ಲೇಖ.
+       *[other] { $ref } ಪಂಡ { $target }ದ ಒಂಜಿ ಉಲ್ಲೇಖ (ಸಾಲು { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ಅವೆನ್ { $role } ಆದ್ ಕನತ್‌ದ್ಂಡ್.
+       *[other] { $owner } ಅವೆನ್ ಸಾಲು { $line }ಡ್ { $role } ಆದ್ ಕನತ್‌ದ್ಂಡ್.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ಪಂಡ { $element }ದ { $property } ಗುಣೊದ ಒಂಜಿ ಉಲ್ಲೇಖ.
+       *[other] { $ref } ಪಂಡ { $element }ದ { $property } ಗುಣೊದ ಒಂಜಿ ಉಲ್ಲೇಖ (ಸಾಲು { $line }).
+    }
+
+help-kind-attribute = ಗುಣ
+help-kind-snippet = ತುಂಡು
+help-kind-array-entry = ಸರಣಿದ ನಮೂದು
+
+help-default = ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನವು:
+help-active-default = ಇತ್ತೆದ ದುಂಬೇ ಗೊತ್ತು ಮಲ್ತಿನವು:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] ನಡೆಪುನ ಮೌಲ್ಯೊಲು (ಪ್ರತಿ ವಸ್ತುಗು ಒಂಜಿ):
+       *[other] ನಡೆಪುನ ಮೌಲ್ಯೊಲು:
+    }
+
+help-suggested-values = ಸಲಹೆ ಕೊರ್ತಿನ ಮೌಲ್ಯೊಲು:
+
+help-inserts = ಸೇರಾವುಂಡು:
+
+help-coordinates =
+    { $count ->
+       *[other] ನಿರ್ದೇಶಾಂಕ:
+    }
+
+help-type = ತರ:
+
+help-resolved-style = ಗೊತ್ತಾಯಿನ ಶೈಲಿ (styleNumber { $styleNumber }):
+
+help-resolved-function-names = ಗೊತ್ತಾಯಿನ ಉತ್ಪನ್ನೊದ ಪುದರುಲು:
+help-reset-list = ಈ input‌ದ ಪಿರ ದೀಪುನ ಪಟ್ಟಿ:
+help-added-on-input = ಈ input‌ಡ್ ಸೇರಾಯಿನವು:
+help-removed-on-input = ಈ input‌ಡ್ ದೆತ್ತಿನವು:
+
+help-reset-overrides = { $reset } { $additional } ಬೊಕ್ಕ { $removed }ದ ಮಿತ್ತ್ ನಡೆಪುಂಡು.

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -1007,28 +1007,28 @@ export const LOCALE_NAME_FALLBACKS: Record<
     // written in — Devanagari for the three Indo-Aryan tags of the Hindi belt
     // and Uttarakhand, the Bengali script for Sylheti, the Perso-Arabic
     // alphabet for Saraiki, and the Latin orthography Garo is printed in, whose
-    // raised dot is the letter `\u00b7` the orthography uses rather than a
+    // raised dot is the letter `·` (U+00B7) the orthography uses rather than a
     // period.
     hne: {
         englishName: "Chhattisgarhi",
-        endonym: "\u091b\u0924\u094d\u0924\u0940\u0938\u0917\u0922\u093c\u0940",
+        endonym: "छत्तीसगढ़ी",
     },
     gbm: {
         englishName: "Garhwali",
-        endonym: "\u0917\u0922\u093c\u0935\u093e\u0932\u0940",
+        endonym: "गढ़वाली",
     },
     kfy: {
         englishName: "Kumaoni",
-        endonym: "\u0915\u0941\u092e\u093e\u0909\u0901\u0928\u0940",
+        endonym: "कुमाउँनी",
     },
     syl: {
         englishName: "Sylheti",
-        endonym: "\u09b8\u09bf\u09b2\u09c7\u099f\u09bf",
+        endonym: "সিলেটি",
     },
-    grt: { englishName: "Garo", endonym: "A\u00b7chik" },
+    grt: { englishName: "Garo", endonym: "A·chik" },
     skr: {
         englishName: "Saraiki",
-        endonym: "\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc",
+        endonym: "سرائیکی",
     },
 };
 

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -995,6 +995,41 @@ export const LOCALE_NAME_FALLBACKS: Record<
     mnw: { englishName: "Mon", endonym: "ဘာသာမန်" },
     ksw: { englishName: "S'gaw Karen", endonym: "ကညီကျိာ်" },
     cbk: { englishName: "Chavacano" },
+    // The six locales of the South Asian batch CLDR has no data for. ICU names
+    // `awa`, `mag`, `mwr`, `new`, `tcy`, `lus`, `kha`, `brh` and `hif` — nine
+    // of the fifteen — and stops at the six below. The split follows nothing
+    // about the languages themselves: Chhattisgarhi has more speakers than
+    // several tags ICU does name, and Garhwali, Kumaoni and Sylheti each have
+    // millions. What they share is that no CLDR locale was ever requested for
+    // them.
+    //
+    // Each gets an endonym as well, written in the script its own catalog is
+    // written in — Devanagari for the three Indo-Aryan tags of the Hindi belt
+    // and Uttarakhand, the Bengali script for Sylheti, the Perso-Arabic
+    // alphabet for Saraiki, and the Latin orthography Garo is printed in, whose
+    // raised dot is the letter `\u00b7` the orthography uses rather than a
+    // period.
+    hne: {
+        englishName: "Chhattisgarhi",
+        endonym: "\u091b\u0924\u094d\u0924\u0940\u0938\u0917\u0922\u093c\u0940",
+    },
+    gbm: {
+        englishName: "Garhwali",
+        endonym: "\u0917\u0922\u093c\u0935\u093e\u0932\u0940",
+    },
+    kfy: {
+        englishName: "Kumaoni",
+        endonym: "\u0915\u0941\u092e\u093e\u0909\u0901\u0928\u0940",
+    },
+    syl: {
+        englishName: "Sylheti",
+        endonym: "\u09b8\u09bf\u09b2\u09c7\u099f\u09bf",
+    },
+    grt: { englishName: "Garo", endonym: "A\u00b7chik" },
+    skr: {
+        englishName: "Saraiki",
+        endonym: "\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc",
+    },
 };
 
 /**

--- a/packages/i18n/src/direction.ts
+++ b/packages/i18n/src/direction.ts
@@ -76,6 +76,7 @@ const RTL_LANGUAGES = new Set([
     "bal", // Balochi
     "bcc", // Southern Balochi
     "bqi", // Bakhtiari
+    "brh", // Brahui
     "ckb", // Central Kurdish
     "dv", // Divehi
     "fa", // Persian
@@ -93,6 +94,7 @@ const RTL_LANGUAGES = new Set([
     "prs", // Dari
     "ps", // Pashto
     "sd", // Sindhi
+    "skr", // Saraiki
     "ug", // Uyghur
     "ur", // Urdu
     "yi", // Yiddish

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -20,6 +20,7 @@ export type SupportedLocale =
     | "as"
     | "ast"
     | "av"
+    | "awa"
     | "ay"
     | "az"
     | "ba"
@@ -39,6 +40,7 @@ export type SupportedLocale =
     | "bn"
     | "bo"
     | "br"
+    | "brh"
     | "brx"
     | "bs"
     | "bua"
@@ -94,6 +96,7 @@ export type SupportedLocale =
     | "ga"
     | "gaa"
     | "gag"
+    | "gbm"
     | "gcf"
     | "gcr"
     | "gd"
@@ -102,6 +105,7 @@ export type SupportedLocale =
     | "glk"
     | "gn"
     | "gor"
+    | "grt"
     | "gsw"
     | "gu"
     | "ha"
@@ -109,7 +113,9 @@ export type SupportedLocale =
     | "haz"
     | "he"
     | "hi"
+    | "hif"
     | "hil"
+    | "hne"
     | "hnj"
     | "hr"
     | "hsb"
@@ -134,7 +140,9 @@ export type SupportedLocale =
     | "kbp"
     | "kca"
     | "kek"
+    | "kfy"
     | "kg"
+    | "kha"
     | "ki"
     | "kjh"
     | "kk"
@@ -172,8 +180,10 @@ export type SupportedLocale =
     | "lt"
     | "lua"
     | "luo"
+    | "lus"
     | "lv"
     | "mad"
+    | "mag"
     | "mai"
     | "mak"
     | "mdf"
@@ -197,6 +207,7 @@ export type SupportedLocale =
     | "mrw"
     | "ms"
     | "mt"
+    | "mwr"
     | "my"
     | "myv"
     | "mzn"
@@ -205,6 +216,7 @@ export type SupportedLocale =
     | "nb"
     | "nds"
     | "ne"
+    | "new"
     | "nia"
     | "niu"
     | "nl"
@@ -253,6 +265,7 @@ export type SupportedLocale =
     | "si"
     | "sjd"
     | "sk"
+    | "skr"
     | "sl"
     | "sm"
     | "sma"
@@ -271,9 +284,11 @@ export type SupportedLocale =
     | "sus"
     | "sv"
     | "sw"
+    | "syl"
     | "szl"
     | "ta"
     | "tab"
+    | "tcy"
     | "te"
     | "tem"
     | "tet"
@@ -428,6 +443,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Asturian (asturianu)",
     },
     { locale: "av", englishName: "Avaric", endonym: "Avaric", label: "Avaric" },
+    {
+        locale: "awa",
+        englishName: "Awadhi",
+        endonym: "Awadhi",
+        label: "Awadhi",
+    },
     { locale: "ay", englishName: "Aymara", endonym: "Aymara", label: "Aymara" },
     {
         locale: "az",
@@ -526,6 +547,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Breton",
         endonym: "brezhoneg",
         label: "Breton (brezhoneg)",
+    },
+    {
+        locale: "brh",
+        englishName: "Brahui",
+        endonym: "Brahui",
+        label: "Brahui",
     },
     { locale: "brx", englishName: "Bodo", endonym: "बर’", label: "Bodo (बर’)" },
     {
@@ -818,6 +845,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Gagauz",
     },
     {
+        locale: "gbm",
+        englishName: "Garhwali",
+        endonym: "गढ़वाली",
+        label: "Garhwali (गढ़वाली)",
+    },
+    {
         locale: "gcf",
         englishName: "Guadeloupean Creole French",
         endonym: "kréyòl gwadloupéyen",
@@ -866,6 +899,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Gorontalo",
     },
     {
+        locale: "grt",
+        englishName: "Garo",
+        endonym: "A·chik",
+        label: "Garo (A·chik)",
+    },
+    {
         locale: "gsw",
         englishName: "Swiss German",
         endonym: "Schwiizertüütsch",
@@ -903,10 +942,22 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Hindi (हिन्दी)",
     },
     {
+        locale: "hif",
+        englishName: "Fiji Hindi",
+        endonym: "Fiji Hindi",
+        label: "Fiji Hindi",
+    },
+    {
         locale: "hil",
         englishName: "Hiligaynon",
         endonym: "Hiligaynon",
         label: "Hiligaynon",
+    },
+    {
+        locale: "hne",
+        englishName: "Chhattisgarhi",
+        endonym: "छत्तीसगढ़ी",
+        label: "Chhattisgarhi (छत्तीसगढ़ी)",
     },
     {
         locale: "hnj",
@@ -1037,7 +1088,14 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Qʼeqchiʼ",
         label: "Qʼeqchiʼ",
     },
+    {
+        locale: "kfy",
+        englishName: "Kumaoni",
+        endonym: "कुमाउँनी",
+        label: "Kumaoni (कुमाउँनी)",
+    },
     { locale: "kg", englishName: "Kongo", endonym: "Kongo", label: "Kongo" },
+    { locale: "kha", englishName: "Khasi", endonym: "Khasi", label: "Khasi" },
     {
         locale: "ki",
         englishName: "Kikuyu",
@@ -1230,6 +1288,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Dholuo",
         label: "Luo (Dholuo)",
     },
+    { locale: "lus", englishName: "Mizo", endonym: "Mizo", label: "Mizo" },
     {
         locale: "lv",
         englishName: "Latvian",
@@ -1241,6 +1300,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Madurese",
         endonym: "Madurese",
         label: "Madurese",
+    },
+    {
+        locale: "mag",
+        englishName: "Magahi",
+        endonym: "Magahi",
+        label: "Magahi",
     },
     {
         locale: "mai",
@@ -1361,6 +1426,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Maltese (Malti)",
     },
     {
+        locale: "mwr",
+        englishName: "Marwari",
+        endonym: "Marwari",
+        label: "Marwari",
+    },
+    {
         locale: "my",
         englishName: "Burmese",
         endonym: "မြန်မာ",
@@ -1402,6 +1473,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Nepali",
         endonym: "नेपाली",
         label: "Nepali (नेपाली)",
+    },
+    {
+        locale: "new",
+        englishName: "Newari",
+        endonym: "Newari",
+        label: "Newari",
     },
     { locale: "nia", englishName: "Nias", endonym: "Nias", label: "Nias" },
     {
@@ -1657,6 +1734,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Slovak (slovenčina)",
     },
     {
+        locale: "skr",
+        englishName: "Saraiki",
+        endonym: "سرائیکی",
+        label: "Saraiki (سرائیکی)",
+    },
+    {
         locale: "sl",
         englishName: "Slovenian",
         endonym: "slovenščina",
@@ -1750,6 +1833,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Swahili (Kiswahili)",
     },
     {
+        locale: "syl",
+        englishName: "Sylheti",
+        endonym: "সিলেটি",
+        label: "Sylheti (সিলেটি)",
+    },
+    {
         locale: "szl",
         englishName: "Silesian",
         endonym: "ślōnski",
@@ -1767,6 +1856,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "tab",
         label: "Tabasaran (tab)",
     },
+    { locale: "tcy", englishName: "Tulu", endonym: "Tulu", label: "Tulu" },
     {
         locale: "te",
         englishName: "Telugu",

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -1333,10 +1333,14 @@ describe("the second South Asian batch's plural categories", () => {
     );
 
     /**
-     * The other half: all fifteen keep English's `[1]` fork in
-     * `field-function-wrong-num-outputs`, which Fluent matches against the
-     * number itself rather than against a category and which is therefore
-     * legal in a locale with no rules of its own.
+     * The other half: all fifteen keep a fork in
+     * `field-function-wrong-num-outputs`, in the one shape a locale with no
+     * plural rules can carry. English selects `$expected` on the *category*
+     * `[one]` (`locales/en/diagnostics.ftl`); each of the fifteen writes the
+     * numeric literal `[1]` in its place, which Fluent matches against the
+     * number itself rather than against a category. So the branch survives
+     * the batch's missing CLDR data instead of being collapsed away with the
+     * category forks the test above rules out.
      */
     it.each(SOUTH_ASIA)(
         "keeps %s's numeric literal, which no plural rule selects",

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -186,6 +186,24 @@ const ES = { es: esChrome };
  */
 const FIL = { fil: `${filChrome}\n${filEditor}` };
 
+/**
+ * A catalog's message bodies with its comment lines dropped. Every batch's
+ * plural-category block needs this: several headers discuss `[one]` and the
+ * other categories in prose, so a search for a branch over the raw file would
+ * match the header rather than a message.
+ */
+const branches = (catalog: string) =>
+    catalog
+        .split("\n")
+        .filter((line) => !line.trimStart().startsWith("#"))
+        .join("\n");
+
+/**
+ * One catalog as a row of a batch table: its tag, its `chrome.ftl` and its
+ * `diagnostics.ftl`, since a batch's count selects are split across the two.
+ */
+type Row = [string, string, string];
+
 describe("createChromeTranslator", () => {
     it("answers in English for the default locale", () => {
         const t = createChromeTranslator("en");
@@ -433,12 +451,6 @@ describe("EN_CHROME_TRANSLATOR", () => {
  */
 describe("the Sami plural categories", () => {
     /** Comment lines dropped: the headers discuss `[two]` in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
     it.each([
         ["sma", smaChrome],
         ["smj", smjChrome],
@@ -589,12 +601,6 @@ describe("the Oceania batch's plural categories", () => {
  */
 describe("the European regional batch's plural categories", () => {
     /** Comment lines dropped: several headers discuss the categories in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
     /** The eight CLDR has rules for. */
     const WITH_RULES: [string, string][] = [
         ["nn", nnChrome],
@@ -759,17 +765,9 @@ describe("the European regional batch's plural categories", () => {
  */
 describe("the Silk Road batch's plural categories", () => {
     /** Comment lines dropped: several headers discuss `[one]` in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
     /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
     const both = ([, chrome, diagnostics]: Row) =>
         `${branches(chrome)}\n${branches(diagnostics)}`;
-
-    type Row = [string, string, string];
 
     /** The fourteen with no CLDR rules of their own. */
     const NO_RULES: Row[] = [
@@ -991,14 +989,6 @@ describe("the Silk Road batch's plural categories", () => {
  */
 describe("the Americas batch's plural categories", () => {
     /** Comment lines dropped: several headers discuss `[one]` in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
-    type Row = [string, string, string];
-
     /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
     const both = ([, chrome, diagnostics]: Row) =>
         `${branches(chrome)}\n${branches(diagnostics)}`;
@@ -1152,14 +1142,6 @@ describe("the Americas batch's plural categories", () => {
 
 describe("the Southeast Asian batch's plural categories", () => {
     /** Comment lines dropped: several headers discuss `[one]` in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
-    type Row = [string, string, string];
-
     /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
     const both = (chrome: string, diagnostics: string) =>
         `${branches(chrome)}\n${branches(diagnostics)}`;
@@ -1266,14 +1248,6 @@ describe("the Southeast Asian batch's plural categories", () => {
 
 describe("the second South Asian batch's plural categories", () => {
     /** Comment lines dropped: several headers discuss `[one]` in prose. */
-    const branches = (catalog: string) =>
-        catalog
-            .split("\n")
-            .filter((line) => !line.trimStart().startsWith("#"))
-            .join("\n");
-
-    type Row = [string, string, string];
-
     /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
     const both = (chrome: string, diagnostics: string) =>
         `${branches(chrome)}\n${branches(diagnostics)}`;

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -85,6 +85,37 @@ import mnwChrome from "../locales/mnw/chrome.ftl?raw";
 import mnwDiagnostics from "../locales/mnw/diagnostics.ftl?raw";
 import kswChrome from "../locales/ksw/chrome.ftl?raw";
 import kswDiagnostics from "../locales/ksw/diagnostics.ftl?raw";
+// The second South Asian batch, both files, for the same reason.
+import awaChrome from "../locales/awa/chrome.ftl?raw";
+import awaDiagnostics from "../locales/awa/diagnostics.ftl?raw";
+import hneChrome from "../locales/hne/chrome.ftl?raw";
+import hneDiagnostics from "../locales/hne/diagnostics.ftl?raw";
+import magChrome from "../locales/mag/chrome.ftl?raw";
+import magDiagnostics from "../locales/mag/diagnostics.ftl?raw";
+import mwrChrome from "../locales/mwr/chrome.ftl?raw";
+import mwrDiagnostics from "../locales/mwr/diagnostics.ftl?raw";
+import gbmChrome from "../locales/gbm/chrome.ftl?raw";
+import gbmDiagnostics from "../locales/gbm/diagnostics.ftl?raw";
+import kfyChrome from "../locales/kfy/chrome.ftl?raw";
+import kfyDiagnostics from "../locales/kfy/diagnostics.ftl?raw";
+import newChrome from "../locales/new/chrome.ftl?raw";
+import newDiagnostics from "../locales/new/diagnostics.ftl?raw";
+import sylChrome from "../locales/syl/chrome.ftl?raw";
+import sylDiagnostics from "../locales/syl/diagnostics.ftl?raw";
+import tcyChrome from "../locales/tcy/chrome.ftl?raw";
+import tcyDiagnostics from "../locales/tcy/diagnostics.ftl?raw";
+import lusChrome from "../locales/lus/chrome.ftl?raw";
+import lusDiagnostics from "../locales/lus/diagnostics.ftl?raw";
+import khaChrome from "../locales/kha/chrome.ftl?raw";
+import khaDiagnostics from "../locales/kha/diagnostics.ftl?raw";
+import grtChrome from "../locales/grt/chrome.ftl?raw";
+import grtDiagnostics from "../locales/grt/diagnostics.ftl?raw";
+import skrChrome from "../locales/skr/chrome.ftl?raw";
+import skrDiagnostics from "../locales/skr/diagnostics.ftl?raw";
+import brhChrome from "../locales/brh/chrome.ftl?raw";
+import brhDiagnostics from "../locales/brh/diagnostics.ftl?raw";
+import hifChrome from "../locales/hif/chrome.ftl?raw";
+import hifDiagnostics from "../locales/hif/diagnostics.ftl?raw";
 // The Americas batch, both files for the same reason as the Silk Road's:
 // each catalog's count selects are split between `chrome.ftl` and
 // `diagnostics.ftl`, so where a category branch falls is only checkable
@@ -1230,5 +1261,101 @@ describe("the Southeast Asian batch's plural categories", () => {
         expect(t("attempts-remaining", { count: 0 })).not.toBe(
             t("attempts-remaining", { count: 3 }),
         );
+    });
+});
+
+describe("the second South Asian batch's plural categories", () => {
+    /** Comment lines dropped: several headers discuss `[one]` in prose. */
+    const branches = (catalog: string) =>
+        catalog
+            .split("\n")
+            .filter((line) => !line.trimStart().startsWith("#"))
+            .join("\n");
+
+    type Row = [string, string, string];
+
+    /** `chrome.ftl` and `diagnostics.ftl` of one catalog, comments dropped. */
+    const both = (chrome: string, diagnostics: string) =>
+        `${branches(chrome)}\n${branches(diagnostics)}`;
+
+    /**
+     * All fifteen. CLDR has plural data for none of them — which is the same
+     * finding the Southeast Asian batch reported, arriving for a region where
+     * it is much less expected: nine of these fifteen are Indo-Aryan, and
+     * `hi`, `bn`, `ur`, `mr` and `ne` beside them all have rules of their own.
+     * A tag's plural data follows whether a CLDR locale was ever requested for
+     * it, not whether its language marks number — and every one of these
+     * fifteen marks it.
+     */
+    const SOUTH_ASIA: Row[] = [
+        ["awa", awaChrome, awaDiagnostics],
+        ["hne", hneChrome, hneDiagnostics],
+        ["mag", magChrome, magDiagnostics],
+        ["mwr", mwrChrome, mwrDiagnostics],
+        ["gbm", gbmChrome, gbmDiagnostics],
+        ["kfy", kfyChrome, kfyDiagnostics],
+        ["new", newChrome, newDiagnostics],
+        ["syl", sylChrome, sylDiagnostics],
+        ["tcy", tcyChrome, tcyDiagnostics],
+        ["lus", lusChrome, lusDiagnostics],
+        ["kha", khaChrome, khaDiagnostics],
+        ["grt", grtChrome, grtDiagnostics],
+        ["skr", skrChrome, skrDiagnostics],
+        ["brh", brhChrome, brhDiagnostics],
+        ["hif", hifChrome, hifDiagnostics],
+    ];
+
+    it.each(SOUTH_ASIA)(
+        "resolves %s against some other language's rules",
+        (locale) => {
+            // CLDR has no rules for the tag, so the categories on offer belong
+            // to the runtime's default locale rather than to the language.
+            expect(new Intl.PluralRules(locale).resolvedOptions().locale) //
+                .not.toBe(locale);
+        },
+    );
+
+    /**
+     * So no catalog writes a category branch. Here that restraint costs
+     * something the Southeast Asian batch's did not: these languages *do*
+     * inflect a noun after a numeral, and their catalogs still cannot fork on
+     * one, because the branch would be selected by whatever rules the runtime
+     * fell back to rather than by the language's own.
+     */
+    it.each(SOUTH_ASIA)(
+        "gives %s no plural category branch anywhere",
+        (_locale, chrome, diagnostics) => {
+            const text = both(chrome, diagnostics);
+            for (const category of ["zero", "one", "two", "few", "many"]) {
+                expect(text).not.toContain(`[${category}]`);
+            }
+        },
+    );
+
+    /**
+     * The other half: all fifteen keep English's `[1]` fork in
+     * `field-function-wrong-num-outputs`, which Fluent matches against the
+     * number itself rather than against a category and which is therefore
+     * legal in a locale with no rules of its own.
+     */
+    it.each(SOUTH_ASIA)(
+        "keeps %s's numeric literal, which no plural rule selects",
+        (_locale, _chrome, diagnostics) => {
+            const message = branches(diagnostics)
+                .split("\nfield-function-wrong-num-outputs =")[1]
+                ?.split(/\n(?=\S)/)[0];
+            expect(message).toBeDefined();
+            expect(message).toContain("[1]");
+        },
+    );
+
+    /** And the counts still render, in Latin digits in all five scripts. */
+    it.each(SOUTH_ASIA)("still renders %s's counts", (locale, chrome) => {
+        const t = createChromeTranslator(locale, { [locale]: chrome });
+        for (const count of [1, 2, 5]) {
+            expect(
+                stripBidiIsolates(t("attempts-remaining", { count })),
+            ).toContain(String(count));
+        }
     });
 });

--- a/packages/i18n/test/direction.test.ts
+++ b/packages/i18n/test/direction.test.ts
@@ -60,6 +60,19 @@ const RTL_LANGUAGES = [
     "lrc",
     "bal",
     "haz",
+    // The second South Asian batch's two, which take the roster's
+    // right-to-left catalogs from sixteen to eighteen. Both are Perso-Arabic
+    // and both are new to `RTL_LANGUAGES` in `direction.ts`, on the same terms
+    // `bal` and `haz` were: each maximizes to `-Arab`, so the script rule
+    // already answered a parseable tag, and the entry earns its keep only on
+    // the fallback path where nothing could be parsed.
+    //
+    // `brh` is the pair worth reading beside `skr`: Brahui is Dravidian and
+    // Saraiki Indo-Aryan, and they run the same way because they are written
+    // in the same script. That is the `ug`/`yi`/`ckb` point reaching a family
+    // the roster's right-to-left half had never included.
+    "skr",
+    "brh",
 ];
 
 describe("directionOf", () => {

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -569,6 +569,11 @@ describe("negotiateLocales", () => {
             ["bo-CN", "bo"],
             ["dz-BT", "dz"],
             ["dv-MV", "dv"],
+            // The three tags this batch answers directly, each of which the
+            // block below used to assert fell to English.
+            ["kfy", "kfy"],
+            ["mag", "mag"],
+            ["grt", "grt"],
         ])("reaches %s's catalog as %s", (requested, expected) => {
             expect(
                 negotiateLocales([normalizeLocaleTag(requested)], available),
@@ -576,15 +581,21 @@ describe("negotiateLocales", () => {
         });
 
         /**
-         * The near misses. `kfy` (Kumaoni) and `mag` (Magahi) are Indo-Aryan
-         * neighbours of `mai` and `bho` that belong to no macrolanguage with a
-         * catalog; `hoc` (Ho) is Munda like Santali and is not a member of
-         * `sat`; `njz` (Nyishi) and `grt` (Garo) are Tibeto-Burman like Bodo
-         * and are not members of `brx`. All fall to English, which is the
-         * membership rule working rather than a gap in it — the moment
-         * "sounds close to" decides the map, nothing in it is checkable.
+         * The near misses. `hoc` (Ho) is Munda like Santali and is not a member
+         * of `sat`; `njz` (Nyishi) is Tibeto-Burman like Bodo and is not a
+         * member of `brx`. Both fall to English, which is the membership rule
+         * working rather than a gap in it — the moment "sounds close to"
+         * decides the map, nothing in it is checkable.
+         *
+         * This list was three entries longer before the second South Asian
+         * batch, and how the three left it is the point. `kfy` (Kumaoni),
+         * `mag` (Magahi) and `grt` (Garo) were listed here as neighbours of
+         * `mai`, `bho` and `brx` that the map declined to fold onto them; each
+         * now has a catalog of its own and is asserted against it just above.
+         * Nothing about `MACROLANGUAGE_MEMBERS` changed to let them through —
+         * the way off this list is a directory, not an entry in the map.
          */
-        it.each(["kfy", "mag", "hoc", "njz", "grt"])(
+        it.each(["hoc", "njz"])(
             "leaves %s on English rather than folding it onto a neighbour",
             (requested) => {
                 expect(

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65443,6 +65443,10 @@
                             "description": "Avaric"
                         },
                         {
+                            "value": "awa",
+                            "description": "Awadhi"
+                        },
+                        {
                             "value": "ay",
                             "description": "Aymara"
                         },
@@ -65517,6 +65521,10 @@
                         {
                             "value": "br",
                             "description": "Breton (brezhoneg)"
+                        },
+                        {
+                            "value": "brh",
+                            "description": "Brahui"
                         },
                         {
                             "value": "brx",
@@ -65739,6 +65747,10 @@
                             "description": "Gagauz"
                         },
                         {
+                            "value": "gbm",
+                            "description": "Garhwali (गढ़वाली)"
+                        },
+                        {
                             "value": "gcf",
                             "description": "Guadeloupean Creole French (kréyòl gwadloupéyen)"
                         },
@@ -65771,6 +65783,10 @@
                             "description": "Gorontalo"
                         },
                         {
+                            "value": "grt",
+                            "description": "Garo (A·chik)"
+                        },
+                        {
                             "value": "gsw",
                             "description": "Swiss German (Schwiizertüütsch)"
                         },
@@ -65799,8 +65815,16 @@
                             "description": "Hindi (हिन्दी)"
                         },
                         {
+                            "value": "hif",
+                            "description": "Fiji Hindi"
+                        },
+                        {
                             "value": "hil",
                             "description": "Hiligaynon"
+                        },
+                        {
+                            "value": "hne",
+                            "description": "Chhattisgarhi (छत्तीसगढ़ी)"
                         },
                         {
                             "value": "hnj",
@@ -65899,8 +65923,16 @@
                             "description": "Qʼeqchiʼ"
                         },
                         {
+                            "value": "kfy",
+                            "description": "Kumaoni (कुमाउँनी)"
+                        },
+                        {
                             "value": "kg",
                             "description": "Kongo"
+                        },
+                        {
+                            "value": "kha",
+                            "description": "Khasi"
                         },
                         {
                             "value": "ki",
@@ -66051,12 +66083,20 @@
                             "description": "Luo (Dholuo)"
                         },
                         {
+                            "value": "lus",
+                            "description": "Mizo"
+                        },
+                        {
                             "value": "lv",
                             "description": "Latvian (latviešu)"
                         },
                         {
                             "value": "mad",
                             "description": "Madurese"
+                        },
+                        {
+                            "value": "mag",
+                            "description": "Magahi"
                         },
                         {
                             "value": "mai",
@@ -66151,6 +66191,10 @@
                             "description": "Maltese (Malti)"
                         },
                         {
+                            "value": "mwr",
+                            "description": "Marwari"
+                        },
+                        {
                             "value": "my",
                             "description": "Burmese (မြန်မာ)"
                         },
@@ -66181,6 +66225,10 @@
                         {
                             "value": "ne",
                             "description": "Nepali (नेपाली)"
+                        },
+                        {
+                            "value": "new",
+                            "description": "Newari"
                         },
                         {
                             "value": "nia",
@@ -66375,6 +66423,10 @@
                             "description": "Slovak (slovenčina)"
                         },
                         {
+                            "value": "skr",
+                            "description": "Saraiki (سرائیکی)"
+                        },
+                        {
                             "value": "sl",
                             "description": "Slovenian (slovenščina)"
                         },
@@ -66447,6 +66499,10 @@
                             "description": "Swahili (Kiswahili)"
                         },
                         {
+                            "value": "syl",
+                            "description": "Sylheti (সিলেটি)"
+                        },
+                        {
                             "value": "szl",
                             "description": "Silesian (ślōnski)"
                         },
@@ -66457,6 +66513,10 @@
                         {
                             "value": "tab",
                             "description": "Tabasaran (tab)"
+                        },
+                        {
+                            "value": "tcy",
+                            "description": "Tulu"
                         },
                         {
                             "value": "te",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -5214,3 +5214,139 @@ describe("the Southeast Asian batch's word order", () => {
         expect(dashOf("mak")).toBe("tappolo-polo");
     });
 });
+
+describe("the second South Asian batch's word order", () => {
+    /**
+     * Fifteen languages of South Asia and its diaspora, and this batch's split
+     * is the Southeast Asian one's arithmetic reversed: thirteen catalogs put
+     * the modifiers in front of the noun and two put them behind. Thirteen to
+     * two is not itself interesting — most of South Asia is left-branching, and
+     * the ten Indo-Aryan catalogs here inherit Hindi's order along with much of
+     * their technical vocabulary.
+     *
+     * What is interesting is *which* two, because the line does not fall where
+     * a reader would draw it. `kha` (Khasi) and `lus` (Mizo) are the two, and
+     * `grt` (Garo) — seeded in the same batch, spoken in the same state as
+     * Khasi, and Tibeto-Burman like Mizo — is on the other side. So neither
+     * family nor geography predicts the split: Meghalaya writes it both ways,
+     * and the two Tibeto-Burman catalogs disagree with each other. Khasi is
+     * Austroasiatic and head-initial like its relatives further east; Mizo puts
+     * its attributives behind the noun; Garo's `-gipa` attributive precedes it.
+     * Three neighbours, three answers.
+     *
+     * The other row worth reading twice is `brh` (Brahui), which is Dravidian
+     * and sits among twelve Indo-Aryan and Tibeto-Burman catalogs writing the
+     * same order as all of them. Head-final order is areal here rather than
+     * genetic, which is the same lesson `cbk` taught from the opposite
+     * direction in the Southeast Asian batch: a phrase's order follows the
+     * neighbourhood, not the family tree or the lexicon.
+     *
+     * `tcy` (Tulu) is Dravidian too and prenominal for the same areal reason,
+     * so the two Dravidian catalogs of this batch agree with the Indo-Aryan
+     * ones and with each other while the two Tibeto-Burman ones do not.
+     *
+     * Every one of the fifteen keeps English's internal sequence of the three
+     * adjectives — width, dash pattern, colour — so what moves in a
+     * postnominal catalog is the noun alone. Nothing here is welded to a
+     * placeable: none of the fifteen writes a linker between modifier and noun
+     * at all, which is why this batch never reaches the README's affix rule
+     * that `pag`'s and `tsg`'s ligatures came so close to.
+     */
+    const prenominal: [string, string][] = [
+        ["awa", "मोट खंडित लाल"],
+        ["hne", "मोट खंडित लाल"],
+        ["mag", "मोट खंडित लाल"],
+        ["mwr", "मोटो खंडित लाल"],
+        ["gbm", "मोटु खंडित लाल"],
+        ["kfy", "मोटो खंडित लाल"],
+        ["new", "बाक्लो धर्के ह्याउँ"],
+        ["syl", "মোটা দাগ-দাগ লাল"],
+        ["tcy", "ದಪ್ಪ ತುಂಡು ತುಂಡುದ ಕೆಂಪು"],
+        ["grt", "dal·gipa dashgipa gitchak"],
+        ["skr", "موٹی منقطع لال"],
+        ["brh", "دبیز خط چین سرخ"],
+        ["hif", "mota dash waala laal"],
+    ];
+
+    const nounOf: Record<string, string> = {
+        awa: "रेखा",
+        hne: "रेखा",
+        mag: "रेखा",
+        mwr: "रेखा",
+        gbm: "रेखा",
+        kfy: "रेखा",
+        new: "रेखा",
+        syl: "রেখা",
+        tcy: "ಗೆರೆ",
+        grt: "lain",
+        skr: "لکیر",
+        brh: "خط",
+        hif: "lakiir",
+    };
+
+    for (const [locale, adjectivesOnly] of prenominal) {
+        it(`puts ${locale}'s adjectives in front of the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: false }),
+            ).toBe(adjectivesOnly);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: true }),
+            ).toBe(`${adjectivesOnly} ${nounOf[locale]}`);
+        });
+    }
+
+    const postnominal: [string, string, string][] = [
+        ["kha", "lain bakhraw badash basaw", "bakhraw badash basaw"],
+        ["lus", "line lian dash-nei sen", "lian dash-nei sen"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
+        it(`puts ${locale}'s adjectives after the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: true }),
+            ).toBe(withNoun);
+            expect(
+                describeStrokedShape(t, words, { noun: line, withNoun: false }),
+            ).toBe(adjectivesOnly);
+            // The description is the tail of the phrase verbatim: the noun
+            // moved and nothing else did.
+            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
+        });
+    }
+
+    /**
+     * The one catalog of the fifteen that agrees its adjectives, held from both
+     * sides. Saraiki keeps Indo-Aryan's marked adjective classes, so `موٹی`
+     * is feminine before the feminine `لکیر` and `موٹا` masculine before a
+     * masculine noun — the fork English ignores, selected on `noun-gender`'s
+     * own answer. The other fourteen write one invariant form: Brahui and Tulu
+     * have no adjective agreement to lose, Fiji Hindi levelled Hindi's away,
+     * and in the rest it is a stated gap in the seed rather than a claim about
+     * the language.
+     */
+    it("agrees skr's adjectives with the noun and no other catalog's", () => {
+        const skr = forLocale("skr");
+        const feminine = describeStrokedShape(skr, words, {
+            noun: line,
+            withNoun: true,
+        });
+        const masculine = describeStrokedShape(skr, words, {
+            noun: { key: "point" },
+            withNoun: true,
+        });
+        expect(feminine).toContain("موٹی");
+        expect(masculine).toContain("موٹا");
+
+        for (const locale of ["brh", "hif", "tcy", "awa"]) {
+            const t = forLocale(locale);
+            const width = (noun: NounKey) =>
+                describeStrokedShape(t, words, {
+                    noun: { key: noun },
+                    withNoun: true,
+                }).split(" ")[0];
+            expect(width("line")).toBe(width("point"));
+        }
+    });
+});

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -5221,7 +5221,7 @@ describe("the second South Asian batch's word order", () => {
      * is the Southeast Asian one's arithmetic reversed: thirteen catalogs put
      * the modifiers in front of the noun and two put them behind. Thirteen to
      * two is not itself interesting — most of South Asia is left-branching, and
-     * the ten Indo-Aryan catalogs here inherit Hindi's order along with much of
+     * the nine Indo-Aryan catalogs here inherit Hindi's order along with much of
      * their technical vocabulary.
      *
      * What is interesting is *which* two, because the line does not fall where
@@ -5229,7 +5229,8 @@ describe("the second South Asian batch's word order", () => {
      * `grt` (Garo) — seeded in the same batch, spoken in the same state as
      * Khasi, and Tibeto-Burman like Mizo — is on the other side. So neither
      * family nor geography predicts the split: Meghalaya writes it both ways,
-     * and the two Tibeto-Burman catalogs disagree with each other. Khasi is
+     * and Garo and Mizo, the batch's two Tibeto-Burman catalogs of Northeast
+     * India, disagree with each other. Khasi is
      * Austroasiatic and head-initial like its relatives further east; Mizo puts
      * its attributives behind the noun; Garo's `-gipa` attributive precedes it.
      * Three neighbours, three answers.
@@ -5243,7 +5244,7 @@ describe("the second South Asian batch's word order", () => {
      *
      * `tcy` (Tulu) is Dravidian too and prenominal for the same areal reason,
      * so the two Dravidian catalogs of this batch agree with the Indo-Aryan
-     * ones and with each other while the two Tibeto-Burman ones do not.
+     * ones and with each other while Garo and Mizo do not agree with each other.
      *
      * Every one of the fifteen keeps English's internal sequence of the three
      * adjectives — width, dash pattern, colour — so what moves in a
@@ -5282,6 +5283,11 @@ describe("the second South Asian batch's word order", () => {
         skr: "لکیر",
         brh: "خط",
         hif: "lakiir",
+        // The two postnominal catalogs' nouns, used below to assert that the
+        // noun is what moved: the full phrase must be exactly the noun, a
+        // space, and the bare description.
+        kha: "lain",
+        lus: "line",
     };
 
     for (const [locale, adjectivesOnly] of prenominal) {
@@ -5304,15 +5310,22 @@ describe("the second South Asian batch's word order", () => {
     for (const [locale, withNoun, adjectivesOnly] of postnominal) {
         it(`puts ${locale}'s adjectives after the noun`, () => {
             const t = forLocale(locale);
-            expect(
-                describeStrokedShape(t, words, { noun: line, withNoun: true }),
-            ).toBe(withNoun);
-            expect(
-                describeStrokedShape(t, words, { noun: line, withNoun: false }),
-            ).toBe(adjectivesOnly);
-            // The description is the tail of the phrase verbatim: the noun
-            // moved and nothing else did.
-            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
+            const rendered = describeStrokedShape(t, words, {
+                noun: line,
+                withNoun: true,
+            });
+            const renderedBare = describeStrokedShape(t, words, {
+                noun: line,
+                withNoun: false,
+            });
+            expect(rendered).toBe(withNoun);
+            expect(renderedBare).toBe(adjectivesOnly);
+            // The bare description is the tail of the full phrase verbatim:
+            // the noun moved to the front and nothing else moved with it.
+            // Asserted on what the catalog rendered, not on the two literals
+            // above, so a catalog that reordered an adjective while keeping
+            // both expectations self-consistent would still fail here.
+            expect(rendered).toBe(`${nounOf[locale]} ${renderedBare}`);
         });
     }
 


### PR DESCRIPTION
Seeds unreviewed machine-generated message catalogs for fifteen more languages of South Asia and its diaspora, taking the roster from 316 locales to 331.

| Tags | Region | Script |
| --- | --- | --- |
| `awa` `hne` `mag` `mwr` `gbm` `kfy` | Hindi belt, Rajasthan, Uttarakhand | Devanagari |
| `new` | Nepal | Devanagari |
| `syl` | Sylhet | Bengali |
| `tcy` | coastal Karnataka | Kannada |
| `lus` `kha` `grt` | Northeast India | Latin |
| `skr` `brh` | Pakistan | Perso-Arabic, **right to left** |
| `hif` | Fiji | Latin |

Every catalog sits at **445/575 keys** — the whole catalog minus the two chemistry tables — and every file's header says it is an unreviewed seed pending review by a speaker (#1521) and names where it is weakest.

## What is in the diff beyond the catalogs

- `src/direction.ts` — `skr` and `brh` join `RTL_LANGUAGES`, on the same terms `bal` and `haz` did: both maximize to `-Arab`, so the entries earn their keep on the fallback path where a tag cannot be parsed at all. The roster's right-to-left catalogs go from sixteen to eighteen.
- `scripts/catalogUtils.ts` — `LOCALE_NAME_FALLBACKS` gains the six tags CLDR has no name for (`hne`, `gbm`, `kfy`, `syl`, `grt`, `skr`), each with an endonym in the script its catalog is written in. The other nine are named by ICU.
- `src/generated/supportedLocales.ts` and `packages/static-assets/src/generated/doenet-schema.json` — regenerated, so `<document lang>` autocompletes all fifteen.
- `test/negotiate.test.ts` — `kfy`, `mag` and `grt` were asserted there as *near misses* that the membership rule declined to fold onto `mai`, `bho` and `brx`. All three now have catalogs and are asserted against them; `hoc` and `njz` stay behind holding the original point. `MACROLANGUAGE_MEMBERS` and `LANGUAGE_ALIASES` are untouched — the way off that list is a directory, not an entry in the map.
- `test/direction.test.ts`, `test/chrome.test.ts`, `packages/utils/test/styleDescriptions.test.ts` — the batch's direction, plural-category and word-order claims, pinned.
- `packages/i18n/README.md` — the roster list, the partial-catalog count (238 → 253), the chemistry rationale for these fifteen, and a batch section.

## What the batch actually shows

**Word order splits thirteen against two, and the two are neighbours.** Thirteen catalogs put the adjectives in front of the noun; `kha` and `lus` put them behind. `grt` does not join them — Khasi and Garo are spoken in the same state, Garo and Mizo are both Tibeto-Burman, and neither family nor geography predicts the row. `brh` makes the same point from the other side: Dravidian, Indo-Aryan neighbours, their order.

**One catalog agrees its adjectives.** `skr` forks on `$gender` and `$role` in `locales/ur`'s shape. Eight of the other fourteen have no attributive agreement to lose, which their `noun-gender` token reports honestly; six (`awa`, `hne`, `mag`, `mwr`, `gbm`, `kfy`) do inflect and write it unagreed, which each header names as the file's largest defect — a confidently wrong gender table is harder to repair than a uniformly unagreed one.

**Most of what these files translate is the frame.** Nine of the fifteen are Indo-Aryan languages with no medium of secondary education and so no technical register of their own, and Newar — Sino-Tibetan, not Indo-Aryan — is in the same position with Nepali in the loan role. The nouns are Hindi, Bengali, Nepali or Urdu loans and the grammar around them is the language. Every header declares that rather than leaving it to be discovered.

**No CLDR plural data for any of the fifteen**, so no catalog writes a plural category branch — and unlike the last batch, that restraint costs something: all fifteen of these languages do mark number after a numeral.

## Review pass

### First pass

A second commit corrects everything in the seed whose header claimed something the messages did not do, which is the defect a batch of hand-written headers is most likely to carry:

- **`field-function-wrong-num-outputs`.** Five headers, the README and `chrome.test.ts` said the `[1]` branch "stays where English has it". English selects that message on the plural *category* `[one]` (`locales/en/diagnostics.ftl:351`); the catalogs substitute the numeric literal. Restated as the substitution it is — which is also the reason the branch survives having no CLDR plural data at all, where the category forks could not.
- **Counted messages.** Six headers said a message "collapses to a single `*[other]`" where the catalog in fact drops the `$count` selector outright, and four cited `attempts-remaining`'s `[0]` as living in `editor.ftl` rather than `chrome.ftl`.
- **`new/chrome.ftl`** illustrated Ranjana with four Khojki codepoints (U+11230 U+11234 U+1121C U+11230) and credited Ranjana with a Unicode block; the encoded Newar script is Newa, U+11400–U+1147F.
- **`kha/content.ftl`** said no article is placed anywhere in the file — thirteen values carry a lexicalized «ki» or «ka» — and that every style word wears its «ba-», when eight of the twelve colours are «rong»-prefixed loans. `ba iaid` in four `fill-style` values is now `ba ïaid`, the spelling the header's own convention declares.
- **Smaller factual corrections:** the wrong language named in `hne`'s and `mag`'s content headers; "128 messages" for a 130-message gap in three; "three words" listing four in two; `border-clause` for `style-border-clause`; `tcy`'s ಬೊಕ್ಕ / `piecewise-condition-or` shared-root claim (the two share nothing, and the message is in the same file); `syl`'s five-to-eight colour split (four); `grt`'s "the other two catalogs of its own batch" (twelve of the other fourteen agree with it); `skr`'s «لال» listed among the words that force the `$gender` fork when it is one of the eight unmarked ones; quoted frame words written nowhere in the catalog (`new` «यानातःगु», `syl` «দিয়া»); and `नितिं` once in `new/diagnostics.ftl` against `निंतिं` in fifty other places.

**README (first pass).** Newar is Sino-Tibetan, so the batch's Indo-Aryan count is nine, not ten. The `$gender` bullet said "three cases" over a list of eight languages. `grt` maximizes to `grt-Beng-IN` while its catalog is written in Latin, so `hif` is not the only tag in the batch reaching the right direction off the wrong script — both are now named. `hif`'s claim is stated by two of its four headers, not by "both".

**Test quality.** `styleDescriptions.test.ts`'s postnominal check ended with `expect(withNoun.endsWith(adjectivesOnly)).toBe(true)` over two *table literals*, asserting a property of the hardcoded expectations rather than of anything a catalog rendered. It now asserts the rendered phrase is exactly the noun plus the rendered bare description, so a catalog that reordered an adjective while keeping both expectations self-consistent would fail. The other new tests hold real claims and are left as they are.

### Second pass

A third commit re-ran the same check as a script rather than by reading — every
«…»-quoted string in every header of all sixty files, compared case-insensitively
against the message bodies of that locale — and found five more headers quoting a
word the catalog does not write:

- **`hif/chrome.ftl`** gave the `-o` imperative as («karo», «dekho», «chuno»).
  «karo» and «chuno» are there; «dekho» is written nowhere — the catalog writes
  «dekhao».
- **`skr/chrome.ftl`** illustrated the retroflex **ݨ** with «کرݨ», «ڋکھاوݨ». The
  second appears nowhere; the catalog writes «ڋکھاؤ». Cited «کھولݨ», which it
  writes, instead.
- **`grt/chrome.ftl`** and **`grt/diagnostics.ftl`** cited six verbs as «baha·a»,
  «rakki·a», «chesot·a», «nik·a», «dongat·a», «ra·kat·a». The catalog writes those
  stems with no raka before the `-a` — `bahaenga`, `Rakkiaha`, `chesotbo`, `nika`,
  `dongatbo`, `ra·katbo` — so a reader following the same paragraph's "a search for
  `·` finds every one of them" finds none of these six. This is the batch's
  characteristic defect at its sharpest: the header invents an orthography for the
  words it is citing as evidence of the orthography.
- **`mag/chrome.ftl`** and **`mag/diagnostics.ftl`** listed «लिखल» among the eastern
  `-ल` participles. The catalog writes लिखा / लिखू / लिखे and no `लिखल`; replaced
  with «रहल», which it writes 54 times.

**README.** The chemistry paragraph said thirteen catalogs are "the school-system
case in six mediums" over a list of five — Hindi, Nepali, Bengali, English, Urdu —
which is the count the changeset already states correctly.

**What the pass checked and found clean**, so a later reader does not repeat it:
every backticked message key named in a header exists in the file the header names
(`attempts-remaining` in `chrome.ftl` and `tcy`'s `slider-next` are all correctly
attributed); all fifteen sit at 445/575 with 130 falling back, as their headers say;
each catalog writes exactly one `[0]` and one `[1]` and no category branch; the
per-catalog colour splits (`kha` 4/8, `syl` 4/8, `tcy` 6/6, `new` 5/7, `lus` 5/7,
`grt` 3/9, `hif` 6/6) each add to twelve; ICU names exactly the nine tags the README
claims and none of the six with `LOCALE_NAME_FALLBACKS` entries; the roster holds 331
locales and 253 partial catalogs, of which the enumerated list is 251; eighteen
right-to-left catalogs; `skr` is the only one of the fifteen with a `$gender` or
`$role` select; no non-ASCII digit in any of the sixty files; and the declared frame
markers do not cross between the six Devanagari catalogs — `awa`'s «अहै» / «नाहीं» /
«खातिर», `hne`'s «नइ» / «मन», `mag`'s «हइ» / «लेल» each appear in their own catalog
and no other, so nothing was copy-pasted between the close neighbours.

### Third pass

A fourth commit checked the messages themselves rather than the headers, by
script: every catalog's placeable set against English's (no message drops a
variable English interpolates), placeable spacing (`{ $x }` throughout, no tight
brace anywhere in the sixty files), bracket and guillemet balance per value,
ellipsis spelling (all fifteen write the ASCII `...` English writes, none an
`…`), and the two right-to-left catalogs' punctuation against `locales/ur`'s —
`skr` and `brh` write `،`, `؛` and `۔` where Urdu does, and their ASCII periods
are all Fluent attribute names. All clean; no message changed.

Two things did change, both outside `locales/`:

- **`scripts/catalogUtils.ts`.** The six new endonyms were the only entries in
  `LOCALE_NAME_FALLBACKS` written as `\u` escapes; the roughly hundred non-Latin
  endonyms already there (`mnw`'s ဘာသာမန်, `lbe`'s лакку маз) are literal text.
  A table whose purpose is that a human can check a name by reading it should
  not hide छत्तीसगढ़ी behind six codepoints, so they are written out. The strings
  are byte-identical and `codegen` reproduces `supportedLocales.ts` unchanged.
- **`test/chrome.test.ts`.** The comment-stripping `branches` helper had six
  byte-identical copies and `type Row` four, one pair per seeding batch, and
  this PR added the sixth and fourth. Both hoisted to module scope. The two
  `both` variants stay local — they take different arguments, and unifying them
  would only move the difference to eight call sites.

## Verification

`npm run lint:i18n` (575 keys × 331 locales), `@doenet/i18n`'s suite (1954 tests), `packages/utils`' `styleDescriptions.test.ts` (565), `@doenet/lsp-tools` (658), `npm run prettier:check`, and `build:schema` with the regenerated schema committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M6tEfZdHZR9sfcCEU1Vsc


