### PR TITLE
fix: resolve a copied reference where it came from when its name is out of scope

### DIFF
--- a/.changeset/repeat-reference-spurious-no-referent.md
+++ b/.changeset/repeat-reference-spurious-no-referent.md
@@ -1,0 +1,24 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop warning that a repeat's `valueName` has no referent when a reference lifts it out of the repeat.
+
+Referencing one iteration of a repeat, as in
+
+```xml
+<repeatForSequence from="1" to="5" valueName="i" name="xiValues">
+  <number>$i</number>
+</repeatForSequence>
+<m>x_3 = $xiValues[3]</m>
+```
+
+copies the iteration's `<number>` — and the `$i` inside it — to where the reference appears. The copy was then re-resolved from where it landed, and `i` lives inside the repeat, invisible from the `<m>`, so the document reported "No referent found for reference: `$i`" even though the reference had resolved and the value showed correctly. The warning went away if the reference or the `<number>` wrapper was removed, which is what made it look spurious.
+
+Re-resolving from where a copy lands is what lets each iteration of a repeat bind `$i` to its own value, so that stays. A copy that lands somewhere the name is out of scope now falls back on resolving the reference where the component it shadows sits, which is where the reference came from and still points.
+
+Closes #1424.

--- a/.changeset/repeat-reference-spurious-no-referent.md
+++ b/.changeset/repeat-reference-spurious-no-referent.md
@@ -19,6 +19,8 @@ Referencing one iteration of a repeat, as in
 
 copies the iteration's `<number>` — and the `$i` inside it — to where the reference appears. The copy was then re-resolved from where it landed, and `i` lives inside the repeat, invisible from the `<m>`, so the document reported "No referent found for reference: `$i`" even though the reference had resolved and the value showed correctly. The warning went away if the reference or the `<number>` wrapper was removed, which is what made it look spurious.
 
