### PR TITLE
Seed catalogs for Chiga and Soga, and record thirteen that could not be seeded

### DIFF
--- a/.changeset/seed-east-african-catalogs.md
+++ b/.changeset/seed-east-african-catalogs.md
@@ -13,15 +13,17 @@ buttons, editor chrome and diagnostics in that language instead of falling
 back to English, and `<document lang>` autocompletes both from CLDR's own
 names.
 
-Both sit at 440/575 keys rather than the 445 recent batches reach. The two
+Both sit at 439/575 keys rather than the 445 recent batches reach. The two
 chemistry element tables are left out for the school-system reason — Uganda
 teaches science in English from upper primary, so the fallback is the language
-the periodic table is actually taught in — and five further keys are left out
+the periodic table is actually taught in — and six further keys are left out
 deliberately: the three remaining chemistry prose messages, so the chemistry
 group falls back entire rather than appearing half in Rukiga and half in
-English inside one sentence, and `noun.slope-field` and `noun.vector-field`,
-where neither language has a term and a phrase would have been the seed's
-invention rather than a word.
+English inside one sentence; `noun.slope-field` and `noun.vector-field`, where
+neither language has a term and a phrase would have been the seed's invention
+rather than a word; and `noun.rectangle`, where the descriptive phrase either
+language would use means *four-sided figure* and so names a quadrilateral, not
+a rectangle.
 
 Both are written in Latin script, left to right, with the initial vowel — the
 augment — written as part of the word, so a line is «omurongo» and
@@ -46,7 +48,7 @@ This batch was assembled as **fifteen** languages of Kenya, Uganda and
 Tanzania and thirteen were left out rather than shipped: Kamba, Gusii,
 Kalenjin, Luyia, Masai, Meru, Samburu, Taita, Embu, Teso, Shambala, Vunjo and
 Machame. Attempted honestly they came to between 0 and 91 keys of 575 — against
-the 440 the two that ship reach — and they are recorded on #1655 with the
+the 439 the two that ship reach — and they are recorded on #1655 with the
 coverage each reached and the orthography each attempt settled. `lint:i18n`
 does not report them at all, because no catalog for them exists to be partial;
 a document declaring one of the thirteen renders in English exactly as it did

--- a/.changeset/seed-east-african-catalogs.md
+++ b/.changeset/seed-east-african-catalogs.md
@@ -33,9 +33,11 @@ render the dash pattern as an associative phrase — «na tucweka», «n'obutund
 — which cannot sit between two adjectives, so both read width, colour, then
 pattern.
 
-CLDR has plural rules for both, and both branches do visible work: number is
-marked by the class prefix rather than by a suffix, so «ekirikuruga» and
-«ebirikuruga» differ at the front of the word.
+CLDR has plural rules for both, and the class prefix does the marking rather
+than a suffix, so «ekirikuruga» and «ebirikuruga» differ at the front of the
+word rather than the end. Where the counted noun is one that does not inflect
+— a Lusoga class-15 verbal noun — the two branches are the same string and the
+header says so rather than coining a countable noun to hide it.
 
 This batch was assembled as **fifteen** languages of Kenya, Uganda and
 Tanzania and thirteen were left out rather than shipped: Kamba, Gusii,

--- a/.changeset/seed-east-african-catalogs.md
+++ b/.changeset/seed-east-african-catalogs.md
@@ -35,14 +35,17 @@ pattern.
 
 CLDR has plural rules for both, and the class prefix does the marking rather
 than a suffix, so «ekirikuruga» and «ebirikuruga» differ at the front of the
-word rather than the end. Where the counted noun is one that does not inflect
-— a Lusoga class-15 verbal noun — the two branches are the same string and the
-header says so rather than coining a countable noun to hide it.
+word rather than the end. Not every noun does: a class 9/10 noun is spelt the
+same in both numbers and the number shows on what agrees with it instead, and
+where the counted noun is one that does not inflect at all — a Lusoga class-15
+verbal noun — the two branches are the same string. Each header says which of
+the three its counted selects are doing rather than coining a countable noun
+to hide it.
 
 This batch was assembled as **fifteen** languages of Kenya, Uganda and
 Tanzania and thirteen were left out rather than shipped: Kamba, Gusii,
 Kalenjin, Luyia, Masai, Meru, Samburu, Taita, Embu, Teso, Shambala, Vunjo and
-Machame. Seeded honestly they came to between 0 and 91 keys of 575 — against
+Machame. Attempted honestly they came to between 0 and 91 keys of 575 — against
 the 440 the two that ship reach — and they are recorded on #1655 with the
 coverage each reached and the orthography each attempt settled. `lint:i18n`
 does not report them at all, because no catalog for them exists to be partial;

