### PR TITLE
Fix a <math> hang and a misplaced list-comma eligibility check

### DIFF
--- a/.changeset/list-comma-eligibility-and-math-hang.md
+++ b/.changeset/list-comma-eligibility-and-math-hang.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix two defects in the automatic commas placed between the replacements of a list composite.
+
+A `<math>` containing a list next to a component froze the document. To decide whether the comma-separated list needs parentheses around it, the core looks at what sits on either side of it, walking past whitespace to find it — but that walk never advanced its index, so it never ended when the neighbor was a component rather than a string. `<math><number>3</number> <numberList>1 2</numberList></math>`, and the same with the list first, both hung.
+
+Commas also appeared around a replacement that cannot be a list item, whenever the composite was not the first thing in its container. A composite holding something that can't be part of a list — a `<me>`, say — is shown without commas, but the record of which replacements are eligible was kept in step with the parent's children rather than with the composite's own, so the answer slid by however far the composite sat from the start. `<p><group asList><numberList>1 2</numberList><me>x</me></group></p>` was correct while `<p>lead <group asList><numberList>1 2</numberList><me>x</me></group></p>` was not.

--- a/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
@@ -967,11 +967,16 @@ export async function replaceCompositeChildren({
                 ),
             );
 
+            // An enclosing composite recorded this child as one entry of its
+            // own range; now that the child has become `replacements.length`
+            // children, widen that range and put the replacements' eligibility
+            // in the entry's place. `potentialListComponents` is indexed from
+            // the range's own `firstInd`, not from the parent's children.
             for (let otherCompositeObject of parent.compositeReplacementActiveRange) {
                 if (otherCompositeObject.lastInd >= childInd) {
                     otherCompositeObject.lastInd += replacements.length - 1;
                     otherCompositeObject.potentialListComponents.splice(
-                        childInd,
+                        childInd - otherCompositeObject.firstInd,
                         1,
                         ...replacementsCanBeInList,
                     );

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -1,0 +1,366 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import {
+    describeCompositeRanges,
+    renderedText,
+} from "../utils/rendered-commas";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+/**
+ * The replacements of a composite that asks to be shown as a list are separated
+ * by commas automatically, and that happens twice over, from the same core data,
+ * in two independent implementations:
+ *
+ * - the renderers insert `", "` between React children
+ *   (`addCommasForCompositeRanges`, `doenetml/src/Viewer/renderers/utils/composites.tsx`);
+ * - the `text` state variable joins the children's text with `", "`
+ *   (`textFromChildren`, `doenetml-worker-javascript/src/utils/text.ts`).
+ *
+ * A third, `applyCompositeListWrapping`
+ * (`doenetml-worker/src/compositeListWrapping.ts`), reproduces the renderers'
+ * grouping for the prototype renderers, and a fourth, `parseMath.ts`, does it
+ * for the children of a `<math>`.
+ *
+ * All of them read one array the core builds in
+ * `CompositeExpander.replaceCompositeChildren`: for each composite that
+ * contributed children, the index range those children occupy, whether the
+ * composite has `asList` set, and whether each replacement is eligible to be a
+ * list item. Every case below therefore checks *both* pathways, since the way
+ * they go wrong is by disagreeing.
+ *
+ * `renderedText` runs the shipped renderer code over the shipped renderer state
+ * and stands in only for the individual child renderers; see
+ * `../utils/rendered-commas.tsx`.
+ */
+
+/**
+ * Build a document from `<p>` bodies keyed by name, then check the text the
+ * `text` state variable reports and the text the renderers would show against
+ * the same expectation.
+ */
+async function checkParagraphs(
+    paragraphs: Record<string, { body: string; expected: string }>,
+    preamble = "",
+) {
+    const doenetML =
+        preamble +
+        Object.entries(paragraphs)
+            .map(([name, { body }]) => `<p name="${name}">${body}</p>`)
+            .join("\n");
+
+    const { core, resolvePathToNodeIdx } = await createTestCore({ doenetML });
+    const stateVariables = await core.returnAllStateVariables(false, true);
+
+    for (const [name, { expected }] of Object.entries(paragraphs)) {
+        const idx = await resolvePathToNodeIdx(name);
+        expect(
+            stateVariables[idx].stateValues.text,
+            `text of <p name="${name}">`,
+        ).eq(expected);
+        expect(
+            renderedText(core, stateVariables, idx),
+            `rendered text of <p name="${name}">`,
+        ).eq(expected);
+    }
+}
+
+describe("Automatic commas between composite replacements @group3", () => {
+    it("separates the replacements of a list component", async () => {
+        await checkParagraphs({
+            plain: {
+                body: `<numberList>1 2 3 4</numberList>`,
+                expected: "1, 2, 3, 4",
+            },
+            oneItem: { body: `<numberList>1</numberList>`, expected: "1" },
+            withText: {
+                body: `Values: <numberList>1 2</numberList>.`,
+                expected: "Values: 1, 2.",
+            },
+        });
+    });
+
+    it("honors asList on the composite", async () => {
+        await checkParagraphs({
+            off: {
+                body: `<numberList asList="false">1 2 3</numberList>`,
+                expected: "123",
+            },
+            on: {
+                body: `<group asList><number>1</number><number>2</number></group>`,
+                expected: "1, 2",
+            },
+            groupDefaultsToNoList: {
+                body: `<group><number>1</number><number>2</number></group>`,
+                expected: "12",
+            },
+        });
+    });
+
+    it("lets the innermost composite decide", async () => {
+        // Composites are meant to be transparent to authors: whichever
+        // composite most closely wraps the replacements settles whether they
+        // are a list, whatever the outer one says.
+        await checkParagraphs({
+            listInsideNonList: {
+                body: `<group><numberList>1 2 3</numberList></group>`,
+                expected: "1, 2, 3",
+            },
+            listInsideExplicitNonList: {
+                body: `<group asList="false"><numberList>1 2 3</numberList></group>`,
+                expected: "1, 2, 3",
+            },
+            nonListInsideList: {
+                body: `<group asList><numberList asList="false">1 2 3</numberList></group>`,
+                expected: "123",
+            },
+        });
+    });
+
+    it("counts an inner composite as a single item of the outer list", async () => {
+        await checkParagraphs({
+            nested: {
+                body: `<group asList><group><number>1</number><number>2</number></group><number>3</number></group>`,
+                expected: "12, 3",
+            },
+            twoInnerLists: {
+                body: `<group asList><group asList><number>1</number><number>2</number></group><group asList><number>3</number><number>4</number></group></group>`,
+                expected: "1, 2, 3, 4",
+            },
+            innerListsNoOuterList: {
+                body: `<group><numberList>1 2</numberList><numberList>3 4</numberList></group>`,
+                expected: "1, 23, 4",
+            },
+        });
+    });
+
+    it("separates the items of a repeat, and the list inside each item", async () => {
+        await checkParagraphs({
+            repeat: {
+                body: `<repeatForSequence from="1" to="2" valueName="v"><numberList>$v 9</numberList></repeatForSequence>`,
+                expected: "1, 9, 2, 9",
+            },
+            repeatNoList: {
+                body: `<repeatForSequence asList="false" from="1" to="3" valueName="v"><number>$v</number></repeatForSequence>`,
+                expected: "123",
+            },
+        });
+    });
+
+    it("records one range per composite that contributed children", async () => {
+        // The array every consumer reads. An outer composite comes first and
+        // the ranges after it, with indices inside its own, are its
+        // replacements' — here, the repeat separates its two items, and the
+        // list inside each item separates its own numbers.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<p name="p"><repeatForSequence name="r" from="1" to="2" valueName="v"><numberList name="nl">$v 9</numberList></repeatForSequence></p>`,
+        });
+        await core.returnAllStateVariables(false, true);
+        expect(
+            describeCompositeRanges(core, await resolvePathToNodeIdx("p")),
+        ).eq(
+            [
+                "r [0-3] asList=true",
+                "  r:1 [0-1] asList=false",
+                "    r:1.nl [0-1] asList=true",
+                "  r:2 [2-3] asList=false",
+                "    r:2.nl [2-3] asList=true",
+            ].join("\n"),
+        );
+    });
+
+    it("holds back the commas when a replacement cannot be a list item", async () => {
+        // `<me>` sets `canBeInList = false`; one such replacement settles it
+        // for the whole composite. Only the `text` pathway is checked here: a
+        // `<me>` renders through MathJax, which the renderer stand-in cannot
+        // show.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<p name="p"><group asList><number>1</number><number>2</number><me>x</me></group></p>`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
+        ).eq("12x");
+    });
+
+    it("holds back the commas wherever the composite sits", async () => {
+        // The eligibility flags are kept in step with each expansion by index
+        // within the composite's own range; getting that index wrong made the
+        // answer depend on whether the composite happened to start at the
+        // parent's first child.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<p name="atStart"><group asList><numberList>1 2</numberList><me>x</me></group></p>
+<p name="shifted">lead <group asList><numberList>1 2</numberList><me>x</me></group></p>
+`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("atStart")].stateValues
+                .text,
+        ).eq("1, 2x");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("shifted")].stateValues
+                .text,
+        ).eq("lead 1, 2x");
+    });
+
+    it("skips a composite that produced no replacements", async () => {
+        await checkParagraphs({
+            emptyInMiddle: {
+                body: `<group asList><number>1</number><sequence length="0" /><number>2</number></group>`,
+                expected: "1, 2",
+            },
+            emptyAtStart: {
+                body: `<group asList><sequence length="0" /><number>1</number><number>2</number></group>`,
+                expected: "1, 2",
+            },
+            emptyAtEnd: {
+                body: `<group asList><number>1</number><number>2</number><sequence length="0" /></group>`,
+                expected: "1, 2",
+            },
+        });
+    });
+
+    it("leaves a hidden replacement out of the list", async () => {
+        await checkParagraphs({
+            hiddenItem: {
+                body: `<group asList><number hide>1</number><number>2</number><number>3</number></group>`,
+                expected: "2, 3",
+            },
+            hiddenList: {
+                body: `<numberList hide>1 2 3</numberList>after`,
+                expected: "after",
+            },
+        });
+    });
+
+    it("keeps the whitespace around replacements out of the list", async () => {
+        // The newlines an author writes around a composite are separators, not
+        // items, and no space is left in front of a comma.
+        await checkParagraphs({
+            onOwnLines: {
+                body: `\n<numberList>1 2 3</numberList>\n`,
+                expected: "\n1, 2, 3\n",
+            },
+        });
+    });
+
+    it("keeps the commas through a reference to the list", async () => {
+        await checkParagraphs(
+            {
+                reference: { body: `$nl`, expected: "1, 2, 3" },
+                extended: {
+                    body: `<numberList extend="$nl" />`,
+                    expected: "1, 2, 3",
+                },
+                referenceTwice: {
+                    body: `$nl $nl`,
+                    expected: "1, 2, 3 1, 2, 3",
+                },
+            },
+            `<setup><numberList name="nl">1 2 3</numberList></setup>\n`,
+        );
+    });
+
+    it("keeps the commas through a reference to the whole repeat", async () => {
+        await checkParagraphs(
+            {
+                whole: { body: `$r`, expected: "1, 2, 3, 4, 1, 2, 3, 4" },
+            },
+            `<setup>
+                <numberList name="nl">1 2 3 4</numberList>
+                <repeatForSequence name="r" from="1" to="2">$nl</repeatForSequence>
+            </setup>\n`,
+        );
+    });
+});
+
+describe("Automatic commas inside a <math> @group3", () => {
+    // `createInputStringFromChildrenSub` (`utils/parseMath.ts`) is the same
+    // algorithm again, joining the children into the string that gets parsed
+    // into a math expression. It wraps the list in parentheses when what sits
+    // next to it is not a delimiter, and to find that out it walks outward past
+    // whitespace-only strings — a walk that used to never move its index, so a
+    // component child (or a blank string) on either side hung the core.
+    it("wraps the list when a neighbor is not a delimiter", async () => {
+        const cases: Record<string, string> = {
+            alone: `<numberList>1 2</numberList>`,
+            inParens: `( <numberList>1 2</numberList> )`,
+            stringLeft: `3 <numberList>1 2</numberList>`,
+            componentLeft: `<number>3</number> <numberList>1 2</numberList>`,
+            componentRight: `<numberList>1 2</numberList> <number>3</number>`,
+            bothSides: `3 + <numberList>1 2</numberList> + 4`,
+        };
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: Object.entries(cases)
+                .map(
+                    ([name, body]) =>
+                        `<p><math name="${name}">${body}</math></p>`,
+                )
+                .join("\n"),
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const latex = async (name: string) =>
+            stateVariables[await resolvePathToNodeIdx(name)].stateValues.latex;
+
+        expect(await latex("alone")).eq("1, 2");
+        expect(await latex("inParens")).eq("\\left( 1, 2 \\right)");
+        expect(await latex("stringLeft")).eq("3 \\left( 1, 2 \\right)");
+        expect(await latex("componentLeft")).eq("3 \\left( 1, 2 \\right)");
+        expect(await latex("componentRight")).eq(
+            "\\left( 1, 2 \\right) \\cdot 3",
+        );
+        expect(await latex("bothSides")).eq("3 + \\left( 1, 2 \\right) + 4");
+    });
+});
+
+/**
+ * Cases that are wrong today. Each is written as the behavior we want and
+ * marked `it.fails`, so it turns red the moment the underlying defect is fixed
+ * and the case can be moved into the suite above.
+ */
+describe("Automatic commas: known defects @group3", () => {
+    // A reference that lands on a composite copies that composite's *final*
+    // replacements — the components, with every composite between them and the
+    // reference flattened away — while `compositeReplacementActiveRange` still
+    // records only the outermost composite. The `asList` of everything in
+    // between is lost, so the list stops being a list.
+    it.fails("keeps the commas through a reference into a repeat", async () => {
+        await checkParagraphs(
+            {
+                item: { body: `$r[1]`, expected: "1, 2, 3, 4" },
+            },
+            `<setup>
+                <numberList name="nl">1 2 3 4</numberList>
+                <repeatForSequence name="r" from="1" to="2">$nl</repeatForSequence>
+            </setup>\n`,
+        );
+    });
+
+    it.fails("keeps the commas through a reference to a group", async () => {
+        await checkParagraphs(
+            {
+                group: { body: `$g`, expected: "1, 2, 3" },
+            },
+            `<setup><group name="g"><numberList>1 2 3</numberList></group></setup>\n`,
+        );
+    });
+
+    // The `text` pathway trims the end of every item but the last, so
+    // whitespace an item ends with never lands in front of a comma. The
+    // renderers' equivalent, `removeEndingBlankString`, only looks inside a
+    // child whose `props.children` is an array, which a rendered component
+    // child never has — so it never reaches the trailing space, and the
+    // rendered list shows "a , b" where the text says "a, b".
+    it.fails("trims an item's trailing space in both pathways", async () => {
+        await checkParagraphs({
+            trailing: {
+                body: `<group asList><text>a </text><text>b</text></group>`,
+                expected: "a, b",
+            },
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/utils/rendered-commas.tsx
+++ b/packages/doenetml-worker-javascript/src/test/utils/rendered-commas.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { addCommasForCompositeRanges } from "../../../../doenetml/src/Viewer/renderers/utils/composites";
+import { PublicDoenetMLCore } from "../../CoreWorker";
+
+/**
+ * Automatic commas between the replacements of a composite are produced twice,
+ * from the same core data, by two independent implementations:
+ *
+ * - the renderers, via `addCommasForCompositeRanges`
+ *   (`doenetml/src/Viewer/renderers/utils/composites.tsx`), which insert `", "`
+ *   between React children; and
+ * - the `text` state variable, via `textFromChildren`
+ *   (`doenetml-worker-javascript/src/utils/text.ts`), which joins strings.
+ *
+ * Both read the same input: the parent's `compositeReplacementActiveRange`,
+ * built in `CompositeExpander.replaceCompositeChildren` and handed to the
+ * renderers as the `_compositeReplacementActiveRange` renderer state value.
+ *
+ * `renderedText` below runs the *real* renderer implementation over the *real*
+ * renderer state of a live core, so a test can compare the two pathways without
+ * a browser. It stands in for the individual child renderers — each rendered
+ * component child becomes a `<span>` holding that component's own text — but
+ * everything above that, the comma insertion itself, is the shipped code.
+ *
+ * The `<span>` stand-in is faithful to the one thing the comma code inspects
+ * about a child element: `removeEndingBlankString` only reaches inside a child
+ * whose `props.children` is an array, and a real child (a `<DoenetRenderer>`
+ * element carrying `componentInstructions`) never has one, exactly as a
+ * `<span>` holding a single string never has one.
+ */
+
+/** A renderer-state entry, as `RendererInstructionBuilder` records it. */
+type RendererStateEntry = {
+    stateValues?: Record<string, any>;
+    childrenInstructions?: (Record<string, any> | string | null)[];
+};
+
+/** The map `core.returnAllStateVariables()` returns. */
+export type AllStateVariables = Record<number, { stateValues: any }>;
+
+function rendererStateOf(core: PublicDoenetMLCore) {
+    return (core as any).core.rendererInstructionBuilder
+        .rendererState as Record<number, RendererStateEntry>;
+}
+
+/**
+ * The text a component's own renderer would show, standing in for whatever
+ * markup that renderer actually produces — the same `text` state variable the
+ * `text` pathway reads, so the two pathways are compared on the commas alone.
+ */
+function ownText(stateVariables: AllStateVariables, componentIdx: number) {
+    const stateValues = stateVariables[componentIdx]?.stateValues;
+    if (typeof stateValues?.text === "string") {
+        return stateValues.text;
+    }
+    // `textFromComponent` gives a component without a text a single space.
+    return " ";
+}
+
+/**
+ * Build the React children a renderer would receive for `componentIdx`, then
+ * run `addCommasForCompositeRanges` over them exactly as `p.tsx` (and every
+ * other container renderer) does.
+ */
+function childrenWithCommas(
+    core: PublicDoenetMLCore,
+    stateVariables: AllStateVariables,
+    componentIdx: number,
+): React.ReactNode[] {
+    const rendererState = rendererStateOf(core);
+    const entry = rendererState[componentIdx];
+
+    if (!entry) {
+        throw Error(`Component ${componentIdx} is not rendered.`);
+    }
+
+    let children: React.ReactNode[] = (entry.childrenInstructions ?? []).map(
+        (childInstruction, ind) => {
+            if (childInstruction === null) {
+                return null;
+            }
+            if (typeof childInstruction === "string") {
+                return childInstruction;
+            }
+            const childIdx = childInstruction.componentIdx;
+            const grandchildren = rendererState[childIdx]?.childrenInstructions;
+            // A rendered child that has rendered children of its own is a
+            // container in its own right (an `<em>`, a nested `<p>`); recurse so
+            // its own commas are added before this level groups it.
+            const inner =
+                grandchildren && grandchildren.length > 0
+                    ? childrenWithCommas(core, stateVariables, childIdx)
+                    : ownText(stateVariables, childIdx);
+            return <span key={ind}>{inner}</span>;
+        },
+    );
+
+    const ranges = entry.stateValues?._compositeReplacementActiveRange;
+    if (ranges) {
+        children = addCommasForCompositeRanges({
+            children,
+            compositeReplacementActiveRange: ranges,
+            startInd: 0,
+            endInd: children.length - 1,
+        });
+    }
+
+    return children;
+}
+
+/**
+ * The text the renderers would show for the component at `componentIdx`,
+ * including the commas `addCommasForCompositeRanges` inserts.
+ */
+export function renderedText(
+    core: PublicDoenetMLCore,
+    stateVariables: AllStateVariables,
+    componentIdx: number,
+): string {
+    const markup = renderToStaticMarkup(
+        <>{childrenWithCommas(core, stateVariables, componentIdx)}</>,
+    );
+    return markup.replace(/<[^>]*>/g, "");
+}
+
+/**
+ * A readable rendering of a component's `compositeReplacementActiveRange`: one
+ * line per composite range, indented by nesting, as
+ * `name [first-last] asList=…`. Nesting is implicit in the array (an outer
+ * range comes before the ranges of the composites it produced), so spelling it
+ * out is what makes a regression in the range data legible.
+ *
+ * A composite that produced nothing is recorded as `lastInd === firstInd - 1`
+ * and is left out: it contributes no children, so where it sits in the nesting
+ * cannot be read off the indices, and it makes no difference to the commas.
+ */
+export function describeCompositeRanges(
+    core: PublicDoenetMLCore,
+    componentIdx: number,
+): string {
+    const ranges =
+        rendererStateOf(core)[componentIdx]?.stateValues
+            ?._compositeReplacementActiveRange ?? [];
+
+    const lines: string[] = [];
+    const openRanges: { firstInd: number; lastInd: number }[] = [];
+
+    for (const range of ranges) {
+        if (range.lastInd < range.firstInd) {
+            continue;
+        }
+        while (
+            openRanges.length > 0 &&
+            !(
+                range.firstInd >= openRanges[openRanges.length - 1].firstInd &&
+                range.lastInd <= openRanges[openRanges.length - 1].lastInd
+            )
+        ) {
+            openRanges.pop();
+        }
+        const indent = "  ".repeat(openRanges.length);
+        const name = range.compositeName ?? `_id_${range.compositeIdx}`;
+        lines.push(
+            `${indent}${name} [${range.firstInd}-${range.lastInd}] asList=${range.asList}`,
+        );
+        openRanges.push({ firstInd: range.firstInd, lastInd: range.lastInd });
+    }
+
+    return lines.join("\n");
+}

--- a/packages/doenetml-worker-javascript/src/utils/parseMath.ts
+++ b/packages/doenetml-worker-javascript/src/utils/parseMath.ts
@@ -213,68 +213,72 @@ function createInputStringFromChildrenSub({
 
                     let wrap = false;
 
-                    // First check if there is a non-delimiter to the left
-                    if (rangeFirstInd > 0) {
+                    // First check if there is a non-delimiter to the left,
+                    // looking past any whitespace-only strings.
+                    for (
                         let prevInd = rangeFirstInd - 1;
-                        while (prevInd >= 0) {
-                            let prevChild = children[prevInd];
-                            if (typeof prevChild === "string") {
-                                prevChild = prevChild.trim();
-                                if (prevChild.length > 0) {
-                                    if (
-                                        !leftDelimiters.includes(
-                                            prevChild[prevChild.length - 1],
-                                        )
-                                    ) {
-                                        // The string to the left did not contain one of the delimiters,
-                                        // so we must wrap the list.
-                                        wrap = true;
-                                    }
-                                    break;
-                                }
-                            } else {
-                                // There is a non-string child to the left,
-                                // so we must wrap the list
-                                wrap = true;
-                            }
+                        prevInd >= 0;
+                        prevInd--
+                    ) {
+                        let prevChild = children[prevInd];
+                        if (typeof prevChild !== "string") {
+                            // There is a non-string child to the left,
+                            // so we must wrap the list
+                            wrap = true;
+                            break;
                         }
+                        prevChild = prevChild.trim();
+                        if (prevChild.length === 0) {
+                            continue;
+                        }
+                        if (
+                            !leftDelimiters.includes(
+                                prevChild[prevChild.length - 1],
+                            )
+                        ) {
+                            // The string to the left did not contain one of the delimiters,
+                            // so we must wrap the list.
+                            wrap = true;
+                        }
+                        break;
                     }
 
                     if (!wrap) {
                         // Since we didn't have a non-delimiter to the left,
-                        // check if there is a non-delimiter to the right.
-                        if (rangeLastInd < children.length - 1) {
+                        // check if there is a non-delimiter to the right,
+                        // again looking past any whitespace-only strings.
+                        for (
                             let nextInd = rangeLastInd + 1;
-                            while (nextInd <= children.length - 1) {
-                                let nextChild = children[nextInd];
-                                if (typeof nextChild === "string") {
-                                    nextChild = nextChild.trim();
-                                    if (nextChild.length > 0) {
-                                        let nextChar = nextChild[0];
-                                        // If the format is latex,
-                                        // the delimiter could be escaped by a \
-                                        if (
-                                            format === "latex" &&
-                                            nextChar === "\\" &&
-                                            nextChild.length > 1
-                                        ) {
-                                            nextChar = nextChild[1];
-                                        }
-                                        if (
-                                            !rightDelimiters.includes(nextChar)
-                                        ) {
-                                            // The string to the right did not contain one of the delimiters,
-                                            // so we must wrap the list.
-                                            wrap = true;
-                                        }
-                                        break;
-                                    }
-                                } else {
-                                    // There is a non-string child to the right,
-                                    // so we must wrap the list
-                                    wrap = true;
-                                }
+                            nextInd < children.length;
+                            nextInd++
+                        ) {
+                            let nextChild = children[nextInd];
+                            if (typeof nextChild !== "string") {
+                                // There is a non-string child to the right,
+                                // so we must wrap the list
+                                wrap = true;
+                                break;
                             }
+                            nextChild = nextChild.trim();
+                            if (nextChild.length === 0) {
+                                continue;
+                            }
+                            let nextChar = nextChild[0];
+                            // If the format is latex,
+                            // the delimiter could be escaped by a \
+                            if (
+                                format === "latex" &&
+                                nextChar === "\\" &&
+                                nextChild.length > 1
+                            ) {
+                                nextChar = nextChild[1];
+                            }
+                            if (!rightDelimiters.includes(nextChar)) {
+                                // The string to the right did not contain one of the delimiters,
+                                // so we must wrap the list.
+                                wrap = true;
+                            }
+                            break;
                         }
                     }
 

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
@@ -1,0 +1,320 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { addCommasForCompositeRanges } from "./composites";
+
+/**
+ * `addCommasForCompositeRanges` is the renderer half of automatic list commas:
+ * every container renderer (`p`, `section`, `cell`, `hint`, `alert`, `list`,
+ * `pre`, `solution`, `feedback`, `containerInline`, `markupRenderer`) hands it
+ * the children it is about to render together with the core's
+ * `_compositeReplacementActiveRange`, and it inserts `", "` between the
+ * replacements of a composite that asked to be shown as a list.
+ *
+ * The core builds that range array in `CompositeExpander.replaceCompositeChildren`;
+ * `textFromChildren` (`doenetml-worker-javascript/src/utils/text.ts`) and
+ * `applyCompositeListWrapping` (`doenetml-worker/src/compositeListWrapping.ts`)
+ * consume the same array and must agree with what is checked here.
+ *
+ * Ranges are half-nested rather than a tree: a composite whose replacements are
+ * themselves composites comes *first* in the array, and the ranges that follow
+ * it, with indices inside its own, are its replacements' ranges.
+ */
+
+type Range = Parameters<
+    typeof addCommasForCompositeRanges
+>[0]["compositeReplacementActiveRange"][number];
+
+/**
+ * A stand-in for a rendered component child. What matters to the code under
+ * test is that it is an element whose `props.children` is not an array — the
+ * one shape `removeEndingBlankString` declines to look inside — which is what a
+ * real `<DoenetRenderer>` child (its props carry `componentInstructions`, never
+ * `children`) also is.
+ */
+function child(text: string, key: number) {
+    return <span key={key}>{text}</span>;
+}
+
+/** What the browser would show for the children the function hands back. */
+function shown(children: React.ReactNode[]) {
+    return renderToStaticMarkup(<>{children}</>).replace(/<[^>]*>/g, "");
+}
+
+function addCommas(
+    children: React.ReactNode[],
+    compositeReplacementActiveRange: Range[],
+    removedInd: number | null = null,
+) {
+    return addCommasForCompositeRanges({
+        children,
+        compositeReplacementActiveRange,
+        startInd: 0,
+        endInd: children.length - 1,
+        removedInd,
+    });
+}
+
+function range(over: Partial<Range> & Pick<Range, "firstInd" | "lastInd">) {
+    return {
+        compositeName: "c",
+        asList: true,
+        ...over,
+    } as Range;
+}
+
+describe("addCommasForCompositeRanges", () => {
+    it("separates the replacements of an asList composite", () => {
+        const children = ["one ", child("2", 1), child("3", 2), child("4", 3)];
+        const result = addCommas(children, [
+            range({
+                firstInd: 1,
+                lastInd: 3,
+                potentialListComponents: [true, true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("one 2, 3, 4");
+    });
+
+    it("leaves the replacements alone when asList is false", () => {
+        const children = [child("2", 0), child("3", 1)];
+        const result = addCommas(children, [
+            range({
+                firstInd: 0,
+                lastInd: 1,
+                asList: false,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("23");
+    });
+
+    it("adds no comma to a composite with a single replacement", () => {
+        const children = [child("2", 0)];
+        const result = addCommas(children, [
+            range({ firstInd: 0, lastInd: 0, potentialListComponents: [true] }),
+        ]);
+        expect(shown(result)).eq("2");
+    });
+
+    it("gives every composite an anchor span carrying its name", () => {
+        // Links to a composite's name scroll to this span, so it is added
+        // whether or not the composite became a list.
+        const children = [child("2", 0), child("3", 1)];
+        const result = addCommas(children, [
+            range({
+                compositeName: "myList",
+                firstInd: 0,
+                lastInd: 1,
+                asList: false,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(renderToStaticMarkup(<>{result}</>)).eq(
+            '<span id="myList"><span>2</span><span>3</span></span>',
+        );
+    });
+
+    it("holds back the commas when a replacement cannot be a list item", () => {
+        // `potentialListComponents` comes from the core: an inline component,
+        // or one whose class sets `canBeInList`, may be an item; a `<me>` or a
+        // block component may not, and one such replacement settles it for the
+        // whole composite.
+        const children = [child("2", 0), child("3", 1), child("x", 2)];
+        const result = addCommas(children, [
+            range({
+                firstInd: 0,
+                lastInd: 2,
+                potentialListComponents: [true, true, false],
+            }),
+        ]);
+        expect(shown(result)).eq("23x");
+    });
+
+    it("lets an inner composite make a list inside a non-list outer one", () => {
+        // <group><numberList>1 2</numberList></group>: the group is not a list
+        // but the numberList inside it still is.
+        const children = [child("1", 0), child("2", 1)];
+        const result = addCommas(children, [
+            range({
+                compositeName: "g",
+                firstInd: 0,
+                lastInd: 1,
+                asList: false,
+                potentialListComponents: [true, true],
+            }),
+            range({
+                compositeName: "nl",
+                firstInd: 0,
+                lastInd: 1,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("1, 2");
+    });
+
+    it("lets an inner composite refuse to be a list inside a list outer one", () => {
+        const children = [child("1", 0), child("2", 1)];
+        const result = addCommas(children, [
+            range({
+                compositeName: "g",
+                firstInd: 0,
+                lastInd: 1,
+                potentialListComponents: [true, true],
+            }),
+            range({
+                compositeName: "nl",
+                firstInd: 0,
+                lastInd: 1,
+                asList: false,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("12");
+    });
+
+    it("counts each inner composite as one item of the outer list", () => {
+        // <group asList><group>1 2</group><number>3</number></group>:
+        // the inner group is a single item, so there are two items, not three.
+        const children = [child("1", 0), child("2", 1), child("3", 2)];
+        const result = addCommas(children, [
+            range({
+                compositeName: "outer",
+                firstInd: 0,
+                lastInd: 2,
+                potentialListComponents: [true, true, true],
+            }),
+            range({
+                compositeName: "inner",
+                firstInd: 0,
+                lastInd: 1,
+                asList: false,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("12, 3");
+    });
+
+    it("keeps the blank strings around replacements out of the list", () => {
+        // Authored whitespace surrounding a composite's replacements is a
+        // separator, not an item: no comma is placed next to one, and the comma
+        // goes in front of the whitespace rather than after it, so nothing puts
+        // a space before a comma. The doubled space that leaves between items
+        // collapses to one in the browser.
+        const children = ["\n  ", child("1", 1), " ", child("2", 3), "\n  "];
+        const result = addCommas(children, [
+            range({
+                firstInd: 0,
+                lastInd: 4,
+                potentialListComponents: [true, true, true, true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("\n  1,  2\n  ");
+    });
+
+    it("skips a composite that produced no replacements", () => {
+        // An empty composite is recorded as `lastInd === firstInd - 1`; the
+        // items around it still form one list.
+        const children = [child("1", 0), child("2", 1)];
+        const result = addCommas(children, [
+            range({
+                compositeName: "outer",
+                firstInd: 0,
+                lastInd: 1,
+                potentialListComponents: [true, true],
+            }),
+            range({
+                compositeName: "empty",
+                firstInd: 1,
+                lastInd: 0,
+                potentialListComponents: [],
+            }),
+        ]);
+        expect(shown(result)).eq("1, 2");
+    });
+
+    it("drops absent children before deciding how many items there are", () => {
+        // A child instruction is `null` when the child is not rendered; two
+        // replacements one of which is absent are not a two-item list.
+        const children = [child("1", 0), null];
+        const result = addCommas(children, [
+            range({
+                firstInd: 0,
+                lastInd: 1,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("1");
+    });
+
+    it("shifts the ranges past a child the renderer removed", () => {
+        // `section.tsx` splices the `<title>` child out of `children` before
+        // asking for commas, and tells this function which index it took.
+        const children = [child("1", 1), child("2", 2), child("3", 3)];
+        const result = addCommas(
+            children,
+            [
+                range({
+                    firstInd: 1,
+                    lastInd: 3,
+                    potentialListComponents: [true, true, true],
+                }),
+            ],
+            0,
+        );
+        expect(shown(result)).eq("1, 2, 3");
+    });
+
+    it("drops a range whose end coincides with the removed child", () => {
+        const children = [child("1", 0), child("3", 2)];
+        const result = addCommas(
+            children,
+            [
+                range({
+                    firstInd: 0,
+                    lastInd: 1,
+                    potentialListComponents: [true, true],
+                }),
+            ],
+            1,
+        );
+        expect(shown(result)).eq("13");
+    });
+
+    it("leaves children outside every range untouched", () => {
+        const children = ["before ", child("1", 1), child("2", 2), " after"];
+        const result = addCommas(children, [
+            range({
+                firstInd: 1,
+                lastInd: 2,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("before 1, 2 after");
+    });
+
+    it("separates two composites of its own, each on its own", () => {
+        const children = [
+            child("1", 0),
+            child("2", 1),
+            " and ",
+            child("3", 3),
+            child("4", 4),
+        ];
+        const result = addCommas(children, [
+            range({
+                compositeName: "first",
+                firstInd: 0,
+                lastInd: 1,
+                potentialListComponents: [true, true],
+            }),
+            range({
+                compositeName: "second",
+                firstInd: 3,
+                lastInd: 4,
+                potentialListComponents: [true, true],
+            }),
+        ]);
+        expect(shown(result)).eq("1, 2 and 3, 4");
+    });
+});

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -479,4 +479,79 @@ $fi.iterates
             ).eq("Title: yes, no, maybe");
         });
     });
+
+    it("commas follow the innermost composite", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<p name="listOnly"><numberList>1 2 3</numberList></p>
+<p name="listOff"><numberList asList="false">1 2 3</numberList></p>
+<p name="listInsideGroup"><group><numberList>1 2 3</numberList></group></p>
+<p name="listInsideGroupNoList"><group asList="false"><numberList>1 2 3</numberList></group></p>
+<p name="noListInsideList"><group asList><numberList asList="false">1 2 3</numberList></group></p>
+<p name="groupIsOneItem"><group asList><group><number>1</number><number>2</number></group><number>3</number></group></p>
+<p name="twoLists"><group><numberList>1 2</numberList><numberList>3 4</numberList></group></p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#listOnly").should("have.text", "1, 2, 3");
+        cy.get("#listOff").should("have.text", "123");
+        cy.get("#listInsideGroup").should("have.text", "1, 2, 3");
+        cy.get("#listInsideGroupNoList").should("have.text", "1, 2, 3");
+        cy.get("#noListInsideList").should("have.text", "123");
+        cy.get("#groupIsOneItem").should("have.text", "12, 3");
+        cy.get("#twoLists").should("have.text", "1, 23, 4");
+    });
+
+    it("skips empty and hidden replacements", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<p name="emptyInMiddle"><group asList><number>1</number><sequence length="0" /><number>2</number></group></p>
+<p name="emptyAtStart"><group asList><sequence length="0" /><number>1</number><number>2</number></group></p>
+<p name="hiddenItem"><group asList><number hide>1</number><number>2</number><number>3</number></group></p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#emptyInMiddle").should("have.text", "1, 2");
+        cy.get("#emptyAtStart").should("have.text", "1, 2");
+        cy.get("#hiddenItem").should("have.text", "2, 3");
+    });
+
+    it("keeps the commas through a reference to a list or a repeat", () => {
+        // A reference to a composite must show the same commas the composite
+        // itself shows. `$r[1]` and `$g` do not today: a reference that lands
+        // on a composite copies its final replacements, flattening away the
+        // inner composite whose `asList` made the list — see the `it.fails`
+        // cases in `compositeCommas.test.tsx`.
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<setup>
+    <numberList name="nl">1 2 3 4</numberList>
+    <group name="g"><numberList>1 2 3 4</numberList></group>
+    <repeatForSequence name="r" from="1" to="2">$nl</repeatForSequence>
+</setup>
+<p name="toList">$nl</p>
+<p name="extendList"><numberList extend="$nl" /></p>
+<p name="toRepeat">$r</p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#toList").should("have.text", "1, 2, 3, 4");
+        cy.get("#extendList").should("have.text", "1, 2, 3, 4");
+        cy.get("#toRepeat").should("have.text", "1, 2, 3, 4, 1, 2, 3, 4");
+    });
 });


### PR DESCRIPTION
Two defects in the automatic commas placed between the replacements of a list composite, plus the regression tests the area was missing.

## A `<math>` holding a list next to a component froze the document

A comma-separated list inside a `<math>` is wrapped in parentheses unless what sits next to it is already a delimiter. Working that out means looking outward past any whitespace — but neither of the two searches ever moved its index, so each ran forever as soon as the neighbor was anything other than a non-blank string.

```
<math><number>3</number> <numberList>1 2</numberList></math>
```

and the same with the list first both hung the core. A string neighbor happened to break out of the loop on the first pass, which is why this survived: every case anyone had written was a string.

## Commas appeared around a replacement that cannot be a list item

A composite holding something that cannot be part of a list — a `<me>`, a block component — is shown without commas. Which replacements are eligible is recorded per composite and kept in step with each expansion by splicing, but the splice used the child's index among the *parent's* children rather than its index within the composite's own range. The flags slid by however far the composite sat from the start of its container, so the answer depended on what preceded it:

```
<p><group asList><numberList>1 2</numberList><me>x</me></group></p>        <!-- 1, 2x   — right -->
<p>lead <group asList><numberList>1 2</numberList><me>x</me></group></p>   <!-- lead 1, 2, x   — wrong -->
```

Both pathways read the same record, so both were wrong.

## Tests

These commas are produced twice over from one array of index ranges the core builds — once by the renderers, once by the `text` state variable — with a third copy for the prototype renderers and a fourth for the children of a `<math>`. Only the third had tests of its own.

- `composites.test.tsx` covers the renderer implementation directly: nesting, eligibility, blank strings, empty composites, absent children, the anchor span, and the index shift a section title forces.
- `compositeCommas.test.tsx` drives a live core and holds the `text` value and the text the renderers would show to the same expectation, since the way the two go wrong is by disagreeing. A helper runs the shipped renderer code over the shipped renderer state, standing in only for the individual child renderers, so the render pathway is testable without a browser.
- Three cases that are still wrong are written as the behavior we want and marked `it.fails`: a reference that indexes into a repeat (`$r[1]`) or lands on a group loses the commas, and an item's trailing space reaches the rendered list but not the text. A stacked PR, #1809, takes those on: it fixes the two reference cases and tracks the third as #1811.
- `renderCommas.cy.js` gains the same matrix in the real DOM.

On the tree rebased onto `main` at #1808 and #1814, neither of which touches a file in this diff: `compositeCommas`, `math`, and `text` in `@doenet/doenetml-worker-javascript`, 107 passing, 3 expected-fail, 1 skipped; `composites.test.tsx` in `@doenet/doenetml`, 15 passing. The full worker-javascript suite (3611 passing, 3 expected-fail) and the Cypress comma specs (58 passing) were run on the tree before that rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqQEbokFDiDUN57722Ah8r
