### PR TITLE
Size an expanded text input, and say what a size may be

### DIFF
--- a/.changeset/component-size-help.md
+++ b/.changeset/component-size-help.md
@@ -1,0 +1,20 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+The context-sensitive help explains what a `width` or `height` accepts.
+
+Cursor on one of these attributes, the help panel now lists the forms its value
+may take — `600`, `600px`, `6in`, `450pt`, `15cm`, and, for a width, `50%` —
+along with the note that a bare number is pixels. A height is offered only the
+absolute forms, since a percentage there has no page height to measure itself
+against. The `width` of a `<graph>`, `<image>` or `<video>` is marked as
+choosing the nearest `size` preset rather than being used exactly.
+
+The panel keys off the attribute's type, so every component taking a size is
+covered. A size default also reads as `120px` now, instead of as the internal
+`{"size":120,"isAbsolute":true}` — in the reference tables as well as the panel.

--- a/.changeset/component-size-help.md
+++ b/.changeset/component-size-help.md
@@ -10,10 +10,12 @@ The context-sensitive help explains what a `width` or `height` accepts.
 
 Cursor on one of these attributes, the help panel now lists the forms its value
 may take — `600`, `600px`, `6in`, `450pt`, `15cm`, and, for a width, `50%` —
-along with the note that a bare number is pixels. A height is offered only the
-absolute forms, since a percentage there has no page height to measure itself
-against. The `width` of a `<graph>`, `<image>` or `<video>` is marked as
-choosing the nearest `size` preset rather than being used exactly.
+along with a note naming the unit each carries. Each attribute is offered only
+what it honors: a height gets the absolute forms, since a percentage there has
+no page height to measure itself against, and a `<sideBySide>` width gets the
+percentage, since it divides a row into shares. The `width` of a `<graph>`,
+`<image>` or `<video>` is marked as choosing the nearest `size` preset rather
+than being used exactly.
 
 The panel keys off the attribute's type, so every component taking a size is
 covered. A size default also reads as `120px` now, instead of as the internal

--- a/.changeset/component-size-help.md
+++ b/.changeset/component-size-help.md
@@ -17,6 +17,7 @@ percentage, since it divides a row into shares. The `width` of a `<graph>`,
 `<image>` or `<video>` is marked as choosing the nearest `size` preset rather
 than being used exactly.
 
-The panel keys off the attribute's type, so every component taking a size is
-covered. A size default also reads as `120px` now, instead of as the internal
-`{"size":120,"isAbsolute":true}` — in the reference tables as well as the panel.
+The panel keys off the attribute's type rather than its name, so every attribute
+taking a single size is covered. A size default also reads as `120px` now,
+instead of as the internal `{"size":120,"isAbsolute":true}` — in the reference
+tables as well as the panel.

--- a/.changeset/component-size-help.md
+++ b/.changeset/component-size-help.md
@@ -8,7 +8,7 @@
 
 The context-sensitive help explains what a `width` or `height` accepts.
 
-Cursor on one of these attributes, the help panel now lists the forms its value
+With the cursor on one of these attributes, the help panel now lists the forms its value
 may take — `600`, `600px`, `6in`, `450pt`, `15cm`, and, for a width, `50%` —
 along with a note naming the unit each carries. Each attribute is offered only
 what it honors: a height gets the absolute forms, since a percentage there has

--- a/.changeset/expanded-input-check-work-layout.md
+++ b/.changeset/expanded-input-check-work-layout.md
@@ -1,0 +1,21 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+An expanded `<textInput>` carries its check-work button beneath it.
+
+An expanded input fills the width it is given, so a button beside it was
+squeezed against the right margin, its label wrapping onto a second line that
+the button's fixed height then clipped. The button now sits under the input, as
+it already does under the choices of a non-inline `<choiceInput>`, and it is the
+full labelled button by default there — `forceFullCheckWorkButton` is no longer
+needed to get one, and `forceSmallCheckWorkButton` asks for the compact one. A
+word-sized input is unchanged: its small button still rides beside it on the
+line.
+
+Every check-work button now grows to hold a label that wraps, rather than
+clipping it, which a long translated label could run into anywhere.

--- a/.changeset/expanded-input-check-work-layout.md
+++ b/.changeset/expanded-input-check-work-layout.md
@@ -15,7 +15,8 @@ it already does under the choices of a non-inline `<choiceInput>`, and it is the
 full labelled button by default there — `forceFullCheckWorkButton` is no longer
 needed to get one, and `forceSmallCheckWorkButton` asks for the compact one. A
 word-sized input is unchanged: its small button still rides beside it on the
-line.
+line. An expanded input's `<description>` popover moves under it too, travelling
+with the button.
 
 Every check-work button now grows to hold a label that wraps, rather than
 clipping it, which a long translated label could run into anywhere.

--- a/.changeset/expanded-text-input-size.md
+++ b/.changeset/expanded-text-input-size.md
@@ -18,3 +18,6 @@ shrink-to-fit row and produced an arbitrary size. Its default width is now 100%
 rather than 600 pixels, and it never grows wider than the column even when an
 absolute width asks for more, so it shrinks to fit a narrow window. The width of
 a word-sized (not `expanded`) input is unchanged.
+
+The reference table and the help panel now name the two defaults, and say that
+`height` applies only to an expanded input.

--- a/.changeset/expanded-text-input-size.md
+++ b/.changeset/expanded-text-input-size.md
@@ -19,5 +19,9 @@ rather than 600 pixels, and it never grows wider than the column even when an
 absolute width asks for more, so it shrinks to fit a narrow window. The width of
 a word-sized (not `expanded`) input is unchanged.
 
+On a `<graph>` a text input is drawn as a one-line field however it is written,
+so `expanded` no longer changes its size there: it is the same width as any
+other input on the graph.
+
 The reference table and the help panel now name the two defaults, and say that
 `height` applies only to an expanded input.

--- a/.changeset/expanded-text-input-size.md
+++ b/.changeset/expanded-text-input-size.md
@@ -1,0 +1,20 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+An expanded `<textInput>` is sized by its `width` and `height` again.
+
+The textarea an expanded input renders had dropped both dimensions from its
+style, so it fell back to the browser's default box — about twenty columns and
+two rows — no matter what was authored, and `width` and `height` did nothing.
+
+An expanded input now also takes a relative width: `width="50%"` is half the
+column it sits in, where before a percentage resolved against the input's own
+shrink-to-fit row and produced an arbitrary size. Its default width is now 100%
+rather than 600 pixels, and it never grows wider than the column even when an
+absolute width asks for more, so it shrinks to fit a narrow window. The width of
+a word-sized (not `expanded`) input is unchanged.

--- a/.changeset/expanded-text-input-size.md
+++ b/.changeset/expanded-text-input-size.md
@@ -21,7 +21,9 @@ a word-sized (not `expanded`) input is unchanged.
 
 On a `<graph>` a text input is drawn as a one-line field however it is written,
 so `expanded` no longer changes its size there: it is the same width as any