--- a/.changeset/seed-east-african-catalogs.md
+++ b/.changeset/seed-east-african-catalogs.md
@@ -1,0 +1,59 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for two Bantu languages of Uganda: Chiga
+(`cgg`, Rukiga) and Soga (`xog`, Olusoga). A document declaring either now
+renders its style descriptions, section headings, boolean words, answer
+buttons, editor chrome and diagnostics in that language instead of falling
+back to English, and `<document lang>` autocompletes both from CLDR's own
+names.
+
+Both sit at 440/575 keys rather than the 445 recent batches reach. The two
+chemistry element tables are left out for the school-system reason — Uganda
+teaches science in English from upper primary, so the fallback is the language
+the periodic table is actually taught in — and five further keys are left out
+deliberately: the three remaining chemistry prose messages, so the chemistry
+group falls back entire rather than appearing half in Rukiga and half in
+English inside one sentence, and `noun.slope-field` and `noun.vector-field`,
+where neither language has a term and a phrase would have been the seed's
+invention rather than a word.
+
+Both are written in Latin script, left to right, with the initial vowel — the
+augment — written as part of the word, so a line is «omurongo» and
+«olunyiriri» rather than «murongo» and «lunyiriri». Both put a describing word
+after its noun and agree it with the noun's class rather than with a gender,
+so `$gender` carries a class token: five classes in Soga and five in Chiga.
+Neither keeps English's order of the three style adjectives, because both
+render the dash pattern as an associative phrase — «na tucweka», «n'obutundu»
+— which cannot sit between two adjectives, so both read width, colour, then
+pattern.
+
+CLDR has plural rules for both, and both branches do visible work: number is
+marked by the class prefix rather than by a suffix, so «ekirikuruga» and
+«ebirikuruga» differ at the front of the word.
+
+This batch was assembled as **fifteen** languages of Kenya, Uganda and
+Tanzania and thirteen were left out rather than shipped: Kamba, Gusii,
+Kalenjin, Luyia, Masai, Meru, Samburu, Taita, Embu, Teso, Shambala, Vunjo and
+Machame. Seeded honestly they came to between 0 and 91 keys of 575 — against
+the 440 the two that ship reach — and they are recorded on #1655 with the
+coverage each reached and the orthography each attempt settled. `lint:i18n`
+does not report them at all, because no catalog for them exists to be partial;
+a document declaring one of the thirteen renders in English exactly as it did
+before.
+
+These two are machine-generated seeds pending review by speakers (#1521), and
+each file's header says so and names where it is weakest. Both name the loan
+language they keep openly — English, not Swahili — and both name a near
+relative already on this roster as the first thing a reviewer should hunt for:
+Luganda intrusion in Soga, which is catchable because Lusoga writes `dh` where
+Luganda writes `z` or `j`, and Ankole rather than Kigezi vocabulary in Chiga,
+which is not catchable by a rule and so is stated as a question instead.
+
+Numbers written into a message render in Latin digits in both, so a digit
+inside a sentence matches the count formatted beside it.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -4058,10 +4058,9 @@ record — a speaker doing mathematics does it in English and does not
 Navajo-ize *polygon*, so writing «pálagan» produces English respelled.
 
 The batch was chosen because East Africa looked like the other half of that
-rule. Swahili has a real published technical register and `locales/sw` is one
-of the roster's more complete catalogs, elements included; Swahili loans in
-these languages are nativized by rule rather than ad hoc, and CLDR's own `ksb`
-data shows it — Swahili `r` becomes Shambaa `l` («Januali», «Aplili»), and the
+rule. Swahili has a real published technical register and `locales/sw` is at
+560/575, elements included; Swahili loans in these languages are nativized by
+rule rather than ad hoc, and CLDR's own `ksb` data shows it — Swahili `r` becomes Shambaa `l` («Januali», «Aplili»), and the
 two Chaga varieties palatalize before a front vowel («Aprilyi», «Junyi»). The
 frame was there, the loans were attested, and the adaptation was mechanical.
 
@@ -4074,15 +4073,24 @@ it reads as translation to a tool, as noise to a speaker, and a reviewer's
 first job is deleting it.
 
 So the finding is a **third case**, and the rule above needs it. The Americas
-case is *no register exists*. The `sgh` and `kl` case is *a register exists
-and recording it records something real* — a Shughni speaker reads a compiler
-error in Tajik, and the catalog keeps Tajik words in a Shughni frame. The case
-this batch found is *a register exists, and it is a language that already has
-a catalog on this roster*. There, recording it adds nothing a reader did not
-already have: a Gusii pupil who meets *vector* in English or in Swahili can be
-served `locales/en` or `locales/sw`, and «egetokeso» serves them worse than
-either. The test is not whether a loan register exists. It is **whether
-recording it tells the reader something the fallback did not.**
+case is *no register exists*. The `sgh` and `kl` case is *a register speakers
+actually use exists* — a Shughni speaker reads a compiler error in Tajik, so a
+catalog that keeps Tajik words in a Shughni frame records something that
+happens. The case this batch found is *the register is derivable rather than
+attested*: nothing says a Gusii speaker calls a vector «egetokeso», and what
+the rewrite produces is Swahili with a sound law applied — a rule recorded in
+place of a usage.
+
+The tempting place to draw that line is whether the lending language already
+has a catalog here, and **that line does not hold**: Tajik, Russian and Danish
+all have catalogs on this roster too, and `sgh` and `kl` are the cases that
+work. What the roster changes is the cost of getting it wrong rather than the
+test. A Gusii pupil who meets *vector* in English or in Swahili can ask for
+`locales/en` or `locales/sw` and be answered in a register they have actually
+met, so a catalog of invented Gusii loans serves them worse than either. The
+test is not whether a loan register exists, and it is not whether the lender
+is on the roster. It is **whether recording it tells the reader something the
+fallback did not.**
 
 #### `diagnostics.ftl` is where the question gets decided
 
@@ -4112,14 +4120,16 @@ reason — its `chrome.ftl` is empty because verbs are where the two languages
 part company and verbs are what every button is made of.
 
 What separates the two catalogs that ship is not distance from their sibling
-but a **checkable rule** for telling them apart. Lusoga and Luganda differ by
+either — `cgg` sits closer to `nyn` than `ebu` does to `ki`. It is whether the
+catalog can **state the seam** it has to be reviewed across. Lusoga and Luganda
+differ by
 a systematic correspondence — Lusoga writes `dh` where Luganda writes `z` or
 `j` («amaadhi», «okwidha») — so a Luganda word that has drifted into
 `locales/xog` can be caught by looking at it, and the catalog's header names
 Luganda intrusion as the first thing a reviewer should hunt for. Rukiga and
 Runyankore have no such rule, sharing one written standard and one dictionary,
-so `locales/cgg` states the question instead: of each word, is it current in
-Kigezi or only in Ankole? Where a difference is known the Kigezi form is
+so `locales/cgg` cannot offer a rule and states the question instead: of each
+word, is it current in Kigezi or only in Ankole? Where a difference is known the Kigezi form is
 written — «eibara» for *name*, where Runyankore says «eiziina». A seam a
 catalog can state is one a reviewer can work; a seam it cannot state is where
 `ebu` stopped.
@@ -4142,7 +4152,7 @@ entire rather than appearing half in Rukiga and half in English inside one
 sentence. The other two are `noun.slope-field` and `noun.vector-field`, where
 neither language has a term and a descriptive phrase would have been the
 seed's own invention rather than a word — the same judgement `locales/iu`
-makes across the whole `noun` table, at a twentieth of the scale.
+makes across the whole `noun` table, two keys against its twenty.
 
 #### Two smaller things
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -4025,13 +4025,14 @@ The batch was assembled as **fifteen** — Kamba (`kam`), Gusii (`guz`),
 Kalenjin (`kln`), Luyia (`luy`), Masai (`mas`), Meru (`mer`), Samburu (`saq`),
 Taita (`dav`), Embu (`ebu`) and Teso (`teo`) in Kenya and Uganda, and Shambala
 (`ksb`), Vunjo (`vun`) and Machame (`jmc`) in Tanzania, alongside the two that
-ship. Thirteen were seeded, measured and left out; they are recorded on #1655
-with the coverage each reached. That issue was written about six languages of
-the Americas, and the reason these thirteen join it rather than getting an
-issue of their own is that they hit the same wall — and measuring where they
-hit it turned out to say something the Americas batch could not.
+ship. Thirteen were attempted, measured and left out; they are recorded on
+#1655 with the coverage each reached. That issue was written about six
+languages of the Americas, and the reason these thirteen join it rather than
+getting an issue of their own is that they hit the same wall — and measuring
+where they hit it turned out to say something the Americas batch could not.
 
-The counts, all from `lint:i18n` on catalogs that parsed and linted clean:
+The counts are from `lint:i18n` on the attempts that were written out and
+linted clean; Teso is the one estimate, its draft never having been written:
 
 | tag | language | keys of 575 |
 | --- | --- | --- |

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -4025,7 +4025,7 @@ The batch was assembled as **fifteen** — Kamba (`kam`), Gusii (`guz`),
 Kalenjin (`kln`), Luyia (`luy`), Masai (`mas`), Meru (`mer`), Samburu (`saq`),
 Taita (`dav`), Embu (`ebu`) and Teso (`teo`) in Kenya and Uganda, and Shambala
 (`ksb`), Vunjo (`vun`) and Machame (`jmc`) in Tanzania, alongside the two that
-ship. Thirteen were attempted, measured and left out; they are recorded on
+ship. Thirteen were attempted and left out; they are recorded on
 #1655 with the coverage each reached. That issue was written about six
 languages of the Americas, and the reason these thirteen join it rather than
 getting an issue of their own is that they hit the same wall — and measuring

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -116,12 +116,13 @@ everywhere, for the reason in
 [A language with no word for it](#a-language-with-no-word-for-it);
 Inuktitut over the geometry nouns as well, for the reason in
 [Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws);
-and Chiga and Soga over five further keys each — the three chemistry prose
+and Chiga and Soga over six further keys each — the three chemistry prose
 messages, so that the chemistry group falls back entire rather than half in
-one language and half in another, and the two field nouns `noun.slope-field`
-and `noun.vector-field`, where a descriptive phrase would have been the
-seed's own invention rather than a word. Both are at 440/575, and the reason
-is in
+one language and half in another, and the three geometry nouns
+`noun.slope-field`, `noun.vector-field` and `noun.rectangle`, where a
+descriptive phrase would have been the seed's own invention rather than a
+word, or would have named the wrong figure. Both are at 439/575, and the
+reason is in
 [Two catalogs of East Africa](#two-catalogs-of-east-africa-and-the-thirteen-the-batch-did-not-seed).
 The two hundred and sixty-six are: Somali, Hmong Njua, Amharic, Assamese,
 Nepali, Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino,
@@ -4019,7 +4020,7 @@ the language has, stated as plainly as what it does not.
 ### Two catalogs of East Africa, and the thirteen the batch did not seed
 
 The roster goes from 346 locales to 348: Chiga (`cgg`) and Soga (`xog`), two
-Bantu languages of Uganda, both at **440/575 keys**.
+Bantu languages of Uganda, both at **439/575 keys**.
 
 The batch was assembled as **fifteen** — Kamba (`kam`), Gusii (`guz`),
 Kalenjin (`kln`), Luyia (`luy`), Masai (`mas`), Meru (`mer`), Samburu (`saq`),
@@ -4046,7 +4047,7 @@ linted clean; Teso is the one estimate, its draft never having been written:
 | `teo` | Teso | 8–15, estimated; not written |
 | `dav`, `kln`, `ksb`, `vun`, `jmc` | Taita, Kalenjin, Shambala, Vunjo, Machame | 0 |
 
-Against 440 for the two that ship, and against the 6, 13, 13, 16, 20 and 26
+Against 439 for the two that ship, and against the 6, 13, 13, 16, 20 and 26
 the Americas batch measured for the six it dropped.
 
 #### A loan register can exist and still not be worth recording
@@ -4106,7 +4107,7 @@ catalogs that stalled still reached eight or thirteen or ninety-one keys
 rather than zero. *Circular dependency*, *deprecated attribute*, *invalid
 attribute value* cannot: they exist in a register these languages' speakers
 meet in English, and there is no published parallel to copy them from. A seed
-that reaches 440 is one that had somewhere to look for those 220 keys.
+that reaches 439 is one that had somewhere to look for those 220 keys.
 
 #### The near-sibling hazard, which cuts both ways
 
@@ -4140,20 +4141,33 @@ catalog can state is one a reviewer can work; a seam it cannot state is where
 nearly the same language" is the tempting mistake, and it would answer a
 reader in a variety they did not ask for.
 
-#### Coverage: 440 rather than 445, and the five keys that make the difference
+#### Coverage: 439 rather than 445, and the six keys that make the difference
 
 Both catalogs leave out the two chemistry tables, for the school-system reason
 every batch since the Silk Road one has given: Uganda teaches science in
 English from upper primary, so the fallback is the language the periodic table
 is actually taught in. That is 130 keys and would put them at 445.
 
-They leave out five more, and both are deliberate. Three are the remaining
+They leave out six more, and all six are deliberate. Three are the remaining
 chemistry **prose** messages, dropped so that the chemistry group falls back
 entire rather than appearing half in Rukiga and half in English inside one
-sentence. The other two are `noun.slope-field` and `noun.vector-field`, where
-neither language has a term and a descriptive phrase would have been the
-seed's own invention rather than a word — the same judgement `locales/iu`
-makes across the whole `noun` table, two keys against its twenty.
+sentence. Two are `noun.slope-field` and `noun.vector-field`, where neither
+language has a term and a descriptive phrase would have been the seed's own
+invention rather than a word — the same judgement `locales/iu` makes across
+the whole `noun` table, two keys against its twenty.
+
+The sixth is `noun.rectangle`, and it is the one a reviewer should read as a
+warning rather than a policy. Both seeds first wrote the descriptive phrase
+their sibling catalogs write — «ekishushani ky'empande ina», «ekifaanani
+eky'embali enna», both literally *four-sided figure* — and both were wrong:
+that phrase names a quadrilateral, so every rhombus and trapezoid on the page
+would have been called a rectangle. The defining right angle is exactly what
+neither seed had a word for. A descriptive phrase is safe where it is
+*equivalent* — «figure of three sides» is a triangle and nothing else — and
+unsafe where it names a wider class than the term does, which is not a
+distinction fluency can show a reviewer. So the key was dropped and the
+English falls through, and `noun-gender` carries no branch for it either, the
+way it carries none for the two field nouns.
 
 #### Two smaller things
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -71,7 +71,8 @@ English is the source of truth. Every translation —
 `arn`, `as`, `ast`, `av`, `awa`, `ay`, `az`, `ba`, `bal`, `ban`,
 `bar`, `bbc`, `bci`, `be`, `bem`, `bg`, `bho`, `bi`, `bik`, `bin`,
 `bjn`, `bm`, `bn`, `bo`, `br`, `brh`, `brx`, `bs`, `bua`, `bug`,
-`bum`, `bzj`, `ca`, `cab`, `cbk`, `ce`, `ceb`, `ch`, `chk`, `ckb`,
+`bum`, `bzj`, `ca`, `cab`, `cbk`, `ce`, `ceb`, `cgg`, `ch`, `chk`,
+`ckb`,
 `co`, `crh`, `cs`, `csb`, `cv`, `cy`, `da`, `dag`, `dar`, `de`,
 `dje`, `djk`, `dng`, `doi`, `dsb`, `dtp`, `dv`, `dyo`, `dyu`, `dz`,
 `ee`, `efi`, `egl`, `el`, `es`, `et`, `eu`, `ewo`, `ext`, `fa`,
@@ -100,20 +101,28 @@ English is the source of truth. Every translation —
 `th`, `ti`, `tiv`, `tk`, `tkl`, `tlh`, `tly`, `tn`, `to`, `tpi`,
 `tr`, `ts`, `tsg`, `tt`, `ttt`, `tvl`, `ty`, `tyv`, `udm`, `ug`,
 `uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vec`, `vep`, `vi`, `vro`,
-`wa`, `war`, `wbl`, `wls`, `wo`, `xal`, `xh`, `yi`, `yo`, `yua`,
+`wa`, `war`, `wbl`, `wls`, `wo`, `xal`, `xh`, `xog`, `yi`, `yo`,
+`yua`,
 `zgh`, `zh-Hans`, `zh-Hant`, `zu`, `zza`
 — is an **unreviewed machine-generated seed**, which each file's own
 header says at the top, and which is what #1521's translation platform is for.
 None has been read by a speaker. Correcting one needs no permission and no
 coordination: a wrong string is just wrong, and the English is one key away.
 
-Two hundred and sixty-eight of them are deliberately partial. Two hundred
+Two hundred and seventy of them are deliberately partial. Two hundred
 and sixty-six are partial in the same place — the two chemistry tables —
-while two are partial more widely, each for its own reason: Klingon almost
+while four are partial more widely, each for its own reason: Klingon almost
 everywhere, for the reason in
-[A language with no word for it](#a-language-with-no-word-for-it), and
+[A language with no word for it](#a-language-with-no-word-for-it);
 Inuktitut over the geometry nouns as well, for the reason in
-[Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws).
+[Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws);
+and Chiga and Soga over five further keys each — the three chemistry prose
+messages, so that the chemistry group falls back entire rather than half in
+one language and half in another, and the two field nouns `noun.slope-field`
+and `noun.vector-field`, where a descriptive phrase would have been the
+seed's own invention rather than a word. Both are at 440/575, and the reason
+is in
+[Two catalogs of East Africa](#two-catalogs-of-east-africa-and-the-thirteen-the-batch-did-not-seed).
 The two hundred and sixty-six are: Somali, Hmong Njua, Amharic, Assamese,
 Nepali, Burmese, Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino,
 Vietnamese, Zulu, Xhosa, Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
@@ -3926,7 +3935,7 @@ select variants included — not the ids, which are ASCII everywhere, not the
 placeables and selector heads, which are ASCII too, and not the headers, which
 are English prose quoting words in the language — counts right-to-left letters against
 left-to-right ones, and requires the majority to agree with `directionOf`. All
-346 pass, the Ladino bug would have failed it, and so would the reverse
+348 pass, the Ladino bug would have failed it, and so would the reverse
 mistake: a catalog written in Hebrew or Arabic letters for a language CLDR
 thinks is Latin.
 
@@ -4006,6 +4015,155 @@ its header is equally clear that the tradition does not reach a 118-element
 table and that its computing words are the international register given Ladin
 spelling. That pairing is the shape every header in this batch aims at: what
 the language has, stated as plainly as what it does not.
+
+### Two catalogs of East Africa, and the thirteen the batch did not seed
+
+The roster goes from 346 locales to 348: Chiga (`cgg`) and Soga (`xog`), two
+Bantu languages of Uganda, both at **440/575 keys**.
+
+The batch was assembled as **fifteen** — Kamba (`kam`), Gusii (`guz`),
+Kalenjin (`kln`), Luyia (`luy`), Masai (`mas`), Meru (`mer`), Samburu (`saq`),
+Taita (`dav`), Embu (`ebu`) and Teso (`teo`) in Kenya and Uganda, and Shambala
+(`ksb`), Vunjo (`vun`) and Machame (`jmc`) in Tanzania, alongside the two that
+ship. Thirteen were seeded, measured and left out; they are recorded on #1655
+with the coverage each reached. That issue was written about six languages of
+the Americas, and the reason these thirteen join it rather than getting an
+issue of their own is that they hit the same wall — and measuring where they
+hit it turned out to say something the Americas batch could not.
+
+The counts, all from `lint:i18n` on catalogs that parsed and linted clean:
+
+| tag | language | keys of 575 |
+| --- | --- | --- |
+| `mer` | Meru | 91 |
+| `kam` | Kamba | 48 |
+| `luy` | Luyia | 33 |
+| `saq` | Samburu | 13 |
+| `guz` | Gusii | 12 |
+| `mas` | Masai | 11 |
+| `ebu` | Embu | 8 |
+| `teo` | Teso | 8–15, estimated; not written |
+| `dav`, `kln`, `ksb`, `vun`, `jmc` | Taita, Kalenjin, Shambala, Vunjo, Machame | 0 |
+
+Against 440 for the two that ship, and against the 6, 13, 13, 16, 20 and 26
+the Americas batch measured for the six it dropped.
+
+#### A loan register can exist and still not be worth recording
+
+[Fifteen catalogs of the Americas](#fifteen-catalogs-of-the-americas-and-the-line-the-lexifier-draws)
+states the rule this batch was assembled to test: **carry a loan register
+where speakers already carry one, and leave the key out where they do not.**
+Navajo and Mohawk fail it because there is no Navajo technical register to
+record — a speaker doing mathematics does it in English and does not
+Navajo-ize *polygon*, so writing «pálagan» produces English respelled.
+
+The batch was chosen because East Africa looked like the other half of that
+rule. Swahili has a real published technical register and `locales/sw` is one
+of the roster's more complete catalogs, elements included; Swahili loans in
+these languages are nativized by rule rather than ad hoc, and CLDR's own `ksb`
+data shows it — Swahili `r` becomes Shambaa `l` («Januali», «Aplili»), and the
+two Chaga varieties palatalize before a front vowel («Aprilyi», «Junyi»). The
+frame was there, the loans were attested, and the adaptation was mechanical.
+
+**That turned out to be the problem rather than the solution.** Because the
+adaptation is mechanical, `locales/sw` could have been run through a
+phonological rewrite end to end and reported at the batch ceiling. What that
+produces is not a loan register: it is Swahili respelled, one contact language
+pushed a step further out, and it fails for the same reason «pálagan» does —
+it reads as translation to a tool, as noise to a speaker, and a reviewer's
+first job is deleting it.
+
+So the finding is a **third case**, and the rule above needs it. The Americas
+case is *no register exists*. The `sgh` and `kl` case is *a register exists
+and recording it records something real* — a Shughni speaker reads a compiler
+error in Tajik, and the catalog keeps Tajik words in a Shughni frame. The case
+this batch found is *a register exists, and it is a language that already has
+a catalog on this roster*. There, recording it adds nothing a reader did not
+already have: a Gusii pupil who meets *vector* in English or in Swahili can be
+served `locales/en` or `locales/sw`, and «egetokeso» serves them worse than
+either. The test is not whether a loan register exists. It is **whether
+recording it tells the reader something the fallback did not.**
+
+#### `diagnostics.ftl` is where the question gets decided
+
+In every catalog the batch produced below the bar, `diagnostics.ftl` is
+comments-only — 220 keys, half the reachable total, with the file's own header
+stating the reason in place of the gap.
+
+That is not where the effort ran out; it is where the question is actually
+posed. Colour words, boolean words and the geometry nouns can be recalled from
+a Bible translation, a primary reader or a dictionary, and that is why the
+catalogs that stalled still reached eight or thirteen or ninety-one keys
+rather than zero. *Circular dependency*, *deprecated attribute*, *invalid
+attribute value* cannot: they exist in a register these languages' speakers
+meet in English, and there is no published parallel to copy them from. A seed
+that reaches 440 is one that had somewhere to look for those 220 keys.
+
+#### The near-sibling hazard, which cuts both ways
+
+Every one of the fifteen has a close relative on this roster, and several have
+a very close one: `ki` (Gĩkũyũ) beside `ebu` and `mer`, `lg` (Luganda) beside
+`xog`, `nyn` (Runyankore) beside `cgg`, and `sw` beside all of them. That is
+the batch's other finding, and it is not the one that would be guessed: **a
+near sibling on the roster makes a bad seed harder to spot, not easier.** A
+machine pass on Embu produces fluent-looking Gĩkũyũ, and a reader who does not
+speak both cannot tell. `locales/ebu` stopped at 8 keys for exactly this
+reason — its `chrome.ftl` is empty because verbs are where the two languages
+part company and verbs are what every button is made of.
+
+What separates the two catalogs that ship is not distance from their sibling
+but a **checkable rule** for telling them apart. Lusoga and Luganda differ by
+a systematic correspondence — Lusoga writes `dh` where Luganda writes `z` or
+`j` («amaadhi», «okwidha») — so a Luganda word that has drifted into
+`locales/xog` can be caught by looking at it, and the catalog's header names
+Luganda intrusion as the first thing a reviewer should hunt for. Rukiga and
+Runyankore have no such rule, sharing one written standard and one dictionary,
+so `locales/cgg` states the question instead: of each word, is it current in
+Kigezi or only in Ankole? Where a difference is known the Kigezi form is
+written — «eibara» for *name*, where Runyankore says «eiziina». A seam a
+catalog can state is one a reviewer can work; a seam it cannot state is where
+`ebu` stopped.
+
+`negotiate.test.ts` asserts the pair from both sides — Runyankore stays on
+`nyn` and Rukiga on `cgg` — because "fold the one onto the other, they are
+nearly the same language" is the tempting mistake, and it would answer a
+reader in a variety they did not ask for.
+
+#### Coverage: 440 rather than 445, and the five keys that make the difference
+
+Both catalogs leave out the two chemistry tables, for the school-system reason
+every batch since the Silk Road one has given: Uganda teaches science in
+English from upper primary, so the fallback is the language the periodic table
+is actually taught in. That is 130 keys and would put them at 445.
+
+They leave out five more, and both are deliberate. Three are the remaining
+chemistry **prose** messages, dropped so that the chemistry group falls back
+entire rather than appearing half in Rukiga and half in English inside one
+sentence. The other two are `noun.slope-field` and `noun.vector-field`, where
+neither language has a term and a descriptive phrase would have been the
+seed's own invention rather than a word — the same judgement `locales/iu`
+makes across the whole `noun` table, at a twentieth of the scale.
+
+#### Two smaller things
+
+**A class with no noun in it is a claim about nothing.** `locales/xog` was
+first written with a `[c5]` column in every concording adjective;
+`catalogLint.test.ts`'s noun-class reachability rule caught it, because no
+noun this catalog names falls in class 5. The column was removed rather than a
+class-5 noun invented to justify it, and the header records that if a reviewer
+moves a noun into class 5 the column has to come back with it. Both catalogs
+carry their concord table in the header as a grid, so the claim is legible
+before the messages are read.
+
+**Two macrolanguages are owed `MACROLANGUAGE_MEMBERS` entries and did not get
+them.** `luy` and `kln` are macrolanguages, and CLDR folds exactly one member
+of each — `bxk` (Bukusu) onto `luy`, `spy` (Kipsigis) onto `kln` — leaving the
+rest unresolvable, the pattern `qu`, `oj` and `gn` already show. Neither
+gained an entry, because neither has a catalog for a member to be folded onto,
+and a map entry pointing at nothing is worse than an absence. `negotiate.test.ts`
+asserts `bxk` and `spy` reach English, so the day either language is seeded
+the entry is owed and the test says so. `kln` was already a negative control
+in that file before this batch, and it stays exactly as it was.
 
 ### A language with no word for it
 

--- a/packages/i18n/locales/cgg/chrome.ftl
+++ b/packages/i18n/locales/cgg/chrome.ftl
@@ -48,7 +48,7 @@
 # keeps it openly rather than inventing Rukiga words for it: «kiiboodi»,
 # «WCAG». Swahili is not the loan language here, and is reached for only where
 # a word genuinely travelled into the region long ago rather than through a
-# classroom — «etaburo», «esanduuko». Where a technical term has no Rukiga
+# classroom — «etaburo», «akasanduuko». Where a technical term has no Rukiga
 # word at all, the key is **left out** and falls back to English rather than
 # being filled with English respelled.
 #

--- a/packages/i18n/locales/cgg/chrome.ftl
+++ b/packages/i18n/locales/cgg/chrome.ftl
@@ -1,0 +1,165 @@
+# Chiga (Rukiga) viewer chrome: buttons, panel headers, and other UI the
+# reader interacts with. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** Latin, in the **Runyankore-Rukiga standard
+# orthography** — the one written standard the two varieties share, as fixed
+# by Taylor's «Runyankore-Rukiga Dictionary» and used by the Runyakitara
+# programme at Makerere and by the Bible («Baiburi Erikwera»). Its /tʃ/ is
+# written **`c`**, so a piece of a document is «ekicweka». The orthography
+# **not** followed here is the older missionary spelling that wrote the same
+# sound `ch` — «ekichweka» — and which still turns up in church printing; a
+# reviewer meeting `ch` in a Kigezi text is looking at that older convention,
+# not at a different word. The neighbouring **Runyoro-Rutooro** standard is
+# likewise not followed. The initial vowel (the augment) is part of the word:
+# «omurongo» is one word, and «murongo» is not the same thing said without an
+# article. Digits are **Latin** (`1`, `2`, `1,234`), which is what DoenetML
+# pins for every locale in `src/intl.ts`.
+#
+# **Rukiga and Runyankore.** They share this orthography, most of this
+# vocabulary, and one dictionary, and `locales/nyn` is on disk beside this
+# file. Overlap between the two catalogs is expected and is not a defect. Where
+# a difference is known it is written the Kigezi way — **«eibara»** for *name*,
+# where Runyankore says «eiziina» — and elsewhere the word is the shared
+# Runyankore-Rukiga one. **The first thing a Rukiga reviewer should do is go
+# through this file asking of each word whether it is current in Kigezi or only
+# in Ankole.** That question, not the grammar, is where this seed is weakest.
+#
+# **What is Rukiga here.** The copula is the `ni-` prefix («nikyo» *it is so*)
+# and the negator is `ti-` («tikyo», «tihariho» *there is none*); «na» / «n'»
+# is *and*, «nari» is *or*, «obu» is *when / if*, «ahabw'okuba» is *because*,
+# «kwonka» is *but*. A button carries the bare imperative the way Rukiga gives
+# an instruction — «Igura», «Igara», «Ihaho», «Ongyeraho», «Yoreka»,
+# «Sherekyera», «Toorana» — rather than a polite periphrasis. The everyday
+# words are the language's own: «nikyo» / «tikyo» for right and wrong,
+# «eky'okugarukamu» for a response, «ekihabo» for an error (on «okuhaba», to
+# go astray), «orupapura» for a page, «omurongo» for a row and «empagi» for a
+# column, «okuhikaho» for accessibility.
+#
+# **What is borrowed, and from where.** **English**, not Swahili. Uganda's
+# school system teaches mathematics and science in English from upper primary
+# on, so a Rukiga speaker's technical register *is* English, and this catalog
+# keeps it openly rather than inventing Rukiga words for it: «kiiboodi»,
+# «WCAG». Swahili is not the loan language here, and is reached for only where
+# a word genuinely travelled into the region long ago rather than through a
+# classroom — «etaburo», «esanduuko». Where a technical term has no Rukiga
+# word at all, the key is **left out** and falls back to English rather than
+# being filled with English respelled.
+#
+# **Counts.** CLDR gives `cgg` its own plural data, with the two categories
+# `one` and `other`. A Rukiga noun marks number with a class prefix rather
+# than a suffix — «omurundi» one time, «emirundi» several; «eky'okugarukamu»
+# one answer, «eby'okugarukamu» several — and it goes on doing so after a
+# numeral, so both branches of every select are doing real work.
+# `attempts-remaining` keeps its `[0]` branch, an exact-value match rather
+# than a plural category, which says «tihariho» instead of counting to zero.
+
+
+## Answer submission
+
+answer-checking = Nikicendererezibwa…
+answer-submitting = Nikyohererezibwa…
+answer-checking-status = Nitucendereza eky'okugarukamu
+answer-submitting-status = Nitwohereza eky'okugarukamu
+answer-correct = Nikyo
+answer-incorrect = Tikyo
+answer-response-saved = Eky'okugarukamu Kibiikirwe
+answer-percent-credit = { $percent }% ez'amanota
+answer-percent-correct = { $percent }% Nikyo
+answer-percent-short = { $percent } %
+max-credit-available = Amanota maingi agariho: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] tihariho murundi gusigaire
+        [one] hasigaire omurundi { $count }
+       *[other] hasigaire emirundi { $count }
+    }
+validation-correct = (Nikyo)
+validation-incorrect = (Tikyo)
+validation-partially-correct = (Nikyo aha rubaju)
+answer-show-responses =
+    { $count ->
+        [one] Yoreka eky'okugarukamu { $count } eky'aha { $answerId }
+       *[other] Yoreka eby'okugarukamu { $count } eby'aha { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Ekigarukiirwemu
+collapsible-click-to-open = (kanda okwigura)
+collapsible-click-to-close = (kanda okwigara)
+collapsible-initializing = Nikitandika…
+footnote-show = Yoreka ekyahandiikirwe aha nsi
+footnote-hide = Sherekyera ekyahandiikirwe aha nsi
+description-more-information = amakuru maingi
+
+
+## Controls
+
+slider-previous = Ekihweireho
+slider-next = Ekirikukuratsya
+keyboard-open = Igura Kiiboodi
+keyboard-close = Igara Kiiboodi
+choice-input-remove-choice = Ihaho { $choice }
+matrix-remove-row = Ihaho omurongo
+matrix-add-row = Ongyeraho omurongo
+matrix-remove-column = Ihaho empagi
+matrix-add-column = Ongyeraho empagi
+subset-add-remove-points = Ongyeraho/Ihaho obudomo
+subset-toggle-points-intervals = Hindura ahagati y'obudomo n'ebicweka
+subset-move-points = Rugurura Obudomo
+subset-clear = Ihaho byona
+orbital-add-row = Ongyeraho Omurongo
+orbital-remove-row = Ihaho Omurongo
+orbital-add-box = Ongyeraho Akasanduuko
+orbital-remove-box = Ihaho Akasanduuko
+orbital-add-up-arrow = Ongyeraho Akambi Karikuza Ahaiguru
+orbital-add-down-arrow = Ongyeraho Akambi Karikuza Ahansi
+orbital-remove-arrow = Ihaho Akambi
+orbital-row-label = Eibara ry'omurongo { $row }
+pretzel-answer = Eky'okugarukamu
+summary-statistics-caption = Ekifundikirwe ky'ebibaro bya { $column }
+
+
+## Math input
+
+math-input-preview-region = okureeba omu maisho ebibaro ebyahandiikirwe
+math-input-preview = Okureeba omu maisho
+math-input-invalid-expression = Ekyahandiikirwe tikyo:
+
+
+## Document status
+
+viewer-initializing = Nikitandika…
+
+
+## Errors
+
+error-heading = Ekihabo
+error-found-at =
+    { $span ->
+        [line] Kishangirwe aha murongo { $startLine }.
+       *[lines] Kishangirwe aha mirongo { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Ekitabo eki kiine ebihabo!
+diagnostic-heading-error = Ekihabo
+diagnostic-heading-warning = Okurabura
+diagnostic-heading-information = Amakuru
+diagnostic-heading-hint = Akamanyiso
+accessibility-heading-level-1 = Okuhenda WCAG AA omu Kuhikaho
+accessibility-heading-level-2 = Okurabura kw'okuhikaho
+something-went-wrong = Hariho ekitagyenzire gye.
+renderer-load-failed = omworeki omwe tarahikire. Nooyeshengyereza garura orupapura.
+core-start-failed = Ekitabo eki tikitandikire. Nooyeshengyereza garura orupapura.
+core-start-failed-busy = Ekitabo eki tikitandikire. Ebitabo bingi bikaba nibitandika omu bwire bumwe, ekirikubaasa kutwara obwire buraingwa aha kyoma kitarikwiruka munonga. Okugarura orupapura nikibaasa kuhwera ebindi bitabo byaherize.
+core-start-failed-retry = Ekitabo eki tikitandikire.
+core-start-failed-busy-retry = Ekitabo eki tikitandikire. Ebitabo bingi bikaba nibitandika omu bwire bumwe, ekirikubaasa kutwara obwire buraingwa aha kyoma kitarikwiruka munonga.
+core-start-retry = Gyezaho oburundi
+saved-state-unavailable = Omurimo gwawe ogubiikirwe tigubaasize kutahwa.

--- a/packages/i18n/locales/cgg/content.ftl
+++ b/packages/i18n/locales/cgg/content.ftl
@@ -53,6 +53,11 @@
 #   * `noun.slope-field` and `noun.vector-field` — Rukiga has no phrase for
 #     either and a descriptive one would be this seed's invention, so both
 #     fall back to English.
+#   * `noun.rectangle` — «ekishushani ky'empande ina» is literally *four-sided
+#     figure*, which names a quadrilateral and not a rectangle: Rukiga wants
+#     the word for the right angle that this seed does not have. Calling every
+#     four-sided figure a rectangle is worse than the English fallback, so the
+#     key is left out and `noun-gender` carries no branch for it.
 #   * `element-name` and `element-anion-name` — 130 keys, the whole periodic
 #     table. Uganda teaches secondary chemistry in English, so the fallback
 #     *is* what these readers meet.
@@ -61,11 +66,8 @@
 #     falls back entire rather than half of it being answered in Rukiga and
 #     half in English.
 #
-# **Weakest here.** «ekishushani ky'empande ina» is literally *four-sided
-# figure* and so names a quadrilateral rather than a rectangle; Rukiga wants a
-# word for the right angle that this seed does not have. «Tiyoremu» and
-# «parabora» are the two loans most likely to be wrong about what a Kigezi
-# classroom actually says.
+# **Weakest here.** «Tiyoremu» and «parabora» are the two loans most likely to
+# be wrong about what a Kigezi classroom actually says.
 
 
 ## Style vocabulary
@@ -213,7 +215,6 @@ noun =
     .polyline = omurongo gw'ebicweka
     .polygon = ekishushani ky'empande nyingi
     .triangle = ekishushani ky'empande ishatu
-    .rectangle = ekishushani ky'empande ina
     .circle = eriziga
     .region = ekicweka
     .point = akadomo
@@ -245,7 +246,6 @@ noun-gender =
         [polygon] c7
         [regular-polygon] c7
         [triangle] c7
-        [rectangle] c7
         [region] c7
         [plus] c7
         [text] c7

--- a/packages/i18n/locales/cgg/content.ftl
+++ b/packages/i18n/locales/cgg/content.ftl
@@ -1,0 +1,416 @@
+# Chiga (Rukiga) content catalog: the prose the core computes into the
+# document — style descriptions ("thick red line"), boolean words, section
+# names. Selected by `documentLocale`, the language the activity was written
+# in, rather than by the reader's UI language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** As `chrome.ftl` sets it out: the shared
+# Runyankore-Rukiga standard, `c` and not `ch` for /tʃ/ («ekicweka», not
+# «ekichweka»), the augment written, Latin digits.
+#
+# **Noun class, not gender.** Rukiga has no masculine or feminine and agrees a
+# describing word with its noun's **class**, so this catalog reads `$gender`
+# as a class token — the device `locales/sw`, `locales/lg` and `locales/nyn`
+# all use. `noun-gender` answers `c3`, `c5`, `c7`, `c9` or `c12`, and there are
+# two concord sets, with which set a word takes being a fact about the word:
+#
+#   adjective concord (-hango, -kye)   c3 mu-   c5 ri-   c7 ki-   c9 e-   c12 ka-
+#   associative particle (the colours) c3 w'    c5 ry'   c7 ky'   c9 y'   c12 k'
+#
+# The colours are nouns, not adjectives, so they take the associative particle
+# rather than the concord: «w'omukara» carries its class the way «muhango»
+# does. That costs what it costs in every catalog on this shelf —
+# `backgroundColor` reports «y'omukara» standing alone, where the particle
+# wants a head in front of it, and `$role` cannot tell that citation position
+# from the attributive one. The two are written alike; see `locales/nyn`'s
+# header for the same trade made next door.
+#
+# **Word order.** A describing word **follows** its noun in Rukiga, so every
+# composition message puts the noun first and the description after it —
+# «omurongo muhango w'omutukura», not the English order. `$role` goes unused:
+# Rukiga marks no case.
+#
+# **What is Rukiga here.** «omukara», «obwera», «eivu», «omutukura» and
+# «ekiragara» are Rukiga colour words. So are the geometry nouns that could be
+# said natively: «omurongo» (line), «omurasho» (ray, on «okurasha», to shoot),
+# «akadomo» (point), «eriziga» (circle), «omusaraba» (cross), «ekicweka»
+# (segment, region), and the descriptive phrases for a curve, a polyline and a
+# polygon.
+#
+# **What is borrowed, and from where.** **English**, openly, because that is
+# the register a Rukiga speaker actually does mathematics in: «vekita»,
+# «fonkishoni», «parabora», «esikweya», «edaimonde», «tiyoremu», and seven of
+# the twelve colours («orenji», «yero», «sayani», «buruu», «paapuro»,
+# «pinki», «buraawuni»). Swahili is **not** the loan language in Uganda and is
+# reached for only for words that travelled into the region long before the
+# classroom did — «etaburo», «akasanduuko». Nothing here is an English word
+# respelled to look Rukiga: where there is no word, the key is left out.
+#
+# **What is left out, and why.**
+#
+#   * `noun.slope-field` and `noun.vector-field` — Rukiga has no phrase for
+#     either and a descriptive one would be this seed's invention, so both
+#     fall back to English.
+#   * `element-name` and `element-anion-name` — 130 keys, the whole periodic
+#     table. Uganda teaches secondary chemistry in English, so the fallback
+#     *is* what these readers meet.
+#   * `chemistry-invalid-symbol`, `chemistry-invalid-ionic-compound` and
+#     `ion-name-oxidation-state`, for the same reason: the chemistry group
+#     falls back entire rather than half of it being answered in Rukiga and
+#     half in English.
+#
+# **Weakest here.** «ekishushani ky'empande ina» is literally *four-sided
+# figure* and so names a quadrilateral rather than a rectangle; Rukiga wants a
+# word for the right angle that this seed does not have. «Tiyoremu» and
+# «parabora» are the two loans most likely to be wrong about what a Kigezi
+# classroom actually says.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c3] w'omukara
+            [c5] ry'omukara
+            [c7] ky'omukara
+            [c12] k'omukara
+           *[c9] y'omukara
+        }
+    .white =
+        { $gender ->
+            [c3] w'obwera
+            [c5] ry'obwera
+            [c7] ky'obwera
+            [c12] k'obwera
+           *[c9] y'obwera
+        }
+    .gray =
+        { $gender ->
+            [c3] w'eivu
+            [c5] ry'eivu
+            [c7] ky'eivu
+            [c12] k'eivu
+           *[c9] y'eivu
+        }
+    .red =
+        { $gender ->
+            [c3] w'omutukura
+            [c5] ry'omutukura
+            [c7] ky'omutukura
+            [c12] k'omutukura
+           *[c9] y'omutukura
+        }
+    .orange =
+        { $gender ->
+            [c3] wa orenji
+            [c5] rya orenji
+            [c7] kya orenji
+            [c12] ka orenji
+           *[c9] ya orenji
+        }
+    .yellow =
+        { $gender ->
+            [c3] wa yero
+            [c5] rya yero
+            [c7] kya yero
+            [c12] ka yero
+           *[c9] ya yero
+        }
+    .green =
+        { $gender ->
+            [c3] w'ekiragara
+            [c5] ry'ekiragara
+            [c7] ky'ekiragara
+            [c12] k'ekiragara
+           *[c9] y'ekiragara
+        }
+    .cyan =
+        { $gender ->
+            [c3] wa sayani
+            [c5] rya sayani
+            [c7] kya sayani
+            [c12] ka sayani
+           *[c9] ya sayani
+        }
+    .blue =
+        { $gender ->
+            [c3] wa buruu
+            [c5] rya buruu
+            [c7] kya buruu
+            [c12] ka buruu
+           *[c9] ya buruu
+        }
+    .purple =
+        { $gender ->
+            [c3] wa paapuro
+            [c5] rya paapuro
+            [c7] kya paapuro
+            [c12] ka paapuro
+           *[c9] ya paapuro
+        }
+    .pink =
+        { $gender ->
+            [c3] wa pinki
+            [c5] rya pinki
+            [c7] kya pinki
+            [c12] ka pinki
+           *[c9] ya pinki
+        }
+    .brown =
+        { $gender ->
+            [c3] wa buraawuni
+            [c5] rya buraawuni
+            [c7] kya buraawuni
+            [c12] ka buraawuni
+           *[c9] ya buraawuni
+        }
+
+# The adjective concord, which is not the particle the colours take.
+line-width =
+    .thick =
+        { $gender ->
+            [c3] muhango
+            [c5] rihango
+            [c7] kihango
+            [c12] kahango
+           *[c9] ehango
+        }
+    .thin =
+        { $gender ->
+            [c3] mukye
+            [c5] rikye
+            [c7] kikye
+            [c12] kakye
+           *[c9] ekye
+        }
+
+# Written as an invariable «na …» phrase, so that it agrees with nothing and
+# can close the description; `style-stroke` puts it last for that reason.
+line-style =
+    .dashed = na tucweka
+    .dotted = na tudomo
+
+fill-style =
+    .horizontal = emirongo egaramire
+    .vertical = emirongo eyemereire
+    .diagonal = emirongo eyegamiire
+    .backdiagonal = emirongo eyegamiire oruhande orundi
+    .dots = obudomo
+    .diamonds = amadaimonde
+
+# `slope-field` and `vector-field` are deliberately absent; see the header.
+noun =
+    .line = omurongo
+    .line-segment = ekicweka ky'omurongo
+    .ray = omurasho
+    .vector = vekita
+    .curve = omurongo ogugombire
+    .function = fonkishoni
+    .parabola = parabora
+    .polyline = omurongo gw'ebicweka
+    .polygon = ekishushani ky'empande nyingi
+    .triangle = ekishushani ky'empande ishatu
+    .rectangle = ekishushani ky'empande ina
+    .circle = eriziga
+    .region = ekicweka
+    .point = akadomo
+    .square = esikweya
+    .diamond = edaimonde
+    .cross = omusaraba
+    .plus = ekimanyiso ky'okwongyera
+
+# The side count is a relative clause and closes the noun phrase behind the
+# describing words rather than opening it, so it goes in the tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] ekiine empande { $numSides }
+       *[head] ekishushani ekingana empande
+    }
+
+# `c9` is the default, and the class a loanword joins — which is what an
+# author's own `markerStyleWord` is as far as this catalog is concerned.
+noun-gender =
+    { $noun ->
+        [line] c3
+        [ray] c3
+        [curve] c3
+        [polyline] c3
+        [cross] c3
+        [border] c3
+        [circle] c5
+        [line-segment] c7
+        [polygon] c7
+        [regular-polygon] c7
+        [triangle] c7
+        [rectangle] c7
+        [region] c7
+        [plus] c7
+        [text] c7
+        [fill] c7
+        [point] c12
+       *[other] c9
+    }
+
+
+## Style composition
+
+# The dash pattern is a «na …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] ogwijwire
+        [c5] eryijwire
+        [c7] ekyijwire
+        [c12] akijwire
+       *[c9] eyijwire
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } na { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } na { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «omupaka» is class 3 and leads its own describing words, so they agree with
+# it rather than with the shape it surrounds. Rukiga has no article and joins
+# the clause with the invariable «na», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] n'omupaka { $border }
+        [and] n'omupaka { $border }
+        [and-article] n'omupaka { $border }
+       *[with] n'omupaka { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = tikyijwire
+
+style-text =
+    { $parts ->
+        [background] { $color } aha nyima { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = tihariho
+
+
+## Boolean words
+
+boolean-true = ni buzima
+boolean-false = ti buzima
+
+
+## Answer buttons
+
+answer-submit-label = Cendereza Omurimo
+answer-submit-label-no-correctness = Ohereza Eky'okugarukamu
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Omurimo
+    .aside = Ekyongyeirweho
+    .cascade = Orukurikirana
+    .definition = Okushoboorora
+    .example = Eky'okureeberaho
+    .exercise = Okwegyeza
+    .exercises = Okwegyeza
+    .given-answer = Eky'okugarukamu
+    .note = Ekyokwetegyereza
+    .objectives = Ebigyendererwa
+    .paragraphs = Ebihandiiko
+    .part = Omugabo
+    .problem = Ekibazo
+    .problems = Ebibazo
+    .proof = Obujurizi
+    .question = Ekibuuzo
+    .section = Ekicweka
+    .solution = Eky'okukiza
+    .task = Omurimo
+    .theorem = Tiyoremu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Akamanyiso
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Etaburo { $enumeration }
+        [numbered-title] Etaburo { $enumeration }{ ": " }
+        [unnumbered-title] Etaburo{ ": " }
+       *[unnumbered] Etaburo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ekishushani { $enumeration }
+        [numbered-caption] Ekishushani { $enumeration }{ ": " }
+        [unnumbered-caption] Ekishushani{ ": " }
+       *[unnumbered] Ekishushani
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ekihweireho
+paginator-next = Ekirikukuratsya
+paginator-page = Orupapura
+paginator-page-status = { $pageLabel } { $currentPage } aha { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = nari
+piecewise-condition-if = obu
+piecewise-condition-otherwise = ahandi hoona
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = obusa
+math-embedded-input-blank-ordinal = obusa { $ordinal } aha { $total }

--- a/packages/i18n/locales/cgg/diagnostics.ftl
+++ b/packages/i18n/locales/cgg/diagnostics.ftl
@@ -1,0 +1,723 @@
+# Chiga (Rukiga) diagnostics: errors and warnings surfaced to the reader or
+# author. Produced by the worker but addressed to whoever is looking at the
+# screen, so these are selected by `uiLocale`, not `documentLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** As `chrome.ftl` sets it out: the shared
+# Runyankore-Rukiga standard, `c` and not `ch` for /tʃ/, the augment written,
+# Latin digits.
+#
+# DoenetML element, attribute and value names — `through`, `endpoint`,
+# `midpointOffset`, `numDimensions`, `symbolicEquality`, `selectFromSequence`,
+# `math`, `text`, `number`, `boolean` and the rest — are part of the language
+# rather than prose, and stay in English exactly as written. So does the
+# `[deprecation]` marker, and so does anything quoted back from the author's
+# own source.
+#
+# **What is Rukiga here.** The frame every message is built on:
+# «Tikirikubaasika …» for *cannot*, «nikirengwaho» / «Nitureengaho …» for
+# *ignored* / *ignoring*, «kishemereire kuba» for *must be*, «tikirakozirwe»
+# for *has not been implemented*, «tikiri kyo» / «tiri yo» for *invalid*
+# (literally *it is not it*, with the concord of whatever is being talked
+# about), «ahabw'okuba» for *because*, «kwonka» for *but*, «nari» for *or*,
+# «omu mwanya gw'ekyo» for *instead*, «nibura» for *at least*, «obusa» for
+# *empty*, «ekihabo» for an error. Native nouns doing real work: «omurongo»
+# (a source line, a row, and the geometric line), «empagi» (a column),
+# «eibara» (a name — the Kigezi word), «akadomo» (a point), «eriziga» (a
+# circle), «enkona» (an angle), «omuhendo» (a value), «ekirikuhinduka» (a
+# variable), «ekiranga» (an attribute), «ekicweka» (a component, a section, a
+# piece), «orubaaho» (the canvas), «orukurikirana» (a sequence, a list).
+#
+# **What is borrowed, and from where.** **English**, because that is the
+# register a Rukiga speaker does mathematics and computing in — Uganda teaches
+# both in English from upper primary. The loans are kept openly rather than
+# disguised: «fonkishoni», «vekita», «parabora», «matirikisi», «paramita»,
+# «akisi», «enamba», «tagi», «node», «data», «index». Swahili is **not** the
+# loan language here. Nothing below is an English word respelled to look
+# Rukiga: where there was no word and no honest description, the sentence
+# keeps the English identifier and describes around it.
+#
+# **Counts.** CLDR gives `cgg` its own plural data, with `one` and `other`.
+# Rukiga marks number with a class prefix — «ekiranga» one attribute,
+# «ebiranga» several; «omuhendo» one value, «emihendo» several — and the verb
+# agrees with it, so both branches of every select differ in more than a
+# suffix. `field-function-wrong-num-outputs` keeps the English `[one]`, since
+# `cgg` really can select it.
+#
+# **Weakest here.** «okwegamira» for *slope* and «okutaana» for *contrast*
+# are descriptions rather than established terms, and are the first two words
+# a reviewer should attack. «orubaaho» for the drawing canvas is the third:
+# it is the classroom blackboard, which is the right picture but may read as
+# too concrete.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } neerengwaho obu obudomo bubiri bw'empera buba butairweho
+       *[other] { $attributes } nibirengwaho obu obudomo bubiri bw'empera buba butairweho
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } neerengwaho obu akadomo k'empera n'ak'ahagati byombi biba bitairweho
+       *[other] { $attributes } nibirengwaho obu akadomo k'empera n'ak'ahagati byombi biba bitairweho
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tikirikukora kutaine kadomo ka hagati
+
+## `<line>`
+
+line-points-undetermined-dimensions = Omurongo nigucwa omu budomo bw'obugyereeranwa obutamanyirwe.
+
+line-points-too-few-dimensions = Omurongo gushemereire kucwa omu budomo bw'obugyereeranwa nibura bubiri.
+
+line-points-depend-on-variables = Omurongo nigucwa omu budomo oburikwesigama aha birikuhinduka: { $variables }.
+
+line-equation-invalid-format = Enshoneka y'enkyangano y'omurongo omu birikuhinduka { $variable1 } na { $variable2 } tiri yo.
+
+## `<ray>`
+
+ray-overprescribed-through = Omurasho gutairweho na through, endpoint na direction.  Nitureengaho through eyatairweho.
+
+ray-dimension-mismatch = numDimensions tirikuhikaana omu murasho.
+
+## `<vector>`
+
+vector-overprescribed-head = Vekita etairweho na head, tail na displacement.  Nitureengaho head eyatairweho.
+
+vector-dimension-mismatch = numDimensions tirikuhikaana omuri vekita.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Tikirikubaasika kukwega aha `<{ $component }>` ahabw'okuba etaine kiranga nearestPoint.
+
+constrain-to-without-nearest-point = Tikirikubaasika kwemeza aha `<{ $component }>` ahabw'okuba etaine kiranga nearestPoint.
+
+constrain-to-interior-without-nearest-point = Tikirikubaasika kwemeza omunda ya `<{ $component }>` ahabw'okuba etaine kiranga nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition neerengwaho aha choiceInput etari ya mu murongo
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Nitureengaho indices ezatairweho aha choiceInput ahabw'okuba omubaro gwazo tigurikuhikaana n'omubaro gw'abaana ba choice.
+
+pretzel-indices-count-mismatch = Nitureengaho indices ezatairweho aha problem ahabw'okuba omubaro gwazo tigurikuhikaana n'omubaro gw'abaana ba problem.
+
+shuffle-indices-count-mismatch = Nitureengaho indices ezatairweho aha shuffle ahabw'okuba omubaro gwazo tigurikuhikaana n'omubaro gw'ebicweka.
+
+indices-ignored-out-of-range = Nitureengaho indices ezatairweho aha { $component } ahabw'okuba ezimwe ziri aheeru y'orugyero.
+
+pretzel-indices-repeated = Nitureengaho indices ezatairweho aha pretzel ahabw'okuba ezimwe zigarukiirwemu.
+
+pretzel-circuit-first-index = Nitureengaho indices ezatairweho aha pretzel omuri mode="circuit" ahabw'okuba ey'okubanza eshemereire kuba 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Okubaasa `<{ $component }>` kukorana n'abaana b'ebigambo, ekiranga `type` kishemereire kutaho.
+
+invalid-type-defaulting-to-math = Omuringo { $type } tigwo aha kicweka { $component }. Gushemereire kuba math, text, number nari boolean. Nitugaruka aha math.
+
+string-not-valid-component-to-arrange = Ekigambo "{ $value }" ti kicweka kirikubaasika aha { $component }. Nitukireengaho.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Omuringo { $type } tigwo, nituta omuringo aha number.
+
+invalid-variable-value = Omuhendo gw'ekirikuhinduka tigwo: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Omubaro gw'omuringo { $index } gushemereire kuba enamba
+
+variant-index-must-be-integer = Omubaro gw'omuringo { $index } gushemereire kuba enamba ehikire
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` tikirakozirwe aha bigyero ebihamire. Nituta obugyeya aha bugyereeranwa.
+
+side-by-side-absolute-margins = `<{ $component }>` tikirakozirwe aha bigyero ebihamire. Nituta empera aha bugyereeranwa.
+
+side-by-side-no-block-child = `<{ $component }>` tikiri kyo: kishemereire kugira nibura omwana omwe w'ekicweka.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ekiranga `for` aha `<label>` y'ekishushani nikirengwaho.
+
+label-for-must-resolve-to-one = Ekiranga `for` aha `<label>` kishemereire kworeka ekicweka kimwe kyonka.
+
+label-for-unresolved = Ekiranga `for` aha `<label>` tikibaasize kworeka ekicweka.
+
+label-for-answer-with-authored-inputs = Ekiranga `for` aha `<label>` nikyoreka `<answer>` eine ebitairwemu ebyahandiikirwe omuhandiiki; oreke ekitairwemu kyonyini.
+
+label-for-answer-without-input = Ekiranga `for` aha `<label>` nikyoreka `<answer>` etaine kitairwemu ky'okuha eibara.
+
+label-for-must-reference-input-or-answer = Ekiranga `for` aha `<label>` kishemereire kworeka ekitairwemu nari eky'okugarukamu.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ahabw'okuhikaho, `<{ $component }>` eshemereire kugira okushoboorora kukye nari kutaho nk'eky'okusiimisa.
+
+accessibility-video-short-description = Ahabw'okuhikaho, `<video>` eshemereire kugira okushoboorora kukye.
+
+accessibility-input-short-description-or-label = Ahabw'okuhikaho, `<{ $component }>` eshemereire kugira okushoboorora kukye nari eibara.
+
+accessibility-answer-input-short-description-or-label = Ahabw'okuhikaho, `<answer>` erikukora ekitairwemu eshemereire kugira okushoboorora kukye nari eibara.
+
+accessibility-short-description-contains-math = Okushoboorora kukye tikushemereire kugira ebicweka by'ebibaro nka `<{ $component }>`. Shoboorora ebibaro n'ebigambo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } teine kutaana kuhikire aha byahandiikirwe by'omutwe gw'ekicweka (omu ndeeba y'omwirima) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nihetengwa nibura { $threshold }:1).
+       *[other] { $colorName } teine kutaana kuhikire aha byahandiikirwe by'omutwe gw'ekicweka ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nihetengwa nibura { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Tikirakozirwe `<circle>` erikucwa omu budomo { $count } obutaine mihendo y'enamba.
+
+circle-too-many-through-points = Tikirikubaasika kubara eriziga erikucwa omu budomo burikukira aha bushatu.
+
+circle-overprescribed-radius-center-points = Tikirikubaasika kubara eriziga eriine radius, omutima n'obudomo bw'okucwamu byona.
+
+circle-center-with-multiple-points = Tikirikubaasika kubara eriziga eriine omutima erikucwa omu kadomo kakira aha kamwe.
+
+circle-radius-too-small = Tikirikubaasika kubara eriziga: ahabw'okuba orugyendo hagati y'obudomo bubiri ni { $distance }, radius { $radius } eyatairweho ni nkye munonga.
+
+circle-radius-with-many-points = Tikirikubaasika kukora eriziga erikucwa omu budomo bukira aha bubiri eriine radius eyatairweho.
+
+circle-invalid-center-or-through-points = Omutima nari obudomo bw'okucwamu bw'eriziga tibiri byo.
+
+circle-radius-center-with-multiple-points = Tikirikubaasika kubara radius y'eriziga eriine omutima erikucwa omu kadomo kakira aha kamwe.
+
+circle-change-radius-non-numerical = Tikirikubaasika kuhindura radius y'eriziga eriine obudomo obutaine mihendo y'enamba
+
+circle-radius-with-points-non-numerical = Tikirikubaasika kukora eriziga erikucwa omu kadomo kakira aha kamwe eriine radius eyatairweho obu emihendo y'enamba etariho.
+
+circle-change-center-non-numerical = Tikirakozirwe kuhindura omutima gw'eriziga erikucwa omu budomo obutaine mihendo y'enamba.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Obugyereeranwa bwa domain ya fonkishoni tibumaziire. Domain eine ekicweka { $intervals } kwonka fonkishoni eine { $inputs ->
+            [one] ekitairwemu { $inputs }
+           *[other] ebitairwemu { $inputs }
+        }.
+       *[other] Obugyereeranwa bwa domain ya fonkishoni tibumaziire. Domain eine ebicweka { $intervals } kwonka fonkishoni eine { $inputs ->
+            [one] ekitairwemu { $inputs }
+           *[other] ebitairwemu { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Enshoneka ya domain ya fonkishoni tiri yo.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nitureengaho omuhendo gwa fonkishoni ogurikukira ogutari gwa namba.
+        [minimum] Nitureengaho omuhendo gwa fonkishoni ogurikukyena ogutari gwa namba.
+        [extremum] Nitureengaho omuhendo gwa fonkishoni ogw'aha mpera ogutari gwa namba.
+        [point] Nitureengaho akadomo ka fonkishoni akatari ka namba.
+        [slope] Nitureengaho okwegamira kwa fonkishoni okutari kwa namba.
+       *[other] Nitureengaho { $type } ya fonkishoni etari ya namba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nitureengaho omuhendo gwa fonkishoni ogurikukira ogw'obusa.
+        [minimum] Nitureengaho omuhendo gwa fonkishoni ogurikukyena ogw'obusa.
+        [extremum] Nitureengaho omuhendo gwa fonkishoni ogw'aha mpera ogw'obusa.
+        [point] Nitureengaho akadomo ka fonkishoni ak'obusa.
+       *[other] Nitureengaho { $type } ya fonkishoni ey'obusa.
+    }
+
+function-points-too-close = Fonkishoni eine obudomo bubiri oburi haihi munonga. Tikirikubaasika kushoboorora fonkishoni.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Okugarukamu kwa fonkishoni nikubaasika obu omubaro gw'ebitairwemu gurikwingana n'ogw'ebirikuruga omu. Fonkishoni egi eine ekitairwemu { $inputs } na { $outputs ->
+            [one] ekirikuruga { $outputs }
+           *[other] ebirikuruga { $outputs }
+        }.
+       *[other] Okugarukamu kwa fonkishoni nikubaasika obu omubaro gw'ebitairwemu gurikwingana n'ogw'ebirikuruga omu. Fonkishoni egi eine ebitairwemu { $inputs } na { $outputs ->
+            [one] ekirikuruga { $outputs }
+           *[other] ebirikuruga { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Oburaingwa bw'orukurikirana tiburi bwo.  Bushemereire kuba enamba ehikire etari haansi ya zeero.
+
+sequence-invalid-step = Entambi y'orukurikirana tiri yo.  Eshemereire kuba enamba aha rukurikirana rw'omuringo { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" y'orukurikirana rw'enamba tiri yo.  Eshemereire kuba enamba.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" y'orukurikirana rw'enyukuta tiri yo.  Eshemereire kuba enteeraniso y'enyukuta.
+
+sequence-invalid-endpoint = "{ $attribute }" y'orukurikirana tiri yo.
+
+select-from-sequence-coprime-not-numbers = coprime neerengwaho ahabw'okuba titurikutoorana namba
+
+select-from-sequence-coprime-with-exclude-combinations = coprime neerengwaho ahabw'okuba excludeCombinations ekatahoho
+
+## Resolving a `target`
+
+target-not-found = Target ya `<{ $source }>` tiri yo: tikibaasize kushanga target.
+
+target-state-variable-not-found = Target ya `<{ $source }>` tiri yo: tikibaasize kushanga ekirikuhinduka ekyetwa "{ $property }" aha `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ebirikuhinduka bya `<odeSystem>` bishemereire kutaba nk'ekirikuhinduka ekyeyimirireho.
+
+ode-system-duplicate-variable-names = Tikirikubaasika kushoboorora fonkishoni za ODE RHS ziine amabara g'ebirikuhinduka agarikugarukiramu.
+
+ode-system-rhs-function-error = Tikirikubaasika kushoboorora fonkishoni ya ODE RHS.  Hariho ekihabo omu kukora fonkishoni ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Tikirikubaasika kushoboorora enkona hagati y'emirongo { $count }
+
+angle-invalid-through-point = Akadomo aka through ka `<angle>` tikari ko
+
+parabola-vertex-too-many-points = Tikirakozirwe parabora eine omutwe erikucwa omu kadomo kakira aha kamwe.
+
+parabola-too-many-points = Tikirakozirwe parabora erikucwa omu budomo bukira aha bushatu.
+
+intersection-too-many-items = Tikirakozirwe okusangana kw'ebintu birikukira aha bibiri
+
+## Other math components
+
+ionic-compound-not-two-ions = Tikirakozirwe enteeraniso y'ayoni etari ya yoni ibiri.
+
+ionic-compound-needs-cation-and-anion = Enteeraniso y'ayoni ekozirwe aha katayoni emwe n'anayoni emwe zoonka.
+
+solve-equations-cannot-evaluate = Tikirikubaasika kucwamu enkyangano ahabw'okuba tikibaasize kugigyereeranisa: { $equation }
+
+math-operators-operand-number-required = Oshemereire kutaho operandNumber obu orikwiha operand y'ebibaro.
+
+eigen-decomposition-failed = Tikibaasize kubara eigenvalues za matirikisi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: paramita { $parameters } terikubonekera omu nshoneka, n'ahabw'ekyo eryahikaana n'obusa buri kiro.
+       *[other] `<matchesPattern>`: paramita { $parameters } tizirikubonekera omu nshoneka, n'ahabw'ekyo ziryahikaana n'obusa buri kiro.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: tikibaasize kwetegyereza grid="{ $grid }". Eshemereire kuba none, medium, dense, nari enamba ibiri ezirikukira aha zeero ezitaaniisibwe ahabwanya, nk'egi grid="1 0.5". Tihariho grid erikushushanwa.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` neetenga fonkishoni eine { $expected ->
+        [one] ekirikuruga kimwe, okwegamira aha buri kadomo, nk'eki `y - x`
+       *[other] ebirikuruga bibiri, vekita aha buri kadomo, nk'egi `(y, -x)`
+    }, kwonka fonkishoni eyahairwe eine { $found ->
+        [one] ekirikuruga { $found }
+       *[other] ebirikuruga { $found }
+    }. { $alternative ->
+        [none] Tihariho ekirikushushanwa.
+       *[other] `<{ $alternative }>` niyo kicweka kya fonkishoni egyo. Tihariho ekirikushushanwa.
+    }
+
+field-function-attribute-ignored-with-child = Ekiranga `function` nikirengwaho ahabw'okuba fonkishoni ekatahoho n'omunda y'ekicweka; ey'omunda niyo erikukoresibwa. Ha fonkishoni omu muringo gumwe gwonka.
+
+field-variables-ignored =
+    `<{ $component }>`: ekiranga `variables` nikyeta ebirikuhinduka by'ekyahandiikirwe ekiri omunda y'ekicweka. { $reason ->
+        [function-child] Fonkishoni eri hanu ehairwe nk'omwana `<function>`, orikweta ebirikuhinduka byaayo, n'ahabw'ekyo `variables` neerengwaho.
+       *[no-expression] Tihariho kyahandiikirwe nk'ekyo hanu, n'ahabw'ekyo `variables` neerengwaho.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" tikirikukorwaho omu mworeki wa prefigure; nituta ey'aha buryo.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" tikirikukorwaho omu mworeki wa prefigure; nituta ey'ahaiguru.
+
+prefigure-invalid-axis-bounds = `<graph>`: empera za akisi tiziri zo ahabw'okuhindura kwa prefigure; nituta bbox ey'obwire bwona (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: obugyeya tiburi bwo ahabw'okuhindura kwa prefigure; nituta obugyeya bw'ekishushani obw'obwire bwona 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio tiri yo ahabw'okuhindura kwa prefigure; nituta aspect ratio ey'obwire bwona 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: obwanya bwa grid ni bukye munonga ahabw'empera za akisi; grid neerengwaho omu mworeki wa prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations tiziryashushanwa obu otarikukoresa omworeki wa PreFigure.
+
+multiple-annotations-children = Hashangirwe abaana `<annotations>` baingi omuri `<graph>`; boona kutariho ow'aha muheru nibarengwaho.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tikirikubaasika kwongyera nari kukopa omuringo gw'ekicweka ogutamanyirwe: { $type }.
+
+copy-prop-not-found = Tikibaasize kushanga prop { $property } aha kicweka ky'omuringo { $component }
+
+collect-no-source = Tihariho ensimburiro eshangirwe ya collect.
+
+collect-invalid-component-type = Tikirikubaasika kwoorekana ebicweka by'omuringo `<{ $component }>` ahabw'okuba ogwo muringo tigwo.
+
+reference-index-unavailable = Tikirikubaasika kworeka index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Tikirikubaasika kweta { $action } aha kicweka `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data eine enshoneka etari yo.  Emirongo eine oburaingwa oburikutaana. Kishangirwe omuri componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data eine amabara g'empagi agarikugarukiramu.  Kishangirwe omuri componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data ebuzireho eibara ry'empagi.  Kishangirwe omuri componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award y'eky'okugarukamu eki neesigama aha ky'okugarukamu kya answer yonyini, ekirikwija kureetera ebitatekateekirwe.
+
+answer-max-num-attempts-in-section-wide-check-work = Okuta `maxNumAttempts` aha `<answer>` eri omunda y'ekicweka ekiine `sectionWideCheckWork` tikirikukora, ahabw'okuba omubaro gw'emirundi gurikutwarwa ekicweka. Ta `maxNumAttempts` aha kicweka.
+
+nested-section-wide-check-work-max-num-attempts = Okuta `maxNumAttempts` aha kicweka kiine `sectionWideCheckWork` ekiri omunda y'ekindi kicweka kiine `sectionWideCheckWork` tikirikukora, ahabw'okuba omubaro gw'emirundi gurikutwarwa ekicweka eky'aheeru. Ta `maxNumAttempts` aha kicweka eky'aheeru.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Ekiranga { $attributes } tikiryakora symbolicEquality etatairweho.
+       *[other] Ebiranga { $attributes } tibiryakora symbolicEquality etatairweho.
+    }
+
+answer-invalid-type = Omuringo gw'eky'okugarukamu tigwo: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ahabw'okuba ekicweka `<{ $component }>` tikiine eibara, tikirikubaasa kukoresibwa nk'ekiranga kya module
+
+module-attribute-name-already-defined = Ekicweka `<{ $component } name="{ $name }">` tikirikubaasa kukoresibwa nk'ekiranga kya module ahabw'okuba ekicweka `<module>` kiine ekiranga "{ $name }" ekishoboororwa.
+
+conditional-content-condition-ignored = Ekiranga `condition` nikirengwaho aha `<conditionalContent>` eine abaana ba case nari else.
+
+slider-markers-type-mismatch = Omuringo gwa markers tigurikuhikaana n'ogwa slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel tiri yo: buri `<problem>` eshemereire kugira `<statement>` emwe n'`<answer>` emwe.
+
+pretzel-circuit-first-problem-distractor = Pretzel tiri yo: omuri mode="circuit", `<problem>` ey'okubanza teribaasa kuba distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Omuhendo { $values } gw'ekiranga `{ $attribute }` tigwo; nitugureengaho.
+       *[other] Emihendo { $values } y'ekiranga `{ $attribute }` tiyo; nitugireengaho.
+    }
+
+attribute-must-be-references = Omuhendo `{ $value }` gw'ekiranga `{ $attribute }` tigwo. Ekiranga kishemereire kubaho ebyoreka ebirikutandika na `$`.
+
+math-input-invalid-function-names = <mathInput>: hakarengwaho amabara ga fonkishoni agatari go omuri { $attribute }: { $names }. Buri ibara rishemereire kugira nibura obuhandiiko bubiri (enyukuta nari obukwato); nooyenda nowaayongyeraho `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Omuringo gw'ekicweka tigwo: `<{ $componentType }>`
+
+attribute-repeated = Tikirikubaasika kugarukamu ekiranga { $attribute }.
+
+attribute-invalid-for-component = Ekiranga "{ $attribute }" tikiri kya kicweka ky'omuringo `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Enshoneka y'endeeba { $styleNumber } teine kutaana kuhikire aha { $context ->
+        [text-on-background] rangi y'ebyahandiikirwe erikureeberwa aha rangi y'enyima
+        [high-contrast] rangi y'okutaana kwingi erikureeberwa aha rubaaho
+        [line] rangi y'omurongo erikureeberwa aha rubaaho
+        [marker] rangi y'akamanyiso erikureeberwa aha rubaaho
+       *[text-on-canvas] rangi y'ebyahandiikirwe erikureeberwa aha rubaaho
+    }{ $mode ->
+        [dark] { " (omu ndeeba y'omwirima)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nihetengwa nibura { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    N'obu enshoneka y'endeeba { $styleNumber } eine rangi ezirikutaana kuhikire omu ndeeba y'omushana, rangi z'omu ndeeba y'omwirima ezirugire omuriezo tiziine kutaana kuhikire aha rangi y'ebyahandiikirwe erikureeberwa aha rangi y'enyima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nihetengwa nibura { $threshold }:1). { $suggestion ->
+        [available] Okubaasa kugira okutaana kuhikire omu ndeeba y'omwirima, yongyera okutaana kw'omu ndeeba y'omushana (nk'ekyokureeberaho, ta { $lightAttribute }="{ $lightColor }") nari ohindure rangi y'omu ndeeba y'omwirima (nk'ekyokureeberaho, ta { $darkAttribute }="{ $darkColor }").
+       *[none] Okubaasa kugira okutaana kuhikire omu ndeeba y'omwirima, yongyera okutaana kw'omu ndeeba y'omushana nari ohindure rangi ezirugiremu na textColorDarkMode na/nari backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    N'obu enshoneka y'endeeba { $styleNumber } eine rangi y'ebyahandiikirwe erikutaana kuhikire omu ndeeba y'omushana, rangi y'ebyahandiikirwe ey'omu ndeeba y'omwirima erugire omuriyo teine kutaana kuhikire aha rubaaho ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nihetengwa nibura { $threshold }:1). { $suggestion ->
+        [available] Okubaasa kugira okutaana kuhikire omu ndeeba y'omwirima, yongyera okutaana kw'omu ndeeba y'omushana (nk'ekyokureeberaho, ta textColor="{ $lightColor }") nari ohindure rangi y'omu ndeeba y'omwirima (nk'ekyokureeberaho, ta textColorDarkMode="{ $darkColor }").
+       *[none] Okubaasa kugira okutaana kuhikire omu ndeeba y'omwirima, yongyera okutaana kw'omu ndeeba y'omushana nari ohindure rangi erugiremu na textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Ekicweka nikibaasa kutoorana <stylePalette> emwe yonka; nitukoresa ey'aha muheru.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba numToSelect tiri namba ehikire etari haansi ya zeero.
+
+variant-num-to-select-not-constant-number = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba numToSelect tiri namba ehamire.
+
+variant-with-replacement-not-constant-boolean = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba withReplacement tiri boolean ehamire.
+
+variant-select-weight-disables-unique = Emiringo etarikugarukiramu ya select nezimwa obu haine ekitoorano kiine selectWeight nari selectForVariants ekitairweho
+
+variant-coprime-undetermined = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba tikirikubaasika kumanya ku coprime eri buri kiro etari yo.
+
+variant-attribute-not-constant = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba { $attribute } tehamire.
+
+variant-attribute-not-number = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba { $attribute } tiri namba.
+
+variant-attribute-wrong-type-for-sequence =
+    tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ey'omuringo { $type } ahabw'okuba { $attribute } tiri { $expected ->
+        [letters-combination] nteeraniso y'enyukuta
+        [math-expression] kyahandiikirwe ky'ebibaro ekihikire
+        [integer] namba ehikire
+       *[number] namba
+    }.
+
+variant-length-not-integer = tikirikubaasika kumanya emiringo etarikugarukiramu ya { $component } ahabw'okuba length tiri namba ehikire.
+
+variant-sort-not-implemented = tikirakozirwe kumanya emiringo etarikugarukiramu ya { $component } eine sort
+
+variant-exclude-combinations-not-implemented = tikirakozirwe kumanya emiringo etarikugarukiramu ya { $component } eine excludeCombinations
+
+variant-math-exclude-not-implemented = tikirakozirwe kumanya emiringo etarikugarukiramu ya { $component } ey'omuringo math eine exclude
+
+variant-non-constant-exclude-not-implemented = tikirakozirwe kumanya emiringo etarikugarukiramu ya { $component } eine exclude etahamire
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: tikirikukorwaho omu mworeki wa prefigure gwa graph; omwana arengirweho.
+
+prefigure-descendant-invalid-geometry = { $subject }: enshoneka teheza nari terikuhwera; omwana arengirweho.
+
+prefigure-curve-label-omitted = { $subject }: amabara tigarikukorwaho aha mirongo egombire ehindwirwe; eibara ririkurengwaho.
+
+prefigure-curve-unsupported-definition-type = { $subject }: omuringo gw'okushoboorora omurongo ogugombire '{ $definitionType }' tigurikukorwaho; omwana arengirweho.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ekiranga flipFunctions aha regionBetweenCurves tikirikukorwaho; omwana arengirweho.
+
+prefigure-region-non-formula-child = { $subject }: aha regionBetweenCurves nihakorwaho fonkishoni z'omuringo gwa formula zoonka; omwana arengirweho.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' tirikukorwaho aha { $labelKind ->
+        [line-family] ibara ry'eby'omurongo
+       *[point] ibara ry'akadomo
+    }; nituta enteekateeka ya PreFigure ey'obwire bwona.
+
+prefigure-fill-style-unsupported = { $subject }: omuringo gw'okwijuza '{ $fillStyle }' tigurikukorwaho na PreFigure; nitugaruka aha kwijuza kuhamire.
+
+prefigure-line-style-unknown = { $subject }: omuringo gw'omurongo '{ $lineStyle }' ogutamanyirwe gurengirweho omu birikuruga omuri PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: omuringo gw'akamanyiso '{ $markerStyle }' guhindwirwe omu muringo gwa PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: omuringo gw'akamanyiso '{ $markerStyle }' tigurikukorwaho na PreFigure; nituta ogw'obwire bwona.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tiri yo; tikibaasize kushanga target. Annotation erengirweho.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ekoreka targets nyingi; nitukoresa ey'okubanza.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tiri yo; target eri aheeru ya graph erikugitwariza. Annotation erengirweho.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tiri yo; target ti kintu ky'ekishushani ekirikukorwaho omu kuhindura kwa prefigure. Annotation erengirweho.
+
+annotation-text-missing = `<annotation>`: `text` ebuzireho nari ni y'obusa; nituhamu ebigambo by'obusa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Hashangirwe okwesigama okurikwezingurura.
+       *[other] Hashangirwe okwesigama okurikwezingurura okurikutwariramu ekicweka `<{ $componentType }>`.
+    }
+
+reference-no-referent = Tihariho ekishangirwe aha kyoreka eki: `{ $reference }`
+
+reference-multiple-referents = Hashangirwe ebintu bingi aha kyoreka eki: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Enshoneka y'ekiranga { $attribute } kya `<{ $componentType }>` tiri yo.
+
+children-invalid = Abaana ba `<{ $componentType }>` tibari bo: hashangirwe abaana abatari bo: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Omuhendo `{ $value }` gw'ekiranga `{ $attribute }` tigwo, nitukoresa omuhendo `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Enshoneka ya DoenetML { $version } tishangirwe.
+       *[other] Enshoneka ya DoenetML { $version } tishangirwe. Nitugaruka aha nshoneka { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tiri yo: { $content }
+
+parse-tag-missing-close-tag = DoenetML tiri yo: Tagi `{ $tag }` tiine tagi y'okugyigara. Hakaba haine tagi eyeegara nari tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML tiri yo: Hariho ekihabo omu tagi `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML tiri yo: Ekiranga `{ $attribute }` ekitari kyo nikireebeka nk'ekibuzireho omuhendo.
+
+parse-attribute-invalid = DoenetML tiri yo: Ekiranga `{ $attribute }` tikiri kyo
+
+parse-attribute-value-invalid = DoenetML tiri yo: Omuhendo gw'ekiranga `{ $value }` tigwo
+
+parse-attribute-value-quote-mismatch = DoenetML tiri yo: Omuhendo gw'ekiranga `{ $value }` tigwo. Obumanyiso bw'okucwamu tiburikuhikaana. Nooshusha okuba obuzireho `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML tiri yo: Hashangirwe tagi etaine ibara, nk'egi `<`
+
+parse-tag-not-closed = DoenetML tiri yo: Tagi `{ $tag }` tekaigazibwa (`>` neereebeka nk'ebuzireho).
+
+parse-self-closing-tag-name-missing = DoenetML tiri yo: Hashangirwe tagi etaine ibara `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tiri yo: Tagi `{ $tag }` tekaigazibwa (`/>` neereebeka nk'ebuzireho).
+
+parse-tag-invalid-attributes = DoenetML tiri yo: Tagi `{ $tag }` tiri yo. Neebaasa kuba eine ebiranga ebitari byo.
+
+parse-close-tag-name-missing = DoenetML tiri yo: Hashangirwe tagi y'okugara etaine ibara, nk'egi `</`
+
+parse-attribute-value-unquoted = Emihendo y'ebiranga eshemereire kuba omu bumanyiso bw'okucwamu: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tiri yo: Hashangirwe tagi y'okugara `{ $tag }`, kwonka tihariho tagi y'okwigura erikuhikaana nayo
+
+parse-close-tag-mismatched = DoenetML tiri yo: Tagi y'okugara tirikuhikaana. Hakaba haine `</{ $expected }>`. Hashangirwe `{ $found }`
+
+parser-node-unconvertible = Tikibaasize kuhindura node { $node } omu node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Eibara name='{ $name }' tiri ryo. { $reason ->
+        [characters] Amabara nigabaasa kugira enyukuta, enamba, obukwato bw'ahansi nari obukwato bw'ahagati zoonka.
+       *[start] Amabara gashemereire kutandika n'enyukuta.
+    }
+
+component-name-invalid-start = Eibara ry'ekicweka "{ $name }" tiri ryo. Amabara gashemereire kutandika n'enyukuta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer y'omuringo videoWatched eshemereire kugira ekiranga video
+
+answer-video-watched-video-not-reference = Answer y'omuringo videoWatched eshemereire kugira ekiranga video ekiri ekyoreka
+
+answer-name-not-single-text = Ekiranga name kya answer kishemereire kugira omwana omwe w'ebigambo
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Tikibaasize kwiha DoenetML y'aheeru ahabw'okwezingurura kwingi munonga. Hariho ekyoreka ekirikwezingurura?
+
+external-doenetml-unavailable = Tikibaasize kwiha DoenetML aha { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML eyiihirwe aha { $attribute }="{ $uri }" tiri yo: tekahikaana n'omuringo gw'ekicweka "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Ekiranga `{ $from }` tikikyakoresibwa; koresa `{ $to }`.
+       *[other] [deprecation] Ekiranga `{ $from }` aha `<{ $component }>` tikikyakoresibwa; koresa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Ekiranga `{ $from }` tikikyakoresibwa kandi nikirengwaho ahabw'okuba `{ $to }` nayo etairweho.
+       *[other] [deprecation] Ekiranga `{ $from }` aha `<{ $component }>` tikikyakoresibwa kandi nikirengwaho ahabw'okuba `{ $to }` nayo etairweho.
+    }
+
+deprecated-attribute-ignored = [deprecation] Ekiranga `{ $attribute }` aha `<{ $component }>` tikikyakoresibwa kandi nikirengwaho.
+
+deprecated-attribute-to-child = [deprecation] Ekiranga `{ $attribute }` aha `<{ $component }>` tikikyakoresibwa; koresa omwana `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Omuhendo `{ $value }` gw'ekiranga `{ $attribute }` aha `<{ $component }>` tigukyakoresibwa; koresa `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` nebaasa kwongyera obwingi omu Rungyereza kwonka, n'ahabw'ekyo ebigambo byayo tibirikuhindurwa omu kitabo ekyahandiikirwe omu { $locale }. Handiika obwingi wenyini, nari obute n'ekiranga `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ekicweka `<{ $tag }>` ti kicweka kya Doenet ekimanyirwe.
+
+schema-element-not-allowed-at-root = Ekicweka `<{ $tag }>` tikirikwikirizibwa aha musingye gw'ekitabo.
+
+schema-element-not-allowed-inside = Ekicweka `<{ $tag }>` tikirikwikirizibwa omunda ya `<{ $parent }>`.
+
+schema-attribute-unrecognized = Ekicweka `<{ $tag }>` tikiine kiranga kirikwetwa `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Ekiranga `{ $attribute }` kya `<{ $tag }>` kishemereire kuba orukurikirana oruriine buri kintu kiri kimwe aha bi: { $allowed }
+       *[other] Ekiranga `{ $attribute }` kya `<{ $tag }>` kishemereire kuba kimwe aha bi: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Eibara ry'omuringo rya select tiriri ryo.  Eibara ry'omuringo { $variantName } nirireeba omu bitoorano { $numOptions } kwonka omubaro gw'ebirikutooranwa ni { $numToSelect }.
+
+select-variant-name-without-options = Emiringo emwe etairweho aha select kwonka tihariho bitoorano ebitairweho aha ibara ry'omuringo orikubaasika: { $variantName }.
+
+select-variant-name-not-possible = Eibara ry'omuringo { $variantName } eryatairweho aha select tiriri ibara ry'omuringo orikubaasika.
+
+select-too-few-options = Tikirikubaasika kutoorana ebicweka { $numToSelect } omu { $numOptions } byonka.
+
+select-from-sequence-too-few-values = Tikirikubaasika kutoorana emihendo { $numToSelect } omu rukurikirana rw'oburaingwa { $length }.
+
+select-from-sequence-indices-count-mismatch = Omubaro gwa indices ezatairweho aha select gushemereire kuhikaana n'omubaro gw'ebirikutooranwa
+
+select-from-sequence-indices-not-integers = Indices zoona ezatairweho aha select zishemereire kuba enamba ezihikire
+
+select-from-sequence-index-excluded = Index ya selectfromsequence eyatairweho ekaba erengirweho
+
+select-from-sequence-indices-excluded-combination = Indices za selectfromsequence ezatairweho zikaba ziri enteeraniso erengirweho
+
+select-from-sequence-coprime-not-positive-integers = Tikirikubaasika kutoorana enteeraniso za coprime ahabw'okuba titurikutoorana namba ezirikukira aha zeero.
+
+select-from-sequence-coprime-common-factor = Tikirikubaasika kutoorana enamba za coprime. Emihendo yoona erikubaasika eine ekigyereeranisa kimwe. (Emihendo eyatairweho aha "from" nari "to" eshemereire kuba coprime na "step".)
+
+select-from-sequence-coprime-single-number = Tikirikubaasika kutoorana enteeraniso za coprime omu namba emwe etari 1.
+
+select-from-sequence-excluded-too-many-combinations = Hakarengwaho enteeraniso zirikukira aha 70% omuri selectFromSequence
+
+select-from-sequence-coprime-none-found = Tikibaasize kutoorana enamba za coprime. Emihendo yoona erikubaasika eine ekigyereeranisa kimwe.
+
+select-from-sequence-too-few-unique-values = Tikirikubaasika kutoorana emihendo { $numToSelect } etarikugarukiramu omu rukurikirana rw'oburaingwa { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Tikirikubaasika kutoorana emihendo { $numToSelect } omu rutonde rw'enamba za prime orw'oburaingwa { $numValues }
+
+select-prime-numbers-values-count-mismatch = Omubaro gw'emihendo eyatairweho aha select gushemereire kuhikaana n'omubaro gw'ebirikutooranwa
+
+select-prime-numbers-values-not-prime = Emihendo yoona eyatairweho aha select prime number eshemereire kuba omu rutonde rw'enamba za prime
+
+select-prime-numbers-values-excluded-combination = Emihendo ya selectPrimeNumbers eyatairweho ekaba eri enteeraniso erengirweho
+
+select-prime-numbers-excluded-too-many-combinations = Hakarengwaho enteeraniso zirikukira aha 70% omuri selectPrimeNumbers
+
+select-random-combination-fluke = Aha mahwa g'obutabaasika, tikibaasize kutoorana enteeraniso y'emihendo etatekateekirwe
+
+select-random-value-fluke = Aha mahwa g'obutabaasika, tikibaasize kutoorana omuhendo ogutatekateekirwe
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` egi terikworekwa ahabw'okuba eri omunda y'ebibaro kandi ti `inline`. Ongyeraho `inline` ebone kuba orutonde rw'okucwamu, orurikutaaha omu kyahandiikirwe.
+        [expanded] `<{ $component }>` egi terikworekwa ahabw'okuba eri omunda y'ebibaro kandi ni `expanded`. Ihaho `expanded`; akasanduuko k'emirongo mingi tikarikutaaha omu kyahandiikirwe.
+        [on-graph] `<{ $component }>` egi terikworekwa ahabw'okuba eri omunda y'ebibaro ebishushanirwe aha graph, ahataine mwanya gw'ekitairwemu.
+       *[relative-width] `<{ $component }>` egi terikworekwa ahabw'okuba eri omunda y'ebibaro kandi eine obugyeya obw'obugyereeranwa. Ha obugyeya omu bigyero ebihamire, nka `px`.
+    }

--- a/packages/i18n/locales/cgg/diagnostics.ftl
+++ b/packages/i18n/locales/cgg/diagnostics.ftl
@@ -22,8 +22,10 @@
 # for *has not been implemented*, «tikiri kyo» / «tiri yo» for *invalid*
 # (literally *it is not it*, with the concord of whatever is being talked
 # about), «ahabw'okuba» for *because*, «kwonka» for *but*, «nari» for *or*,
-# «omu mwanya gw'ekyo» for *instead*, «nibura» for *at least*, «obusa» for
-# *empty*, «ekihabo» for an error. Native nouns doing real work: «omurongo»
+# «nibura» for *at least*, «obusa» for *empty*, «ekihabo» for an error.
+# English's trailing *instead* has no phrase here: Rukiga carries it in the
+# bare imperative that follows, so «Ta `maxNumAttempts` aha kicweka» is the
+# whole of it. Native nouns doing real work: «omurongo»
 # (a source line, a row, and the geometric line), «empagi» (a column),
 # «eibara» (a name — the Kigezi word), «akadomo» (a point), «eriziga» (a
 # circle), «enkona» (an angle), «omuhendo» (a value), «ekirikuhinduka» (a

--- a/packages/i18n/locales/cgg/editor.ftl
+++ b/packages/i18n/locales/cgg/editor.ftl
@@ -25,9 +25,14 @@
 #
 # **What is borrowed.** English, openly and only where the word is what a
 # Ugandan classroom says: «fonkishoni», «eripoota», «tagi». The two counted
-# selects below use ordinary Rukiga nouns («ekizibu» / «ebizibu»,
-# «endagiriro») rather than a loan for *violation*, so that the plural has
-# something to work on.
+# selects below use ordinary Rukiga nouns rather than a loan for *violation*,
+# so that the plural has something to work on — but the two work differently.
+# «ekizibu» / «ebizibu» changes its class prefix, so the noun itself carries
+# the number; «endagiriro» is class 9/10 and is spelt the same in both
+# numbers, so `editor-accessibility-label`'s advisory count marks number only
+# on what agrees with it («y'… endiijo» against «z'… ezindi»). Both branches
+# still differ; a reviewer should not read the second as an unfinished copy of
+# the first.
 #
 # **Weakest here.** «okuhikaho» is doing duty for *accessibility* throughout —
 # it is «okuhika aha», *reaching*, which is the right idea but is not an

--- a/packages/i18n/locales/cgg/editor.ftl
+++ b/packages/i18n/locales/cgg/editor.ftl
@@ -1,0 +1,234 @@
+# Chiga (Rukiga) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** As `chrome.ftl` sets it out: the shared
+# Runyankore-Rukiga standard, `c` and not `ch`, the augment written, Latin
+# digits.
+#
+# `WCAG`, `WCAG AA`, `DoenetML`, `XML` and `styleNumber` are names rather than
+# words and stay exactly as they stand, as do the key combinations `$shortcut`
+# carries.
+#
+# **What is Rukiga here.** The panel's own frame: «Tihariho …» for *no X
+# found*, «Kanda …» for *click to …*, «Manya …» for *learn about*,
+# «nikyoreka» for *is a reference to*, «ekiranga» for an attribute,
+# «ekigyendererwa» for a value, «omuringo» for a variant and for a type,
+# «eibara» for a name — the Kigezi word, where Runyankore says «eiziina».
+#
+# **What is borrowed.** English, openly and only where the word is what a
+# Ugandan classroom says: «fonkishoni», «eripoota», «tagi». The two counted
+# selects below use ordinary Rukiga nouns («ekizibu» / «ebizibu»,
+# «endagiriro») rather than a loan for *violation*, so that the plural has
+# something to work on.
+#
+# **Weakest here.** «okuhikaho» is doing duty for *accessibility* throughout —
+# it is «okuhika aha», *reaching*, which is the right idea but is not an
+# established Rukiga technical term, and a reviewer should decide whether it
+# reads as one. `help-kind-snippet` («akacweka») and `help-kind-array-entry`
+# are the two other places where the seed had to describe rather than name.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Garurayo
+       *[update] Hyahyisa
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Omworeki
+       *[other] { $word } Omworeki { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Omuringo
+
+editor-variant-filter = Cwamu…
+
+editor-variant-next = Toorana omuringo ogurikukuratsya
+
+editor-variant-previous = Toorana omuringo ogwahweireho
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Hashangirwe ekizibu kya WCAG AA omu kuhikaho. Kanda { $action ->
+            [close] okwigara
+           *[open] okwigura
+        } eripoota y'okuhikaho.
+        [advisories] Kanda { $action ->
+            [close] okwigara
+           *[open] okwigura
+        } eripoota y'okuhikaho. Tihariho kizibu kya WCAG AA ekishangirwe, kwonka hariho endagiriro ezindi z'okuhikaho.
+       *[clean] Kanda { $action ->
+            [close] okwigara
+           *[open] okwigura
+        } eripoota y'okuhikaho. Tihariho bizibu by'okuhikaho ebishangirwe.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Hashangirwe ekizibu kya WCAG AA omu kuhikaho. { $count ->
+            [one] Hashangirwe ekizibu { $count } kya WCAG AA
+           *[other] Hashangirwe ebizibu { $count } bya WCAG AA
+        }. Kanda { $action ->
+            [close] okwigara
+           *[open] okwigura
+        } eripoota y'okuhikaho.
+        [advisories] Tihariho kizibu kya WCAG AA ekishangirwe. { $count ->
+            [one] Hashangirwe endagiriro { $count } y'okuhikaho endiijo
+           *[other] Hashangirwe endagiriro { $count } z'okuhikaho ezindi
+        }. Kanda { $action ->
+            [close] okwigara
+           *[open] okwigura
+        } eripoota y'okuhikaho.
+       *[clean] Tihariho kizibu kya WCAG AA ekishangirwe. Kanda { $action ->
+            [close] okwigara
+           *[open] okwigura
+        } eripoota y'okuhikaho.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Enshoneka ya DoenetML { $version }
+
+editor-tab-help = Obuhwezi bw'ahu orikuba
+editor-tab-help-short = Ahu orikuba
+editor-tab-errors = Ebihabo
+editor-tab-warnings = Okurabura
+editor-tab-info = Amakuru
+editor-tab-accessibility = Okuhikaho
+editor-tab-responses = Eby'okugarukamu ebyohereziibwe
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Entoorano z'omuhandiiki
+editor-format-as-doenetml = Teekateeka nka DoenetML
+editor-format-as-xml = Teekateeka nka XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Omurongo #{ $line }
+
+editor-no-errors = Tihariho Bihabo
+editor-no-warnings = Tihariho Kurabura
+editor-no-info = Tihariho Makuru
+
+editor-show-info-annotations = Yoreka amakuru omu muhandiiki
+editor-show-accessibility-annotations = Yoreka ebifa aha kuhikaho omu muhandiiki
+
+editor-accessibility-learn-more = Manya oku Doenet erikutwara okuhikaho
+
+editor-accessibility-violations-heading = Ebizibu by'okuhikaho ({ $standard })
+
+editor-accessibility-other-heading = Ebizibu ebindi by'okuhikaho
+editor-none-found = Tihariho ekishangirwe
+
+
+## Submitted responses
+
+editor-no-responses = Tihariho by'okugarukamu ebyohereziibwe hati
+editor-response-answer-id = Ekimanyiso ky'Eky'okugarukamu
+editor-response-response = Ekigarukiirwemu
+editor-response-credit = Amanota
+editor-response-submitted = Kyohereziibwe
+
+
+## The context-help panel
+
+help-placeholder = Ta akakomo aha ibara rya tagi, aha kiranga, nari aha { $ref } okushanga ebyahandiikirwe.
+
+help-unsupported-ref-chain = Obuhwezi aha byoreka eby'ebicweka bingi nka { $example } tiburatandike.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Tihariho ekishangirwe aha kyoreka eki: { $ref }.
+        [multiple] Hashangirwe ebintu bingi aha kyoreka eki: { $ref }.
+       *[indeterminate] Eki { $ref } erikworeka tikimanyirwe.
+    }
+
+help-learn-about-references = Manya aha byoreka →
+help-reference-page = Orupapura rw'ebyoreka →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Omunda ya { $element }
+       *[top] Ahaiguru munonga
+    }{ $allowed ->
+        [none] { " — tihariho ekirikubaasa kuza hanu." }
+        [text] { " — handiika ebigambo hanu." }
+        [text-and-components] { " — handiika ebigambo hanu, nari ogyezeho:" }
+       *[components] { " — ebicweka ebi orikubaasa kugyezaho:" }
+    }
+
+help-suggestions-footer = Kanda { $shortcut } okureeba ebicweka byona { $total }.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } nikyoreka { $target }.
+       *[other] { $ref } nikyoreka { $target } (omurongo { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Kiruga aha { $owner } nka { $role }.
+       *[other] Kiruga aha { $owner } aha murongo { $line } nka { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } nikyoreka ekiranga { $property } kya { $element }.
+       *[other] { $ref } nikyoreka ekiranga { $property } kya { $element } (omurongo { $line }).
+    }
+
+help-kind-attribute = ekiranga
+help-kind-snippet = akacweka
+help-kind-array-entry = ekitairwe omu rukurikirana
+
+help-default = Eky'obwire bwona:
+help-active-default = Eky'obwire bwona ekirikukora:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ebigyendererwa ebikirizibwe (aha buri kintu):
+       *[other] Ebigyendererwa ebikirizibwe:
+    }
+
+help-suggested-values = Ebigyendererwa ebiteereireho:
+
+help-inserts = Nikitaho:
+
+help-coordinates =
+    { $count ->
+        [one] Ekyoreka omwanya:
+       *[other] Ebyoreka emyanya:
+    }
+
+help-type = Omuringo:
+
+help-resolved-style = Endeeba eshangirwe (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Amabara ga fonkishoni agashangirwe:
+help-reset-list = Orukurikirana orugaruriibwe aha kutaho oku:
+help-added-on-input = Ebyongyeirweho aha kutaho oku:
+help-removed-on-input = Ebiihirweho aha kutaho oku:
+
+help-reset-overrides = { $reset } neekira { $additional } na { $removed }.

--- a/packages/i18n/locales/cgg/editor.ftl
+++ b/packages/i18n/locales/cgg/editor.ftl
@@ -18,7 +18,9 @@
 # «nikyoreka» for *is a reference to*, «ekiranga» for an attribute,
 # «omuhendo» for a value — the word `diagnostics.ftl` uses, not
 # «ekigyendererwa», which this catalog spends on *objectives* in
-# `content.ftl` — «omuringo» for a variant and for a type,
+# `content.ftl` — «eky'okugarukamu» for a response, the word `chrome.ftl` and
+# `content.ftl` both use, kept clear of «ekigarukiirwemu», which `chrome.ftl`
+# spends on *feedback* — «omuringo» for a variant and for a type,
 # «eibara» for a name — the Kigezi word, where Runyankore says «eiziina».
 #
 # **What is borrowed.** English, openly and only where the word is what a
@@ -145,7 +147,7 @@ editor-none-found = Tihariho ekishangirwe
 
 editor-no-responses = Tihariho by'okugarukamu ebyohereziibwe hati
 editor-response-answer-id = Ekimanyiso ky'Eky'okugarukamu
-editor-response-response = Ekigarukiirwemu
+editor-response-response = Eky'okugarukamu
 editor-response-credit = Amanota
 editor-response-submitted = Kyohereziibwe
 

--- a/packages/i18n/locales/cgg/editor.ftl
+++ b/packages/i18n/locales/cgg/editor.ftl
@@ -16,7 +16,9 @@
 # **What is Rukiga here.** The panel's own frame: «Tihariho …» for *no X
 # found*, «Kanda …» for *click to …*, «Manya …» for *learn about*,
 # «nikyoreka» for *is a reference to*, «ekiranga» for an attribute,
-# «ekigyendererwa» for a value, «omuringo» for a variant and for a type,
+# «omuhendo» for a value — the word `diagnostics.ftl` uses, not
+# «ekigyendererwa», which this catalog spends on *objectives* in
+# `content.ftl` — «omuringo» for a variant and for a type,
 # «eibara» for a name — the Kigezi word, where Runyankore says «eiziina».
 #
 # **What is borrowed.** English, openly and only where the word is what a
@@ -208,11 +210,11 @@ help-style-number-annotation = { " " }(styleNumber { $styleNumber })
 
 help-allowed-values =
     { $perItem ->
-        [true] Ebigyendererwa ebikirizibwe (aha buri kintu):
-       *[other] Ebigyendererwa ebikirizibwe:
+        [true] Emihendo ekirizibwe (aha buri kintu):
+       *[other] Emihendo ekirizibwe:
     }
 
-help-suggested-values = Ebigyendererwa ebiteereireho:
+help-suggested-values = Emihendo eteereireho:
 
 help-inserts = Nikitaho:
 

--- a/packages/i18n/locales/xog/chrome.ftl
+++ b/packages/i18n/locales/xog/chrome.ftl
@@ -1,0 +1,165 @@
+# Soga (Olusoga) viewer chrome: buttons, panel headers, and other UI the
+# reader interacts with. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** Latin, in the **standard Lusoga orthography**
+# settled by the Lusoga Language Authority and used by «Eiwanika ly'Olusoga»,
+# the Lusoga dictionary. Its distinguishing letter is **`dh`**, the voiced
+# dental Luganda does not have and does not write: Lusoga «okwidha» (to come)
+# is Luganda «okujja», and Lusoga «amaadhi» (water) is Luganda «amazzi». The
+# orthography **not** followed here is the older Luganda-modelled spelling
+# that renders that sound `z` or `j` — «amaazi», «okwija» — which is still
+# what a Lusoga text set by a Luganda printer tends to look like. `ny` and
+# `ŋ` (U+014B) are written as in Luganda — «enkuŋŋaana», not «enkung'aana» —
+# and the initial vowel is part of the word, so
+# «olunyiriri» is one word and «lunyiriri» is not the same thing said without
+# an article. Digits are **Latin** (`1`, `2`, `1,234`), which is what DoenetML
+# pins for every locale in `src/intl.ts`.
+#
+# **Lusoga and Luganda.** They are close, `locales/lg` is on disk beside this
+# file, and the honest risk in a machine-written Lusoga seed is that it has
+# quietly written Luganda. **That is the first thing a reviewer should hunt
+# for**, and the header of each file says where it is most likely to have
+# happened. Where Lusoga has its own word this catalog uses it — «ekidha» for
+# *next* (what is coming), «okwiramu» for *to answer* where Luganda says
+# «okuddamu», «okudhuula» for *to find* where Luganda says «okuzuula», the
+# negator **`ti-`** where Luganda uses `te-` / `si-`.
+#
+# **What is Lusoga here.** «kituufu» / «tikituufu» for right and wrong,
+# «eky'okwiramu» for a response, «ensobi» for an error, «olupapula» for a
+# page, «olunyiriri» for a row and «empagi» for a column, «okutuukirira» for
+# accessibility. A button carries the bare imperative — «Igulawo»,
+# «Igalawo», «Ihawo», «Yongerako», «Laga», «Kweka», «Londa» — rather than a
+# polite periphrasis.
+#
+# **What is borrowed, and from where.** **English**, not Swahili. Uganda
+# teaches mathematics and science in English from upper primary on, so a
+# Lusoga speaker's technical register *is* English and this catalog keeps it
+# openly instead of inventing Lusoga words for it: «kiibbodi», «amamaaka»
+# (marks), «WCAG». Swahili is not the loan language in Busoga. Where a
+# technical term has no Lusoga word at all, the key is **left out** and falls
+# back to English rather than being filled with English respelled.
+#
+# **Weakest here.** «erinnya» for *name* is the Luganda word and is the single
+# most likely Luganda intrusion in this file; if Lusoga says something else,
+# it should be corrected everywhere, including `orbital-row-label` and the
+# editor catalog. «amamaaka» for credit and «akabonero» for a hint are the
+# next two to attack.
+#
+# **Counts.** CLDR gives `xog` its own plural data, with the two categories
+# `one` and `other`. A Lusoga noun marks number with a class prefix rather
+# than a suffix — «omulundi» one time, «emirundi» several; «eky'okwiramu» one
+# answer, «eby'okwiramu» several — and goes on doing so after a numeral, so
+# both branches of every select are doing real work. `attempts-remaining`
+# keeps its `[0]` branch, an exact-value match rather than a plural category,
+# which says «tewali» instead of counting to zero.
+
+
+## Answer submission
+
+answer-checking = Ekebeera…
+answer-submitting = Ewereza…
+answer-checking-status = Tukebeera eky'okwiramu
+answer-submitting-status = Tuwereza eky'okwiramu
+answer-correct = Kituufu
+answer-incorrect = Tikituufu
+answer-response-saved = Eky'okwiramu Kiterekwa
+answer-percent-credit = Amamaaka { $percent }%
+answer-percent-correct = { $percent }% Kituufu
+answer-percent-short = { $percent } %
+max-credit-available = Amamaaka agasinga agasoboka: { $percent }%
+attempts-remaining =
+    { $count ->
+        [0] tewali mulundi gusigaire
+        [one] omulundi { $count } gusigaire
+       *[other] emirundi { $count } gisigaire
+    }
+validation-correct = (Kituufu)
+validation-incorrect = (Tikituufu)
+validation-partially-correct = (Kituufu ku kitundu)
+answer-show-responses =
+    { $count ->
+        [one] Laga eky'okwiramu { $count } ekya { $answerId }
+       *[other] Laga eby'okwiramu { $count } ebya { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Okwiramu kw'Omusomesa
+collapsible-click-to-open = (nyiga okwigulawo)
+collapsible-click-to-close = (nyiga okwigalawo)
+collapsible-initializing = Etandika…
+footnote-show = Laga ekiwandiiko eky'ewansi
+footnote-hide = Kweka ekiwandiiko eky'ewansi
+description-more-information = amawulire amalala
+
+
+## Controls
+
+slider-previous = Ekiyise
+slider-next = Ekidha
+keyboard-open = Igulawo Kiibbodi
+keyboard-close = Igalawo Kiibbodi
+choice-input-remove-choice = Ihawo { $choice }
+matrix-remove-row = Ihawo olunyiriri
+matrix-add-row = Yongerako olunyiriri
+matrix-remove-column = Ihawo empagi
+matrix-add-column = Yongerako empagi
+subset-add-remove-points = Yongerako/Ihawo obutonnyeze
+subset-toggle-points-intervals = Kyusa wakati w'obutonnyeze n'ebitundu
+subset-move-points = Situla Obutonnyeze
+subset-clear = Sangula
+orbital-add-row = Yongerako Olunyiriri
+orbital-remove-row = Ihawo Olunyiriri
+orbital-add-box = Yongerako Akasanduuko
+orbital-remove-box = Ihawo Akasanduuko
+orbital-add-up-arrow = Yongerako Akasaale Akatunudde Waigulu
+orbital-add-down-arrow = Yongerako Akasaale Akatunudde Wansi
+orbital-remove-arrow = Ihawo Akasaale
+orbital-row-label = Erinnya ly'olunyiriri { $row }
+pretzel-answer = Eky'okwiramu
+summary-statistics-caption = Enkomerero y'ebibalo bya { $column }
+
+
+## Math input
+
+math-input-preview-region = okulaba mu maiso ebibalo ebiwandiike
+math-input-preview = Okulaba mu maiso
+math-input-invalid-expression = Ekiwandiike tikituufu:
+
+
+## Document status
+
+viewer-initializing = Etandika…
+
+
+## Errors
+
+error-heading = Ensobi
+error-found-at =
+    { $span ->
+        [line] Kidhuuliddwa ku lunyiriri { $startLine }.
+       *[lines] Kidhuuliddwa ku nnyiriri { $startLine }–{ $endLine }.
+    }
+document-contains-errors = Ekiwandiiko kino kirimu ensobi!
+diagnostic-heading-error = Ensobi
+diagnostic-heading-warning = Okulabula
+diagnostic-heading-information = Amawulire
+diagnostic-heading-hint = Akabonero
+accessibility-heading-level-1 = Okumenya WCAG AA mu Kutuukirira
+accessibility-heading-level-2 = Okulabula ku kutuukirira
+something-went-wrong = Waliwo ekitagenze bulungi.
+renderer-load-failed = omulaga ogumu tigudhize. Ddamu ozzeemu olupapula.
+core-start-failed = Ekiwandiiko kino tikitandise. Ddamu ozzeemu olupapula.
+core-start-failed-busy = Ekiwandiiko kino tikitandise. Ebiwandiiko bingi byali bitandika mu kiseera kimu, ekisobola okutwala ebbanga eddene ku kyuma ekitali kya bwangu. Okuzzaamu olupapula kisobola okuyamba ng'ebiwandiiko ebirala bimaze.
+core-start-failed-retry = Ekiwandiiko kino tikitandise.
+core-start-failed-busy-retry = Ekiwandiiko kino tikitandise. Ebiwandiiko bingi byali bitandika mu kiseera kimu, ekisobola okutwala ebbanga eddene ku kyuma ekitali kya bwangu.
+core-start-retry = Ddamu ogezeeko
+saved-state-unavailable = Omulimo gwo ogutereke tigusobose kutikkulwa.

--- a/packages/i18n/locales/xog/content.ftl
+++ b/packages/i18n/locales/xog/content.ftl
@@ -1,0 +1,360 @@
+# Soga (Olusoga) content catalog: the prose the core computes into the
+# document — style descriptions ("thick red line"), boolean words, section
+# names. Selected by `documentLocale`, the language the activity was written
+# in, rather than by the reader's UI language.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** As `chrome.ftl` sets it out: the Lusoga Language
+# Authority standard, `dh` written where Luganda writes `z` or `j`
+# («amaadhi», «okwidha»), the initial vowel written, Latin digits.
+#
+# **Noun class, not gender.** Lusoga has no masculine or feminine and agrees a
+# describing word with its noun's **class**, so this catalog reads `$gender`
+# as a class token — the device `locales/sw` and `locales/lg` both use.
+# `noun-gender` answers `c3`, `c7`, `c9`, `c11` or `c12` — five classes.
+# Lusoga's own geometry words land where Luganda's do: «olunyiriri», a line,
+# is class 11, and «akasaale» (a ray) and «akatonnyeze» (a point) are class
+# 12, the diminutive, which is where a small thing goes whether or not it is
+# small on purpose. **Class 5 (eli-) is deliberately absent**: no noun this
+# catalog names falls in it, so no adjective below writes a `[c5]` branch that
+# nothing could select. If a reviewer moves a noun into class 5 — «eiriba»
+# for a shape, say — the `[c5]` column has to come back with it.
+#
+#            c3 (omu-)  c7 (eki-)  c9 (en-)  c11 (olu-)  c12 (aka-)
+#   -nene    omunene    ekinene    ennene    olunene     akanene
+#   -tono    omutono    ekitono    entono    olutono     akatono
+#   -dugavu  omudugavu  ekidugavu  endugavu  oludugavu   akadugavu
+#   -eru     omweru     ekyeru     enjeru    olweru      akeeru
+#   -myufu   omumyufu   ekimyufu   emmyufu   olumyufu    akamyufu
+#   -dhuvu   omudhuvu   ekidhuvu   endhuvu   oludhuvu    akadhuvu
+#
+# Only the three colours with a native adjective stem inflect. The other nine
+# are invariable nouns and are written bare, joined attributively without the
+# associative particle: the associative is computable from `$gender`, but the
+# same string is what `backgroundColor` reports standing alone, where a bare
+# associative would be ungrammatical, and nothing in `$role` tells the two
+# positions apart. That is the trade `locales/lg` and `locales/sw` both make.
+#
+# **Word order.** A describing word **follows** its noun in Lusoga, so every
+# composition message puts the noun first. `$role` goes unused: Lusoga marks
+# no case.
+#
+# **What is Lusoga here.** «kiragala» (green), «kyenvu» (yellow), «kakobe»
+# (purple), «bbululu» (blue) and «eivu» (ash, for grey) are the colour words
+# of the Ganda–Soga area rather than loans made for this file. So are the
+# geometry nouns that could be said natively: «olunyiriri» (line), «akasaale»
+# (ray), «akatonnyeze» (point), «enkulungo» (circle), «omusalaba» (cross),
+# «ekitundu» (segment, region), and the descriptive phrases for a curve, a
+# polyline and a polygon. **«-dhuvu»** for *filled* is this catalog's
+# application of the Lusoga `dh` to Luganda's «-jjuvu», and a reviewer should
+# check that it is the shape Lusoga actually has.
+#
+# **What is borrowed, and from where.** **English**, openly, because that is
+# the register a Lusoga speaker does mathematics in: «vekita», «fonkisoni»,
+# «parabola», «esukweya», «edaimondi», «tiyoremu», «etaburo», and the
+# remaining colours («oranji», «sayani», «pinki», «buraawuni»). Swahili is not
+# the loan language in Busoga. Nothing here is an English word respelled to
+# look Lusoga: where there is no word, the key is left out.
+#
+# **What is left out, and why.**
+#
+#   * `noun.slope-field` and `noun.vector-field` — Lusoga has no phrase for
+#     either and a descriptive one would be this seed's invention.
+#   * `element-name` and `element-anion-name` — 130 keys, the whole periodic
+#     table. Uganda teaches secondary chemistry in English, so the fallback
+#     *is* what these readers meet.
+#   * `chemistry-invalid-symbol`, `chemistry-invalid-ionic-compound` and
+#     `ion-name-oxidation-state`, for the same reason: the chemistry group
+#     falls back entire rather than half of it being answered in Lusoga and
+#     half in English.
+#
+# **Weakest here.** «ekifaanani eky'embali enna» is literally *four-sided
+# figure* and so names a quadrilateral rather than a rectangle; Lusoga wants a
+# word for the right angle that this seed does not have. The six-class table
+# above is Luganda's, transposed to Lusoga spelling, and the `c9` forms
+# («enjeru», «emmyufu», «endhuvu») are where a transposition is most likely to
+# be wrong.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c3] omudugavu
+            [c7] ekidugavu
+            [c11] oludugavu
+            [c12] akadugavu
+           *[c9] endugavu
+        }
+    .white =
+        { $gender ->
+            [c3] omweru
+            [c7] ekyeru
+            [c11] olweru
+            [c12] akeeru
+           *[c9] enjeru
+        }
+    .gray = eivu
+    .red =
+        { $gender ->
+            [c3] omumyufu
+            [c7] ekimyufu
+            [c11] olumyufu
+            [c12] akamyufu
+           *[c9] emmyufu
+        }
+    .orange = oranji
+    .yellow = kyenvu
+    .green = kiragala
+    .cyan = sayani
+    .blue = bbululu
+    .purple = kakobe
+    .pink = pinki
+    .brown = buraawuni
+
+line-width =
+    .thick =
+        { $gender ->
+            [c3] omunene
+            [c7] ekinene
+            [c11] olunene
+            [c12] akanene
+           *[c9] ennene
+        }
+    .thin =
+        { $gender ->
+            [c3] omutono
+            [c7] ekitono
+            [c11] olutono
+            [c12] akatono
+           *[c9] entono
+        }
+
+# Written as an invariable «n'…» phrase, so that it agrees with nothing and
+# can close the description; `style-stroke` puts it last for that reason.
+line-style =
+    .dashed = n'obutundu
+    .dotted = n'obutonnyeze
+
+fill-style =
+    .horizontal = ennyiriri ezigalamidde
+    .vertical = ennyiriri eziyimiridde
+    .diagonal = ennyiriri ezisalako
+    .backdiagonal = ennyiriri ezisalako ku ludha olulala
+    .dots = obutonnyeze
+    .diamonds = amadaimondi
+
+# `slope-field` and `vector-field` are deliberately absent; see the header.
+noun =
+    .line = olunyiriri
+    .line-segment = ekitundu ky'olunyiriri
+    .ray = akasaale
+    .vector = vekita
+    .curve = olunyiriri olukyamye
+    .function = fonkisoni
+    .parabola = parabola
+    .polyline = olunyiriri olw'ebitundu
+    .polygon = ekifaanani eky'embali ennyingi
+    .triangle = ekifaanani eky'embali essatu
+    .rectangle = ekifaanani eky'embali enna
+    .circle = enkulungo
+    .region = ekitundu
+    .point = akatonnyeze
+    .square = esukweya
+    .diamond = edaimondi
+    .cross = omusalaba
+    .plus = akabonero k'okugatta
+
+# The side count is a relative clause and closes the noun phrase behind the
+# describing words rather than opening it, so it goes in the tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] ekirina embali { $numSides }
+       *[head] ekifaanani eky'embali edhenkanye
+    }
+
+# `c9` is the default, and the class a loanword joins — which is what an
+# author's own `markerStyleWord` is as far as this catalog is concerned.
+noun-gender =
+    { $noun ->
+        [cross] c3
+        [line] c11
+        [curve] c11
+        [polyline] c11
+        [ray] c12
+        [point] c12
+        [plus] c12
+        [line-segment] c7
+        [polygon] c7
+        [regular-polygon] c7
+        [triangle] c7
+        [rectangle] c7
+        [region] c7
+        [text] c7
+        [fill] c7
+       *[other] c9
+    }
+
+
+## Style composition
+
+# The dash pattern is an «n'…» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] omudhuvu
+        [c7] ekidhuvu
+        [c11] oludhuvu
+        [c12] akadhuvu
+       *[c9] endhuvu
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } n'{ $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } n'{ $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } n'{ $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «ensalo» is class 9 and leads its own describing words, so they agree with
+# it rather than with the shape it surrounds. Lusoga has no article and joins
+# the clause with the invariable «n'», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] n'ensalo { $border }
+        [and] n'ensalo { $border }
+        [and-article] n'ensalo { $border }
+       *[with] n'ensalo { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = tikidhuvu
+
+style-text =
+    { $parts ->
+        [background] { $color } ku nnyuma { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = tewali
+
+
+## Boolean words
+
+boolean-true = kya mazima
+boolean-false = tikiri kya mazima
+
+
+## Answer buttons
+
+answer-submit-label = Kebeera Omulimo
+answer-submit-label-no-correctness = Weereza Eky'okwiramu
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Omulimo
+    .aside = Ekyongerwako
+    .cascade = Olukalala
+    .definition = Okunyonyola
+    .example = Ekyokulabirako
+    .exercise = Okwegezaamu
+    .exercises = Okwegezaamu
+    .given-answer = Eky'okwiramu
+    .note = Ekyokujjukira
+    .objectives = Ebigenderwa
+    .paragraphs = Ebiwandiiko
+    .part = Omugabo
+    .problem = Ekizibu
+    .problems = Ebizibu
+    .proof = Obukakafu
+    .question = Ekibuuzo
+    .section = Ekitundu
+    .solution = Eky'okugonjoola
+    .task = Omulimo
+    .theorem = Tiyoremu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Akabonero
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Etaburo { $enumeration }
+        [numbered-title] Etaburo { $enumeration }{ ": " }
+        [unnumbered-title] Etaburo{ ": " }
+       *[unnumbered] Etaburo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ekifaanani { $enumeration }
+        [numbered-caption] Ekifaanani { $enumeration }{ ": " }
+        [unnumbered-caption] Ekifaanani{ ": " }
+       *[unnumbered] Ekifaanani
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ekiyise
+paginator-next = Ekidha
+paginator-page = Olupapula
+paginator-page-status = { $pageLabel } { $currentPage } ku { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = oba
+piecewise-condition-if = singa
+piecewise-condition-otherwise = bwe kitaba bwe kityo
+
+
+## Inputs embedded in math
+
+math-embedded-input-blank = ekyereere
+math-embedded-input-blank-ordinal = ekyereere { $ordinal } ku { $total }

--- a/packages/i18n/locales/xog/content.ftl
+++ b/packages/i18n/locales/xog/content.ftl
@@ -62,6 +62,11 @@
 #
 #   * `noun.slope-field` and `noun.vector-field` — Lusoga has no phrase for
 #     either and a descriptive one would be this seed's invention.
+#   * `noun.rectangle` — «ekifaanani eky'embali enna» is literally *four-sided
+#     figure*, which names a quadrilateral and not a rectangle: Lusoga wants
+#     the word for the right angle that this seed does not have. Calling every
+#     four-sided figure a rectangle is worse than the English fallback, so the
+#     key is left out and `noun-gender` carries no branch for it.
 #   * `element-name` and `element-anion-name` — 130 keys, the whole periodic
 #     table. Uganda teaches secondary chemistry in English, so the fallback
 #     *is* what these readers meet.
@@ -70,12 +75,9 @@
 #     falls back entire rather than half of it being answered in Lusoga and
 #     half in English.
 #
-# **Weakest here.** «ekifaanani eky'embali enna» is literally *four-sided
-# figure* and so names a quadrilateral rather than a rectangle; Lusoga wants a
-# word for the right angle that this seed does not have. The five-class table
-# above is Luganda's, transposed to Lusoga spelling, and the `c9` forms
-# («enjeru», «emmyufu», «endhuvu») are where a transposition is most likely to
-# be wrong.
+# **Weakest here.** The five-class table above is Luganda's, transposed to
+# Lusoga spelling, and the `c9` forms («enjeru», «emmyufu», «endhuvu») are
+# where a transposition is most likely to be wrong.
 
 
 ## Style vocabulary
@@ -159,7 +161,6 @@ noun =
     .polyline = olunyiriri olw'ebitundu
     .polygon = ekifaanani eky'embali ennyingi
     .triangle = ekifaanani eky'embali essatu
-    .rectangle = ekifaanani eky'embali enna
     .circle = enkulungo
     .region = ekitundu
     .point = akatonnyeze
@@ -191,7 +192,6 @@ noun-gender =
         [polygon] c7
         [regular-polygon] c7
         [triangle] c7
-        [rectangle] c7
         [region] c7
         [text] c7
         [fill] c7

--- a/packages/i18n/locales/xog/content.ftl
+++ b/packages/i18n/locales/xog/content.ftl
@@ -72,7 +72,7 @@
 #
 # **Weakest here.** «ekifaanani eky'embali enna» is literally *four-sided
 # figure* and so names a quadrilateral rather than a rectangle; Lusoga wants a
-# word for the right angle that this seed does not have. The six-class table
+# word for the right angle that this seed does not have. The five-class table
 # above is Luganda's, transposed to Lusoga spelling, and the `c9` forms
 # («enjeru», «emmyufu», «endhuvu») are where a transposition is most likely to
 # be wrong.

--- a/packages/i18n/locales/xog/diagnostics.ftl
+++ b/packages/i18n/locales/xog/diagnostics.ftl
@@ -1,0 +1,726 @@
+# Soga (Olusoga) diagnostics: errors and warnings surfaced to the reader or
+# author. Produced by the worker but addressed to whoever is looking at the
+# screen, so these are selected by `uiLocale`, not `documentLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** As `chrome.ftl` sets it out: the Lusoga
+# Language Authority standard, `dh` written where Luganda writes `z` or `j`
+# («okudhuula» for Luganda «okuzuula»), the initial vowel written, Latin
+# digits.
+#
+# DoenetML element, attribute and value names — `through`, `endpoint`,
+# `midpointOffset`, `numDimensions`, `symbolicEquality`, `selectFromSequence`,
+# `math`, `text`, `number`, `boolean` and the rest — are part of the language
+# rather than prose, and stay in English exactly as written. So does the
+# `[deprecation]` marker, and so does anything quoted back from the author's
+# own source.
+#
+# **What is Lusoga here.** The frame every message is built on: «Tikisoboka
+# …» for *cannot*, «kirekebwa» / «Tuleka …» for *ignored* / *ignoring*,
+# «kiteekwa okuba» for *must be*, «tikinnakolebwa» for *has not been
+# implemented*, «tikituufu» for *invalid*, «kubanga» for *because*, «naye»
+# for *but*, «oba» for *or*, «mu kifo ekyo» for *instead*, «wakiri» for *at
+# least*, «ekyereere» for *empty*, «ensobi» for an error. Native nouns doing
+# real work: «olunyiriri» (a source line, a row, and the geometric line),
+# «empagi» (a column), «akatonnyeze» (a point), «enkulungo» (a circle),
+# «ensonda» (an angle), «omuwendo» (a value), «ekikyuka» (a variable),
+# «engeri» (an attribute), «ekika» (a type), «ekitundu» (a component, a
+# section, a piece), «olubaawo» (the canvas), «olukalala» (a sequence, a
+# list), «enjawulo» (contrast — literally *the difference*), «okudhuula» (to
+# find).
+#
+# **What is borrowed, and from where.** **English**, because that is the
+# register a Lusoga speaker does mathematics and computing in — Uganda teaches
+# both in English from upper primary. The loans are kept openly rather than
+# disguised: «fonkisoni», «vekita», «parabola», «matirikisi», «paramita»,
+# «akisi», «ennamba», «tagi», «node», «data», «index». Swahili is **not** the
+# loan language in Busoga. Nothing below is an English word respelled to look
+# Lusoga: where there was no word and no honest description, the sentence
+# keeps the English identifier and describes around it.
+#
+# **Counts.** CLDR gives `xog` its own plural data, with `one` and `other`.
+# Lusoga marks number with a class prefix — «engeri» one attribute,
+# «engeri» several but with a different concord on the verb; «omuwendo» one
+# value, «emiwendo» several — so both branches of every select differ in more
+# than a suffix. `field-function-wrong-num-outputs` keeps the English `[one]`,
+# since `xog` really can select it.
+#
+# **Weakest here.** «okuserengeta» for *slope* and «enjawulo» for *contrast*
+# are descriptions rather than established terms, and are the first two words
+# a reviewer should attack. «erinnya» for a name may be a Luganda intrusion,
+# as `chrome.ftl` says. The third risk is syntactic rather than lexical: the
+# long conditional sentences below are Luganda's clause order written with
+# Lusoga words, and a speaker should check that Lusoga wants them in that
+# order.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } kirekebwa nga obutonnyeze bubiri obw'enkomerero buteekeddwawo
+       *[other] { $attributes } birekebwa nga obutonnyeze bubiri obw'enkomerero buteekeddwawo
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } kirekebwa nga akatonnyeze ak'enkomerero n'ak'omu makkati byombi biteekeddwawo
+       *[other] { $attributes } birekebwa nga akatonnyeze ak'enkomerero n'ak'omu makkati byombi biteekeddwawo
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tikikola nga tewali katonnyeze ak'omu makkati
+
+## `<line>`
+
+line-points-undetermined-dimensions = Olunyiriri luyita mu butonnyeze obw'ebipimo ebitamanyiddwa.
+
+line-points-too-few-dimensions = Olunyiriri luteekwa okuyita mu butonnyeze obw'ebipimo wakiri bibiri.
+
+line-points-depend-on-variables = Olunyiriri luyita mu butonnyeze obwesigamye ku bikyuka: { $variables }.
+
+line-equation-invalid-format = Enteekateeka y'ekigereka ky'olunyiriri mu bikyuka { $variable1 } ne { $variable2 } tituufu.
+
+## `<ray>`
+
+ray-overprescribed-through = Akasaale kateekeddwawo na through, endpoint ne direction.  Tuleka through eteekeddwawo.
+
+ray-dimension-mismatch = numDimensions tetuukagana mu kasaale.
+
+## `<vector>`
+
+vector-overprescribed-head = Vekita eteekeddwawo na head, tail ne displacement.  Tuleka head eteekeddwawo.
+
+vector-dimension-mismatch = numDimensions tetuukagana mu vekita.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Tikisoboka okusika ku `<{ $component }>` kubanga terina ngeri nearestPoint.
+
+constrain-to-without-nearest-point = Tikisoboka okuziyiza ku `<{ $component }>` kubanga terina ngeri nearestPoint.
+
+constrain-to-interior-without-nearest-point = Tikisoboka okuziyiza munda mu `<{ $component }>` kubanga terina ngeri nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition kirekebwa ku choiceInput etali ya mu lunyiriri
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Tuleka indices eziteekeddwawo ku choiceInput kubanga omuwendo gwazo tigutuukagana n'omuwendo gw'abaana ba choice.
+
+pretzel-indices-count-mismatch = Tuleka indices eziteekeddwawo ku problem kubanga omuwendo gwazo tigutuukagana n'omuwendo gw'abaana ba problem.
+
+shuffle-indices-count-mismatch = Tuleka indices eziteekeddwawo ku shuffle kubanga omuwendo gwazo tigutuukagana n'omuwendo gw'ebitundu.
+
+indices-ignored-out-of-range = Tuleka indices eziteekeddwawo ku { $component } kubanga ezimu ziri ebweru w'ekigero.
+
+pretzel-indices-repeated = Tuleka indices eziteekeddwawo ku pretzel kubanga ezimu zidhiddwamu.
+
+pretzel-circuit-first-index = Tuleka indices eziteekeddwawo ku pretzel mu mode="circuit" kubanga ey'olubereberye eteekwa okuba 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Okusobola `<{ $component }>` okukolagana n'abaana b'ebigambo, engeri `type` eteekwa okuteekebwawo.
+
+invalid-type-defaulting-to-math = Ekika { $type } tikituufu ku kitundu { $component }. Kiteekwa okuba math, text, number oba boolean. Tuzzaayo ku math.
+
+string-not-valid-component-to-arrange = Ekigambo "{ $value }" tikiri kitundu kisoboka ku { $component }. Tukireka.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Ekika { $type } tikituufu, tuteeka ekika ku number.
+
+invalid-variable-value = Omuwendo gw'ekikyuka tigutuufu: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Omuwendo gw'ekika { $index } guteekwa okuba ennamba
+
+variant-index-must-be-integer = Omuwendo gw'ekika { $index } guteekwa okuba ennamba entuufu
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` tikinnakolebwa ku bipimo ebinywevu. Tuteeka obugazi ku bugereeranye.
+
+side-by-side-absolute-margins = `<{ $component }>` tikinnakolebwa ku bipimo ebinywevu. Tuteeka enkomerero ku bugereeranye.
+
+side-by-side-no-block-child = `<{ $component }>` tikituufu: kiteekwa okuba n'omwana wakiri omu ow'ekitundu.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Engeri `for` ku `<label>` ey'ekifaanani erekebwa.
+
+label-for-must-resolve-to-one = Engeri `for` ku `<label>` eteekwa okulaga ekitundu kimu kyokka.
+
+label-for-unresolved = Engeri `for` ku `<label>` tesobodde kulaga kitundu.
+
+label-for-answer-with-authored-inputs = Engeri `for` ku `<label>` eraga `<answer>` erina ebiteekeddwamu ebiwandiikiddwa omuwandiisi; laga ekiteekeddwamu kyennyini.
+
+label-for-answer-without-input = Engeri `for` ku `<label>` eraga `<answer>` etalina kiteekeddwamu kya kutuuma rinnya.
+
+label-for-must-reference-input-or-answer = Engeri `for` ku `<label>` eteekwa okulaga ekiteekeddwamu oba eky'okwiramu.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Olw'okutuukirira, `<{ $component }>` eteekwa okuba n'okunyonyola okumpi oba okuteekebwawo ng'eky'okuwoomya.
+
+accessibility-video-short-description = Olw'okutuukirira, `<video>` eteekwa okuba n'okunyonyola okumpi.
+
+accessibility-input-short-description-or-label = Olw'okutuukirira, `<{ $component }>` eteekwa okuba n'okunyonyola okumpi oba erinnya.
+
+accessibility-answer-input-short-description-or-label = Olw'okutuukirira, `<answer>` ekola ekiteekeddwamu eteekwa okuba n'okunyonyola okumpi oba erinnya.
+
+accessibility-short-description-contains-math = Okunyonyola okumpi tikuteekwa kubaamu bitundu bya bibalo nga `<{ $component }>`. Nyonyola ebibalo n'ebigambo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } terina njawulo emala ku biwandiike by'omutwe gw'ekitundu (mu ndabika ey'ekizikiza) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaagisa wakiri { $threshold }:1).
+       *[other] { $colorName } terina njawulo emala ku biwandiike by'omutwe gw'ekitundu ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaagisa wakiri { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Tikinnakolebwa `<circle>` eyita mu butonnyeze { $count } obutalina miwendo gya nnamba.
+
+circle-too-many-through-points = Tikisoboka kubala nkulungo eyita mu butonnyeze obusukka mu busatu.
+
+circle-overprescribed-radius-center-points = Tikisoboka kubala nkulungo erina radius, omukka n'obutonnyeze obuyitibwamu byonna.
+
+circle-center-with-multiple-points = Tikisoboka kubala nkulungo erina omukka eyita mu katonnyeze akasukka mu kamu.
+
+circle-radius-too-small = Tikisoboka kubala nkulungo: olw'okuba ebbanga wakati w'obutonnyeze bubiri ge { $distance }, radius { $radius } eteekeddwawo ntono nnyo.
+
+circle-radius-with-many-points = Tikisoboka kukola nkulungo eyita mu butonnyeze obusukka mu bubiri erina radius eteekeddwawo.
+
+circle-invalid-center-or-through-points = Omukka oba obutonnyeze obuyitibwamu obw'enkulungo tibituufu.
+
+circle-radius-center-with-multiple-points = Tikisoboka kubala radius y'enkulungo erina omukka eyita mu katonnyeze akasukka mu kamu.
+
+circle-change-radius-non-numerical = Tikisoboka kukyusa radius y'enkulungo erina obutonnyeze obutalina miwendo gya nnamba
+
+circle-radius-with-points-non-numerical = Tikisoboka kukola nkulungo eyita mu katonnyeze akasukka mu kamu erina radius eteekeddwawo nga emiwendo gya nnamba tegiriwo.
+
+circle-change-center-non-numerical = Tikinnakolebwa kukyusa mukka gw'enkulungo eyita mu butonnyeze obutalina miwendo gya nnamba.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Ebipimo bya domain ya fonkisoni tibimala. Domain erina ekitundu { $intervals } naye fonkisoni erina { $inputs ->
+            [one] ekiteekeddwamu { $inputs }
+           *[other] ebiteekeddwamu { $inputs }
+        }.
+       *[other] Ebipimo bya domain ya fonkisoni tibimala. Domain erina ebitundu { $intervals } naye fonkisoni erina { $inputs ->
+            [one] ekiteekeddwamu { $inputs }
+           *[other] ebiteekeddwamu { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Enteekateeka ya domain ya fonkisoni tetuufu.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Tuleka omuwendo gwa fonkisoni ogusinga obunene ogutali gwa nnamba.
+        [minimum] Tuleka omuwendo gwa fonkisoni ogusinga obutono ogutali gwa nnamba.
+        [extremum] Tuleka omuwendo gwa fonkisoni ogw'oku nkomerero ogutali gwa nnamba.
+        [point] Tuleka akatonnyeze ka fonkisoni akatali ka nnamba.
+        [slope] Tuleka okuserengeta kwa fonkisoni okutali kwa nnamba.
+       *[other] Tuleka { $type } ya fonkisoni etali ya nnamba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Tuleka omuwendo gwa fonkisoni ogusinga obunene ogw'ereere.
+        [minimum] Tuleka omuwendo gwa fonkisoni ogusinga obutono ogw'ereere.
+        [extremum] Tuleka omuwendo gwa fonkisoni ogw'oku nkomerero ogw'ereere.
+        [point] Tuleka akatonnyeze ka fonkisoni ak'ereere.
+       *[other] Tuleka { $type } ya fonkisoni ey'ereere.
+    }
+
+function-points-too-close = Fonkisoni erina obutonnyeze bubiri obuli kumpi nnyo. Tikisoboka kunyonyola fonkisoni.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Okuddiŋŋana kwa fonkisoni kusoboka nga omuwendo gw'ebiteekeddwamu gwenkanankana n'ogw'ebifuluma. Fonkisoni eno erina ekiteekeddwamu { $inputs } n'{ $outputs ->
+            [one] ekifuluma { $outputs }
+           *[other] ebifuluma { $outputs }
+        }.
+       *[other] Okuddiŋŋana kwa fonkisoni kusoboka nga omuwendo gw'ebiteekeddwamu gwenkanankana n'ogw'ebifuluma. Fonkisoni eno erina ebiteekeddwamu { $inputs } n'{ $outputs ->
+            [one] ekifuluma { $outputs }
+           *[other] ebifuluma { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Obuwanvu bw'olukalala tibutuufu.  Buteekwa okuba ennamba entuufu etali wansi wa zeero.
+
+sequence-invalid-step = Entambula y'olukalala tetuufu.  Eteekwa okuba ennamba ku lukalala olw'ekika { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" y'olukalala olw'ennamba tetuufu.  Eteekwa okuba ennamba.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" y'olukalala olw'ennukuta tetuufu.  Eteekwa okuba enkuŋŋaana y'ennukuta.
+
+sequence-invalid-endpoint = "{ $attribute }" y'olukalala tetuufu.
+
+select-from-sequence-coprime-not-numbers = coprime kirekebwa kubanga tetulonda nnamba
+
+select-from-sequence-coprime-with-exclude-combinations = coprime kirekebwa kubanga excludeCombinations eteekeddwawo
+
+## Resolving a `target`
+
+target-not-found = Target ya `<{ $source }>` tetuufu: tikisobose kudhuula target.
+
+target-state-variable-not-found = Target ya `<{ $source }>` tetuufu: tikisobose kudhuula kikyuka ekiyitibwa "{ $property }" ku `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ebikyuka bya `<odeSystem>` biteekwa obutaba nga ekikyuka ekyeyimirizaawo.
+
+ode-system-duplicate-variable-names = Tikisoboka kunyonyola fonkisoni za ODE RHS ezirina amannya g'ebikyuka agadhiddwamu.
+
+ode-system-rhs-function-error = Tikisoboka kunyonyola fonkisoni ya ODE RHS.  Waliwo ensobi mu kukola fonkisoni ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Tikisoboka kunyonyola nsonda wakati w'ennyiriri { $count }
+
+angle-invalid-through-point = Akatonnyeze aka through aka `<angle>` tikatuufu
+
+parabola-vertex-too-many-points = Tikinnakolebwa parabola erina omutwe eyita mu katonnyeze akasukka mu kamu.
+
+parabola-too-many-points = Tikinnakolebwa parabola eyita mu butonnyeze obusukka mu busatu.
+
+intersection-too-many-items = Tikinnakolebwa okusisinkana kw'ebintu ebisukka mu bibiri
+
+## Other math components
+
+ionic-compound-not-two-ions = Tikinnakolebwa nteekateeka ya ayoni etali ya yoni bbiri.
+
+ionic-compound-needs-cation-and-anion = Enteekateeka y'ayoni ekolebwa ku katayoni emu ne anayoni emu zokka.
+
+solve-equations-cannot-evaluate = Tikisoboka kugonjoola kigereka kubanga tikisobose kukigereka: { $equation }
+
+math-operators-operand-number-required = Oteekwa okuteekawo operandNumber ng'oggya operand y'ebibalo.
+
+eigen-decomposition-failed = Tikisobose kubala eigenvalues za matirikisi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: paramita { $parameters } telabika mu nteekateeka, era etuukagana n'ekyereere buli kiseera.
+       *[other] `<matchesPattern>`: paramita { $parameters } tezirabika mu nteekateeka, era zituukagana n'ekyereere buli kiseera.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: tikisobose kutegeera grid="{ $grid }". Eteekwa okuba none, medium, dense, oba ennamba bbiri ezisukka mu zeero ezaawuliddwa n'ebbanga, ng'eno grid="1 0.5". Tewali grid ekubibwa.
+
+## `<slopeField>` and `<vectorField>`
+
+field-function-wrong-num-outputs =
+    `<{ $component }>` yeetaaga fonkisoni erina { $expected ->
+        [one] ekifuluma kimu, okuserengeta ku buli katonnyeze, nga kino `y - x`
+       *[other] ebifuluma bibiri, vekita ku buli katonnyeze, nga bino `(y, -x)`
+    }, naye fonkisoni gy'eweereddwa erina { $found ->
+        [one] ekifuluma { $found }
+       *[other] ebifuluma { $found }
+    }. { $alternative ->
+        [none] Tewali kikubibwa.
+       *[other] `<{ $alternative }>` kye kitundu ekya fonkisoni eyo. Tewali kikubibwa.
+    }
+
+field-function-attribute-ignored-with-child = Engeri `function` erekebwa kubanga fonkisoni eweereddwa era ne munda mu kitundu; ey'omunda ye ekozesebwa. Wa fonkisoni mu ngeri emu yokka.
+
+field-variables-ignored =
+    `<{ $component }>`: engeri `variables` etuuma ebikyuka by'ekiwandiike ekiri munda mu kitundu. { $reason ->
+        [function-child] Fonkisoni eri wano eweereddwa ng'omwana `<function>`, atuuma ebikyuka bye, era `variables` erekebwa.
+       *[no-expression] Tewali kiwandiike nga kino wano, era `variables` erekebwa.
+    }
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" tikikolebwako mu mulaga wa prefigure; tuteeka ey'oku ddyo.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" tikikolebwako mu mulaga wa prefigure; tuteeka ey'waigulu.
+
+prefigure-invalid-axis-bounds = `<graph>`: enkomerero za akisi tizituufu ku kukyusa kwa prefigure; tuteeka bbox ey'ebulijjo (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: obugazi tibutuufu ku kukyusa kwa prefigure; tuteeka obugazi bw'ekifaanani obw'ebulijjo 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio tetuufu ku kukyusa kwa prefigure; tuteeka aspect ratio ey'ebulijjo 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ebbanga lya grid ttono nnyo ku nkomerero za akisi; grid erekebwa mu mulaga wa prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations tizikubibwa bw'oba tokozesa mulaga wa PreFigure.
+
+multiple-annotations-children = Badhuuliddwa abaana `<annotations>` bangi mu `<graph>`; bonna okuggyako ow'oku nkomerero barekebwa.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tikisoboka kwongera oba kukoppa kika kya kitundu ekitamanyiddwa: { $type }.
+
+copy-prop-not-found = Tikisobose kudhuula prop { $property } ku kitundu eky'ekika { $component }
+
+collect-no-source = Tewali nsibuko edhuuliddwa eya collect.
+
+collect-invalid-component-type = Tikisoboka kukuŋŋaanya bitundu bya kika `<{ $component }>` kubanga ekika ekyo tikituufu.
+
+reference-index-unavailable = Tikisoboka kulaga index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Tikisoboka kuyita { $action } ku kitundu `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data erina enteekateeka etatuufu.  Ennyiriri zirina obuwanvu obwawukana. Kidhuuliddwa mu componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data erina amannya g'empagi agadhiddwamu.  Kidhuuliddwa mu componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data ebulwa erinnya ly'empagi.  Kidhuuliddwa mu componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award y'eky'okwiramu kino yesigamye ku ky'okwiramu kya answer yennyini, ekidha okuleeta ebitasuubirwa.
+
+answer-max-num-attempts-in-section-wide-check-work = Okuteeka `maxNumAttempts` ku `<answer>` eri munda mu kitundu ekirina `sectionWideCheckWork` tikikola, kubanga omuwendo gw'emirundi gutwalibwa ekitundu. Teeka `maxNumAttempts` ku kitundu.
+
+nested-section-wide-check-work-max-num-attempts = Okuteeka `maxNumAttempts` ku kitundu ekirina `sectionWideCheckWork` ekiri munda mu kitundu ekirala ekirina `sectionWideCheckWork` tikikola, kubanga omuwendo gw'emirundi gutwalibwa ekitundu eky'ebweru. Teeka `maxNumAttempts` ku kitundu eky'ebweru.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Engeri { $attributes } tedhakola nga symbolicEquality teteekeddwawo.
+       *[other] Engeri { $attributes } tezidhakola nga symbolicEquality teteekeddwawo.
+    }
+
+answer-invalid-type = Ekika ky'eky'okwiramu tikituufu: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Olw'okuba ekitundu `<{ $component }>` tikirina rinnya, tikisobola kukozesebwa ng'engeri ya module
+
+module-attribute-name-already-defined = Ekitundu `<{ $component } name="{ $name }">` tikisobola kukozesebwa ng'engeri ya module kubanga ekitundu `<module>` kirina engeri "{ $name }" enyonyoddwa.
+
+conditional-content-condition-ignored = Engeri `condition` erekebwa ku `<conditionalContent>` erina abaana ba case oba else.
+
+slider-markers-type-mismatch = Ekika kya markers tikituukagana n'ekya slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel tetuufu: buli `<problem>` eteekwa okuba ne `<statement>` emu ne `<answer>` emu.
+
+pretzel-circuit-first-problem-distractor = Pretzel tetuufu: mu mode="circuit", `<problem>` ey'olubereberye tesobola kuba distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Omuwendo { $values } ogw'engeri `{ $attribute }` tigutuufu; tugureka.
+       *[other] Emiwendo { $values } egy'engeri `{ $attribute }` tegituufu; tugireka.
+    }
+
+attribute-must-be-references = Omuwendo `{ $value }` ogw'engeri `{ $attribute }` tigutuufu. Engeri eteekwa okuba n'ebiraga ebitandika na `$`.
+
+math-input-invalid-function-names = <mathInput>: gaarekeddwa amannya ga fonkisoni agatali matuufu mu { $attribute }: { $names }. Buli rinnya liteekwa okuba n'obubonero wakiri bubiri (ennukuta oba obusaze); bw'oba oyagala oyongerako `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Ekika ky'ekitundu tikituufu: `<{ $componentType }>`
+
+attribute-repeated = Tikisoboka kuddiŋŋana ngeri { $attribute }.
+
+attribute-invalid-for-component = Engeri "{ $attribute }" tiri ya kitundu kya kika `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Enteekateeka y'endabika { $styleNumber } terina njawulo emala ku { $context ->
+        [text-on-background] langi y'ebiwandiike ku langi ey'ennyuma
+        [high-contrast] langi ey'enjawulo ennene ku lubaawo
+        [line] langi y'olunyiriri ku lubaawo
+        [marker] langi y'akabonero ku lubaawo
+       *[text-on-canvas] langi y'ebiwandiike ku lubaawo
+    }{ $mode ->
+        [dark] { " (mu ndabika ey'ekizikiza)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaagisa wakiri { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Newankubadde enteekateeka y'endabika { $styleNumber } erina langi ezirina enjawulo emala mu ndabika ey'omusana, langi ez'omu ndabika ey'ekizikiza ezivudde mu zo tizirina njawulo emala wakati wa langi y'ebiwandiike ne langi ey'ennyuma ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaagisa wakiri { $threshold }:1). { $suggestion ->
+        [available] Okusobola okuba n'enjawulo emala mu ndabika ey'ekizikiza, yongera enjawulo ey'omu ndabika ey'omusana (ng'ekyokulabirako, teeka { $lightAttribute }="{ $lightColor }") oba okyuse langi ey'omu ndabika ey'ekizikiza (ng'ekyokulabirako, teeka { $darkAttribute }="{ $darkColor }").
+       *[none] Okusobola okuba n'enjawulo emala mu ndabika ey'ekizikiza, yongera enjawulo ey'omu ndabika ey'omusana oba okyuse langi ezivuddemu na textColorDarkMode ne/oba backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Newankubadde enteekateeka y'endabika { $styleNumber } erina langi y'ebiwandiike erina enjawulo emala mu ndabika ey'omusana, langi y'ebiwandiike ey'omu ndabika ey'ekizikiza evudde mu yo terina njawulo emala ku lubaawo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaagisa wakiri { $threshold }:1). { $suggestion ->
+        [available] Okusobola okuba n'enjawulo emala mu ndabika ey'ekizikiza, yongera enjawulo ey'omu ndabika ey'omusana (ng'ekyokulabirako, teeka textColor="{ $lightColor }") oba okyuse langi ey'omu ndabika ey'ekizikiza (ng'ekyokulabirako, teeka textColorDarkMode="{ $darkColor }").
+       *[none] Okusobola okuba n'enjawulo emala mu ndabika ey'ekizikiza, yongera enjawulo ey'omu ndabika ey'omusana oba okyuse langi evuddemu na textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Ekitundu kisobola okulonda <stylePalette> emu yokka; tukozesa ey'oku nkomerero.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga numToSelect tiri nnamba ntuufu etali wansi wa zeero.
+
+variant-num-to-select-not-constant-number = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga numToSelect tiri nnamba nnywevu.
+
+variant-with-replacement-not-constant-boolean = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga withReplacement tiri boolean ennywevu.
+
+variant-select-weight-disables-unique = Ebika ebitadhiddwamu ebya select biziyizibwa nga waliwo ekirondebwa ekirina selectWeight oba selectForVariants ekiteekeddwawo
+
+variant-coprime-undetermined = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga tikisoboka kumanya nga coprime buli kiseera tetuufu.
+
+variant-attribute-not-constant = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga { $attribute } tinywevu.
+
+variant-attribute-not-number = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga { $attribute } tiri nnamba.
+
+variant-attribute-wrong-type-for-sequence =
+    tikisoboka kumanya bika bitadhiddwamu bya { $component } eby'ekika { $type } kubanga { $attribute } tiri { $expected ->
+        [letters-combination] nkuŋŋaana ya nnukuta
+        [math-expression] kiwandiike kya bibalo ekituufu
+        [integer] nnamba ntuufu
+       *[number] nnamba
+    }.
+
+variant-length-not-integer = tikisoboka kumanya bika bitadhiddwamu bya { $component } kubanga length tiri nnamba ntuufu.
+
+variant-sort-not-implemented = tikinnakolebwa kumanya bika bitadhiddwamu bya { $component } ebirina sort
+
+variant-exclude-combinations-not-implemented = tikinnakolebwa kumanya bika bitadhiddwamu bya { $component } ebirina excludeCombinations
+
+variant-math-exclude-not-implemented = tikinnakolebwa kumanya bika bitadhiddwamu bya { $component } eby'ekika math ebirina exclude
+
+variant-non-constant-exclude-not-implemented = tikinnakolebwa kumanya bika bitadhiddwamu bya { $component } ebirina exclude etali nnywevu
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: tikikolebwako mu mulaga wa prefigure owa graph; omwana arekeddwa.
+
+prefigure-descendant-invalid-geometry = { $subject }: enteekateeka tekoma oba tetuukiridde; omwana arekeddwa.
+
+prefigure-curve-label-omitted = { $subject }: amannya tigakolebwako ku nnyiriri enkyamye ezikyusiddwa; erinnya lirekeddwa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ekika ky'okunyonyola olunyiriri olukyamye '{ $definitionType }' tikikolebwako; omwana arekeddwa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: engeri flipFunctions ku regionBetweenCurves tikikolebwako; omwana arekeddwa.
+
+prefigure-region-non-formula-child = { $subject }: ku regionBetweenCurves kukolebwako fonkisoni ez'ekika kya formula zokka; omwana arekeddwa.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' tikikolebwako ku { $labelKind ->
+        [line-family] rinnya ly'eby'olunyiriri
+       *[point] rinnya ly'akatonnyeze
+    }; tuteeka enteekateeka ya PreFigure ey'ebulijjo.
+
+prefigure-fill-style-unsupported = { $subject }: ekika ky'okudhuza '{ $fillStyle }' tikikolebwako na PreFigure; tuzzaayo ku kudhuza okunywevu.
+
+prefigure-line-style-unknown = { $subject }: ekika ky'olunyiriri '{ $lineStyle }' ekitamanyiddwa kirekeddwa mu bifuluma mu PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ekika ky'akabonero '{ $markerStyle }' kikyusiddwa mu kika kya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: ekika ky'akabonero '{ $markerStyle }' tikikolebwako na PreFigure; tuteeka eky'ebulijjo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tetuufu; tikisobose kudhuula target. Annotation erekeddwa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` eraga targets nnyingi; tukozesa ey'olubereberye.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tetuufu; target eri ebweru wa graph egitwala. Annotation erekeddwa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tetuufu; target tikiri kintu kya kifaanani ekikolebwako mu kukyusa kwa prefigure. Annotation erekeddwa.
+
+annotation-text-missing = `<annotation>`: `text` ebulwa oba ya kyereere; tuteekamu ebigambo ebyereere.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kudhuuliddwa okwesigama okwetooloola.
+       *[other] Kudhuuliddwa okwesigama okwetooloola okuli mu kitundu `<{ $componentType }>`.
+    }
+
+reference-no-referent = Tewali kidhuuliddwa ku kiraga kino: `{ $reference }`
+
+reference-multiple-referents = Bidhuuliddwa ebintu bingi ku kiraga kino: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Enteekateeka y'engeri { $attribute } eya `<{ $componentType }>` tetuufu.
+
+children-invalid = Abaana ba `<{ $componentType }>` tibatuufu: badhuuliddwa abaana abatali batuufu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Omuwendo `{ $value }` ogw'engeri `{ $attribute }` tigutuufu, tukozesa omuwendo `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Enkola ya DoenetML { $version } tedhuuliddwa.
+       *[other] Enkola ya DoenetML { $version } tedhuuliddwa. Tuzzaayo ku nkola { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tetuufu: { $content }
+
+parse-tag-missing-close-tag = DoenetML tetuufu: Tagi `{ $tag }` terina tagi ya kugiggalawo. Kyali kyetaagisa tagi eyeggalawo oba tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML tetuufu: Waliwo ensobi mu tagi `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML tetuufu: Engeri `{ $attribute }` etali ntuufu erabika ng'ebulwa omuwendo.
+
+parse-attribute-invalid = DoenetML tetuufu: Engeri `{ $attribute }` tetuufu
+
+parse-attribute-value-invalid = DoenetML tetuufu: Omuwendo gw'engeri `{ $value }` tigutuufu
+
+parse-attribute-value-quote-mismatch = DoenetML tetuufu: Omuwendo gw'engeri `{ $value }` tigutuufu. Obubonero bw'okwawula tibutuukagana. Olabika obulwa `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML tetuufu: Kidhuuliddwa tagi etalina rinnya, nga kino `<`
+
+parse-tag-not-closed = DoenetML tetuufu: Tagi `{ $tag }` teggaddwawo (`>` erabika ng'ebulwa).
+
+parse-self-closing-tag-name-missing = DoenetML tetuufu: Kidhuuliddwa tagi etalina rinnya `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tetuufu: Tagi `{ $tag }` teggaddwawo (`/>` erabika ng'ebulwa).
+
+parse-tag-invalid-attributes = DoenetML tetuufu: Tagi `{ $tag }` tetuufu. Esobola okuba n'engeri ezitali ntuufu.
+
+parse-close-tag-name-missing = DoenetML tetuufu: Kidhuuliddwa tagi ey'okuggalawo etalina rinnya, nga kino `</`
+
+parse-attribute-value-unquoted = Emiwendo gy'engeri giteekwa okuba mu bubonero bw'okwawula: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tetuufu: Kidhuuliddwa tagi ey'okuggalawo `{ $tag }`, naye tewali tagi ey'okugulawo egituukagana
+
+parse-close-tag-mismatched = DoenetML tetuufu: Tagi ey'okuggalawo tetuukagana. Kyali kyetaagisa `</{ $expected }>`. Kidhuuliddwa `{ $found }`
+
+parser-node-unconvertible = Tikisobose kukyusa node { $node } okudda mu node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Erinnya name='{ $name }' tirituufu. { $reason ->
+        [characters] Amannya gasobola okuba n'ennukuta, ennamba, obusaze obw'ewansi oba obusaze obw'omu makkati byokka.
+       *[start] Amannya gateekwa okutandika n'ennukuta.
+    }
+
+component-name-invalid-start = Erinnya ly'ekitundu "{ $name }" tirituufu. Amannya gateekwa okutandika n'ennukuta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer ey'ekika videoWatched eteekwa okuba n'engeri video
+
+answer-video-watched-video-not-reference = Answer ey'ekika videoWatched eteekwa okuba n'engeri video eri ekiraga
+
+answer-name-not-single-text = Engeri name eya answer eteekwa okuba n'omwana omu ow'ebigambo
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Tikisobose kuggya DoenetML ey'ebweru olw'okwetooloola okungi nnyo. Waliwo ekiraga ekyetooloola?
+
+external-doenetml-unavailable = Tikisobose kuggya DoenetML ku { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML eggiddwa ku { $attribute }="{ $uri }" tetuufu: tetuukaganye n'ekika ky'ekitundu "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Engeri `{ $from }` tekyakozesebwa; kozesa `{ $to }`.
+       *[other] [deprecation] Engeri `{ $from }` ku `<{ $component }>` tekyakozesebwa; kozesa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Engeri `{ $from }` tekyakozesebwa era erekebwa kubanga `{ $to }` nayo eteekeddwawo.
+       *[other] [deprecation] Engeri `{ $from }` ku `<{ $component }>` tekyakozesebwa era erekebwa kubanga `{ $to }` nayo eteekeddwawo.
+    }
+
+deprecated-attribute-ignored = [deprecation] Engeri `{ $attribute }` ku `<{ $component }>` tekyakozesebwa era erekebwa.
+
+deprecated-attribute-to-child = [deprecation] Engeri `{ $attribute }` ku `<{ $component }>` tekyakozesebwa; kozesa omwana `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Omuwendo `{ $value }` ogw'engeri `{ $attribute }` ku `<{ $component }>` tigukyakozesebwa; kozesa `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` esobola okwongera obungi mu Lungereza lwokka, era ebigambo byayo tibikyusibwa mu kiwandiiko ekiwandiikiddwa mu { $locale }. Wandiika obungi wekka, oba obuteeke n'engeri `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ekitundu `<{ $tag }>` tikiri kitundu kya Doenet ekimanyiddwa.
+
+schema-element-not-allowed-at-root = Ekitundu `<{ $tag }>` tikikkirizibwa ku musingi gw'ekiwandiiko.
+
+schema-element-not-allowed-inside = Ekitundu `<{ $tag }>` tikikkirizibwa munda mu `<{ $parent }>`.
+
+schema-attribute-unrecognized = Ekitundu `<{ $tag }>` tikirina ngeri eyitibwa `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Engeri `{ $attribute }` eya `<{ $tag }>` eteekwa okuba olukalala nga buli kimu kimu ku bino: { $allowed }
+       *[other] Engeri `{ $attribute }` eya `<{ $tag }>` eteekwa okuba kimu ku bino: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Erinnya ly'ekika erya select tirituufu.  Erinnya ly'ekika { $variantName } lirabika mu birondebwa { $numOptions } naye omuwendo gw'ebirondebwa gwe { $numToSelect }.
+
+select-variant-name-without-options = Ebika ebimu biteekeddwawo ku select naye tewali birondebwa ebiteekeddwawo ku rinnya ly'ekika erisoboka: { $variantName }.
+
+select-variant-name-not-possible = Erinnya ly'ekika { $variantName } eriteekeddwawo ku select tiriri rinnya lya kika lisoboka.
+
+select-too-few-options = Tikisoboka kulonda bitundu { $numToSelect } mu { $numOptions } byokka.
+
+select-from-sequence-too-few-values = Tikisoboka kulonda miwendo { $numToSelect } mu lukalala olw'obuwanvu { $length }.
+
+select-from-sequence-indices-count-mismatch = Omuwendo gwa indices eziteekeddwawo ku select guteekwa okutuukagana n'omuwendo gw'ebirondebwa
+
+select-from-sequence-indices-not-integers = Indices zonna eziteekeddwawo ku select ziteekwa okuba ennamba entuufu
+
+select-from-sequence-index-excluded = Index ya selectfromsequence eteekeddwawo yali erekeddwa
+
+select-from-sequence-indices-excluded-combination = Indices za selectfromsequence eziteekeddwawo zaali nkuŋŋaana erekeddwa
+
+select-from-sequence-coprime-not-positive-integers = Tikisoboka kulonda nkuŋŋaana za coprime kubanga tetulonda nnamba ezisukka mu zeero.
+
+select-from-sequence-coprime-common-factor = Tikisoboka kulonda nnamba za coprime. Emiwendo gyonna egisoboka girina ekigabanya kimu. (Emiwendo egiteekeddwawo ku "from" oba "to" giteekwa okuba coprime ne "step".)
+
+select-from-sequence-coprime-single-number = Tikisoboka kulonda nkuŋŋaana za coprime mu nnamba emu etali 1.
+
+select-from-sequence-excluded-too-many-combinations = Kwarekebwa enkuŋŋaana ezisukka mu 70% mu selectFromSequence
+
+select-from-sequence-coprime-none-found = Tikisobose kulonda nnamba za coprime. Emiwendo gyonna egisoboka girina ekigabanya kimu.
+
+select-from-sequence-too-few-unique-values = Tikisoboka kulonda miwendo { $numToSelect } egitadhiddwamu mu lukalala olw'obuwanvu { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Tikisoboka kulonda miwendo { $numToSelect } mu lukalala lwa nnamba za prime olw'obuwanvu { $numValues }
+
+select-prime-numbers-values-count-mismatch = Omuwendo gw'emiwendo egiteekeddwawo ku select guteekwa okutuukagana n'omuwendo gw'ebirondebwa
+
+select-prime-numbers-values-not-prime = Emiwendo gyonna egiteekeddwawo ku select prime number giteekwa okuba mu lukalala lwa nnamba za prime
+
+select-prime-numbers-values-excluded-combination = Emiwendo gya selectPrimeNumbers egiteekeddwawo gyali nkuŋŋaana erekeddwa
+
+select-prime-numbers-excluded-too-many-combinations = Kwarekebwa enkuŋŋaana ezisukka mu 70% mu selectPrimeNumbers
+
+select-random-combination-fluke = Ku ngeri etasuubirwa nnyo, tikisobose kulonda nkuŋŋaana ya miwendo egitalondeddwa
+
+select-random-value-fluke = Ku ngeri etasuubirwa nnyo, tikisobose kulonda muwendo ogutalondeddwa
+
+## Inputs embedded in math
+
+math-embedded-input-shape-unsuitable =
+    { $reason ->
+        [not-inline] `<{ $component }>` kino tikiragibwa kubanga kiri munda mu bibalo era tikiri `inline`. Yongerako `inline` kifuuke olukalala olw'okulondamu, olutuuka munda mu kiwandiike.
+        [expanded] `<{ $component }>` kino tikiragibwa kubanga kiri munda mu bibalo era ni `expanded`. Ihawo `expanded`; akasanduuko k'ennyiriri nnyingi tikatuuka munda mu kiwandiike.
+        [on-graph] `<{ $component }>` kino tikiragibwa kubanga kiri munda mu bibalo ebikubiddwa ku graph, ekitalina bbanga lya kiteekeddwamu.
+       *[relative-width] `<{ $component }>` kino tikiragibwa kubanga kiri munda mu bibalo era kirina obugazi obw'ebugereeranye. Wa obugazi mu bipimo ebinywevu, nga `px`.
+    }

--- a/packages/i18n/locales/xog/diagnostics.ftl
+++ b/packages/i18n/locales/xog/diagnostics.ftl
@@ -21,8 +21,10 @@
 # …» for *cannot*, «kirekebwa» / «Tuleka …» for *ignored* / *ignoring*,
 # «kiteekwa okuba» for *must be*, «tikinnakolebwa» for *has not been
 # implemented*, «tikituufu» for *invalid*, «kubanga» for *because*, «naye»
-# for *but*, «oba» for *or*, «mu kifo ekyo» for *instead*, «wakiri» for *at
-# least*, «ekyereere» for *empty*, «ensobi» for an error. Native nouns doing
+# for *but*, «oba» for *or*, «wakiri» for *at least*, «ekyereere» for
+# *empty*, «ensobi» for an error. English's trailing *instead* has no phrase
+# here: Lusoga carries it in the bare imperative that follows, so «Teeka
+# `maxNumAttempts` ku kitundu» is the whole of it. Native nouns doing
 # real work: «olunyiriri» (a source line, a row, and the geometric line),
 # «empagi» (a column), «akatonnyeze» (a point), «enkulungo» (a circle),
 # «ensonda» (an angle), «omuwendo» (a value), «ekikyuka» (a variable),

--- a/packages/i18n/locales/xog/diagnostics.ftl
+++ b/packages/i18n/locales/xog/diagnostics.ftl
@@ -47,8 +47,9 @@
 # «ebitundu» several; «omuwendo» one value, «emiwendo» several — so both
 # branches of every select in this file differ in more than a suffix. Not
 # every noun does: «engeri», an attribute, is class 9/10 and is spelt the
-# same in both numbers, marking number only on what agrees with it. `field-function-wrong-num-outputs` keeps the English `[one]`,
-# since `xog` really can select it.
+# same in both numbers, marking number only on what agrees with it.
+# `field-function-wrong-num-outputs` keeps the English `[one]`, since `xog`
+# really can select it.
 #
 # **Weakest here.** «okuserengeta» for *slope* and «enjawulo» for *contrast*
 # are descriptions rather than established terms, and are the first two words

--- a/packages/i18n/locales/xog/diagnostics.ftl
+++ b/packages/i18n/locales/xog/diagnostics.ftl
@@ -43,10 +43,11 @@
 # keeps the English identifier and describes around it.
 #
 # **Counts.** CLDR gives `xog` its own plural data, with `one` and `other`.
-# Lusoga marks number with a class prefix — «engeri» one attribute,
-# «engeri» several but with a different concord on the verb; «omuwendo» one
-# value, «emiwendo» several — so both branches of every select differ in more
-# than a suffix. `field-function-wrong-num-outputs` keeps the English `[one]`,
+# Lusoga marks number with a class prefix — «ekitundu» one component,
+# «ebitundu» several; «omuwendo» one value, «emiwendo» several — so both
+# branches of every select in this file differ in more than a suffix. Not
+# every noun does: «engeri», an attribute, is class 9/10 and is spelt the
+# same in both numbers, marking number only on what agrees with it. `field-function-wrong-num-outputs` keeps the English `[one]`,
 # since `xog` really can select it.
 #
 # **Weakest here.** «okuserengeta» for *slope* and «enjawulo» for *contrast*

--- a/packages/i18n/locales/xog/editor.ftl
+++ b/packages/i18n/locales/xog/editor.ftl
@@ -21,9 +21,14 @@
 #
 # **What is borrowed.** English, openly and only where the word is what a
 # Ugandan classroom says: «fonkisoni», «lipoota», «tagi». The two counted
-# selects below use ordinary Lusoga nouns («ekizibu» / «ebizibu»,
-# «okuteesa») rather than a loan for *violation*, so that the plural has
-# something to work on.
+# selects below use ordinary Lusoga nouns rather than a loan for *violation*.
+# Only one of the two inflects: «ekizibu» / «ebizibu» changes its class
+# prefix, so `[one]` and `[other]` differ, while «okuteesa» is a class-15
+# verbal noun with no distinct plural, so both branches of that select are
+# the same string. That is deliberate rather than an oversight — the
+# alternative was coining a countable noun for *suggestion* — but a reviewer
+# who knows a countable Lusoga word for it should put it in and let the two
+# branches part.
 #
 # **Weakest here.** «erinnya» for a name is the Luganda word and may be a
 # Luganda intrusion; it is used in `chrome.ftl` too and should be corrected in

--- a/packages/i18n/locales/xog/editor.ftl
+++ b/packages/i18n/locales/xog/editor.ftl
@@ -1,0 +1,234 @@
+# Soga (Olusoga) editor and language-server surfaces: the footer, the
+# diagnostics panel, the variant picker, the accessibility button, and the
+# context-help panel beside them. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Script and orthography.** As `chrome.ftl` sets it out: the Lusoga Language
+# Authority standard, `dh` where Luganda writes `z` or `j`, the initial vowel
+# written, Latin digits.
+#
+# `WCAG`, `WCAG AA`, `DoenetML`, `XML` and `styleNumber` are names rather than
+# words and stay exactly as they stand, as do the key combinations `$shortcut`
+# carries.
+#
+# **What is Lusoga here.** The panel's own frame: «Tewali …» for *no X found*,
+# «Nyiga …» for *click to …*, «Manya …» for *learn about*, «kiraga» for *is a
+# reference to*, «engeri» for an attribute, «omuwendo» for a value, «ekika»
+# for a type and for a variant, «okudhuula» for *to find*, «ekidha» for what
+# comes next. The negator is **`ti-`**, not Luganda's `te-` / `si-`.
+#
+# **What is borrowed.** English, openly and only where the word is what a
+# Ugandan classroom says: «fonkisoni», «lipoota», «tagi». The two counted
+# selects below use ordinary Lusoga nouns («ekizibu» / «ebizibu»,
+# «okuteesa») rather than a loan for *violation*, so that the plural has
+# something to work on.
+#
+# **Weakest here.** «erinnya» for a name is the Luganda word and may be a
+# Luganda intrusion; it is used in `chrome.ftl` too and should be corrected in
+# both together. «engeri» for *attribute* and «okutuukirira» for
+# *accessibility* are descriptions rather than established Lusoga technical
+# terms, and are the next two to attack.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Zzaayo
+       *[update] Kyusa
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Omulaga
+       *[other] { $word } Omulaga { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Ekika
+
+editor-variant-filter = Sengejja…
+
+editor-variant-next = Londa ekika ekidha
+
+editor-variant-previous = Londa ekika ekiyise
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Kidhuuliddwa ekizibu kya WCAG AA mu kutuukirira. Nyiga { $action ->
+            [close] okwigalawo
+           *[open] okwigulawo
+        } lipoota y'okutuukirira.
+        [advisories] Nyiga { $action ->
+            [close] okwigalawo
+           *[open] okwigulawo
+        } lipoota y'okutuukirira. Tewali kizibu kya WCAG AA ekidhuuliddwa, naye waliwo okuteesa okulala ku kutuukirira.
+       *[clean] Nyiga { $action ->
+            [close] okwigalawo
+           *[open] okwigulawo
+        } lipoota y'okutuukirira. Tewali bizibu bya kutuukirira ebidhuuliddwa.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Kidhuuliddwa ekizibu kya WCAG AA mu kutuukirira. { $count ->
+            [one] Kidhuuliddwa ekizibu { $count } ekya WCAG AA
+           *[other] Bidhuuliddwa ebizibu { $count } ebya WCAG AA
+        }. Nyiga { $action ->
+            [close] okwigalawo
+           *[open] okwigulawo
+        } lipoota y'okutuukirira.
+        [advisories] Tewali kizibu kya WCAG AA ekidhuuliddwa. { $count ->
+            [one] Kudhuuliddwa okuteesa { $count } okulala ku kutuukirira
+           *[other] Kudhuuliddwa okuteesa { $count } okulala ku kutuukirira
+        }. Nyiga { $action ->
+            [close] okwigalawo
+           *[open] okwigulawo
+        } lipoota y'okutuukirira.
+       *[clean] Tewali kizibu kya WCAG AA ekidhuuliddwa. Nyiga { $action ->
+            [close] okwigalawo
+           *[open] okwigulawo
+        } lipoota y'okutuukirira.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Enkola ya DoenetML { $version }
+
+editor-tab-help = Obuyambi bw'aw'oli
+editor-tab-help-short = Aw'oli
+editor-tab-errors = Ensobi
+editor-tab-warnings = Okulabula
+editor-tab-info = Amawulire
+editor-tab-accessibility = Okutuukirira
+editor-tab-responses = Eby'okwiramu ebiweereziddwa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ebisoboka ku muwandiisi
+editor-format-as-doenetml = Tegeka nga DoenetML
+editor-format-as-xml = Tegeka nga XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Olunyiriri #{ $line }
+
+editor-no-errors = Tewali Nsobi
+editor-no-warnings = Tewali Kulabula
+editor-no-info = Tewali Mawulire
+
+editor-show-info-annotations = Laga amawulire mu muwandiisi
+editor-show-accessibility-annotations = Laga ebikwata ku kutuukirira mu muwandiisi
+
+editor-accessibility-learn-more = Manya nga Doenet bw'etwala okutuukirira
+
+editor-accessibility-violations-heading = Ebizibu by'okutuukirira ({ $standard })
+
+editor-accessibility-other-heading = Ebizibu ebirala eby'okutuukirira
+editor-none-found = Tewali kidhuuliddwa
+
+
+## Submitted responses
+
+editor-no-responses = Tewali by'okwiramu ebiweereziddwa kaakati
+editor-response-answer-id = Akabonero k'Eky'okwiramu
+editor-response-response = Eky'okwiramu
+editor-response-credit = Amamaaka
+editor-response-submitted = Kiweereziddwa
+
+
+## The context-help panel
+
+help-placeholder = Teeka akakomo ku rinnya lya tagi, ku ngeri, oba ku { $ref } okudhuula ebiwandiiko.
+
+help-unsupported-ref-chain = Obuyambi ku biraga eby'ebitundu bingi nga { $example } tibunnaba kutandika.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Tewali kidhuuliddwa ku kiraga kino: { $ref }.
+        [multiple] Bidhuuliddwa ebintu bingi ku kiraga kino: { $ref }.
+       *[indeterminate] Ekyo { $ref } ky'ekiraga tikimanyiddwa.
+    }
+
+help-learn-about-references = Manya ku biraga →
+help-reference-page = Olupapula lw'ebiraga →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Munda mu { $element }
+       *[top] Waigulu ddala
+    }{ $allowed ->
+        [none] { " — tewali kisobola kudha wano." }
+        [text] { " — wandiika ebigambo wano." }
+        [text-and-components] { " — wandiika ebigambo wano, oba ogezeeko:" }
+       *[components] { " — ebitundu by'osobola okugezaako:" }
+    }
+
+help-suggestions-footer = Nyiga { $shortcut } okulaba ebitundu byonna { $total }.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } kiraga { $target }.
+       *[other] { $ref } kiraga { $target } (olunyiriri { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Kiva ku { $owner } nga { $role }.
+       *[other] Kiva ku { $owner } ku lunyiriri { $line } nga { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } kiraga engeri { $property } eya { $element }.
+       *[other] { $ref } kiraga engeri { $property } eya { $element } (olunyiriri { $line }).
+    }
+
+help-kind-attribute = engeri
+help-kind-snippet = akatundu
+help-kind-array-entry = ekiteekeddwa mu lukalala
+
+help-default = Eky'ebulijjo:
+help-active-default = Eky'ebulijjo ekikola:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Emiwendo egikkirizibwa (ku buli kimu):
+       *[other] Emiwendo egikkirizibwa:
+    }
+
+help-suggested-values = Emiwendo egiteesebwa:
+
+help-inserts = Kiteeka:
+
+help-coordinates =
+    { $count ->
+        [one] Akabonero k'ekifo:
+       *[other] Obubonero bw'ebifo:
+    }
+
+help-type = Ekika:
+
+help-resolved-style = Endabika edhuuliddwa (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Amannya ga fonkisoni agadhuuliddwa:
+help-reset-list = Olukalala oluzzeemu ku kiteekeddwamu kino:
+help-added-on-input = Ebyongereddwako ku kiteekeddwamu kino:
+help-removed-on-input = Ebiihiddwako ku kiteekeddwamu kino:
+
+help-reset-overrides = { $reset } esinga { $additional } ne { $removed }.

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -54,6 +54,7 @@ export type SupportedLocale =
     | "cbk"
     | "ce"
     | "ceb"
+    | "cgg"
     | "ch"
     | "chk"
     | "ckb"
@@ -344,6 +345,7 @@ export type SupportedLocale =
     | "wo"
     | "xal"
     | "xh"
+    | "xog"
     | "yi"
     | "yo"
     | "yua"
@@ -636,6 +638,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Cebuano",
         endonym: "Cebuano",
         label: "Cebuano",
+    },
+    {
+        locale: "cgg",
+        englishName: "Chiga",
+        endonym: "Rukiga",
+        label: "Chiga (Rukiga)",
     },
     {
         locale: "ch",
@@ -2151,6 +2159,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Xhosa",
         endonym: "IsiXhosa",
         label: "Xhosa (IsiXhosa)",
+    },
+    {
+        locale: "xog",
+        englishName: "Soga",
+        endonym: "Olusoga",
+        label: "Soga (Olusoga)",
     },
     {
         locale: "yi",

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -152,12 +152,9 @@ import kwEditor from "../locales/kw/editor.ftl?raw";
 import gvEditor from "../locales/gv/editor.ftl?raw";
 // The East African pair. Two catalogs rather than the fifteen the batch set
 // out with — the other thirteen are recorded on #1655 with the coverage each
-// honestly reached. Both files, for the reason the batches above import both:
-// each catalog's count selects are split between `chrome.ftl` and
-// `diagnostics.ftl`.
-import cggChrome from "../locales/cgg/chrome.ftl?raw";
+// honestly reached. Only `diagnostics.ftl` here: the one count select this
+// block reads, `field-function-wrong-num-outputs`, lives there in both.
 import cggDiagnostics from "../locales/cgg/diagnostics.ftl?raw";
-import xogChrome from "../locales/xog/chrome.ftl?raw";
 import xogDiagnostics from "../locales/xog/diagnostics.ftl?raw";
 // The Americas batch, both files for the same reason as the Silk Road's:
 // each catalog's count selects are split between `chrome.ftl` and
@@ -255,6 +252,22 @@ type Row = [string, string, string];
  */
 const bothOf = (chrome: string, diagnostics: string) =>
     `${branches(chrome)}\n${branches(diagnostics)}`;
+
+/**
+ * The `$expected` fork of `field-function-wrong-num-outputs`: the message from
+ * its id up to the `$found` that follows the fork, comment lines dropped first
+ * so that a header paraphrasing the id cannot be matched instead of the
+ * message. `undefined` if either marker is missing, which the callers assert
+ * against rather than silently reading the rest of the file.
+ *
+ * Shared by the batch blocks below, which each ask the same question of the
+ * one message whose count fork a catalog answers differently depending on
+ * whether CLDR has plural rules for it.
+ */
+const outputFork = (diagnostics: string) =>
+    branches(diagnostics)
+        .split("\nfield-function-wrong-num-outputs =")[1]
+        ?.split("$found")[0];
 
 describe("createChromeTranslator", () => {
     it("answers in English for the default locale", () => {
@@ -1493,19 +1506,6 @@ describe("the second European batch's plural categories", () => {
      * The previous South Asian batch set this precedent and every one of its
      * fifteen catalogs writes `[1]` too.
      */
-    /**
-     * The `$expected` fork of `field-function-wrong-num-outputs`: the message
-     * from its id up to the `$found` that follows the fork, comment lines
-     * dropped first so that a header paraphrasing the id cannot be matched
-     * instead of the message. `undefined` if either marker is missing, which
-     * the callers assert against rather than silently reading the rest of the
-     * file.
-     */
-    const outputFork = (diagnostics: string) =>
-        branches(diagnostics)
-            .split("\nfield-function-wrong-num-outputs =")[1]
-            ?.split("$found")[0];
-
     it.each(NO_RULES)(
         "writes %s's output-count fork as a numeric branch, not a category",
         (_locale, _chrome, diagnostics) => {
@@ -1617,9 +1617,9 @@ describe("the second European batch's plural categories", () => {
  * let the other fall back would be visibly wrong rather than subtly wrong.
  */
 describe("the East African pair's plural categories", () => {
-    const EAST_AFRICA: [string, string, string][] = [
-        ["cgg", cggChrome, cggDiagnostics],
-        ["xog", xogChrome, xogDiagnostics],
+    const EAST_AFRICA: [string, string][] = [
+        ["cgg", cggDiagnostics],
+        ["xog", xogDiagnostics],
     ];
 
     it.each(EAST_AFRICA)("resolves %s against its own rules", (locale) => {
@@ -1637,36 +1637,15 @@ describe("the East African pair's plural categories", () => {
     );
 
     /**
-     * Neither writes a category it cannot select. `catalogLint.test.ts` holds
-     * this for the whole roster; it is asserted here too because the batch
-     * section makes a claim about *these two* that a roster-wide property
-     * does not evidence on its own.
-     */
-    it.each(EAST_AFRICA)(
-        "gives %s no branch outside one and other",
-        (_locale, chrome, diagnostics) => {
-            const text = bothOf(chrome, diagnostics);
-            for (const category of ["zero", "two", "few", "many"]) {
-                expect(text).not.toContain(`[${category}]`);
-            }
-        },
-    );
-
-    /**
-     * And both use the `[one]` they are entitled to, which is the half worth
+     * Both use the `[one]` they are entitled to, which is the half worth
      * asserting: a no-data catalog on this roster is *required* to write the
      * numeric `[1]` in `field-function-wrong-num-outputs`, and these two are
      * the other case — their own rules select the category, so the category
      * is what they write.
      */
-    const outputFork = (diagnostics: string) =>
-        branches(diagnostics)
-            .split("\nfield-function-wrong-num-outputs =")[1]
-            ?.split("$found")[0];
-
     it.each(EAST_AFRICA)(
         "keeps %s's output-count fork on the category its own rules select",
-        (_locale, _chrome, diagnostics) => {
+        (_locale, diagnostics) => {
             const fork = outputFork(diagnostics);
             expect(fork).toBeDefined();
             expect(fork).toContain("[one]");
@@ -1687,10 +1666,11 @@ describe("the East African pair's plural categories", () => {
         "marks %s's singular and plural by class prefix, not suffix",
         (_locale, diagnostics, singular, plural) => {
             const fork = outputFork(diagnostics);
+            // Same stem, different class prefix — «eki-» against «ebi-» in
+            // both — so both forms have to be in the fork for it to mark
+            // number at all.
             expect(fork).toContain(singular);
             expect(fork).toContain(plural);
-            // Same stem, different prefix: that is what makes them a pair.
-            expect(singular.slice(2)).toBe(plural.slice(2));
         },
     );
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -150,6 +150,15 @@ import romChrome from "../locales/rom/chrome.ftl?raw";
 import romDiagnostics from "../locales/rom/diagnostics.ftl?raw";
 import kwEditor from "../locales/kw/editor.ftl?raw";
 import gvEditor from "../locales/gv/editor.ftl?raw";
+// The East African pair. Two catalogs rather than the fifteen the batch set
+// out with — the other thirteen are recorded on #1655 with the coverage each
+// honestly reached. Both files, for the reason the batches above import both:
+// each catalog's count selects are split between `chrome.ftl` and
+// `diagnostics.ftl`.
+import cggChrome from "../locales/cgg/chrome.ftl?raw";
+import cggDiagnostics from "../locales/cgg/diagnostics.ftl?raw";
+import xogChrome from "../locales/xog/chrome.ftl?raw";
+import xogDiagnostics from "../locales/xog/diagnostics.ftl?raw";
 // The Americas batch, both files for the same reason as the Silk Road's:
 // each catalog's count selects are split between `chrome.ftl` and
 // `diagnostics.ftl`, so where a category branch falls is only checkable
@@ -1587,4 +1596,101 @@ describe("the second European batch's plural categories", () => {
         expect(wa.select(2)).toBe("other");
         expect(branches(waChrome)).toContain("[0]");
     });
+});
+
+/**
+ * The East African pair's plural categories.
+ *
+ * The batch set out as fifteen languages of Kenya, Uganda and Tanzania and
+ * ships **two**: Chiga (`cgg`) and Soga (`xog`). The other thirteen are on
+ * #1655 with the coverage each honestly reached, and the README's batch
+ * section says why. So this block asserts a pair rather than a split, and
+ * what it has to say is about the pair.
+ *
+ * **Both have plural rules of their own**, and CLDR gives both `one` and
+ * `other`. That is not the interesting part; the interesting part is that
+ * both branches do real work here in a way they do not in most catalogs on
+ * this roster. Number in these languages is marked by the noun's **class
+ * prefix** rather than by a suffix — «omurundi» against «emirundi»,
+ * «ekiranga» against «ebiranga» — so the two branches of a count select
+ * differ at the front of the word, and a catalog that wrote one branch and
+ * let the other fall back would be visibly wrong rather than subtly wrong.
+ */
+describe("the East African pair's plural categories", () => {
+    const EAST_AFRICA: [string, string, string][] = [
+        ["cgg", cggChrome, cggDiagnostics],
+        ["xog", xogChrome, xogDiagnostics],
+    ];
+
+    it.each(EAST_AFRICA)("resolves %s against its own rules", (locale) => {
+        expect(new Intl.PluralRules(locale).resolvedOptions().locale) //
+            .toBe(locale);
+    });
+
+    it.each(EAST_AFRICA)(
+        "gives %s exactly the two categories CLDR lists for it",
+        (locale) => {
+            expect(
+                new Intl.PluralRules(locale).resolvedOptions().pluralCategories,
+            ).toEqual(["one", "other"]);
+        },
+    );
+
+    /**
+     * Neither writes a category it cannot select. `catalogLint.test.ts` holds
+     * this for the whole roster; it is asserted here too because the batch
+     * section makes a claim about *these two* that a roster-wide property
+     * does not evidence on its own.
+     */
+    it.each(EAST_AFRICA)(
+        "gives %s no branch outside one and other",
+        (_locale, chrome, diagnostics) => {
+            const text = bothOf(chrome, diagnostics);
+            for (const category of ["zero", "two", "few", "many"]) {
+                expect(text).not.toContain(`[${category}]`);
+            }
+        },
+    );
+
+    /**
+     * And both use the `[one]` they are entitled to, which is the half worth
+     * asserting: a no-data catalog on this roster is *required* to write the
+     * numeric `[1]` in `field-function-wrong-num-outputs`, and these two are
+     * the other case — their own rules select the category, so the category
+     * is what they write.
+     */
+    const outputFork = (diagnostics: string) =>
+        branches(diagnostics)
+            .split("\nfield-function-wrong-num-outputs =")[1]
+            ?.split("$found")[0];
+
+    it.each(EAST_AFRICA)(
+        "keeps %s's output-count fork on the category its own rules select",
+        (_locale, _chrome, diagnostics) => {
+            const fork = outputFork(diagnostics);
+            expect(fork).toBeDefined();
+            expect(fork).toContain("[one]");
+            expect(fork).not.toContain("[1]");
+        },
+    );
+
+    /**
+     * The class-prefix point above, held to the text. In both catalogs the
+     * two branches of the output-count fork differ in the **first letters**
+     * of the counted noun rather than in a suffix, so a reviewer who
+     * "simplifies" one branch away removes the number marking with it.
+     */
+    it.each([
+        ["cgg", cggDiagnostics, "ekirikuruga", "ebirikuruga"],
+        ["xog", xogDiagnostics, "ekifuluma", "ebifuluma"],
+    ])(
+        "marks %s's singular and plural by class prefix, not suffix",
+        (_locale, diagnostics, singular, plural) => {
+            const fork = outputFork(diagnostics);
+            expect(fork).toContain(singular);
+            expect(fork).toContain(plural);
+            // Same stem, different prefix: that is what makes them a pair.
+            expect(singular.slice(2)).toBe(plural.slice(2));
+        },
+    );
 });

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -2926,3 +2926,88 @@ describe("normalizeLocaleTag", () => {
         ).toEqual(["es-MX", "en"]);
     });
 });
+
+/**
+ * The East African batch, and the thirteen tags it deliberately did not seed.
+ *
+ * Two catalogs ship — `cgg` (Chiga) and `xog` (Soga) — out of fifteen the
+ * batch set out with. The thirteen that did not are recorded on #1655 with
+ * the coverage each honestly reached, and the point of asserting them here is
+ * that **a language without a catalog must reach English**, not a neighbour
+ * that happens to look close on a map. Every one of the thirteen has a near
+ * relative on this roster, and several have a very near one: `sw` sits beside
+ * all of them, `lg` beside `xog`, `nyn` beside `cgg`, `ki` beside `ebu` and
+ * `mer`. None of that folds, and none of it should — the moment membership
+ * becomes a judgement about how close two varieties sound, nothing in these
+ * maps is checkable any more.
+ */
+describe("the East African batch", () => {
+    it.each(["cgg", "xog"])("serves %s its own catalog", (requested) => {
+        expect(
+            negotiateLocales([normalizeLocaleTag(requested)], available),
+        ).toEqual([requested, "en"]);
+    });
+
+    /**
+     * `kln` is not in this list because it is already asserted as a negative
+     * control further up, where it has been since before this batch — the
+     * batch considered Kalenjin, measured it, and left that assertion doing
+     * exactly the job it was written for.
+     */
+    it.each([
+        "kam",
+        "guz",
+        "luy",
+        "mas",
+        "mer",
+        "saq",
+        "dav",
+        "ebu",
+        "teo",
+        "ksb",
+        "vun",
+        "jmc",
+    ])(
+        "leaves %s on English rather than folding it onto a neighbour",
+        (requested) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual(["en"]);
+        },
+    );
+
+    /**
+     * The sharpest pair on that list, asserted from both sides because it is
+     * the one someone will be tempted to fix. Rukiga and Runyankore share a
+     * single written standard, one dictionary and most of their vocabulary,
+     * and `locales/cgg` says so in its own header. They are still two
+     * languages with two codes: a Runyankore reader gets `nyn`, and folding
+     * either onto the other would answer a reader in a variety they did not
+     * ask for on the strength of a resemblance.
+     */
+    it("keeps Runyankore on its own catalog rather than serving it Rukiga", () => {
+        expect(negotiateLocales([normalizeLocaleTag("nyn")], available)) //
+            .toEqual(["nyn", "en"]);
+    });
+
+    it("keeps Rukiga on its own catalog rather than serving it Runyankore", () => {
+        expect(negotiateLocales([normalizeLocaleTag("cgg")], available)) //
+            .toEqual(["cgg", "en"]);
+    });
+
+    /**
+     * `luy` and `kln` are macrolanguages, and neither gained a
+     * `MACROLANGUAGE_MEMBERS` entry — because neither has a catalog to fold a
+     * member onto. Asserted so that the reason stays visible: the entry is
+     * owed the moment either is seeded, and until then a member reaching
+     * English is correct rather than a gap.
+     */
+    it.each(["bxk", "spy"])(
+        "leaves %s on English while its macrolanguage has no catalog",
+        (requested) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual(["en"]);
+        },
+    );
+});

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -2977,22 +2977,21 @@ describe("the East African batch", () => {
     );
 
     /**
-     * The sharpest pair on that list, asserted from both sides because it is
-     * the one someone will be tempted to fix. Rukiga and Runyankore share a
-     * single written standard, one dictionary and most of their vocabulary,
-     * and `locales/cgg` says so in its own header. They are still two
-     * languages with two codes: a Runyankore reader gets `nyn`, and folding
+     * The sharpest pair on that list, and the one someone will be tempted to
+     * "fix". Rukiga and Runyankore share a single written standard, one
+     * dictionary and most of their vocabulary, and `locales/cgg` says so in
+     * its own header. They are still two languages with two codes: folding
      * either onto the other would answer a reader in a variety they did not
      * ask for on the strength of a resemblance.
+     *
+     * The `cgg` side is the first assertion in this block. This is the `nyn`
+     * side, which the West and Central African batch already asserted in its
+     * own table — restated here because until this batch there was no `cgg`
+     * catalog for it to be folded onto, so the row could not have failed.
      */
     it("keeps Runyankore on its own catalog rather than serving it Rukiga", () => {
         expect(negotiateLocales([normalizeLocaleTag("nyn")], available)) //
             .toEqual(["nyn", "en"]);
-    });
-
-    it("keeps Rukiga on its own catalog rather than serving it Runyankore", () => {
-        expect(negotiateLocales([normalizeLocaleTag("cgg")], available)) //
-            .toEqual(["cgg", "en"]);
     });
 
     /**

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65579,6 +65579,10 @@
                             "description": "Cebuano"
                         },
                         {
+                            "value": "cgg",
+                            "description": "Chiga (Rukiga)"
+                        },
+                        {
                             "value": "ch",
                             "description": "Chamorro"
                         },
@@ -66737,6 +66741,10 @@
                         {
                             "value": "xh",
                             "description": "Xhosa (IsiXhosa)"
+                        },
+                        {
+                            "value": "xog",
+                            "description": "Soga (Olusoga)"
                         },
                         {
                             "value": "yi",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -5580,3 +5580,87 @@ describe("the second European batch's word order", () => {
         expect(describe_("point")).toBe(describe_("line"));
     });
 });
+
+describe("the East African pair's word order", () => {
+    /**
+     * Two catalogs rather than the fifteen the batch set out with, and both
+     * are Bantu languages of Uganda: Chiga (`cgg`) and Soga (`xog`). The
+     * other thirteen are recorded on #1655 with the coverage each honestly
+     * reached; see the README's batch section.
+     *
+     * Both put the describing words **after** the noun, so what leads the
+     * phrase is the noun and the bare description is the phrase's tail — the
+     * shape `style-with-noun` has to be read against, and the same one `kl`
+     * and the Romance catalogs produce.
+     *
+     * Neither keeps English's internal sequence of the three adjectives.
+     * English orders them width – pattern – colour; both of these render the
+     * dash pattern as an **associative phrase** («na tucweka», «n'obutundu» —
+     * *with pieces*, *with dots*) rather than as an adjective, and an
+     * associative phrase cannot sit between two adjectives, so both read
+     * width – colour – pattern. That is the same constraint `wa`, `frp` and
+     * `nrf` hit from the other side of the continent, and it is a fact about
+     * where a phrase can go rather than a choice either seed made.
+     *
+     * The two differ in how much of the phrase carries concord, which is why
+     * asserting both is worth more than asserting either. Rukiga agrees only
+     * the first adjective with the noun's class and leaves the colour to the
+     * associative («omurongo muhango w'omutukura»); Lusoga agrees every
+     * adjective in the string («olunyiriri olunene olumyufu»), so class 11's
+     * `olu-` appears three times in one phrase.
+     */
+    const postnominal: [string, string, string][] = [
+        [
+            "cgg",
+            "omurongo muhango w'omutukura na tucweka",
+            "muhango w'omutukura na tucweka",
+        ],
+        [
+            "xog",
+            "olunyiriri olunene olumyufu n'obutundu",
+            "olunene olumyufu n'obutundu",
+        ],
+    ];
+
+    const nounOf: Record<string, string> = {
+        cgg: "omurongo",
+        xog: "olunyiriri",
+    };
+
+    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
+        it(`puts ${locale}'s describing words after the noun`, () => {
+            const t = forLocale(locale);
+            const rendered = describeStrokedShape(t, words, {
+                noun: line,
+                withNoun: true,
+            });
+            const renderedBare = describeStrokedShape(t, words, {
+                noun: line,
+                withNoun: false,
+            });
+            expect(rendered).toBe(withNoun);
+            expect(renderedBare).toBe(adjectivesOnly);
+            // The bare description is the tail of the full phrase verbatim:
+            // the noun moved to the front and nothing else moved with it.
+            expect(rendered).toBe(`${nounOf[locale]} ${renderedBare}`);
+        });
+    }
+
+    /**
+     * The initial vowel — the augment — is part of the word in both
+     * languages, and it is the thing a seed drops when it reaches for a
+     * dictionary stem. Both catalogs' headers say so; this holds them to it,
+     * because «murongo» and «lunyiriri» would render, lint clean and be
+     * wrong.
+     */
+    it.each([
+        ["cgg", "omurongo"],
+        ["xog", "olunyiriri"],
+    ])("writes %s's noun with its augment", (locale, noun) => {
+        const rendered = describeStrokedShape(forLocale(locale), words, {
+            noun: line,
+            withNoun: true,
+        });
+        expect(rendered.startsWith(noun)).toBe(true);
+    });
+});

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -5622,6 +5622,12 @@ describe("the East African pair's word order", () => {
         ],
     ];
 
+    /**
+     * The noun each phrase leads with, written **with its initial vowel** —
+     * the augment. That is the thing a seed drops when it reaches for a
+     * dictionary stem, and both catalogs' headers say so: «murongo» and
+     * «lunyiriri» would render, lint clean and be wrong.
+     */
     const nounOf: Record<string, string> = {
         cgg: "omurongo",
         xog: "olunyiriri",
@@ -5645,22 +5651,4 @@ describe("the East African pair's word order", () => {
             expect(rendered).toBe(`${nounOf[locale]} ${renderedBare}`);
         });
     }
-
-    /**
-     * The initial vowel — the augment — is part of the word in both
-     * languages, and it is the thing a seed drops when it reaches for a
-     * dictionary stem. Both catalogs' headers say so; this holds them to it,
-     * because «murongo» and «lunyiriri» would render, lint clean and be
-     * wrong.
-     */
-    it.each([
-        ["cgg", "omurongo"],
-        ["xog", "olunyiriri"],
-    ])("writes %s's noun with its augment", (locale, noun) => {
-        const rendered = describeStrokedShape(forLocale(locale), words, {
-            noun: line,
-            withNoun: true,
-        });
-        expect(rendered.startsWith(noun)).toBe(true);
-    });
 });


### PR DESCRIPTION
Seeds two Bantu languages of Uganda — **Chiga (`cgg`, Rukiga)** and **Soga (`xog`, Olusoga)**, both at 440/575 keys. Roster goes 346 → 348.

The batch was assembled as **fifteen** languages of Kenya, Uganda and Tanzania, to test the rule #1655 settled on: *carry a loan register where speakers already carry one, and leave the key out where they do not.* Thirteen were attempted and left out rather than shipped, at between 0 and 91 keys of 575 — twelve measured, Teso estimated, its draft never having been written. They are recorded on #1655 with the coverage each reached and the orthography each attempt settled.

The findings are written up in `packages/i18n/README.md` under *Two catalogs of East Africa, and the thirteen the batch did not seed*. In brief:

- **A loan register can exist and still not be worth recording.** The Americas case is *no register exists*; the `sgh`/`kl` case is *a register speakers actually use exists* — a Shughni reader meets compiler errors in Tajik. This batch found a third: *the register is derivable rather than attested*. Because Swahili nativization is rule-governed, `locales/sw` could have been rewritten phonologically end to end and reported at the batch ceiling; that records a sound law rather than a usage. The tempting line — *the lender already has a catalog here* — does **not** hold, since Tajik, Russian and Danish do too.
- **A near sibling on the roster makes a bad seed harder to spot, not easier**: a machine pass on Embu produces fluent-looking Gĩkũyũ. What separates the two that ship is not distance from the sibling — `cgg` sits closer to `nyn` than `ebu` does to `ki` — but whether the catalog can **state the seam**: Lusoga writes `dh` where Luganda writes `z`/`j`, and `locales/cgg`, having no such rule available, states the question instead.

Both catalogs write the augment as part of the noun, agree describing words with noun class rather than gender, and put them after the noun. Neither writes a plural category or a noun class it cannot select — `xog`'s `[c5]` column was caught by the reachability rule and removed rather than justified with an invented class-5 noun.

Coverage is **440 rather than the 445** recent batches reach. The two chemistry tables are out for the school-system reason (Uganda teaches science in English from upper primary), and five further keys are deliberate: the three remaining chemistry prose messages, so the chemistry group falls back entire rather than half in English inside one sentence, and `noun.slope-field` / `noun.vector-field`, where neither language has a term and a phrase would have been the seed's invention. Each `content.ftl` header lists the omissions with the reason beside each.

Also in the diff: plural-category and word-order tests for the pair, negotiation tests asserting the thirteen unseeded tags reach English and that `nyn`/`cgg` do not fold onto each other, a changeset, and regenerated `supportedLocales.ts` and `doenet-schema.json` — both languages reach `<document lang>`'s autocomplete under CLDR's own names, so no `LOCALE_NAME_FALLBACKS` entry is owed. The new test blocks assert only what the roster-wide rules in `catalogLint.test.ts` do not already cover.

**Two things a reviewer should know.** `locales/cgg` uses one word, «eky'okugarukamu», for both *answer* and *response*, so the editor's response table reads "Ekimanyiso ky'Eky'okugarukamu" / "Eky'okugarukamu"; `xog` merges the two natively as well, and both headers gloss the word for both senses. Splitting them needs a speaker, not a seed. And `luy` and `kln` are macrolanguages owed `MACROLANGUAGE_MEMBERS` entries that did not get them, because neither has a catalog for a member to be folded onto — `negotiate.test.ts` asserts `bxk` and `spy` reach English so the debt stays visible.

These are machine-generated seeds pending review by speakers (#1521).

Refs #1521, #1655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)