### PR TITLE
Let a number check refuse a quantity written with a unit

### DIFF
--- a/.changeset/math-has-units-allow-units.md
+++ b/.changeset/math-has-units-allow-units.md
@@ -26,8 +26,8 @@ Two additions close that gap:
   `0.5`, `1/2`, and every other unit-free way of writing the same value. The
   same attribute is available on `<boolean>`, `<when>`, `<award>`, and
   `<answer>`, where it governs the `isnumber(...)` and `isinteger(...)`
-  functions, so both spellings of each check agree. On an `<answer>` it carries
-  down to the awards and conditions inside it.
+  functions, so both spellings of each check treat units the same way. On an
+  `<answer>` it carries down to the awards and conditions inside it.
 
 So an answer that wants a decimal rather than a percent can now say so:
 

--- a/.changeset/math-has-units-allow-units.md
+++ b/.changeset/math-has-units-allow-units.md
@@ -26,8 +26,14 @@ Two additions close that gap:
   `0.5`, `1/2`, and every other unit-free way of writing the same value. The
   same attribute is available on `<boolean>`, `<when>`, `<award>`, and
   `<answer>`, where it governs the `isnumber(...)` and `isinteger(...)`
-  functions, so both spellings of each check treat units the same way. On an
-  `<answer>` it carries down to the awards and conditions inside it.
+  functions, so both spellings of each check treat units the same way.
+
+Set on an `<answer>`, `allowUnits` carries down to the awards and conditions
+inside it, and reaches both spellings alike: `<isNumber>` written inside an
+award picks it up just as `isnumber(...)` does. An `<isNumber>` or
+`<isInteger>` takes the setting from whatever component encloses it, so a
+`<boolean allowUnits="false">` governs the tags nested in it too. One written
+with nothing relevant around it keeps the default of allowing units.
 
 So an answer that wants a decimal rather than a percent can now say so:
 

--- a/.changeset/math-has-units-allow-units.md
+++ b/.changeset/math-has-units-allow-units.md
@@ -1,0 +1,42 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+A number check can now refuse a quantity written with a unit, so `50%` need not
+count as a number between 0 and 1.
+
+`50%` is worth `0.5`, and every numeric check in Doenet went by what a value is
+worth: `<isNumber>`, `isnumber(...)`, and the inequalities all accepted a
+percent, and nothing an author could write told the two apart. `<math>` had an
+`isNumber` property that did tell them apart, but only because it demanded the
+expression be spelled as a bare number — it turned down `1/2` as readily as
+`50%`.
+
+Two additions close that gap:
+
+- `<math>` gains a `hasUnits` property, true when the expression contains a
+  quantity written with a unit — a percent, a currency such as `$5`, or an angle
+  such as `30 deg` — anywhere within it.
+- `<isNumber>` and `<isInteger>` gain an `allowUnits` attribute, defaulting to
+  `true`. With `allowUnits="false"` they refuse `50%` while still accepting
+  `0.5`, `1/2`, and every other unit-free way of writing the same value. The
+  same attribute is available on `<boolean>`, `<when>`, `<award>`, and
+  `<answer>`, where it governs the `isnumber(...)` and `isinteger(...)`
+  functions, so both spellings of each check agree. On an `<answer>` it carries
+  down to the awards and conditions inside it.
+
+So an answer that wants a decimal rather than a percent can now say so:
+
+```
+<answer allowUnits="false">
+  <mathInput name="mi"/>
+  <award><when>isnumber($mi) and 0 <= $mi <= 1</when></award>
+</answer>
+```
+
+`allowUnits` governs the number checks only. Inequalities and equality
+comparisons continue to use what a value is worth, so `50% = 0.5` remains true.

--- a/packages/docs-nextra/pages/reference/isInteger.mdx
+++ b/packages/docs-nextra/pages/reference/isInteger.mdx
@@ -37,8 +37,8 @@ The `<isInteger>{:dn}` component checks to see whether the enclosed value is an 
 
 ```doenet-editor-horiz
 <p><mathInput name="mi" prefill="100%"><label>Enter an integer</label></mathInput></p>
-<p>Counting a percent as a number: <isInteger>$mi</isInteger></p>
-<p>Not counting a percent as a number: <isInteger allowUnits="false">$mi</isInteger></p>
+<p>Counting a percent as an integer: <isInteger>$mi</isInteger></p>
+<p>Not counting a percent as an integer: <isInteger allowUnits="false">$mi</isInteger></p>
 ```
 
 
@@ -50,12 +50,12 @@ the same value, such as `1` or `4/4`.
 
 
 The `isinteger()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>{:dn}`](when),
