### PR TITLE
Let a hand-graded answer complete a cascade step

### DIFF
--- a/.changeset/cascade-hand-graded-progress.md
+++ b/.changeset/cascade-hand-graded-progress.md
@@ -1,0 +1,27 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+A `handGraded` answer no longer stops a `<cascade>`, and no longer holds a
+section's title banner gray.
+
+A hand-graded answer keeps a credit of 0 until an instructor grades it, which
+happens well after the reader is done with the document. A cascade step
+containing one therefore never reached full credit, and the reader was left
+there with no way forward however much they wrote.
+
+Such an answer now counts as complete as soon as the reader submits a response
+that is not blank; submitting an untouched input does not count. The same rule
+colors the title banner of a `boxed` or `collapsible` section, so a section
+whose questions have all been answered shows as completed rather than waiting
+for a grade the reader cannot see.
+
+The new `completedColorRequiresCredit` attribute opts a section's banner back
+into waiting for the real credit, and is inherited by the sections within it.
+It affects only the color, never when a cascade advances. Either way the
+reported `creditAchieved` is unchanged — a hand-graded answer is still awaiting
+its grade.

--- a/.changeset/cascade-hand-graded-progress.md
+++ b/.changeset/cascade-hand-graded-progress.md
@@ -15,10 +15,11 @@ containing one therefore never reached full credit, and the reader was left
 there with no way forward however much they wrote.
 
 Such an answer now counts as complete as soon as the reader submits a response
-that is not blank; submitting an untouched input does not count. The same rule
-colors the title banner of a `boxed` or `collapsible` section, so a section
-whose questions have all been answered shows as completed rather than waiting
-for a grade the reader cannot see.
+that is not blank; submitting an untouched input does not count, except for a
+`<booleanInput>`, whose unchecked box is itself an answer. The same rule colors
+the title banner of a `boxed` or `collapsible` section, so a section whose
+questions have all been answered shows as completed rather than waiting for a
+grade the reader cannot see.
 
 The new `completedColorRequiresCredit` attribute opts a section's banner back
 into waiting for the real credit, and is inherited by the sections within it.

--- a/packages/docs-nextra/pages/reference/answer2a.mdx
+++ b/packages/docs-nextra/pages/reference/answer2a.mdx
@@ -100,7 +100,8 @@ The answer scores no credit until then. Progress does not wait for the grade,
 though: a hand-graded answer counts as completed as soon as the student submits
 a response that is not blank, which is what advances a
 [`<cascade>{:dn}`](cascade) and colors a section's title banner. Submitting an
-untouched input does not count.
+untouched input does not count — except for a `<booleanInput>{:dn}`, where an
+unchecked box is itself an answer and so counts either way.
 
 ---
 

--- a/packages/docs-nextra/pages/reference/answer2a.mdx
+++ b/packages/docs-nextra/pages/reference/answer2a.mdx
@@ -96,6 +96,12 @@ For a multiple choice question, the `inline` attribute causes the choices to dis
 The `handGraded` attribute is applied when auto-grading is not possible or 
 preferred. The student's responses are stored for future grading.
 
+The answer scores no credit until then. Progress does not wait for the grade,
+though: a hand-graded answer counts as completed as soon as the student submits
+a response that is not blank, which is what advances a
+[`<cascade>{:dn}`](cascade) and colors a section's title banner. Submitting an
+untouched input does not count.
+
 ---
 
 ### Example: matchPartial