-other input on the graph.
+other input on the graph. A percentage width has nothing to be a share of on a
+graph, so an input given one falls back to the word-sized 100 pixels rather than
+to the arbitrary size it used to get.
 
 The reference table and the help panel now name the two defaults, and say that
 `height` applies only to an expanded input.

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -702,6 +702,8 @@ function formatType(typeName?: PropAttrType, isArray?: boolean) {
  * altogether. Math-expression defaults (the `{ type: "math", latex }`
  * sentinel produced by `get-schema.ts`) are rendered through MathJax so the
  * actual expression — not the raw serialized object — appears in the docs.
+ * Size defaults (the runtime's `{ size, isAbsolute }` pair) are printed the
+ * same way an author would write them, `120px` or `50%`, for the same reason.
  */
 function renderDefaultValue(value: unknown): React.ReactNode {
     if (value == null) {

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -3,7 +3,11 @@
 import { Link } from "nextra-theme-docs";
 import React, { useMemo, useState } from "react";
 import { MathJax, MathJaxContext } from "better-react-mathjax";
-import { isMathDefaultValue } from "@doenet/static-assets/schema";
+import {
+    formatComponentSize,
+    isComponentSizeValue,
+    isMathDefaultValue,
+} from "@doenet/static-assets/schema";
 
 /** Types the rendering code special-cases. */
 export type KnownPropAttrType =
@@ -727,6 +731,11 @@ function renderDefaultValue(value: unknown): React.ReactNode {
     }
     if (typeof value === "boolean" || typeof value === "number") {
         return String(value);
+    }
+    if (isComponentSizeValue(value)) {
+        // The schema carries a size as the runtime's `{ size, isAbsolute }`
+        // pair; show the author the `120px` / `50%` they would actually type.
+        return formatComponentSize(value);
     }
     return JSON.stringify(value);
 }

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -143,8 +143,10 @@ Write the percentage you mean instead.
 <Callout type="info">
 A unit DoenetML does not recognize is quietly read as pixels: `width="300
 furlongs"` renders 300 pixels wide. A value that does not begin with a number at
-all — `width="wide"` — yields no size at all, and the component renders as
-though the attribute had not been written.
+all — `width="wide"` — yields no size. That is not the same as leaving the
+attribute off: the component does not fall back to its default width, it is laid
+out with no width of its own. Delete the attribute rather than give it a value
+DoenetML cannot read.
 </Callout>
 
 ### Sizes that snap to a preset
@@ -164,6 +166,10 @@ named sizes, which you can also set directly with their `size` attribute:
 So `width="400px"` and `width="50%"` both render one of these components at
 `medium`, 425 pixels wide. Reading back the component's `size` property tells
 you which preset a width landed on.
+
+An `<image/>{:dn}` drawn on a `<graph/>{:dn}` is the exception to the exception:
+there its `width` is used as given, measured against the graph's own scale
+rather than snapped to a preset.
 
 ### Sizes that must be relative
 

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -90,3 +90,76 @@ When you need to access the value of the named component or one of its stored pr
 <p>line1.yIntercept = $line1.yIntercept</p>
 ```
 
+
+<a id="sizes"></a>
+## Sizes: `width` and `height`
+
+Several components let you set their rendered size with a `width` attribute and,
+where a component has a height of its own to set, a `height` attribute:
+`<textInput/>{:dn}`, `<codeEditor/>{:dn}`, `<spreadsheet/>{:dn}`,
+`<tabular/>{:dn}`, `<slider/>{:dn}`, `<sideBySide/>{:dn}`, `<graph/>{:dn}`,
+`<image/>{:dn}`, and `<video/>{:dn}`. Every one of them reads the value the
+same way.
+
+**A bare number means pixels.** `width="600"` and `width="600px"` are the same
+size. You can also write the size in physical units:
+
+| Value | Meaning |
+| ----- | ------- |
+| `600` | 600 pixels |
+| `600px` | 600 pixels; the unit may also be spelled `pixel` or `pixels`, with or without a space before it |
+| `6in` | 6 inches, or 576 pixels; also spelled `inch` or `inches` |
+| `450pt` | 450 points, or 600 pixels |
+| `15cm` | 15 centimeters, or about 567 pixels; also spelled `centimeter` or `centimeters` |
+| `150mm` | 150 millimeters, the same size; also spelled `millimeter` or `millimeters` |
+
+A `height` takes one of these sizes. A `width` takes them too, and may instead
+be written as a percentage.
+
+### Relative sizes
+
+A percentage is measured against the width available to the component — the
+width of the page column it sits in, or of whatever encloses it. It is the one
+form that keeps a component in proportion when the reader's window is narrow,
+so reach for it when a fixed number of pixels would be too wide on a phone:
+
+```doenet-example
+<codeEditor width="50%" height="150px" showResults>
+  <p>Half the width of the column, whatever that column turns out to be.</p>
+</codeEditor>
+```
+
+An expanded `<textInput/>{:dn}` takes a percentage the same way, and is 100%
+wide unless you say otherwise. A word-sized input does not take one: it keeps a
+width of its own so that it can flow inline with the sentence around it.
+
+<Callout type="warning">
+**`em` is not a font-relative size here.** Unlike in CSS, DoenetML reads `em` as
+a multiple of 100%, so `width="2em"` means 200% and `width="1em"` means 100%.
+Write the percentage you mean instead.
+</Callout>
+
+<Callout type="info">
+A unit DoenetML does not recognize is quietly read as pixels: `width="300
+furlongs"` renders 300 pixels wide. A value that does not begin with a number at
+all — `width="wide"` — sets no width, and the component falls back to its
+default size.
+</Callout>
+
+### Sizes that snap to a preset
+
+`<graph/>{:dn}`, `<image/>{:dn}`, and `<video/>{:dn}` are the exception to all of
+this. Their `width` does not set an exact width; it picks the nearest of five
+named sizes, which you can also set directly with their `size` attribute:
+
+| `size` | Width |
+| ------ | ----- |
+| `tiny` | 70 pixels |
+| `small` | 255 pixels |
+| `medium` | 425 pixels |
+| `large` | 595 pixels |
+| `full` | 850 pixels |
+
+So `width="400px"` and `width="50%"` both render one of these components at
+`medium`, 425 pixels wide. Reading back the component's `size` property tells
+you which preset a width landed on.

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -97,9 +97,9 @@ When you need to access the value of the named component or one of its stored pr
 Several components let you set their rendered size with a `width` attribute and,
 where a component has a height of its own to set, a `height` attribute:
 `<textInput/>{:dn}`, `<codeEditor/>{:dn}`, `<spreadsheet/>{:dn}`,
-`<tabular/>{:dn}`, `<slider/>{:dn}`, `<sideBySide/>{:dn}`, `<graph/>{:dn}`,
-`<image/>{:dn}`, and `<video/>{:dn}`. They all read the value the same way,
-with two exceptions noted at the end of this section.
+`<tabular/>{:dn}`, `<slider/>{:dn}`, `<sideBySide/>{:dn}`, `<sbsGroup/>{:dn}`,
+`<graph/>{:dn}`, `<image/>{:dn}`, and `<video/>{:dn}`. They all read the value
+the same way, with two exceptions noted at the end of this section.
 
 **A bare number means pixels.** `width="600"` and `width="600px"` are the same
 size. You can also write the size in physical units:
@@ -130,8 +130,9 @@ so reach for it when a fixed number of pixels would be too wide on a phone:
 ```
 
 An expanded `<textInput/>{:dn}` takes a percentage the same way, and is 100%
-wide unless you say otherwise. A word-sized input does not take one: it keeps a
-width of its own so that it can flow inline with the sentence around it.
+wide unless you say otherwise. A word-sized input is the exception: it shrinks
+to fit the sentence it flows in, so there is no column there for a percentage to
+be a share of. Give a word-sized input an absolute width.
 
 <Callout type="warning">
 **`em` is not a font-relative size here.** Unlike in CSS, DoenetML reads `em` as
@@ -166,8 +167,8 @@ you which preset a width landed on.
 
 ### Sizes that must be relative
 
-`<sideBySide/>{:dn}` is the second exception. It divides a row into shares, so
-its `width`, `widths`, and `margins` are read as percentages only. An absolute
-size there raises a warning and is treated as the percentage of the same
-number, which is rarely what you meant — write `width="50%"`, not
-`width="50"`.
+`<sideBySide/>{:dn}` and `<sbsGroup/>{:dn}` are the second exception. They
+divide a row into shares, so their `width`, `widths`, and `margins` are read as
+percentages only. An absolute size there raises a warning and is treated as the
+percentage of the same number, which is rarely what you meant — write
+`width="50%"`, not `width="50"`.

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -98,8 +98,8 @@ Several components let you set their rendered size with a `width` attribute and,
 where a component has a height of its own to set, a `height` attribute:
 `<textInput/>{:dn}`, `<codeEditor/>{:dn}`, `<spreadsheet/>{:dn}`,
 `<tabular/>{:dn}`, `<slider/>{:dn}`, `<sideBySide/>{:dn}`, `<graph/>{:dn}`,
-`<image/>{:dn}`, and `<video/>{:dn}`. Every one of them reads the value the
-same way.
+`<image/>{:dn}`, and `<video/>{:dn}`. They all read the value the same way,
+with two exceptions noted at the end of this section.
 
 **A bare number means pixels.** `width="600"` and `width="600px"` are the same
 size. You can also write the size in physical units:
@@ -142,14 +142,14 @@ Write the percentage you mean instead.
 <Callout type="info">
 A unit DoenetML does not recognize is quietly read as pixels: `width="300
 furlongs"` renders 300 pixels wide. A value that does not begin with a number at
-all — `width="wide"` — sets no width, and the component falls back to its
-default size.
+all — `width="wide"` — yields no size at all, and the component renders as
+though the attribute had not been written.
 </Callout>
 
 ### Sizes that snap to a preset
 
-`<graph/>{:dn}`, `<image/>{:dn}`, and `<video/>{:dn}` are the exception to all of
-this. Their `width` does not set an exact width; it picks the nearest of five
+`<graph/>{:dn}`, `<image/>{:dn}`, and `<video/>{:dn}` are the first exception.
+Their `width` does not set an exact width; it picks the nearest of five
 named sizes, which you can also set directly with their `size` attribute:
 
 | `size` | Width |
@@ -163,3 +163,11 @@ named sizes, which you can also set directly with their `size` attribute:
 So `width="400px"` and `width="50%"` both render one of these components at
 `medium`, 425 pixels wide. Reading back the component's `size` property tells
 you which preset a width landed on.
+
+### Sizes that must be relative
+
+`<sideBySide/>{:dn}` is the second exception. It divides a row into shares, so
+its `width`, `widths`, and `margins` are read as percentages only. An absolute
+size there raises a warning and is treated as the percentage of the same
+number, which is rarely what you meant — write `width="50%"`, not
+`width="50"`.

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -124,7 +124,7 @@ form that keeps a component in proportion when the reader's window is narrow,
 so reach for it when a fixed number of pixels would be too wide on a phone:
 
 ```doenet-example
-<codeEditor width="50%" height="150px" showResults>
+<codeEditor width="50%" height="150px">
   <p>Half the width of the column, whatever that column turns out to be.</p>
 </codeEditor>
 ```

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -168,6 +168,11 @@ So `width="400px"` and `width="50%"` both render one of these components at
 `medium`, 425 pixels wide. Reading back the component's `size` property tells
 you which preset a width landed on.
 
+A percentage means something different here than it does elsewhere. It is a
+share of the 850 pixels of the `full` preset — the widest any component may be —
+rather than of the space around the component, so `width="50%"` picks `medium`
+however narrow the surrounding column happens to be.
+
 An `<image/>{:dn}` drawn on a `<graph/>{:dn}` is the exception to the exception:
 there its `width` is used as given, measured against the graph's own scale
 rather than snapped to a preset.

--- a/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/concepts/essentialConcepts.mdx
@@ -130,9 +130,10 @@ so reach for it when a fixed number of pixels would be too wide on a phone:
 ```
 
 An expanded `<textInput/>{:dn}` takes a percentage the same way, and is 100%
-wide unless you say otherwise. A word-sized input is the exception: it shrinks
-to fit the sentence it flows in, so there is no column there for a percentage to
-be a share of. Give a word-sized input an absolute width.
+wide unless you say otherwise. A word-sized input is the exception: it keeps
+whatever width it is given, and the line it sits in closes around it, so a
+percentage there would be a share of a box whose own width depends on the input.
+Give a word-sized input an absolute width.
 
 <Callout type="warning">
 **`em` is not a font-relative size here.** Unlike in CSS, DoenetML reads `em` as

--- a/packages/docs-nextra/pages/reference/answer1.mdx
+++ b/packages/docs-nextra/pages/reference/answer1.mdx
@@ -90,7 +90,7 @@ Multiple `<award>{:dn}` components may also be used for answers with more comple
 ### Example: `<answer>{:dn}` for graded free-response
 ```doenet-example
 <p>
-  <answer type="text" handGraded expanded forceFullCheckWorkButton>
+  <answer type="text" handGraded expanded>
     <label>Explain how you solved the problem</label>
   </answer>
 </p>
@@ -100,6 +100,7 @@ Multiple `<award>{:dn}` components may also be used for answers with more comple
 
 The `handGraded` attribute defers grading for a human to score later. 
  When combined with the `expanded` attribute of a text answer, the result is a 
- graded free-response style question.  The `forceFullCheckWorkButton` attribute was added just for aesthetics.
+ graded free-response style question. The expanded input fills the width available to it,
+ and its full check work button sits beneath it.
 
 

--- a/packages/docs-nextra/pages/reference/answer2a.mdx
+++ b/packages/docs-nextra/pages/reference/answer2a.mdx
@@ -190,8 +190,13 @@ combine `symbolicEquality` with the `simplifyOnCompare` and `expandOnCompare` at
 
 
 
-When an `<answer>{:dn}` has an input field inside it, it will, by default use a small check work button to the right of the 
+When an `<answer>{:dn}` has a word-sized input field inside it, it will, by default use a small check work button to the right of the 
 input field.  To override this default and use the large button, add the  `forceFullCheckWorkButton` attribute.
+
+
+An input that takes a block of its own rather than a word of a sentence — an expanded
+`<textInput/>{:dn}`, or a `<choiceInput/>{:dn}` that is not `inline` — uses the large button by
+default instead, placed beneath the input.
 
 
 An answer without an input field uses the large button, by default. (See `forceSmallCheckWorkButton`, below).
@@ -231,7 +236,8 @@ When an `<answer>{:dn}` does not have an input field inside it, it will, by defa
 To override this default and use the small button, add the  `forceSmallCheckWorkButton` attribute.
 
 
-An answer with an input field always uses the small button, by default. (See `forceFullCheckWorkButton`, above.)
+An answer with a word-sized input field uses the small button by default; one whose input takes a
+block of its own uses the full button. (See `forceFullCheckWorkButton`, above.)
 
 
 If both `forceFullCheckWorkButton` and `forceSmallCheckWorkButton` are supplied, `forceFullCheckWorkButton` takes precedence.

--- a/packages/docs-nextra/pages/reference/answer2a.mdx
+++ b/packages/docs-nextra/pages/reference/answer2a.mdx
@@ -190,7 +190,7 @@ combine `symbolicEquality` with the `simplifyOnCompare` and `expandOnCompare` at
 
 
 
-When an `<answer>{:dn}` has a word-sized input field inside it, it will, by default use a small check work button to the right of the 
+When an `<answer>{:dn}` has a word-sized input field inside it, it will, by default, use a small check work button to the right of the 
 input field.  To override this default and use the large button, add the  `forceFullCheckWorkButton` attribute.
 
 

--- a/packages/docs-nextra/pages/reference/codeEditor.mdx
+++ b/packages/docs-nextra/pages/reference/codeEditor.mdx
@@ -114,8 +114,11 @@ cannot modify the source text.
 ```
 
 
-`width` and `height` accept CSS-style sizes. The defaults are full available
-width and a moderate fixed height.
+`width` and `height` both accept a number of pixels (`500` or `500px`) or a
+physical measurement (`6in`, `15cm`); a `width` may also be a percentage of the
+available width (`50%`). See [Sizes](../concepts/essentialConcepts#sizes) for the full list of forms.
+
+The defaults are full available width and a moderate fixed height.
 
 
 

--- a/packages/docs-nextra/pages/reference/graph.mdx
+++ b/packages/docs-nextra/pages/reference/graph.mdx
@@ -253,7 +253,9 @@ the `size` category that corresponds to that width and sizes the graph according
 so the graph is not drawn at exactly the width given: `width="400px"` and
 `width="50%"` both produce a `medium` graph, 425 pixels wide. A width may be
 written as a number of pixels, as a physical measurement (`6in`), or as a
-percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
+percentage — but of the 850-pixel maximum a component may take, not of the
+space around the graph, so `50%` picks `medium` however narrow the surrounding
+column is. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/graph.mdx
+++ b/packages/docs-nextra/pages/reference/graph.mdx
@@ -248,8 +248,12 @@ $g.size</p>
 
 
 
-The `width` attribute specifies the absolute width of the graph. Doenet determines 
-the `size` category that corresponds to that width and sizes the graph accordingly.
+The `width` attribute specifies the width of the graph. Doenet determines 
+the `size` category that corresponds to that width and sizes the graph accordingly,
+so the graph is not drawn at exactly the width given: `width="400px"` and
+`width="50%"` both produce a `medium` graph, 425 pixels wide. A width may be
+written as a number of pixels, as a physical measurement (`6in`), or as a
+percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/image.mdx
+++ b/packages/docs-nextra/pages/reference/image.mdx
@@ -90,7 +90,7 @@ An `<image/>{:dn}` can be placed on a `<graph>{:dn}`. Control the size of the im
 
 
 
-The `width` attribute specifies the width of the image. Doenet determines the `size` category that corresponds to that width and sizes the image accordingly, so the image is not drawn at exactly the width given: `width="400px"` and `width="50%"` both produce a `medium` image, 425 pixels wide. A width may be written as a number of pixels, as a physical measurement (`6in`), or as a percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
+The `width` attribute specifies the width of the image. Doenet determines the `size` category that corresponds to that width and sizes the image accordingly, so the image is not drawn at exactly the width given: `width="400px"` and `width="50%"` both produce a `medium` image, 425 pixels wide. (On a `<graph/>{:dn}` the width is used as given instead, measured against the graph's own scale.) A width may be written as a number of pixels, as a physical measurement (`6in`), or as a percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/image.mdx
+++ b/packages/docs-nextra/pages/reference/image.mdx
@@ -90,7 +90,7 @@ An `<image/>{:dn}` can be placed on a `<graph>{:dn}`. Control the size of the im
 
 
 
-The `width` attribute specifies the width of the image. Doenet determines the `size` category that corresponds to that width and sizes the image accordingly, so the image is not drawn at exactly the width given: `width="400px"` and `width="50%"` both produce a `medium` image, 425 pixels wide. (On a `<graph/>{:dn}` the width is used as given instead, measured against the graph's own scale.) A width may be written as a number of pixels, as a physical measurement (`6in`), or as a percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
+The `width` attribute specifies the width of the image. Doenet determines the `size` category that corresponds to that width and sizes the image accordingly, so the image is not drawn at exactly the width given: `width="400px"` and `width="50%"` both produce a `medium` image, 425 pixels wide. (On a `<graph/>{:dn}` the width is used as given instead, measured against the graph's own scale.) A width may be written as a number of pixels, as a physical measurement (`6in`), or as a percentage — but of the 850-pixel maximum a component may take, not of the space around the image, so `50%` picks `medium` however narrow the surrounding column is. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/image.mdx
+++ b/packages/docs-nextra/pages/reference/image.mdx
@@ -90,7 +90,7 @@ An `<image/>{:dn}` can be placed on a `<graph>{:dn}`. Control the size of the im
 
 
 
-The `width` attribute specifies the absolute width of the image. Doenet determines the `size` category corresponds to that width and sizes the image accordingly.
+The `width` attribute specifies the width of the image. Doenet determines the `size` category that corresponds to that width and sizes the image accordingly, so the image is not drawn at exactly the width given: `width="400px"` and `width="50%"` both produce a `medium` image, 425 pixels wide. A width may be written as a number of pixels, as a physical measurement (`6in`), or as a percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/slider.mdx
+++ b/packages/docs-nextra/pages/reference/slider.mdx
@@ -111,7 +111,9 @@ initial value of the slider defaults to the starting value.
 
 
 The default `width` for a `<slider>{:dn}` is 300 pixels, in absolute measurement; this 
-value can be adjusted with the `width` attribute.
+value can be adjusted with the `width` attribute. A bare number is a number of
+pixels; a physical measurement (`6in`) or a percentage of the available width
+(`50%`) may be given instead. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 ---

--- a/packages/docs-nextra/pages/reference/spreadsheet.mdx
+++ b/packages/docs-nextra/pages/reference/spreadsheet.mdx
@@ -229,6 +229,10 @@ the `minNumRows` and the `minNumColumns` attributes.
 The default size `<spreadsheet>{:dn}` component (100% of available screen width) is shown 
 above one with a specified `width` of 50% of available width.
 
+A width may equally be given as a number of pixels (`600`, `600px`) or a
+physical measurement (`6in`); a `height` takes those same absolute sizes. See
+[Sizes](../concepts/essentialConcepts#sizes).
+
 
 
 ---

--- a/packages/docs-nextra/pages/reference/tabular.mdx
+++ b/packages/docs-nextra/pages/reference/tabular.mdx
@@ -149,7 +149,11 @@ The `width` and `hAlign` attributes within a `<tabular>{:dn}` can control the wi
 
 
 
-The `width` and `height` attributes for the `<tabular>{:dn}` component accept measurements for the extents of the `<tabular>{:dn}`. Width is specified as a percentage of screen width, and height is specified in absolute measurements. Individual rows and cells are then scaled in proportion to these extents.
+The `width` and `height` attributes for the `<tabular>{:dn}` component accept measurements for the extents of the `<tabular>{:dn}`. Individual rows and cells are then scaled in proportion to these extents.
+
+Either may be given as a number of pixels (`600`, `600px`) or as a physical
+measurement (`6in`, `15cm`). A width may also be a percentage of the available
+width, as above. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/textInput.mdx
+++ b/packages/docs-nextra/pages/reference/textInput.mdx
@@ -268,8 +268,9 @@ is narrow. That is also its default: an expanded input with no `width` of its
 own is 100% wide. An expanded input never grows wider than the column it sits
 in, even when it asks for more.
 
-A word-sized (not `expanded`) input takes no percentage: it keeps a width of its
-own so that it can flow inline with the sentence around it.
+A word-sized (not `expanded`) input is the exception: it shrinks to fit the
+sentence it flows in, so there is no column there for a percentage to be a share
+of. Give a word-sized input an absolute width.
 
 
 

--- a/packages/docs-nextra/pages/reference/textInput.mdx
+++ b/packages/docs-nextra/pages/reference/textInput.mdx
@@ -50,7 +50,8 @@ The default `<textInput/>{:dn}` blank is wide enough for approximately 2-4 words
 
 
 
-The expanded `<textInput/>{:dn}` blank is approximately large enough for 4-6 sentences to be visible at a time.
+The expanded `<textInput/>{:dn}` blank spans the width available to it and is
+approximately tall enough for 4-6 sentences to be visible at a time.
 
 
 ---
@@ -186,7 +187,9 @@ The `prefill` attribute specifies initial text for the `<textInput/>{:dn}`.
 
 
 
-The `expanded` attribute renders a larger `<textInput/>{:dn}` space. The dimensions of the input space can be further customized with the `height` and `width` attributes.
+The `expanded` attribute renders a larger `<textInput/>{:dn}` space. An expanded
+input fills the width available to it, and is 120 pixels tall. Both dimensions
+can be customized with the `width` and `height` attributes.
 
 ---
 
@@ -238,6 +241,35 @@ Specifying the attribute `forAnswer` of a `<textInput>` does two things:
 
 
 The default width of the input space can be customized with the `width` attribute.
+A bare number is a number of pixels, and physical units such as `6in` or `15cm`
+are read as well — see [Sizes](../concepts/essentialConcepts#sizes) for the full
+list of forms a size may take.
+
+
+
+---
+
+### Attribute Example: width as a percentage
+
+
+```doenet-example
+<p>
+  <textInput expanded width="50%">
+    <label>Half the width of the column</label>
+  </textInput>
+</p>
+```
+
+
+
+An expanded `<textInput/>{:dn}` may be given its width as a percentage of the
+width available to it, so that it stays in proportion when the reader's window
+is narrow. That is also its default: an expanded input with no `width` of its
+own is 100% wide. An expanded input never grows wider than the column it sits
+in, even when it asks for more.
+
+A word-sized (not `expanded`) input takes no percentage: it keeps a width of its
+own so that it can flow inline with the sentence around it.
 
 
 
@@ -257,6 +289,8 @@ The default width of the input space can be customized with the `width` attribut
 
 
 The default height of the input space can be customized with the `height` attribute. This must be used in combination with the `expanded` attribute.
+A bare number is a number of pixels, and physical units such as `6in` or `15cm`
+are read as well. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/textInput.mdx
+++ b/packages/docs-nextra/pages/reference/textInput.mdx
@@ -268,9 +268,10 @@ is narrow. That is also its default: an expanded input with no `width` of its
 own is 100% wide. An expanded input never grows wider than the column it sits
 in, even when it asks for more.
 
-A word-sized (not `expanded`) input is the exception: it shrinks to fit the
-sentence it flows in, so there is no column there for a percentage to be a share
-of. Give a word-sized input an absolute width.
+A word-sized (not `expanded`) input is the exception: it keeps whatever width
+it is given — 100 pixels by default — and the line it sits in closes around it,
+so a percentage there would be a share of a box whose own width depends on the
+input. Give a word-sized input an absolute width.
 
 
 

--- a/packages/docs-nextra/pages/reference/video.mdx
+++ b/packages/docs-nextra/pages/reference/video.mdx
@@ -107,8 +107,12 @@ with a `<callAction>{:dn}` employing the `submitAnswer` action.
 
 
 
-The `width` attribute specifies the absolute width of the video. Doenet determines 
-the `size` category that corresponds to that width and sizes the video accordingly.
+The `width` attribute specifies the width of the video. Doenet determines 
+the `size` category that corresponds to that width and sizes the video accordingly,
+so the player is not drawn at exactly the width given: `width="400px"` and
+`width="50%"` both produce a `medium` video, 425 pixels wide. A width may be
+written as a number of pixels, as a physical measurement (`6in`), or as a
+percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/docs-nextra/pages/reference/video.mdx
+++ b/packages/docs-nextra/pages/reference/video.mdx
@@ -112,7 +112,9 @@ the `size` category that corresponds to that width and sizes the video according
 so the player is not drawn at exactly the width given: `width="400px"` and
 `width="50%"` both produce a `medium` video, 425 pixels wide. A width may be
 written as a number of pixels, as a physical measurement (`6in`), or as a
-percentage of the available width. See [Sizes](../concepts/essentialConcepts#sizes).
+percentage — but of the 850-pixel maximum a component may take, not of the
+space around the player, so `50%` picks `medium` however narrow the surrounding
+column is. See [Sizes](../concepts/essentialConcepts#sizes).
 
 
 

--- a/packages/doenetml-worker-javascript/src/components/TextInput.js
+++ b/packages/doenetml-worker-javascript/src/components/TextInput.js
@@ -148,7 +148,11 @@ export default class Textinput extends Input {
         Object.assign(stateVariableDefinitions, anchorDefinition);
 
         stateVariableDefinitions.width = {
-            description: "Display width of the input.",
+            // Matches the `width` attribute's description: the attribute and
+            // the property are listed side by side in the reference tables and
+            // in the help panel, so they say the same thing about the default.
+            description:
+                "Display width of the input. Defaults to 100% when expanded, and to 100px otherwise.",
             forRenderer: true,
             hasEssential: true,
             public: true,

--- a/packages/doenetml-worker-javascript/src/components/TextInput.js
+++ b/packages/doenetml-worker-javascript/src/components/TextInput.js
@@ -64,10 +64,16 @@ export default class Textinput extends Input {
         };
         attributes.width = {
             createComponentOfType: "componentSize",
-            description: "Display width of the input.",
+            // The default is conditional, so it cannot be declared here for
+            // the schema to pick up; saying it in the description is what puts
+            // it in front of an author, in the reference table and the
+            // context-sensitive help alike.
+            description:
+                "Display width of the input. Defaults to 100% when expanded, and to 100px otherwise.",
         };
         attributes.height = {
-            description: "Display height of the input.",
+            description:
+                "Display height of the input. Applies only to an expanded input.",
             createComponentOfType: "componentSize",
             createStateVariable: "height",
             defaultValue: { size: 120, isAbsolute: true },
@@ -169,13 +175,18 @@ export default class Textinput extends Input {
                         },
                     };
                 } else {
+                    // An expanded input is a block of writing space, so it
+                    // fills the column it sits in and stays in proportion when
+                    // the reader's window is narrow. A word-sized input keeps
+                    // an absolute width instead: it flows inline with the
+                    // sentence around it, where a share of the column would
+                    // mean nothing.
                     return {
                         useEssentialOrDefaultValue: {
                             width: {
-                                defaultValue: {
-                                    size: dependencyValues.expanded ? 600 : 100,
-                                    isAbsolute: true,
-                                },
+                                defaultValue: dependencyValues.expanded
+                                    ? { size: 100, isAbsolute: false }
+                                    : { size: 100, isAbsolute: true },
                             },
                         },
                     };

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -873,6 +873,17 @@ function sizeUnitsNote(t: Translator, sizeSyntax: SizeSyntaxPayload): string {
             "A bare number is pixels.",
         );
     }
+    if (sizeSyntax.snapsToSizePreset) {
+        // A percentage here is not a share of the surrounding width — it is a
+        // share of the widest any component may be, which is then rounded to a
+        // preset. Saying "a share of the width around the component" would
+        // contradict the preset note the panel prints directly beneath this.
+        return t(
+            "help-size-units-preset",
+            undefined,
+            "A bare number is pixels, and a percentage is a share of the widest a component can be.",
+        );
+    }
     return t(
         "help-size-units",
         undefined,

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -1,11 +1,16 @@
 import React from "react";
 import { MathJax } from "better-react-mathjax";
 import { parseInlineMarkdown } from "@doenet/utils/markdown/parseInlineMarkdown";
-import { isMathDefaultValue } from "@doenet/static-assets/schema";
+import {
+    formatComponentSize,
+    isComponentSizeValue,
+    isMathDefaultValue,
+} from "@doenet/static-assets/schema";
 import { isMacPlatform } from "@doenet/utils";
 import type {
     FunctionNamesBreakdownPayload,
     HelpContent,
+    SizeSyntaxPayload,
 } from "@doenet/lsp-tools";
 import type { Translator } from "@doenet/i18n";
 import { useT } from "../../utils/i18n";
@@ -439,6 +444,7 @@ export function ContextHelpPanel({
                 activeDefault,
                 styleBreakdown,
                 functionNamesBreakdown,
+                sizeSyntax,
             } = content;
             return (
                 <div className="help-panel">
@@ -506,6 +512,7 @@ export function ContextHelpPanel({
                     {styleBreakdown && renderStyleBreakdown(t, styleBreakdown)}
                     {functionNamesBreakdown &&
                         renderFunctionNamesBreakdown(t, functionNamesBreakdown)}
+                    {sizeSyntax && renderSizeSyntax(t, sizeSyntax)}
                     {allowedValues && allowedValues.length > 0 && (
                         <div className="help-detail help-allowed-values">
                             <span className="help-detail-label">
@@ -803,6 +810,59 @@ function renderLabeledChipList(
 }
 
 /**
+ * "Accepted sizes" section surfaced for any attribute whose value is a
+ * `componentSize`. The attribute description says what the dimension means
+ * but never that a plain number is pixels, that `6in` and
+ * `15cm` are read, or that a percentage is allowed — so the forms are listed
+ * as chips, with a note naming the unit a bare number carries.
+ *
+ * A height is offered only the absolute forms, and its note says nothing about
+ * percentages: the runtime takes a percentage height and does nothing with it,
+ * and raising a form only to rule it out reads worse than never raising it.
+ */
+function renderSizeSyntax(
+    t: Translator,
+    sizeSyntax: SizeSyntaxPayload,
+): React.ReactNode {
+    const hasRelative = sizeSyntax.examples.some((e) => e.kind === "relative");
+    return (
+        <div className="help-detail help-size-syntax">
+            {renderLabeledChipList(
+                t("help-accepted-sizes", undefined, "Accepted sizes:"),
+                sizeSyntax.examples.map(({ value }) => value),
+            )}
+            <span className="help-detail-annotation">
+                {/* Two flat keys rather than one with a branch: a height is
+                    offered no percentage at all, so its note must not raise
+                    the idea only to take it back. */}
+                {hasRelative
+                    ? t(
+                          "help-size-units",
+                          undefined,
+                          "A bare number is pixels. A percentage is a share of the width around the component.",
+                      )
+                    : t(
+                          "help-size-units-absolute",
+                          undefined,
+                          "A bare number is pixels.",
+                      )}
+            </span>
+            {sizeSyntax.snapsToSizePreset && (
+                <span className="help-detail-annotation">
+                    {t(
+                        "help-size-snaps-to-preset",
+                        // `size` names the sibling attribute, so it is an
+                        // argument rather than a word in the sentence.
+                        { size: "size" },
+                        "This width picks the nearest size preset rather than being used exactly.",
+                    )}
+                </span>
+            )}
+        </div>
+    );
+}
+
+/**
  * "Resolved function names" section surfaced when the cursor sits on
  * `additionalFunctionNames`, `removedFunctionNames`, or
  * `resetFunctionNames` of a `<mathInput>` (#1205). The author writes
@@ -903,6 +963,12 @@ function formatValue(val: unknown): React.ReactNode {
                 {formatValue(v)}
             </React.Fragment>
         ));
+    }
+    if (isComponentSizeValue(val)) {
+        // The schema carries a size as the runtime's `{ size, isAbsolute }`
+        // pair. Printing that raw would show the author a shape they cannot
+        // type back into the attribute.
+        return formatComponentSize(val);
     }
     if (typeof val === "string") {
         return resolveCssVariables(val);

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -787,9 +787,9 @@ function renderStyleBreakdown(
 }
 
 /**
- * Render a label + chip-list pair used by the function-names breakdown
- * section. Each chip is a `help-value-item` pill and the chips wrap via
- * the parent `help-values-list` flex row.
+ * Render a label + chip-list pair, used by the function-names breakdown and
+ * accepted-sizes sections. Each chip is a `help-value-item` pill and the chips
+ * wrap via the parent `help-values-list` flex row.
  */
 function renderLabeledChipList(
     label: string,
@@ -832,8 +832,6 @@ function renderSizeSyntax(
                 sizeSyntax.examples.map(({ value }) => value),
             )}
             <span className="help-detail-annotation">
-                {/* Three flat keys rather than one with branches, so each
-                    reads as a whole sentence in translation. */}
                 {sizeUnitsNote(t, sizeSyntax)}
             </span>
             {sizeSyntax.snapsToSizePreset && (

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -816,15 +816,15 @@ function renderLabeledChipList(
  * `15cm` are read, or that a percentage is allowed — so the forms are listed
  * as chips, with a note naming the unit a bare number carries.
  *
- * A height is offered only the absolute forms, and its note says nothing about
- * percentages: the runtime takes a percentage height and does nothing with it,
- * and raising a form only to rule it out reads worse than never raising it.
+ * `examples` already carries only the forms the attribute honors (a height
+ * gets no percentage; a side-by-side width gets nothing else), so the note is
+ * chosen from what is in the list rather than from the attribute's identity:
+ * raising a form only to rule it out reads worse than never raising it.
  */
 function renderSizeSyntax(
     t: Translator,
     sizeSyntax: SizeSyntaxPayload,
 ): React.ReactNode {
-    const hasRelative = sizeSyntax.examples.some((e) => e.kind === "relative");
     return (
         <div className="help-detail help-size-syntax">
             {renderLabeledChipList(
@@ -832,20 +832,9 @@ function renderSizeSyntax(
                 sizeSyntax.examples.map(({ value }) => value),
             )}
             <span className="help-detail-annotation">
-                {/* Two flat keys rather than one with a branch: a height is
-                    offered no percentage at all, so its note must not raise
-                    the idea only to take it back. */}
-                {hasRelative
-                    ? t(
-                          "help-size-units",
-                          undefined,
-                          "A bare number is pixels. A percentage is a share of the width around the component.",
-                      )
-                    : t(
-                          "help-size-units-absolute",
-                          undefined,
-                          "A bare number is pixels.",
-                      )}
+                {/* Three flat keys rather than one with branches, so each
+                    reads as a whole sentence in translation. */}
+                {sizeUnitsNote(t, sizeSyntax)}
             </span>
             {sizeSyntax.snapsToSizePreset && (
                 <span className="help-detail-annotation">
@@ -859,6 +848,36 @@ function renderSizeSyntax(
                 </span>
             )}
         </div>
+    );
+}
+
+/**
+ * The sentence under the "Accepted sizes" chips, naming the unit each listed
+ * form carries. One key per combination the payload can produce, so no
+ * translation has to assemble a sentence out of clauses.
+ */
+function sizeUnitsNote(t: Translator, sizeSyntax: SizeSyntaxPayload): string {
+    const hasAbsolute = sizeSyntax.examples.some((e) => e.kind === "absolute");
+    const hasRelative = sizeSyntax.examples.some((e) => e.kind === "relative");
+
+    if (!hasAbsolute) {
+        return t(
+            "help-size-units-relative",
+            undefined,
+            "A percentage is a share of the width around the component.",
+        );
+    }
+    if (!hasRelative) {
+        return t(
+            "help-size-units-absolute",
+            undefined,
+            "A bare number is pixels.",
+        );
+    }
+    return t(
+        "help-size-units",
+        undefined,
+        "A bare number is pixels. A percentage is a share of the width around the component.",
     );
 }
 

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -817,9 +817,10 @@ function renderLabeledChipList(
  * as chips, with a note naming the unit a bare number carries.
  *
  * `examples` already carries only the forms the attribute honors (a height
- * gets no percentage; a side-by-side width gets nothing else), so the note is
- * chosen from what is in the list rather than from the attribute's identity:
- * raising a form only to rule it out reads worse than never raising it.
+ * gets no percentage; a side-by-side width gets nothing but the percentage),
+ * so the note is chosen from what is in the list rather than from the
+ * attribute's identity: raising a form only to rule it out reads worse than
+ * never raising it.
  */
 function renderSizeSyntax(
     t: Translator,

--- a/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
+++ b/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
@@ -265,6 +265,17 @@
 }
 
 /*
+ * Accepted-sizes list for a `componentSize` attribute. Same column stack as
+ * the function-names breakdown above: the chips wrap under their label rather
+ * than competing with it, and the notes below read as full sentences.
+ */
+.editor-panel .help-size-syntax {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+}
+
+/*
  * "What can go here?" suggestions surfaced when the cursor sits in an
  * element body or at the top level. The header names the location, the list
  * shows curated starter components as links, and a muted footer points at the

--- a/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
+++ b/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
@@ -253,22 +253,14 @@
 }
 
 /*
- * Resolved function-names breakdown (#1205). Stacks a label/values pair —
- * optionally repeated for `Added on this input:` and `Removed on this
- * input:` rows — vertically so the chip list wraps without competing
- * with the labels.
+ * Sections that stack a label above a wrapping chip list instead of sharing a
+ * row with it, so the chips never compete with the label for width:
+ *  - the resolved function-names breakdown (#1205), whose label/values pair
+ *    repeats for the `Added on this input:` and `Removed on this input:` rows;
+ *  - the accepted-sizes list for a `componentSize` attribute, which adds notes
+ *    below the chips that read as full sentences.
  */
-.editor-panel .help-function-names-breakdown {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
-}
-
-/*
- * Accepted-sizes list for a `componentSize` attribute. Same column stack as
- * the function-names breakdown above: the chips wrap under their label rather
- * than competing with it, and the notes below read as full sentences.
- */
+.editor-panel .help-function-names-breakdown,
 .editor-panel .help-size-syntax {
     flex-direction: column;
     align-items: flex-start;

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -7,6 +7,7 @@ import { AnswerResponseButton } from "./utils/AnswerResponseButton";
 import {
     calculateValidationState,
     createCheckWorkComponent,
+    wantsFullCheckWorkButton,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { DynamicMath } from "./utils/DynamicMath";
@@ -104,7 +105,10 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
         id,
         validationState,
         submitActionWithPending,
-        SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton,
+        // An `<answer>` renders its own button only when it has no input
+        // field to hang one off, so it stands on a line of its own: the full
+        // labelled button is the default.
+        wantsFullCheckWorkButton(SVs, true),
         isPending,
         tContent,
     );

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -16,6 +16,7 @@ import "./choiceInput.css";
 import {
     calculateValidationState,
     createCheckWorkComponent,
+    wantsFullCheckWorkButton,
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { addValidationStateToShortDescription } from "./utils/validationState";
@@ -338,11 +339,9 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         .filter(Boolean)
         .join(" ");
 
-    // For inline, the default is a small check work button,
-    // for non-inline, the default is a full check work button
-    const fullCheckWork = SVs.inline
-        ? SVs.forceFullCheckWorkButton
-        : SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton;
+    // An inline choice input is a word-sized dropdown in a sentence; a
+    // non-inline one is a block of choices with room beneath it.
+    const fullCheckWork = wantsFullCheckWorkButton(SVs, !SVs.inline);
 
     const checkWorkComponent = createCheckWorkComponent(
         SVs,

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -15,6 +15,7 @@ import { JXGObject } from "./jsxgraph-distrib/types";
 import {
     calculateValidationState,
     createCheckWorkComponent,
+    wantsFullCheckWorkButton,
 } from "./utils/checkWork";
 import "./textInput.css";
 import { DescriptionPopover } from "./utils/Description";
@@ -658,14 +659,10 @@ export default function TextInput(props: UseDoenetRendererProps) {
 
     const inputKey = id + "_input";
 
-    // A word-sized input sits in a sentence, where a full-width button beside
-    // it would crowd the line, so the small one is the default there. An
-    // expanded input is a block of its own with room beneath it, so the full
-    // labelled button is the default instead — the same rule a `<choiceInput>`
-    // applies to its inline and non-inline forms.
-    const fullCheckWork = SVs.expanded
-        ? SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton
-        : SVs.forceFullCheckWorkButton;
+    // An expanded input is a block of its own with room beneath it; a
+    // word-sized one flows in a sentence. Same rule a `<choiceInput>` applies
+    // to its non-inline and inline forms.
+    const fullCheckWork = wantsFullCheckWorkButton(SVs, SVs.expanded);
 
     const checkWorkComponent = createCheckWorkComponent(
         SVs,

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -31,6 +31,13 @@ import { useMathJaxOutOfTabOrder } from "./utils/useMathJaxOutOfTabOrder";
  */
 const EXPANDED_INPUT_MARGIN_X = 4;
 
+/**
+ * Width a text input falls back to on a graph when its own width is a
+ * percentage. Matches the word-sized default the worker gives an input that
+ * is not `expanded`. See `boardWidth`.
+ */
+const BOARD_INPUT_FALLBACK_WIDTH = "100px";
+
 interface TextInputSVs {
     [key: string]: any;
     hidden: boolean;
@@ -66,6 +73,14 @@ export default function TextInput(props: UseDoenetRendererProps) {
 
     let width = sizeToCSS(SVs.width);
     let height = sizeToCSS(SVs.height); // only for TextArea
+
+    // JSXGraph draws every text input as a one-line field, so `expanded` means
+    // nothing on a graph — including the 100% width it defaults to. The field
+    // floats in a shrink-to-fit box above the graph, which gives a percentage
+    // no column to be a share of, so a relative width falls back to the
+    // word-sized default and an input on a graph is the same size either way.
+    const boardWidth =
+        SVs.width?.isAbsolute === false ? BOARD_INPUT_FALLBACK_WIDTH : width;
 
     // @ts-ignore
     TextInput.baseStateVariable = "immediateValue";
@@ -330,7 +345,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
         newInputJXG.rendNodeInput.addEventListener("blur", handleBlur);
         newInputJXG.rendNodeInput.addEventListener("focus", handleFocus);
 
-        newInputJXG.rendNodeInput.style.width = width!;
+        newInputJXG.rendNodeInput.style.width = boardWidth!;
         newInputJXG.rendNodeInput.style.color = "var(--canvasText)";
         applyDisabledStyleJXG(newInputJXG.rendNodeInput, SVs.disabled);
 
@@ -574,7 +589,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
 
             inputJXG.current.setText(SVs.label);
 
-            inputJXG.current.rendNodeInput.style.width = width!;
+            inputJXG.current.rendNodeInput.style.width = boardWidth!;
 
             let visible = !SVs.hidden;
 

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -808,16 +808,22 @@ export default function TextInput(props: UseDoenetRendererProps) {
                 // An expanded input fills the width it is given, leaving a
                 // button beside it squeezed to nothing. Stacking puts the
                 // button on its own line under the input, as a non-inline
-                // `<choiceInput>` puts it under the choices.
-                ...(SVs.expanded ? { flexDirection: "column" as const } : {}),
+                // `<choiceInput>` puts it under the choices. The row is capped
+                // at the text column as well, so an expanded input given a
+                // width the window cannot hold shrinks with it.
+                //
+                // A word-sized input keeps the plain shrink-to-fit row it has
+                // always had: it flows in a sentence, and capping that row
+                // would let flex shrink the field below the width it was
+                // given.
+                ...(SVs.expanded
+                    ? { flexDirection: "column" as const, maxWidth: "100%" }
+                    : {}),
                 alignItems: "flex-start",
                 // The input row flows as inline content (see the container
                 // comment). `vertical-align: baseline` aligns it with the text
                 // baseline of its line.
                 verticalAlign: "baseline",
-                // Never wider than the text column, so an expanded input given
-                // a width the window cannot hold shrinks with it.
-                maxWidth: "100%",
                 // See `expandedRelativeWidth`: only a relative width needs the
                 // row stretched to the column to measure itself against.
                 ...(expandedRelativeWidth ? { width: "100%" } : {}),

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -24,6 +24,13 @@ import { useContentT } from "../../utils/i18n";
 import { useInMathSlot, useMathSlotEditing } from "./utils/mathInputSlots";
 import { useMathJaxOutOfTabOrder } from "./utils/useMathJaxOutOfTabOrder";
 
+/**
+ * Horizontal margin, in pixels, on an expanded input's textarea. Named because
+ * the width cap has to subtract it: the margin sits outside the box, so a
+ * textarea capped at the full column width would still overhang by it.
+ */
+const EXPANDED_INPUT_MARGIN_X = 4;
+
 interface TextInputSVs {
     [key: string]: any;
     hidden: boolean;
@@ -707,7 +714,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
     // definite containing block to measure against, without disturbing the
     // shrink-to-fit row an absolute width still wants.
     const expandedRelativeWidth =
-        SVs.expanded && Boolean(SVs.width) && !SVs.width.isAbsolute;
+        SVs.expanded && SVs.width?.isAbsolute === false;
 
     if (SVs.expanded) {
         input = (
@@ -727,14 +734,20 @@ export default function TextInput(props: UseDoenetRendererProps) {
                 aria-description={hasLabel ? shortDescription : undefined}
                 aria-details={descriptionId}
                 style={{
-                    margin: "0px 4px 4px 4px",
+                    margin: `0px ${EXPANDED_INPUT_MARGIN_X}px 4px ${EXPANDED_INPUT_MARGIN_X}px`,
                     color: "var(--canvasText)",
                     background: "var(--canvas)",
+                    // The authored width is the width of the box an author
+                    // sees, border and padding included, so `width="600"` and
+                    // `maxWidth` below both measure the same edges.
+                    boxSizing: "border-box",
                     width,
                     height,
                     // A window narrower than the authored width shrinks the
                     // input rather than pushing it out of the text column.
-                    maxWidth: "100%",
+                    // The margins sit outside the box, so they come off the
+                    // cap or the input would overhang by exactly them.
+                    maxWidth: `calc(100% - ${2 * EXPANDED_INPUT_MARGIN_X}px)`,
                 }}
             />
         );

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -41,6 +41,7 @@ interface TextInputSVs {
     width: { size: string; isAbsolute: boolean };
     height?: { size: string; isAbsolute: boolean };
     forceFullCheckWorkButton: boolean;
+    forceSmallCheckWorkButton: boolean;
     justSubmitted: boolean;
     showCheckWork: boolean;
     colorCorrectness: boolean;
@@ -635,12 +636,21 @@ export default function TextInput(props: UseDoenetRendererProps) {
 
     const inputKey = id + "_input";
 
+    // A word-sized input sits in a sentence, where a full-width button beside
+    // it would crowd the line, so the small one is the default there. An
+    // expanded input is a block of its own with room beneath it, so the full
+    // labelled button is the default instead — the same rule a `<choiceInput>`
+    // applies to its inline and non-inline forms.
+    const fullCheckWork = SVs.expanded
+        ? SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton
+        : SVs.forceFullCheckWorkButton;
+
     const checkWorkComponent = createCheckWorkComponent(
         SVs,
         id,
         validationState,
         submitActionWithPending,
-        SVs.forceFullCheckWorkButton,
+        fullCheckWork,
         isPending,
         tContent,
     );
@@ -687,6 +697,18 @@ export default function TextInput(props: UseDoenetRendererProps) {
         );
     }
 
+    // An expanded input is a block of writing space rather than a word-sized
+    // field, so it is the one shape of text input a relative width makes sense
+    // for. A percentage on the textarea would otherwise resolve against the
+    // inline-flex input row, which shrink-wraps its content — a circular
+    // reference that yields an arbitrary width rather than the share of the
+    // text column the author asked for. Stretching the row to the full column
+    // when (and only when) the width is relative gives the percentage a
+    // definite containing block to measure against, without disturbing the
+    // shrink-to-fit row an absolute width still wants.
+    const expandedRelativeWidth =
+        SVs.expanded && Boolean(SVs.width) && !SVs.width.isAbsolute;
+
     if (SVs.expanded) {
         input = (
             <textarea
@@ -708,6 +730,11 @@ export default function TextInput(props: UseDoenetRendererProps) {
                     margin: "0px 4px 4px 4px",
                     color: "var(--canvasText)",
                     background: "var(--canvas)",
+                    width,
+                    height,
+                    // A window narrower than the authored width shrinks the
+                    // input rather than pushing it out of the text column.
+                    maxWidth: "100%",
                 }}
             />
         );
@@ -739,20 +766,40 @@ export default function TextInput(props: UseDoenetRendererProps) {
         );
     }
 
+    // The button and the description popover ride beside a word-sized input and
+    // beneath an expanded one, so they travel together either way.
+    const trailingControls =
+        checkWorkComponent || description ? (
+            <span style={{ display: "inline-flex", alignItems: "flex-start" }}>
+                {checkWorkComponent}
+                {description}
+            </span>
+        ) : null;
+
     const inputRow = (
         <span
             style={{
                 display: "inline-flex",
+                // An expanded input fills the width it is given, leaving a
+                // button beside it squeezed to nothing. Stacking puts the
+                // button on its own line under the input, as a non-inline
+                // `<choiceInput>` puts it under the choices.
+                ...(SVs.expanded ? { flexDirection: "column" as const } : {}),
                 alignItems: "flex-start",
                 // The input row flows as inline content (see the container
                 // comment). `vertical-align: baseline` aligns it with the text
                 // baseline of its line.
                 verticalAlign: "baseline",
+                // Never wider than the text column, so an expanded input given
+                // a width the window cannot hold shrinks with it.
+                maxWidth: "100%",
+                // See `expandedRelativeWidth`: only a relative width needs the
+                // row stretched to the column to measure itself against.
+                ...(expandedRelativeWidth ? { width: "100%" } : {}),
             }}
         >
             {input}
-            {checkWorkComponent}
-            {description}
+            {trailingControls}
         </span>
     );
 

--- a/packages/doenetml/src/Viewer/renderers/utils/checkWork.css
+++ b/packages/doenetml/src/Viewer/renderers/utils/checkWork.css
@@ -1,6 +1,12 @@
 .doenet-viewer button.check-work {
     position: relative;
-    height: 24px;
+    /*
+     * A minimum rather than a fixed height: the label is a translated phrase
+     * ("Submit Response", and longer in other languages) that wraps when the
+     * button is narrow, and a fixed height clipped the second line instead of
+     * growing to hold it.
+     */
+    min-height: 24px;
     display: inline-block;
     padding: 1px 6px 1px 6px;
     /* border: var(--mainBorder); */

--- a/packages/doenetml/src/Viewer/renderers/utils/checkWork.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/checkWork.tsx
@@ -60,8 +60,9 @@ export function wantsFullCheckWorkButton(
     fullByDefault: boolean,
 ): boolean {
     return fullByDefault
-        ? SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton
-        : SVs.forceFullCheckWorkButton;
+        ? Boolean(SVs.forceFullCheckWorkButton) ||
+              !SVs.forceSmallCheckWorkButton
+        : Boolean(SVs.forceFullCheckWorkButton);
 }
 
 /**

--- a/packages/doenetml/src/Viewer/renderers/utils/checkWork.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/checkWork.tsx
@@ -38,6 +38,33 @@ export function calculateValidationState(
 }
 
 /**
+ * Whether the check-work button should carry its label, rather than being the
+ * compact icon-only one — the `showText` argument of
+ * `createCheckWorkComponent`.
+ *
+ * Which size is the default depends on the shape of what the button sits with,
+ * so the caller passes that in as `fullByDefault`. An input that takes a block
+ * of its own — an expanded `<textInput>`, a `<choiceInput>` that is not
+ * `inline`, an `<answer>` with no input field at all — has a line beneath it to
+ * put a labelled button on, so the full button is its default. A word-sized
+ * input flows in a sentence, where a labelled button beside it would crowd the
+ * line, so the compact one is the default there.
+ *
+ * `forceFullCheckWorkButton` overrides either default. `forceSmallCheckWorkButton`
+ * overrides only the full one — an input whose default is already the small
+ * button has nothing to ask for — and loses to `forceFullCheckWorkButton` when
+ * both are given, which is the precedence the `<answer>` reference documents.
+ */
+export function wantsFullCheckWorkButton(
+    SVs: Record<string, any>,
+    fullByDefault: boolean,
+): boolean {
+    return fullByDefault
+        ? SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton
+        : SVs.forceFullCheckWorkButton;
+}
+
+/**
  * Create the check work button and state text of an answers.
  *
  * Inputs:

--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -313,5 +313,9 @@ help-size-units = A bare number is pixels. A percentage is a share of the width 
 # the attribute does not support.
 help-size-units-absolute = A bare number is pixels.
 
+# For a side-by-side `width`, which is offered no absolute form: the same rule,
+# the other way round.
+help-size-units-relative = A percentage is a share of the width around the component.
+
 # `size` names a sibling attribute an author writes, so it stays as written.
 help-size-snaps-to-preset = This width picks the nearest { $size } preset rather than being used exactly.

--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -303,3 +303,15 @@ help-removed-on-input = Removed on this input:
 
 # The three names are attributes an author writes, so they stay as written.
 help-reset-overrides = { $reset } overrides { $additional } and { $removed }.
+
+# Length syntax for a `componentSize` attribute (`width`, `height`). The values
+# listed alongside this label are examples the panel renders as chips.
+help-accepted-sizes = Accepted sizes:
+help-size-units = A bare number is pixels. A percentage is a share of the width around the component.
+
+# For a `height`, which is offered no percentage: the note must not raise a form
+# the attribute does not support.
+help-size-units-absolute = A bare number is pixels.
+
+# `size` names a sibling attribute an author writes, so it stays as written.
+help-size-snaps-to-preset = This width picks the nearest { $size } preset rather than being used exactly.

--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -313,6 +313,11 @@ help-size-units = A bare number is pixels. A percentage is a share of the width 
 # the attribute does not support.
 help-size-units-absolute = A bare number is pixels.
 
+# For a width that picks a named `size` preset (`<graph>`, `<image>`, `<video>`):
+# a percentage there is a share of the largest width any component may take, not
+# of the space around this one.
+help-size-units-preset = A bare number is pixels, and a percentage is a share of the widest a component can be.
+
 # For a side-by-side `width`, which is offered no absolute form: the same rule,
 # the other way round.
 help-size-units-relative = A percentage is a share of the width around the component.

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -585,6 +585,7 @@ export type MessageKey =
     | "help-accepted-sizes"
     | "help-size-units"
     | "help-size-units-absolute"
+    | "help-size-units-relative"
     | "help-size-snaps-to-preset";
 
 /** Every key in the English catalogs, in catalog order. */
@@ -1167,5 +1168,6 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "help-accepted-sizes",
     "help-size-units",
     "help-size-units-absolute",
+    "help-size-units-relative",
     "help-size-snaps-to-preset",
 ];

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -581,7 +581,11 @@ export type MessageKey =
     | "help-reset-list"
     | "help-added-on-input"
     | "help-removed-on-input"
-    | "help-reset-overrides";
+    | "help-reset-overrides"
+    | "help-accepted-sizes"
+    | "help-size-units"
+    | "help-size-units-absolute"
+    | "help-size-snaps-to-preset";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -1160,4 +1164,8 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "help-added-on-input",
     "help-removed-on-input",
     "help-reset-overrides",
+    "help-accepted-sizes",
+    "help-size-units",
+    "help-size-units-absolute",
+    "help-size-snaps-to-preset",
 ];

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -585,6 +585,7 @@ export type MessageKey =
     | "help-accepted-sizes"
     | "help-size-units"
     | "help-size-units-absolute"
+    | "help-size-units-preset"
     | "help-size-units-relative"
     | "help-size-snaps-to-preset";
 
@@ -1168,6 +1169,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "help-accepted-sizes",
     "help-size-units",
     "help-size-units-absolute",
+    "help-size-units-preset",
     "help-size-units-relative",
     "help-size-snaps-to-preset",
 ];

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -52,6 +52,15 @@ export {
 export type SchemaAttribute = {
     name: string;
     description?: string;
+    /**
+     * Component type the attribute's value is parsed as (the worker's
+     * `createComponentOfType`). Carried so author-facing surfaces can explain
+     * a value syntax the description alone can't — the help panel reads
+     * `componentSize` to list the length units an attribute accepts.
+     * Optional: a synthesized attribute (an author-declared `<module>` one)
+     * may have no single component type.
+     */
+    type?: string;
     values?: string[];
     autocompleteValues?: ValidValueEntry[];
     /**

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -57,8 +57,10 @@ export type SchemaAttribute = {
      * `createComponentOfType`). Carried so author-facing surfaces can explain
      * a value syntax the description alone can't — the help panel reads
      * `componentSize` to list the length units an attribute accepts.
-     * Optional: a synthesized attribute (an author-declared `<module>` one)
-     * may have no single component type.
+     * Optional: only attributes read from the generated schema carry one. A
+     * synthesized attribute (an author-declared `<module>` one, from
+     * `mergeDeclaredIntoSchemaAttributes`) leaves it unset, so the surfaces
+     * that key off it treat the value as unexplained rather than mistyped.
      */
     type?: string;
     values?: string[];

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -1692,6 +1692,24 @@ describe("computeContextHelp — sizeSyntax on componentSize attributes", () => 
         expect(help.sizeSyntax.snapsToSizePreset).toBeUndefined();
     });
 
+    it("offers a side-by-side width the percentage and nothing else", async () => {
+        for (const elementName of ["sideBySide", "sbsGroup"]) {
+            const source = `<${elementName} width="50%"/>`;
+            const offset = source.indexOf("width") + 2;
+            const help = await helpAt(source, offset);
+            if (help.kind !== "attribute" || !help.sizeSyntax) {
+                expect.fail(`expected sizeSyntax on <${elementName} width>`);
+                return;
+            }
+            // An absolute width is warned about and coerced to relative, so
+            // the panel never puts one in front of an author.
+            expect(help.sizeSyntax.examples.map((e) => e.value)).toEqual([
+                "50%",
+            ]);
+            expect(help.sizeSyntax.snapsToSizePreset).toBeUndefined();
+        }
+    });
+
     it("is absent on an attribute that is not a size", async () => {
         const source = `<textInput expanded="true"/>`;
         const offset = source.indexOf("expanded") + 2;

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -1625,6 +1625,85 @@ describe("computeContextHelp — repeat-introduced names (valueName/indexName)",
     });
 });
 
+describe("computeContextHelp — sizeSyntax on componentSize attributes", () => {
+    it("lists the accepted length forms on a width", async () => {
+        const source = `<textInput expanded width="600"/>`;
+        const offset = source.indexOf("width") + 2;
+        const help = await helpAt(source, offset);
+        if (help.kind !== "attribute" || !help.sizeSyntax) {
+            expect.fail("expected attribute help with sizeSyntax");
+            return;
+        }
+        const values = help.sizeSyntax.examples.map((e) => e.value);
+        // A bare number and a percentage are the two forms an author cannot
+        // guess from the attribute description alone.
+        expect(values).toContain("600");
+        expect(values).toContain("50%");
+        expect(values).toContain("6in");
+        expect(
+            help.sizeSyntax.examples.find((e) => e.value === "50%")?.kind,
+        ).toBe("relative");
+        expect(
+            help.sizeSyntax.examples.find((e) => e.value === "600")?.kind,
+        ).toBe("absolute");
+        // A `<textInput>` uses its width literally.
+        expect(help.sizeSyntax.snapsToSizePreset).toBeUndefined();
+    });
+
+    it("offers a height the absolute forms and no percentage", async () => {
+        const source = `<textInput expanded height="300"/>`;
+        const offset = source.indexOf("height") + 2;
+        const help = await helpAt(source, offset);
+        if (help.kind !== "attribute" || !help.sizeSyntax) {
+            expect.fail("expected attribute help with sizeSyntax");
+            return;
+        }
+        // The runtime takes a percentage height and does nothing with it, so
+        // the panel never raises one — not as an offer, and not as a caveat.
+        const values = help.sizeSyntax.examples.map((e) => e.value);
+        expect(values).toContain("600px");
+        expect(values).not.toContain("50%");
+        expect(
+            help.sizeSyntax.examples.every((e) => e.kind === "absolute"),
+        ).toBe(true);
+    });
+
+    it("flags the widths that snap to a size preset", async () => {
+        for (const elementName of ["graph", "image", "video"]) {
+            const source = `<${elementName} width="400px"/>`;
+            const offset = source.indexOf("width") + 2;
+            const help = await helpAt(source, offset);
+            if (help.kind !== "attribute" || !help.sizeSyntax) {
+                expect.fail(`expected sizeSyntax on <${elementName} width>`);
+                return;
+            }
+            expect(help.sizeSyntax.snapsToSizePreset).toBe(true);
+        }
+    });
+
+    it("does not flag a width that is used literally", async () => {
+        const source = `<codeEditor width="50%"/>`;
+        const offset = source.indexOf("width") + 2;
+        const help = await helpAt(source, offset);
+        if (help.kind !== "attribute" || !help.sizeSyntax) {
+            expect.fail("expected attribute help with sizeSyntax");
+            return;
+        }
+        expect(help.sizeSyntax.snapsToSizePreset).toBeUndefined();
+    });
+
+    it("is absent on an attribute that is not a size", async () => {
+        const source = `<textInput expanded="true"/>`;
+        const offset = source.indexOf("expanded") + 2;
+        const help = await helpAt(source, offset);
+        if (help.kind !== "attribute") {
+            expect.fail("expected attribute help");
+            return;
+        }
+        expect(help.sizeSyntax).toBeUndefined();
+    });
+});
+
 describe("computeContextHelp — functionNamesBreakdown on <mathInput> (#1205)", () => {
     it("populates functionNamesBreakdown when cursor is on additionalFunctionNames", async () => {
         const source = `<mathInput additionalFunctionNames="erf" removedFunctionNames="min"/>`;

--- a/packages/lsp-tools/src/context-help/computeContextHelp.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.ts
@@ -899,6 +899,14 @@ function componentSizeExamplesFor(
     return COMPONENT_SIZE_EXAMPLES;
 }
 
+/**
+ * Build the "Accepted sizes" payload for an attribute, or `undefined` when the
+ * attribute's value is not a length. Every `componentSize` attribute qualifies,
+ * so a size attribute added to the worker later is explained without a change
+ * here; `_componentSizeList` attributes (a `<sideBySide>`'s `widths` and
+ * `margins`) are deliberately not, since a list of sizes needs a different
+ * explanation than a single one.
+ */
 function computeSizeSyntaxForAttribute(
     elementName: string,
     schemaAttr: SchemaAttribute,

--- a/packages/lsp-tools/src/context-help/computeContextHelp.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.ts
@@ -841,14 +841,26 @@ const ELEMENTS_SNAPPING_WIDTH_TO_SIZE: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Elements whose `width` is read only as a share of the width around them.
+ * A side-by-side layout divides its row into percentages; an absolute width
+ * there raises the `side-by-side-absolute-widths` warning and is coerced to
+ * relative, so the absolute forms are not offered.
+ */
+const ELEMENTS_WITH_RELATIVE_ONLY_WIDTH: ReadonlySet<string> = new Set([
+    "sideBySide",
+    "sbsGroup",
+]);
+
+/**
  * The accepted length forms, in the order the panel lists them: the absolute
  * units first (pixels being the one an author reaches for), then the relative
  * one. `mm` is left out as the near-duplicate of `cm` rather than because it
  * is rejected.
  *
- * The relative entry is filtered out for a height — the runtime accepts a
- * percentage there, but nothing comes of it, and naming a form only to rule it
- * out is more confusing than never raising it.
+ * The list is filtered down for the two attributes that take only part of it
+ * — see {@link computeSizeSyntaxForAttribute}. Naming a form only to rule it
+ * out is more confusing than never raising it, so each attribute is offered
+ * exactly what it honors.
  */
 const COMPONENT_SIZE_EXAMPLES: SizeSyntaxPayload["examples"] = [
     { value: "600", kind: "absolute" },
@@ -862,6 +874,31 @@ const COMPONENT_SIZE_EXAMPLES: SizeSyntaxPayload["examples"] = [
 const COMPONENT_SIZE_ABSOLUTE_EXAMPLES: SizeSyntaxPayload["examples"] =
     COMPONENT_SIZE_EXAMPLES.filter((e) => e.kind === "absolute");
 
+const COMPONENT_SIZE_RELATIVE_EXAMPLES: SizeSyntaxPayload["examples"] =
+    COMPONENT_SIZE_EXAMPLES.filter((e) => e.kind === "relative");
+
+/**
+ * Pick the forms an attribute actually honors:
+ *
+ * - A **height** gets the absolute forms only. A percentage needs a containing
+ *   block with a definite size to measure against; along the block axis there
+ *   is none, so a percentage height resolves to `auto` and the element falls
+ *   back to its content height.
+ * - A **side-by-side width** gets the relative form only, since the runtime
+ *   coerces an absolute one (see {@link ELEMENTS_WITH_RELATIVE_ONLY_WIDTH}).
+ * - Every other `componentSize` attribute gets the full list.
+ */
+function componentSizeExamplesFor(
+    elementName: string,
+    isHeight: boolean,
+): SizeSyntaxPayload["examples"] {
+    if (isHeight) return COMPONENT_SIZE_ABSOLUTE_EXAMPLES;
+    if (ELEMENTS_WITH_RELATIVE_ONLY_WIDTH.has(elementName)) {
+        return COMPONENT_SIZE_RELATIVE_EXAMPLES;
+    }
+    return COMPONENT_SIZE_EXAMPLES;
+}
+
 function computeSizeSyntaxForAttribute(
     elementName: string,
     schemaAttr: SchemaAttribute,
@@ -872,15 +909,8 @@ function computeSizeSyntaxForAttribute(
     const snapsToSizePreset =
         !isHeight && ELEMENTS_SNAPPING_WIDTH_TO_SIZE.has(elementName);
 
-    // A percentage needs a containing block with a definite size to measure
-    // against. Along the inline axis there always is one; along the block axis
-    // there is not, so a percentage height resolves to `auto` and the element
-    // falls back to its content height — which is why a height is offered the
-    // absolute forms and nothing else.
     return {
-        examples: isHeight
-            ? COMPONENT_SIZE_ABSOLUTE_EXAMPLES
-            : COMPONENT_SIZE_EXAMPLES,
+        examples: componentSizeExamplesFor(elementName, isHeight),
         ...(snapsToSizePreset ? { snapsToSizePreset: true } : {}),
     };
 }

--- a/packages/lsp-tools/src/context-help/computeContextHelp.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.ts
@@ -40,6 +40,7 @@ import { COMPLETION_TYPES } from "../completion-types";
 import type {
     FunctionNamesBreakdownPayload,
     HelpContent,
+    SizeSyntaxPayload,
     SuggestionItem,
 } from "./types";
 
@@ -820,6 +821,70 @@ function computeFunctionNamesBreakdownForAttribute(
     };
 }
 
+/**
+ * Component type whose value is a length: a bare number of pixels, a number
+ * with a unit, or a percentage. Matching on the type rather than on
+ * `width`/`height` by name means a `componentSize` attribute added to the
+ * worker later is explained without a change here.
+ */
+const COMPONENT_SIZE_TYPE = "componentSize";
+
+/**
+ * Elements whose `width` selects the nearest named `size` preset instead of
+ * being used as a literal length — the value is a hint, not a measurement, so
+ * the panel says so. See {@link SizeSyntaxPayload.snapsToSizePreset}.
+ */
+const ELEMENTS_SNAPPING_WIDTH_TO_SIZE: ReadonlySet<string> = new Set([
+    "graph",
+    "image",
+    "video",
+]);
+
+/**
+ * The accepted length forms, in the order the panel lists them: the absolute
+ * units first (pixels being the one an author reaches for), then the relative
+ * one. `mm` is left out as the near-duplicate of `cm` rather than because it
+ * is rejected.
+ *
+ * The relative entry is filtered out for a height — the runtime accepts a
+ * percentage there, but nothing comes of it, and naming a form only to rule it
+ * out is more confusing than never raising it.
+ */
+const COMPONENT_SIZE_EXAMPLES: SizeSyntaxPayload["examples"] = [
+    { value: "600", kind: "absolute" },
+    { value: "600px", kind: "absolute" },
+    { value: "6in", kind: "absolute" },
+    { value: "450pt", kind: "absolute" },
+    { value: "15cm", kind: "absolute" },
+    { value: "50%", kind: "relative" },
+];
+
+const COMPONENT_SIZE_ABSOLUTE_EXAMPLES: SizeSyntaxPayload["examples"] =
+    COMPONENT_SIZE_EXAMPLES.filter((e) => e.kind === "absolute");
+
+function computeSizeSyntaxForAttribute(
+    elementName: string,
+    schemaAttr: SchemaAttribute,
+): SizeSyntaxPayload | undefined {
+    if (schemaAttr.type !== COMPONENT_SIZE_TYPE) return undefined;
+
+    const isHeight = schemaAttr.name.toLowerCase() === "height";
+    const snapsToSizePreset =
+        !isHeight && ELEMENTS_SNAPPING_WIDTH_TO_SIZE.has(elementName);
+
+    // A percentage needs a containing block with a definite size to measure
+    // against. Along the inline axis there always is one; along the block axis
+    // there is not, so a percentage height resolves to `auto` and the element
+    // falls back to its content height — which is why a height is offered the
+    // absolute forms and nothing else.
+    return {
+        examples: isHeight
+            ? COMPONENT_SIZE_ABSOLUTE_EXAMPLES
+            : COMPONENT_SIZE_EXAMPLES,
+        ...(snapsToSizePreset ? { snapsToSizePreset: true } : {}),
+    };
+}
+
 function helpForAttribute(
     ownEntry: ElementSchema | undefined,
     effectiveEntry: SchemaEntryForHelp | undefined,
@@ -849,6 +914,8 @@ function helpForAttribute(
         activeDefaultCtx,
     );
 
+    const sizeSyntax = computeSizeSyntaxForAttribute(ownEntry.name, schemaAttr);
+
     return {
         kind: "attribute",
         elementName: ownEntry.name,
@@ -871,6 +938,7 @@ function helpForAttribute(
         ...(activeDefault ? { activeDefault } : {}),
         ...(styleBreakdown ? { styleBreakdown } : {}),
         ...(functionNamesBreakdown ? { functionNamesBreakdown } : {}),
+        ...(sizeSyntax ? { sizeSyntax } : {}),
     };
 }
 

--- a/packages/lsp-tools/src/context-help/types.ts
+++ b/packages/lsp-tools/src/context-help/types.ts
@@ -78,6 +78,13 @@ export type SizeSyntaxPayload = {
      * nearest of the five named `size` presets (`tiny` 70px, `small` 255px,
      * `medium` 425px, `large` 595px, `full` 850px) instead of being used
      * literally — `width="400px"` and `width="50%"` both render 425px there.
+     *
+     * The flag is set from the element name alone, which overstates one case:
+     * an `<image>` drawn on a `<graph>` uses its width as given, against the
+     * graph's own scale. The panel sees an attribute, not where its element
+     * sits, and a caveat about a graph would be noise on the far commoner
+     * standalone image, so the note is left as written and the docs carry the
+     * exception.
      */
     snapsToSizePreset?: boolean;
 };

--- a/packages/lsp-tools/src/context-help/types.ts
+++ b/packages/lsp-tools/src/context-help/types.ts
@@ -50,21 +50,22 @@ export type FunctionNamesBreakdownPayload = {
 };
 
 /**
- * Length syntax surfaced for an attribute whose value is a `componentSize`
- * (`width`, `height` — 15 of them across `textInput`, `codeEditor`,
- * `spreadsheet`, `tabular`, `slider`, `sideBySide`, `graph`, `image` and
- * `video`).  The attribute description says what the dimension means; nothing
- * else tells an author that `600`, `6in` and `50%` are all accepted, so the
- * panel lists the forms.
+ * Length syntax surfaced for an attribute whose value is a `componentSize` —
+ * the `width` and `height` of `textInput`, `codeEditor`, `spreadsheet`,
+ * `tabular`, `slider`, `sideBySide`, `sbsGroup`, `graph`, `image` and `video`.
+ * The attribute description says what the dimension means; nothing else tells
+ * an author that `600`, `6in` and `50%` are all accepted, so the panel lists
+ * the forms.
  *
  * `em` is deliberately absent from `examples`: the runtime reads it as a
  * multiple of 100% rather than as a font-relative length, so offering it here
  * would teach the wrong thing. The reference docs cover it as a caveat.
  *
- * A `height` carries only the absolute forms. The runtime accepts a percentage
- * there and then does nothing with it — its containing block has no definite
- * height to measure against — so the panel leaves percentages out of the height
- * story altogether rather than naming a form only to rule it out.
+ * `examples` carries only the forms the attribute honors, so the panel never
+ * names one only to rule it out. A `height` gets the absolute forms alone (a
+ * percentage there has no definite containing height to measure against), and
+ * a side-by-side `width` gets the relative form alone (an absolute one is
+ * warned about and coerced to relative).
  */
 export type SizeSyntaxPayload = {
     /** Accepted forms, each an example value and the unit it stands for. */

--- a/packages/lsp-tools/src/context-help/types.ts
+++ b/packages/lsp-tools/src/context-help/types.ts
@@ -50,6 +50,38 @@ export type FunctionNamesBreakdownPayload = {
 };
 
 /**
+ * Length syntax surfaced for an attribute whose value is a `componentSize`
+ * (`width`, `height` — 15 of them across `textInput`, `codeEditor`,
+ * `spreadsheet`, `tabular`, `slider`, `sideBySide`, `graph`, `image` and
+ * `video`).  The attribute description says what the dimension means; nothing
+ * else tells an author that `600`, `6in` and `50%` are all accepted, so the
+ * panel lists the forms.
+ *
+ * `em` is deliberately absent from `examples`: the runtime reads it as a
+ * multiple of 100% rather than as a font-relative length, so offering it here
+ * would teach the wrong thing. The reference docs cover it as a caveat.
+ *
+ * A `height` carries only the absolute forms. The runtime accepts a percentage
+ * there and then does nothing with it — its containing block has no definite
+ * height to measure against — so the panel leaves percentages out of the height
+ * story altogether rather than naming a form only to rule it out.
+ */
+export type SizeSyntaxPayload = {
+    /** Accepted forms, each an example value and the unit it stands for. */
+    examples: Array<{
+        value: string;
+        kind: "absolute" | "relative";
+    }>;
+    /**
+     * `true` for `<graph>`, `<image>` and `<video>`, whose width picks the
+     * nearest of the five named `size` presets (`tiny` 70px, `small` 255px,
+     * `medium` 425px, `large` 595px, `full` 850px) instead of being used
+     * literally — `width="400px"` and `width="50%"` both render 425px there.
+     */
+    snapsToSizePreset?: boolean;
+};
+
+/**
  * One element entry in a `suggestions` payload's `suggested` list. Snippets
  * are deliberately excluded from the panel — with only six slots, surfacing
  * several variations of the same element (e.g. all the `<answer>` snippets)
@@ -173,6 +205,14 @@ export type HelpContent =
            * contract.
            */
           functionNamesBreakdown?: FunctionNamesBreakdownPayload;
+          /**
+           * Accepted length syntax, populated for every attribute whose value
+           * is a `componentSize`. Keyed off the attribute's type rather than a
+           * list of names, so an attribute added to the worker later is
+           * explained without touching this package. See
+           * {@link SizeSyntaxPayload}.
+           */
+          sizeSyntax?: SizeSyntaxPayload;
       }
     /**
      * A reference to a *property* of another component, e.g.

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -102990,7 +102990,7 @@
                     "name": "width",
                     "type": "componentSize",
                     "isArray": false,
-                    "description": "Display width of the input."
+                    "description": "Display width of the input. Defaults to 100% when expanded, and to 100px otherwise."
                 },
                 {
                     "name": "value",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -102903,7 +102903,7 @@
                     "name": "height",
                     "type": "componentSize",
                     "isArray": false,
-                    "description": "Display height of the input.",
+                    "description": "Display height of the input. Applies only to an expanded input.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -85683,7 +85683,7 @@
                     "name": "width",
                     "type": "componentSize",
                     "isArray": false,
-                    "description": "Display width of the input."
+                    "description": "Display width of the input. Defaults to 100% when expanded, and to 100px otherwise."
                 },
                 {
                     "name": "value",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -85449,12 +85449,12 @@
                 },
                 {
                     "name": "width",
-                    "description": "Display width of the input.",
+                    "description": "Display width of the input. Defaults to 100% when expanded, and to 100px otherwise.",
                     "type": "componentSize"
                 },
                 {
                     "name": "height",
-                    "description": "Display height of the input.",
+                    "description": "Display height of the input. Applies only to an expanded input.",
                     "defaultValue": {
                         "size": 120,
                         "isAbsolute": true
@@ -85593,7 +85593,7 @@
                     "name": "height",
                     "type": "componentSize",
                     "isArray": false,
-                    "description": "Display height of the input.",
+                    "description": "Display height of the input. Applies only to an expanded input.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/schema.ts
+++ b/packages/static-assets/src/schema.ts
@@ -37,15 +37,30 @@ export function isMathDefaultValue(val: unknown): val is MathDefaultValue {
  * `height="{"size":120,"isAbsolute":true}"`. Renderers detect it with
  * `isComponentSizeValue` and print it with `formatComponentSize`, which gives
  * back exactly the text an author would put in the attribute.
+ *
+ * `size` is a number or a string of digits: the worker's component classes
+ * declare these defaults by hand, and a few write the number as a string
+ * (`<codeEditor>`'s `width` is `{ size: "100", isAbsolute: false }`). Both
+ * spellings mean the same size, so both are recognized — a guard that took
+ * only numbers would leave those attributes printing their raw JSON.
  */
-export type ComponentSizeValue = { size: number; isAbsolute: boolean };
+export type ComponentSizeValue = {
+    size: number | string;
+    isAbsolute: boolean;
+};
 
 export function isComponentSizeValue(val: unknown): val is ComponentSizeValue {
+    if (
+        typeof val !== "object" ||
+        val === null ||
+        typeof (val as { isAbsolute?: unknown }).isAbsolute !== "boolean"
+    ) {
+        return false;
+    }
+    const size = (val as { size?: unknown }).size;
     return (
-        typeof val === "object" &&
-        val !== null &&
-        typeof (val as { size?: unknown }).size === "number" &&
-        typeof (val as { isAbsolute?: unknown }).isAbsolute === "boolean"
+        typeof size === "number" ||
+        (typeof size === "string" && size.trim() !== "" && !isNaN(Number(size)))
     );
 }
 

--- a/packages/static-assets/src/schema.ts
+++ b/packages/static-assets/src/schema.ts
@@ -31,6 +31,32 @@ export function isMathDefaultValue(val: unknown): val is MathDefaultValue {
 }
 
 /**
+ * Internal shape a `componentSize` default value carries in the schema — the
+ * runtime's own `{ size, isAbsolute }` pair, where `isAbsolute` picks between
+ * pixels and a percentage. It is not a value an author can write: nobody types
+ * `height="{"size":120,"isAbsolute":true}"`. Renderers detect it with
+ * `isComponentSizeValue` and print it with `formatComponentSize`, which gives
+ * back exactly the text an author would put in the attribute.
+ */
+export type ComponentSizeValue = { size: number; isAbsolute: boolean };
+
+export function isComponentSizeValue(val: unknown): val is ComponentSizeValue {
+    return (
+        typeof val === "object" &&
+        val !== null &&
+        typeof (val as { size?: unknown }).size === "number" &&
+        typeof (val as { isAbsolute?: unknown }).isAbsolute === "boolean"
+    );
+}
+
+/**
+ * Render a `componentSize` as an author would write it: `120px` or `50%`.
+ */
+export function formatComponentSize(value: ComponentSizeValue): string {
+    return `${value.size}${value.isAbsolute ? "px" : "%"}`;
+}
+
+/**
  * Per-dimension entry shape emitted by `get-schema.ts:singlePropFromDescription`
  * for each slot of an array property — the public mirror of the generator's
  * local `ArrayElementDescription`. `type` is optional for the same reason as

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { getSchema } from "../scripts/get-schema";
+import { formatComponentSize, isComponentSizeValue } from "../src/schema";
 
 describe("generated schema help fields", () => {
     const schema = getSchema();
@@ -199,6 +200,43 @@ describe("generated schema help fields", () => {
             type: "math",
             latex: "＿",
         });
+    });
+
+    it("recognizes every componentSize default, however its size is spelled", () => {
+        // The author-facing surfaces (the docs prop tables, the help panel)
+        // print a `componentSize` default through `formatComponentSize` rather
+        // than as the raw `{ size, isAbsolute }` pair, and reach it through
+        // `isComponentSizeValue`. The component classes write these defaults by
+        // hand and do not agree on the spelling — `<codeEditor>`'s width is
+        // `{ size: "100", isAbsolute: false }` where the rest use a number — so
+        // the guard has to accept both, or those attributes fall back to
+        // printing their JSON.
+        const sizeDefaults = schema.elements.flatMap((element) =>
+            element.attributes
+                .filter(
+                    (attribute) =>
+                        attribute.type === "componentSize" &&
+                        attribute.defaultValue != null,
+                )
+                .map((attribute) => ({
+                    where: `<${element.name} ${attribute.name}>`,
+                    defaultValue: attribute.defaultValue,
+                })),
+        );
+        expect(sizeDefaults.length).toBeGreaterThan(0);
+        for (const { where, defaultValue } of sizeDefaults) {
+            expect(
+                isComponentSizeValue(defaultValue),
+                `${where} default is not recognized as a componentSize`,
+            ).toBe(true);
+        }
+
+        expect(formatComponentSize({ size: 120, isAbsolute: true })).toBe(
+            "120px",
+        );
+        expect(formatComponentSize({ size: "100", isAbsolute: false })).toBe(
+            "100%",
+        );
     });
 
     it("uses a schema subarray's own description when set", () => {

--- a/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
@@ -193,6 +193,35 @@ describe("Context-sensitive help panel", { tags: ["@group5"] }, function () {
         });
     });
 
+    it("offers a sideBySide width the percentage only", () => {
+        const doenetML = `<sideBySide width="50%"><p>a</p><p>b</p></sideBySide>`;
+        cy.window().then((win) => {
+            win.postMessage({ doenetML }, "*");
+        });
+        cy.get(".cm-content", { timeout: 10000 }).should(
+            "contain.text",
+            "width",
+        );
+
+        openHelpTab();
+        moveCursorToOffset(doenetML.indexOf("width") + 2);
+
+        cy.get(".help-panel", { timeout: 5000 }).within(() => {
+            // A side-by-side divides its row into shares, so an absolute width
+            // is coerced. Neither the chips nor the note raise one.
+            cy.get(".help-size-syntax").should("contain.text", "50%");
+            cy.get(".help-size-syntax").should("not.contain.text", "px");
+            cy.get(".help-size-syntax").should(
+                "not.contain.text",
+                "A bare number",
+            );
+            cy.get(".help-size-syntax").should(
+                "contain.text",
+                "A percentage is a share of the width",
+            );
+        });
+    });
+
     it("redirects <row> inside <matrix> to matrixRow help via childAliases", () => {
         const doenetML = `<matrix>\n<row>1 2 3</row>\n</matrix>`;
         cy.window().then((win) => {

--- a/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
@@ -119,6 +119,80 @@ describe("Context-sensitive help panel", { tags: ["@group5"] }, function () {
         });
     });
 
+    it("shows the accepted sizes, and offers a height no percentage", () => {
+        const doenetML = `<textInput expanded width="600" height="300"/>`;
+        cy.window().then((win) => {
+            win.postMessage({ doenetML }, "*");
+        });
+        cy.get(".cm-content", { timeout: 10000 }).should(
+            "contain.text",
+            "width",
+        );
+
+        openHelpTab();
+        // Cursor inside the "width" attribute name.
+        moveCursorToOffset(doenetML.indexOf("width") + 2);
+
+        cy.get(".help-panel", { timeout: 5000 }).within(() => {
+            cy.get(".help-attribute-name").should("contain.text", "width");
+            cy.contains(".help-detail-label", "Accepted sizes:").should(
+                "exist",
+            );
+            // The two forms an author cannot guess from the description alone.
+            cy.get(".help-size-syntax").should("contain.text", "600px");
+            cy.get(".help-size-syntax").should("contain.text", "50%");
+            cy.get(".help-size-syntax").should(
+                "contain.text",
+                "A bare number is pixels. A percentage is a share of the width",
+            );
+            // The conditional default rides in the description, since the
+            // schema can only carry an unconditional one.
+            cy.get(".help-description").should(
+                "contain.text",
+                "Defaults to 100% when expanded",
+            );
+        });
+
+        // A height takes the absolute forms only, and a percentage is not
+        // raised at all — neither offered nor ruled out.
+        moveCursorToOffset(doenetML.indexOf("height") + 2);
+        cy.get(".help-panel", { timeout: 5000 }).within(() => {
+            cy.get(".help-attribute-name").should("contain.text", "height");
+            cy.get(".help-size-syntax").should("contain.text", "600px");
+            cy.get(".help-size-syntax").should("not.contain.text", "%");
+            // The note stops at the pixels sentence — no percentage clause.
+            cy.get(".help-size-syntax").should(
+                "contain.text",
+                "A bare number is pixels.",
+            );
+            // The schema's `{ size, isAbsolute }` pair is shown as authorable
+            // text, not as the raw object.
+            cy.contains(".help-detail-label", "Default:").should("exist");
+            cy.get(".help-value-item").should("contain.text", "120px");
+        });
+    });
+
+    it("says a graph width picks the nearest size preset", () => {
+        const doenetML = `<graph width="400px"/>`;
+        cy.window().then((win) => {
+            win.postMessage({ doenetML }, "*");
+        });
+        cy.get(".cm-content", { timeout: 10000 }).should(
+            "contain.text",
+            "width",
+        );
+
+        openHelpTab();
+        moveCursorToOffset(doenetML.indexOf("width") + 2);
+
+        cy.get(".help-panel", { timeout: 5000 }).within(() => {
+            cy.get(".help-size-syntax").should(
+                "contain.text",
+                "nearest size preset",
+            );
+        });
+    });
+
     it("redirects <row> inside <matrix> to matrixRow help via childAliases", () => {
         const doenetML = `<matrix>\n<row>1 2 3</row>\n</matrix>`;
         cy.window().then((win) => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -73,11 +73,15 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
         cy.get("#tiDefault_input").then(($el) => {
             const el = $el[0];
             const win = el.ownerDocument.defaultView;
+            // Measure the paragraph, not the input row: the row is only as
+            // wide as the column because this default works. Measuring it
+            // would let a regression to the old absolute 600px default pass,
+            // since the row would shrink-wrap to the input either way.
             const columnWidth = parseFloat(
-                win.getComputedStyle(el.parentElement).width,
+                win.getComputedStyle(el.closest("div.para")).width,
             );
             const inputWidth = parseFloat(win.getComputedStyle(el).width);
-            expect(columnWidth).to.be.greaterThan(200);
+            expect(columnWidth).to.be.greaterThan(700);
             // Fills the column but for its own margins — well past the fixed
             // 600px this used to default to.
             expect(inputWidth).to.be.at.most(columnWidth);
@@ -107,11 +111,14 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
         cy.get("#half_input").then(($el) => {
             const el = $el[0];
             const win = el.ownerDocument.defaultView;
+            // The paragraph is the containing block a percentage resolves
+            // against. The input row is not: it shrink-wraps its contents,
+            // which is the circular reference this fix exists to avoid.
             const columnWidth = parseFloat(
-                win.getComputedStyle(el.parentElement).width,
+                win.getComputedStyle(el.closest("div.para")).width,
             );
             const inputWidth = parseFloat(win.getComputedStyle(el).width);
-            expect(columnWidth).to.be.greaterThan(200);
+            expect(columnWidth).to.be.greaterThan(700);
             expect(inputWidth).to.be.closeTo(columnWidth / 2, 1);
         });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -50,6 +50,187 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
         cy.get("#p1").should("have.text", "new\nold\nhello\nbye\n");
     });
 
+    it("expanded textInput is sized by width and height", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <p><textInput name="ti" expanded width="600" height="600" /></p>
+    <p><textInput name="tiDefault" expanded /></p>
+    <p><textInput name="plainDefault" /></p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ti_input").should("have.css", "width", "600px");
+        cy.get("#ti_input").should("have.css", "height", "600px");
+
+        // An expanded input with no width of its own fills the column it sits
+        // in, so it stays in proportion when the reader's window is narrow.
+        cy.get("#tiDefault_input").should("have.css", "height", "120px");
+        cy.get("#tiDefault_input").then(($el) => {
+            const el = $el[0];
+            const win = el.ownerDocument.defaultView;
+            const columnWidth = parseFloat(
+                win.getComputedStyle(el.parentElement).width,
+            );
+            const inputWidth = parseFloat(win.getComputedStyle(el).width);
+            expect(columnWidth).to.be.greaterThan(200);
+            // Fills the column but for its own margins and border — well past
+            // the fixed 600px this used to default to.
+            expect(inputWidth).to.be.at.most(columnWidth);
+            expect(inputWidth).to.be.greaterThan(columnWidth - 25);
+        });
+
+        // A word-sized input keeps its own absolute width, unchanged.
+        cy.get("#plainDefault_input").should("have.css", "width", "100px");
+    });
+
+    it("expanded textInput takes a relative width", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <p><textInput name="half" expanded width="50%" /></p>
+    <p><textInput name="plain" width="50%" /></p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // A percentage is a share of the text column the input sits in, not of
+        // the input row, which shrink-wraps whatever it holds.
+        cy.get("#half_input").should("exist");
+        cy.get("#half_input").then(($el) => {
+            const el = $el[0];
+            const win = el.ownerDocument.defaultView;
+            const columnWidth = parseFloat(
+                win.getComputedStyle(el.parentElement).width,
+            );
+            const inputWidth = parseFloat(win.getComputedStyle(el).width);
+            expect(columnWidth).to.be.greaterThan(200);
+            expect(inputWidth).to.be.closeTo(columnWidth / 2, 1);
+        });
+
+        // Only an expanded input stretches its row to the column. A word-sized
+        // input keeps the shrink-to-fit row that lets it flow inline.
+        cy.get("#plain_input").then(($el) => {
+            const el = $el[0];
+            const win = el.ownerDocument.defaultView;
+            const rowWidth = parseFloat(
+                win.getComputedStyle(el.parentElement).width,
+            );
+            const columnWidth = parseFloat(
+                win.getComputedStyle(el.closest("div")).width,
+            );
+            expect(rowWidth).to.be.lessThan(columnWidth);
+        });
+    });
+
+    it("expanded textInput never overflows a narrow column", () => {
+        cy.viewport(500, 800);
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <p><textInput name="huge" expanded width="4000px" /></p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#huge_input").should("exist");
+        cy.get("#huge_input").then(($el) => {
+            const el = $el[0];
+            const win = el.ownerDocument.defaultView;
+            const columnWidth = parseFloat(
+                win.getComputedStyle(el.parentElement).width,
+            );
+            const inputWidth = parseFloat(win.getComputedStyle(el).width);
+            expect(inputWidth).to.be.lessThan(4000);
+            expect(inputWidth).to.be.at.most(columnWidth);
+        });
+    });
+
+    // The check-work button carries its label three times over: once in the
+    // icon's `<title>`, once in a visually-hidden span for screen readers, and
+    // — only on the full-size button — as visible text beside the icon. So
+    // `textContent` cannot tell the two sizes apart; the visible text node can.
+    function visibleButtonLabel(btn) {
+        const iconSpan = btn.querySelector('span[aria-hidden="true"]');
+        return Array.from(iconSpan.childNodes)
+            .filter((node) => node.nodeType === Node.TEXT_NODE)
+            .map((node) => node.textContent)
+            .join("")
+            .trim();
+    }
+
+    it("puts an expanded input's check-work button below it, at full size", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <p><answer name="big" handGraded><textInput name="bigTi" expanded /></answer></p>
+    <p><answer name="small" handGraded><textInput name="smallTi" /></answer></p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#bigTi_input").should("exist");
+
+        // An expanded input fills its column, so a button beside it would be
+        // squeezed to nothing: it goes underneath instead.
+        cy.get("#bigTi_button").then(($btn) => {
+            const btn = $btn[0];
+            const win = btn.ownerDocument.defaultView;
+            const input = win.document.getElementById("bigTi_input");
+            const btnBox = btn.getBoundingClientRect();
+            const inputBox = input.getBoundingClientRect();
+            expect(btnBox.top).to.be.at.least(inputBox.bottom - 1);
+            // Full-size button: the label rides along with the icon, and it is
+            // the default for an expanded input, with no `forceFullCheckWorkButton`.
+            expect(visibleButtonLabel(btn)).to.contain("Submit Response");
+            // Nothing is clipped — a wrapped label grows the button instead.
+            expect(btn.scrollHeight).to.be.at.most(btn.clientHeight);
+        });
+
+        // A word-sized input keeps the small button beside it, on the same line.
+        cy.get("#smallTi_button").then(($btn) => {
+            const btn = $btn[0];
+            const win = btn.ownerDocument.defaultView;
+            const input = win.document.getElementById("smallTi_input");
+            const btnBox = btn.getBoundingClientRect();
+            const inputBox = input.getBoundingClientRect();
+            expect(btnBox.left).to.be.greaterThan(inputBox.left);
+            expect(btnBox.top).to.be.lessThan(inputBox.bottom);
+            expect(visibleButtonLabel(btn)).to.equal("");
+        });
+    });
+
+    it("lets forceSmallCheckWorkButton shrink an expanded input's button", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <p><answer name="a" handGraded forceSmallCheckWorkButton><textInput name="ti" expanded /></answer></p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ti_input").should("exist");
+        cy.get("#ti_button").then(($btn) => {
+            expect(visibleButtonLabel($btn[0])).to.equal("");
+        });
+    });
+
     it("set value from immediateValue on reload", () => {
         let doenetML = `
     <p><textInput name="ti" /></p>

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -242,6 +242,57 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
         });
     });
 