-Re-resolving from where a copy lands is what lets each iteration of a repeat bind `$i` to its own value, so that stays. A copy that lands somewhere the name is out of scope now falls back on resolving the reference where the component it shadows sits, which is where the reference came from and still points.
+Re-resolving from where a copy lands is what lets each iteration of a repeat bind `$i` to its own value, so that stays. A copy that lands somewhere the name is out of scope now falls back on resolving the reference where the component it shadows sits — which is where the reference came from and still points — and keeps falling back however many times the reference has been copied, so referencing the `<m>` above stays quiet too.
+
+A reference that resolves nowhere still reports the same warning it always did, at the same place.
 
 Closes #1424.

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -164,7 +164,8 @@ export class RefResolutionIndexDependencies extends Dependency {
  *
  * If `refResolution.nodeIdx` has any composite descendants
  * or any indices of the path have composites, these composites are first expanded.
- * Then, the `originalPath` path is resolved using the first node of `refResolution.nodesInResolvedPath` as the origin;
+ * Then, the `originalPath` path is resolved from the first of the candidate origins that
+ * `originsToResolveFrom` yields (normally the first node of `refResolution.nodesInResolvedPath`);
  * `nodeIdx` is updated to the matched component, and `unresolvedPath` is updated to any remaining unresolved path.
  *
  * If an index is encountered (which halts the rust resolver), then
@@ -193,7 +194,7 @@ export class RefResolutionDependency extends Dependency {
     }
 
     /**
-     * The origins to re-resolve this composite's reference from, best first.
+     * The origins to re-resolve `composite`'s reference from, best first.
      *
      * A reference is normally re-resolved from where it now sits, which is what lets a
      * copied reference find a copied referent: every iteration of a `<repeat>` supplies
@@ -206,9 +207,17 @@ export class RefResolutionDependency extends Dependency {
      * lives inside the repeat, invisible from there. Such a copy shadows the component
      * it was copied from, and still refers to whatever that one refers to, so fall back
      * on resolving the reference where the shadowed component sits.
+     *
+     * A shadowing copy is a structural duplicate of what it shadows, so every component
+     * in the `shadows` chain carries the same reference — the same path resolved from a
+     * different place — which is what makes their origins interchangeable candidates.
      */
     *originsToResolveFrom(composite: any) {
+        // Guards against a cycle in the `shadows` chain, so the walk terminates even if
+        // the chain does not.
         const visitedSources = new Set<number>();
+        // Two components in the chain can share an origin; resolving from the same place
+        // a second time would only repeat the same failure.
         const yieldedOrigins = new Set<number>();
 
         let source = composite;
@@ -226,6 +235,7 @@ export class RefResolutionDependency extends Dependency {
                 yield origin;
             }
 
+            // A component that shadows nothing, or whose source is gone, ends the chain.
             source =
                 this.dependencyHandler._components[
                     source.shadows?.componentIdx
@@ -355,8 +365,6 @@ export class RefResolutionDependency extends Dependency {
             ]);
         }
 
-        let refResolution;
-
         /**
          * Given the ref resolution `composite.refResolution`
          * and the DoenetML string from `this.dependencyHandler.core.allDoenetMLs[0]`,
@@ -375,11 +383,19 @@ export class RefResolutionDependency extends Dependency {
         // console.log(
         //     "resolve path",
         //     { path: resolveComponentResult.path },
-        //     composite.refResolution.nodesInResolvedPath[0],
+        //     [...this.originsToResolveFrom(composite)],
         //     skip_parent_search,
         // );
 
-        let resolutionError: unknown;
+        // The resolution from the first candidate origin that produced one; left
+        // `undefined` if every candidate failed (or if there was no candidate to try).
+        let refResolution;
+
+        // The failure reported if no candidate origin resolves. It is the failure of the
+        // first candidate — the reference's own position — since that is the one that
+        // describes the document the author wrote; later candidates are only fallbacks.
+        let firstResolutionError:
+            "NonUniqueReferent" | "NoReferent" | undefined;
 
         for (const origin of this.originsToResolveFrom(composite)) {
             try {
@@ -388,19 +404,18 @@ export class RefResolutionDependency extends Dependency {
                     origin,
                     skip_parent_search,
                 );
-                resolutionError = undefined;
                 break;
             } catch (e) {
                 // console.log("resolve error", e);
                 if (e === "NonUniqueReferent" || e === "NoReferent") {
-                    resolutionError = e;
+                    firstResolutionError ??= e;
                 } else {
                     throw e;
                 }
             }
         }
 
-        if (resolutionError !== undefined) {
+        if (refResolution === undefined) {
             const referenceText = getDoenetMLStringForReference();
 
             // TODO: these message match the messages from `format_error_message` of `ref_resolve.ts`.
@@ -412,7 +427,7 @@ export class RefResolutionDependency extends Dependency {
                     // Spread rather than a ternary on the value: the
                     // code has to sit next to `code:` as a literal, or
                     // `lint:i18n` reads it as a code nothing raises.
-                    ...(resolutionError === "NonUniqueReferent"
+                    ...(firstResolutionError === "NonUniqueReferent"
                         ? { code: "doenet-w0105" as const }
                         : { code: "doenet-w0104" as const }),
                     args: { reference: `$${referenceText}` },

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -192,6 +192,47 @@ export class RefResolutionDependency extends Dependency {
         this.missingComponentBlockers = [];
     }
 
+    /**
+     * The origins to re-resolve this composite's reference from, best first.
+     *
+     * A reference is normally re-resolved from where it now sits, which is what lets a
+     * copied reference find a copied referent: every iteration of a `<repeat>` supplies
+     * its own `valueName`, so the copy of `$i` in each iteration must resolve against
+     * that iteration and not the template.
+     *
+     * A copy can also land where the name it references is not in scope at all, though.
+     * `$r[3]` on `<repeat name="r" valueName="i"><number>$i</number></repeat>` copies
+     * the `<number>` and the `$i` inside it to wherever the reference appears, and `i`
+     * lives inside the repeat, invisible from there. Such a copy shadows the component
+     * it was copied from, and still refers to whatever that one refers to, so fall back
+     * on resolving the reference where the shadowed component sits.
+     */
+    *originsToResolveFrom(composite: any) {
+        const visitedSources = new Set<number>();
+        const yieldedOrigins = new Set<number>();
+
+        let source = composite;
+
+        while (
+            source?.refResolution &&
+            !visitedSources.has(source.componentIdx)
+        ) {
+            visitedSources.add(source.componentIdx);
+
+            const origin = source.refResolution.nodesInResolvedPath[0];
+
+            if (origin != undefined && !yieldedOrigins.has(origin)) {
+                yieldedOrigins.add(origin);
+                yield origin;
+            }
+
+            source =
+                this.dependencyHandler._components[
+                    source.shadows?.componentIdx
+                ];
+        }
+    }
+
     async determineDownstreamComponents({ force = false } = {}) {
         this.compositeReplacementDependencies = [];
 
@@ -338,45 +379,55 @@ export class RefResolutionDependency extends Dependency {
         //     skip_parent_search,
         // );
 
-        try {
-            refResolution = this.dependencyHandler.core.resolvePath!(
-                { path: resolveComponentResult.path },
-                composite.refResolution.nodesInResolvedPath[0],
-                skip_parent_search,
-            );
-        } catch (e) {
-            // console.log("resolve error", e);
-            if (e === "NonUniqueReferent" || e === "NoReferent") {
-                const referenceText = getDoenetMLStringForReference();
+        let resolutionError: unknown;
 
-                // TODO: these message match the messages from `format_error_message` of `ref_resolve.ts`.
-                // Rather than duplicating code to make the messages,
-                // we could make sure that `ref_resolve` formats the messages in this case, too.
-                this.dependencyHandler.core.addDiagnostic(
-                    codedDiagnostic({
-                        type: "warning",
-                        // Spread rather than a ternary on the value: the
-                        // code has to sit next to `code:` as a literal, or
-                        // `lint:i18n` reads it as a code nothing raises.
-                        ...(e === "NonUniqueReferent"
-                            ? { code: "doenet-w0105" as const }
-                            : { code: "doenet-w0104" as const }),
-                        args: { reference: `$${referenceText}` },
-                        position: composite.position,
-                        sourceDoc: composite.sourceDoc,
-                    }),
+        for (const origin of this.originsToResolveFrom(composite)) {
+            try {
+                refResolution = this.dependencyHandler.core.resolvePath!(
+                    { path: resolveComponentResult.path },
+                    origin,
+                    skip_parent_search,
                 );
-
-                this.extendIdx = -1;
-                this.unresolvedPath = this.originalPath;
-                return {
-                    success: true,
-                    downstreamComponentIndices: [],
-                    downstreamComponentTypes: [],
-                };
-            } else {
-                throw e;
+                resolutionError = undefined;
+                break;
+            } catch (e) {
+                // console.log("resolve error", e);
+                if (e === "NonUniqueReferent" || e === "NoReferent") {
+                    resolutionError = e;
+                } else {
+                    throw e;
+                }
             }
+        }
+
+        if (resolutionError !== undefined) {
+            const referenceText = getDoenetMLStringForReference();
+
+            // TODO: these message match the messages from `format_error_message` of `ref_resolve.ts`.
+            // Rather than duplicating code to make the messages,
+            // we could make sure that `ref_resolve` formats the messages in this case, too.
+            this.dependencyHandler.core.addDiagnostic(
+                codedDiagnostic({
+                    type: "warning",
+                    // Spread rather than a ternary on the value: the
+                    // code has to sit next to `code:` as a literal, or
+                    // `lint:i18n` reads it as a code nothing raises.
+                    ...(resolutionError === "NonUniqueReferent"
+                        ? { code: "doenet-w0105" as const }
+                        : { code: "doenet-w0104" as const }),
+                    args: { reference: `$${referenceText}` },
+                    position: composite.position,
+                    sourceDoc: composite.sourceDoc,
+                }),
+            );
+
+            this.extendIdx = -1;
+            this.unresolvedPath = this.originalPath;
+            return {
+                success: true,
+                downstreamComponentIndices: [],
+                downstreamComponentTypes: [],
+            };
         }
 
         this.extendIdx = refResolution.nodeIdx;

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -208,11 +208,14 @@ export class RefResolutionDependency extends Dependency {
      * it was copied from, and still refers to whatever that one refers to, so fall back
      * on resolving the reference where the shadowed component sits.
      *
-     * A shadowing copy is a structural duplicate of what it shadows, so every component
-     * in the `shadows` chain carries the same reference — the same path resolved from a
-     * different place — which is what makes their origins interchangeable candidates.
+     * A shadowing copy is a structural duplicate of what it shadows: its `refResolution`
+     * is serialized from the shadowed component's, so the two carry the same reference —
+     * the same path resolved from a different place — which is what makes their origins
+     * interchangeable candidates. That is why the walk stops at the first link with no
+     * `refResolution` of its own: a component whose reference did not come from the one
+     * it shadows says nothing about where this reference should resolve.
      */
-    *originsToResolveFrom(composite: any) {
+    *originsToResolveFrom(composite: any): Generator<number> {
         // Guards against a cycle in the `shadows` chain, so the walk terminates even if
         // the chain does not.
         const visitedSources = new Set<number>();

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -319,6 +319,10 @@ describe("coded diagnostics reach the record @group4", () => {
         // Extending with an index defers resolution until core knows the
         // group's replacements, so this warning is the worker's own rather
         // than the one the Rust resolver raises for a plainly absent name.
+        // The resolver hands back `g` with the index still unresolved, so this
+        // is `RefResolutionDependency`'s *later* warning — the one for an
+        // expanded composite with no replacement at that index — and not the
+        // one the test below reaches.
         const { core } = await createTestCore({
             doenetML: `
 <group name="g"></group>
@@ -335,13 +339,17 @@ describe("coded diagnostics reach the record @group4", () => {
         );
     });
 
-    // The other branch of the same warning site — the one `RefResolutionDependency`
-    // reaches once no candidate origin resolves the reference. Both codes have to sit
-    // next to `code:` as literals for `lint:i18n` to see them raised, which is why
-    // that site spreads a ternary of objects rather than choosing the value —
-    // and a workaround that only one branch exercises is a workaround nobody
-    // would notice breaking.
-    it("codes the other resolution failure the same warning site reports", async () => {
+    // A different site: the warning `RefResolutionDependency` raises once no
+    // candidate origin resolves the reference. It reports `doenet-w0105` here
+    // and `doenet-w0104` when the failure is a missing rather than an ambiguous
+    // referent, and both codes have to sit next to `code:` as literals for
+    // `lint:i18n` to see them raised — which is why that site spreads a ternary
+    // of objects rather than choosing the value. This pins the ambiguous branch;
+    // the missing one is pinned by "reference to an iteration still warns when
+    // the nested reference resolves nowhere" in `repeatForSequence.test.ts`, and
+    // a workaround that only one branch exercises is a workaround nobody would
+    // notice breaking.
+    it("codes the resolution failure raised after every candidate origin fails", async () => {
         const { core } = await createTestCore({
             doenetML: `
 <repeat name="r" for="1 2" valueName="v">

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -335,12 +335,13 @@ describe("coded diagnostics reach the record @group4", () => {
         );
     });
 
-    // The other branch of the same `catch`. Both codes have to sit next to
-    // `code:` as literals for `lint:i18n` to see them raised, which is why
+    // The other branch of the same warning site — the one `RefResolutionDependency`
+    // reaches once no candidate origin resolves the reference. Both codes have to sit
+    // next to `code:` as literals for `lint:i18n` to see them raised, which is why
     // that site spreads a ternary of objects rather than choosing the value —
     // and a workaround that only one branch exercises is a workaround nobody
     // would notice breaking.
-    it("codes the other resolution failure the same catch reports", async () => {
+    it("codes the other resolution failure the same warning site reports", async () => {
         const { core } = await createTestCore({
             doenetML: `
 <repeat name="r" for="1 2" valueName="v">

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2720,4 +2720,64 @@ describe("RepeatForSequence tag tests @group3", async () => {
         expect(warnings[0].code).eq("doenet-w0104");
         expect(warnings[0].args).eqls({ reference: "$g[$n]" });
     });
+
+    it("reference to an iteration keeps the nested referent when the index changes", async () => {
+        // The cases above resolve once, while the document is being built. Changing the
+        // index makes the reference copy a *different* iteration and re-resolve, so this
+        // covers the fallback on the update path rather than only the initial one.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <mathInput name="n" prefill="3" />
+
+    <p><repeatForSequence from="1" to="5" valueName="i" name="r">
+      <number>$i</number>
+    </repeatForSequence></p>
+
+    <p name="p2"><m>x = $r[$n]</m></p>
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
+        ).eq("x = 3");
+        expect(getDiagnosticsByType(core).warnings).eqls([]);
+
+        await updateMathInputValue({
+            latex: "5",
+            componentIdx: await resolvePathToNodeIdx("n"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
+        ).eq("x = 5");
+        expect(getDiagnosticsByType(core).warnings).eqls([]);
+    });
+
+    it("reference into nested repeats keeps both nested referents", async () => {
+        // Lifting an iteration out of two nested repeats carries references to two
+        // different `valueName`s, each out of scope at the landing site, and each has to
+        // fall back independently.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <repeatForSequence from="1" to="3" valueName="i" name="outer">
+      <repeatForSequence from="1" to="3" valueName="j" name="inner">
+        <group><number>$i</number> <number>$j</number></group>
+      </repeatForSequence>
+    </repeatForSequence>
+
+    <p name="p2">$outer[2].inner[3]</p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
+        ).eq("2 3");
+
+        expect(getDiagnosticsByType(core).warnings).eqls([]);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2684,4 +2684,28 @@ describe("RepeatForSequence tag tests @group3", async () => {
 
         expect(getDiagnosticsByType(core).warnings).eqls([]);
     });
+
+    it("reference to an iteration still warns when the nested reference resolves nowhere", async () => {
+        // The counterpart of the two cases above: falling back to the origins up the
+        // `shadows` chain must not swallow a reference that has no referent anywhere.
+        // `$g[1]` indexes past the end of an empty group, which the Rust resolver leaves
+        // for the worker, so every candidate origin fails and the warning is still
+        // raised — once, and reported at the reference the author wrote.
+        let { core } = await createTestCore({
+            doenetML: `
+    <group name="g" />
+
+    <p><repeatForSequence from="1" to="5" valueName="i" name="r">
+      <number extend="$g[1]" />
+    </repeatForSequence></p>
+
+    <p name="p2"><m>x_3 = $r[3]</m></p>
+    `,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0104");
+        expect(warnings[0].args).eqls({ reference: "$g[1]" });
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2688,24 +2688,36 @@ describe("RepeatForSequence tag tests @group3", async () => {
     it("reference to an iteration still warns when the nested reference resolves nowhere", async () => {
         // The counterpart of the two cases above: falling back to the origins up the
         // `shadows` chain must not swallow a reference that has no referent anywhere.
-        // `$g[1]` indexes past the end of an empty group, which the Rust resolver leaves
-        // for the worker, so every candidate origin fails and the warning is still
-        // raised — once, and reported at the reference the author wrote.
+        //
+        // With the `<mathInput>` left blank, `$n` is not an index the resolver can use,
+        // so `$g[$n]` has no referent — not from inside the iteration where it was
+        // written, and not from the copy `$r[3]` lifts into the `<div>`. Every candidate
+        // origin therefore throws, and the diagnostic that follows the candidate loop is
+        // still raised: once (identical warnings are deduplicated by source position),
+        // reported against `$g[$n]` as the author wrote it rather than against `$r[3]`.
+        //
+        // The reference has to fail on an *index* to reach that loop at all: a name the
+        // Rust resolver cannot find is reported when the document is flattened, long
+        // before this dependency re-resolves anything. An index the resolver simply
+        // leaves unresolved (`$g[1]` against an empty group, say) does not reach it
+        // either — the resolution succeeds and the missing replacement is reported
+        // further down, at a site this change does not touch.
         let { core } = await createTestCore({
             doenetML: `
-    <group name="g" />
+    <mathInput name="n" />
+    <group name="g"><number>7</number></group>
 
-    <p><repeatForSequence from="1" to="5" valueName="i" name="r">
-      <number extend="$g[1]" />
-    </repeatForSequence></p>
+    <repeatForSequence from="1" to="5" valueName="i" name="r">
+      <p><number>$i</number> <number extend="$g[$n]" /></p>
+    </repeatForSequence>
 
-    <p name="p2"><m>x_3 = $r[3]</m></p>
+    <div name="d">$r[3]</div>
     `,
         });
 
         const { warnings } = getDiagnosticsByType(core);
         expect(warnings.length).eq(1);
         expect(warnings[0].code).eq("doenet-w0104");
-        expect(warnings[0].args).eqls({ reference: "$g[1]" });
+        expect(warnings[0].args).eqls({ reference: "$g[$n]" });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -8,6 +8,7 @@ import {
     updateValue,
 } from "../utils/actions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
+import { getDiagnosticsByType } from "../utils/diagnostics";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -2634,5 +2635,29 @@ describe("RepeatForSequence tag tests @group3", async () => {
         }));
 
         await check_items(2, 2);
+    });
+
+    it("reference to an iteration keeps the referent of a reference nested inside it", async () => {
+        // The copy of `<number>$i</number>` that `$r[3]` creates lands in the `<m>`,
+        // where the repeat's `i` is out of scope. The copy still refers to the third
+        // iteration's `i`, so it resolves where the component it shadows sits rather
+        // than reporting no referent for `$i`.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p><repeatForSequence from="1" to="5" valueName="i" name="r">
+      <number>$i</number>
+    </repeatForSequence></p>
+
+    <p name="p2"><m>x_3 = $r[3]</m></p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
+        ).eq("x₃ = 3");
+
+        expect(getDiagnosticsByType(core).warnings).eqls([]);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2660,4 +2660,28 @@ describe("RepeatForSequence tag tests @group3", async () => {
 
         expect(getDiagnosticsByType(core).warnings).eqls([]);
     });
+
+    it("reference to a reference to an iteration keeps the nested referent", async () => {
+        // Referencing the `<m>` copies the copy of `$i` again, so the reference that has
+        // to be resolved is two shadows away from the iteration whose `i` it means. The
+        // whole `shadows` chain has to be walked, not just its first link.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p><repeatForSequence from="1" to="5" valueName="i" name="r">
+      <number>$i</number>
+    </repeatForSequence></p>
+
+    <p><m name="m1">x_3 = $r[3]</m></p>
+    <p name="p3">$m1</p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p3")].stateValues.text,
+        ).eq("x₃ = 3");
+
+        expect(getDiagnosticsByType(core).warnings).eqls([]);
+    });
 });


### PR DESCRIPTION
## The bug

```xml
<p>
  Sequence:
  <repeatForSequence from="1" to="5" step="1" valueName="i" name="xiValues">
    <number>$i</number>
  </repeatForSequence>
</p>

<p><m>x_3 = $xiValues[3]</m></p>
```

reported **"No referent found for reference: `$i`"** even though `$i` resolved and everything rendered correctly (`1, 2, 3, 4, 5` and `x₃ = 3`). Dropping either `$xiValues[3]` or the `<number>` wrapper made the warning go away, which is what made it look spurious.

## Cause

`$xiValues[3]` copies the third iteration's `<number>` — and the `$i` nested inside it — into the `<m>`. `RefResolutionDependency` re-resolves every copied reference from where the copy now sits (`nodesInResolvedPath[0]`, remapped to the copy in `componentIndices.ts`).

That remap is load-bearing: it is what binds each iteration's `$i` to that iteration's own `i` rather than to the template's dummy, since the repeat re-supplies `valueName` per iteration. But a copy lifted *out* of the repeat lands in the `<m>`, and `repeat` is tagged `ChildrenInvisibleToTheirGrandparents`, so `i` is not resolvable from there. The resolver returned `NoReferent` and the warning was raised.

The value still rendered because a shadowing copy's replacements come from `expandShadowingComposite`, not from this resolution — the failure set `extendIdx = -1` and was otherwise inert.

## The fix

Resolution now walks a list of candidate origins (`originsToResolveFrom`) instead of a single one: the reference's own position first, then the origin of each component up its `shadows` chain. The first candidate that resolves wins.

A copy that resolves at its own position behaves exactly as before, so the repeat-iteration binding is untouched. A copy that landed somewhere its name is out of scope resolves where the component it shadows sits — which is where the reference came from and still points. A shadowing copy's `refResolution` is serialized from the shadowed component's, so the two carry the same reference, which is what makes their origins interchangeable candidates; the walk stops at the first link with no `refResolution` of its own, since a component whose reference did not come from the one it shadows says nothing about where this reference should resolve.

The whole chain matters, not just its first link: referencing the `<m>` above copies the copy of `$i` again, and that reference only resolves on the third candidate.

The warning is raised only when no candidate resolves, and it then reports the failure of the *first* candidate — the reference's own position — so a reference that resolves nowhere raises exactly the warning it raised before this change.

## Rejected alternative

Not remapping the origin in `componentIndices.ts` when the referent was not copied along. It breaks every repeat: the `valueName` referent is remapped later by `Repeat.js`'s dummy-alias mapping, not by the copy's `idxMap`, so the heuristic cannot see it and each iteration's `$i` falls back to the template dummy (`NaN` everywhere).

## Testing

Five new cases in `repeatForSequence.test.ts`:

- a reference to an iteration — the reported bug — asserting the rendered value and an empty warning list;
- a reference to *that* reference, which only resolves on the third candidate and so exercises walking past the first link of the `shadows` chain;
- a reference whose index comes from a `<mathInput>`, so changing the index copies a different iteration and re-resolves: the fallback has to hold on the update path, not only while the document is first built;
- a reference into two nested repeats, where the lifted iteration carries references to two different `valueName`s and each has to fall back independently;
- the counterpart guarding the fallback against swallowing a real failure: `extend="$g[$n]"` inside the repeat with the `<mathInput name="n">` left blank, so the index is unusable and no candidate origin resolves — from inside the iteration or from the copy the outer reference lifts out. The warning is still raised, once, with the same code (`doenet-w0104`) and reference text as before.

Every one of the five was confirmed to fail against `upstream/main`'s `refResolutionDependencies.ts` (the first two also by capping the candidate list at one and at two origins respectively), so they are genuine regression guards rather than tests that would pass either way.

The candidate loop was also instrumented directly to check which path each test takes, rather than inferring it from the markup:

| case | candidate origins | outcome |
| --- | --- | --- |
| reference to an iteration | 2 | resolves on the 2nd |
| reference to a reference | 3 | resolves on the 3rd |
| `$g[$n]` copy lifted out of the repeat | 2 | all fail → warning after the loop |
| `$r[1].z` (`diagnosticCodes.test.ts`) | 1 | fails → `doenet-w0105` after the loop |
| `$g[1]` (`diagnosticCodes.test.ts`) | 1 | resolves; warning comes from the later index site |

`diagnosticCodes.test.ts` pins the ambiguous branch of the post-loop diagnostic (`doenet-w0105`); the missing-referent branch (`doenet-w0104`) is the `$g[$n]` `repeatForSequence` case above, so both literal codes at that site stay exercised. Two comments there were corrected: one claimed the neighbouring `$g[1]` test shared the site (it reaches the later, index-past-end warning instead), and one still described the site as a `catch` rather than the candidate loop.

vitest, all green against the final code: `diagnostics`, `copying`, `baseComponent`, `repeat`, `repeatForSequence` (304 tests). `npm run lint:i18n` passes. The full `tagSpecific` suite (116 files, 2753 tests) was green against the first revision of the fix; CI covers it for the current one.

Closes #1424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wc9VV7AZRbh3criE985CKK