-[`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
+[`<award>{:dn}`](award), or [`<answer>{:dn}`](answer1) takes the same `allowUnits` attribute, so
 both spellings of the check treat units the same way. To ask the question of a `<math>{:dn}`
 directly, use its [`hasUnits`](math2#property-example-hasunits) property.
 
 
 `<isInteger>{:dn}` also takes `allowUnits` from whatever component encloses it, when that component
-sets it. Writing `allowUnits="false"` once on an [`<answer>{:dn}`](answer) therefore governs the
+sets it. Writing `allowUnits="false"` once on an [`<answer>{:dn}`](answer1) therefore governs the
 `<isInteger>{:dn}` tags inside its awards as well as the `isinteger()` functions written there. An
 `<isInteger>{:dn}` with nothing relevant around it keeps the default of allowing units.

--- a/packages/docs-nextra/pages/reference/isInteger.mdx
+++ b/packages/docs-nextra/pages/reference/isInteger.mdx
@@ -27,3 +27,29 @@ component that returns the boolean value of `true` or `false` depending on wheth
 
 The `<isInteger>{:dn}` component checks to see whether the enclosed value is an integer.
 
+
+---
+
+## Attribute Examples
+
+### Attribute Example: allowUnits
+
+
+```doenet-editor-horiz
+<p><mathInput name="mi" prefill="100%"><label>Enter an integer</label></mathInput></p>
+<p>Counting a percent as a number: <isInteger>$mi</isInteger></p>
+<p>Not counting a percent as a number: <isInteger allowUnits="false">$mi</isInteger></p>
+```
+
+
+
+A quantity written with a unit — a percent such as `100%`, a currency such as `$5`, or an angle
+such as `30 deg` — is worth the plain number it equals, so by default `<isInteger>{:dn}` accepts
+it. Setting `allowUnits="false"` rejects it while still accepting every unit-free way of writing
+the same value, such as `1` or `4/4`.
+
+
+The `isinteger()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>{:dn}`](when),
+[`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
+both spellings of the check agree. To ask the question of a `<math>{:dn}` directly, use its
+[`hasUnits`](math2#property-example-hasunits) property.

--- a/packages/docs-nextra/pages/reference/isInteger.mdx
+++ b/packages/docs-nextra/pages/reference/isInteger.mdx
@@ -53,3 +53,9 @@ The `isinteger()` function written inside a [`<boolean>{:dn}`](boolean), [`<when
 [`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
 both spellings of the check treat units the same way. To ask the question of a `<math>{:dn}`
 directly, use its [`hasUnits`](math2#property-example-hasunits) property.
+
+
+`<isInteger>{:dn}` also takes `allowUnits` from whatever component encloses it, when that component
+sets it. Writing `allowUnits="false"` once on an [`<answer>{:dn}`](answer) therefore governs the
+`<isInteger>{:dn}` tags inside its awards as well as the `isinteger()` functions written there. An
+`<isInteger>{:dn}` with nothing relevant around it keeps the default of allowing units.

--- a/packages/docs-nextra/pages/reference/isInteger.mdx
+++ b/packages/docs-nextra/pages/reference/isInteger.mdx
@@ -51,5 +51,5 @@ the same value, such as `1` or `4/4`.
 
 The `isinteger()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>{:dn}`](when),
 [`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
-both spellings of the check agree. To ask the question of a `<math>{:dn}` directly, use its
-[`hasUnits`](math2#property-example-hasunits) property.
+both spellings of the check treat units the same way. To ask the question of a `<math>{:dn}`
+directly, use its [`hasUnits`](math2#property-example-hasunits) property.

--- a/packages/docs-nextra/pages/reference/isNumber.mdx
+++ b/packages/docs-nextra/pages/reference/isNumber.mdx
@@ -59,12 +59,12 @@ the same value, such as `0.5` or `1/2`.
 
 
 The `isnumber()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>{:dn}`](when),
-[`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
+[`<award>{:dn}`](award), or [`<answer>{:dn}`](answer1) takes the same `allowUnits` attribute, so
 both spellings of the check treat units the same way. To ask the question of a `<math>{:dn}`
 directly, use its [`hasUnits`](math2#property-example-hasunits) property.
 
 
 `<isNumber>{:dn}` also takes `allowUnits` from whatever component encloses it, when that component
-sets it. Writing `allowUnits="false"` once on an [`<answer>{:dn}`](answer) therefore governs the
+sets it. Writing `allowUnits="false"` once on an [`<answer>{:dn}`](answer1) therefore governs the
 `<isNumber>{:dn}` tags inside its awards as well as the `isnumber()` functions written there. An
 `<isNumber>{:dn}` with nothing relevant around it keeps the default of allowing units.

--- a/packages/docs-nextra/pages/reference/isNumber.mdx
+++ b/packages/docs-nextra/pages/reference/isNumber.mdx
@@ -62,3 +62,9 @@ The `isnumber()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>
 [`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
 both spellings of the check treat units the same way. To ask the question of a `<math>{:dn}`
 directly, use its [`hasUnits`](math2#property-example-hasunits) property.
+
+
+`<isNumber>{:dn}` also takes `allowUnits` from whatever component encloses it, when that component
+sets it. Writing `allowUnits="false"` once on an [`<answer>{:dn}`](answer) therefore governs the
+`<isNumber>{:dn}` tags inside its awards as well as the `isnumber()` functions written there. An
+`<isNumber>{:dn}` with nothing relevant around it keeps the default of allowing units.

--- a/packages/docs-nextra/pages/reference/isNumber.mdx
+++ b/packages/docs-nextra/pages/reference/isNumber.mdx
@@ -34,3 +34,31 @@ component that returns the boolean value of `true` or `false` depending on wheth
 
 The `<isNumber>{:dn}` component checks to see whether the enclosed value is a real number.
 
+
+---
+
+## Attribute Examples
+
+### Attribute Example: allowUnits
+
+
+```doenet-editor-horiz
+<p><mathInput name="mi" prefill="50%"><label>Enter a number between 0 and 1</label></mathInput></p>
+<p>Counting a percent as a number:
+  <boolean><isNumber>$mi</isNumber> and 0 <= $mi <= 1</boolean></p>
+<p>Not counting a percent as a number:
+  <boolean><isNumber allowUnits="false">$mi</isNumber> and 0 <= $mi <= 1</boolean></p>
+```
+
+
+
+A quantity written with a unit — a percent such as `50%`, a currency such as `$5`, or an angle
+such as `30 deg` — is worth the plain number it equals, so by default `<isNumber>{:dn}` accepts
+it. Setting `allowUnits="false"` rejects it while still accepting every unit-free way of writing
+the same value, such as `0.5` or `1/2`.
+
+
+The `isnumber()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>{:dn}`](when),
+[`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
+both spellings of the check agree. To ask the question of a `<math>{:dn}` directly, use its
+[`hasUnits`](math2#property-example-hasunits) property.

--- a/packages/docs-nextra/pages/reference/isNumber.mdx
+++ b/packages/docs-nextra/pages/reference/isNumber.mdx
@@ -60,5 +60,5 @@ the same value, such as `0.5` or `1/2`.
 
 The `isnumber()` function written inside a [`<boolean>{:dn}`](boolean), [`<when>{:dn}`](when),
 [`<award>{:dn}`](award), or [`<answer>{:dn}`](answer) takes the same `allowUnits` attribute, so
-both spellings of the check agree. To ask the question of a `<math>{:dn}` directly, use its
-[`hasUnits`](math2#property-example-hasunits) property.
+both spellings of the check treat units the same way. To ask the question of a `<math>{:dn}`
+directly, use its [`hasUnits`](math2#property-example-hasunits) property.

--- a/packages/docs-nextra/pages/reference/math2.mdx
+++ b/packages/docs-nextra/pages/reference/math2.mdx
@@ -400,6 +400,35 @@ The `isNumeric` property returns `true` if the `<math>{:dn}` evaluates to a numb
 
 ---
 
+### Property Example: hasUnits
+
+
+```doenet-example
+<math name="percent">50%</math>
+<p><c>number</c> = $percent.number</p>
+<p><c>hasUnits</c> = $percent.hasUnits</p>
+<math name="decimal">0.5</math>
+<p><c>number</c> = $decimal.number</p>
+<p><c>hasUnits</c> = $decimal.hasUnits</p>
+```
+
+
+
+The `hasUnits` property returns `true` if the `<math>{:dn}` contains a quantity written with a
+unit, such as a percent, a currency, or an angle in degrees. A percent is worth the decimal it
+equals, so `50%` and `0.5` have the same `number`; `hasUnits` is what tells them apart.
+
+
+To require a number that was not written as a percent, pair `hasUnits` with a check that the
+value is a number at all, as in `<boolean>isnumber($m) and not $m.hasUnits</boolean>{:dn}` for
+a `<math>{:dn}` named `m`. The [`<isNumber>{:dn}`](isNumber) and
+[`<isInteger>{:dn}`](isInteger) components spell the same requirement more directly with their
+`allowUnits` attribute.
+
+
+
+---
+
 ### Property Example: latex
 
 

--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -75,6 +75,14 @@ export default class Answer extends InlineComponent {
             description:
                 "Whether comparison uses symbolic equality (rather than numeric evaluation).",
         };
+        attributes.allowUnits = {
+            createComponentOfType: "boolean",
+            createStateVariable: "allowUnits",
+            defaultValue: true,
+            public: true,
+            description:
+                "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+        };
         attributes.forceFullCheckWorkButton = {
             createComponentOfType: "boolean",
             createStateVariable: "forceFullCheckWorkButton",

--- a/packages/doenetml-worker-javascript/src/components/Award.js
+++ b/packages/doenetml-worker-javascript/src/components/Award.js
@@ -52,6 +52,15 @@ export default class Award extends BaseComponent {
             description:
                 "Whether comparison uses symbolic equality (rather than numeric evaluation).",
         };
+        attributes.allowUnits = {
+            createComponentOfType: "boolean",
+            createStateVariable: "allowUnits",
+            defaultValue: true,
+            public: true,
+            fallBackToParentStateVariable: "allowUnits",
+            description:
+                "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+        };
         attributes.expandOnCompare = {
             createComponentOfType: "boolean",
             createStateVariable: "expandOnCompare",
@@ -503,6 +512,10 @@ export default class Award extends BaseComponent {
                 symbolicEquality: {
                     dependencyType: "stateVariable",
                     variableName: "symbolicEquality",
+                },
+                allowUnits: {
+                    dependencyType: "stateVariable",
+                    variableName: "allowUnits",
                 },
                 expandOnCompare: {
                     dependencyType: "stateVariable",

--- a/packages/doenetml-worker-javascript/src/components/Boolean.js
+++ b/packages/doenetml-worker-javascript/src/components/Boolean.js
@@ -33,6 +33,14 @@ export default class BooleanComponent extends InlineComponent {
             description:
                 "Whether children compared via this boolean use symbolic equality.",
         };
+        attributes.allowUnits = {
+            createComponentOfType: "boolean",
+            createStateVariable: "allowUnits",
+            defaultValue: true,
+            public: true,
+            description:
+                "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+        };
         attributes.expandOnCompare = {
             createComponentOfType: "boolean",
             createStateVariable: "expandOnCompare",
@@ -246,6 +254,10 @@ export default class BooleanComponent extends InlineComponent {
                 symbolicEquality: {
                     dependencyType: "stateVariable",
                     variableName: "symbolicEquality",
+                },
+                allowUnits: {
+                    dependencyType: "stateVariable",
+                    variableName: "allowUnits",
                 },
                 expandOnCompare: {
                     dependencyType: "stateVariable",

--- a/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
@@ -8,15 +8,15 @@ import { evaluateNumericPredicate } from "../utils/math";
  *
  * No children at all is the ordinary state of a half-typed document, so it
  * answers `false` quietly; two or more is an authoring mistake, so it warns and
- * answers `null`. `componentName` is the class name used in that warning.
+ * answers `null`. `componentType` is the tag name reported in that warning.
  */
-function returnSingleMathChildOperator(componentName, evaluate) {
+function returnSingleMathChildOperator(componentType, evaluate) {
     return function (values) {
         if (values.length === 0) {
             return false;
         }
         if (values.length !== 1) {
-            console.warn(`${componentName} requires exactly one math child`);
+            console.warn(`<${componentType}> requires exactly one math child`);
             return null;
         }
         return evaluate(values[0]);
@@ -24,102 +24,87 @@ function returnSingleMathChildOperator(componentName, evaluate) {
 }
 
 /**
- * The `booleanOperator` state variable shared by `<isNumber>` and
- * `<isInteger>`. Both apply the correspondingly named check to their single
- * math child, honoring the `allowUnits` attribute they inherit from
- * `<boolean>` so that they treat a quantity written with a unit the same way
- * the `isnumber(...)` / `isinteger(...)` functions do.
- */
-function returnNumericPredicateOperator({ predicate, componentName }) {
-    return {
-        returnDependencies: () => ({
-            allowUnits: {
-                dependencyType: "stateVariable",
-                variableName: "allowUnits",
-            },
-        }),
-        definition: ({ dependencyValues }) => ({
-            setValue: {
-                booleanOperator: returnSingleMathChildOperator(
-                    componentName,
-                    (expression) =>
-                        evaluateNumericPredicate({
-                            predicate,
-                            expression,
-                            allowUnits: dependencyValues.allowUnits,
-                        }),
-                ),
-            },
-        }),
-    };
-}
-
-/**
- * Give `<isNumber>` and `<isInteger>` the parent fall-back for `allowUnits`
- * that `<boolean>` deliberately does not have.
+ * Shared implementation of `<isNumber>` and `<isInteger>`, which differ only in
+ * which check they name. Each applies its check to its single math child,
+ * honoring the `allowUnits` attribute they inherit from `<boolean>` so that
+ * they treat a quantity written with a unit the same way the `isnumber(...)` /
+ * `isinteger(...)` functions do.
  *
- * The comparison settings `<boolean>` declares — `symbolicEquality` and the
- * rest — each govern a comparison the `<boolean>` performs itself, so there is
- * no second way to spell them and nothing to stay consistent with. `allowUnits`
- * is the exception: the same check is written either as one of these tags or as
- * the matching `isnumber(...)` / `isinteger(...)` function, and the function is
+ * These two tags also take a parent fall-back for `allowUnits` that `<boolean>`
+ * deliberately does not have. The comparison settings `<boolean>` declares —
+ * `symbolicEquality` and the rest — each govern a comparison the `<boolean>`
+ * performs itself, so there is no second way to spell them and nothing to stay
+ * consistent with. `allowUnits` is the exception: the same check is written
+ * either as one of these tags or as the matching function, and the function is
  * evaluated by the enclosing `<when>` or `<award>`, which does fall back to its
- * parent. Without this, `<answer allowUnits="false">` would reach the function
- * spelling and not the tag.
+ * parent. Without the fall-back, `<answer allowUnits="false">` would reach the
+ * function spelling and not the tag.
  *
- * The fall-back is a single level and fires only when the parent's value was
- * set rather than defaulted, so a tag written anywhere else keeps its own
- * default: a parent without the state variable resolves to null.
+ * Each component consults only its immediate parent, and only when that
+ * parent's value was set rather than defaulted (a parent without the state
+ * variable resolves to null). A setting can still travel several levels,
+ * because each link in an `<answer>` → `<award>` → `<when>` chain falls back in
+ * turn; but a tag written outside such a chain keeps its own default.
  */
-function addAllowUnitsParentFallback(attributes) {
-    attributes.allowUnits.fallBackToParentStateVariable = "allowUnits";
-    return attributes;
+class NumericPredicateOfMath extends BooleanBaseOperatorOfMath {
+    /**
+     * Which check to apply: `"isnumber"` or `"isinteger"`, the same names the
+     * function spelling uses. Set by each subclass.
+     */
+    static predicate;
+
+    static createAttributesObject() {
+        const attributes = super.createAttributesObject();
+        attributes.allowUnits.fallBackToParentStateVariable = "allowUnits";
+        return attributes;
+    }
+
+    static returnStateVariableDefinitions() {
+        const stateVariableDefinitions = super.returnStateVariableDefinitions();
+        const { predicate, componentType } = this;
+
+        stateVariableDefinitions.booleanOperator = {
+            returnDependencies: () => ({
+                allowUnits: {
+                    dependencyType: "stateVariable",
+                    variableName: "allowUnits",
+                },
+            }),
+            definition: ({ dependencyValues }) => ({
+                setValue: {
+                    booleanOperator: returnSingleMathChildOperator(
+                        componentType,
+                        (expression) =>
+                            evaluateNumericPredicate({
+                                predicate,
+                                expression,
+                                allowUnits: dependencyValues.allowUnits,
+                            }),
+                    ),
+                },
+            }),
+        };
+
+        return stateVariableDefinitions;
+    }
 }
 
-export class IsInteger extends BooleanBaseOperatorOfMath {
+export class IsInteger extends NumericPredicateOfMath {
     static componentType = "isInteger";
+    static predicate = "isinteger";
 
     static componentDocs = {
         summary: "True when the math child evaluates to an integer",
     };
-    static createAttributesObject() {
-        return addAllowUnitsParentFallback(super.createAttributesObject());
-    }
-
-    static returnStateVariableDefinitions() {
-        let stateVariableDefinitions = super.returnStateVariableDefinitions();
-
-        stateVariableDefinitions.booleanOperator =
-            returnNumericPredicateOperator({
-                predicate: "isinteger",
-                componentName: "IsInteger",
-            });
-
-        return stateVariableDefinitions;
-    }
 }
 
-export class IsNumber extends BooleanBaseOperatorOfMath {
+export class IsNumber extends NumericPredicateOfMath {
     static componentType = "isNumber";
+    static predicate = "isnumber";
 
     static componentDocs = {
         summary: "True when the math child evaluates to a finite number",
     };
-    static createAttributesObject() {
-        return addAllowUnitsParentFallback(super.createAttributesObject());
-    }
-
-    static returnStateVariableDefinitions() {
-        let stateVariableDefinitions = super.returnStateVariableDefinitions();
-
-        stateVariableDefinitions.booleanOperator =
-            returnNumericPredicateOperator({
-                predicate: "isnumber",
-                componentName: "IsNumber",
-            });
-
-        return stateVariableDefinitions;
-    }
 }
 
 export class IsBetween extends BooleanBaseOperatorOfMath {
@@ -151,6 +136,7 @@ export class IsBetween extends BooleanBaseOperatorOfMath {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+        const componentType = this.componentType;
 
         stateVariableDefinitions.booleanOperator = {
             returnDependencies: () => ({
@@ -184,7 +170,7 @@ export class IsBetween extends BooleanBaseOperatorOfMath {
                 return {
                     setValue: {
                         booleanOperator: returnSingleMathChildOperator(
-                            "IsBetween",
+                            componentType,
                             (expression) => {
                                 let numericValue =
                                     expression.evaluate_to_constant();

--- a/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
@@ -45,6 +45,9 @@ function returnSingleMathChildOperator(componentType, evaluate) {
  * variable resolves to null). A setting can still travel several levels,
  * because each link in an `<answer>` → `<award>` → `<when>` chain falls back in
  * turn; but a tag written outside such a chain keeps its own default.
+ *
+ * Must stay unexported: `ComponentTypes.js` registers every export of this file
+ * as a component type, and this class declares no `componentType` of its own.
  */
 class NumericPredicateOfMath extends BooleanBaseOperatorOfMath {
     /**

--- a/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
@@ -54,12 +54,38 @@ function returnNumericPredicateOperator({ predicate, componentName }) {
     };
 }
 
+/**
+ * Give `<isNumber>` and `<isInteger>` the parent fall-back for `allowUnits`
+ * that `<boolean>` deliberately does not have.
+ *
+ * The comparison settings `<boolean>` declares — `symbolicEquality` and the
+ * rest — each govern a comparison the `<boolean>` performs itself, so there is
+ * no second way to spell them and nothing to stay consistent with. `allowUnits`
+ * is the exception: the same check is written either as one of these tags or as
+ * the matching `isnumber(...)` / `isinteger(...)` function, and the function is
+ * evaluated by the enclosing `<when>` or `<award>`, which does fall back to its
+ * parent. Without this, `<answer allowUnits="false">` would reach the function
+ * spelling and not the tag.
+ *
+ * The fall-back is a single level and fires only when the parent's value was
+ * set rather than defaulted, so a tag written anywhere else keeps its own
+ * default: a parent without the state variable resolves to null.
+ */
+function addAllowUnitsParentFallback(attributes) {
+    attributes.allowUnits.fallBackToParentStateVariable = "allowUnits";
+    return attributes;
+}
+
 export class IsInteger extends BooleanBaseOperatorOfMath {
     static componentType = "isInteger";
 
     static componentDocs = {
         summary: "True when the math child evaluates to an integer",
     };
+    static createAttributesObject() {
+        return addAllowUnitsParentFallback(super.createAttributesObject());
+    }
+
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
@@ -79,6 +105,10 @@ export class IsNumber extends BooleanBaseOperatorOfMath {
     static componentDocs = {
         summary: "True when the math child evaluates to a finite number",
     };
+    static createAttributesObject() {
+        return addAllowUnitsParentFallback(super.createAttributesObject());
+    }
+
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 

--- a/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
@@ -2,14 +2,33 @@ import BooleanBaseOperatorOfMath from "./abstract/BooleanBaseOperatorOfMath";
 import { evaluateNumericPredicate } from "../utils/math";
 
 /**
- * The `booleanOperator` state variable shared by `<isNumber>` and
- * `<isInteger>`. Both take exactly one math child and apply the correspondingly
- * named check to it, honoring the inherited `allowUnits` attribute so that they
- * agree with the `isnumber(...)` / `isinteger(...)` functions written inside a
- * `<boolean>`.
+ * Wrap `evaluate` in the arity check every operator in this file needs: a
+ * `booleanOperator` receives the values of all math children, but each of these
+ * operators is defined only on a single one.
  *
- * `componentName` is the class name used in the arity warning, matching how the
- * sibling operators in this file name themselves.
+ * No children at all is the ordinary state of a half-typed document, so it
+ * answers `false` quietly; two or more is an authoring mistake, so it warns and
+ * answers `null`. `componentName` is the class name used in that warning.
+ */
+function returnSingleMathChildOperator(componentName, evaluate) {
+    return function (values) {
+        if (values.length === 0) {
+            return false;
+        }
+        if (values.length !== 1) {
+            console.warn(`${componentName} requires exactly one math child`);
+            return null;
+        }
+        return evaluate(values[0]);
+    };
+}
+
+/**
+ * The `booleanOperator` state variable shared by `<isNumber>` and
+ * `<isInteger>`. Both apply the correspondingly named check to their single
+ * math child, honoring the `allowUnits` attribute they inherit from
+ * `<boolean>` so that they treat a quantity written with a unit the same way
+ * the `isnumber(...)` / `isinteger(...)` functions do.
  */
 function returnNumericPredicateOperator({ predicate, componentName }) {
     return {
@@ -21,23 +40,15 @@ function returnNumericPredicateOperator({ predicate, componentName }) {
         }),
         definition: ({ dependencyValues }) => ({
             setValue: {
-                booleanOperator: function (values) {
-                    if (values.length === 0) {
-                        return false;
-                    }
-                    if (values.length !== 1) {
-                        console.warn(
-                            `${componentName} requires exactly one math child`,
-                        );
-                        return null;
-                    }
-
-                    return evaluateNumericPredicate({
-                        predicate,
-                        expression: values[0],
-                        allowUnits: dependencyValues.allowUnits,
-                    });
-                },
+                booleanOperator: returnSingleMathChildOperator(
+                    componentName,
+                    (expression) =>
+                        evaluateNumericPredicate({
+                            predicate,
+                            expression,
+                            allowUnits: dependencyValues.allowUnits,
+                        }),
+                ),
             },
         }),
     };
@@ -142,30 +153,25 @@ export class IsBetween extends BooleanBaseOperatorOfMath {
 
                 return {
                     setValue: {
-                        booleanOperator: function (values) {
-                            if (values.length === 0) {
-                                return false;
-                            }
-                            if (values.length !== 1) {
-                                console.warn(
-                                    "IsBetween requires exactly one math child",
-                                );
-                                return null;
-                            }
-                            let numericValue = values[0].evaluate_to_constant();
+                        booleanOperator: returnSingleMathChildOperator(
+                            "IsBetween",
+                            (expression) => {
+                                let numericValue =
+                                    expression.evaluate_to_constant();
 
-                            if (strict) {
-                                return (
-                                    numericValue > lowerLimit &&
-                                    numericValue < upperLimit
-                                );
-                            } else {
-                                return (
-                                    numericValue >= lowerLimit &&
-                                    numericValue <= upperLimit
-                                );
-                            }
-                        },
+                                if (strict) {
+                                    return (
+                                        numericValue > lowerLimit &&
+                                        numericValue < upperLimit
+                                    );
+                                } else {
+                                    return (
+                                        numericValue >= lowerLimit &&
+                                        numericValue <= upperLimit
+                                    );
+                                }
+                            },
+                        ),
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
@@ -1,4 +1,47 @@
 import BooleanBaseOperatorOfMath from "./abstract/BooleanBaseOperatorOfMath";
+import { evaluateNumericPredicate } from "../utils/math";
+
+/**
+ * The `booleanOperator` state variable shared by `<isNumber>` and
+ * `<isInteger>`. Both take exactly one math child and apply the correspondingly
+ * named check to it, honoring the inherited `allowUnits` attribute so that they
+ * agree with the `isnumber(...)` / `isinteger(...)` functions written inside a
+ * `<boolean>`.
+ *
+ * `componentName` names the component in the arity warning, so it reads as the
+ * tag the author wrote.
+ */
+function returnNumericPredicateOperator({ predicate, componentName }) {
+    return {
+        returnDependencies: () => ({
+            allowUnits: {
+                dependencyType: "stateVariable",
+                variableName: "allowUnits",
+            },
+        }),
+        definition: ({ dependencyValues }) => ({
+            setValue: {
+                booleanOperator: function (values) {
+                    if (values.length === 0) {
+                        return false;
+                    }
+                    if (values.length !== 1) {
+                        console.warn(
+                            `${componentName} requires exactly one math child`,
+                        );
+                        return null;
+                    }
+
+                    return evaluateNumericPredicate({
+                        predicate,
+                        expression: values[0],
+                        allowUnits: dependencyValues.allowUnits,
+                    });
+                },
+            },
+        }),
+    };
+}
 
 export class IsInteger extends BooleanBaseOperatorOfMath {
     static componentType = "isInteger";
@@ -9,38 +52,11 @@ export class IsInteger extends BooleanBaseOperatorOfMath {
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
-        stateVariableDefinitions.booleanOperator.definition = () => ({
-            setValue: {
-                booleanOperator: function (values) {
-                    if (values.length === 0) {
-                        return false;
-                    }
-                    if (values.length !== 1) {
-                        console.warn(
-                            "IsInteger requires exactly one math child",
-                        );
-                        return null;
-                    }
-                    let numericValue = values[0].evaluate_to_constant();
-
-                    if (!Number.isFinite(numericValue)) {
-                        return false;
-                    }
-
-                    // to account for round off error, round to nearest integer
-                    // and check if close to that integer
-                    let rounded = Math.round(numericValue);
-                    if (
-                        Math.abs(rounded - numericValue) <=
-                        1e-15 * Math.abs(numericValue)
-                    ) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                },
-            },
-        });
+        stateVariableDefinitions.booleanOperator =
+            returnNumericPredicateOperator({
+                predicate: "isinteger",
+                componentName: "IsInteger",
+            });
 
         return stateVariableDefinitions;
     }
@@ -55,24 +71,11 @@ export class IsNumber extends BooleanBaseOperatorOfMath {
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
-        stateVariableDefinitions.booleanOperator.definition = () => ({
-            setValue: {
-                booleanOperator: function (values) {
-                    if (values.length === 0) {
-                        return false;
-                    }
-                    if (values.length !== 1) {
-                        console.warn(
-                            "IsNumber requires exactly one math child",
-                        );
-                        return null;
-                    }
-                    let numericValue = values[0].evaluate_to_constant();
-
-                    return Number.isFinite(numericValue);
-                },
-            },
-        });
+        stateVariableDefinitions.booleanOperator =
+            returnNumericPredicateOperator({
+                predicate: "isnumber",
+                componentName: "IsNumber",
+            });
 
         return stateVariableDefinitions;
     }

--- a/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanOperatorsOfMath.js
@@ -8,8 +8,8 @@ import { evaluateNumericPredicate } from "../utils/math";
  * agree with the `isnumber(...)` / `isinteger(...)` functions written inside a
  * `<boolean>`.
  *
- * `componentName` names the component in the arity warning, so it reads as the
- * tag the author wrote.
+ * `componentName` is the class name used in the arity warning, matching how the
+ * sibling operators in this file name themselves.
  */
 function returnNumericPredicateOperator({ predicate, componentName }) {
     return {

--- a/packages/doenetml-worker-javascript/src/components/Math.js
+++ b/packages/doenetml-worker-javascript/src/components/Math.js
@@ -803,31 +803,6 @@ export default class MathComponent extends InlineComponent {
             },
         };
 
-        // hasUnits distinguishes a quantity written with a unit from the bare
-        // number it is worth: `50%` and `0.5` evaluate to the same constant,
-        // but only the former has units.
-        stateVariableDefinitions.hasUnits = {
-            description:
-                "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees.",
-            public: true,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({
-                value: {
-                    dependencyType: "stateVariable",
-                    variableName: "value",
-                },
-            }),
-            definition: function ({ dependencyValues }) {
-                return {
-                    setValue: {
-                        hasUnits: treeHasUnits(dependencyValues.value.tree),
-                    },
-                };
-            },
-        };
-
         // isNumeric is weaker than isNumber
         // isNumeric is true if the value can be evaluated as a number,
         // i.e., if the number state variable is a number
@@ -848,6 +823,31 @@ export default class MathComponent extends InlineComponent {
                 return {
                     setValue: {
                         isNumeric: Number.isFinite(dependencyValues.number),
+                    },
+                };
+            },
+        };
+
+        // hasUnits is independent of isNumber and isNumeric: it asks how the
+        // expression is written rather than what it is worth. `50%` and `0.5`
+        // evaluate to the same constant, but only the former has units.
+        stateVariableDefinitions.hasUnits = {
+            description:
+                "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                return {
+                    setValue: {
+                        hasUnits: treeHasUnits(dependencyValues.value.tree),
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/Math.js
+++ b/packages/doenetml-worker-javascript/src/components/Math.js
@@ -28,6 +28,7 @@ import {
     superSubscriptsToUnicode,
     unicodeToSuperSubscripts,
     preprocessMathInverseDefinition,
+    treeHasUnits,
 } from "../utils/math";
 import { createInputStringFromChildren } from "../utils/parseMath";
 import { returnMathVectorMatrixStateVariableDefinitions } from "../utils/mathVectorMatrixStateVariables";
@@ -797,6 +798,31 @@ export default class MathComponent extends InlineComponent {
                 return {
                     setValue: {
                         isNumber: Number.isFinite(dependencyValues.value.tree),
+                    },
+                };
+            },
+        };
+
+        // hasUnits distinguishes a quantity written with a unit from the bare
+        // number it is worth: `50%` and `0.5` evaluate to the same constant,
+        // but only the former has units.
+        stateVariableDefinitions.hasUnits = {
+            description:
+                "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                return {
+                    setValue: {
+                        hasUnits: treeHasUnits(dependencyValues.value.tree),
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/When.js
+++ b/packages/doenetml-worker-javascript/src/components/When.js
@@ -28,6 +28,7 @@ export default class When extends BooleanComponent {
 
         for (let attrName of [
             "symbolicEquality",
+            "allowUnits",
             "expandOnCompare",
             "simplifyOnCompare",
             "unorderedCompare",
@@ -84,6 +85,10 @@ export default class When extends BooleanComponent {
                 symbolicEquality: {
                     dependencyType: "stateVariable",
                     variableName: "symbolicEquality",
+                },
+                allowUnits: {
+                    dependencyType: "stateVariable",
+                    variableName: "allowUnits",
                 },
                 expandOnCompare: {
                     dependencyType: "stateVariable",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/booleanoperatorsonmath.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/booleanoperatorsonmath.test.ts
@@ -598,4 +598,36 @@ describe("Boolean Operator tag tests @group4", async () => {
         expect(await value("numOutside"), "numOutside").eq(true);
         expect(await value("intOutside"), "intOutside").eq(true);
     });
+
+    it("allowUnits looks at the expression as written, before simplification", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <boolean name="cancelingUnits">isnumber(50% - 50%)</boolean>
+    <boolean name="cancelingUnitsNoUnits" allowUnits="false">isnumber(50% - 50%)</boolean>
+    <isNumber name="tagSimplifies">x-x</isNumber>
+    <boolean name="fnSimplifies">isnumber(x-x)</boolean>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        async function value(name: string) {
+            return stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                .value;
+        }
+
+        // The function spelling simplifies before evaluating, so `50% - 50%`
+        // is worth 0. `allowUnits="false"` still refuses it, because the unit
+        // test runs against the expression as written.
+        expect(await value("cancelingUnits"), "cancelingUnits").eq(true);
+        expect(
+            await value("cancelingUnitsNoUnits"),
+            "cancelingUnitsNoUnits",
+        ).eq(false);
+
+        // That simplification is the one respect in which the two spellings
+        // still differ: `x-x` has no numeric value until it is simplified, so
+        // only the function spelling calls it a number.
+        expect(await value("tagSimplifies"), "tagSimplifies").eq(false);
+        expect(await value("fnSimplifies"), "fnSimplifies").eq(true);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/booleanoperatorsonmath.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/booleanoperatorsonmath.test.ts
@@ -563,4 +563,39 @@ describe("Boolean Operator tag tests @group4", async () => {
         await set_inputs("0.5");
         await check_credit(1, 1);
     });
+    it("isNumber and isInteger inherit allowUnits from an enclosing component", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <answer name="ans" allowUnits="false">
+      <mathInput name="mi" prefill="100%"/>
+      <award><when><isNumber name="numInWhen">$mi</isNumber></when></award>
+      <award><when><isInteger name="intInWhen">$mi</isInteger></when></award>
+    </answer>
+    <boolean name="wrapper" allowUnits="false"><isNumber name="numInBoolean">100%</isNumber></boolean>
+    <p><isNumber name="numOutside">100%</isNumber></p>
+    <p><isInteger name="intOutside">100%</isInteger></p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        async function value(name: string) {
+            return stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                .value;
+        }
+
+        // The tag spelling follows the same answer -> award -> when chain the
+        // `isnumber(...)` function spelling follows, so both react to
+        // `allowUnits` on the answer.
+        expect(await value("numInWhen"), "numInWhen").eq(false);
+        expect(await value("intInWhen"), "intInWhen").eq(false);
+
+        // The fall-back is to whatever component encloses the tag, not to the
+        // answer specifically.
+        expect(await value("numInBoolean"), "numInBoolean").eq(false);
+
+        // Nothing encloses these but a `<p>`, which has no `allowUnits`, so
+        // they keep their own default of allowing units.
+        expect(await value("numOutside"), "numOutside").eq(true);
+        expect(await value("intOutside"), "intOutside").eq(true);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/booleanoperatorsonmath.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/booleanoperatorsonmath.test.ts
@@ -390,4 +390,177 @@ describe("Boolean Operator tag tests @group4", async () => {
         });
         await check_items(x, x1, x2, strict);
     });
+    it("allowUnits excludes quantities written with a unit", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <mathInput name="n"/>
+    <isNumber name="num">$n</isNumber>
+    <isNumber name="numNoUnits" allowUnits="false">$n</isNumber>
+    <boolean name="numFn">isnumber($n)</boolean>
+    <boolean name="numFnNoUnits" allowUnits="false">isnumber($n)</boolean>
+    <isInteger name="int">$n</isInteger>
+    <isInteger name="intNoUnits" allowUnits="false">$n</isInteger>
+    <boolean name="intFn">isinteger($n)</boolean>
+    <boolean name="intFnNoUnits" allowUnits="false">isinteger($n)</boolean>
+    `,
+        });
+
+        // The component and function spellings of each check must agree, so
+        // every expectation is asserted against both.
+        async function check_items({
+            isNumber,
+            isNumberNoUnits,
+            isInteger,
+            isIntegerNoUnits,
+        }: {
+            isNumber: boolean;
+            isNumberNoUnits: boolean;
+            isInteger: boolean;
+            isIntegerNoUnits: boolean;
+        }) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const expected = {
+                num: isNumber,
+                numFn: isNumber,
+                numNoUnits: isNumberNoUnits,
+                numFnNoUnits: isNumberNoUnits,
+                int: isInteger,
+                intFn: isInteger,
+                intNoUnits: isIntegerNoUnits,
+                intFnNoUnits: isIntegerNoUnits,
+            };
+            for (const [name, value] of Object.entries(expected)) {
+                expect(
+                    stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                        .value,
+                    name,
+                ).eq(value);
+            }
+        }
+
+        async function set_input(latex: string) {
+            await updateMathInputValue({
+                latex,
+                componentIdx: await resolvePathToNodeIdx("n"),
+                core,
+            });
+        }
+
+        // A percent evaluates to a number, so only `allowUnits="false"`
+        // rejects it.
+        await set_input("50\\%");
+        await check_items({
+            isNumber: true,
+            isNumberNoUnits: false,
+            isInteger: false,
+            isIntegerNoUnits: false,
+        });
+
+        // `100%` is 1, an integer, until units are excluded.
+        await set_input("100\\%");
+        await check_items({
+            isNumber: true,
+            isNumberNoUnits: false,
+            isInteger: true,
+            isIntegerNoUnits: false,
+        });
+
+        // A unit anywhere in the expression is enough to reject it.
+        await set_input("50\\%+0");
+        await check_items({
+            isNumber: true,
+            isNumberNoUnits: false,
+            isInteger: false,
+            isIntegerNoUnits: false,
+        });
+
+        // The decimal a percent equals is still accepted, which is the whole
+        // point of the attribute.
+        await set_input("0.5");
+        await check_items({
+            isNumber: true,
+            isNumberNoUnits: true,
+            isInteger: false,
+            isIntegerNoUnits: false,
+        });
+
+        // As is any other unit-free way of writing it.
+        await set_input("\\frac{1}{2}");
+        await check_items({
+            isNumber: true,
+            isNumberNoUnits: true,
+            isInteger: false,
+            isIntegerNoUnits: false,
+        });
+
+        await set_input("3");
+        await check_items({
+            isNumber: true,
+            isNumberNoUnits: true,
+            isInteger: true,
+            isIntegerNoUnits: true,
+        });
+
+        // `allowUnits` changes nothing about what is not a number at all.
+        await set_input("x");
+        await check_items({
+            isNumber: false,
+            isNumberNoUnits: false,
+            isInteger: false,
+            isIntegerNoUnits: false,
+        });
+    });
+
+    it("allowUnits on an answer reaches isnumber inside a when", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <answer name="ans">
+      <mathInput name="mi"/>
+      <award name="award"><when>isnumber($mi) and 0 <= $mi <= 1</when></award>
+    </answer>
+    <answer name="ansNoUnits" allowUnits="false">
+      <mathInput name="miNoUnits"/>
+      <award name="awardNoUnits"><when>isnumber($miNoUnits) and 0 <= $miNoUnits <= 1</when></award>
+    </answer>
+    `,
+        });
+
+        async function check_credit(award: number, awardNoUnits: number) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("award")].stateValues
+                    .creditAchievedIfSubmit,
+                "award",
+            ).eq(award);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("awardNoUnits")]
+                    .stateValues.creditAchievedIfSubmit,
+                "awardNoUnits",
+            ).eq(awardNoUnits);
+        }
+
+        async function set_inputs(latex: string) {
+            for (const name of ["mi", "miNoUnits"]) {
+                await updateMathInputValue({
+                    latex,
+                    componentIdx: await resolvePathToNodeIdx(name),
+                    core,
+                });
+            }
+        }
+
+        // `allowUnits` set on the answer reaches the `<when>` through the
+        // `<award>`, so only the second answer rejects a percent.
+        await set_inputs("50\\%");
+        await check_credit(1, 0);
+
+        await set_inputs("0.5");
+        await check_credit(1, 1);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
@@ -13557,7 +13557,7 @@ describe("Math tag tests @group3", async () => {
     <math name="currency">&#36;5</math>
     <math name="nested">50% + 0</math>
     <math name="variable">x</math>
-    <math name="unitVariable">unit</math>
+    <math name="unitVariable" splitSymbols="false">unit</math>
     `,
         });
 