+    it("grows the check-work button to hold a label that wraps", () => {
+        cy.viewport(700, 800);
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <sideBySide widths="14% 86%">
+      <p><answer name="a" handGraded><textInput name="ti" expanded /></answer></p>
+      <p>filler</p>
+    </sideBySide>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ti_input").should("exist");
+        cy.get("#ti_button").then(($btn) => {
+            const btn = $btn[0];
+            // A narrow column squeezes the button until "Submit Response" no
+            // longer fits on one line, so its content is taller than the 24px
+            // a one-line button stands. Asserted first so the check below is
+            // testing what it says it is.
+            expect(btn.scrollHeight).to.be.greaterThan(24);
+            // Having wrapped, the button grows to hold the second line rather
+            // than clipping it — which a fixed height did.
+            expect(btn.clientHeight).to.be.at.least(btn.scrollHeight);
+        });
+    });
+
+    it("sizes an expanded input on a graph like a word-sized one", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph name="gPlain"><textInput name="plain" /></graph>
+    <graph name="gExpanded"><textInput name="big" expanded /></graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        // JSXGraph draws every text input as a one-line field, so `expanded`
+        // means nothing on a graph — and neither does the 100% width it brings
+        // with it: the field floats in a shrink-to-fit box above the graph,
+        // which gives a percentage no column to be a share of.
+        cy.get("#gPlain").find("input").should("have.css", "width", "100px");
+        cy.get("#gExpanded").find("input").should("have.css", "width", "100px");
+    });
+
     it("set value from immediateValue on reload", () => {
         let doenetML = `
     <p><textInput name="ti" /></p>

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -78,8 +78,8 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
             );
             const inputWidth = parseFloat(win.getComputedStyle(el).width);
             expect(columnWidth).to.be.greaterThan(200);
-            // Fills the column but for its own margins and border — well past
-            // the fixed 600px this used to default to.
+            // Fills the column but for its own margins — well past the fixed
+            // 600px this used to default to.
             expect(inputWidth).to.be.at.most(columnWidth);
             expect(inputWidth).to.be.greaterThan(columnWidth - 25);
         });
@@ -124,7 +124,7 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
                 win.getComputedStyle(el.parentElement).width,
             );
             const columnWidth = parseFloat(
-                win.getComputedStyle(el.closest("div")).width,
+                win.getComputedStyle(el.closest("div.para")).width,
             );
             expect(rowWidth).to.be.lessThan(columnWidth);
         });
@@ -137,23 +137,34 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
                 {
                     doenetML: `
     <p><textInput name="huge" expanded width="4000px" /></p>
+    <p><textInput name="wide" expanded /></p>
     `,
                 },
                 "*",
             );
         });
 
+        // Measured on the rendered edges, not the computed width: the margins
+        // and the border sit outside the width, so a box capped at the column
+        // width would still hang past its right edge.
+        function expectWithinColumn(el) {
+            const paragraph = el.closest("div.para");
+            const inputBox = el.getBoundingClientRect();
+            const columnBox = paragraph.getBoundingClientRect();
+            expect(columnBox.width).to.be.greaterThan(100);
+            expect(inputBox.right).to.be.at.most(columnBox.right + 0.5);
+            expect(inputBox.left).to.be.at.least(columnBox.left - 0.5);
+        }
+
+        // An absolute width the window cannot hold shrinks to fit.
         cy.get("#huge_input").should("exist");
         cy.get("#huge_input").then(($el) => {
-            const el = $el[0];
-            const win = el.ownerDocument.defaultView;
-            const columnWidth = parseFloat(
-                win.getComputedStyle(el.parentElement).width,
-            );
-            const inputWidth = parseFloat(win.getComputedStyle(el).width);
-            expect(inputWidth).to.be.lessThan(4000);
-            expect(inputWidth).to.be.at.most(columnWidth);
+            expect($el[0].getBoundingClientRect().width).to.be.lessThan(4000);
+            expectWithinColumn($el[0]);
         });
+
+        // So does the 100% default, whose margins would otherwise push it out.
+        cy.get("#wide_input").then(($el) => expectWithinColumn($el[0]));
     });
 
     // The check-work button carries its label three times over: once in the

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -138,6 +138,7 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
                     doenetML: `
     <p><textInput name="huge" expanded width="4000px" /></p>
     <p><textInput name="wide" expanded /></p>
+    <p><textInput name="labelled" expanded><label>A label of its own</label></textInput></p>
     `,
                 },
                 "*",
@@ -165,6 +166,11 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
 
         // So does the 100% default, whose margins would otherwise push it out.
         cy.get("#wide_input").then(($el) => expectWithinColumn($el[0]));
+
+        // A label shares the line the input row starts on, so a row stretched
+        // to the full column has to wrap below the label rather than hang off
+        // the right of it.
+        cy.get("#labelled_input").then(($el) => expectWithinColumn($el[0]));
     });
 
     // The check-work button carries its label three times over: once in the
@@ -279,6 +285,8 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
                     doenetML: `
     <graph name="gPlain"><textInput name="plain" /></graph>
     <graph name="gExpanded"><textInput name="big" expanded /></graph>
+    <graph name="gRelative"><textInput name="half" width="50%" /></graph>
+    <graph name="gAbsolute"><textInput name="wide" width="240px" /></graph>
     `,
                 },
                 "*",
@@ -291,6 +299,11 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
         // which gives a percentage no column to be a share of.
         cy.get("#gPlain").find("input").should("have.css", "width", "100px");
         cy.get("#gExpanded").find("input").should("have.css", "width", "100px");
+        // An authored percentage falls back the same way, whether or not it
+        // came from the `expanded` default.
+        cy.get("#gRelative").find("input").should("have.css", "width", "100px");
+        // An absolute width is still honored on a graph.
+        cy.get("#gAbsolute").find("input").should("have.css", "width", "240px");
     });
 
     it("set value from immediateValue on reload", () => {


### PR DESCRIPTION
## Why

`<textInput expanded width="600" height="600" />` ignored both attributes, rendering at the browser's default textarea size instead. Chasing that turned up a cluster of related problems in how a size is authored, applied, and explained.

## The original bug

The `expanded` branch of `textInput.tsx` computed `width` and `height` (lines 59-60) but listed neither in the textarea's `style`, so the box fell back to the browser default — about twenty columns and two rows — whatever was authored.

It is an old regression, not a recent one. Commit 97e52280e ("add label and description to answer and all input") moved the non-expanded `<input>`'s `width`/`height` from invalid HTML attributes into its style object and, in the same edit, deleted them from the textarea's style rather than leaving them. The expanded case has been unsized since. The other renderers that commit touched lost only dead check-work styles superseded by a shared helper, so nothing else regressed.

The core was fine throughout: `width` and `height` are both `forRenderer` on `TextInput.js`.

## Relative sizes

`componentSize` — the type behind 15 attributes across `textInput`, `codeEditor`, `spreadsheet`, `tabular`, `slider`, `sideBySide`, `sbsGroup`, `graph`, `image` and `video` — accepts more than pixels. Measured in a browser across all ten components:

| Form | Example | Result |
| --- | --- | --- |
| bare number | `600` | 600px |
| `px`/`pixel`/`pixels` | `300 pixels` | 300px (space optional) |
| `in`/`inch(es)` | `2in` | 192px |
| `pt` | `72pt` | 96px |
| `mm`/`cm` (+ long names) | `5cm` | 188.98px |
| `%` | `50%` | relative |
| `em` | `2em` | relative — 200%, not font-relative |

A percentage width worked on every block component (50% of an 850px column → 425px) but not on a `textInput`, where the input sits in an `inline-flex` row that shrink-wraps its content: the percentage resolved circularly and produced 100px. Stretching that row to the column when — and only when — the width is relative gives the percentage a definite containing block, without disturbing the shrink-to-fit row an absolute width still wants.

An expanded input also now defaults to 100% wide rather than 600px, and its row is capped at the column so an over-wide absolute width shrinks with the window. Only the expanded row is capped: a word-sized input keeps the plain shrink-to-fit row it has always had, where a cap would let flex shrink the field below the width it was given. The textarea is `border-box` so that the authored width is the width of the box an author sees, and the cap subtracts the textarea's own horizontal margins, which sit outside the box and would otherwise let a full-width input overhang the column by exactly them. **The width of a word-sized (not `expanded`) input is unchanged at 100px**, and it is left on the shrink-to-fit row: it flows inline with the sentence around it, so there is no column there for a percentage to be a share of, and the docs tell an author to give it an absolute width.

On a `<graph>` neither applies. JSXGraph draws every text input as a one-line field, so `expanded` means nothing there — including the 100% width it now brings with it: the field floats in a shrink-to-fit box above the graph, which gives a percentage no column to be a share of. Any relative width falls back to the word-sized default there, whether it came from the `expanded` default or was written out, so an input on a graph is the same size however it is written (it used to be 600px when `expanded` was set, from the old default). An absolute width on a graph is honored as before.

## Check-work layout

With the input filling its column, a button beside it was squeezed against the right margin and its label wrapped onto a second line that `height: 24px` then clipped (measured: `scrollHeight` 31 against `clientHeight` 24).

- The button — and the `<description>` popover that travels with it — moves beneath an expanded input, where a non-inline `<choiceInput>` already puts the button.
- `min-height` replaces the fixed height, so a wrapped label grows the button anywhere it happens — a long translated label could run into this on any input.
- The full labelled button becomes the default for an expanded input. `forceFullCheckWorkButton` is no longer needed; `forceSmallCheckWorkButton`, which already existed and already flowed from `<answer>` down through `Input.js`, asks for the compact one.
- That default rule was written out three times across the renderers (`answer.tsx`, `choiceInput.tsx`, and now `textInput.tsx`), so it is now one documented helper, `wantsFullCheckWorkButton(SVs, fullByDefault)`, in `utils/checkWork.tsx`. Each caller passes only the shape question it can answer — `!SVs.inline`, `SVs.expanded`, `true` — and the precedence between the two `force…` attributes lives in one place.

## Explaining a size

Nothing told an author that `600` is pixels, that `6in` is read, or that a percentage is allowed — the reference table showed only the bare type name `componentSize`.

- **Context-sensitive help**: an "Accepted sizes" row keyed off the attribute's *type*, so all 15 attributes are covered and any added later are too. Each attribute is offered only the forms it honors, so the panel never names one to rule it out. A `textInput` width lists `600 · 600px · 6in · 450pt · 15cm · 50%`; a height lists the absolute five only, since the runtime accepts a percentage there and does nothing with it; a `<sideBySide>` or `<sbsGroup>` width lists `50%` only, since an absolute width there raises `side-by-side-absolute-widths` and is coerced to relative. The note under the chips follows the list, so it never claims a bare number is pixels where it isn't. The `width` of a `<graph>`, `<image>` or `<video>` is marked as choosing the nearest `size` preset rather than being used exactly (`width="400px"` and `width="50%"` both render 425px).
- **A size default reads as `120px`** instead of as the internal `{"size":120,"isAbsolute":true}`, via a formatter shared by the help panel and the docs attribute table. The component classes declare these defaults by hand and do not agree on the spelling — `<codeEditor>`'s width is `{ size: "100", isAbsolute: false }`, a string, where the rest use a number — so the detector accepts both; a unit test walks every `componentSize` default in the generated schema and asserts each one is recognized.
- **`width`'s description names its conditional default** ("Defaults to 100% when expanded, and to 100px otherwise"). That default is computed from `expanded` inside the state-variable definition, so the schema cannot carry it as a static `defaultValue`; putting it in the description reaches the reference table, the autocomplete dropdown and the help panel with no new machinery. The `width` *property*'s description is set to match, since the attribute and the property are listed side by side (`height` shares one description already, its attribute declaring `createStateVariable`).
- **Docs**: a Sizes section in Essential Concepts (unit table, relative sizes, and the two exceptions — the preset table for `<graph>`/`<image>`/`<video>`, and the percentage-only `<sideBySide>`/`<sbsGroup>`), linked from the eight reference pages that document one of these attributes.
- **Docs**: the `<answer>` reference pages said an answer with an input field "always" uses the small button by default; that is now stated for a word-sized input, with the block-shaped inputs (an expanded `<textInput>`, a non-inline `<choiceInput>`) named as taking the full button beneath. The hand-graded free-response example drops its `forceFullCheckWorkButton`, which is now what it gets anyway.

`em` being a multiple of 100% rather than font-relative, and an unrecognized unit being silently read as pixels (`width="300 furlongs"` → 300px), are both pre-existing and documented as callouts rather than changed. A value that begins with no number at all (`width="wide"`) yields `null` rather than the component's default — the attribute is dropped, not ignored — which the same callout now says, since `validateAttributeValue` passes the `null` straight through to the state variable.

## Not changed

- A percentage `height` still does nothing. It is simply not offered anywhere.
- An absolute `<sideBySide>` width still warns and coerces. It is simply not offered anywhere.
- `<sideBySide>`'s `widths` and `margins` get no "Accepted sizes" row. They are `_componentSizeList`, not `componentSize`; a list of sizes needs a different explanation than a single one, and the Sizes docs section covers them in prose.
- `<answer type="text" expanded/>` still renders a lone check-work button with no input. `skipFirstSugaredInput` in `Answer.js` drops a sugar-created input unless an award requires it or the answer is `handGraded`; that is intended, and a plain `<answer/>` behaves the same way.
- The help panel's preset note is set from the element name alone, which overstates one case: an `<image>` on a `<graph>` uses its width as given, against the graph's scale (`widthForGraph`), not snapped. The panel sees an attribute rather than where its element sits, and a graph caveat would be noise on the far commoner standalone image, so the exception is carried in the docs and in a comment on the payload type instead.
- `<embed>`, `<subsetOfRealsInput>` and `<discreteSimulationResultList>` also declare `componentSize` attributes, but all three are `excludeFromSchema`, so they reach neither the help panel nor the reference tables.

## Testing

- `computeContextHelp.test.ts`: 141 pass, 6 covering the size payload, the height and side-by-side filters, and the preset flag.
- `schema-help.test.ts` (`@doenet/static-assets`): 59 pass across the package, 1 new test walking every `componentSize` default in the generated schema through the detector and the formatter.
- `textinput.cy.js`: 16 pass, 7 new — sizing by `width`/`height`, relative width, the narrow-column cap (measured on the rendered edges, so the margins count, and including a labelled input, whose label shares the line the stretched row starts on), the stacked full-size button, `forceSmallCheckWorkButton`, a wrapped button label, and a graph input's size for each of the four ways a width can reach it.
- `contextSensitiveHelp.cy.js`: 11 pass, 3 new asserting the panel row renders live.
- Regression sweep, since the button rule and CSS are shared: `answer.cy.js` 34 pass and `choiceinput.cy.js` 26 pass against the extracted helper, plus `mathinput`, `matrixinput`, `booleaninput`, `fractioninput` and `mathEmbeddedInputs`.
- Also green: `lint:i18n`, `tsc --noEmit` on `@doenet/doenetml`, and prettier.

Each of the load-bearing assertions was confirmed to be a real guard by reverting the source line it covers (rebuilding for the Cypress ones) and watching that test — and only that test — fail: the textarea's width cap, the graph fallback, the height-only example filter, and the string-spelled size default. The button's `min-height` had *no* such guard: the original stacked-button test measured a button that never wraps, and passed unchanged with the fixed height restored. A test that squeezes the button into a narrow `<sideBySide>` column until "Submit Response" wraps replaces that assertion, and does fail (`clientHeight` 24 against `scrollHeight` 31) with `height: 24px` back.

## Filed, not fixed

Four behaviors this PR met and documented rather than changed:

- #1788 — `em` is read as a multiple of 100% rather than as a font-relative length; an unrecognized unit is silently read as pixels; a value not beginning with a number sets no size at all.
- #1789 — a percentage `height` is accepted everywhere and honored nowhere.
- #1790 — `<slider>` declares a `height` the renderer never reads. Raised by Copilot on this PR; the attribute has never had an effect, and this PR surfaces its units without special-casing it.
- #1791 — a percentage width on a word-sized `<textInput>` resolves circularly against its own shrink-to-fit row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f3t6w4cvNQvZJxjXsWXqr