--- a/packages/docs-nextra/pages/reference/cascade.mdx
+++ b/packages/docs-nextra/pages/reference/cascade.mdx
@@ -39,8 +39,9 @@ The same rule colors the heading bar of a `boxed` or `collapsible` section, so a
 step whose questions have all been answered shows as completed rather than
 staying gray until an instructor gets to it. Set
 [`completedColorRequiresCredit`](section#attribute-example-completedcolorrequirescredit)
-on a section, or on any section around it, to have the bar wait for the real
-credit instead; that affects only the color, never when the cascade advances.
+on a section, or on any section that encloses it, to have the bar wait for the
+real credit instead; that affects only the color, never when the cascade
+advances.
 
 
 <AttrPropDisplay name='cascade'/>

--- a/packages/docs-nextra/pages/reference/cascade.mdx
+++ b/packages/docs-nextra/pages/reference/cascade.mdx
@@ -26,19 +26,21 @@ into its own, and the cascade would have no way to tell when the child is
 "done". You therefore do not need to set `aggregateScores` by hand on
 cascade children.
 
-A `handGraded` [`<answer>{:dn}`](answer1) is the one exception to "answered
-correctly". Its credit stays at 0 until an instructor grades it, which happens
-long after the learner has moved on, so a cascade would otherwise stop there for
-good. Instead, such an answer counts as completed as soon as the learner submits
-a response that is not blank — submitting an untouched input does not count. The
-answer's actual `creditAchieved` is unchanged; it is still awaiting a grade.
+A `handGraded` [`<answer>{:dn}`](answer2a#example-handgraded) is the one
+exception to "answered correctly". Its credit stays at 0 until an instructor
+grades it, which happens long after the learner has moved on, so a cascade would
+otherwise stop there for good. Instead, such an answer counts as completed as
+soon as the learner submits a response that is not blank — submitting an
+untouched input does not count, except for a `<booleanInput>{:dn}`, whose
+unchecked box is itself an answer. The answer's actual `creditAchieved` is
+unchanged; it is still awaiting a grade.
 
 The same rule colors the heading bar of a `boxed` or `collapsible` section, so a
 step whose questions have all been answered shows as completed rather than
 staying gray until an instructor gets to it. Set
-[`completedColorRequiresCredit`](section) on a section, or on any section around
-it, to have the bar wait for the real credit instead; that affects only the
-color, never when the cascade advances.
+[`completedColorRequiresCredit`](section#attribute-example-completedcolorrequirescredit)
+on a section, or on any section around it, to have the bar wait for the real
+credit instead; that affects only the color, never when the cascade advances.
 
 
 <AttrPropDisplay name='cascade'/>

--- a/packages/docs-nextra/pages/reference/cascade.mdx
+++ b/packages/docs-nextra/pages/reference/cascade.mdx
@@ -26,6 +26,20 @@ into its own, and the cascade would have no way to tell when the child is
 "done". You therefore do not need to set `aggregateScores` by hand on
 cascade children.
 
+A `handGraded` [`<answer>{:dn}`](answer1) is the one exception to "answered
+correctly". Its credit stays at 0 until an instructor grades it, which happens
+long after the learner has moved on, so a cascade would otherwise stop there for
+good. Instead, such an answer counts as completed as soon as the learner submits
+a response that is not blank — submitting an untouched input does not count. The
+answer's actual `creditAchieved` is unchanged; it is still awaiting a grade.
+
+The same rule colors the heading bar of a `boxed` or `collapsible` section, so a
+step whose questions have all been answered shows as completed rather than
+staying gray until an instructor gets to it. Set
+[`completedColorRequiresCredit`](section) on a section, or on any section around
+it, to have the bar wait for the real credit instead; that affects only the
+color, never when the cascade advances.
+
 
 <AttrPropDisplay name='cascade'/>
 

--- a/packages/docs-nextra/pages/reference/section.mdx
+++ b/packages/docs-nextra/pages/reference/section.mdx
@@ -293,17 +293,19 @@ will instead be colored according to its own answer's correctness.
 
 
 
-A [`handGraded`](answer1) `<answer>{:dn}` scores no credit until an instructor
-grades it, which happens after the learner has finished. By default the title
-banner does not wait for that: such an answer counts as completed as soon as the
-learner submits a response that is not blank, so answering both questions above
-turns the first banner green.
+A [`handGraded`](answer2a#example-handgraded) `<answer>{:dn}` scores no credit
+until an instructor grades it, which happens after the learner has finished. By
+default the title banner does not wait for that: such an answer counts as
+completed as soon as the learner submits a response that is not blank, so
+answering both questions above turns the first banner green.
 
-The `completedColorRequiresCredit` attribute opts out, and the second banner
-stays in its in-progress color until the hand-graded answer has actually been
-given credit. It is inherited by the sections within, so setting it once on an
-enclosing section applies it throughout. Either way the reported
-`creditAchieved` is the same — only the color differs.
+The `completedColorRequiresCredit` attribute opts out, and the second banner does
+not reach its completed color until the hand-graded answer has actually been
+given credit — here it stays in the in-progress color, since the other answer is
+right. It is inherited by the sections within, so setting it once on an enclosing
+section applies it throughout. Either way the reported `creditAchieved` is the
+same — only the color differs, never when a [`<cascade>{:dn}`](cascade)
+advances.
 
 
 ---

--- a/packages/docs-nextra/pages/reference/section.mdx
+++ b/packages/docs-nextra/pages/reference/section.mdx
@@ -303,13 +303,15 @@ default the title banner does not wait for that: such an answer counts as
 completed as soon as the learner submits a response that is not blank, so
 answering both questions above turns the first banner green.
 
-The `completedColorRequiresCredit` attribute opts out, and the second banner does
-not reach its completed color until the hand-graded answer has actually been
-given credit — here it stays in the in-progress color, since the other answer is
-right. It is inherited by the sections within, so setting it once on an enclosing
-section applies it throughout. Either way the reported `creditAchieved` is the
-same — only the color differs, never when a [`<cascade>{:dn}`](cascade)
-advances.
+The second section sets `completedColorRequiresCredit`, which opts out of that.
+Its banner stays gray no matter what the learner submits, and turns green only
+once an instructor has given the hand-graded answer credit. The attribute is
+inherited by every section nested inside the one that sets it, so an instructor
+who wants this throughout an activity can set it once on the outermost section.
+
+The attribute changes the color and nothing else. Both sections report the same
+`creditAchieved`, and in a [`<cascade>{:dn}`](cascade) both would reveal the next
+step alike.
 
 Both sections above set `aggregateScores`, without which a plain
 `<section>{:dn}` does not roll up the credit of the answers it contains and so

--- a/packages/docs-nextra/pages/reference/section.mdx
+++ b/packages/docs-nextra/pages/reference/section.mdx
@@ -278,16 +278,20 @@ will instead be colored according to its own answer's correctness.
 
 
 ```doenet-example
-<section boxed name="lenient">
+<section boxed aggregateScores name="lenient">
   <title>Colored once answered</title>
-  <p>What is <m>1+1</m>? <answer>2</answer></p>
-  <p>Explain your reasoning. <answer handGraded type="text" /></p>
+  <p><answer><label>What is <m>1+1</m>?</label>2</answer></p>
+  <p><answer handGraded type="text">
+    <label>Explain your reasoning.</label>
+  </answer></p>
 </section>
 
-<section boxed completedColorRequiresCredit name="strict">
+<section boxed aggregateScores completedColorRequiresCredit name="strict">
   <title>Colored once graded</title>
-  <p>What is <m>1+1</m>? <answer>2</answer></p>
-  <p>Explain your reasoning. <answer handGraded type="text" /></p>
+  <p><answer><label>What is <m>1+1</m>?</label>2</answer></p>
+  <p><answer handGraded type="text">
+    <label>Explain your reasoning.</label>
+  </answer></p>
 </section>
 ```
 
@@ -306,6 +310,12 @@ right. It is inherited by the sections within, so setting it once on an enclosin
 section applies it throughout. Either way the reported `creditAchieved` is the
 same — only the color differs, never when a [`<cascade>{:dn}`](cascade)
 advances.
+
+Both sections above set `aggregateScores`, without which a plain
+`<section>{:dn}` does not roll up the credit of the answers it contains and so
+never leaves its not-started color. A `<cascade>{:dn}` turns that on for its
+children automatically, and `<problem>{:dn}` and `<exercise>{:dn}` have it on by
+default, so it is only a plain section that needs it spelled out.
 
 
 ---

--- a/packages/docs-nextra/pages/reference/section.mdx
+++ b/packages/docs-nextra/pages/reference/section.mdx
@@ -316,8 +316,10 @@ step alike.
 Both sections above set `aggregateScores`, without which a plain
 `<section>{:dn}` does not roll up the credit of the answers it contains and so
 never leaves its not-started color. A `<cascade>{:dn}` turns that on for its
-children automatically, and `<problem>{:dn}` and `<exercise>{:dn}` have it on by
-default, so it is only a plain section that needs it spelled out.
+children automatically, and the problem-flavored sections — `<problem>{:dn}`,
+`<exercise>{:dn}`, `<question>{:dn}` and `<activity>{:dn}` — have it on by
+default. Everywhere else, `<section>{:dn}` and `<aside>{:dn}` and the rest, it
+has to be spelled out.
 
 
 ---

--- a/packages/docs-nextra/pages/reference/section.mdx
+++ b/packages/docs-nextra/pages/reference/section.mdx
@@ -274,6 +274,40 @@ will instead be colored according to its own answer's correctness.
 
 ---
 
+### Attribute Example: completedColorRequiresCredit
+
+
+```doenet-example
+<section boxed name="lenient">
+  <title>Colored once answered</title>
+  <p>What is <m>1+1</m>? <answer>2</answer></p>
+  <p>Explain your reasoning. <answer handGraded type="text" /></p>
+</section>
+
+<section boxed completedColorRequiresCredit name="strict">
+  <title>Colored once graded</title>
+  <p>What is <m>1+1</m>? <answer>2</answer></p>
+  <p>Explain your reasoning. <answer handGraded type="text" /></p>
+</section>
+```
+
+
+
+A [`handGraded`](answer1) `<answer>{:dn}` scores no credit until an instructor
+grades it, which happens after the learner has finished. By default the title
+banner does not wait for that: such an answer counts as completed as soon as the
+learner submits a response that is not blank, so answering both questions above
+turns the first banner green.
+
+The `completedColorRequiresCredit` attribute opts out, and the second banner
+stays in its in-progress color until the hand-graded answer has actually been
+given credit. It is inherited by the sections within, so setting it once on an
+enclosing section applies it throughout. Either way the reported
+`creditAchieved` is the same — only the color differs.
+
+
+---
+
 ### Attribute Example: boxed
 
 

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -95,18 +95,25 @@ export default class Cascade extends SectioningComponent {
             definition: () => ({ setValue: { childrenAggregateScores: true } }),
         };
 
+        // Progress reads `creditAchievedForProgress` rather than
+        // `creditAchieved`, and the two differ in exactly one place: a
+        // hand-graded answer. Its `creditAchieved` stays 0 until an instructor
+        // grades it, long after the reader has moved on, so scoring the cascade
+        // on it would strand the reader at that step for good. Progress counts
+        // such an answer as correct once the reader has actually responded.
         stateVariableDefinitions.childCreditAchieved = {
             returnDependencies: () => ({
                 children: {
                     dependencyType: "child",
                     childGroups: ["anything"],
-                    variableNames: ["creditAchieved"],
+                    variableNames: ["creditAchievedForProgress"],
                     variablesOptional: true,
                 },
             }),
             definition({ dependencyValues }) {
                 const childCreditAchieved = dependencyValues.children.map(
-                    (child) => child.stateValues?.creditAchieved ?? null,
+                    (child) =>
+                        child.stateValues?.creditAchievedForProgress ?? null,
                 );
 
                 return { setValue: { childCreditAchieved } };

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -151,6 +151,12 @@ export default class Document extends BaseComponent {
         // state variable.
         delete stateVariableDefinitions.aggregateScores;
 
+        // `creditAchievedForProgress` exists so a `<cascade>` can ask whether a
+        // step is complete. A document is never a step of one, and the shared
+        // definition is written against the `aggregateScores` just deleted, so
+        // it goes too rather than being overridden the way `creditAchieved` is.
+        delete stateVariableDefinitions.creditAchievedForProgress;
+
         // The shared submit labels read the *enclosing* document's language,
         // which is right for everything inside a document and wrong for the
         // document itself: an ancestor dependency skips the component it runs

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -1197,11 +1197,17 @@ export class SectioningComponent extends BlockComponent {
                 // is to the nearest *ancestor* carrying the variable, the way
                 // `showCorrectness` resolves — unlike the colors themselves,
                 // which read only their immediate parent section.
-                let completedColorRequiresCredit = false;
-                if (!usedDefault.completedColorRequiresCreditPreliminary) {
-                    completedColorRequiresCredit =
-                        dependencyValues.completedColorRequiresCreditPreliminary;
-                } else if (
+                //
+                // Start from the attribute's own value rather than restating
+                // its default here, so the default lives in exactly one place:
+                // the attribute's `defaultValue`. Written the other way the two
+                // could drift apart unnoticed, which is a real risk on a base
+                // class this many components extend and override attributes on.
+                let completedColorRequiresCredit =
+                    dependencyValues.completedColorRequiresCreditPreliminary;
+
+                if (
+                    usedDefault.completedColorRequiresCreditPreliminary &&
                     dependencyValues.completedColorRequiresCreditAncestor
                 ) {
                     completedColorRequiresCredit =

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -1207,13 +1207,7 @@ export class SectioningComponent extends BlockComponent {
                             .stateValues.completedColorRequiresCredit;
                 }
 
-                return {
-                    setValue: {
-                        completedColorRequiresCredit: Boolean(
-                            completedColorRequiresCredit,
-                        ),
-                    },
-                };
+                return { setValue: { completedColorRequiresCredit } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -278,7 +278,7 @@ export class SectioningComponent extends BlockComponent {
             // enclosing section before reaching it.
             defaultValue: false,
             description:
-                "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
         };
 
         attributes.inProgressColor = {
@@ -1175,7 +1175,7 @@ export class SectioningComponent extends BlockComponent {
 
         stateVariableDefinitions.completedColorRequiresCredit = {
             description:
-                "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it.",
+                "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "boolean",
@@ -1192,9 +1192,11 @@ export class SectioningComponent extends BlockComponent {
             }),
             definition({ dependencyValues, usedDefault }) {
                 // Set once on an enclosing section and every section within it
-                // follows, the way the colors themselves inherit — an
-                // instructor who wants graded coloring wants it for the whole
-                // activity, not one section at a time.
+                // follows: an instructor who wants graded coloring wants it for
+                // the whole activity, not one section at a time. The fallback
+                // is to the nearest *ancestor* carrying the variable, the way
+                // `showCorrectness` resolves — unlike the colors themselves,
+                // which read only their immediate parent section.
                 let completedColorRequiresCredit = false;
                 if (!usedDefault.completedColorRequiresCreditPreliminary) {
                     completedColorRequiresCredit =

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -262,6 +262,25 @@ export class SectioningComponent extends BlockComponent {
                 "Color used to indicate this section has been completed.",
         };
 
+        // Whether the heading bar waits for a grade. The completion states are
+        // driven by `creditAchievedForProgress`, which counts a `handGraded`
+        // answer as correct once the reader has responded — a bar that stayed
+        // gray until an instructor got to it would withhold the reward for work
+        // the reader has finished, and they have no way to tell the two apart.
+        // An instructor who wants the bar to mean "graded and correct" sets
+        // this, and the real `creditAchieved` drives the states instead.
+        attributes.completedColorRequiresCredit = {
+            createComponentOfType: "boolean",
+            createStateVariable: "completedColorRequiresCreditPreliminary",
+            // See the note on `showCorrectness` in
+            // `returnScoredSectionAttributes`: this default is shown to authors
+            // but is not what resolves the value, which falls back to the
+            // enclosing section before reaching it.
+            defaultValue: false,
+            description:
+                "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+        };
+
         attributes.inProgressColor = {
             createComponentOfType: "text",
             createStateVariable: "inProgressColor",
@@ -1154,6 +1173,50 @@ export class SectioningComponent extends BlockComponent {
             },
         };
 
+        stateVariableDefinitions.completedColorRequiresCredit = {
+            description:
+                "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                completedColorRequiresCreditPreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "completedColorRequiresCreditPreliminary",
+                },
+                completedColorRequiresCreditAncestor: {
+                    dependencyType: "ancestor",
+                    variableNames: ["completedColorRequiresCredit"],
+                },
+            }),
+            definition({ dependencyValues, usedDefault }) {
+                // Set once on an enclosing section and every section within it
+                // follows, the way the colors themselves inherit — an
+                // instructor who wants graded coloring wants it for the whole
+                // activity, not one section at a time.
+                let completedColorRequiresCredit = false;
+                if (!usedDefault.completedColorRequiresCreditPreliminary) {
+                    completedColorRequiresCredit =
+                        dependencyValues.completedColorRequiresCreditPreliminary;
+                } else if (
+                    dependencyValues.completedColorRequiresCreditAncestor
+                ) {
+                    completedColorRequiresCredit =
+                        dependencyValues.completedColorRequiresCreditAncestor
+                            .stateValues.completedColorRequiresCredit;
+                }
+
+                return {
+                    setValue: {
+                        completedColorRequiresCredit: Boolean(
+                            completedColorRequiresCredit,
+                        ),
+                    },
+                };
+            },
+        };
+
         stateVariableDefinitions.sectionTitleStateColors = {
             additionalStateVariablesDefined: [
                 "sectionTitleStateColorsDarkMode",
@@ -1309,6 +1372,14 @@ export class SectioningComponent extends BlockComponent {
                     dependencyType: "stateVariable",
                     variableName: "creditAchieved",
                 },
+                creditAchievedForProgress: {
+                    dependencyType: "stateVariable",
+                    variableName: "creditAchievedForProgress",
+                },
+                completedColorRequiresCredit: {
+                    dependencyType: "stateVariable",
+                    variableName: "completedColorRequiresCredit",
+                },
                 boxed: {
                     dependencyType: "stateVariable",
                     variableName: "boxed",
@@ -1319,8 +1390,13 @@ export class SectioningComponent extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
+                // The two differ only where a `handGraded` answer is involved;
+                // see `completedColorRequiresCredit` above for which is right
+                // when.
                 const titleStateKey = titleStateKeyFromCredit(
-                    dependencyValues.creditAchieved,
+                    dependencyValues.completedColorRequiresCredit
+                        ? dependencyValues.creditAchieved
+                        : dependencyValues.creditAchievedForProgress,
                 );
                 const titleColor =
                     dependencyValues.sectionTitleStateColors[titleStateKey];

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -2722,4 +2722,52 @@ describe("Cascade tag tests @group4", async () => {
         expect(stateVariables[wIdx].stateValues.numCompleted).eq(2);
         expect(stateVariables[booleanAnsIdx].stateValues.creditAchieved).eq(0);
     });
+
+    // `completedColorRequiresCredit` is about the heading bar only. A cascade
+    // that stopped advancing because a section was colored strictly would trap
+    // the reader again, which is the whole thing this is meant to prevent.
+    it("completedColorRequiresCredit does not hold back a cascade", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w" completedColorRequiresCredit>
+  <section name="section1" boxed completedColor="blue" inProgressColor="cyan" notStartedColor="beige">
+    <p name="p">Explain your reasoning. <answer handGraded name="ans" type="text" /></p>
+  </section>
+
+  <section name="section2">
+    <p name="p">What is 1+1? <answer name="ans">2</answer></p>
+  </section>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const section1Idx = await resolvePathToNodeIdx("section1");
+        const section2Idx = await resolvePathToNodeIdx("section2");
+        const ansIdx = await resolvePathToNodeIdx("section1.p.ans");
+
+        let stateVariables = await getStateVariables(core);
+        const textInputIdx =
+            stateVariables[ansIdx].stateValues.inputChildren[0].componentIdx;
+
+        // Inherited from the cascade, which is itself a section.
+        expect(
+            stateVariables[section1Idx].stateValues
+                .completedColorRequiresCredit,
+        ).eq(true);
+
+        await updateTextInputValue({
+            text: "because it is",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: ansIdx, core });
+
+        stateVariables = await getStateVariables(core);
+
+        // The step is complete and the next one is revealed, even though the
+        // bar is still waiting for the grade.
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+        expect(stateVariables[section2Idx].stateValues.hideChildren).eq(false);
+        expect(stateVariables[section1Idx].stateValues.titleColor).eq("beige");
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -2663,4 +2663,63 @@ describe("Cascade tag tests @group4", async () => {
         stateVariables = await getStateVariables(core);
         expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
     });
+
+    // The two inputs with no placeholder of their own. An unselected
+    // `<choiceInput>` submits no response value at all, whereas an unchecked
+    // `<booleanInput>` submits `false` — indistinguishable from the reader
+    // deliberately leaving the box unchecked, so it counts as an answer.
+    it("a choice must be chosen, but an unchecked box is already an answer", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section name="section1">
+    <p name="p">Pick one.
+      <answer handGraded name="ans">
+        <choiceInput name="ci"><choice>a</choice><choice>b</choice></choiceInput>
+      </answer>
+    </p>
+  </section>
+
+  <section name="section2">
+    <p name="p">Agree?
+      <answer handGraded name="ans">
+        <booleanInput name="bi" />
+        <award><boolean>true</boolean></award>
+      </answer>
+    </p>
+  </section>
+
+  <section name="section3">
+    <p name="p">What is 1+1? <answer name="ans">2</answer></p>
+  </section>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const choiceAnsIdx = await resolvePathToNodeIdx("section1.p.ans");
+        const choiceInputIdx = await resolvePathToNodeIdx("section1.p.ans.ci");
+        const booleanAnsIdx = await resolvePathToNodeIdx("section2.p.ans");
+
+        await submitAnswer({ componentIdx: choiceAnsIdx, core });
+
+        let stateVariables = await getStateVariables(core);
+        expect(
+            stateVariables[choiceAnsIdx].stateValues.submittedResponses,
+        ).eqls([]);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(0);
+
+        await updateSelectedIndices({
+            componentIdx: choiceInputIdx,
+            selectedIndices: [2],
+            core,
+        });
+        await submitAnswer({ componentIdx: choiceAnsIdx, core });
+
+        // The box is left alone, and submitting it as it stands is an answer.
+        await submitAnswer({ componentIdx: booleanAnsIdx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(2);
+        expect(stateVariables[booleanAnsIdx].stateValues.creditAchieved).eq(0);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -4,6 +4,7 @@ import {
     submitAnswer,
     updateMathInputValue,
     updateSelectedIndices,
+    updateTextInputValue,
 } from "../utils/actions";
 
 const Mock = vi.fn();
@@ -2406,5 +2407,214 @@ describe("Cascade tag tests @group4", async () => {
         expect(stateVariables[lead2Idx].stateValues.renderInlineForListItem).eq(
             true,
         );
+    });
+
+    // A hand-graded answer's `creditAchieved` stays 0 until an instructor grades
+    // it, which happens outside the document entirely. Scoring the cascade on it
+    // would leave the reader stuck at that step no matter what they wrote, so
+    // progress asks instead whether they actually responded.
+    it("a hand-graded answer completes a step once a non-blank response is submitted", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section name="section1">
+    <p name="p">What is 1+1? <answer name="ans">2</answer></p>
+  </section>
+
+  <section name="section2">
+    <p name="p">Explain your reasoning. <answer handGraded name="ans" type="text" /></p>
+  </section>
+
+  <section name="section3">
+    <p name="p">What is 3-4? <answer name="ans">-1</answer></p>
+  </section>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const section2Idx = await resolvePathToNodeIdx("section2");
+        const section3Idx = await resolvePathToNodeIdx("section3");
+        const ans1Idx = await resolvePathToNodeIdx("section1.p.ans");
+        const ans2Idx = await resolvePathToNodeIdx("section2.p.ans");
+        const ans3Idx = await resolvePathToNodeIdx("section3.p.ans");
+
+        let stateVariables = await getStateVariables(core);
+        const mathInput1Idx = getMathInputIdx(stateVariables, ans1Idx);
+        const textInputIdx =
+            stateVariables[ans2Idx].stateValues.inputChildren[0].componentIdx;
+        const mathInput3Idx = getMathInputIdx(stateVariables, ans3Idx);
+
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(0);
+
+        await submitMathAnswer({
+            core,
+            latex: "2",
+            mathInputIdx: mathInput1Idx,
+            answerIdx: ans1Idx,
+        });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+        expect(stateVariables[section3Idx].stateValues.hideChildren).eq(true);
+
+        // Submitting an untouched input is not a response, so the step stays put.
+        await submitAnswer({ componentIdx: ans2Idx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[ans2Idx].stateValues.responseHasBeenSubmitted).eq(
+            true,
+        );
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+        expect(stateVariables[section3Idx].stateValues.hideChildren).eq(true);
+
+        // Nor is whitespace. The response is recorded exactly as typed, so it
+        // is the blankness test that has to trim rather than the input.
+        await updateTextInputValue({
+            text: "   ",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: ans2Idx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[ans2Idx].stateValues.submittedResponses).eqls([
+            "   ",
+        ]);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+        expect(stateVariables[section3Idx].stateValues.hideChildren).eq(true);
+
+        await updateTextInputValue({
+            text: "because it is",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: ans2Idx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(2);
+        expect(stateVariables[section3Idx].stateValues.hideChildren).eq(false);
+
+        // The score itself is untouched: the answer is still awaiting grading.
+        expect(stateVariables[ans2Idx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[section2Idx].stateValues.creditAchieved).eq(0);
+
+        await submitMathAnswer({
+            core,
+            latex: "-1",
+            mathInputIdx: mathInput3Idx,
+            answerIdx: ans3Idx,
+        });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(3);
+
+        // Clearing the response takes the step back: what the cascade tracks is
+        // the response standing now, not that one was submitted at some point.
+        await updateTextInputValue({
+            text: "",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: ans2Idx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+    });
+
+    // The same rule for a math response, where "blank" is the placeholder an
+    // empty `<mathInput>` submits rather than an empty string.
+    it("a blank math response does not complete a hand-graded step", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section name="section1">
+    <p name="p">Show your work. <answer handGraded name="ans" /></p>
+  </section>
+
+  <section name="section2">
+    <p name="p">What is 1+1? <answer name="ans">2</answer></p>
+  </section>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const ansIdx = await resolvePathToNodeIdx("section1.p.ans");
+
+        let stateVariables = await getStateVariables(core);
+        const mathInputIdx = getMathInputIdx(stateVariables, ansIdx);
+
+        await submitAnswer({ componentIdx: ansIdx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(0);
+
+        await submitMathAnswer({
+            core,
+            latex: "x+1",
+            mathInputIdx,
+            answerIdx: ansIdx,
+        });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+        expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(0);
+    });
+
+    // A step that mixes the two kinds of answer is complete only when both are:
+    // the hand-graded one contributes its full weight once answered, so the
+    // auto-graded one still has to be right.
+    it("a hand-graded answer alongside an auto-graded one", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section name="section1">
+    <p name="p1">What is 1+1? <answer name="ans">2</answer></p>
+    <p name="p2">Why? <answer handGraded name="ans" type="text" /></p>
+  </section>
+
+  <section name="section2">
+    <p name="p">What is 3-4? <answer name="ans">-1</answer></p>
+  </section>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const autoIdx = await resolvePathToNodeIdx("section1.p1.ans");
+        const handIdx = await resolvePathToNodeIdx("section1.p2.ans");
+
+        let stateVariables = await getStateVariables(core);
+        const mathInputIdx = getMathInputIdx(stateVariables, autoIdx);
+        const textInputIdx =
+            stateVariables[handIdx].stateValues.inputChildren[0].componentIdx;
+
+        await updateTextInputValue({
+            text: "it just is",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: handIdx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(0);
+
+        await submitMathAnswer({
+            core,
+            latex: "3",
+            mathInputIdx,
+            answerIdx: autoIdx,
+        });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(0);
+
+        await submitMathAnswer({
+            core,
+            latex: "2",
+            mathInputIdx,
+            answerIdx: autoIdx,
+        });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -3,6 +3,7 @@ import { createTestCore } from "../utils/test-core";
 import {
     submitAnswer,
     updateMathInputValue,
+    updateMatrixInputValue,
     updateSelectedIndices,
     updateTextInputValue,
 } from "../utils/actions";
@@ -2554,6 +2555,51 @@ describe("Cascade tag tests @group4", async () => {
             mathInputIdx,
             answerIdx: ansIdx,
         });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);
+        expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(0);
+    });
+
+    // An untouched `<matrixInput>` submits a matrix of placeholders rather than
+    // a bare one, so the blankness test has to look inside the matrix.
+    it("a blank matrix response does not complete a hand-graded step", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section name="section1">
+    <p name="p">Write the matrix.
+      <answer handGraded name="ans">
+        <matrixInput name="mi" numRows="2" numColumns="2" />
+        <award><matrix><row>1 2</row><row>3 4</row></matrix></award>
+      </answer>
+    </p>
+  </section>
+
+  <section name="section2">
+    <p name="p">What is 1+1? <answer name="ans">2</answer></p>
+  </section>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const ansIdx = await resolvePathToNodeIdx("section1.p.ans");
+        const matrixInputIdx = await resolvePathToNodeIdx("section1.p.ans.mi");
+
+        await submitAnswer({ componentIdx: ansIdx, core });
+
+        let stateVariables = await getStateVariables(core);
+        expect(stateVariables[wIdx].stateValues.numCompleted).eq(0);
+
+        // One filled cell is a response, even though the rest stay blank.
+        await updateMatrixInputValue({
+            latex: "5",
+            componentIdx: matrixInputIdx,
+            rowInd: 1,
+            colInd: 0,
+            core,
+        });
+        await submitAnswer({ componentIdx: ansIdx, core });
 
         stateVariables = await getStateVariables(core);
         expect(stateVariables[wIdx].stateValues.numCompleted).eq(1);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -2770,4 +2770,62 @@ describe("Cascade tag tests @group4", async () => {
         expect(stateVariables[section2Idx].stateValues.hideChildren).eq(false);
         expect(stateVariables[section1Idx].stateValues.titleColor).eq("beige");
     });
+
+    // A reader who closes the page and comes back has to find the step still
+    // open. `creditAchievedForProgress` is recomputed rather than saved — only
+    // `responseHasBeenSubmitted` and `submittedResponses` are essential — so
+    // what is restored has to be enough to rebuild it. For an auto-graded
+    // answer the restored `creditAchieved` carries the progress directly, and
+    // this is the case where it cannot.
+    it("hand-graded progress survives a reload", async () => {
+        const doenetML = `
+<cascade name="w">
+  <section name="section1">
+    <p name="p">Explain your reasoning. <answer handGraded name="ans" type="text" /></p>
+  </section>
+
+  <section name="section2">
+    <p name="p">What is 1+1? <answer name="ans">2</answer></p>
+  </section>
+</cascade>`;
+
+        let { core, resolvePathToNodeIdx, scoreState } = await createTestCore({
+            doenetML,
+        });
+
+        const ansIdx = await resolvePathToNodeIdx("section1.p.ans");
+        let stateVariables = await getStateVariables(core);
+        const textInputIdx =
+            stateVariables[ansIdx].stateValues.inputChildren[0].componentIdx;
+
+        await updateTextInputValue({
+            text: "because it is",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: ansIdx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("w")].stateValues
+                .numCompleted,
+        ).eq(1);
+
+        await core.saveImmediately();
+
+        ({ core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+            initialState: scoreState.state,
+        }));
+
+        stateVariables = await getStateVariables(core);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("w")].stateValues
+                .numCompleted,
+        ).eq(1);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("section2")].stateValues
+                .hideChildren,
+        ).eq(false);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1597,6 +1597,12 @@ describe("Sectioning tag tests @group3", async () => {
 
         <p>Why? <answer handGraded name="ans" type="text" /></p>
       </exercise>
+
+      <exercise name="optedOut" completedColorRequiresCredit="false" boxed notStartedColor="beige" inProgressColor="cyan" completedColor="blue">
+        <title>An exercise that opts back out</title>
+
+        <p>Why? <answer handGraded name="ans" type="text" /></p>
+      </exercise>
     </section>
 
     <exercise name="loose" boxed notStartedColor="beige" inProgressColor="cyan" completedColor="blue">
@@ -1609,8 +1615,10 @@ describe("Sectioning tag tests @group3", async () => {
 
         const exerIdx = await resolvePathToNodeIdx("exer");
         const looseIdx = await resolvePathToNodeIdx("loose");
+        const optedOutIdx = await resolvePathToNodeIdx("optedOut");
         const strictAnswerIdx = await resolvePathToNodeIdx("exer.ans");
         const looseAnswerIdx = await resolvePathToNodeIdx("loose.ans");
+        const optedOutAnswerIdx = await resolvePathToNodeIdx("optedOut.ans");
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
@@ -1622,9 +1630,19 @@ describe("Sectioning tag tests @group3", async () => {
             stateVariables[looseIdx].stateValues.completedColorRequiresCredit,
         ).eq(false);
 
+        // An explicit value wins over an inheriting ancestor, in the direction
+        // that returns to the default as well as away from it. This is what the
+        // `usedDefault` guard buys: without it the ancestor would overwrite a
+        // value the author wrote out.
+        expect(
+            stateVariables[optedOutIdx].stateValues
+                .completedColorRequiresCredit,
+        ).eq(false);
+
         for (const [answerIdx, sectionIdx] of [
             [strictAnswerIdx, exerIdx],
             [looseAnswerIdx, looseIdx],
+            [optedOutAnswerIdx, optedOutIdx],
         ]) {
             const textInputIdx =
                 stateVariables[answerIdx].stateValues.inputChildren[0]
@@ -1642,8 +1660,10 @@ describe("Sectioning tag tests @group3", async () => {
         // Same response, same ungraded score, opposite bars.
         expect(stateVariables[exerIdx].stateValues.titleColor).eq("beige");
         expect(stateVariables[looseIdx].stateValues.titleColor).eq("blue");
+        expect(stateVariables[optedOutIdx].stateValues.titleColor).eq("blue");
         expect(stateVariables[exerIdx].stateValues.creditAchieved).eq(0);
         expect(stateVariables[looseIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[optedOutIdx].stateValues.creditAchieved).eq(0);
     });
 
     // Mirrors the `completedColorRequiresCredit` example on the `<section>`

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -8,6 +8,7 @@ import {
     submitAnswer,
     updateBooleanInputValue,
     updateMathInputValue,
+    updateTextInputValue,
 } from "../utils/actions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
 
@@ -1522,6 +1523,127 @@ describe("Sectioning tag tests @group3", async () => {
         });
         await submitAnswer({ componentIdx: answer1Idx, core });
         await check_values(0.5);
+    });
+
+    // A hand-graded answer scores 0 until an instructor gets to it, which is
+    // long after the reader has finished. The bar reflects what the reader can
+    // act on, so by default it goes green once they have answered everything.
+    it("title color counts a hand-graded answer as completed once answered", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <exercise name="exer" boxed notStartedColor="beige" inProgressColor="cyan" completedColor="blue">
+      <title>An exercise</title>
+
+      <p>1+1=<answer name="ans1">2</answer></p>
+      <p>Why? <answer handGraded name="ans2" type="text" /></p>
+    </exercise>
+    `,
+        });
+
+        const exerIdx = await resolvePathToNodeIdx("exer");
+        const answer1Idx = await resolvePathToNodeIdx("ans1");
+        const answer2Idx = await resolvePathToNodeIdx("ans2");
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        const mathInputIdx =
+            stateVariables[answer1Idx].stateValues.inputChildren[0]
+                .componentIdx;
+        const textInputIdx =
+            stateVariables[answer2Idx].stateValues.inputChildren[0]
+                .componentIdx;
+
+        expect(stateVariables[exerIdx].stateValues.titleColor).eq("beige");
+
+        await updateMathInputValue({
+            latex: "2",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answer1Idx, core });
+
+        // Half the answers are done, so the bar is in progress either way.
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[exerIdx].stateValues.titleColor).eq("cyan");
+
+        // An untouched input is not an answer, so it does not finish the bar.
+        await submitAnswer({ componentIdx: answer2Idx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[exerIdx].stateValues.titleColor).eq("cyan");
+
+        await updateTextInputValue({
+            text: "because it is",
+            componentIdx: textInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answer2Idx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[exerIdx].stateValues.titleColor).eq("blue");
+
+        // The score itself is still half, awaiting the grade.
+        expect(stateVariables[exerIdx].stateValues.creditAchieved).eq(0.5);
+    });
+
+    // The opt-out, for an instructor who wants the bar to mean "graded and
+    // correct". It inherits, so setting it on the enclosing section covers
+    // every section within.
+    it("completedColorRequiresCredit holds the bar until the grade arrives", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <section name="outer" completedColorRequiresCredit>
+      <exercise name="exer" boxed notStartedColor="beige" inProgressColor="cyan" completedColor="blue">
+        <title>An exercise</title>
+
+        <p>Why? <answer handGraded name="ans" type="text" /></p>
+      </exercise>
+    </section>
+
+    <exercise name="loose" boxed notStartedColor="beige" inProgressColor="cyan" completedColor="blue">
+      <title>Another exercise</title>
+
+      <p>Why? <answer handGraded name="ans" type="text" /></p>
+    </exercise>
+    `,
+        });
+
+        const exerIdx = await resolvePathToNodeIdx("exer");
+        const looseIdx = await resolvePathToNodeIdx("loose");
+        const strictAnswerIdx = await resolvePathToNodeIdx("exer.ans");
+        const looseAnswerIdx = await resolvePathToNodeIdx("loose.ans");
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        // Inherited from the enclosing section rather than set on the exercise.
+        expect(
+            stateVariables[exerIdx].stateValues.completedColorRequiresCredit,
+        ).eq(true);
+        expect(
+            stateVariables[looseIdx].stateValues.completedColorRequiresCredit,
+        ).eq(false);
+
+        for (const [answerIdx, sectionIdx] of [
+            [strictAnswerIdx, exerIdx],
+            [looseAnswerIdx, looseIdx],
+        ]) {
+            const textInputIdx =
+                stateVariables[answerIdx].stateValues.inputChildren[0]
+                    .componentIdx;
+            await updateTextInputValue({
+                text: "because it is",
+                componentIdx: textInputIdx,
+                core,
+            });
+            await submitAnswer({ componentIdx: answerIdx, core });
+        }
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+
+        // Same response, same ungraded score, opposite bars.
+        expect(stateVariables[exerIdx].stateValues.titleColor).eq("beige");
+        expect(stateVariables[looseIdx].stateValues.titleColor).eq("blue");
+        expect(stateVariables[exerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[looseIdx].stateValues.creditAchieved).eq(0);
     });
 
     it("determine if starts with introduction or ends with conclusion", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1646,6 +1646,102 @@ describe("Sectioning tag tests @group3", async () => {
         expect(stateVariables[looseIdx].stateValues.creditAchieved).eq(0);
     });
 
+    // Mirrors the `completedColorRequiresCredit` example on the `<section>`
+    // reference page, which nothing else executes — docs examples are rendered
+    // at build time, never run. It is a plain `<section>`, so it needs
+    // `aggregateScores` spelled out to roll up the answers it contains at all;
+    // the third section here is the same markup without it, and is why the
+    // example says so.
+    it("the section reference example for completedColorRequiresCredit", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <section boxed aggregateScores name="lenient">
+      <title>Colored once answered</title>
+      <p><answer name="auto"><label>What is <m>1+1</m>?</label>2</answer></p>
+      <p><answer handGraded type="text" name="hand">
+        <label>Explain your reasoning.</label>
+      </answer></p>
+    </section>
+
+    <section boxed aggregateScores completedColorRequiresCredit name="strict">
+      <title>Colored once graded</title>
+      <p><answer name="auto"><label>What is <m>1+1</m>?</label>2</answer></p>
+      <p><answer handGraded type="text" name="hand">
+        <label>Explain your reasoning.</label>
+      </answer></p>
+    </section>
+
+    <section boxed name="unaggregated">
+      <title>No aggregateScores</title>
+      <p><answer name="auto"><label>What is <m>1+1</m>?</label>2</answer></p>
+      <p><answer handGraded type="text" name="hand">
+        <label>Explain your reasoning.</label>
+      </answer></p>
+    </section>
+    `,
+        });
+
+        const sectionNames = ["lenient", "strict", "unaggregated"] as const;
+
+        async function answerSection(name: string) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const autoIdx = await resolvePathToNodeIdx(`${name}.auto`);
+            const handIdx = await resolvePathToNodeIdx(`${name}.hand`);
+
+            await updateMathInputValue({
+                latex: "2",
+                componentIdx:
+                    stateVariables[autoIdx].stateValues.inputChildren[0]
+                        .componentIdx,
+                core,
+            });
+            await submitAnswer({ componentIdx: autoIdx, core });
+
+            await updateTextInputValue({
+                text: "because it is",
+                componentIdx:
+                    stateVariables[handIdx].stateValues.inputChildren[0]
+                        .componentIdx,
+                core,
+            });
+            await submitAnswer({ componentIdx: handIdx, core });
+        }
+
+        // Every input the example creates carries a label, so the page does not
+        // model markup that trips the accessibility diagnostic.
+        expect(
+            core.core?.diagnostics?.filter((d: any) =>
+                d.message.includes("accessibility"),
+            ),
+        ).eqls([]);
+
+        for (const name of sectionNames) {
+            await answerSection(name);
+        }
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const titleColorOf = async (name: string) =>
+            stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                .titleColor;
+
+        // The claim the page makes: answering both questions turns the first
+        // banner green, and the second stays gray awaiting the grade.
+        expect(await titleColorOf("lenient")).eq("var(--lightGreen)");
+        expect(await titleColorOf("strict")).eq("var(--mainGray)");
+
+        // And the reason `aggregateScores` is in the example: without it a
+        // plain section rolls up nothing, so the banner never turns green
+        // however much the reader answers.
+        expect(await titleColorOf("unaggregated")).eq("var(--mainGray)");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("unaggregated")]
+                .stateValues.creditAchieved,
+        ).eq(0);
+    });
+
     it("determine if starts with introduction or ends with conclusion", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1731,10 +1731,12 @@ describe("Sectioning tag tests @group3", async () => {
         }
 
         // Every input the example creates carries a label, so the page does not
-        // model markup that trips the accessibility diagnostic.
+        // model markup that trips the accessibility diagnostic. Matched on the
+        // record's `type` rather than on its English message, the way the
+        // heading-contrast tests below do.
         expect(
-            core.core?.diagnostics?.filter((d: any) =>
-                d.message.includes("accessibility"),
+            core.core!.diagnostics.filter(
+                (d: any) => d.type === "accessibility",
             ),
         ).eqls([]);
 

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -102,6 +102,11 @@ function responseIsBlank(response) {
  * Whether a submission carried nothing the reader entered, either because there
  * were no response values at all or because every one of them is blank.
  *
+ * Filling one input of several is entering something, so a single non-blank
+ * value is enough. Note that an author can add values of their own to the
+ * responses with `<considerAsResponses>` or `isResponse`; those count here like
+ * any other, having been declared responses.
+ *
  * @param {unknown[]} submittedResponses - the answer's `submittedResponses`
  * @returns {boolean}
  */
@@ -453,38 +458,35 @@ export function returnStandardAnswerStateVariableDefinition() {
             "The credit this answer contributes when deciding whether the content around it has been completed, as a `<cascade>` does. Equal to `creditAchieved`, except that a hand-graded answer counts as fully correct once a non-blank response has been submitted.",
         stateVariablesDeterminingDependencies: ["handGraded"],
         returnDependencies({ stateValues }) {
-            if (!stateValues.handGraded) {
-                return {
-                    handGraded: {
-                        dependencyType: "stateVariable",
-                        variableName: "handGraded",
-                    },
-                    creditAchieved: {
-                        dependencyType: "stateVariable",
-                        variableName: "creditAchieved",
-                    },
-                };
-            }
-
-            // The submitted responses are worth resolving only for a
-            // hand-graded answer. Every enclosing section aggregates this
-            // variable to color its heading, so an unconditional dependency
-            // would pull the whole response array of every answer in the
-            // document into the initial render.
-            return {
+            const dependencies = {
                 handGraded: {
                     dependencyType: "stateVariable",
                     variableName: "handGraded",
                 },
-                responseHasBeenSubmitted: {
+            };
+
+            if (stateValues.handGraded) {
+                // The submitted responses are worth resolving only for a
+                // hand-graded answer. Every enclosing section aggregates this
+                // variable to color its heading, so an unconditional dependency
+                // would pull the whole response array of every answer in the
+                // document into the initial render.
+                dependencies.responseHasBeenSubmitted = {
                     dependencyType: "stateVariable",
                     variableName: "responseHasBeenSubmitted",
-                },
-                submittedResponses: {
+                };
+                dependencies.submittedResponses = {
                     dependencyType: "stateVariable",
                     variableName: "submittedResponses",
-                },
-            };
+                };
+            } else {
+                dependencies.creditAchieved = {
+                    dependencyType: "stateVariable",
+                    variableName: "creditAchieved",
+                };
+            }
+
+            return dependencies;
         },
         definition({ dependencyValues }) {
             if (!dependencyValues.handGraded) {

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -14,15 +14,67 @@ function returnScoredContainerAncestorDependency(...variableNames) {
 }
 
 /**
+ * Whether a math expression's tree carries nothing the reader typed.
+ *
+ * A whole expression that is the placeholder U+FF3F — what math-expressions
+ * uses for a missing subexpression, and what an untouched math-flavored input
+ * submits — is blank. One that is merely *partly* blank, `x + \uFF3F`, is
+ * something the reader typed and is not.
+ *
+ * A `<matrixInput>` is the case that needs unwrapping: untouched, it submits a
+ * matrix of placeholders rather than a bare one, and neither the dimensions
+ * around them nor the tuples holding the rows are a response.
+ *
+ * @param {unknown} tree - a math-expression `tree`, or a subtree of one
+ * @returns {boolean}
+ */
+function mathTreeIsBlank(tree) {
+    if (tree === BLANK_PLACEHOLDER) {
+        return true;
+    }
+
+    // ["matrix", ["tuple", nRows, nColumns], ["tuple", ...rows]], each row
+    // itself a tuple of entries.
+    if (Array.isArray(tree) && tree[0] === "matrix") {
+        return matrixEntriesAreBlank(tree[2]);
+    }
+
+    return false;
+}
+
+/**
+ * Whether every entry of a matrix's rows tuple — or of one such row — is the
+ * blank placeholder. Anything that is not the tuple structure a matrix is built
+ * from is not something this can call blank.
+ *
+ * @param {unknown} tuple - the rows of a matrix tree, or one of those rows
+ * @returns {boolean}
+ */
+function matrixEntriesAreBlank(tuple) {
+    return (
+        Array.isArray(tuple) &&
+        tuple[0] === "tuple" &&
+        tuple
+            .slice(1)
+            .every(
+                (entry) =>
+                    entry === BLANK_PLACEHOLDER || matrixEntriesAreBlank(entry),
+            )
+    );
+}
+
+/**
  * Whether a single submitted response value carries nothing the reader typed.
  *
  * Pressing submit on an untouched input still records a response, so "was
  * something submitted?" and "did the reader respond?" are different questions.
- * The empty value differs by input: a math input submits the placeholder
- * U+FF3F that math-expressions uses for a missing subexpression, a text input
- * an empty string, a number input `NaN`, and a choice input nothing at all. A
- * response that is merely *partly* blank — `x + \uFF3F` — is something the
- * reader typed, so only a whole expression that is the placeholder counts.
+ * The empty value differs by input: the math-flavored inputs submit a
+ * math-expression built from the blank placeholder, a `<textInput>` an empty
+ * string, and a `<choiceInput>` with nothing selected no response value at all.
+ *
+ * A `<booleanInput>` is the exception with no blank state of its own: untouched
+ * it submits `false`, which is indistinguishable from the reader deliberately
+ * leaving the box unchecked, so it counts as a response either way.
  *
  * @param {unknown} response - one entry of `submittedResponses`
  * @returns {boolean}
@@ -40,9 +92,8 @@ function responseIsBlank(response) {
     if (Array.isArray(response)) {
         return response.every(responseIsBlank);
     }
-    // A math-expression: blank when the whole expression is the placeholder.
     if (typeof response === "object" && "tree" in response) {
-        return response.tree === BLANK_PLACEHOLDER;
+        return mathTreeIsBlank(response.tree);
     }
     return false;
 }
@@ -400,24 +451,41 @@ export function returnStandardAnswerStateVariableDefinition() {
     stateVariableDefinitions.creditAchievedForProgress = {
         description:
             "The credit this answer contributes when deciding whether the content around it has been completed, as a `<cascade>` does. Equal to `creditAchieved`, except that a hand-graded answer counts as fully correct once a non-blank response has been submitted.",
-        returnDependencies: () => ({
-            creditAchieved: {
-                dependencyType: "stateVariable",
-                variableName: "creditAchieved",
-            },
-            handGraded: {
-                dependencyType: "stateVariable",
-                variableName: "handGraded",
-            },
-            responseHasBeenSubmitted: {
-                dependencyType: "stateVariable",
-                variableName: "responseHasBeenSubmitted",
-            },
-            submittedResponses: {
-                dependencyType: "stateVariable",
-                variableName: "submittedResponses",
-            },
-        }),
+        stateVariablesDeterminingDependencies: ["handGraded"],
+        returnDependencies({ stateValues }) {
+            if (!stateValues.handGraded) {
+                return {
+                    handGraded: {
+                        dependencyType: "stateVariable",
+                        variableName: "handGraded",
+                    },
+                    creditAchieved: {
+                        dependencyType: "stateVariable",
+                        variableName: "creditAchieved",
+                    },
+                };
+            }
+
+            // The submitted responses are worth resolving only for a
+            // hand-graded answer. Every enclosing section aggregates this
+            // variable to color its heading, so an unconditional dependency
+            // would pull the whole response array of every answer in the
+            // document into the initial render.
+            return {
+                handGraded: {
+                    dependencyType: "stateVariable",
+                    variableName: "handGraded",
+                },
+                responseHasBeenSubmitted: {
+                    dependencyType: "stateVariable",
+                    variableName: "responseHasBeenSubmitted",
+                },
+                submittedResponses: {
+                    dependencyType: "stateVariable",
+                    variableName: "submittedResponses",
+                },
+            };
+        },
         definition({ dependencyValues }) {
             if (!dependencyValues.handGraded) {
                 return {

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -4,12 +4,58 @@ import Base64 from "crypto-js/enc-base64";
 import stringify from "json-stringify-deterministic";
 import { codedDiagnostic } from "./diagnostics";
 import { returnLocalizedDefaultStateVariableDefinition } from "./contentLocale";
+import { BLANK_PLACEHOLDER } from "./embeddedMathInputs";
 
 function returnScoredContainerAncestorDependency(...variableNames) {
     return {
         dependencyType: "ancestor",
         variableNames,
     };
+}
+
+/**
+ * Whether a single submitted response value carries nothing the reader typed.
+ *
+ * Pressing submit on an untouched input still records a response, so "was
+ * something submitted?" and "did the reader respond?" are different questions.
+ * The empty value differs by input: a math input submits the placeholder
+ * U+FF3F that math-expressions uses for a missing subexpression, a text input
+ * an empty string, a number input `NaN`, and a choice input nothing at all. A
+ * response that is merely *partly* blank — `x + \uFF3F` — is something the
+ * reader typed, so only a whole expression that is the placeholder counts.
+ *
+ * @param {unknown} response - one entry of `submittedResponses`
+ * @returns {boolean}
+ */
+function responseIsBlank(response) {
+    if (response === null || response === undefined) {
+        return true;
+    }
+    if (typeof response === "string") {
+        return response.trim() === "";
+    }
+    if (typeof response === "number") {
+        return Number.isNaN(response);
+    }
+    if (Array.isArray(response)) {
+        return response.every(responseIsBlank);
+    }
+    // A math-expression: blank when the whole expression is the placeholder.
+    if (typeof response === "object" && "tree" in response) {
+        return response.tree === BLANK_PLACEHOLDER;
+    }
+    return false;
+}
+
+/**
+ * Whether a submission carried nothing the reader entered, either because there
+ * were no response values at all or because every one of them is blank.
+ *
+ * @param {unknown[]} submittedResponses - the answer's `submittedResponses`
+ * @returns {boolean}
+ */
+function submittedResponsesAreBlank(submittedResponses) {
+    return submittedResponses.every(responseIsBlank);
 }
 
 export function returnStandardAnswerAttributes() {
@@ -347,6 +393,53 @@ export function returnStandardAnswerStateVariableDefinition() {
                         value: desiredStateVariableValues.responseHasBeenSubmitted,
                     },
                 ],
+            };
+        },
+    };
+
+    stateVariableDefinitions.creditAchievedForProgress = {
+        description:
+            "The credit this answer contributes when deciding whether the content around it has been completed, as a `<cascade>` does. Equal to `creditAchieved`, except that a hand-graded answer counts as fully correct once a non-blank response has been submitted.",
+        returnDependencies: () => ({
+            creditAchieved: {
+                dependencyType: "stateVariable",
+                variableName: "creditAchieved",
+            },
+            handGraded: {
+                dependencyType: "stateVariable",
+                variableName: "handGraded",
+            },
+            responseHasBeenSubmitted: {
+                dependencyType: "stateVariable",
+                variableName: "responseHasBeenSubmitted",
+            },
+            submittedResponses: {
+                dependencyType: "stateVariable",
+                variableName: "submittedResponses",
+            },
+        }),
+        definition({ dependencyValues }) {
+            if (!dependencyValues.handGraded) {
+                return {
+                    setValue: {
+                        creditAchievedForProgress:
+                            dependencyValues.creditAchieved,
+                    },
+                };
+            }
+
+            // A hand-graded answer keeps `creditAchieved` at 0 until an
+            // instructor grades it, which is well after the reader is done
+            // with it. Progress therefore asks the only question that can be
+            // answered here: did the reader actually respond?
+            const responded =
+                dependencyValues.responseHasBeenSubmitted &&
+                !submittedResponsesAreBlank(
+                    dependencyValues.submittedResponses,
+                );
+
+            return {
+                setValue: { creditAchievedForProgress: responded ? 1 : 0 },
             };
         },
     };

--- a/packages/doenetml-worker-javascript/src/utils/scoredSection.js
+++ b/packages/doenetml-worker-javascript/src/utils/scoredSection.js
@@ -55,9 +55,16 @@ function returnAggregateCreditDependencies(variableName) {
  *
  * @param {object} dependencyValues - the resolved dependencies
  * @param {string} variableName - the same name passed to the dependency builder
- * @returns {number} a credit between 0 and 1; 1 when there is nothing scored
+ * @param {number} [creditWhenNothingScored] - the credit for a section with no
+ *   scored descendants at all, where there is no average to take; full credit
+ *   unless the caller says otherwise
+ * @returns {number} a credit between 0 and 1
  */
-function aggregateCreditOverScoredDescendants(dependencyValues, variableName) {
+function aggregateCreditOverScoredDescendants(
+    dependencyValues,
+    variableName,
+    creditWhenNothingScored = 1,
+) {
     let creditSum = 0;
     let totalWeight = 0;
 
@@ -67,8 +74,7 @@ function aggregateCreditOverScoredDescendants(dependencyValues, variableName) {
         totalWeight += weight;
     }
 
-    // give full credit if there are no scored items
-    return totalWeight > 0 ? creditSum / totalWeight : 1;
+    return totalWeight > 0 ? creditSum / totalWeight : creditWhenNothingScored;
 }
 
 /**
@@ -644,26 +650,20 @@ export function returnScoredSectionStateVariableDefinition() {
                 };
             }
 
-            // Averaged here rather than through
-            // `aggregateCreditOverScoredDescendants` because it does not share
-            // that function's zero-weight case: a section with nothing scored
-            // leaves this NaN rather than at full credit. Preserved as it was
-            // rather than changed alongside an unrelated fix.
-            let creditSum = 0;
-            let totalWeight = 0;
-
-            for (let [
-                ind,
-                component,
-            ] of dependencyValues.scoredDescendants.entries()) {
-                let weight = component.stateValues.weight;
-                creditSum +=
-                    dependencyValues["creditAchievedIfSubmit" + ind] * weight;
-                totalWeight += weight;
-            }
-            let creditAchievedIfSubmit = creditSum / totalWeight;
-
-            return { setValue: { creditAchievedIfSubmit } };
+            return {
+                setValue: {
+                    creditAchievedIfSubmit:
+                        aggregateCreditOverScoredDescendants(
+                            dependencyValues,
+                            "creditAchievedIfSubmit",
+                            // Unlike `creditAchieved`, a section with nothing
+                            // scored has long left this NaN rather than at full
+                            // credit. Kept as it was rather than changed alongside
+                            // an unrelated fix.
+                            NaN,
+                        ),
+                },
+            };
         },
     };
 

--- a/packages/doenetml-worker-javascript/src/utils/scoredSection.js
+++ b/packages/doenetml-worker-javascript/src/utils/scoredSection.js
@@ -563,6 +563,71 @@ export function returnScoredSectionStateVariableDefinition() {
         },
     };
 
+    stateVariableDefinitions.creditAchievedForProgress = {
+        description:
+            "Aggregate credit achieved (between 0 and 1) for scored descendants of this section, used when deciding whether the section has been completed. Differs from `creditAchieved` only in that a hand-graded answer counts as fully correct once a non-blank response has been submitted.",
+        defaultValue: 0,
+        stateVariablesDeterminingDependencies: [
+            "aggregateScores",
+            "scoredDescendants",
+        ],
+        returnDependencies({ stateValues }) {
+            let dependencies = {
+                aggregateScores: {
+                    dependencyType: "stateVariable",
+                    variableName: "aggregateScores",
+                },
+            };
+            if (stateValues.aggregateScores) {
+                dependencies.scoredDescendants = {
+                    dependencyType: "stateVariable",
+                    variableName: "scoredDescendants",
+                };
+                for (let [
+                    ind,
+                    descendant,
+                ] of stateValues.scoredDescendants.entries()) {
+                    dependencies["creditAchievedForProgress" + ind] = {
+                        dependencyType: "stateVariable",
+                        componentIdx: descendant.componentIdx,
+                        variableName: "creditAchievedForProgress",
+                    };
+                }
+            }
+
+            return dependencies;
+        },
+        definition({ dependencyValues }) {
+            if (!dependencyValues.aggregateScores) {
+                return { setValue: { creditAchievedForProgress: 0 } };
+            }
+
+            let creditSum = 0;
+            let totalWeight = 0;
+
+            for (let [
+                ind,
+                component,
+            ] of dependencyValues.scoredDescendants.entries()) {
+                let weight = component.stateValues.weight;
+                creditSum +=
+                    dependencyValues["creditAchievedForProgress" + ind] *
+                    weight;
+                totalWeight += weight;
+            }
+
+            let creditAchievedForProgress;
+            if (totalWeight > 0) {
+                creditAchievedForProgress = creditSum / totalWeight;
+            } else {
+                // give full credit if there are no scored items
+                creditAchievedForProgress = 1;
+            }
+
+            return { setValue: { creditAchievedForProgress } };
+        },
+    };
+
     stateVariableDefinitions.creditAchievedIfSubmit = {
         defaultValue: 0,
         stateVariablesDeterminingDependencies: [

--- a/packages/doenetml-worker-javascript/src/utils/scoredSection.js
+++ b/packages/doenetml-worker-javascript/src/utils/scoredSection.js
@@ -2,6 +2,76 @@ import { codedDiagnostic } from "./diagnostics";
 import { returnSubmitLabelStateVariableDefinitions } from "./answer";
 
 /**
+ * Builds the `returnDependencies` of a state variable that aggregates one
+ * credit variable over a section's scored descendants.
+ *
+ * A section aggregates several credit variables — `creditAchieved`,
+ * `creditAchievedForProgress`, `creditAchievedIfSubmit` — that differ only in
+ * which variable is read off each descendant, so they all gather their
+ * dependencies here. Each descendant's value arrives as `<variableName><index>`
+ * alongside the `scoredDescendants` that give the indices their meaning; when
+ * the section does not aggregate scores, nothing but `aggregateScores` is
+ * depended on.
+ *
+ * Requires `stateVariablesDeterminingDependencies` of `["aggregateScores",
+ * "scoredDescendants"]` on the state variable using it.
+ *
+ * @param {string} variableName - the credit variable read off each scored descendant
+ * @returns {({ stateValues }: { stateValues: any }) => any} a `returnDependencies` function
+ */
+function returnAggregateCreditDependencies(variableName) {
+    return function ({ stateValues }) {
+        const dependencies = {
+            aggregateScores: {
+                dependencyType: "stateVariable",
+                variableName: "aggregateScores",
+            },
+        };
+
+        if (stateValues.aggregateScores) {
+            dependencies.scoredDescendants = {
+                dependencyType: "stateVariable",
+                variableName: "scoredDescendants",
+            };
+            for (let [
+                ind,
+                descendant,
+            ] of stateValues.scoredDescendants.entries()) {
+                dependencies[variableName + ind] = {
+                    dependencyType: "stateVariable",
+                    componentIdx: descendant.componentIdx,
+                    variableName,
+                };
+            }
+        }
+
+        return dependencies;
+    };
+}
+
+/**
+ * The weight-averaged credit over the scored descendants gathered by
+ * `returnAggregateCreditDependencies(variableName)`.
+ *
+ * @param {object} dependencyValues - the resolved dependencies
+ * @param {string} variableName - the same name passed to the dependency builder
+ * @returns {number} a credit between 0 and 1; 1 when there is nothing scored
+ */
+function aggregateCreditOverScoredDescendants(dependencyValues, variableName) {
+    let creditSum = 0;
+    let totalWeight = 0;
+
+    for (let [ind, component] of dependencyValues.scoredDescendants.entries()) {
+        const weight = component.stateValues.weight;
+        creditSum += dependencyValues[variableName + ind] * weight;
+        totalWeight += weight;
+    }
+
+    // give full credit if there are no scored items
+    return totalWeight > 0 ? creditSum / totalWeight : 1;
+}
+
+/**
  * Attributes implementing a "scored section": score aggregation plus the
  * "section-wide check work" feature.
  *
@@ -503,32 +573,7 @@ export function returnScoredSectionStateVariableDefinition() {
             "aggregateScores",
             "scoredDescendants",
         ],
-        returnDependencies({ stateValues }) {
-            let dependencies = {
-                aggregateScores: {
-                    dependencyType: "stateVariable",
-                    variableName: "aggregateScores",
-                },
-            };
-            if (stateValues.aggregateScores) {
-                dependencies.scoredDescendants = {
-                    dependencyType: "stateVariable",
-                    variableName: "scoredDescendants",
-                };
-                for (let [
-                    ind,
-                    descendant,
-                ] of stateValues.scoredDescendants.entries()) {
-                    dependencies["creditAchieved" + ind] = {
-                        dependencyType: "stateVariable",
-                        componentIdx: descendant.componentIdx,
-                        variableName: "creditAchieved",
-                    };
-                }
-            }
-
-            return dependencies;
-        },
+        returnDependencies: returnAggregateCreditDependencies("creditAchieved"),
         definition({ dependencyValues }) {
             if (!dependencyValues.aggregateScores) {
                 return {
@@ -539,27 +584,17 @@ export function returnScoredSectionStateVariableDefinition() {
                 };
             }
 
-            let creditSum = 0;
-            let totalWeight = 0;
+            const creditAchieved = aggregateCreditOverScoredDescendants(
+                dependencyValues,
+                "creditAchieved",
+            );
 
-            for (let [
-                ind,
-                component,
-            ] of dependencyValues.scoredDescendants.entries()) {
-                let weight = component.stateValues.weight;
-                creditSum += dependencyValues["creditAchieved" + ind] * weight;
-                totalWeight += weight;
-            }
-            let creditAchieved;
-            if (totalWeight > 0) {
-                creditAchieved = creditSum / totalWeight;
-            } else {
-                // give full credit if there are no scored items
-                creditAchieved = 1;
-            }
-            let percentCreditAchieved = creditAchieved * 100;
-
-            return { setValue: { creditAchieved, percentCreditAchieved } };
+            return {
+                setValue: {
+                    creditAchieved,
+                    percentCreditAchieved: creditAchieved * 100,
+                },
+            };
         },
     };
 
@@ -571,60 +606,23 @@ export function returnScoredSectionStateVariableDefinition() {
             "aggregateScores",
             "scoredDescendants",
         ],
-        returnDependencies({ stateValues }) {
-            let dependencies = {
-                aggregateScores: {
-                    dependencyType: "stateVariable",
-                    variableName: "aggregateScores",
-                },
-            };
-            if (stateValues.aggregateScores) {
-                dependencies.scoredDescendants = {
-                    dependencyType: "stateVariable",
-                    variableName: "scoredDescendants",
-                };
-                for (let [
-                    ind,
-                    descendant,
-                ] of stateValues.scoredDescendants.entries()) {
-                    dependencies["creditAchievedForProgress" + ind] = {
-                        dependencyType: "stateVariable",
-                        componentIdx: descendant.componentIdx,
-                        variableName: "creditAchievedForProgress",
-                    };
-                }
-            }
-
-            return dependencies;
-        },
+        returnDependencies: returnAggregateCreditDependencies(
+            "creditAchievedForProgress",
+        ),
         definition({ dependencyValues }) {
             if (!dependencyValues.aggregateScores) {
                 return { setValue: { creditAchievedForProgress: 0 } };
             }
 
-            let creditSum = 0;
-            let totalWeight = 0;
-
-            for (let [
-                ind,
-                component,
-            ] of dependencyValues.scoredDescendants.entries()) {
-                let weight = component.stateValues.weight;
-                creditSum +=
-                    dependencyValues["creditAchievedForProgress" + ind] *
-                    weight;
-                totalWeight += weight;
-            }
-
-            let creditAchievedForProgress;
-            if (totalWeight > 0) {
-                creditAchievedForProgress = creditSum / totalWeight;
-            } else {
-                // give full credit if there are no scored items
-                creditAchievedForProgress = 1;
-            }
-
-            return { setValue: { creditAchievedForProgress } };
+            return {
+                setValue: {
+                    creditAchievedForProgress:
+                        aggregateCreditOverScoredDescendants(
+                            dependencyValues,
+                            "creditAchievedForProgress",
+                        ),
+                },
+            };
         },
     };
 
@@ -634,32 +632,9 @@ export function returnScoredSectionStateVariableDefinition() {
             "aggregateScores",
             "scoredDescendants",
         ],
-        returnDependencies({ stateValues }) {
-            let dependencies = {
-                aggregateScores: {
-                    dependencyType: "stateVariable",
-                    variableName: "aggregateScores",
-                },
-            };
-            if (stateValues.aggregateScores) {
-                dependencies.scoredDescendants = {
-                    dependencyType: "stateVariable",
-                    variableName: "scoredDescendants",
-                };
-                for (let [
-                    ind,
-                    descendant,
-                ] of stateValues.scoredDescendants.entries()) {
-                    dependencies["creditAchievedIfSubmit" + ind] = {
-                        dependencyType: "stateVariable",
-                        componentIdx: descendant.componentIdx,
-                        variableName: "creditAchievedIfSubmit",
-                    };
-                }
-            }
-
-            return dependencies;
-        },
+        returnDependencies: returnAggregateCreditDependencies(
+            "creditAchievedIfSubmit",
+        ),
         definition({ dependencyValues }) {
             if (!dependencyValues.aggregateScores) {
                 return {
@@ -669,6 +644,11 @@ export function returnScoredSectionStateVariableDefinition() {
                 };
             }
 
+            // Averaged here rather than through
+            // `aggregateCreditOverScoredDescendants` because it does not share
+            // that function's zero-weight case: a section with nothing scored
+            // leaves this NaN rather than at full credit. Preserved as it was
+            // rather than changed alongside an unrelated fix.
             let creditSum = 0;
             let totalWeight = 0;
 

--- a/packages/doenetml-worker-javascript/src/utils/scoredSection.js
+++ b/packages/doenetml-worker-javascript/src/utils/scoredSection.js
@@ -656,10 +656,12 @@ export function returnScoredSectionStateVariableDefinition() {
                         aggregateCreditOverScoredDescendants(
                             dependencyValues,
                             "creditAchievedIfSubmit",
-                            // Unlike `creditAchieved`, a section with nothing
-                            // scored has long left this NaN rather than at full
-                            // credit. Kept as it was rather than changed alongside
-                            // an unrelated fix.
+                            // A section with nothing scored has always left
+                            // this at NaN — the `0 / 0` of the average it used
+                            // to take inline — where `creditAchieved` gives
+                            // full credit. Passed explicitly so extracting the
+                            // shared helper preserves the behavior rather than
+                            // quietly changing it.
                             NaN,
                         ),
                 },

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -44708,7 +44708,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -45877,7 +45877,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -47046,7 +47046,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -48215,7 +48215,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -49391,7 +49391,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -50560,7 +50560,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -51736,7 +51736,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -52912,7 +52912,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -54088,7 +54088,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -55264,7 +55264,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -56433,7 +56433,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -57602,7 +57602,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -58771,7 +58771,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -59940,7 +59940,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -61109,7 +61109,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -62278,7 +62278,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -63446,7 +63446,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -64607,7 +64607,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -65768,7 +65768,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -151610,7 +151610,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -43752,6 +43752,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -44696,6 +44703,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -44908,6 +44921,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -45852,6 +45872,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -46064,6 +46090,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -47008,6 +47041,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -47220,6 +47259,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -48166,6 +48212,12 @@
                     "description": "The displayed title text for this section."
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                },
+                {
                     "name": "open",
                     "type": "boolean",
                     "isArray": false,
@@ -48374,6 +48426,13 @@
                     "optional": true,
                     "type": [
                         "string"
+                    ]
+                },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
                     ]
                 },
                 "inProgressColor": {
@@ -49329,6 +49388,12 @@
                     "description": "The displayed title text for this section."
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                },
+                {
                     "name": "open",
                     "type": "boolean",
                     "isArray": false,
@@ -49537,6 +49602,13 @@
                     "optional": true,
                     "type": [
                         "string"
+                    ]
+                },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
                     ]
                 },
                 "inProgressColor": {
@@ -50483,6 +50555,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -50695,6 +50773,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -51646,6 +51731,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -51858,6 +51949,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -52809,6 +52907,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -53021,6 +53125,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -53972,6 +54083,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -54184,6 +54301,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -55137,6 +55261,12 @@
                     "description": "The displayed title text for this section."
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                },
+                {
                     "name": "open",
                     "type": "boolean",
                     "isArray": false,
@@ -55345,6 +55475,13 @@
                     "optional": true,
                     "type": [
                         "string"
+                    ]
+                },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
                     ]
                 },
                 "inProgressColor": {
@@ -56291,6 +56428,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -56503,6 +56646,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -57447,6 +57597,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -57659,6 +57815,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -58603,6 +58766,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -58815,6 +58984,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -59759,6 +59935,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -59971,6 +60153,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -60915,6 +61104,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -61127,6 +61322,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -62071,6 +62273,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -62287,6 +62495,13 @@
                     "optional": true,
                     "type": [
                         "string"
+                    ]
+                },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
                     ]
                 },
                 "inProgressColor": {
@@ -63228,6 +63443,12 @@
                     "description": "The displayed title text for this section."
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                },
+                {
                     "name": "open",
                     "type": "boolean",
                     "isArray": false,
@@ -63442,6 +63663,13 @@
                     "optional": true,
                     "type": [
                         "string"
+                    ]
+                },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
                     ]
                 },
                 "inProgressColor": {
@@ -64374,6 +64602,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -64592,6 +64826,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -65522,6 +65763,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -150400,6 +150647,13 @@
                         "string"
                     ]
                 },
+                "completedColorRequiresCredit": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "inProgressColor": {
                     "optional": true,
                     "type": [
@@ -151351,6 +151605,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -38013,7 +38013,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -38278,7 +38278,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -38802,7 +38802,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -39067,7 +39067,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -39591,7 +39591,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -39856,7 +39856,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -40380,7 +40380,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -40645,7 +40645,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -41169,7 +41169,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -41443,7 +41443,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -41967,7 +41967,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -42232,7 +42232,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -42756,7 +42756,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -43030,7 +43030,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -43554,7 +43554,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -43828,7 +43828,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -44352,7 +44352,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -44626,7 +44626,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -45150,7 +45150,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -45424,7 +45424,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -45948,7 +45948,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -46213,7 +46213,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -46737,7 +46737,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -47002,7 +47002,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -47526,7 +47526,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -47791,7 +47791,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -48315,7 +48315,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -48580,7 +48580,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -49104,7 +49104,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -49369,7 +49369,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -49893,7 +49893,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -50158,7 +50158,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -50687,7 +50687,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -50944,7 +50944,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -51472,7 +51472,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -51720,7 +51720,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -52248,7 +52248,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -52496,7 +52496,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -122798,7 +122798,7 @@
                 },
                 {
                     "name": "completedColorRequiresCredit",
-                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer is not colored as completed until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted. Affects only the color, not when a `<cascade>` advances.",
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -123076,7 +123076,7 @@
                     "name": "completedColorRequiresCredit",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer keeps the section from being colored as completed until an instructor grades it."
                 },
                 {
                     "name": "open",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -38012,6 +38012,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -38263,6 +38273,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -38785,6 +38801,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -39036,6 +39062,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -39558,6 +39590,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -39809,6 +39851,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -40331,6 +40379,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -40582,6 +40640,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -41104,6 +41168,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -41364,6 +41438,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -41886,6 +41966,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -42137,6 +42227,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -42659,6 +42755,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -42919,6 +43025,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -43441,6 +43553,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -43701,6 +43823,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -44223,6 +44351,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -44483,6 +44621,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -45005,6 +45149,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -45265,6 +45419,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -45787,6 +45947,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -46038,6 +46208,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -46560,6 +46736,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -46811,6 +46997,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -47333,6 +47525,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -47584,6 +47786,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -48106,6 +48314,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -48357,6 +48575,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -48879,6 +49103,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -49130,6 +49364,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -49652,6 +49892,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -49903,6 +50153,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -50430,6 +50686,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -50673,6 +50939,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -51199,6 +51471,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -51433,6 +51715,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -51959,6 +52247,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -52193,6 +52491,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",
@@ -122493,6 +122797,16 @@
                     "type": "text"
                 },
                 {
+                    "name": "completedColorRequiresCredit",
+                    "description": "Whether the completed color requires full `creditAchieved`, so that a section holding a hand-graded answer stays in progress until an instructor grades it. By default a hand-graded answer counts as completed once a non-blank response has been submitted.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "inProgressColor",
                     "description": "Color used to indicate this section is in progress.",
                     "defaultValue": "var(--mainGray)",
@@ -122757,6 +123071,12 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The displayed title text for this section."
+                },
+                {
+                    "name": "completedColorRequiresCredit",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the heading bar's completion state is driven by the real `creditAchieved` rather than by progress, so that a hand-graded answer holds the section in progress until an instructor grades it."
                 },
                 {
                     "name": "open",


### PR DESCRIPTION
## The problem

With a `<cascade>`, the next step is revealed only when the previous one reaches
full credit. An `<answer handGraded>` never does: its `creditAchieved` stays at 0
until an instructor reviews it, which happens outside the document entirely and
well after the reader has finished. A cascade step containing one was therefore a
dead end — the reader could write anything at all and never move on.

## The fix

A new `creditAchievedForProgress` runs alongside `creditAchieved` and differs
from it in exactly one place.

- **On an answer** (`utils/answer.js`) it equals `creditAchieved`, except that a
  `handGraded` answer is 1 once `responseHasBeenSubmitted` **and**
  `submittedResponses` is non-blank. Requiring both means pressing submit on an
  untouched input does not advance the cascade. Blankness is per input type: the
  math-flavored inputs (`<mathInput>`, `<matrixInput>`, `<fractionInput>`,
  `<subsetOfRealsInput>`) submit a math expression built from the U+FF3F
  placeholder, a `<textInput>` a whitespace-only string (trimmed before
  comparing), and a `<choiceInput>` with nothing selected no response values at
  all. An untouched `<matrixInput>` submits a *matrix* of placeholders rather
  than a bare one, so the math test unwraps a matrix and looks at its entries. A
  partly-blank expression such as `x + ＿` is something the reader typed, so it
  counts as a response — as does a `<booleanInput>`, which has no blank state of
  its own to tell apart from a deliberate "unchecked".
  The `submittedResponses` dependency is gathered only when the answer is
  `handGraded`: every enclosing section aggregates this variable to color its
  heading, so an unconditional dependency would pull the whole response array of
  every answer in the document into the initial render.
- **On a section** (`utils/scoredSection.js`) it aggregates over
  `scoredDescendants` with the same weighting `creditAchieved` uses, so a step
  mixing a hand-graded and an auto-graded answer is complete only when both are.
  It is deleted on `<document>`, which drops the `aggregateScores` the shared
  definition is written against and is never a cascade step.
- **On the cascade** (`components/Cascade.js`) `childCreditAchieved` reads it
  instead of `creditAchieved`.

`creditAchieved` itself is untouched — a hand-graded answer still scores 0 and
still awaits its grade.

The three credit variables a section aggregates — `creditAchieved`,
`creditAchievedForProgress`, `creditAchievedIfSubmit` — had three copies of the
same `returnDependencies` and of the same weighted average. They now share
`returnAggregateCreditDependencies` and `aggregateCreditOverScoredDescendants`.
The one place they differ is a section with nothing scored at all, where there is
no average to take: `creditAchievedIfSubmit` has long left that at `NaN` rather
than at full credit, so it passes that value to the shared helper explicitly
rather than having it changed alongside an unrelated fix.

## Title color

The same rule now colors the title banner of a `boxed` or `collapsible` section:
a section whose questions have all been answered shows as completed rather than
staying gray until a grade the reader cannot see arrives. That matches what a
student expects, and rewards work they have actually finished.

The new **`completedColorRequiresCredit`** attribute opts a banner back into
waiting for the real `creditAchieved`, for an instructor who wants the banner to
mean "graded and correct". It is inherited by the sections within, so setting it
once on an enclosing section applies it throughout, and it affects only the
color — never when a cascade advances.

The name deliberately keeps `completedColor` in it without using it as a suffix:
every other `*Color` attribute on a section takes a color value, while the
booleans about coloring read the other way round (`colorCorrectness`,
`colorAnswersSeparately`). `strictCompletedColor="blue"` would have been an easy
mistake to make.

## Tests

Ten new tests, each verified to fail without the corresponding change (the
`completedColorRequiresCredit` cascade test is a regression guard on an
invariant, so it passes either way today).

`cascade.test.ts`
- a hand-graded step completes on a real text response, does not complete on an
  untouched submit or a whitespace-only one (asserting the response is recorded
  untrimmed, so the trim has to live in the blankness test), and un-completes
  when the response is cleared
- the blank-math case, where "blank" is the placeholder rather than an empty
  string
- the blank-matrix case, where an untouched `<matrixInput>` submits a matrix of
  placeholders and one filled cell is enough to count as a response
- the two inputs with no placeholder of their own: an unselected `<choiceInput>`
  submits no response values at all and does not complete a step, while an
  unchecked `<booleanInput>` does
- a step mixing a hand-graded and an auto-graded answer
- a cascade carrying `completedColorRequiresCredit` still advancing past a
  hand-graded step while that step's own bar stays in the not-started color,
  pinning the "affects only the color" claim and the attribute's inheritance
  from the cascade itself
- a completed hand-graded step surviving a save and reload.
  `creditAchievedForProgress` is recomputed rather than saved, so the restored
  `responseHasBeenSubmitted` and `submittedResponses` have to be enough to
  rebuild it — for an auto-graded answer the restored `creditAchieved` would
  carry the progress on its own, and this is the case where it cannot

`sectioning.test.ts`
- the banner going `notStarted → inProgress → completed` across a hand-graded
  answer while `creditAchieved` stays at 0.5
- two exercises with identical responses and identical credit of 0, one inside a
  `completedColorRequiresCredit` section, ending on opposite colors — which also
  pins the inheritance, including a third exercise that writes
  `completedColorRequiresCredit="false"` under an inheriting ancestor and keeps
  it, the case the `usedDefault` guard in the definition exists for
- the `completedColorRequiresCredit` example from the `<section>` reference,
  run as written. Docs examples are rendered at build time and never executed,
  so nothing else checks that the page's claims hold: this asserts the colors
  the prose promises, that the example raises no accessibility diagnostic, and
  — via a third section that omits `aggregateScores` — why the example has to
  set it

Ran locally: cascade, sectioning, document, answer, problem, module,
sectionWideCheckWork, pretzel, lists, paginator, divisions, sort, repeat,
extend_references, callAction — all passing. Full suites left to CI.

## Also

- Regenerated `doenet-schema.json` and `doenet-relaxng-schema.json` — the new
  attribute and its description across the sectioning component types, nothing
  removed or renamed; `check:docs-coverage` is clean.
- Documented the rule in the `<cascade>` reference, alongside the `handGraded`
  example in the `<answer>` reference — including the `<booleanInput>` exception,
  named in both places and in the changeset so none of them says flatly that an
  untouched input never counts — and added an
  `Attribute Example: completedColorRequiresCredit` to the `<section>` reference,
  since the color change reaches any boxed or collapsible section rather than
  only cascade steps. The `handGraded` cross-references point at the `<answer>`
  reference's handGraded example, where the progress rule is written, rather than
  at the page that only names the attribute.
- The `completedColorRequiresCredit` default is written once, as the
  attribute's `defaultValue`. The state-variable definition starts from the
  attribute's own value and overwrites it from the ancestor only when
  `usedDefault` says nothing was authored, rather than restating `false` a
  second time where the two could drift apart.
- The `<section>` example labels every input it creates, so the page does not
  model markup that trips the unlabeled-input accessibility diagnostic; and it
  sets `aggregateScores`, without which a plain `<section>` rolls up no credit
  and the banners the prose describes could never turn green.
- The attribute's public description said a strictly-colored section "stays in
  progress" until it is graded; a section holding only hand-graded answers shows
  the *not-started* color, so it now says "not colored as completed" and names
  the fact that it never affects when a cascade advances. Its inheritance
  comment claimed it falls back the way the title colors do — the colors read
  their immediate parent, while this reads the nearest ancestor carrying the
  variable, as `showCorrectness` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f3t6w4cvNQvZJxjXsWXqr