@@ -13579,7 +13579,8 @@ describe("Math tag tests @group3", async () => {
         // A unit anywhere in the expression counts, not just at the top.
         expect(await hasUnits("nested")).eq(true);
         expect(await hasUnits("variable")).eq(false);
-        // A variable named `unit` is a symbol, not a unit.
+        // A variable spelled `unit` is a symbol, not a unit. (`splitSymbols`
+        // is off so that it stays one symbol rather than a product of four.)
         expect(await hasUnits("unitVariable")).eq(false);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
@@ -13553,6 +13553,8 @@ describe("Math tag tests @group3", async () => {
     <math name="decimal">0.5</math>
     <math name="fraction">1/2</math>
     <math name="degrees">30 deg</math>
+    <math name="degreeSymbol" format="latex">30^\\circ</math>
+    <math name="currency">&#36;5</math>
     <math name="nested">50% + 0</math>
     <math name="variable">x</math>
     <math name="unitVariable">unit</math>
@@ -13572,6 +13574,8 @@ describe("Math tag tests @group3", async () => {
         expect(await hasUnits("decimal")).eq(false);
         expect(await hasUnits("fraction")).eq(false);
         expect(await hasUnits("degrees")).eq(true);
+        expect(await hasUnits("degreeSymbol")).eq(true);
+        expect(await hasUnits("currency")).eq(true);
         // A unit anywhere in the expression counts, not just at the top.
         expect(await hasUnits("nested")).eq(true);
         expect(await hasUnits("variable")).eq(false);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
@@ -13545,4 +13545,37 @@ describe("Math tag tests @group3", async () => {
                 .renderMode,
         ).eq("inline");
     });
+
+    it("hasUnits distinguishes a quantity with a unit from the number it equals", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math name="percent">50%</math>
+    <math name="decimal">0.5</math>
+    <math name="fraction">1/2</math>
+    <math name="degrees">30 deg</math>
+    <math name="nested">50% + 0</math>
+    <math name="variable">x</math>
+    <math name="unitVariable">unit</math>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        async function hasUnits(name: string) {
+            return stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                .hasUnits;
+        }
+
+        // `50%` and `0.5` evaluate to the same constant, so only `hasUnits`
+        // tells them apart.
+        expect(await hasUnits("percent")).eq(true);
+        expect(await hasUnits("decimal")).eq(false);
+        expect(await hasUnits("fraction")).eq(false);
+        expect(await hasUnits("degrees")).eq(true);
+        // A unit anywhere in the expression counts, not just at the top.
+        expect(await hasUnits("nested")).eq(true);
+        expect(await hasUnits("variable")).eq(false);
+        // A variable named `unit` is a symbol, not a unit.
+        expect(await hasUnits("unitVariable")).eq(false);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/utils/booleanLogic.js
+++ b/packages/doenetml-worker-javascript/src/utils/booleanLogic.js
@@ -366,10 +366,11 @@ export function evaluateLogic({
         return evaluateNumericPredicate({
             predicate: operands[0],
             expression,
-            // `allowUnits` is absent for callers that don't offer the
-            // attribute — `<number convertBoolean>` builds its dependency
-            // values by hand — which the helper reads as its default of
-            // `true`, so units stay allowed there as they always have been.
+            // `<boolean>`, `<when>`, and `<award>` all supply `allowUnits`.
+            // `<number convertBoolean>`, the one caller that offers no such
+            // attribute, leaves the key absent, which the helper reads as its
+            // default of `true` — so units stay allowed there as they always
+            // have been.
             allowUnits: dependencyValues.allowUnits,
             // TODO: should we simplify before evaluating to constant?
             simplify: true,

--- a/packages/doenetml-worker-javascript/src/utils/booleanLogic.js
+++ b/packages/doenetml-worker-javascript/src/utils/booleanLogic.js
@@ -363,12 +363,14 @@ export function evaluateLogic({
         // try to see if operand can be evaluated to a number
         let expression = me.fromAst(replaceMath(operands[1]));
 
-        // `allowUnits` is absent for callers that don't offer the attribute,
-        // in which case units are allowed, as they always have been.
         return evaluateNumericPredicate({
             predicate: operands[0],
             expression,
-            allowUnits: dependencyValues.allowUnits !== false,
+            // `allowUnits` is absent for callers that don't offer the
+            // attribute — `<number convertBoolean>` builds its dependency
+            // values by hand — which the helper reads as its default of
+            // `true`, so units stay allowed there as they always have been.
+            allowUnits: dependencyValues.allowUnits,
             // TODO: should we simplify before evaluating to constant?
             simplify: true,
         })

--- a/packages/doenetml-worker-javascript/src/utils/booleanLogic.js
+++ b/packages/doenetml-worker-javascript/src/utils/booleanLogic.js
@@ -3,6 +3,7 @@ import me from "math-expressions";
 import { buildSubsetFromMathExpression, deepCompare } from "@doenet/utils";
 import {
     appliedFunctionSymbolsDefault,
+    evaluateNumericPredicate,
     textToMathFactory,
     numberToMathExpression,
 } from "./math";
@@ -362,28 +363,17 @@ export function evaluateLogic({
         // try to see if operand can be evaluated to a number
         let expression = me.fromAst(replaceMath(operands[1]));
 
-        // TODO: should we simplify before evaluating to constant?
-        let numericalValue = expression.simplify().evaluate_to_constant();
-
-        if (!Number.isFinite(numericalValue)) {
-            return 0;
-        }
-
-        if (operands[0] === "isnumber") {
-            return 1;
-        } else {
-            // to account for round off error, round to nearest integer
-            // and check if close to that integer
-            let rounded = Math.round(numericalValue);
-            if (
-                Math.abs(rounded - numericalValue) <=
-                1e-15 * Math.abs(numericalValue)
-            ) {
-                return 1;
-            } else {
-                return 0;
-            }
-        }
+        // `allowUnits` is absent for callers that don't offer the attribute,
+        // in which case units are allowed, as they always have been.
+        return evaluateNumericPredicate({
+            predicate: operands[0],
+            expression,
+            allowUnits: dependencyValues.allowUnits !== false,
+            // TODO: should we simplify before evaluating to constant?
+            simplify: true,
+        })
+            ? 1
+            : 0;
     }
 
     // TODO: other set operations

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -502,15 +502,19 @@ export function treeHasUnits(tree: Tree): boolean {
  *
  * Shared by the two spellings of each check — the components `<isNumber>` and
  * `<isInteger>`, and the functions `isnumber(...)` and `isinteger(...)` written
- * inside a `<boolean>` or `<when>` — so that a single rule decides what counts.
+ * inside a `<boolean>`, `<when>`, or `<award>` — so that a single rule decides
+ * what counts.
  *
  * When `allowUnits` is false, a quantity written with a unit fails the check
  * even though it evaluates to a number: `50%` is rejected while the `1/2` it
- * equals is still accepted. `simplify` controls whether the expression is
- * simplified before it is evaluated, which the function spelling does and the
- * component spelling does not — the one respect in which the two spellings
- * still differ, so `isnumber(x-x)` is true where `<isNumber>x-x</isNumber>` is
- * not.
+ * equals is still accepted. The unit test runs against the expression as
+ * written, before any simplification, so `isnumber(50% - 50%)` is refused too
+ * rather than slipping through as the `0` it simplifies to.
+ *
+ * `simplify` controls whether the expression is simplified before it is
+ * evaluated, which the function spelling does and the component spelling does
+ * not — the one respect in which the two spellings still differ, so
+ * `isnumber(x-x)` is true where `<isNumber>x-x</isNumber>` is not.
  */
 export function evaluateNumericPredicate({
     predicate,

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -502,13 +502,15 @@ export function treeHasUnits(tree: Tree): boolean {
  *
  * Shared by the two spellings of each check — the components `<isNumber>` and
  * `<isInteger>`, and the functions `isnumber(...)` and `isinteger(...)` written
- * inside a `<boolean>` or `<when>` — so the two always agree on what counts.
+ * inside a `<boolean>` or `<when>` — so that a single rule decides what counts.
  *
  * When `allowUnits` is false, a quantity written with a unit fails the check
  * even though it evaluates to a number: `50%` is rejected while the `1/2` it
  * equals is still accepted. `simplify` controls whether the expression is
  * simplified before it is evaluated, which the function spelling does and the
- * component spelling does not.
+ * component spelling does not — the one respect in which the two spellings
+ * still differ, so `isnumber(x-x)` is true where `<isNumber>x-x</isNumber>` is
+ * not.
  */
 export function evaluateNumericPredicate({
     predicate,
@@ -529,7 +531,10 @@ export function evaluateNumericPredicate({
         simplify ? expression.simplify() : expression
     ).evaluate_to_constant();
 
-    if (numericValue === null || !Number.isFinite(numericValue)) {
+    // `evaluate_to_constant` never answers `null`: it answers `NaN` when the
+    // expression has no numeric value, and a `Complex` when the value is not
+    // real. Neither is a number this check accepts.
+    if (typeof numericValue !== "number" || !Number.isFinite(numericValue)) {
         return false;
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -485,9 +485,10 @@ export function normalizeLatexString(
  * evaluate to the same constant. That distinction is what lets a numeric check
  * such as `<isNumber>` refuse `50%` while still accepting `1/2`.
  *
- * The head of an operator node names the operation rather than an operand, so
- * only the operands are descended into — a variable that happens to be spelled
- * `unit` is a string, not a `unit` node, and is correctly ignored.
+ * Only an operator node can be a unit, so a leaf — a number, or a symbol, even
+ * one spelled `unit` — is never one. Within a node the first element names the
+ * operation and is tested directly; the remaining elements are the operands and
+ * are the only ones descended into.
  */
 export function treeHasUnits(tree: Tree): boolean {
     if (!Array.isArray(tree)) {

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -1,5 +1,5 @@
 import me from "math-expressions";
-import type { Tree } from "math-expressions";
+import type { Expression, Tree } from "math-expressions";
 
 import { subsets, vectorOperators, roundForDisplay } from "@doenet/utils";
 
@@ -516,7 +516,7 @@ export function evaluateNumericPredicate({
     simplify = false,
 }: {
     predicate: "isnumber" | "isinteger";
-    expression: any;
+    expression: Expression;
     allowUnits?: boolean;
     simplify?: boolean;
 }): boolean {
@@ -528,7 +528,7 @@ export function evaluateNumericPredicate({
         simplify ? expression.simplify() : expression
     ).evaluate_to_constant();
 
-    if (!Number.isFinite(numericValue)) {
+    if (numericValue === null || !Number.isFinite(numericValue)) {
         return false;
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -476,6 +476,73 @@ export function normalizeLatexString(
     return latexString;
 }
 
+/**
+ * Whether `tree` carries a unit anywhere within it.
+ *
+ * A quantity written with a unit — `50%`, `$5`, `30 deg`, `30^\circ` — parses
+ * to a `unit` operator node rather than to the bare number it is worth, so a
+ * percent and the decimal it equals are distinguishable here even though both
+ * evaluate to the same constant. That distinction is what lets a numeric check
+ * such as `<isNumber>` refuse `50%` while still accepting `1/2`.
+ *
+ * The head of an operator node names the operation rather than an operand, so
+ * only the operands are descended into — a variable that happens to be spelled
+ * `unit` is a string, not a `unit` node, and is correctly ignored.
+ */
+export function treeHasUnits(tree: Tree): boolean {
+    if (!Array.isArray(tree)) {
+        return false;
+    }
+    return tree[0] === "unit" || tree.slice(1).some(treeHasUnits);
+}
+
+/**
+ * Evaluate the `isNumber` / `isInteger` check on a math expression.
+ *
+ * Shared by the two spellings of each check — the components `<isNumber>` and
+ * `<isInteger>`, and the functions `isnumber(...)` and `isinteger(...)` written
+ * inside a `<boolean>` or `<when>` — so the two always agree on what counts.
+ *
+ * When `allowUnits` is false, a quantity written with a unit fails the check
+ * even though it evaluates to a number: `50%` is rejected while the `1/2` it
+ * equals is still accepted. `simplify` controls whether the expression is
+ * simplified before it is evaluated, which the function spelling does and the
+ * component spelling does not.
+ */
+export function evaluateNumericPredicate({
+    predicate,
+    expression,
+    allowUnits = true,
+    simplify = false,
+}: {
+    predicate: "isnumber" | "isinteger";
+    expression: any;
+    allowUnits?: boolean;
+    simplify?: boolean;
+}): boolean {
+    if (!allowUnits && treeHasUnits(expression.tree)) {
+        return false;
+    }
+
+    const numericValue = (
+        simplify ? expression.simplify() : expression
+    ).evaluate_to_constant();
+
+    if (!Number.isFinite(numericValue)) {
+        return false;
+    }
+
+    if (predicate === "isnumber") {
+        return true;
+    }
+
+    // Evaluating an expression numerically can land an integer result just
+    // beside the integer, so accept anything within a relative tolerance of
+    // the nearest one.
+    const rounded = Math.round(numericValue);
+    return Math.abs(rounded - numericValue) <= 1e-15 * Math.abs(numericValue);
+}
+
 export function isValidVariable(expression: {
     tree: any;
     [key: string]: unknown;

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -1592,13 +1592,23 @@ function createArrayElementDescription(
  * `Parent`, so walking the constructor prototype chain visits each ancestor
  * class in turn. The walk stops at the first prototype that isn't a class
  * with a `componentType` (i.e. `Function.prototype` / `Object`).
+ *
+ * A componentType is recorded once. An intermediate class that shares
+ * implementation between siblings without being a component type of its own
+ * (e.g. the base of `<isNumber>` and `<isInteger>`) declares no
+ * `componentType` and so inherits its parent's, which would otherwise appear
+ * twice in a row.
  */
 function abstractAncestorChain(cClass: ComponentClass): string[] {
     const chain: string[] = [];
     let current: unknown = Object.getPrototypeOf(cClass);
     while (typeof current === "function") {
         const ct = (current as { componentType?: unknown }).componentType;
-        if (typeof ct === "string" && ct.startsWith("_")) {
+        if (
+            typeof ct === "string" &&
+            ct.startsWith("_") &&
+            !chain.includes(ct)
+        ) {
             chain.push(ct);
         }
         current = Object.getPrototypeOf(current);

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -1486,6 +1486,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -10717,6 +10723,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -11121,6 +11134,13 @@
                     "fromAttribute": true
                 },
                 {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "fromAttribute": true
+                },
+                {
                     "name": "expandOnCompare",
                     "type": "boolean",
                     "isArray": false,
@@ -11311,6 +11331,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -11466,6 +11493,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -11659,6 +11693,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -11814,6 +11855,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -12007,6 +12055,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -12162,6 +12217,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -12355,6 +12417,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -12510,6 +12579,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -12703,6 +12779,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -12858,6 +12941,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -13051,6 +13141,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -13398,6 +13495,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -13591,6 +13695,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -13941,6 +14052,13 @@
                     "fromAttribute": true
                 },
                 {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "fromAttribute": true
+                },
+                {
                     "name": "expandOnCompare",
                     "type": "boolean",
                     "isArray": false,
@@ -14125,6 +14243,13 @@
                     ]
                 },
                 "symbolicEquality": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "allowUnits": {
                     "optional": true,
                     "type": [
                         "true",
@@ -14491,6 +14616,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -15345,6 +15477,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -16211,6 +16349,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -17071,6 +17215,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -17935,6 +18085,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -18797,6 +18953,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -19646,6 +19808,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -20467,6 +20635,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -21305,6 +21479,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -22139,6 +22319,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -22977,6 +23163,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -23811,6 +24003,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -24677,6 +24875,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -25539,6 +25743,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -26419,6 +26629,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -27297,6 +27513,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -28159,6 +28381,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -29025,6 +29253,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -29887,6 +30121,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -30753,6 +30993,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -31617,6 +31863,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -32479,6 +32731,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -33351,6 +33609,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -72297,6 +72561,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -84715,6 +84985,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -85116,6 +85393,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -86107,6 +86391,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -89939,6 +90229,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -99551,6 +99847,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "forceFullCheckWorkButton": {
                     "optional": true,
                     "type": [
@@ -100143,6 +100446,13 @@
                     "fromAttribute": true
                 },
                 {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "fromAttribute": true
+                },
+                {
                     "name": "forceFullCheckWorkButton",
                     "type": "boolean",
                     "isArray": false,
@@ -100558,6 +100868,13 @@
                     ]
                 },
                 "symbolicEquality": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "allowUnits": {
                     "optional": true,
                     "type": [
                         "true",
@@ -101017,6 +101334,13 @@
                     "fromAttribute": true
                 },
                 {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "fromAttribute": true
+                },
+                {
                     "name": "expandOnCompare",
                     "type": "boolean",
                     "isArray": false,
@@ -101273,6 +101597,13 @@
                     ]
                 },
                 "symbolicEquality": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "allowUnits": {
                     "optional": true,
                     "type": [
                         "true",
@@ -101687,6 +102018,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -110052,6 +110390,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -122884,6 +123228,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -125341,6 +125691,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -139921,6 +140277,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -144170,6 +144532,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -144544,6 +144913,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -145653,6 +146029,13 @@
                         "false"
                     ]
                 },
+                "allowUnits": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "expandOnCompare": {
                     "optional": true,
                     "type": [
@@ -146053,6 +146436,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -146717,6 +147107,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -1486,16 +1486,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -15479,16 +15479,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -16349,16 +16349,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -17217,16 +17217,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -18085,16 +18085,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -18953,16 +18953,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -19808,16 +19808,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -20637,16 +20637,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -21479,16 +21479,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -22321,16 +22321,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -23163,16 +23163,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -24005,16 +24005,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -24875,16 +24875,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -25745,16 +25745,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -26629,16 +26629,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -27513,16 +27513,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -28383,16 +28383,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -29253,16 +29253,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -30123,16 +30123,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -30993,16 +30993,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -31863,16 +31863,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -32733,16 +32733,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -33611,16 +33611,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -72561,16 +72561,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -86393,16 +86393,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -90231,16 +90231,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -110392,16 +110392,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -123228,16 +123228,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -125693,16 +125693,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -140277,16 +140277,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -147109,16 +147109,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -991,6 +991,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -7354,6 +7360,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -7506,6 +7522,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -7743,6 +7766,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -7895,6 +7928,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -8132,6 +8172,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -8284,6 +8334,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -8521,6 +8578,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -8673,6 +8740,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -8910,6 +8984,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -9062,6 +9146,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -9299,6 +9390,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -9451,6 +9552,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -9752,6 +9860,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -9904,6 +10022,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -10205,6 +10330,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -10357,6 +10492,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -10658,6 +10800,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -10826,6 +10978,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -11695,6 +11854,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -12576,6 +12741,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -13445,6 +13616,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -14318,6 +14495,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -15189,6 +15372,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -16047,6 +16236,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -16874,6 +17069,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -17721,6 +17922,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -18564,6 +18771,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -19411,6 +19624,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -20254,6 +20473,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -21135,6 +21360,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -22012,6 +22243,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -22910,6 +23147,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -23806,6 +24049,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -24683,6 +24932,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -25564,6 +25819,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -26441,6 +26702,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -27322,6 +27589,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -28201,6 +28474,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -29078,6 +29357,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -29984,6 +30269,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -58821,6 +59112,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -68562,6 +68859,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -68714,6 +69021,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -69701,6 +70015,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -72657,6 +72977,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -82840,6 +83166,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "forceFullCheckWorkButton",
                     "description": "Whether to always render a full-size check-work button.",
                     "defaultValue": false,
@@ -83231,6 +83567,13 @@
                     "description": "Whether comparison uses symbolic equality (rather than numeric evaluation).",
                     "fromAttribute": true,
                     "highlighted": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceFullCheckWorkButton",
@@ -83784,6 +84127,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing them.",
                     "defaultValue": false,
@@ -83987,6 +84340,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether comparison uses symbolic equality (rather than numeric evaluation).",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -84377,6 +84737,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -84539,6 +84909,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -92180,6 +92557,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -101686,6 +102069,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -104063,6 +104452,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",
@@ -113910,6 +114305,12 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
+                },
+                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
@@ -117473,6 +117874,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -117664,6 +118075,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -118719,6 +119137,16 @@
                     "type": "boolean"
                 },
                 {
+                    "name": "allowUnits",
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
                     "name": "expandOnCompare",
                     "description": "Whether to expand math expressions before comparing.",
                     "defaultValue": false,
@@ -118945,6 +119373,13 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether children compared via this boolean use symbolic equality.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "allowUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether a quantity written with a unit, such as 50%, counts as a number for the isNumber and isInteger checks.",
                     "fromAttribute": true
                 },
                 {
@@ -119778,6 +120213,12 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "isNumeric",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -991,16 +991,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -11856,16 +11856,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -12741,16 +12741,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -13618,16 +13618,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -14495,16 +14495,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -15372,16 +15372,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -16236,16 +16236,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -17071,16 +17071,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -17922,16 +17922,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -18773,16 +18773,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -19624,16 +19624,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -20475,16 +20475,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -21360,16 +21360,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -22245,16 +22245,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -23147,16 +23147,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -24049,16 +24049,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -24934,16 +24934,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -25819,16 +25819,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -26704,16 +26704,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -27589,16 +27589,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -28474,16 +28474,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -29359,16 +29359,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -30271,16 +30271,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -59112,16 +59112,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -70017,16 +70017,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -72979,16 +72979,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -92559,16 +92559,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -102069,16 +102069,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -104454,16 +104454,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -114305,16 +114305,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",
@@ -120215,16 +120215,16 @@
                     "description": "Whether the expression evaluates to a finite number."
                 },
                 {
-                    "name": "hasUnits",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
-                },
-                {
                     "name": "isNumeric",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "hasUnits",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression contains a unit, such as a percent, a currency, or an angle in degrees."
                 },
                 {
                     "name": "latex",


### PR DESCRIPTION
`50%` is worth `0.5`, and every numeric check in Doenet went by what a value is worth — `<isNumber>`, `isnumber(...)`, and the inequalities all accepted a percent, and nothing an author could write told the two apart. `<math>`'s `isNumber` property did tell them apart, but only by demanding the expression be spelled as a bare number, so it turned down `1/2` as readily as `50%`.

## What this adds

- **`<math>` gains a `hasUnits` property** — true when the expression contains a quantity written with a unit anywhere within it. math-expressions parses `50%`, `$5`, and `30 deg`/`30^\circ` alike to a `unit` operator node, so all three are covered.
- **`allowUnits` attribute, defaulting to `true`** — `<isNumber allowUnits="false">` and `<isInteger allowUnits="false">` refuse `50%` while still accepting `0.5`, `1/2`, and every other unit-free way of writing the same value.

The attribute is declared on `<boolean>`, which `<isNumber>` and `<isInteger>` already extend, so the `isnumber(...)` and `isinteger(...)` function forms take it too and both spellings of each check treat units the same way. `<when>`, `<award>`, and `<answer>` carry it down the same way they carry `symbolicEquality`, so setting it on an answer reaches the conditions inside it:

```
<answer allowUnits="false">
  <mathInput name="mi"/>
  <award><when>isnumber($mi) and 0 <= $mi <= 1</when></award>
</answer>
```

Both spellings follow that chain. `allowUnits` on `<boolean>` has no parent fall-back — matching `symbolicEquality` and the other comparison settings, each of which governs a comparison the `<boolean>` performs itself and has no second spelling — but `allowUnits` is the exception, because the same check is also written as a tag. So `<isNumber>` and `<isInteger>` add the fall-back themselves: they take `allowUnits` from whatever component encloses them, and an `<isNumber>` written inside an award picks up the answer's setting just as `isnumber(...)` does. Without it, `<answer allowUnits="false">` would have reached one spelling and not the other. Each component consults only its immediate parent, and only when that parent's value was set rather than defaulted; a setting still travels several levels because each link in an `<answer>` → `<award>` → `<when>` chain falls back in turn, while a tag written outside such a chain keeps its own default.

`allowUnits` governs the number checks only. Inequalities and equality comparisons continue to go by what a value is worth, so `50% = 0.5` remains true — a symbolic inequality isn't well-defined, which is also why `symbolicEquality` never applied to them.

## Implementation notes

- `treeHasUnits` and `evaluateNumericPredicate` in `utils/math.ts` are the single home for the check. The latter replaces the two copies of the evaluate-and-test logic that had drifted apart in `BooleanOperatorsOfMath.js` and `booleanLogic.js` — including the integer round-off tolerance, which was duplicated verbatim.
- `<isNumber>` and `<isInteger>` were near-identical; they now share an unexported `NumericPredicateOfMath` base class and declare only their `componentType`, their `predicate`, and their docs summary. The "exactly one math child" arity check that all three operators in the file repeated — `<isBetween>` included — is now `returnSingleMathChildOperator`, and its warning names the tag (`<isBetween> requires …`) rather than the class, which also keeps it readable in a minified worker bundle.
- `abstractAncestorChain` in `packages/static-assets/scripts/get-schema.ts` now records each abstract componentType once. An intermediate class that shares implementation without being a component type of its own — `NumericPredicateOfMath` — declares no `componentType` and so inherits its parent's, which would otherwise have been emitted twice in a row for `<isNumber>` and `<isInteger>`.
- `booleanLogic.js` passes `dependencyValues.allowUnits` straight through rather than coercing it: `<boolean>`, `<when>`, and `<award>` all supply it, while `<number convertBoolean>` — the one caller that offers no such attribute — leaves it absent, and `evaluateNumericPredicate`'s default of `true` is the one place that decides what an absent value means.
- `evaluate_to_constant` answers `NaN` for an expression with no numeric value and a `Complex` for a non-real one, never `null`; `evaluateNumericPredicate` narrows with `typeof === "number"` accordingly.
- The unit test runs against the expression as written, before any simplification, so `isnumber(50% - 50%)` is refused under `allowUnits="false"` rather than slipping through as the `0` it simplifies to.
- The one behavior difference between the spellings is preserved: the function form simplifies before evaluating, the component form does not, so `isnumber(x-x)` is true where `<isNumber>x-x</isNumber>` is not. `evaluateNumericPredicate` takes that as a `simplify` flag rather than papering over it, and the prose in the docs and the changeset claims only that the two spellings agree *about units*.

## Testing

- `math.test.ts` — `hasUnits` across percent, decimal, fraction, `30 deg`, `30^\circ`, a currency, a nested unit, a plain variable, and a variable spelled `unit`.
- `booleanoperatorsonmath.test.ts` — `allowUnits` across `50%`, `100%`, `50%+0`, `0.5`, `1/2`, `3`, and `x`, asserting the component and function spellings agree on every case; a test that `allowUnits` on an `<answer>` reaches `isnumber` inside a `<when>`; a test of the tag spelling's inheritance covering all four positions — inside an award's `<when>`, inside a `<boolean allowUnits="false">`, and standalone in a `<p>` for both tags; and a test pinning the simplification boundary, that `allowUnits="false"` refuses `isnumber(50% - 50%)` and that only the function spelling calls `x-x` a number. Confirmed the inheritance test fails without the fall-back rather than passing vacuously.
- Probed the fall-back for misfires: an `<isNumber>` in a `<section>` or a `<p>`, an explicit `allowUnits="true"` inside an `<answer allowUnits="false">`, and an `<isNumber>` nested in a plain `<boolean>` inside a `<boolean allowUnits="false">` all keep the value their own position implies; a component extended into an answer takes its new position's setting, the same as `styleNumber` and the other parent fall-backs.
- Docs examples were run through core to confirm they behave as the prose says.
- Full `booleanoperatorsonmath`, `boolean`, `booleanoperators`, `number`, `math`, `mathoperators`, `answer`, and `answerValidation` suites pass.

Schema regenerated; docs added for the `hasUnits` property (`math2.mdx`) and the `allowUnits` attribute (`isNumber.mdx`, `isInteger.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBb6egFn7UyTYY5vTBKXRh
