### PR TITLE
Work out the list commas once, and keep them through a reference

### DIFF
--- a/.changeset/composite-list-commas-one-implementation.md
+++ b/.changeset/composite-list-commas-one-implementation.md
@@ -14,4 +14,4 @@ Whitespace at the end of a list item no longer lands in front of the comma that 
 
 The whitespace an author puts between the items of a list group is where the commas go, in `text` as in the rendered list. `<group asList><number>1</number> <number>2</number></group>` had a `text` of `1, , 2`; it now reads `1, 2`, and an empty composite among the items, such as a sequence of length zero, changes nothing.
 
-Underneath, the commas were being worked out four times over from the same data — once for the renderers, once for `text`, once for the string a `<math>` parses, and once for the FlatDast the prototype renderers read. Those four now share one implementation of the grouping, so what a reader sees and what `text` says cannot drift apart again.
+Underneath, the commas were being worked out four times over from the same data — once for the renderers, once for `text`, once for the string a `<math>` parses, and once for the FlatDast the prototype renderers read. Those four now share one implementation of the grouping, so where the commas go is decided once for all of them.

--- a/.changeset/composite-list-commas-one-implementation.md
+++ b/.changeset/composite-list-commas-one-implementation.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+A reference to a list keeps the list's commas, and no comma has a space in front of it.
+
+`$r[1]` and `$g` showed `1234` where the composite they name showed `1, 2, 3, 4`, in the rendered list and in `text` alike. A reference that lands on a composite copies its replacements, and did so recursively down to plain components — which is what makes `$mp[1]` reach the point inside a repeat item rather than the `<setup>` beside it — but recursing that far also flattened away every composite in between, and with it the `asList` that made the replacements a list. The recursion now stops at a composite that can be a list of its own, so the reference copies that composite and the list survives; composites that cannot be a list are still recursed through, so what a reference resolves to is unchanged.
+
+Whitespace at the end of a list item no longer lands in front of the comma that follows it. `<group asList><group><number>1</number> </group><group><number>2</number> </group></group>` read `1 , 2` and now reads `1, 2`.
+
+Underneath, the commas were being worked out four times over from the same data — once for the renderers, once for `text`, once for the string a `<math>` parses, and once for the FlatDast the prototype renderers read. Those four now share one implementation of the grouping, so what a reader sees and what `text` says cannot drift apart again.

--- a/.changeset/composite-list-commas-one-implementation.md
+++ b/.changeset/composite-list-commas-one-implementation.md
@@ -12,4 +12,6 @@ A reference to a list keeps the list's commas, and no comma has a space in front
 
 Whitespace at the end of a list item no longer lands in front of the comma that follows it. `<group asList><group><number>1</number> </group><group><number>2</number> </group></group>` read `1 , 2` and now reads `1, 2`.
 
+The whitespace an author puts between the items of a list group is where the commas go, in `text` as in the rendered list. `<group asList><number>1</number> <number>2</number></group>` had a `text` of `1, , 2`; it now reads `1, 2`, and an empty composite among the items, such as a sequence of length zero, changes nothing.
+
 Underneath, the commas were being worked out four times over from the same data — once for the renderers, once for `text`, once for the string a `<math>` parses, and once for the FlatDast the prototype renderers read. Those four now share one implementation of the grouping, so what a reader sees and what `text` says cannot drift apart again.

--- a/.changeset/composite-list-commas-one-implementation.md
+++ b/.changeset/composite-list-commas-one-implementation.md
@@ -6,7 +6,7 @@
 "doenet-vscode-extension": patch
 ---
 
-A reference to a list keeps the list's commas, and no comma has a space in front of it.
+A reference to a list keeps the list's commas, and the whitespace an author writes around the items of a list no longer lands in front of a comma.
 
 `$r[1]` and `$g` showed `1234` where the composite they name showed `1, 2, 3, 4`, in the rendered list and in `text` alike. A reference that lands on a composite copies its replacements, and did so recursively down to plain components — which is what makes `$mp[1]` reach the point inside a repeat item rather than the `<setup>` beside it — but recursing that far also flattened away every composite in between, and with it the `asList` that made the replacements a list. The recursion now stops at a composite that can be a list of its own, so the reference copies that composite and the list survives; composites that cannot be a list are still recursed through, so what a reference resolves to is unchanged.
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -332,6 +332,11 @@ export default class Copy extends CompositeComponent {
                             recursive: true,
                             recurseNonStandardComposites:
                                 stateValues.unresolvedPath != null,
+                            // While a path is still to be resolved, the
+                            // recursion has to reach every replacement. Once
+                            // the reference has resolved to the composite
+                            // itself, a list composite among its replacements
+                            // is kept whole, so the copy shows its commas.
                             stopAtListComposites:
                                 stateValues.unresolvedPath == null,
                             includeWithheldReplacements: true,

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -332,6 +332,8 @@ export default class Copy extends CompositeComponent {
                             recursive: true,
                             recurseNonStandardComposites:
                                 stateValues.unresolvedPath != null,
+                            stopAtListComposites:
+                                stateValues.unresolvedPath == null,
                             includeWithheldReplacements: true,
                             stopIfHaveProp: firstPropNameFromPath,
                         };

--- a/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
@@ -1240,7 +1240,9 @@ export async function changeInactiveComponentAndDescendants({
  * keeps replacements past `replacementsToWithhold`. `stopIfHaveProp`,
  * if set, names a state variable: a composite that publicly exposes
  * that variable is treated as the replacement itself rather than
- * recursed into.
+ * recursed into. `stopAtListComposites` does the same for a composite
+ * that can be shown as a list (its state has `asList`), so that a copy
+ * of the replacements keeps the list, commas and all.
  */
 export function recursivelyReplaceCompositesWithReplacements({
     core,

--- a/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
@@ -1248,12 +1248,14 @@ export function recursivelyReplaceCompositesWithReplacements({
     recurseNonStandardComposites = false,
     includeWithheldReplacements = false,
     stopIfHaveProp,
+    stopAtListComposites = false,
 }: {
     core: Core;
     replacements: any[];
     recurseNonStandardComposites?: boolean;
     includeWithheldReplacements?: boolean;
     stopIfHaveProp?: string;
+    stopAtListComposites?: boolean;
 }): {
     compositesFound: number[];
     newReplacements: any[];
@@ -1290,6 +1292,11 @@ export function recursivelyReplaceCompositesWithReplacements({
             }
         }
 
+        if (stopAtListComposites && "asList" in replacement.state) {
+            newReplacements.push(replacement);
+            continue;
+        }
+
         compositesFound.push(replacement.componentIdx);
 
         if (!replacement.isExpanded) {
@@ -1318,6 +1325,7 @@ export function recursivelyReplaceCompositesWithReplacements({
             recurseNonStandardComposites,
             includeWithheldReplacements,
             stopIfHaveProp,
+            stopAtListComposites,
         });
         compositesFound.push(...recursionResult.compositesFound);
         newReplacements.push(...recursionResult.newReplacements);

--- a/packages/doenetml-worker-javascript/src/core/dependencies/replacementDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/replacementDependencies.ts
@@ -50,6 +50,8 @@ export class ReplacementDependency extends Dependency {
         // then we won't returns its replacements but instead return the composite itself.
         this.stopIfHaveProp = this.definition.stopIfHaveProp;
 
+        this.stopAtListComposites = this.definition.stopAtListComposites;
+
         this.includeWithheldReplacements =
             this.definition.includeWithheldReplacements;
 
@@ -191,6 +193,7 @@ export class ReplacementDependency extends Dependency {
                 core: this.dependencyHandler.core,
                 replacements,
                 recurseNonStandardComposites: this.recurseNonStandardComposites,
+                stopAtListComposites: this.stopAtListComposites,
                 includeWithheldReplacements: this.includeWithheldReplacements,
                 stopIfHaveProp: this.stopIfHaveProp,
             });

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -261,6 +261,33 @@ describe("Automatic commas between composite replacements @group3", () => {
         });
     });
 
+    it("puts the comma where the whitespace between two items was", async () => {
+        // Issue #499: the spaces an author puts between the items of a list
+        // group are where the commas go, and an empty composite among them
+        // is nothing at all.
+        await checkParagraphs(
+            {
+                spaced: {
+                    body: `<group asList><number>1</number> <number>2</number> <number>3</number></group>`,
+                    expected: "1, 2, 3",
+                },
+                withEmpty: {
+                    body: `<group asList><number>1</number> <number>2</number> $s <number>3</number></group>`,
+                    expected: "1, 2, 3",
+                },
+                withTwoEmpty: {
+                    body: `<group asList><number>1</number> <number>2</number> $s $s2 <number>3</number></group>`,
+                    expected: "1, 2, 3",
+                },
+                onOwnLines: {
+                    body: `\n<group asList>\n<number>1</number> <number>2</number> $s <number>3</number>\n</group>\n`,
+                    expected: "\n\n1, 2, 3\n\n",
+                },
+            },
+            `<setup><sequence name="s" length="0" /><sequence name="s2" length="0" /></setup>\n`,
+        );
+    });
+
     it("keeps the commas through a reference to the list", async () => {
         await checkParagraphs(
             {
@@ -287,6 +314,25 @@ describe("Automatic commas between composite replacements @group3", () => {
             `<setup>
                 <numberList name="nl">1 2 3 4</numberList>
                 <repeatForSequence name="r" from="1" to="2">$nl</repeatForSequence>
+            </setup>\n`,
+        );
+    });
+
+    it("keeps the commas through a reference into a nested repeat", async () => {
+        // Issue #596.
+        await checkParagraphs(
+            {
+                item: {
+                    body: `This should have commas: $a[1]`,
+                    expected: "This should have commas: 6, 8",
+                },
+            },
+            `<setup>
+                <repeatForSequence from="1" to="2" name="a" valueName="x">
+                    <repeatForSequence from="5" to="7" step="2" name="b" valueName="y">
+                        <number>$x+$y</number>
+                    </repeatForSequence>
+                </repeatForSequence>
             </setup>\n`,
         );
     });

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -248,6 +248,19 @@ describe("Automatic commas between composite replacements @group3", () => {
         });
     });
 
+    it("takes an item's trailing whitespace off in front of a comma", async () => {
+        await checkParagraphs({
+            blankInsideItem: {
+                body: `<group asList><group><number>1</number> </group><group><number>2</number> </group></group>`,
+                expected: "1, 2 ",
+            },
+            blankBetweenItems: {
+                body: `<repeatForSequence from="1" to="3" valueName="v" asList><number>$v</number> </repeatForSequence>`,
+                expected: "1, 2, 3",
+            },
+        });
+    });
+
     it("keeps the commas through a reference to the list", async () => {
         await checkParagraphs(
             {
@@ -337,12 +350,13 @@ describe("Automatic commas inside a <math> @group3", () => {
  * and the case can be moved into the suite above.
  */
 describe("Automatic commas: known defects @group3", () => {
-    // The `text` pathway trims the end of every item but the last, so
-    // whitespace an item ends with never lands in front of a comma. The
-    // renderers' equivalent, `removeEndingBlankString`, only looks inside a
-    // child whose `props.children` is an array, which a rendered component
-    // child never has — so it never reaches the trailing space, and the
-    // rendered list shows "a , b" where the text says "a, b".
+    // Whitespace that belongs to the list — a blank string between two
+    // replacements — is now taken off in front of a comma in both pathways.
+    // Whitespace inside a child component's own text is not: `text` reads that
+    // component's text and can trim it, while the renderers only hand React the
+    // child and never see, let alone reach into, what it draws. Closing this
+    // means either giving up the trim on the `text` side, which reads worse, or
+    // telling the child renderer it leads a comma.
     it.fails("trims an item's trailing space in both pathways", async () => {
         await checkParagraphs({
             trailing: {

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -265,15 +265,29 @@ describe("Automatic commas between composite replacements @group3", () => {
         );
     });
 
-    it("keeps the commas through a reference to the whole repeat", async () => {
+    it("keeps the commas through a reference into a repeat", async () => {
         await checkParagraphs(
             {
                 whole: { body: `$r`, expected: "1, 2, 3, 4, 1, 2, 3, 4" },
+                item: { body: `$r[1]`, expected: "1, 2, 3, 4" },
             },
             `<setup>
                 <numberList name="nl">1 2 3 4</numberList>
                 <repeatForSequence name="r" from="1" to="2">$nl</repeatForSequence>
             </setup>\n`,
+        );
+    });
+
+    it("keeps the commas through a reference to a group", async () => {
+        await checkParagraphs(
+            {
+                group: { body: `$g`, expected: "1, 2, 3" },
+                extended: {
+                    body: `<group extend="$g" />`,
+                    expected: "1, 2, 3",
+                },
+            },
+            `<setup><group name="g"><numberList>1 2 3</numberList></group></setup>\n`,
         );
     });
 });
@@ -323,32 +337,6 @@ describe("Automatic commas inside a <math> @group3", () => {
  * and the case can be moved into the suite above.
  */
 describe("Automatic commas: known defects @group3", () => {
-    // A reference that lands on a composite copies that composite's *final*
-    // replacements — the components, with every composite between them and the
-    // reference flattened away — while `compositeReplacementActiveRange` still
-    // records only the outermost composite. The `asList` of everything in
-    // between is lost, so the list stops being a list.
-    it.fails("keeps the commas through a reference into a repeat", async () => {
-        await checkParagraphs(
-            {
-                item: { body: `$r[1]`, expected: "1, 2, 3, 4" },
-            },
-            `<setup>
-                <numberList name="nl">1 2 3 4</numberList>
-                <repeatForSequence name="r" from="1" to="2">$nl</repeatForSequence>
-            </setup>\n`,
-        );
-    });
-
-    it.fails("keeps the commas through a reference to a group", async () => {
-        await checkParagraphs(
-            {
-                group: { body: `$g`, expected: "1, 2, 3" },
-            },
-            `<setup><group name="g"><numberList>1 2 3</numberList></group></setup>\n`,
-        );
-    });
-
     // The `text` pathway trims the end of every item but the last, so
     // whitespace an item ends with never lands in front of a comma. The
     // renderers' equivalent, `removeEndingBlankString`, only looks inside a

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -11,25 +11,25 @@ vi.mock("hyperformula");
 
 /**
  * The replacements of a composite that asks to be shown as a list are separated
- * by commas automatically, and that happens twice over, from the same core data,
- * in two independent implementations:
+ * by commas automatically, and that happens four times over from the same core
+ * data:
  *
  * - the renderers insert `", "` between React children
  *   (`addCommasForCompositeRanges`, `doenetml/src/Viewer/renderers/utils/composites.tsx`);
  * - the `text` state variable joins the children's text with `", "`
- *   (`textFromChildren`, `doenetml-worker-javascript/src/utils/text.ts`).
+ *   (`textFromChildren`, `doenetml-worker-javascript/src/utils/text.ts`);
+ * - the string a `<math>` parses gets its commas
+ *   (`createInputStringFromChildren`, `doenetml-worker-javascript/src/utils/parseMath.ts`);
+ * - the FlatDast the prototype renderers read gets `<asList>` wrappers
+ *   (`applyCompositeListWrapping`, `doenetml-worker/src/compositeListWrapping.ts`).
  *
- * A third, `applyCompositeListWrapping`
- * (`doenetml-worker/src/compositeListWrapping.ts`), reproduces the renderers'
- * grouping for the prototype renderers, and a fourth, `parseMath.ts`, does it
- * for the children of a `<math>`.
- *
- * All of them read one array the core builds in
- * `CompositeExpander.replaceCompositeChildren`: for each composite that
+ * All four read one array the core builds in
+ * `CompositeExpander.replaceCompositeChildren` — for each composite that
  * contributed children, the index range those children occupy, whether the
  * composite has `asList` set, and whether each replacement is eligible to be a
- * list item. Every case below therefore checks *both* pathways, since the way
- * they go wrong is by disagreeing.
+ * list item — and group it with `groupCompositeRanges` (`@doenet/utils`). What
+ * each does with a group is its own, so every case below checks the `text`
+ * value and the text the renderers would show against the same expectation.
  *
  * `renderedText` runs the shipped renderer code over the shipped renderer state
  * and stands in only for the individual child renderers; see
@@ -352,12 +352,12 @@ describe("Automatic commas between composite replacements @group3", () => {
 });
 
 describe("Automatic commas inside a <math> @group3", () => {
-    // `createInputStringFromChildrenSub` (`utils/parseMath.ts`) is the same
-    // algorithm again, joining the children into the string that gets parsed
-    // into a math expression. It wraps the list in parentheses when what sits
-    // next to it is not a delimiter, and to find that out it walks outward past
-    // whitespace-only strings — a walk that used to never move its index, so a
-    // component child (or a blank string) on either side hung the core.
+    // `createInputStringFromChildren` (`utils/parseMath.ts`) joins the children
+    // into the string that gets parsed into a math expression. It wraps a list
+    // in parentheses when what sits next to it is not a delimiter, and to find
+    // that out it walks outward past whitespace-only strings — a walk that used
+    // to never move its index, so a component child (or a blank string) on
+    // either side hung the core.
     it("wraps the list when a neighbor is not a delimiter", async () => {
         const cases: Record<string, string> = {
             alone: `<numberList>1 2</numberList>`,

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -396,9 +396,9 @@ describe("Automatic commas inside a <math> @group3", () => {
  * and the case can be moved into the suite above.
  */
 describe("Automatic commas: known defects @group3", () => {
-    // Whitespace that belongs to the list — a blank string between two
-    // replacements — is now taken off in front of a comma in both pathways.
-    // Whitespace inside a child component's own text is not: `text` reads that
+    // Issue #1811. A blank string between two replacements belongs to the
+    // list, and both pathways take it off in front of a comma. Whitespace
+    // inside a child component's own text is another matter: `text` reads that
     // component's text and can trim it, while the renderers only hand React the
     // child and never see, let alone reach into, what it draws. Closing this
     // means either giving up the trim on the `text` side, which reads worse, or

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -280,6 +280,10 @@ describe("Automatic commas between composite replacements @group3", () => {
                     body: `<group asList><number>1</number> <number>2</number> $s $s2 <number>3</number></group>`,
                     expected: "1, 2, 3",
                 },
+                blankGroupBetween: {
+                    body: `<group asList><number>1</number><group> </group><number>2</number></group>`,
+                    expected: "1, 2",
+                },
                 withItems: {
                     body: `<group asList><number>1</number> <number>2</number> $s3 <number>3</number></group>`,
                     expected: "1, 2, 7, 8, 3",

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -342,6 +342,38 @@ describe("Automatic commas between composite replacements @group3", () => {
         );
     });
 
+    it("keeps the commas of a list operator, directly and through a reference", async () => {
+        // The list operators (`<cumulativeSum>`, `<differences>`, and so on)
+        // are composites with `asList` of their own, so a reference to one
+        // copies the operator and keeps its list.
+        await checkParagraphs(
+            {
+                direct: {
+                    body: `<cumulativeSum>1 2 3</cumulativeSum>`,
+                    expected: "1, 3, 6",
+                },
+                off: {
+                    body: `<cumulativeSum asList="false">1 2 3</cumulativeSum>`,
+                    expected: "136",
+                },
+                reference: { body: `$cs`, expected: "3, 4, 6" },
+                item: { body: `$cs[2]`, expected: "4" },
+                extended: {
+                    body: `<numberList extend="$cs" />`,
+                    expected: "3, 4, 6",
+                },
+                inGroup: {
+                    body: `<group asList><differences>1 4 9</differences> <text>x</text></group>`,
+                    expected: "3, 5, x",
+                },
+            },
+            `<setup>
+                <numberList name="nl">3 1 2</numberList>
+                <cumulativeSum name="cs">$nl</cumulativeSum>
+            </setup>\n`,
+        );
+    });
+
     it("keeps the commas through a reference to a group", async () => {
         await checkParagraphs(
             {

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/compositeCommas.test.tsx
@@ -263,8 +263,9 @@ describe("Automatic commas between composite replacements @group3", () => {
 
     it("puts the comma where the whitespace between two items was", async () => {
         // Issue #499: the spaces an author puts between the items of a list
-        // group are where the commas go, and an empty composite among them
-        // is nothing at all.
+        // group are where the commas go. An empty composite among them is
+        // nothing at all, and one that has items is a single item of the
+        // list, with commas of its own.
         await checkParagraphs(
             {
                 spaced: {
@@ -279,12 +280,16 @@ describe("Automatic commas between composite replacements @group3", () => {
                     body: `<group asList><number>1</number> <number>2</number> $s $s2 <number>3</number></group>`,
                     expected: "1, 2, 3",
                 },
+                withItems: {
+                    body: `<group asList><number>1</number> <number>2</number> $s3 <number>3</number></group>`,
+                    expected: "1, 2, 7, 8, 3",
+                },
                 onOwnLines: {
                     body: `\n<group asList>\n<number>1</number> <number>2</number> $s <number>3</number>\n</group>\n`,
                     expected: "\n\n1, 2, 3\n\n",
                 },
             },
-            `<setup><sequence name="s" length="0" /><sequence name="s2" length="0" /></setup>\n`,
+            `<setup><sequence name="s" length="0" /><sequence name="s2" length="0" /><sequence name="s3" from="7" to="8" /></setup>\n`,
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/test/utils/rendered-commas.tsx
+++ b/packages/doenetml-worker-javascript/src/test/utils/rendered-commas.tsx
@@ -5,29 +5,27 @@ import { PublicDoenetMLCore } from "../../CoreWorker";
 
 /**
  * Automatic commas between the replacements of a composite are produced twice,
- * from the same core data, by two independent implementations:
+ * from the same core data:
  *
  * - the renderers, via `addCommasForCompositeRanges`
- *   (`doenetml/src/Viewer/renderers/utils/composites.tsx`), which insert `", "`
+ *   (`doenetml/src/Viewer/renderers/utils/composites.tsx`), insert `", "`
  *   between React children; and
  * - the `text` state variable, via `textFromChildren`
- *   (`doenetml-worker-javascript/src/utils/text.ts`), which joins strings.
+ *   (`doenetml-worker-javascript/src/utils/text.ts`), joins strings.
  *
  * Both read the same input: the parent's `compositeReplacementActiveRange`,
  * built in `CompositeExpander.replaceCompositeChildren` and handed to the
  * renderers as the `_compositeReplacementActiveRange` renderer state value.
+ * Both group it with `groupCompositeRanges` (`@doenet/utils`); what each does
+ * with a group once it has one is its own, and is what a test compares.
  *
  * `renderedText` below runs the *real* renderer implementation over the *real*
  * renderer state of a live core, so a test can compare the two pathways without
  * a browser. It stands in for the individual child renderers — each rendered
  * component child becomes a `<span>` holding that component's own text — but
- * everything above that, the comma insertion itself, is the shipped code.
- *
- * The `<span>` stand-in is faithful to the one thing the comma code inspects
- * about a child element: `removeEndingBlankString` only reaches inside a child
- * whose `props.children` is an array, and a real child (a `<DoenetRenderer>`
- * element carrying `componentInstructions`) never has one, exactly as a
- * `<span>` holding a single string never has one.
+ * everything above that, the comma insertion itself, is the shipped code. The
+ * comma code never looks inside a child element (it trims and drops only string
+ * children), so the `<span>` is as faithful as a real `<DoenetRenderer>`.
  */
 
 /** A renderer-state entry, as `RendererInstructionBuilder` records it. */

--- a/packages/doenetml-worker-javascript/src/test/utils/rendered-commas.tsx
+++ b/packages/doenetml-worker-javascript/src/test/utils/rendered-commas.tsx
@@ -4,8 +4,9 @@ import { addCommasForCompositeRanges } from "../../../../doenetml/src/Viewer/ren
 import { PublicDoenetMLCore } from "../../CoreWorker";
 
 /**
- * Automatic commas between the replacements of a composite are produced twice,
- * from the same core data:
+ * Of the four places that produce the automatic commas between the
+ * replacements of a composite (listed in `compositeCommas.test.tsx`), two are
+ * compared here:
  *
  * - the renderers, via `addCommasForCompositeRanges`
  *   (`doenetml/src/Viewer/renderers/utils/composites.tsx`), insert `", "`

--- a/packages/doenetml-worker-javascript/src/utils/parseMath.ts
+++ b/packages/doenetml-worker-javascript/src/utils/parseMath.ts
@@ -1,5 +1,6 @@
 import {
     groupCompositeRanges,
+    joinListText,
     type CompositeGroup,
     type CompositeRange,
 } from "@doenet/utils";
@@ -118,15 +119,12 @@ function stringFromGroups(
             continue;
         }
 
-        // Add commas between the children from a single composite, trimming any
-        // white space to the right of all but the last so that nothing puts a
-        // space in front of a comma.
-        let listString = parts
-            .filter((part) => part.trim() !== "")
-            .map((part, ind, all) =>
-                ind === all.length - 1 ? part : part.trimEnd(),
-            )
-            .join(", ");
+        // The commas go where `text` puts them. Every part is a string here,
+        // so a whitespace-only one is blank whatever produced it.
+        const listString = joinListText(
+            parts,
+            parts.map((part) => part.trim() === ""),
+        );
 
         strings.push(wrapListIfNeeded(listString, group.range, context));
     }

--- a/packages/doenetml-worker-javascript/src/utils/parseMath.ts
+++ b/packages/doenetml-worker-javascript/src/utils/parseMath.ts
@@ -43,8 +43,8 @@ export function createInputStringFromChildren({
     /**
      * Returns the marker to stand in for `child` instead of its content, or
      * `null` to render the child as usual. Keyed on the child object rather
-     * than its index so that it survives the composite regrouping below, which
-     * reorders and regroups children but never changes their identity.
+     * than its index, so that it does not depend on how the children are
+     * grouped by composite below.
      */
     displayedMathSlotForChild?: (child: any) => string | null;
 }) {

--- a/packages/doenetml-worker-javascript/src/utils/parseMath.ts
+++ b/packages/doenetml-worker-javascript/src/utils/parseMath.ts
@@ -1,9 +1,22 @@
-type CompositeReplacementRange = {
-    firstInd: number;
-    lastInd: number;
-    asList: boolean;
-    hidden: boolean;
-    potentialListComponents: boolean[];
+import {
+    groupCompositeRanges,
+    type CompositeGroup,
+    type CompositeRange,
+} from "@doenet/utils";
+
+/** What every step of the walk below needs but never changes. */
+type StringFromGroupsContext = {
+    children: any[];
+    nonStringIndByChild: (null | number)[];
+    format: "latex" | "text";
+    codePre: string;
+    createInternalLists: boolean;
+    /** Advanced as internal lists are created, so each gets its own code. */
+    nextInternalListInd: number;
+    internalLists: Record<string, any>;
+    parser?: (arg0: string) => any;
+    createDisplayedMathString: boolean;
+    displayedMathSlotForChild?: (child: any) => string | null;
 };
 
 // concatenate strings with a numbered code for each non-string child
@@ -45,311 +58,183 @@ export function createInputStringFromChildren({
         }
     }
 
-    let result = createInputStringFromChildrenSub({
-        compositeReplacementRange: children.compositeReplacementRange,
+    // Which children came from which composite, and which of those composites
+    // are lists, is `groupCompositeRanges`, shared with the renderers and with
+    // the `text` state variable.
+    const groups = groupCompositeRanges<any>({
         children,
-        startInd: 0,
-        endInd: children.length - 1,
+        ranges: children.compositeReplacementRange as
+            CompositeRange[] | undefined,
+        isBlank: (child) => typeof child === "string" && child.trim() === "",
+    });
+
+    const context: StringFromGroupsContext = {
+        children,
         nonStringIndByChild,
         format,
         codePre,
         createInternalLists,
         nextInternalListInd: nonStringInd,
+        internalLists: {},
         parser,
         createDisplayedMathString,
         displayedMathSlotForChild,
-    });
+    };
 
     let joinString = createDisplayedMathString ? " " : "";
     return {
-        string: result.newChildren.join(joinString),
-        internalLists: result.internalLists,
+        string: stringFromGroups(groups, context).join(joinString),
+        internalLists: context.internalLists,
     };
 }
 
-function createInputStringFromChildrenSub({
-    compositeReplacementRange,
-    children,
-    startInd,
-    endInd,
-    nonStringIndByChild,
-    format,
-    codePre,
-    potentialListComponents,
-    createInternalLists,
-    nextInternalListInd,
-    parser,
-    createDisplayedMathString,
-    displayedMathSlotForChild,
-}: {
-    compositeReplacementRange: CompositeReplacementRange[] | undefined;
-    children: any;
-    startInd: number;
-    endInd: number;
-    nonStringIndByChild: (null | number)[];
-    format: "latex" | "text";
-    codePre: string;
-    potentialListComponents?: boolean[];
-    createInternalLists: boolean;
-    nextInternalListInd: number;
-    parser?: (arg0: string) => any;
-    createDisplayedMathString: boolean;
-    displayedMathSlotForChild?: (child: any) => string | null;
-}): {
-    newChildren: string[];
-    newPotentialListComponents: boolean[];
-    internalLists: Record<string, any>;
-} {
-    let newChildren: string[] = [];
-    let newPotentialListComponents: boolean[] = [];
-    let lastChildInd = startInd - 1;
-    let internalLists: Record<string, any> = {};
+function stringFromGroups(
+    groups: CompositeGroup<any>[],
+    context: StringFromGroupsContext,
+): string[] {
+    const strings: string[] = [];
 
-    let leftDelimiters = ["{", "[", "(", "|", ","];
-    let rightDelimiters = ["}", "]", ")", "|", ","];
-
-    if (compositeReplacementRange) {
-        for (
-            let rangeInd = 0;
-            rangeInd < compositeReplacementRange.length;
-            rangeInd++
-        ) {
-            let range = compositeReplacementRange[rangeInd];
-
-            let rangeFirstInd = range.firstInd;
-            let rangeLastInd = range.lastInd;
-
-            if (rangeFirstInd > lastChildInd && rangeLastInd <= endInd) {
-                if (lastChildInd + 1 < rangeFirstInd) {
-                    for (
-                        let ind = lastChildInd + 1;
-                        ind < rangeFirstInd;
-                        ind++
-                    ) {
-                        // we are not grouping these children
-                        // but we are separately turning each one into a string
-                        // (turning the non-string children into a code based on codePre and its nonStringInd)
-                        newChildren.push(
-                            baseStringFromChildren({
-                                children,
-                                startInd: ind,
-                                endInd: ind,
-                                nonStringIndByChild,
-                                format,
-                                codePre,
-                                createDisplayedMathString,
-                                displayedMathSlotForChild,
-                            }),
-                        );
-                    }
-                    if (potentialListComponents) {
-                        // Since we didn't change the components,
-                        // their status of being a potential list component is not changed
-                        newPotentialListComponents.push(
-                            ...potentialListComponents.slice(
-                                lastChildInd - startInd + 1,
-                                rangeFirstInd - startInd,
-                            ),
-                        );
-                    }
-                }
-
-                // If a composite produced composites that produced children,
-                // then this outer composite is first in the array of replacement ranges.
-                // We first process the children corresponding to any of these replacement composites,
-                // which will concatenate the replacements of each composite into a single text,
-                // which may be be turned into a list according to the settings of that composite.
-
-                // We remove the replacement range of the current composite (any all earlier ones)
-                let subReplacementRange = compositeReplacementRange.slice(
-                    rangeInd + 1,
-                );
-
-                let {
-                    newChildren: childrenInRange,
-                    newPotentialListComponents: potentialListComponentsInRange,
-                    internalLists: newInternalLists,
-                } = createInputStringFromChildrenSub({
-                    compositeReplacementRange: subReplacementRange,
-                    children,
-                    startInd: rangeFirstInd,
-                    endInd: rangeLastInd,
-                    nonStringIndByChild,
-                    format,
-                    codePre,
-                    potentialListComponents: range.potentialListComponents,
-                    createInternalLists,
-                    nextInternalListInd,
-                    parser,
-                    createDisplayedMathString,
-                    displayedMathSlotForChild,
-                });
-
-                Object.assign(internalLists, newInternalLists);
-                nextInternalListInd += Object.keys(newInternalLists).length;
-
-                let allAreListComponents = potentialListComponentsInRange.every(
-                    (x) => x,
-                );
-
-                if (
-                    range.asList &&
-                    allAreListComponents &&
-                    childrenInRange.length > 1
-                ) {
-                    // add commas between all children from a single composite
-                    let listString = childrenInRange
-                        .filter((v) => v.trim() !== "")
-                        .map((v, i, a) =>
-                            i === a.length - 1 ? v : v.trimEnd(),
-                        )
-                        .join(", ");
-
-                    // The following implements the logic to determine if this comma-separated list
-                    // should be wrapped by parens.
-                    // Wrap with parens if the lists is surrounded by a non-delimiter on either side.
-                    // The parens will generally turn the list into a tuple (or to arguments of a function)
-                    // when it is parsed into a math-expression.
-
-                    let wrap = false;
-
-                    // First check if there is a non-delimiter to the left,
-                    // looking past any whitespace-only strings.
-                    for (
-                        let prevInd = rangeFirstInd - 1;
-                        prevInd >= 0;
-                        prevInd--
-                    ) {
-                        let prevChild = children[prevInd];
-                        if (typeof prevChild !== "string") {
-                            // There is a non-string child to the left,
-                            // so we must wrap the list
-                            wrap = true;
-                            break;
-                        }
-                        prevChild = prevChild.trim();
-                        if (prevChild.length === 0) {
-                            continue;
-                        }
-                        if (
-                            !leftDelimiters.includes(
-                                prevChild[prevChild.length - 1],
-                            )
-                        ) {
-                            // The string to the left did not contain one of the delimiters,
-                            // so we must wrap the list.
-                            wrap = true;
-                        }
-                        break;
-                    }
-
-                    if (!wrap) {
-                        // Since we didn't have a non-delimiter to the left,
-                        // check if there is a non-delimiter to the right,
-                        // again looking past any whitespace-only strings.
-                        for (
-                            let nextInd = rangeLastInd + 1;
-                            nextInd < children.length;
-                            nextInd++
-                        ) {
-                            let nextChild = children[nextInd];
-                            if (typeof nextChild !== "string") {
-                                // There is a non-string child to the right,
-                                // so we must wrap the list
-                                wrap = true;
-                                break;
-                            }
-                            nextChild = nextChild.trim();
-                            if (nextChild.length === 0) {
-                                continue;
-                            }
-                            let nextChar = nextChild[0];
-                            // If the format is latex,
-                            // the delimiter could be escaped by a \
-                            if (
-                                format === "latex" &&
-                                nextChar === "\\" &&
-                                nextChild.length > 1
-                            ) {
-                                nextChar = nextChild[1];
-                            }
-                            if (!rightDelimiters.includes(nextChar)) {
-                                // The string to the right did not contain one of the delimiters,
-                                // so we must wrap the list.
-                                wrap = true;
-                            }
-                            break;
-                        }
-                    }
-
-                    if (wrap) {
-                        if (createInternalLists) {
-                            // if `createInternalLists` is set, rather than wrapping in parens,
-                            // we will put a list into the ast at this point
-                            // (even though one wouldn't be able to get that by parsing a string into math)
-                            let code = codePre + nextInternalListInd;
-                            internalLists[code] = parser?.(listString) ?? "";
-                            nextInternalListInd++;
-                            listString = returnStringForCode(format, code);
-                        } else if (!createDisplayedMathString) {
-                            listString = "(" + listString + ")";
-                        }
-                    }
-
-                    newChildren.push(listString);
-                } else {
-                    // We are not turning the children in a list,
-                    // so just concatenate the strings
-                    let joinString = createDisplayedMathString ? " " : "";
-                    newChildren.push(childrenInRange.join(joinString));
-                }
-
-                if (potentialListComponents) {
-                    // record whether the result from the composite (a single string now)
-                    // should be considered a list component for any outer composite
-                    newPotentialListComponents.push(allAreListComponents);
-                }
-                lastChildInd = rangeLastInd;
-            }
-        }
-    }
-
-    if (lastChildInd < endInd) {
-        for (let ind = lastChildInd + 1; ind <= endInd; ind++) {
-            // we are not grouping these children
-            // but we are separately turning each one into a string
-            // (turning the non-string children into a code based on codePre and its nonStringInd)
-            newChildren.push(
+    for (const group of groups) {
+        if (group.kind === "child") {
+            // Not grouped with anything, so just turn this one child into a
+            // string (a non-string child becoming a code based on `codePre`).
+            strings.push(
                 baseStringFromChildren({
-                    children,
-                    startInd: ind,
-                    endInd: ind,
-                    nonStringIndByChild,
-                    format,
-                    codePre,
-                    createDisplayedMathString,
-                    displayedMathSlotForChild,
+                    children: context.children,
+                    startInd: group.index,
+                    endInd: group.index,
+                    nonStringIndByChild: context.nonStringIndByChild,
+                    format: context.format,
+                    codePre: context.codePre,
+                    createDisplayedMathString:
+                        context.createDisplayedMathString,
+                    displayedMathSlotForChild:
+                        context.displayedMathSlotForChild,
                 }),
             );
+            continue;
         }
 
-        if (potentialListComponents) {
-            // Since we didn't change the components,
-            // their status of being a potential list component is not changed
-            newPotentialListComponents.push(
-                ...potentialListComponents.slice(
-                    lastChildInd - startInd + 1,
-                    endInd - startInd + 1,
-                ),
+        const parts = stringFromGroups(group.items, context);
+
+        if (!group.asList) {
+            // Not a list, so just concatenate what the composite produced.
+            strings.push(
+                parts.join(context.createDisplayedMathString ? " " : ""),
             );
+            continue;
+        }
+
+        // Add commas between the children from a single composite, trimming any
+        // white space to the right of all but the last so that nothing puts a
+        // space in front of a comma.
+        let listString = parts
+            .filter((part) => part.trim() !== "")
+            .map((part, ind, all) =>
+                ind === all.length - 1 ? part : part.trimEnd(),
+            )
+            .join(", ");
+
+        strings.push(wrapListIfNeeded(listString, group.range, context));
+    }
+
+    return strings;
+}
+
+/**
+ * Wrap a comma-separated list in parens if it is surrounded by a non-delimiter
+ * on either side. The parens will generally turn the list into a tuple (or into
+ * the arguments of a function) when it is parsed into a math-expression.
+ */
+function wrapListIfNeeded(
+    listString: string,
+    range: CompositeRange,
+    context: StringFromGroupsContext,
+): string {
+    const { children, format, codePre, createInternalLists, parser } = context;
+    const leftDelimiters = ["{", "[", "(", "|", ","];
+    const rightDelimiters = ["}", "]", ")", "|", ","];
+
+    let wrap = false;
+
+    // First check if there is a non-delimiter to the left,
+    // looking past any whitespace-only strings.
+    for (let prevInd = range.firstInd - 1; prevInd >= 0; prevInd--) {
+        let prevChild = children[prevInd];
+        if (typeof prevChild !== "string") {
+            // There is a non-string child to the left, so we must wrap the list
+            wrap = true;
+            break;
+        }
+        prevChild = prevChild.trim();
+        if (prevChild.length === 0) {
+            continue;
+        }
+        if (!leftDelimiters.includes(prevChild[prevChild.length - 1])) {
+            // The string to the left did not end with one of the delimiters,
+            // so we must wrap the list.
+            wrap = true;
+        }
+        break;
+    }
+
+    if (!wrap) {
+        // Since we didn't have a non-delimiter to the left,
+        // check if there is a non-delimiter to the right,
+        // again looking past any whitespace-only strings.
+        for (
+            let nextInd = range.lastInd + 1;
+            nextInd < children.length;
+            nextInd++
+        ) {
+            let nextChild = children[nextInd];
+            if (typeof nextChild !== "string") {
+                // There is a non-string child to the right,
+                // so we must wrap the list
+                wrap = true;
+                break;
+            }
+            nextChild = nextChild.trim();
+            if (nextChild.length === 0) {
+                continue;
+            }
+            let nextChar = nextChild[0];
+            // If the format is latex, the delimiter could be escaped by a \\
+            if (
+                format === "latex" &&
+                nextChar === "\\" &&
+                nextChild.length > 1
+            ) {
+                nextChar = nextChild[1];
+            }
+            if (!rightDelimiters.includes(nextChar)) {
+                // The string to the right did not start with one of the
+                // delimiters, so we must wrap the list.
+                wrap = true;
+            }
+            break;
         }
     }
 
-    return {
-        newChildren,
-        newPotentialListComponents,
-        internalLists,
-    };
+    if (!wrap) {
+        return listString;
+    }
+
+    if (createInternalLists) {
+        // if `createInternalLists` is set, rather than wrapping in parens,
+        // we will put a list into the ast at this point
+        // (even though one wouldn't be able to get that by parsing a string into math)
+        const code = codePre + context.nextInternalListInd;
+        context.internalLists[code] = parser?.(listString) ?? "";
+        context.nextInternalListInd++;
+        return returnStringForCode(format, code);
+    }
+
+    if (context.createDisplayedMathString) {
+        return listString;
+    }
+
+    return "(" + listString + ")";
 }
 
 // concatenate string children and codes from non-string children

--- a/packages/doenetml-worker-javascript/src/utils/parseMath.ts
+++ b/packages/doenetml-worker-javascript/src/utils/parseMath.ts
@@ -100,16 +100,9 @@ function stringFromGroups(
             // string (a non-string child becoming a code based on `codePre`).
             strings.push(
                 baseStringFromChildren({
-                    children: context.children,
+                    ...context,
                     startInd: group.index,
                     endInd: group.index,
-                    nonStringIndByChild: context.nonStringIndByChild,
-                    format: context.format,
-                    codePre: context.codePre,
-                    createDisplayedMathString:
-                        context.createDisplayedMathString,
-                    displayedMathSlotForChild:
-                        context.displayedMathSlotForChild,
                 }),
             );
             continue;

--- a/packages/doenetml-worker-javascript/src/utils/text.ts
+++ b/packages/doenetml-worker-javascript/src/utils/text.ts
@@ -28,8 +28,7 @@ function isBlankString(child: any) {
  *
  * The grouping — which children came from which composite, which of those
  * composites are lists, and where the commas go — is shared with the renderers
- * through `@doenet/utils`, so that what a reader sees and what `text` says
- * cannot drift apart.
+ * through `@doenet/utils`, so both decide the commas the same way.
  */
 export function textFromChildren(
     children: any,

--- a/packages/doenetml-worker-javascript/src/utils/text.ts
+++ b/packages/doenetml-worker-javascript/src/utils/text.ts
@@ -18,8 +18,9 @@ export function textFromComponent(component: any): string {
     }
 }
 
-const isBlankString = (child: any) =>
-    typeof child === "string" && child.trim() === "";
+function isBlankString(child: any) {
+    return typeof child === "string" && child.trim() === "";
+}
 
 /**
  * Concatenate the text from `children` into one string, putting commas between
@@ -43,41 +44,36 @@ export function textFromChildren(
         skipRange: (range) => Boolean(range.hidden),
     });
 
-    return textFromGroups(groups, textFromComponentConverter);
+    return groups
+        .map((group) => textFromGroup(group, textFromComponentConverter))
+        .join("");
 }
 
-function textFromGroups(
-    groups: CompositeGroup<any>[],
-    convert: (value: any, index: number, array: any[]) => string,
+/** The text of one child, or of everything one composite produced. */
+function textFromGroup(
+    group: CompositeGroup<any>,
+    convert: (value: any) => string,
 ): string {
-    return groups
-        .map((group) => {
-            if (group.kind === "child") {
-                return convert(group.value, 0, [group.value]);
-            }
-            const parts = group.items.map((item) =>
-                textFromGroups([item], convert),
-            );
-            if (!group.asList) {
-                return parts.join("");
-            }
-            // A part that came out empty — a hidden child, say — is no more an
-            // item of the list than whitespace is.
-            const commaBefore = listCommaPositions(
-                group.items.map(
-                    (item, ind) =>
-                        parts[ind] === "" || isBlankGroup(item, isBlankString),
-                ),
-            );
-            // Whitespace an item's own text ends with is left off in front of
-            // the comma that follows it.
-            return parts
-                .map((part, ind) =>
-                    commaBefore[ind + 1] ? part.trimEnd() : part,
-                )
-                .map((part, ind) => (commaBefore[ind] ? ", " + part : part))
-                .join("");
-        })
+    if (group.kind === "child") {
+        return convert(group.value);
+    }
+    const parts = group.items.map((item) => textFromGroup(item, convert));
+    if (!group.asList) {
+        return parts.join("");
+    }
+    // A part that came out empty — a hidden child, say — is no more an item of
+    // the list than whitespace is.
+    const commaBefore = listCommaPositions(
+        group.items.map(
+            (item, ind) =>
+                parts[ind] === "" || isBlankGroup(item, isBlankString),
+        ),
+    );
+    // Whitespace an item's own text ends with is left off in front of the comma
+    // that follows it.
+    return parts
+        .map((part, ind) => (commaBefore[ind + 1] ? part.trimEnd() : part))
+        .map((part, ind) => (commaBefore[ind] ? ", " + part : part))
         .join("");
 }
 

--- a/packages/doenetml-worker-javascript/src/utils/text.ts
+++ b/packages/doenetml-worker-javascript/src/utils/text.ts
@@ -1,5 +1,7 @@
 import {
     groupCompositeRanges,
+    isBlankGroup,
+    listCommaPositions,
     type CompositeGroup,
     type CompositeRange,
 } from "@doenet/utils";
@@ -16,13 +18,17 @@ export function textFromComponent(component: any): string {
     }
 }
 
+const isBlankString = (child: any) =>
+    typeof child === "string" && child.trim() === "";
+
 /**
  * Concatenate the text from `children` into one string, putting commas between
  * the replacements of a composite that asks to be shown as a list.
  *
- * The grouping — which children came from which composite, and which of those
- * composites are lists — is `groupCompositeRanges`, shared with the renderers
- * so that what a reader sees and what `text` says cannot drift apart.
+ * The grouping — which children came from which composite, which of those
+ * composites are lists, and where the commas go — is shared with the renderers
+ * through `@doenet/utils`, so that what a reader sees and what `text` says
+ * cannot drift apart.
  */
 export function textFromChildren(
     children: any,
@@ -32,7 +38,7 @@ export function textFromChildren(
         children,
         ranges: children.compositeReplacementRange as
             CompositeRange[] | undefined,
-        isBlank: (child) => typeof child === "string" && child.trim() === "",
+        isBlank: isBlankString,
         // A hidden composite contributes nothing, not even its children's text.
         skipRange: (range) => Boolean(range.hidden),
     });
@@ -55,16 +61,22 @@ function textFromGroups(
             if (!group.asList) {
                 return parts.join("");
             }
-            // A part that came out empty — a hidden child, say — is not an item
-            // of the list and gets no comma of its own. Trailing whitespace an
-            // item's own text ends with is left off in front of a comma; the
-            // last item keeps it, since it separates the list from what follows.
+            // A part that came out empty — a hidden child, say — is no more an
+            // item of the list than whitespace is.
+            const commaBefore = listCommaPositions(
+                group.items.map(
+                    (item, ind) =>
+                        parts[ind] === "" || isBlankGroup(item, isBlankString),
+                ),
+            );
+            // Whitespace an item's own text ends with is left off in front of
+            // the comma that follows it.
             return parts
-                .filter((part) => part !== "")
-                .map((part, ind, all) =>
-                    ind === all.length - 1 ? part : part.trimEnd(),
+                .map((part, ind) =>
+                    commaBefore[ind + 1] ? part.trimEnd() : part,
                 )
-                .join(", ");
+                .map((part, ind) => (commaBefore[ind] ? ", " + part : part))
+                .join("");
         })
         .join("");
 }

--- a/packages/doenetml-worker-javascript/src/utils/text.ts
+++ b/packages/doenetml-worker-javascript/src/utils/text.ts
@@ -1,3 +1,9 @@
+import {
+    groupCompositeRanges,
+    type CompositeGroup,
+    type CompositeRange,
+} from "@doenet/utils";
+
 export function textFromComponent(component: any): string {
     if (typeof component !== "object") {
         return component.toString();
@@ -10,172 +16,57 @@ export function textFromComponent(component: any): string {
     }
 }
 
-// Concatenate the text from children into one string.
-// Add commas between the components that are all from one composite
-// if that composite has asList set to true
+/**
+ * Concatenate the text from `children` into one string, putting commas between
+ * the replacements of a composite that asks to be shown as a list.
+ *
+ * The grouping — which children came from which composite, and which of those
+ * composites are lists — is `groupCompositeRanges`, shared with the renderers
+ * so that what a reader sees and what `text` says cannot drift apart.
+ */
 export function textFromChildren(
     children: any,
     textFromComponentConverter = textFromComponent,
 ) {
-    let result = textFromChildrenSub({
-        compositeReplacementRange: children.compositeReplacementRange,
+    const groups = groupCompositeRanges<any>({
         children,
-        startInd: 0,
-        endInd: children.length - 1,
-        textFromComponentConverter,
+        ranges: children.compositeReplacementRange as
+            CompositeRange[] | undefined,
+        isBlank: (child) => typeof child === "string" && child.trim() === "",
+        // A hidden composite contributes nothing, not even its children's text.
+        skipRange: (range) => Boolean(range.hidden),
     });
 
-    return result.newChildren.map(textFromComponentConverter).join("");
+    return textFromGroups(groups, textFromComponentConverter);
 }
 
-function textFromChildrenSub({
-    compositeReplacementRange,
-    children,
-    startInd,
-    endInd,
-    textFromComponentConverter,
-    potentialListComponents,
-}: {
-    compositeReplacementRange: {
-        firstInd: number;
-        lastInd: number;
-        asList: boolean;
-        hidden: boolean;
-        potentialListComponents: boolean[];
-    }[];
-    children: any;
-    startInd: number;
-    endInd: number;
-    textFromComponentConverter: (
-        value: any,
-        index: number,
-        array: any[],
-    ) => string;
-    potentialListComponents?: boolean[];
-}) {
-    let newChildren: any[] = [];
-    let newPotentialListComponents: boolean[] = [];
-    let lastChildInd = startInd - 1;
-    let lastChildIndIncludingEmptyComposites = lastChildInd;
-
-    for (
-        let rangeInd = 0;
-        rangeInd < compositeReplacementRange.length;
-        rangeInd++
-    ) {
-        let range = compositeReplacementRange[rangeInd];
-
-        let rangeFirstInd = range.firstInd;
-        let rangeLastInd = range.lastInd;
-
-        if (rangeFirstInd > lastChildInd && rangeLastInd <= endInd) {
-            if (lastChildInd + 1 < rangeFirstInd) {
-                // don't process these children, so just add them back to newChildren
-                newChildren.push(
-                    ...children.slice(lastChildInd + 1, rangeFirstInd),
-                );
-                if (potentialListComponents) {
-                    // Since we didn't change the components,
-                    // their status of being a potential list component is not changed
-                    newPotentialListComponents.push(
-                        ...potentialListComponents.slice(
-                            lastChildInd - startInd + 1,
-                            rangeFirstInd - startInd,
-                        ),
-                    );
-                }
+function textFromGroups(
+    groups: CompositeGroup<any>[],
+    convert: (value: any, index: number, array: any[]) => string,
+): string {
+    return groups
+        .map((group) => {
+            if (group.kind === "child") {
+                return convert(group.value, 0, [group.value]);
             }
-
-            if (!range.hidden) {
-                // If a composite produced composites that produced children,
-                // then this outer composite is first in the array of replacement ranges.
-                // We first process the children corresponding to any of these replacement composites,
-                // which will concatenate the replacements of each composite into a single text,
-                // which may be be turned into a list according to the settings of that composite.
-
-                // We remove the replacement range of the current composite (any all earlier ones)
-                let subReplacementRange = compositeReplacementRange.slice(
-                    rangeInd + 1,
-                );
-
-                let {
-                    newChildren: childrenInRange,
-                    newPotentialListComponents: potentialListComponentsInRange,
-                } = textFromChildrenSub({
-                    compositeReplacementRange: subReplacementRange,
-                    children,
-                    startInd: rangeFirstInd,
-                    endInd: rangeLastInd,
-                    textFromComponentConverter,
-                    potentialListComponents: range.potentialListComponents,
-                });
-
-                let allAreListComponents = potentialListComponentsInRange.every(
-                    (x) => x,
-                );
-
-                if (
-                    range.asList &&
-                    allAreListComponents &&
-                    childrenInRange.length > 1
-                ) {
-                    // add commas between all children from a single composite
-                    // (after converting them into strings)
-                    // trimming any white space to the right of all but the last child
-                    // so that there is not a space before each comma
-
-                    newChildren.push(
-                        childrenInRange
-                            .map(textFromComponentConverter)
-                            .filter((v) => v !== "")
-                            .map((v, i, a) =>
-                                i === a.length - 1 ? v : v.trimEnd(),
-                            )
-                            .join(", "),
-                    );
-                } else {
-                    // We are not turning the children in a list,
-                    // so just convert the children into strings and concatenate
-                    newChildren.push(
-                        childrenInRange
-                            .map(textFromComponentConverter)
-                            .join(""),
-                    );
-                }
-
-                if (potentialListComponents) {
-                    // record whether the result from the composite (a single string now)
-                    // should be considered a list component for any outer composite
-                    newPotentialListComponents.push(allAreListComponents);
-                }
+            const parts = group.items.map((item) =>
+                textFromGroups([item], convert),
+            );
+            if (!group.asList) {
+                return parts.join("");
             }
-            lastChildInd = rangeLastInd;
-            // If we had an empty composite, then rangeLastInd = rangeFirstInd -1.
-            // In this case, we still don't want to add the composite back to `potentialListComponents`
-            // so we make sure `lastChildIndIncludingEmptyComposites` is after that composite
-            lastChildIndIncludingEmptyComposites = Math.max(
-                rangeFirstInd,
-                rangeLastInd,
-            );
-        }
-    }
-
-    if (lastChildInd < endInd) {
-        // don't process these children, so just add them back to newChildren
-        newChildren.push(...children.slice(lastChildInd + 1, endInd + 1));
-        if (potentialListComponents) {
-            // Since we didn't change the components,
-            // their status of being a potential list component is not changed
-            newPotentialListComponents.push(
-                ...potentialListComponents.slice(
-                    lastChildIndIncludingEmptyComposites - startInd + 1,
-                    endInd - startInd + 1,
-                ),
-            );
-        }
-    }
-
-    return { newChildren, newPotentialListComponents };
+            // A part that came out empty — a hidden child, say — is not an item
+            // of the list and gets no comma of its own. Trailing whitespace an
+            // item's own text ends with is left off in front of a comma; the
+            // last item keeps it, since it separates the list from what follows.
+            return parts
+                .filter((part) => part !== "")
+                .map((part, ind, all) =>
+                    ind === all.length - 1 ? part : part.trimEnd(),
+                )
+                .join(", ");
+        })
+        .join("");
 }
 
 export function returnTextPieceStateVariableDefinitions() {

--- a/packages/doenetml-worker-javascript/src/utils/text.ts
+++ b/packages/doenetml-worker-javascript/src/utils/text.ts
@@ -1,7 +1,7 @@
 import {
     groupCompositeRanges,
     isBlankGroup,
-    listCommaPositions,
+    joinListText,
     type CompositeGroup,
     type CompositeRange,
 } from "@doenet/utils";
@@ -63,18 +63,13 @@ function textFromGroup(
     }
     // A part that came out empty — a hidden child, say — is no more an item of
     // the list than whitespace is.
-    const commaBefore = listCommaPositions(
+    return joinListText(
+        parts,
         group.items.map(
             (item, ind) =>
                 parts[ind] === "" || isBlankGroup(item, isBlankString),
         ),
     );
-    // Whitespace an item's own text ends with is left off in front of the comma
-    // that follows it.
-    return parts
-        .map((part, ind) => (commaBefore[ind + 1] ? part.trimEnd() : part))
-        .map((part, ind) => (commaBefore[ind] ? ", " + part : part))
-        .join("");
 }
 
 export function returnTextPieceStateVariableDefinitions() {

--- a/packages/doenetml-worker/package.json
+++ b/packages/doenetml-worker/package.json
@@ -48,6 +48,7 @@
                 "dist/**/*.wasm*"
             ],
             "dependencies": [
+                "../utils:build",
                 "../doenetml-worker-javascript:build",
                 "../doenetml-worker-rust:build"
             ]

--- a/packages/doenetml-worker/src/compositeListWrapping.test.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.test.ts
@@ -320,6 +320,69 @@ describe("applyCompositeListWrapping", () => {
         expect(byId[11]).toBeUndefined();
     });
 
+    it("leaves a composite that produced only whitespace out of the list", () => {
+        // The grouping keeps such a composite in its place, for the doenetml
+        // renderers to anchor its name to; the prototype's <asList> would show
+        // it as an item, so it is left out here, however many blank strings it
+        // produced.
+        const contents: ChildContent[] = [ref(1), " ", " ", ref(2)];
+        const crar: CompositeReplacementRange[] = [
+            {
+                compositeIdx: 10,
+                firstInd: 0,
+                lastInd: 3,
+                asList: true,
+                potentialListComponents: [true, true, true, true],
+            },
+            {
+                compositeIdx: 11,
+                firstInd: 1,
+                lastInd: 2,
+                asList: false,
+                potentialListComponents: [true, true],
+            },
+        ];
+
+        const { children, wrapperElements } = applyCompositeListWrapping(
+            contents,
+            crar,
+        );
+
+        expect(children).toEqual([ref(10)]);
+        expect(wrapperElements).toHaveLength(1);
+        expect(wrapperElements[0].data.id).toBe(10);
+        expect(wrapperElements[0].children).toEqual([ref(1), ref(2)]);
+    });
+
+    it("puts the whitespace a list ends with outside the wrapper, from a composite too", () => {
+        const contents: ChildContent[] = [ref(1), ref(2), " ", " "];
+        const crar: CompositeReplacementRange[] = [
+            {
+                compositeIdx: 10,
+                firstInd: 0,
+                lastInd: 3,
+                asList: true,
+                potentialListComponents: [true, true, true, true],
+            },
+            {
+                compositeIdx: 11,
+                firstInd: 2,
+                lastInd: 3,
+                asList: false,
+                potentialListComponents: [true, true],
+            },
+        ];
+
+        const { children, wrapperElements } = applyCompositeListWrapping(
+            contents,
+            crar,
+        );
+
+        expect(children).toEqual([ref(10), " ", " "]);
+        expect(wrapperElements).toHaveLength(1);
+        expect(wrapperElements[0].children).toEqual([ref(1), ref(2)]);
+    });
+
     it("nests an inner asList composite inside an outer asList composite", () => {
         // Outer asList (idx 10) with two replacements: a plain ref and an inner
         // asList composite (idx 11) with two items.

--- a/packages/doenetml-worker/src/compositeListWrapping.test.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.test.ts
@@ -285,11 +285,10 @@ describe("applyCompositeListWrapping", () => {
         expect(byId[12].children).toEqual([ref(3), ref(4)]);
     });
 
-    it("leaves trailing blank strings inside nested composite wrappers, matching production", () => {
-        // Production stores a grouped nested composite as an array containing a
-        // React fragment. `removeEndingBlankString` does not recurse into that
-        // array before the enclosing asList comma, so the FlatDast bridge must
-        // not pre-trim nested synthetic wrappers either.
+    it("takes the trailing blank off an item a comma will follow", () => {
+        // Nothing should put a space in front of a comma, so the whitespace an
+        // item ends with is left off. Here that leaves the inner composite with
+        // a single child, which needs no wrapper of its own.
         const contents: ChildContent[] = [ref(1), " ", ref(2)];
         const crar: CompositeReplacementRange[] = [
             {
@@ -317,9 +316,8 @@ describe("applyCompositeListWrapping", () => {
         const byId = Object.fromEntries(
             wrapperElements.map((w) => [w.data.id, w]),
         );
-        expect(byId[10].children).toEqual([ref(11), ref(2)]);
-        expect(byId[11].name).toBe("_fragment");
-        expect(byId[11].children).toEqual([ref(1), " "]);
+        expect(byId[10].children).toEqual([ref(1), ref(2)]);
+        expect(byId[11]).toBeUndefined();
     });
 
     it("nests an inner asList composite inside an outer asList composite", () => {

--- a/packages/doenetml-worker/src/compositeListWrapping.test.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.test.ts
@@ -320,6 +320,29 @@ describe("applyCompositeListWrapping", () => {
         expect(byId[11]).toBeUndefined();
     });
 
+    it("takes the trailing whitespace off a string that ends an item", () => {
+        // The prototype's `<asList>` renderer puts the comma right after each
+        // child, so the string must not end with a space.
+        const contents: ChildContent[] = ["a ", ref(2)];
+        const crar: CompositeReplacementRange[] = [
+            {
+                compositeIdx: 10,
+                firstInd: 0,
+                lastInd: 1,
+                asList: true,
+                potentialListComponents: [true, true],
+            },
+        ];
+
+        const { children, wrapperElements } = applyCompositeListWrapping(
+            contents,
+            crar,
+        );
+
+        expect(children).toEqual([ref(10)]);
+        expect(wrapperElements[0].children).toEqual(["a", ref(2)]);
+    });
+
     it("leaves a composite that produced only whitespace out of the list", () => {
         // The grouping keeps such a composite in its place, for the doenetml
         // renderers to anchor its name to; the prototype's <asList> would show

--- a/packages/doenetml-worker/src/compositeListWrapping.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.ts
@@ -1,5 +1,6 @@
 import {
     groupCompositeRanges,
+    isBlankGroup,
     type CompositeGroup,
     type CompositeRange,
 } from "@doenet/utils";
@@ -15,48 +16,8 @@ export type { CompositeRange as CompositeReplacementRange };
  */
 export type ChildContent = FlatDastElementContent | null;
 
-function isBlankStringChild(child: FlatDastElementContent) {
+function isBlankChild(child: ChildContent) {
     return typeof child === "string" && child.trim() === "";
-}
-
-/**
- * The prototype's `<asList>` renderer treats each FlatDast child as a list item.
- * The whitespace at either end of a list, which the grouping keeps because it
- * separates the list from what surrounds it, is moved outside the wrapper; and
- * a blank string that reaches the middle (the grouping drops the blanks between
- * items, but a composite that produced only whitespace is spliced in as one) is
- * left out of it.
- */
-function trimAsListBlankChildren(children: FlatDastElementContent[]): {
-    leadingBlankChildren: FlatDastElementContent[];
-    listChildren: FlatDastElementContent[];
-    trailingBlankChildren: FlatDastElementContent[];
-} {
-    const firstNonBlankInd = children.findIndex((c) => !isBlankStringChild(c));
-
-    if (firstNonBlankInd === -1) {
-        return {
-            leadingBlankChildren: children,
-            listChildren: [],
-            trailingBlankChildren: [],
-        };
-    }
-
-    let lastNonBlankInd = children.length - 1;
-    while (
-        lastNonBlankInd > firstNonBlankInd &&
-        isBlankStringChild(children[lastNonBlankInd])
-    ) {
-        lastNonBlankInd--;
-    }
-
-    return {
-        leadingBlankChildren: children.slice(0, firstNonBlankInd),
-        listChildren: children
-            .slice(firstNonBlankInd, lastNonBlankInd + 1)
-            .filter((c) => !isBlankStringChild(c)),
-        trailingBlankChildren: children.slice(lastNonBlankInd + 1),
-    };
 }
 
 /**
@@ -83,8 +44,13 @@ function makeWrapperElement(
  * Turn the grouped children into FlatDast children, emitting the wrapper
  * elements that need to exist in `elements[]`.
  *
- * - A list group always becomes an `<asList>` wrapper (it has more than one
- *   non-blank item).
+ * - A list group becomes an `<asList>` wrapper holding its items; the grouping
+ *   has settled that there are at least two. The prototype's `<asList>`
+ *   renderer treats every child as an item, so what the grouping keeps in a
+ *   list without its being an item cannot go inside the wrapper: the
+ *   whitespace at either end of the list goes outside it — or nowhere, when an
+ *   enclosing list would take it for an item in turn — and a composite that
+ *   produced only whitespace is left out.
  * - A non-list group is materialized as a single unit only when it must be —
  *   i.e. it has more than one child *and* sits inside a list, where the list
  *   would otherwise treat each of its children as a separate item. It is then
@@ -108,42 +74,46 @@ function materializeGroups(
         }
 
         if (group.asList) {
-            const rawChildren = materializeGroups(
-                group.items,
-                true,
-                wrapperElements,
+            const blank = group.items.map((item) =>
+                isBlankGroup(item, isBlankChild),
             );
-            const {
-                leadingBlankChildren,
-                listChildren,
-                trailingBlankChildren,
-            } = trimAsListBlankChildren(rawChildren);
+            const firstItemInd = blank.indexOf(false);
+            const lastItemInd = blank.lastIndexOf(false);
+            const items = group.items
+                .slice(firstItemInd, lastItemInd + 1)
+                .filter((_, ind) => !blank[firstItemInd + ind]);
 
             if (!contextIsList) {
-                out.push(...leadingBlankChildren);
+                out.push(
+                    ...materializeGroups(
+                        group.items.slice(0, firstItemInd),
+                        false,
+                        wrapperElements,
+                    ),
+                );
             }
             wrapperElements.push(
                 makeWrapperElement(
                     group.range.compositeIdx,
                     "asList",
-                    listChildren,
+                    materializeGroups(items, true, wrapperElements),
                 ),
             );
             out.push({ id: group.range.compositeIdx, annotation: "original" });
             if (!contextIsList) {
-                out.push(...trailingBlankChildren);
+                out.push(
+                    ...materializeGroups(
+                        group.items.slice(lastItemInd + 1),
+                        false,
+                        wrapperElements,
+                    ),
+                );
             }
             continue;
         }
 
         const children = materializeGroups(group.items, false, wrapperElements);
-        if (children.length === 0) {
-            continue;
-        }
-        if (children.length === 1) {
-            // Already a single unit; no wrapper needed.
-            out.push(children[0]);
-        } else if (contextIsList) {
+        if (contextIsList && children.length > 1) {
             // Must be one unit so the enclosing list delimits it correctly.
             wrapperElements.push(
                 makeWrapperElement(
@@ -154,7 +124,8 @@ function materializeGroups(
             );
             out.push({ id: group.range.compositeIdx, annotation: "original" });
         } else {
-            // Not inside a list: splice inline, adding no structure.
+            // A single child is already one unit, and outside a list the
+            // children are spliced inline, adding no structure.
             out.push(...children);
         }
     }
@@ -167,9 +138,10 @@ function materializeGroups(
  * requires it, `<_fragment>`) parents that reproduce exactly the commas the
  * doenetml renderers add.
  *
- * The grouping itself — which children came from which composite, and which of
- * those composites are lists — is `groupCompositeRanges`, shared with the
- * renderers and with the `text` state variable, so the three cannot drift apart.
+ * The grouping itself — which children came from which composite, which of
+ * those composites are lists, and what whitespace belongs to a list — is
+ * `groupCompositeRanges`, shared with the renderers, the `text` state
+ * variable, and the string a `<math>` parses, so the four cannot drift apart.
  *
  * @param childContents The parent's children aligned with the child-instruction
  *   index space (use `null` for absent child instructions) so the range indices
@@ -187,7 +159,7 @@ export function applyCompositeListWrapping(
         children: childContents,
         ranges: compositeReplacementActiveRange,
         isAbsent: (child) => child === null,
-        isBlank: (child) => child !== null && isBlankStringChild(child),
+        isBlank: isBlankChild,
     });
 
     const wrapperElements: FlatDastElement[] = [];

--- a/packages/doenetml-worker/src/compositeListWrapping.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.ts
@@ -1,174 +1,19 @@
+import {
+    groupCompositeRanges,
+    type CompositeGroup,
+    type CompositeRange,
+} from "@doenet/utils";
 import type { FlatDastElement, FlatDastElementContent } from "./CoreWorker";
 
-/**
- * A single entry of a component's `_compositeReplacementActiveRange` state
- * value (built in the JS core's `CompositeExpander` and surfaced on the parent
- * component's renderer state by `RendererInstructionBuilder`).
- *
- * `firstInd`/`lastInd` are indices into the parent's children array in the
- * *child-instruction* index space (i.e. the same space as
- * `rendererState.childrenInstructions`, which includes `null` placeholders for
- * absent children). `potentialListComponents[i]` records whether the
- * replacement at `firstInd + i` is eligible to be an element of a list (an
- * inline component, or any component with `canBeInList`).
- */
-export type CompositeReplacementRange = {
-    compositeIdx: number;
-    compositeName?: string;
-    firstInd: number;
-    lastInd: number;
-    asList: boolean;
-    potentialListComponents?: boolean[];
-};
+export type { CompositeRange as CompositeReplacementRange };
 
 /**
  * A child slot, kept aligned with the child-instruction index space so the
- * `firstInd`/`lastInd` of a `CompositeReplacementRange` index directly into it.
- * `null` mirrors an absent child instruction (e.g. an unrendered branch); it is
- * preserved during processing — exactly as the renderer's
- * `addCommasForCompositeRanges` keeps `null` React children — and dropped only
- * when materializing the final FlatDast children.
+ * `firstInd`/`lastInd` of a composite range index directly into it. `null`
+ * mirrors an absent child instruction (e.g. an unrendered branch) and is
+ * dropped during grouping.
  */
 export type ChildContent = FlatDastElementContent | null;
-
-/**
- * Intermediate tree node produced by {@link processCompositeRanges}. A `content`
- * node is a passthrough string/ref (or `null`); a `group` node is a composite
- * range whose children have already been grouped. `isAsList` records whether the
- * renderer's `addCommasForCompositeRanges` would have inserted commas for this
- * range (`asList && allListComponents && groupedChildCount > 1`).
- */
-type Item =
-    | { kind: "content"; value: ChildContent }
-    | { kind: "group"; isAsList: boolean; compositeIdx: number; items: Item[] };
-
-/**
- * Faithful re-implementation of the grouping performed by
- * `addCommasForCompositeRanges` (in
- * `packages/doenetml/src/Viewer/renderers/utils/composites.tsx`), but producing
- * a tree of {@link Item} nodes instead of React nodes.
- *
- * Mirrors `addCommasForCompositeRangesSub`: it walks the ranges in order,
- * recursively groups nested composite ranges (a composite whose replacements are
- * themselves composites — the outer range comes first in the array), and for
- * each range computes `allListComponents` from the (post-grouping) list
- * eligibility of its items. The `removedInd` reconciliation the renderer needs
- * is intentionally omitted: the FlatDast always reflects the current children,
- * so there is no stale-React-child to skip.
- */
-function processCompositeRanges(
-    contents: ChildContent[],
-    ranges: CompositeReplacementRange[],
-    startInd: number,
-    endInd: number,
-    potentialListComponents: boolean[] | null,
-): { items: Item[]; eligible: boolean[] } {
-    const items: Item[] = [];
-    const eligible: boolean[] = [];
-    let lastChildInd = startInd - 1;
-    let lastChildIndIncludingEmptyComposites = lastChildInd;
-
-    for (let rangeInd = 0; rangeInd < ranges.length; rangeInd++) {
-        const range = ranges[rangeInd];
-        const rangeFirstInd = range.firstInd;
-        const rangeLastInd = range.lastInd;
-
-        if (rangeFirstInd > lastChildInd && rangeLastInd <= endInd) {
-            // Plain children sitting between the previous range and this one.
-            if (lastChildInd + 1 < rangeFirstInd) {
-                for (let i = lastChildInd + 1; i < rangeFirstInd; i++) {
-                    items.push({ kind: "content", value: contents[i] });
-                }
-                if (potentialListComponents) {
-                    for (let i = lastChildInd + 1; i < rangeFirstInd; i++) {
-                        eligible.push(potentialListComponents[i - startInd]);
-                    }
-                }
-            }
-
-            // The outer composite is first in the array, so its nested
-            // composites are exactly the ranges after it. Group them first.
-            const subRanges = ranges.slice(rangeInd + 1);
-            const { items: rawItems, eligible: rawEligible } =
-                processCompositeRanges(
-                    contents,
-                    subRanges,
-                    rangeFirstInd,
-                    rangeLastInd,
-                    range.potentialListComponents ?? null,
-                );
-
-            // Drop null children before deciding list-ness, mirroring
-            // `childrenInRange.filter((x) => x !== null)`.
-            const itemsInRange = rawItems.filter((it) => !isNullContent(it));
-            const eligibleInRange = rawEligible.filter(
-                (_, i) => !isNullContent(rawItems[i]),
-            );
-            const listItemsInRange = itemsInRange.filter(
-                (it) => !isBlankStringContent(it),
-            );
-            const eligibleListItemsInRange = eligibleInRange.filter(
-                (_, i) => !isBlankStringContent(itemsInRange[i]),
-            );
-
-            const allListComponents = eligibleListItemsInRange.every((x) => x);
-            const isAsList =
-                Boolean(range.asList) &&
-                allListComponents &&
-                listItemsInRange.length > 1;
-
-            if (itemsInRange.length > 0) {
-                items.push({
-                    kind: "group",
-                    isAsList,
-                    compositeIdx: range.compositeIdx,
-                    items: itemsInRange,
-                });
-                if (potentialListComponents) {
-                    eligible.push(allListComponents);
-                }
-            }
-
-            lastChildInd = rangeLastInd;
-            // For an empty composite, `rangeLastInd === rangeFirstInd - 1`; keep
-            // the eligibility cursor past the composite so we don't re-add it.
-            lastChildIndIncludingEmptyComposites = Math.max(
-                rangeFirstInd,
-                rangeLastInd,
-            );
-        }
-    }
-
-    // Trailing plain children after the last range.
-    if (lastChildInd < endInd) {
-        for (let i = lastChildInd + 1; i <= endInd; i++) {
-            items.push({ kind: "content", value: contents[i] });
-        }
-        if (potentialListComponents) {
-            for (
-                let i = lastChildIndIncludingEmptyComposites + 1;
-                i <= endInd;
-                i++
-            ) {
-                eligible.push(potentialListComponents[i - startInd]);
-            }
-        }
-    }
-
-    return { items, eligible };
-}
-
-function isNullContent(item: Item | undefined) {
-    return item?.kind === "content" && item.value === null;
-}
-
-function isBlankStringContent(item: Item | undefined) {
-    return (
-        item?.kind === "content" &&
-        typeof item.value === "string" &&
-        item.value.trim() === ""
-    );
-}
 
 function isBlankStringChild(child: FlatDastElementContent) {
     return typeof child === "string" && child.trim() === "";
@@ -234,36 +79,36 @@ function makeWrapperElement(
 }
 
 /**
- * Convert the {@link Item} tree into FlatDast children, emitting the wrapper
+ * Turn the grouped children into FlatDast children, emitting the wrapper
  * elements that need to exist in `elements[]`.
  *
- * - An `asList` group always becomes an `<asList>` wrapper (it has more than
- *   one non-blank list item).
+ * - A list group always becomes an `<asList>` wrapper (it has more than one
+ *   non-blank item).
  * - A non-list group is materialized as a single unit only when it must be —
- *   i.e. it has more than one child *and* sits inside an enclosing list, where
- *   the list would otherwise treat each of its children as a separate item. It
- *   is then wrapped in a passthrough `<_fragment>`. Everywhere else (top level,
- *   or a single child) its children are spliced inline, so non-list composites
- *   add no structure and the comma output matches the renderer exactly.
+ *   i.e. it has more than one child *and* sits inside a list, where the list
+ *   would otherwise treat each of its children as a separate item. It is then
+ *   wrapped in a passthrough `<_fragment>`. Everywhere else (top level, or a
+ *   single child) its children are spliced inline, so non-list composites add
+ *   no structure and the comma output matches the renderers exactly.
  */
-function materializeItems(
-    items: Item[],
+function materializeGroups(
+    groups: CompositeGroup<ChildContent>[],
     contextIsList: boolean,
     wrapperElements: FlatDastElement[],
 ): FlatDastElementContent[] {
     const out: FlatDastElementContent[] = [];
 
-    for (const item of items) {
-        if (item.kind === "content") {
-            if (item.value !== null) {
-                out.push(item.value);
+    for (const group of groups) {
+        if (group.kind === "child") {
+            if (group.value !== null) {
+                out.push(group.value);
             }
             continue;
         }
 
-        if (item.isAsList) {
-            const rawChildren = materializeItems(
-                item.items,
+        if (group.asList) {
+            const rawChildren = materializeGroups(
+                group.items,
                 true,
                 wrapperElements,
             );
@@ -277,17 +122,20 @@ function materializeItems(
                 out.push(...leadingBlankChildren);
             }
             wrapperElements.push(
-                makeWrapperElement(item.compositeIdx, "asList", listChildren),
+                makeWrapperElement(
+                    group.range.compositeIdx,
+                    "asList",
+                    listChildren,
+                ),
             );
-            out.push({ id: item.compositeIdx, annotation: "original" });
+            out.push({ id: group.range.compositeIdx, annotation: "original" });
             if (!contextIsList) {
                 out.push(...trailingBlankChildren);
             }
             continue;
         }
 
-        // Non-list group.
-        const children = materializeItems(item.items, false, wrapperElements);
+        const children = materializeGroups(group.items, false, wrapperElements);
         if (children.length === 0) {
             continue;
         }
@@ -297,9 +145,13 @@ function materializeItems(
         } else if (contextIsList) {
             // Must be one unit so the enclosing list delimits it correctly.
             wrapperElements.push(
-                makeWrapperElement(item.compositeIdx, "_fragment", children),
+                makeWrapperElement(
+                    group.range.compositeIdx,
+                    "_fragment",
+                    children,
+                ),
             );
-            out.push({ id: item.compositeIdx, annotation: "original" });
+            out.push({ id: group.range.compositeIdx, annotation: "original" });
         } else {
             // Not inside a list: splice inline, adding no structure.
             out.push(...children);
@@ -312,7 +164,11 @@ function materializeItems(
 /**
  * Wrap a parent element's children in synthetic `<asList>` (and, where nesting
  * requires it, `<_fragment>`) parents that reproduce exactly the commas the
- * doenetml renderers add via `addCommasForCompositeRanges`.
+ * doenetml renderers add.
+ *
+ * The grouping itself — which children came from which composite, and which of
+ * those composites are lists — is `groupCompositeRanges`, shared with the
+ * renderers and with the `text` state variable, so the three cannot drift apart.
  *
  * @param childContents The parent's children aligned with the child-instruction
  *   index space (use `null` for absent child instructions) so the range indices
@@ -320,35 +176,21 @@ function materializeItems(
  * @param compositeReplacementActiveRange The parent's
  *   `_compositeReplacementActiveRange` state value (may be `undefined`/empty).
  * @returns The rewritten children plus any wrapper elements that must be added
- *   to the FlatDast `elements` array. When there are no ranges, `children` is
- *   simply `childContents` with `null`s dropped and `wrapperElements` is empty.
+ *   to the FlatDast `elements` array.
  */
 export function applyCompositeListWrapping(
     childContents: ChildContent[],
-    compositeReplacementActiveRange: CompositeReplacementRange[] | undefined,
+    compositeReplacementActiveRange: CompositeRange[] | undefined,
 ): { children: FlatDastElementContent[]; wrapperElements: FlatDastElement[] } {
-    if (
-        !compositeReplacementActiveRange ||
-        compositeReplacementActiveRange.length === 0
-    ) {
-        return {
-            children: childContents.filter(
-                (c): c is FlatDastElementContent => c !== null,
-            ),
-            wrapperElements: [],
-        };
-    }
-
-    const { items } = processCompositeRanges(
-        childContents,
-        compositeReplacementActiveRange,
-        0,
-        childContents.length - 1,
-        null,
-    );
+    const groups = groupCompositeRanges<ChildContent>({
+        children: childContents,
+        ranges: compositeReplacementActiveRange,
+        isAbsent: (child) => child === null,
+        isBlank: (child) => child !== null && isBlankStringChild(child),
+    });
 
     const wrapperElements: FlatDastElement[] = [];
-    const children = materializeItems(items, false, wrapperElements);
+    const children = materializeGroups(groups, false, wrapperElements);
 
     return { children, wrapperElements };
 }

--- a/packages/doenetml-worker/src/compositeListWrapping.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.ts
@@ -141,7 +141,8 @@ function materializeGroups(
  * The grouping itself — which children came from which composite, which of
  * those composites are lists, and what whitespace belongs to a list — is
  * `groupCompositeRanges`, shared with the renderers, the `text` state
- * variable, and the string a `<math>` parses, so the four cannot drift apart.
+ * variable, and the string a `<math>` parses, so all four decide the commas the
+ * same way.
  *
  * @param childContents The parent's children aligned with the child-instruction
  *   index space (use `null` for absent child instructions) so the range indices

--- a/packages/doenetml-worker/src/compositeListWrapping.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.ts
@@ -161,6 +161,10 @@ export function applyCompositeListWrapping(
         ranges: compositeReplacementActiveRange,
         isAbsent: (child) => child === null,
         isBlank: isBlankChild,
+        // A string that ends an item loses its trailing whitespace, as in the
+        // React renderers, so the prototype's comma sits right against it.
+        trimEnd: (child) =>
+            typeof child === "string" ? child.trimEnd() : child,
     });
 
     const wrapperElements: FlatDastElement[] = [];

--- a/packages/doenetml-worker/src/compositeListWrapping.ts
+++ b/packages/doenetml-worker/src/compositeListWrapping.ts
@@ -21,10 +21,11 @@ function isBlankStringChild(child: FlatDastElementContent) {
 
 /**
  * The prototype's `<asList>` renderer treats each FlatDast child as a list item.
- * Whitespace-only strings in the JS child-instruction stream are separators
- * around authored inline replacements, not their own list items, so keep leading
- * and trailing blanks outside the wrapper when possible and remove inter-item
- * blanks from the wrapper's child list.
+ * The whitespace at either end of a list, which the grouping keeps because it
+ * separates the list from what surrounds it, is moved outside the wrapper; and
+ * a blank string that reaches the middle (the grouping drops the blanks between
+ * items, but a composite that produced only whitespace is spliced in as one) is
+ * left out of it.
  */
 function trimAsListBlankChildren(children: FlatDastElementContent[]): {
     leadingBlankChildren: FlatDastElementContent[];

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
@@ -315,4 +315,29 @@ describe("addCommasForCompositeRanges", () => {
         ]);
         expect(shown(result)).eq("1, 2 and 3, 4");
     });
+
+    it("keeps the anchor of a composite that produced only whitespace", () => {
+        // The composite's span stays where it was, so a link to its name still
+        // scrolls there, but the whitespace it produced goes: the comma takes
+        // its place.
+        const children = [child("1", 0), " ", child("2", 2)];
+        const result = addCommas(children, [
+            range({
+                compositeName: "outer",
+                firstInd: 0,
+                lastInd: 2,
+                potentialListComponents: [true, true, true],
+            }),
+            range({
+                compositeName: "g",
+                firstInd: 1,
+                lastInd: 1,
+                asList: false,
+                potentialListComponents: [true],
+            }),
+        ]);
+        expect(renderToStaticMarkup(<>{result}</>)).eq(
+            '<span id="outer"><span>1</span>, <span id="g"></span><span>2</span></span>',
+        );
+    });
 });

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
@@ -11,10 +11,12 @@ import { addCommasForCompositeRanges } from "./composites";
  * `_compositeReplacementActiveRange`, and it inserts `", "` between the
  * replacements of a composite that asked to be shown as a list.
  *
- * The core builds that range array in `CompositeExpander.replaceCompositeChildren`;
- * `textFromChildren` (`doenetml-worker-javascript/src/utils/text.ts`) and
- * `applyCompositeListWrapping` (`doenetml-worker/src/compositeListWrapping.ts`)
- * consume the same array and must agree with what is checked here.
+ * The core builds that range array in `CompositeExpander.replaceCompositeChildren`.
+ * `textFromChildren` (`doenetml-worker-javascript/src/utils/text.ts`),
+ * `createInputStringFromChildren` (`doenetml-worker-javascript/src/utils/parseMath.ts`),
+ * and `applyCompositeListWrapping` (`doenetml-worker/src/compositeListWrapping.ts`)
+ * read the same array through the same grouping, `groupCompositeRanges` in
+ * `@doenet/utils`, and must agree with what is checked here.
  *
  * Ranges are half-nested rather than a tree: a composite whose replacements are
  * themselves composites comes *first* in the array, and the ranges that follow
@@ -26,11 +28,9 @@ type Range = Parameters<
 >[0]["compositeReplacementActiveRange"][number];
 
 /**
- * A stand-in for a rendered component child. What matters to the code under
- * test is that it is an element whose `props.children` is not an array — the
- * one shape `removeEndingBlankString` declines to look inside — which is what a
- * real `<DoenetRenderer>` child (its props carry `componentInstructions`, never
- * `children`) also is.
+ * A stand-in for a rendered component child. The code under test never looks
+ * inside a child element — it trims and drops only string children — so an
+ * element holding the child's text is as faithful as a real `<DoenetRenderer>`.
  */
 function child(text: string, key: number) {
     return <span key={key}>{text}</span>;
@@ -196,11 +196,9 @@ describe("addCommasForCompositeRanges", () => {
     });
 
     it("keeps the blank strings around replacements out of the list", () => {
-        // Authored whitespace surrounding a composite's replacements is a
-        // separator, not an item: no comma is placed next to one, and the comma
-        // goes in front of the whitespace rather than after it, so nothing puts
-        // a space before a comma. The doubled space that leaves between items
-        // collapses to one in the browser.
+        // Authored whitespace around a composite's replacements is a separator,
+        // not an item: the whitespace between two items is where the comma
+        // goes, and the whitespace before the first and after the last stays.
         const children = ["\n  ", child("1", 1), " ", child("2", 3), "\n  "];
         const result = addCommas(children, [
             range({

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
@@ -6,10 +6,10 @@ import { addCommasForCompositeRanges } from "./composites";
 /**
  * `addCommasForCompositeRanges` is the renderer half of automatic list commas:
  * every container renderer (`p`, `section`, `cell`, `hint`, `alert`, `list`,
- * `pre`, `solution`, `feedback`, `containerInline`, `markupRenderer`) hands it
- * the children it is about to render together with the core's
- * `_compositeReplacementActiveRange`, and it inserts `", "` between the
- * replacements of a composite that asked to be shown as a list.
+ * `pre`, `solution`, `feedback`, `containerInline`, `containerBlock`,
+ * `markupRenderer`) hands it the children it is about to render together with
+ * the core's `_compositeReplacementActiveRange`, and it inserts `", "` between
+ * the replacements of a composite that asked to be shown as a list.
  *
  * The core builds that range array in `CompositeExpander.replaceCompositeChildren`.
  * `textFromChildren` (`doenetml-worker-javascript/src/utils/text.ts`),

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.test.tsx
@@ -209,7 +209,7 @@ describe("addCommasForCompositeRanges", () => {
                 potentialListComponents: [true, true, true, true, true],
             }),
         ]);
-        expect(shown(result)).eq("\n  1,  2\n  ");
+        expect(shown(result)).eq("\n  1, 2\n  ");
     });
 
     it("skips a composite that produced no replacements", () => {

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
@@ -7,11 +7,16 @@ import {
     type CompositeRange,
 } from "@doenet/utils";
 
-// If consecutive children are from a composite with asList set,
-// then display those children separated by commas.
-// compositeReplacementActiveRange is an array for each composite that
-// contributed to the active children of the component.
-
+/**
+ * Put `", "` between the replacements of a composite that asks to be shown as
+ * a list, and wrap every composite's replacements in a span carrying its name.
+ *
+ * `compositeReplacementActiveRange` is the core's record of which of
+ * `children` each composite produced. Which of those composites are lists, and
+ * where the commas go among a list's items, is decided by the grouping in
+ * `@doenet/utils`, shared with the `text` state variable so that what a reader
+ * sees and what `text` says cannot drift apart.
+ */
 export function addCommasForCompositeRanges({
     compositeReplacementActiveRange,
     children,
@@ -41,39 +46,30 @@ export function addCommasForCompositeRanges({
         removedInd,
     });
 
-    return renderGroups(groups);
+    return groups.map(renderGroup);
 }
 
 function isBlankStringChild(child: React.ReactNode) {
     return typeof child === "string" && child.trim() === "";
 }
 
-function renderGroups(
-    groups: CompositeGroup<React.ReactNode>[],
-): React.ReactNode[] {
-    const rendered: React.ReactNode[] = [];
-
-    for (const group of groups) {
-        if (group.kind === "child") {
-            rendered.push(group.value);
-            continue;
-        }
-
-        const items = group.asList
-            ? separateWithCommas(group.items)
-            : renderGroups(group.items);
-
-        // Whether or not we added commas, we still add a span with the id of
-        // the composite so that links to the composite name will scroll to the
-        // right location.
-        rendered.push(
-            <React.Fragment key={group.range.compositeName}>
-                <span id={group.range.compositeName}>{items}</span>
-            </React.Fragment>,
-        );
+/**
+ * A child as it was given, or a composite's items inside a span with the id of
+ * the composite, so that a link to the composite's name scrolls to its place —
+ * whether or not the composite became a list.
+ */
+function renderGroup(group: CompositeGroup<React.ReactNode>): React.ReactNode {
+    if (group.kind === "child") {
+        return group.value;
     }
-
-    return rendered;
+    const items = group.asList
+        ? separateWithCommas(group.items)
+        : group.items.map(renderGroup);
+    return (
+        <span key={group.range.compositeName} id={group.range.compositeName}>
+            {items}
+        </span>
+    );
 }
 
 /**
@@ -87,8 +83,7 @@ function separateWithCommas(
     const commaBefore = listCommaPositions(
         items.map((item) => isBlankGroup(item, isBlankStringChild)),
     );
-    return items.flatMap((item, ind) => [
-        ...(commaBefore[ind] ? [", "] : []),
-        ...renderGroups([item]),
-    ]);
+    return items.flatMap((item, ind) =>
+        commaBefore[ind] ? [", ", renderGroup(item)] : [renderGroup(item)],
+    );
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
@@ -14,8 +14,8 @@ import {
  * `compositeReplacementActiveRange` is the core's record of which of
  * `children` each composite produced. Which of those composites are lists, and
  * where the commas go among a list's items, is decided by the grouping in
- * `@doenet/utils`, shared with the `text` state variable so that what a reader
- * sees and what `text` says cannot drift apart.
+ * `@doenet/utils`, shared with the `text` state variable, so both decide the
+ * commas the same way.
  */
 export function addCommasForCompositeRanges({
     compositeReplacementActiveRange,

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import {
     groupCompositeRanges,
+    isBlankGroup,
+    listCommaPositions,
     type CompositeGroup,
     type CompositeRange,
 } from "@doenet/utils";
@@ -46,13 +48,6 @@ function isBlankStringChild(child: React.ReactNode) {
     return typeof child === "string" && child.trim() === "";
 }
 
-function isBlankGroup(group: CompositeGroup<React.ReactNode>): boolean {
-    if (group.kind === "child") {
-        return isBlankStringChild(group.value);
-    }
-    return group.items.every(isBlankGroup);
-}
-
 function renderGroups(
     groups: CompositeGroup<React.ReactNode>[],
 ): React.ReactNode[] {
@@ -83,28 +78,17 @@ function renderGroups(
 
 /**
  * Put `", "` between the items of a composite shown as a list. The whitespace
- * an author wrote around the replacements is not an item: no comma is placed
- * next to it, and the comma goes in front of it rather than after, so nothing
- * puts a space before a comma.
+ * an author wrote around the replacements is not an item, and no comma is
+ * placed next to it.
  */
 function separateWithCommas(
     items: CompositeGroup<React.ReactNode>[],
 ): React.ReactNode[] {
-    const blank = items.map(isBlankGroup);
-    const separated: React.ReactNode[] = [];
-
-    for (const [ind, item] of items.entries()) {
-        if (
-            ind > 0 &&
-            !blank[ind - 1] &&
-            blank.slice(ind).some((isBlank) => !isBlank)
-        ) {
-            // The item before this one is not whitespace and some item still to
-            // come is not either, so the two are separated by a comma.
-            separated.push(", ");
-        }
-        separated.push(...renderGroups([item]));
-    }
-
-    return separated;
+    const commaBefore = listCommaPositions(
+        items.map((item) => isBlankGroup(item, isBlankStringChild)),
+    );
+    return items.flatMap((item, ind) => [
+        ...(commaBefore[ind] ? [", "] : []),
+        ...renderGroups([item]),
+    ]);
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.tsx
@@ -1,8 +1,13 @@
 import React from "react";
+import {
+    groupCompositeRanges,
+    type CompositeGroup,
+    type CompositeRange,
+} from "@doenet/utils";
 
 // If consecutive children are from a composite with asList set,
 // then display those children separated by commas.
-// compositeReplacementActiveChange is an array for each composite that
+// compositeReplacementActiveRange is an array for each composite that
 // contributed to the active children of the component.
 
 export function addCommasForCompositeRanges({
@@ -12,266 +17,94 @@ export function addCommasForCompositeRanges({
     endInd,
     removedInd = null,
 }: {
-    compositeReplacementActiveRange: Array<{
-        firstInd: number;
-        lastInd: number;
-        compositeName: string;
-        asList: boolean;
-        potentialListComponents?: Array<boolean>;
-    }>;
+    compositeReplacementActiveRange: CompositeRange[];
     children: React.ReactNode[];
     startInd: number;
     endInd: number;
     removedInd?: number | null;
 }) {
-    let result = addCommasForCompositeRangesSub({
-        compositeReplacementActiveRange,
+    const groups = groupCompositeRanges<React.ReactNode>({
         children,
+        ranges: compositeReplacementActiveRange,
+        isAbsent: (child) => child === null,
+        isBlank: isBlankStringChild,
+        // A string child that ends an item loses its trailing whitespace, so
+        // the comma that follows sits right against the item. A rendered
+        // component child keeps its own: the renderers only hand React the
+        // child and never see what it draws.
+        trimEnd: (child) =>
+            typeof child === "string" ? child.trimEnd() : child,
         startInd,
         endInd,
         removedInd,
     });
 
-    return result.newChildren;
+    return renderGroups(groups);
 }
 
-function addCommasForCompositeRangesSub({
-    compositeReplacementActiveRange,
-    children,
-    startInd,
-    endInd,
-    removedInd = null,
-    potentialListComponents = null,
-}: {
-    compositeReplacementActiveRange: {
-        firstInd: number;
-        lastInd: number;
-        compositeName: string;
-        asList: boolean;
-        potentialListComponents?: Array<boolean>;
-    }[];
-    children: React.ReactNode[];
-    startInd: number;
-    endInd: number;
-    removedInd?: number | null;
-    potentialListComponents?: Array<boolean> | null;
-}): {
-    newChildren: React.ReactNode[];
-    newPotentialListComponents: React.ReactNode[];
-} {
-    let newChildren = [];
-    let newPotentialListComponents = [];
-    let lastChildInd = startInd - 1;
-    let lastChildIndIncludingEmptyComposites = lastChildInd;
-
-    for (
-        let rangeInd = 0;
-        rangeInd < compositeReplacementActiveRange.length;
-        rangeInd++
-    ) {
-        let range = compositeReplacementActiveRange[rangeInd];
-
-        let rangeFirstInd = range.firstInd;
-        let rangeLastInd = range.lastInd;
-
-        if (removedInd !== null) {
-            if (rangeFirstInd === removedInd || rangeLastInd === removedInd) {
-                continue;
-            }
-            if (rangeFirstInd > removedInd) {
-                rangeFirstInd -= 1;
-            }
-            if (rangeLastInd > removedInd) {
-                rangeLastInd -= 1;
-            }
-        }
-
-        if (rangeFirstInd > lastChildInd && rangeLastInd <= endInd) {
-            if (lastChildInd + 1 < rangeFirstInd) {
-                newChildren.push(
-                    ...children.slice(lastChildInd + 1, rangeFirstInd),
-                );
-                if (potentialListComponents) {
-                    newPotentialListComponents.push(
-                        ...potentialListComponents.slice(
-                            lastChildInd - startInd + 1,
-                            rangeFirstInd - startInd,
-                        ),
-                    );
-                }
-            }
-
-            // If a composite produced composites that produced children,
-            // then this outer composite is first in the array of replacement ranges.
-            // We first process the children corresponding to any of these replacement composites,
-            // which will wrap the replacements of each composite into a single child,
-            // which may be separated according to the settings of that composite.
-
-            // We remove the replacement range of the current composite (any all earlier ones)
-            let subReplacementRange = compositeReplacementActiveRange.slice(
-                rangeInd + 1,
-            );
-
-            let {
-                newChildren: childrenInRange,
-                newPotentialListComponents: potentialListComponentsInRange,
-            } = addCommasForCompositeRangesSub({
-                compositeReplacementActiveRange: subReplacementRange,
-                children,
-                startInd: rangeFirstInd,
-                endInd: rangeLastInd,
-                removedInd,
-                potentialListComponents: range.potentialListComponents,
-            });
-
-            potentialListComponentsInRange =
-                potentialListComponentsInRange.filter(
-                    (x, i) => childrenInRange[i] !== null,
-                );
-            childrenInRange = childrenInRange.filter((x) => x !== null);
-
-            let allListComponents = potentialListComponentsInRange.every(
-                (x) => x,
-            );
-
-            let isBlankStringChild = childrenInRange.map(
-                (child) => typeof child === "string" && child.trim() === "",
-            );
-
-            if (
-                range.asList &&
-                allListComponents &&
-                childrenInRange.length > 1
-            ) {
-                // add commas between all children from a single composite
-                let newChildrenInRange = [childrenInRange[0]];
-
-                for (let [prevInd, child] of childrenInRange
-                    .slice(1)
-                    .entries()) {
-                    if (
-                        !isBlankStringChild[prevInd] &&
-                        isBlankStringChild.slice(prevInd + 1).some((x) => !x)
-                    ) {
-                        // The previous child is not a blank string
-                        // and we have some future child that is not a blank string,
-                        // so we want to add a comma between them, with no space showing before the comma.
-                        // The previous child could have ended with a child that was a blank string.
-                        // To eliminate the space before the comma from that blank string,
-                        // remove any ending blank string children from that child
-                        newChildrenInRange[newChildrenInRange.length - 1] =
-                            removeEndingBlankString(
-                                newChildrenInRange[
-                                    newChildrenInRange.length - 1
-                                ],
-                            );
-                        newChildrenInRange.push(", ");
-                    }
-                    newChildrenInRange.push(child);
-                }
-                childrenInRange = newChildrenInRange;
-            }
-
-            if (childrenInRange.length > 0) {
-                // Whether or not we added commas, we still add a span and a anchor with the id of the composite
-                // so that links to the composite name will scroll to the right location.
-                childrenInRange = [
-                    <React.Fragment key={range.compositeName}>
-                        <span id={range.compositeName}>{childrenInRange}</span>
-                    </React.Fragment>,
-                ];
-                newChildren.push(childrenInRange);
-                if (potentialListComponents) {
-                    newPotentialListComponents.push(allListComponents);
-                }
-            }
-            lastChildInd = rangeLastInd;
-            // If we had an empty composite, then rangeLastInd = rangeFirstInd -1.
-            // In this case, we still don't want to add the composite back to `potentialListComponents`
-            // so we make sure `lastChildIndIncludingEmptyComposites` is after that composite
-            lastChildIndIncludingEmptyComposites = Math.max(
-                rangeFirstInd,
-                rangeLastInd,
-            );
-        }
-    }
-
-    if (lastChildInd < endInd) {
-        newChildren.push(...children.slice(lastChildInd + 1, endInd + 1));
-        if (potentialListComponents) {
-            newPotentialListComponents.push(
-                ...potentialListComponents.slice(
-                    lastChildIndIncludingEmptyComposites - startInd + 1,
-                    endInd - startInd + 1,
-                ),
-            );
-        }
-    }
-
-    return { newChildren, newPotentialListComponents };
+function isBlankStringChild(child: React.ReactNode) {
+    return typeof child === "string" && child.trim() === "";
 }
 
-function removeEndingBlankString(component: React.ReactNode) {
-    if (
-        !component ||
-        typeof component === "boolean" ||
-        typeof component === "number"
-    ) {
-        return component;
+function isBlankGroup(group: CompositeGroup<React.ReactNode>): boolean {
+    if (group.kind === "child") {
+        return isBlankStringChild(group.value);
     }
-    if (typeof component === "string") {
-        return component.trimEnd();
-    }
-    if (!(
-        typeof component === "object" &&
-        "props" in component &&
-        typeof component.props === "object" &&
-        component.props !== null &&
-        "children" in component.props &&
-        Array.isArray(component.props.children)
-    )) {
-        return component;
-    }
-    if (!(component.props.children?.length > 0)) {
-        return component;
-    }
+    return group.items.every(isBlankGroup);
+}
 
-    let children = [...component.props.children];
-    let originalLastChild = children[children.length - 1];
-    let lastChild = originalLastChild;
-    while (typeof lastChild === "string" && lastChild.trim() === "") {
-        // the last child was a blank string so remove it,
-        // looping to previous child if it exists
-        children.pop();
-        if (children.length === 0) {
-            // we need to recreate component since React makes it read only
-            component = { ...component };
-            component.props = { ...(component.props as any) } as Record<
-                string,
-                any
-            >;
-            (component.props as Record<string, any>).children = [];
-            return component;
+function renderGroups(
+    groups: CompositeGroup<React.ReactNode>[],
+): React.ReactNode[] {
+    const rendered: React.ReactNode[] = [];
+
+    for (const group of groups) {
+        if (group.kind === "child") {
+            rendered.push(group.value);
+            continue;
         }
-        lastChild = children[children.length - 1];
+
+        const items = group.asList
+            ? separateWithCommas(group.items)
+            : renderGroups(group.items);
+
+        // Whether or not we added commas, we still add a span with the id of
+        // the composite so that links to the composite name will scroll to the
+        // right location.
+        rendered.push(
+            <React.Fragment key={group.range.compositeName}>
+                <span id={group.range.compositeName}>{items}</span>
+            </React.Fragment>,
+        );
     }
 
-    // recurse to remove any blank string children from lastChild
-    // (or blank end of the string lastChild)
-    lastChild = removeEndingBlankString(lastChild);
+    return rendered;
+}
 
-    if (lastChild !== originalLastChild) {
-        // we need to recreate component since React makes it read only
-        component = { ...component };
-        component.props = { ...(component.props as any) } as Record<
-            string,
-            any
-        >;
-        (component.props as Record<string, any>).children = [
-            ...children.slice(0, children.length - 1),
-            lastChild,
-        ];
+/**
+ * Put `", "` between the items of a composite shown as a list. The whitespace
+ * an author wrote around the replacements is not an item: no comma is placed
+ * next to it, and the comma goes in front of it rather than after, so nothing
+ * puts a space before a comma.
+ */
+function separateWithCommas(
+    items: CompositeGroup<React.ReactNode>[],
+): React.ReactNode[] {
+    const blank = items.map(isBlankGroup);
+    const separated: React.ReactNode[] = [];
+
+    for (const [ind, item] of items.entries()) {
+        if (
+            ind > 0 &&
+            !blank[ind - 1] &&
+            blank.slice(ind).some((isBlank) => !isBlank)
+        ) {
+            // The item before this one is not whitespace and some item still to
+            // come is not either, so the two are separated by a comma.
+            separated.push(", ");
+        }
+        separated.push(...renderGroups([item]));
     }
 
-    return component;
+    return separated;
 }

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -526,12 +526,11 @@ $fi.iterates
         cy.get("#hiddenItem").should("have.text", "2, 3");
     });
 
-    it("keeps the commas through a reference to a list or a repeat", () => {
-        // A reference to a composite must show the same commas the composite
-        // itself shows. `$r[1]` and `$g` do not today: a reference that lands
-        // on a composite copies its final replacements, flattening away the
-        // inner composite whose `asList` made the list — see the `it.fails`
-        // cases in `compositeCommas.test.tsx`.
+    it("keeps the commas through a reference to a list, a group, or a repeat", () => {
+        // A reference to a composite shows the same commas the composite
+        // itself shows: a reference that lands on a composite copies its
+        // replacements, keeping whole any composite among them that can be a
+        // list of its own.
         cy.window().then(async (win) => {
             win.postMessage(
                 {
@@ -543,7 +542,9 @@ $fi.iterates
 </setup>
 <p name="toList">$nl</p>
 <p name="extendList"><numberList extend="$nl" /></p>
+<p name="toGroup">$g</p>
 <p name="toRepeat">$r</p>
+<p name="toRepeatItem">$r[1]</p>
   `,
                 },
                 "*",
@@ -552,7 +553,9 @@ $fi.iterates
 
         cy.get("#toList").should("have.text", "1, 2, 3, 4");
         cy.get("#extendList").should("have.text", "1, 2, 3, 4");
+        cy.get("#toGroup").should("have.text", "1, 2, 3, 4");
         cy.get("#toRepeat").should("have.text", "1, 2, 3, 4, 1, 2, 3, 4");
+        cy.get("#toRepeatItem").should("have.text", "1, 2, 3, 4");
     });
 
     it("puts the comma where the whitespace between two items was", () => {

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -554,4 +554,29 @@ $fi.iterates
         cy.get("#extendList").should("have.text", "1, 2, 3, 4");
         cy.get("#toRepeat").should("have.text", "1, 2, 3, 4, 1, 2, 3, 4");
     });
+
+    it("puts the comma where the whitespace between two items was", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<setup><sequence name="s" length="0" /><sequence name="s2" length="0" /></setup>
+<p name="spaced"><group asList><number>1</number> <number>2</number> <number>3</number></group></p>
+<p name="withEmpty"><group asList><number>1</number> <number>2</number> $s $s2 <number>3</number></group></p>
+<repeatForSequence from="1" to="2" name="a" valueName="x">
+  <repeatForSequence from="5" to="7" step="2" name="b" valueName="y">
+    <number>$x+$y</number>
+  </repeatForSequence>
+</repeatForSequence>
+<p name="nestedRepeatItem">$a[1]</p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#spaced").should("have.text", "1, 2, 3");
+        cy.get("#withEmpty").should("have.text", "1, 2, 3");
+        cy.get("#nestedRepeatItem").should("have.text", "6, 8");
+    });
 });

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -139,6 +139,34 @@ describe("groupCompositeRanges", () => {
         ).eq(`list10(group11("1" "2") "3")`);
     });
 
+    it("nests two composites with the same span in the order they were recorded", () => {
+        // A composite whose only replacement is a composite has the same span
+        // as that replacement. The core records the outer one first, and the
+        // ordering keeps them that way, so the inner one decides the list.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 0,
+                            lastInd: 1,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`group10(list11("1" "2"))`);
+    });
+
     it("finds a composite's replacements wherever their ranges were recorded", () => {
         // The core records a range when a composite expands, so the ranges of
         // one composite's replacements can come after its sibling's.
@@ -416,6 +444,34 @@ describe("groupCompositeRanges", () => {
                             firstInd: 1,
                             lastInd: 2,
                             hidden: true,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                    skipRange: (candidate) => Boolean(candidate.hidden),
+                }),
+            ),
+        ).eq(`"before" "after"`);
+    });
+
+    it("drops the composites inside a skipped composite along with it", () => {
+        // The replacements of a hidden composite can be composites of their
+        // own, each with a range of its own; those go with the one skipped.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["before", "1", "2", "after"],
+                    ranges: [
+                        range({
+                            compositeIdx: 7,
+                            firstInd: 1,
+                            lastInd: 2,
+                            hidden: true,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 8,
+                            firstInd: 1,
+                            lastInd: 2,
                             potentialListComponents: [true, true],
                         }),
                     ],

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -33,7 +33,9 @@ function sketch(groups: CompositeGroup<string>[]): string {
         .join(" ");
 }
 
-const isBlank = (value: string) => value.trim() === "";
+function isBlank(value: string) {
+    return value.trim() === "";
+}
 
 describe("groupCompositeRanges", () => {
     it("hands back the children when no composite contributed any", () => {

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from "vitest";
+import {
+    groupCompositeRanges,
+    type CompositeGroup,
+    type CompositeRange,
+} from "./compositeLists";
+
+/**
+ * The grouping every consumer of `compositeReplacementActiveRange` shares. The
+ * consumers are tested against real documents elsewhere; what is checked here
+ * is the shape of the tree they are handed, since that is what decides where a
+ * comma may go.
+ */
+
+function range(
+    over: Partial<CompositeRange> &
+        Pick<CompositeRange, "firstInd" | "lastInd">,
+): CompositeRange {
+    return { compositeIdx: 1, asList: true, ...over };
+}
+
+/** A compact rendering of the tree, so a case reads as what it asserts. */
+function sketch(groups: CompositeGroup<string>[]): string {
+    return groups
+        .map((group) => {
+            if (group.kind === "child") {
+                return JSON.stringify(group.value);
+            }
+            const label = group.asList ? "list" : "group";
+            return `${label}${group.range.compositeIdx}(${sketch(group.items)})`;
+        })
+        .join(" ");
+}
+
+const isBlank = (value: string) => value.trim() === "";
+
+describe("groupCompositeRanges", () => {
+    it("hands back the children when no composite contributed any", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["a", "b"],
+                    ranges: undefined,
+                }),
+            ),
+        ).eq(`"a" "b"`);
+    });
+
+    it("groups the children of one composite", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["before", "1", "2", "after"],
+                    ranges: [
+                        range({
+                            compositeIdx: 7,
+                            firstInd: 1,
+                            lastInd: 2,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`"before" list7("1" "2") "after"`);
+    });
+
+    it("is not a list with one item, or with asList off", () => {
+        const one = groupCompositeRanges<string>({
+            children: ["1"],
+            ranges: [
+                range({
+                    firstInd: 0,
+                    lastInd: 0,
+                    potentialListComponents: [true],
+                }),
+            ],
+        });
+        expect(sketch(one)).eq(`group1("1")`);
+
+        const off = groupCompositeRanges<string>({
+            children: ["1", "2"],
+            ranges: [
+                range({
+                    firstInd: 0,
+                    lastInd: 1,
+                    asList: false,
+                    potentialListComponents: [true, true],
+                }),
+            ],
+        });
+        expect(sketch(off)).eq(`group1("1" "2")`);
+    });
+
+    it("is not a list when a replacement cannot be an item", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2", "x"],
+                    ranges: [
+                        range({
+                            firstInd: 0,
+                            lastInd: 2,
+                            potentialListComponents: [true, true, false],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`group1("1" "2" "x")`);
+    });
+
+    it("nests the composites a composite produced", () => {
+        // The outer composite comes first, and the ranges after it that lie
+        // inside its own are its replacements'.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2", "3"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 2,
+                            potentialListComponents: [true, true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 0,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`list10(group11("1" "2") "3")`);
+    });
+
+    it("counts an inner composite as one item, so two of them are two", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 1,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 0,
+                            lastInd: 0,
+                            potentialListComponents: [true],
+                        }),
+                        range({
+                            compositeIdx: 12,
+                            firstInd: 1,
+                            lastInd: 1,
+                            potentialListComponents: [true],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`list10(group11("1") group12("2"))`);
+    });
+
+    it("leaves out a composite that produced nothing", () => {
+        // An empty composite is recorded as `lastInd === firstInd - 1`; the
+        // children around it still form one list.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 1,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 1,
+                            lastInd: 0,
+                            potentialListComponents: [],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`list10("1" "2")`);
+    });
+
+    it("leaves out an absent child, and does not count it as an item", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string | null>({
+                    children: ["1", null],
+                    ranges: [
+                        range({
+                            firstInd: 0,
+                            lastInd: 1,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                    isAbsent: (value) => value === null,
+                }) as CompositeGroup<string>[],
+            ),
+        ).eq(`group1("1")`);
+    });
+
+    it("keeps whitespace in the tree but not as an item", () => {
+        // Two replacements separated by authored whitespace are a two-item
+        // list, not a three-item one.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["\n", "1", " ", "2", "\n"],
+                    ranges: [
+                        range({
+                            firstInd: 0,
+                            lastInd: 4,
+                            potentialListComponents: [
+                                true,
+                                true,
+                                true,
+                                true,
+                                true,
+                            ],
+                        }),
+                    ],
+                    isBlank,
+                }),
+            ),
+        ).eq(`list1("\\n" "1" " " "2" "\\n")`);
+    });
+
+    it("takes the whitespace off the end of an item a comma will follow", () => {
+        // The last item keeps its own: no comma follows it, and it separates
+        // the list from whatever comes next.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", " ", "2", " "],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 3,
+                            potentialListComponents: [true, true, true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 0,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 12,
+                            firstInd: 2,
+                            lastInd: 3,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                    isBlank,
+                }),
+            ),
+        ).eq(`list10(group11("1") group12("2" " "))`);
+    });
+
+    it("takes the trailing whitespace off a child that ends an item", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["-6 ", "1", "-8"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 2,
+                            potentialListComponents: [true, true, true],
+                        }),
+                    ],
+                    isBlank,
+                    trimEnd: (value) => value.trimEnd(),
+                }),
+            ),
+        ).eq(`list10("-6" "1" "-8")`);
+    });
+
+    it("drops a composite the caller asked to skip, along with its children", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["before", "1", "2", "after"],
+                    ranges: [
+                        range({
+                            compositeIdx: 7,
+                            firstInd: 1,
+                            lastInd: 2,
+                            hidden: true,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                    skipRange: (candidate) => Boolean(candidate.hidden),
+                }),
+            ),
+        ).eq(`"before" "after"`);
+    });
+
+    it("moves the ranges past a child the caller removed", () => {
+        // `section.tsx` takes the `<title>` out of the children it renders.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2"],
+                    ranges: [
+                        range({
+                            compositeIdx: 7,
+                            firstInd: 1,
+                            lastInd: 2,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                    removedInd: 0,
+                }),
+            ),
+        ).eq(`list7("1" "2")`);
+    });
+
+    it("drops a range that ended on the removed child", () => {
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "3"],
+                    ranges: [
+                        range({
+                            firstInd: 0,
+                            lastInd: 1,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                    removedInd: 1,
+                }),
+            ),
+        ).eq(`"1" "3"`);
+    });
+
+    it("keeps each child's own index, for callers that need its neighbors", () => {
+        const groups = groupCompositeRanges<string>({
+            children: ["a", "1", "2"],
+            ranges: [
+                range({
+                    firstInd: 1,
+                    lastInd: 2,
+                    potentialListComponents: [true, true],
+                }),
+            ],
+        });
+        const indices: number[] = [];
+        const collect = (items: CompositeGroup<string>[]) => {
+            for (const item of items) {
+                if (item.kind === "child") {
+                    indices.push(item.index);
+                } else {
+                    collect(item.items);
+                }
+            }
+        };
+        collect(groups);
+        expect(indices).toEqual([0, 1, 2]);
+    });
+});

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -139,6 +139,46 @@ describe("groupCompositeRanges", () => {
         ).eq(`list10(group11("1" "2") "3")`);
     });
 
+    it("finds a composite's replacements wherever their ranges were recorded", () => {
+        // The core records a range when a composite expands, so the ranges of
+        // one composite's replacements can come after its sibling's.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", "2", "3", "4"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 3,
+                            potentialListComponents: [true, true, true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 0,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 12,
+                            firstInd: 2,
+                            lastInd: 3,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 13,
+                            firstInd: 0,
+                            lastInd: 1,
+                            potentialListComponents: [true, true],
+                        }),
+                    ],
+                }),
+            ),
+        ).eq(`list10(group11(list13("1" "2")) group12("3" "4"))`);
+    });
+
     it("counts an inner composite as one item, so two of them are two", () => {
         expect(
             sketch(

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     groupCompositeRanges,
+    listCommaPositions,
     type CompositeGroup,
     type CompositeRange,
 } from "./compositeLists";
@@ -209,9 +210,10 @@ describe("groupCompositeRanges", () => {
         ).eq(`group1("1")`);
     });
 
-    it("keeps whitespace in the tree but not as an item", () => {
+    it("keeps the whitespace at the ends of a list, and drops what a comma replaces", () => {
         // Two replacements separated by authored whitespace are a two-item
-        // list, not a three-item one.
+        // list, not a three-item one. The comma takes the place of the
+        // whitespace between them; the whitespace around the list stays.
         expect(
             sketch(
                 groupCompositeRanges<string>({
@@ -232,7 +234,34 @@ describe("groupCompositeRanges", () => {
                     isBlank,
                 }),
             ),
-        ).eq(`list1("\\n" "1" " " "2" "\\n")`);
+        ).eq(`list1("\\n" "1" "2" "\\n")`);
+    });
+
+    it("keeps a composite that produced only whitespace in its place", () => {
+        // The renderers anchor the composite's name there.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", " ", "2"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 2,
+                            potentialListComponents: [true, true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 1,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true],
+                        }),
+                    ],
+                    isBlank,
+                }),
+            ),
+        ).eq(`list10("1" group11(" ") "2")`);
     });
 
     it("takes the whitespace off the end of an item a comma will follow", () => {
@@ -371,5 +400,32 @@ describe("groupCompositeRanges", () => {
         };
         collect(groups);
         expect(indices).toEqual([0, 1, 2]);
+    });
+});
+
+describe("listCommaPositions", () => {
+    it("puts a comma in front of every item that has one before it", () => {
+        expect(listCommaPositions([false, false, false])).toEqual([
+            false,
+            true,
+            true,
+        ]);
+    });
+
+    it("puts none next to the whitespace at either end", () => {
+        expect(listCommaPositions([true, false, false, true])).toEqual([
+            false,
+            false,
+            true,
+            false,
+        ]);
+    });
+
+    it("puts one comma, not two, around a blank in the middle", () => {
+        expect(listCommaPositions([false, true, false])).toEqual([
+            false,
+            true,
+            false,
+        ]);
     });
 });

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -240,8 +240,9 @@ describe("groupCompositeRanges", () => {
         ).eq(`list1("\\n" "1" "2" "\\n")`);
     });
 
-    it("keeps a composite that produced only whitespace in its place", () => {
-        // The renderers anchor the composite's name there.
+    it("keeps a composite that produced only whitespace in its place, emptied", () => {
+        // The renderers anchor the composite's name there; the whitespace
+        // itself goes, since the comma takes its place.
         expect(
             sketch(
                 groupCompositeRanges<string>({
@@ -264,7 +265,7 @@ describe("groupCompositeRanges", () => {
                     isBlank,
                 }),
             ),
-        ).eq(`list10("1" group11(" ") "2")`);
+        ).eq(`list10("1" group11() "2")`);
     });
 
     it("takes the whitespace off the end of an item a comma will follow", () => {

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -343,6 +343,48 @@ describe("groupCompositeRanges", () => {
         ).eq(`list10(group11("1") group12("2" " "))`);
     });
 
+    it("keeps a whitespace-only composite at the end of an item, emptied", () => {
+        // Its anchor stays with the item it ended; its whitespace goes with
+        // the rest of the item's trailing whitespace.
+        expect(
+            sketch(
+                groupCompositeRanges<string>({
+                    children: ["1", " ", "2"],
+                    ranges: [
+                        range({
+                            compositeIdx: 10,
+                            firstInd: 0,
+                            lastInd: 2,
+                            potentialListComponents: [true, true, true],
+                        }),
+                        range({
+                            compositeIdx: 11,
+                            firstInd: 0,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true, true],
+                        }),
+                        range({
+                            compositeIdx: 13,
+                            firstInd: 1,
+                            lastInd: 1,
+                            asList: false,
+                            potentialListComponents: [true],
+                        }),
+                        range({
+                            compositeIdx: 12,
+                            firstInd: 2,
+                            lastInd: 2,
+                            asList: false,
+                            potentialListComponents: [true],
+                        }),
+                    ],
+                    isBlank,
+                }),
+            ),
+        ).eq(`list10(group11("1" group13()) group12("2"))`);
+    });
+
     it("takes the trailing whitespace off a child that ends an item", () => {
         expect(
             sketch(

--- a/packages/utils/src/components/compositeLists.test.ts
+++ b/packages/utils/src/components/compositeLists.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     groupCompositeRanges,
+    joinListText,
     listCommaPositions,
     type CompositeGroup,
     type CompositeRange,
@@ -429,5 +430,25 @@ describe("listCommaPositions", () => {
             true,
             false,
         ]);
+    });
+});
+
+describe("joinListText", () => {
+    it("puts a comma and a space between the items", () => {
+        expect(joinListText(["1", "2", "3"], [false, false, false])).eq(
+            "1, 2, 3",
+        );
+    });
+
+    it("takes the whitespace off the end of an item a comma will follow", () => {
+        // The last item keeps its own, and the whitespace at either end of the
+        // list stays where it is.
+        expect(
+            joinListText(["\n", "1 ", "2 ", "\n"], [true, false, false, true]),
+        ).eq("\n1, 2 \n");
+    });
+
+    it("puts one comma, not two, around an item that came out empty", () => {
+        expect(joinListText(["1", "", "2"], [false, true, false])).eq("1, 2");
     });
 });

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -102,8 +102,11 @@ export type GroupCompositeRangesOptions<T> = {
  * A composite's range is recorded before its replacements' ranges, and each of
  * those lies inside it. Ordered by where they start, the wider first where two
  * start together, every range comes right before the ranges of the composites
- * inside it, whatever order they were recorded in. One pass over them, with a
- * stack of the composites still open, then builds the tree.
+ * inside it, however the ranges of one composite's replacements were
+ * interleaved with its siblings'. Two ranges with the same span — a composite
+ * whose only replacement is a composite — keep their recorded order, the outer
+ * first, since the sort is stable. One pass over them, with a stack of the
+ * composites still open, then builds the tree.
  */
 export function groupCompositeRanges<T>({
     children,
@@ -193,7 +196,9 @@ export function groupCompositeRanges<T>({
         }
         const parent = open[open.length - 1];
         if (firstInd < parent.nextInd) {
-            // Inside a composite already left: not a range the core records.
+            // The replacement of a composite the caller asked to skip: its
+            // children were passed over above without opening it, so this
+            // range goes with it.
             continue;
         }
 
@@ -317,8 +322,9 @@ export function joinListText(parts: string[], blank: boolean[]): string {
  * at the end of an item a comma will follow, so that nothing puts a space in
  * front of a comma. The whitespace before the first item and after the last
  * stays: no comma replaces it, and it separates the list from what surrounds
- * it. A composite that produced only whitespace stays as well, emptied of that
- * whitespace, so that the renderers can still anchor its name to its place.
+ * it. Between two items, a composite that produced only whitespace stays as
+ * well, emptied of that whitespace, so that the renderers can still anchor its
+ * name to its place.
  */
 function prepareListItems<T>(
     items: CompositeGroup<T>[],

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -365,10 +365,11 @@ function withoutBlankChildren<T>(
 }
 
 /**
- * Drop the blank groups an item ends with — whitespace-only children, and
- * composites that produced only those — and take the trailing whitespace off
- * the child that is left at its end. `item` is not itself blank, so a
- * composite always has such a child.
+ * Take the whitespace off the end of an item a comma will follow: the
+ * whitespace-only children it ends with go, the composites among them stay
+ * for their anchors but emptied of their whitespace, and the child left at its
+ * end loses its trailing whitespace. `item` is not itself blank, so a composite
+ * always has such a child.
  */
 function trimItemEnd<T>(
     item: CompositeGroup<T>,
@@ -384,12 +385,18 @@ function trimItemEnd<T>(
     while (isBlankGroup(item.items[end - 1], isBlank)) {
         end--;
     }
+    const emptiedComposites = item.items
+        .slice(end)
+        .flatMap((sub) =>
+            sub.kind === "composite" ? [withoutBlankChildren(sub)] : [],
+        );
 
     return {
         ...item,
         items: [
             ...item.items.slice(0, end - 1),
             trimItemEnd(item.items[end - 1], isBlank, trimEnd),
+            ...emptiedComposites,
         ],
     };
 }

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -108,19 +108,9 @@ export function groupCompositeRanges<T>({
     endInd = children.length - 1,
     removedInd = null,
 }: GroupCompositeRangesOptions<T>): CompositeGroup<T>[] {
-    if (!ranges || ranges.length === 0) {
-        const items: CompositeGroup<T>[] = [];
-        for (let ind = startInd; ind <= endInd; ind++) {
-            if (!isAbsent(children[ind])) {
-                items.push({ kind: "child", value: children[ind], index: ind });
-            }
-        }
-        return items;
-    }
-
     const { items } = groupRange({
         children,
-        ranges,
+        ranges: ranges ?? [],
         startInd,
         endInd,
         eligibility: null,
@@ -170,7 +160,7 @@ function groupRange<T>({
     // are not picked up as plain ones.
     let nextInd = startInd;
 
-    const addPlainChildren = (upTo: number) => {
+    function addPlainChildren(upTo: number) {
         for (let ind = nextInd; ind < upTo; ind++) {
             const value = children[ind];
             if (isAbsent(value)) {
@@ -181,7 +171,7 @@ function groupRange<T>({
                 eligible.push(eligibility[ind - startInd] ?? false);
             }
         }
-    };
+    }
 
     for (let rangeInd = 0; rangeInd < ranges.length; rangeInd++) {
         const range = ranges[rangeInd];

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -1,0 +1,343 @@
+/**
+ * Grouping the children a parent received from composites, so that the
+ * replacements of a composite that asks to be shown as a list can be separated
+ * by commas.
+ *
+ * The core records, for each composite that contributed children to a parent,
+ * the range of children it produced (`compositeReplacementActiveRange`, built
+ * in `CompositeExpander.replaceCompositeChildren`). Four places turn that into
+ * output — the renderers, the `text` state variable, the string a `<math>`
+ * parses, and the FlatDast the prototype renderers read — and they differ only
+ * in what they do with a group once they have one. {@link groupCompositeRanges}
+ * is the part they share: it turns the flat array of ranges into a tree, and
+ * decides which nodes of that tree are lists.
+ */
+
+/**
+ * One entry of a parent's `compositeReplacementActiveRange`.
+ *
+ * `firstInd`/`lastInd` are inclusive indices into the parent's children. A
+ * composite that produced nothing is recorded as `lastInd === firstInd - 1`.
+ * `potentialListComponents[i]` says whether the child at `firstInd + i` is
+ * eligible to be an item of a list — inline components are, and so is anything
+ * whose class sets `canBeInList`.
+ */
+export type CompositeRange = {
+    compositeIdx: number;
+    compositeName?: string;
+    firstInd: number;
+    lastInd: number;
+    asList?: boolean;
+    hidden?: boolean;
+    potentialListComponents?: boolean[];
+};
+
+/**
+ * A child of the parent, or the children one composite produced. `asList` says
+ * whether this composite's items are to be separated by commas — the question
+ * every caller is really asking.
+ */
+export type CompositeGroup<T> =
+    | { kind: "child"; value: T; index: number }
+    | {
+          kind: "composite";
+          range: CompositeRange;
+          asList: boolean;
+          items: CompositeGroup<T>[];
+      };
+
+export type GroupCompositeRangesOptions<T> = {
+    /** The parent's children, in the index space the ranges refer to. */
+    children: T[];
+    /** The parent's `compositeReplacementActiveRange`, or nothing. */
+    ranges: CompositeRange[] | undefined;
+    /**
+     * A child that is not there — a `null` where a child instruction would be
+     * for a child that is not rendered. Such a child is left out of the tree
+     * and does not count towards the item that would make a list.
+     */
+    isAbsent?: (value: T) => boolean;
+    /**
+     * A whitespace-only child. Authored whitespace around a composite's
+     * replacements separates them rather than being one of them: it stays in
+     * the tree, but is not an item, and it is dropped from the end of an item a
+     * comma will follow.
+     */
+    isBlank?: (value: T) => boolean;
+    /**
+     * A composite to leave out along with everything it produced — how the
+     * `text` pathway drops a hidden composite.
+     */
+    skipRange?: (range: CompositeRange) => boolean;
+    /**
+     * Take the trailing whitespace off a child, for the child that ends an item
+     * a comma will follow. Whitespace-only children at the end of such an item
+     * are dropped whether or not this is given; this is for a child that ends
+     * with whitespace without being only whitespace.
+     */
+    trimEnd?: (value: T) => T;
+    /** First child to group; defaults to the first. */
+    startInd?: number;
+    /** Last child to group, inclusive; defaults to the last. */
+    endInd?: number;
+    /**
+     * The index of a child the caller removed from `children` before calling —
+     * `section.tsx` takes the `<title>` out of the array it renders. Ranges are
+     * shifted to match, and a range that ended on that child is dropped.
+     */
+    removedInd?: number | null;
+};
+
+/**
+ * Group `children` by the composites that produced them.
+ *
+ * Nesting is implicit in `ranges`: a composite whose replacements are
+ * themselves composites comes first, and the ranges after it whose indices lie
+ * inside its own are its replacements'. The tree makes that explicit.
+ */
+export function groupCompositeRanges<T>({
+    children,
+    ranges,
+    isAbsent = () => false,
+    isBlank = () => false,
+    skipRange = () => false,
+    trimEnd = (value) => value,
+    startInd = 0,
+    endInd = children.length - 1,
+    removedInd = null,
+}: GroupCompositeRangesOptions<T>): CompositeGroup<T>[] {
+    if (!ranges || ranges.length === 0) {
+        const items: CompositeGroup<T>[] = [];
+        for (let ind = startInd; ind <= endInd; ind++) {
+            if (!isAbsent(children[ind])) {
+                items.push({ kind: "child", value: children[ind], index: ind });
+            }
+        }
+        return items;
+    }
+
+    const { items } = groupRange({
+        children,
+        ranges,
+        startInd,
+        endInd,
+        eligibility: null,
+        isAbsent,
+        isBlank,
+        skipRange,
+        trimEnd,
+        removedInd,
+    });
+
+    return items;
+}
+
+/**
+ * The items of one range, together with whether each is eligible to be an item
+ * of the list the enclosing composite might form. Eligibility is only asked for
+ * inside a range, since only a composite forms a list.
+ */
+function groupRange<T>({
+    children,
+    ranges,
+    startInd,
+    endInd,
+    eligibility,
+    isAbsent,
+    isBlank,
+    skipRange,
+    trimEnd,
+    removedInd,
+}: {
+    children: T[];
+    ranges: CompositeRange[];
+    startInd: number;
+    endInd: number;
+    eligibility: boolean[] | null;
+    isAbsent: (value: T) => boolean;
+    isBlank: (value: T) => boolean;
+    skipRange: (range: CompositeRange) => boolean;
+    trimEnd: (value: T) => T;
+    removedInd: number | null;
+}): { items: CompositeGroup<T>[]; eligible: boolean[] } {
+    const items: CompositeGroup<T>[] = [];
+    const eligible: boolean[] = [];
+
+    // The child after the last one already accounted for. A composite that
+    // produced nothing still moves this past itself, so its (absent) children
+    // are not picked up as plain ones.
+    let nextInd = startInd;
+
+    const addPlainChildren = (upTo: number) => {
+        for (let ind = nextInd; ind < upTo; ind++) {
+            const value = children[ind];
+            if (isAbsent(value)) {
+                continue;
+            }
+            items.push({ kind: "child", value, index: ind });
+            if (eligibility) {
+                eligible.push(eligibility[ind - startInd] ?? false);
+            }
+        }
+    };
+
+    for (let rangeInd = 0; rangeInd < ranges.length; rangeInd++) {
+        const range = ranges[rangeInd];
+        const shifted = shiftForRemovedChild(range, removedInd);
+        if (!shifted) {
+            continue;
+        }
+        const { firstInd, lastInd } = shifted;
+
+        if (firstInd < nextInd || lastInd > endInd) {
+            // Not one of this range's own composites: either already accounted
+            // for, or reaching past the children being grouped.
+            continue;
+        }
+
+        addPlainChildren(firstInd);
+        nextInd = Math.max(firstInd, lastInd + 1);
+
+        if (skipRange(range)) {
+            continue;
+        }
+
+        // The composite comes before the composites it produced, so its own are
+        // exactly the ranges after it.
+        const { items: rangeItems, eligible: rangeEligible } = groupRange({
+            children,
+            ranges: ranges.slice(rangeInd + 1),
+            startInd: firstInd,
+            endInd: lastInd,
+            eligibility: range.potentialListComponents ?? null,
+            isAbsent,
+            isBlank,
+            skipRange,
+            trimEnd,
+            removedInd,
+        });
+
+        if (rangeItems.length === 0) {
+            continue;
+        }
+
+        const listItems = rangeItems.filter(
+            (item) => !isBlankItem(item, isBlank),
+        );
+        const allEligible = rangeEligible.every(
+            (value, ind) => value || isBlankItem(rangeItems[ind], isBlank),
+        );
+        const asList =
+            Boolean(range.asList) && allEligible && listItems.length > 1;
+
+        items.push({
+            kind: "composite",
+            range,
+            asList,
+            items: asList
+                ? trimBeforeCommas(rangeItems, isBlank, trimEnd)
+                : rangeItems,
+        });
+        if (eligibility) {
+            eligible.push(allEligible);
+        }
+    }
+
+    addPlainChildren(endInd + 1);
+
+    return { items, eligible };
+}
+
+/**
+ * Where the caller removed a child before grouping, move a range to match.
+ * Returns nothing for a range that ended on the removed child, which is no
+ * longer a range of the children being grouped.
+ */
+function shiftForRemovedChild(
+    range: CompositeRange,
+    removedInd: number | null,
+): { firstInd: number; lastInd: number } | undefined {
+    let { firstInd, lastInd } = range;
+    if (removedInd === null) {
+        return { firstInd, lastInd };
+    }
+    if (firstInd === removedInd || lastInd === removedInd) {
+        return undefined;
+    }
+    if (firstInd > removedInd) {
+        firstInd -= 1;
+    }
+    if (lastInd > removedInd) {
+        lastInd -= 1;
+    }
+    return { firstInd, lastInd };
+}
+
+function isBlankItem<T>(
+    item: CompositeGroup<T> | undefined,
+    isBlank: (value: T) => boolean,
+): boolean {
+    if (item === undefined) {
+        return true;
+    }
+    if (item.kind === "child") {
+        return isBlank(item.value);
+    }
+    return item.items.every((sub) => isBlankItem(sub, isBlank));
+}
+
+/**
+ * Take the whitespace off the end of every item a comma will follow, so that
+ * nothing puts a space in front of a comma. The last item keeps its trailing
+ * whitespace: no comma follows it, and it separates the list from whatever
+ * comes next.
+ */
+function trimBeforeCommas<T>(
+    items: CompositeGroup<T>[],
+    isBlank: (value: T) => boolean,
+    trimEnd: (value: T) => T,
+): CompositeGroup<T>[] {
+    let lastItemInd = items.length - 1;
+    while (lastItemInd >= 0 && isBlankItem(items[lastItemInd], isBlank)) {
+        lastItemInd--;
+    }
+
+    // Only an item a comma actually follows: whitespace between two items is a
+    // separator in its own right and stays as it is.
+    return items.map((item, ind) =>
+        ind < lastItemInd && !isBlankItem(item, isBlank)
+            ? trimItemEnd(item, isBlank, trimEnd)
+            : item,
+    );
+}
+
+/**
+ * Drop the whitespace-only children an item ends with, and take the trailing
+ * whitespace off the child that is left at its end.
+ */
+function trimItemEnd<T>(
+    item: CompositeGroup<T>,
+    isBlank: (value: T) => boolean,
+    trimEnd: (value: T) => T,
+): CompositeGroup<T> {
+    if (item.kind === "child") {
+        const trimmed = trimEnd(item.value);
+        return trimmed === item.value ? item : { ...item, value: trimmed };
+    }
+
+    let end = item.items.length;
+    while (end > 0 && isBlankItem(item.items[end - 1], isBlank)) {
+        end--;
+    }
+    if (end === 0) {
+        return { ...item, items: [] };
+    }
+
+    return {
+        ...item,
+        items: [
+            ...item.items.slice(0, end - 1),
+            trimItemEnd(item.items[end - 1], isBlank, trimEnd),
+        ],
+    };
+}

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -90,7 +90,8 @@ export type GroupCompositeRangesOptions<T> = {
     /**
      * The index of a child the caller removed from `children` before calling —
      * `section.tsx` takes the `<title>` out of the array it renders. Ranges are
-     * shifted to match, and a range that ended on that child is dropped.
+     * shifted to match, and a range that began or ended on that child is
+     * dropped.
      */
     removedInd?: number | null;
 };
@@ -248,8 +249,9 @@ function groupRange<T>({
 
 /**
  * Where the caller removed a child before grouping, move a range to match.
- * Returns nothing for a range that ended on the removed child, which is no
- * longer a range of the children being grouped.
+ * Returns nothing for a range that began or ended on the removed child — the
+ * composite that produced the `<title>` — whose other children, if it had any,
+ * are then grouped as if no composite had produced them.
  */
 function shiftForRemovedChild(
     range: CompositeRange,
@@ -353,9 +355,10 @@ function prepareListItems<T>(
 }
 
 /**
- * Drop the whitespace-only children an item ends with, and take the trailing
- * whitespace off the child that is left at its end. `item` is not itself
- * blank, so a composite always has such a child.
+ * Drop the blank groups an item ends with — whitespace-only children, and
+ * composites that produced only those — and take the trailing whitespace off
+ * the child that is left at its end. `item` is not itself blank, so a
+ * composite always has such a child.
  */
 function trimItemEnd<T>(
     item: CompositeGroup<T>,

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -11,7 +11,8 @@
  * in what they do with a group once they have one. {@link groupCompositeRanges}
  * is the part they share: it turns the flat array of ranges into a tree, and
  * decides which nodes of that tree are lists. {@link listCommaPositions} then
- * says where the commas go among a list's items.
+ * says where the commas go among a list's items, and {@link joinListText}
+ * joins the text of those items for the pathways that produce a string.
  */
 
 /**
@@ -292,6 +293,20 @@ export function listCommaPositions(blank: boolean[]): boolean[] {
             !blank[ind - 1] &&
             blank.slice(ind).some((isBlank) => !isBlank),
     );
+}
+
+/**
+ * The text of a list, from the text of its items and which of those items are
+ * blank. The commas go where {@link listCommaPositions} puts them, and an item
+ * a comma will follow loses the whitespace its text ends with, so that nothing
+ * puts a space in front of a comma.
+ */
+export function joinListText(parts: string[], blank: boolean[]): string {
+    const commaBefore = listCommaPositions(blank);
+    return parts
+        .map((part, ind) => (commaBefore[ind + 1] ? part.trimEnd() : part))
+        .map((part, ind) => (commaBefore[ind] ? ", " + part : part))
+        .join("");
 }
 
 /**

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -99,9 +99,11 @@ export type GroupCompositeRangesOptions<T> = {
 /**
  * Group `children` by the composites that produced them.
  *
- * Nesting is implicit in `ranges`: a composite whose replacements are
- * themselves composites comes first, and the ranges after it whose indices lie
- * inside its own are its replacements'. The tree makes that explicit.
+ * A composite's range is recorded before its replacements' ranges, and each of
+ * those lies inside it. Ordered by where they start, the wider first where two
+ * start together, every range comes right before the ranges of the composites
+ * inside it, whatever order they were recorded in. One pass over them, with a
+ * stack of the composites still open, then builds the tree.
  */
 export function groupCompositeRanges<T>({
     children,
@@ -114,138 +116,129 @@ export function groupCompositeRanges<T>({
     endInd = children.length - 1,
     removedInd = null,
 }: GroupCompositeRangesOptions<T>): CompositeGroup<T>[] {
-    const { items } = groupRange({
-        children,
-        ranges: ranges ?? [],
-        startInd,
-        endInd,
+    const ordered = (ranges ?? [])
+        .flatMap((range) => {
+            const span = shiftForRemovedChild(range, removedInd);
+            return span && span.firstInd >= startInd && span.lastInd <= endInd
+                ? [{ range, ...span }]
+                : [];
+        })
+        .sort((a, b) => a.firstInd - b.firstInd || b.lastInd - a.lastInd);
+
+    const root: OpenComposite<T> = {
+        range: null,
+        firstInd: startInd,
+        lastInd: endInd,
+        nextInd: startInd,
         eligibility: null,
-        isAbsent,
-        isBlank,
-        skipRange,
-        trimEnd,
-        removedInd,
-    });
-
-    return items;
-}
-
-/**
- * The items of one range, together with whether each is eligible to be an item
- * of the list the enclosing composite might form. Eligibility is only asked for
- * inside a range, since only a composite forms a list.
- */
-function groupRange<T>({
-    children,
-    ranges,
-    startInd,
-    endInd,
-    eligibility,
-    isAbsent,
-    isBlank,
-    skipRange,
-    trimEnd,
-    removedInd,
-}: {
-    children: T[];
-    ranges: CompositeRange[];
-    startInd: number;
-    endInd: number;
-    eligibility: boolean[] | null;
-    isAbsent: (value: T) => boolean;
-    isBlank: (value: T) => boolean;
-    skipRange: (range: CompositeRange) => boolean;
-    trimEnd: (value: T) => T;
-    removedInd: number | null;
-}): { items: CompositeGroup<T>[]; eligible: boolean[] } {
-    const items: CompositeGroup<T>[] = [];
-    const eligible: boolean[] = [];
-
-    // The first child not yet placed in the tree.
-    let nextInd = startInd;
+        items: [],
+        eligible: [],
+    };
+    const open: OpenComposite<T>[] = [root];
 
     /** Place the children before `upTo` that no composite produced. */
-    function addPlainChildren(upTo: number) {
-        for (; nextInd < upTo; nextInd++) {
-            const value = children[nextInd];
+    function addPlainChildren(node: OpenComposite<T>, upTo: number) {
+        for (; node.nextInd < upTo; node.nextInd++) {
+            const value = children[node.nextInd];
             if (isAbsent(value)) {
                 continue;
             }
-            items.push({ kind: "child", value, index: nextInd });
-            if (eligibility) {
-                eligible.push(eligibility[nextInd - startInd] ?? false);
+            node.items.push({ kind: "child", value, index: node.nextInd });
+            if (node.eligibility) {
+                node.eligible.push(
+                    node.eligibility[node.nextInd - node.firstInd] ?? false,
+                );
             }
         }
     }
 
-    for (let rangeInd = 0; rangeInd < ranges.length; rangeInd++) {
-        const range = ranges[rangeInd];
-        const shifted = shiftForRemovedChild(range, removedInd);
-        if (!shifted) {
+    /**
+     * Leave the innermost open composite: place the last of its children,
+     * decide whether it is a list, and put its group into the composite around
+     * it. A composite that produced nothing leaves nothing behind.
+     */
+    function closeInnermost() {
+        const node = open.pop()!;
+        addPlainChildren(node, node.lastInd + 1);
+        if (node.items.length === 0) {
+            return;
+        }
+        const parent = open[open.length - 1];
+        const listItems = node.items.filter(
+            (item) => !isBlankGroup(item, isBlank),
+        );
+        const allEligible = node.eligible.every(
+            (value, ind) => value || isBlankGroup(node.items[ind], isBlank),
+        );
+        const asList =
+            Boolean(node.range!.asList) && allEligible && listItems.length > 1;
+
+        parent.items.push({
+            kind: "composite",
+            range: node.range!,
+            asList,
+            items: asList
+                ? prepareListItems(node.items, isBlank, trimEnd)
+                : node.items,
+        });
+        if (parent.eligibility) {
+            parent.eligible.push(allEligible);
+        }
+    }
+
+    for (const { range, firstInd, lastInd } of ordered) {
+        // Leave every composite this range does not lie inside.
+        while (open.length > 1 && lastInd > open[open.length - 1].lastInd) {
+            closeInnermost();
+        }
+        const parent = open[open.length - 1];
+        if (firstInd < parent.nextInd) {
+            // Inside a composite already left: not a range the core records.
             continue;
         }
-        const { firstInd, lastInd } = shifted;
 
-        if (firstInd < nextInd || lastInd > endInd) {
-            // Not one of this range's own composites: either already accounted
-            // for, or reaching past the children being grouped.
-            continue;
-        }
-
-        addPlainChildren(firstInd);
-        // Past the composite's children — of which a composite that produced
-        // nothing, recorded with `lastInd === firstInd - 1`, has none.
-        nextInd = lastInd + 1;
+        addPlainChildren(parent, firstInd);
+        // Past the composite's children, of which one that produced nothing,
+        // recorded with `lastInd === firstInd - 1`, has none.
+        parent.nextInd = lastInd + 1;
 
         if (skipRange(range)) {
             continue;
         }
-
-        // The composite comes before the composites it produced, so its own are
-        // exactly the ranges after it.
-        const { items: rangeItems, eligible: rangeEligible } = groupRange({
-            children,
-            ranges: ranges.slice(rangeInd + 1),
-            startInd: firstInd,
-            endInd: lastInd,
-            eligibility: range.potentialListComponents ?? null,
-            isAbsent,
-            isBlank,
-            skipRange,
-            trimEnd,
-            removedInd,
-        });
-
-        if (rangeItems.length === 0) {
-            continue;
-        }
-
-        const listItems = rangeItems.filter(
-            (item) => !isBlankGroup(item, isBlank),
-        );
-        const allEligible = rangeEligible.every(
-            (value, ind) => value || isBlankGroup(rangeItems[ind], isBlank),
-        );
-        const asList =
-            Boolean(range.asList) && allEligible && listItems.length > 1;
-
-        items.push({
-            kind: "composite",
+        open.push({
             range,
-            asList,
-            items: asList
-                ? prepareListItems(rangeItems, isBlank, trimEnd)
-                : rangeItems,
+            firstInd,
+            lastInd,
+            nextInd: firstInd,
+            eligibility: range.potentialListComponents ?? null,
+            items: [],
+            eligible: [],
         });
-        if (eligibility) {
-            eligible.push(allEligible);
-        }
     }
+    while (open.length > 1) {
+        closeInnermost();
+    }
+    addPlainChildren(root, endInd + 1);
 
-    addPlainChildren(endInd + 1);
-
-    return { items, eligible };
+    return root.items;
 }
+
+/**
+ * A composite whose range has been entered and not yet left: what it holds so
+ * far, and whether each of those items is eligible to be an item of the list
+ * it might form. The root stands for the children being grouped as a whole;
+ * their eligibility is never asked for, since only a composite forms a list.
+ */
+type OpenComposite<T> = {
+    range: CompositeRange | null;
+    firstInd: number;
+    lastInd: number;
+    /** The first of its children not yet placed in the tree. */
+    nextInd: number;
+    eligibility: boolean[] | null;
+    items: CompositeGroup<T>[];
+    eligible: boolean[];
+};
 
 /**
  * Where the caller removed a child before grouping, move a range to match.

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -21,8 +21,9 @@
  * `firstInd`/`lastInd` are inclusive indices into the parent's children. A
  * composite that produced nothing is recorded as `lastInd === firstInd - 1`.
  * `potentialListComponents[i]` says whether the child at `firstInd + i` is
- * eligible to be an item of a list — inline components are, and so is anything
- * whose class sets `canBeInList`.
+ * eligible to be an item of a list: a string is, an inline component is unless
+ * its class sets `canBeInList` to `false`, and any other component is only if
+ * its class sets `canBeInList` to `true`.
  */
 export type CompositeRange = {
     compositeIdx: number;
@@ -37,7 +38,10 @@ export type CompositeRange = {
 /**
  * A child of the parent, or the children one composite produced. `asList` says
  * whether this composite's items are to be separated by commas — the question
- * every caller is really asking.
+ * every caller is really asking. The items of a list are already as the commas
+ * will separate them (see `isBlank` and `trimEnd` in
+ * {@link GroupCompositeRangesOptions}); {@link listCommaPositions} says where
+ * among them the commas go.
  */
 export type CompositeGroup<T> =
     | { kind: "child"; value: T; index: number }
@@ -156,20 +160,19 @@ function groupRange<T>({
     const items: CompositeGroup<T>[] = [];
     const eligible: boolean[] = [];
 
-    // The child after the last one already accounted for. A composite that
-    // produced nothing still moves this past itself, so its (absent) children
-    // are not picked up as plain ones.
+    // The first child not yet placed in the tree.
     let nextInd = startInd;
 
+    /** Place the children before `upTo` that no composite produced. */
     function addPlainChildren(upTo: number) {
-        for (let ind = nextInd; ind < upTo; ind++) {
-            const value = children[ind];
+        for (; nextInd < upTo; nextInd++) {
+            const value = children[nextInd];
             if (isAbsent(value)) {
                 continue;
             }
-            items.push({ kind: "child", value, index: ind });
+            items.push({ kind: "child", value, index: nextInd });
             if (eligibility) {
-                eligible.push(eligibility[ind - startInd] ?? false);
+                eligible.push(eligibility[nextInd - startInd] ?? false);
             }
         }
     }
@@ -189,7 +192,9 @@ function groupRange<T>({
         }
 
         addPlainChildren(firstInd);
-        nextInd = Math.max(firstInd, lastInd + 1);
+        // Past the composite's children — of which a composite that produced
+        // nothing, recorded with `lastInd === firstInd - 1`, has none.
+        nextInd = lastInd + 1;
 
         if (skipRange(range)) {
             continue;
@@ -349,7 +354,8 @@ function prepareListItems<T>(
 
 /**
  * Drop the whitespace-only children an item ends with, and take the trailing
- * whitespace off the child that is left at its end.
+ * whitespace off the child that is left at its end. `item` is not itself
+ * blank, so a composite always has such a child.
  */
 function trimItemEnd<T>(
     item: CompositeGroup<T>,
@@ -362,11 +368,8 @@ function trimItemEnd<T>(
     }
 
     let end = item.items.length;
-    while (end > 0 && isBlankGroup(item.items[end - 1], isBlank)) {
+    while (isBlankGroup(item.items[end - 1], isBlank)) {
         end--;
-    }
-    if (end === 0) {
-        return { ...item, items: [] };
     }
 
     return {

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -294,12 +294,14 @@ export function isBlankGroup<T>(
  * composite that produced only whitespace, gets one comma rather than two.
  */
 export function listCommaPositions(blank: boolean[]): boolean[] {
-    return blank.map(
-        (_, ind) =>
-            ind > 0 &&
-            !blank[ind - 1] &&
-            blank.slice(ind).some((isBlank) => !isBlank),
-    );
+    const commaBefore: boolean[] = new Array(blank.length);
+    // Walking from the right, whether an item is at this position or after it.
+    let itemAtOrAfter = false;
+    for (let ind = blank.length - 1; ind >= 0; ind--) {
+        itemAtOrAfter ||= !blank[ind];
+        commaBefore[ind] = ind > 0 && !blank[ind - 1] && itemAtOrAfter;
+    }
+    return commaBefore;
 }
 
 /**
@@ -322,8 +324,8 @@ export function joinListText(parts: string[], blank: boolean[]): string {
  * at the end of an item a comma will follow, so that nothing puts a space in
  * front of a comma. The whitespace before the first item and after the last
  * stays: no comma replaces it, and it separates the list from what surrounds
- * it. A composite that produced only whitespace also stays, so that the
- * renderers can still anchor its name to its place.
+ * it. A composite that produced only whitespace stays as well, emptied of that
+ * whitespace, so that the renderers can still anchor its name to its place.
  */
 function prepareListItems<T>(
     items: CompositeGroup<T>[],
@@ -348,10 +350,25 @@ function prepareListItems<T>(
         } else if (!isBlankGroup(item, isBlank)) {
             prepared.push(trimItemEnd(item, isBlank, trimEnd));
         } else if (item.kind === "composite") {
-            prepared.push(item);
+            prepared.push(withoutBlankChildren(item));
         }
     }
     return prepared;
+}
+
+/**
+ * A composite that produced only whitespace, with that whitespace taken out
+ * and only the composites inside it left, each emptied the same way.
+ */
+function withoutBlankChildren<T>(
+    group: CompositeGroup<T> & { kind: "composite" },
+): CompositeGroup<T> {
+    return {
+        ...group,
+        items: group.items.flatMap((item) =>
+            item.kind === "composite" ? [withoutBlankChildren(item)] : [],
+        ),
+    };
 }
 
 /**

--- a/packages/utils/src/components/compositeLists.ts
+++ b/packages/utils/src/components/compositeLists.ts
@@ -10,7 +10,8 @@
  * parses, and the FlatDast the prototype renderers read — and they differ only
  * in what they do with a group once they have one. {@link groupCompositeRanges}
  * is the part they share: it turns the flat array of ranges into a tree, and
- * decides which nodes of that tree are lists.
+ * decides which nodes of that tree are lists. {@link listCommaPositions} then
+ * says where the commas go among a list's items.
  */
 
 /**
@@ -59,9 +60,10 @@ export type GroupCompositeRangesOptions<T> = {
     isAbsent?: (value: T) => boolean;
     /**
      * A whitespace-only child. Authored whitespace around a composite's
-     * replacements separates them rather than being one of them: it stays in
-     * the tree, but is not an item, and it is dropped from the end of an item a
-     * comma will follow.
+     * replacements separates them rather than being one of them: it is never
+     * an item, and in a list it stays only where no comma takes its place,
+     * before the first item and after the last. Between two items it goes, as
+     * does the whitespace at the end of an item a comma will follow.
      */
     isBlank?: (value: T) => boolean;
     /**
@@ -222,10 +224,10 @@ function groupRange<T>({
         }
 
         const listItems = rangeItems.filter(
-            (item) => !isBlankItem(item, isBlank),
+            (item) => !isBlankGroup(item, isBlank),
         );
         const allEligible = rangeEligible.every(
-            (value, ind) => value || isBlankItem(rangeItems[ind], isBlank),
+            (value, ind) => value || isBlankGroup(rangeItems[ind], isBlank),
         );
         const asList =
             Boolean(range.asList) && allEligible && listItems.length > 1;
@@ -235,7 +237,7 @@ function groupRange<T>({
             range,
             asList,
             items: asList
-                ? trimBeforeCommas(rangeItems, isBlank, trimEnd)
+                ? prepareListItems(rangeItems, isBlank, trimEnd)
                 : rangeItems,
         });
         if (eligibility) {
@@ -273,42 +275,71 @@ function shiftForRemovedChild(
     return { firstInd, lastInd };
 }
 
-function isBlankItem<T>(
-    item: CompositeGroup<T> | undefined,
+/**
+ * Whether a node of the tree is only whitespace: a blank child, or a composite
+ * that produced nothing but blank children.
+ */
+export function isBlankGroup<T>(
+    group: CompositeGroup<T>,
     isBlank: (value: T) => boolean,
 ): boolean {
-    if (item === undefined) {
-        return true;
+    if (group.kind === "child") {
+        return isBlank(group.value);
     }
-    if (item.kind === "child") {
-        return isBlank(item.value);
-    }
-    return item.items.every((sub) => isBlankItem(sub, isBlank));
+    return group.items.every((item) => isBlankGroup(item, isBlank));
 }
 
 /**
- * Take the whitespace off the end of every item a comma will follow, so that
- * nothing puts a space in front of a comma. The last item keeps its trailing
- * whitespace: no comma follows it, and it separates the list from whatever
- * comes next.
+ * Where the commas go among the items of a list, given which items are blank:
+ * in front of every item that has an item before it. No comma lands next to
+ * the whitespace at either end of the list, and a blank left in the middle, a
+ * composite that produced only whitespace, gets one comma rather than two.
  */
-function trimBeforeCommas<T>(
+export function listCommaPositions(blank: boolean[]): boolean[] {
+    return blank.map(
+        (_, ind) =>
+            ind > 0 &&
+            !blank[ind - 1] &&
+            blank.slice(ind).some((isBlank) => !isBlank),
+    );
+}
+
+/**
+ * The items of a list as the commas will separate them. A blank child between
+ * two items goes, since the comma takes its place, and so does the whitespace
+ * at the end of an item a comma will follow, so that nothing puts a space in
+ * front of a comma. The whitespace before the first item and after the last
+ * stays: no comma replaces it, and it separates the list from what surrounds
+ * it. A composite that produced only whitespace also stays, so that the
+ * renderers can still anchor its name to its place.
+ */
+function prepareListItems<T>(
     items: CompositeGroup<T>[],
     isBlank: (value: T) => boolean,
     trimEnd: (value: T) => T,
 ): CompositeGroup<T>[] {
+    const firstItemInd = items.findIndex(
+        (item) => !isBlankGroup(item, isBlank),
+    );
     let lastItemInd = items.length - 1;
-    while (lastItemInd >= 0 && isBlankItem(items[lastItemInd], isBlank)) {
+    while (
+        lastItemInd > firstItemInd &&
+        isBlankGroup(items[lastItemInd], isBlank)
+    ) {
         lastItemInd--;
     }
 
-    // Only an item a comma actually follows: whitespace between two items is a
-    // separator in its own right and stays as it is.
-    return items.map((item, ind) =>
-        ind < lastItemInd && !isBlankItem(item, isBlank)
-            ? trimItemEnd(item, isBlank, trimEnd)
-            : item,
-    );
+    const prepared: CompositeGroup<T>[] = [];
+    for (const [ind, item] of items.entries()) {
+        if (ind < firstItemInd || ind >= lastItemInd) {
+            prepared.push(item);
+        } else if (!isBlankGroup(item, isBlank)) {
+            prepared.push(trimItemEnd(item, isBlank, trimEnd));
+        } else if (item.kind === "composite") {
+            prepared.push(item);
+        }
+    }
+    return prepared;
 }
 
 /**
@@ -326,7 +357,7 @@ function trimItemEnd<T>(
     }
 
     let end = item.items.length;
-    while (end > 0 && isBlankItem(item.items[end - 1], isBlank)) {
+    while (end > 0 && isBlankGroup(item.items[end - 1], isBlank)) {
         end--;
     }
     if (end === 0) {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,6 +8,7 @@ export * from "./media/retrieveTextFile";
 export * from "./copy/deepFunctions";
 export * from "./copy/parseStringify";
 export * from "./components/domain";
+export * from "./components/compositeLists";
 export * from "./components/enumeration";
 export * from "./components/function";
 export * from "./components/mathInputFunctionNames";


### PR DESCRIPTION
Follows #1807, now merged; this branch is rebased onto `main` with it, so the diff here is only this PR's own commits.

Closes #596. Closes #499.

The commas between the replacements of a list composite were worked out four times over from the same array of index ranges: once for the renderers, once for the `text` state variable, once for the string a `<math>` parses, and once for the FlatDast the prototype renderers read. Each carried its own copy of the index arithmetic, and they had drifted apart.

## One grouping, four uses

`groupCompositeRanges` (`@doenet/utils`) is the part the four have in common: it turns the flat array of ranges into a tree of children and composites and says which of those composites are lists. Nesting, list eligibility, empty composites, absent children, whitespace, and the index shift a section title forces are decided there, once, and `listCommaPositions` beside it says where the commas go among a list's items, with `joinListText` joining the text of those items for `text` and `<math>` alike. What is left in each caller is only what it does with a group once it has one — the renderers their anchor span, `text` its hidden composites, `<math>` the parens it puts around a list, the FlatDast bridge its wrapper elements. The bridge reads the whitespace a list keeps at its ends, and a composite that produced only whitespace, off the tree as well, so neither can become an item of the prototype's `<asList>`; a composite that produced two blank strings used to.

The tree is built in one pass: the ranges are ordered by where they start, the wider first where two start together, which puts every composite right before the composites inside it however the core interleaved them, and a stack of the composites still open does the rest. Two ranges with the same span — a composite whose only replacement is a composite — keep their recorded order, the outer first.

About 900 lines of duplicated walking come out; the shared module and its tests go in.

## A reference to a list keeps the list's commas

`$r[1]` and `$g` showed `1234` where the composite they name showed `1, 2, 3, 4`, in the rendered list and in `text` alike — the bug this branch started from, and #596.

A reference that lands on a composite copies its replacements, and did so recursively down to plain components. That recursion is what makes `<point extend="$mp[1]" />` reach the point inside a repeat item rather than the `<setup>` beside it — but recursing that far also flattened away every composite in between, and with it the `asList` that made the replacements a list. The single range left behind recorded only the outermost composite, so both pathways read `asList: false`.

The recursion now stops at a composite that can be a list of its own, so the reference copies that composite and the list survives with real component indices and real nesting. Composites that cannot be a list, `<setup>` among them, are still recursed through, so what a reference resolves to is unchanged. #596's nested-repeat example is a test in both pathways and in the DOM.

## No space in front of a comma

The renderers' `removeEndingBlankString` only looked inside a child whose `props.children` was an array — which neither a rendered component child nor the wrapper the comma code builds for a nested composite ever has. So it almost never fired, and `<group asList><group><number>1</number> </group><group><number>2</number> </group></group>` read `1 , 2`.

The grouping now takes the whitespace off the end of any item a comma will follow, so every pathway agrees. The last item keeps its own: no comma follows it, and it separates the list from what comes next.

One case is deliberately left: whitespace inside a child component's own text, as in `<group asList><text>a </text><text>b</text></group>`. `text` reads that component's text and can trim it; the renderers only hand React the child and never see, let alone reach into, what it draws. Closing that means either giving up the trim on the `text` side, which reads worse, or telling the child renderer that it leads a comma — worth doing, but not quietly inside this PR (#1811). `compositeCommas.test.tsx` keeps it as an `it.fails` naming it as the one place the two still differ.

## The comma goes where the whitespace between two items was

`<group asList><number>1</number> <number>2</number></group>` had a `text` of `1, , 2`: the space between the two items was joined into the list as an item of its own, with a comma on either side, while the renderers left it out. With an empty composite among the items — the sequence of length zero in #499 — the two drifted further apart.

The grouping now drops the whitespace between two items of a list, since the comma takes its place, and keeps only the whitespace before the first item and after the last, which separates the list from what surrounds it. A composite that produced only whitespace keeps its place, emptied, whether it sits between two items or at the end of one, so the renderers can still anchor its name there. Where the commas go among the items a list has left is decided once as well, in `listCommaPositions`, which the renderers read directly and `text` and `<math>` read through `joinListText`; neither has a join rule of its own. #499's example is a test in both pathways with one empty sequence, with two, and with a sequence that has items, which the outer list counts as one item with commas of its own; the two-sequence case is a test in the DOM as well.

## Verified

On the final tree, rebased onto `main` past #1808, #1814, and #1824, none of which has since moved into a file in this diff:

- `@doenet/utils`, `compositeLists.test.ts`: 26 passing — the shared grouping, with ranges recorded out of tree order, two ranges with the same span, an empty composite, a whitespace-only composite between two items and at the end of one, a skipped composite with a composite inside it, and the `<title>` shift.
- `@doenet/doenetml`, `composites.test.tsx`: 16 passing, including the anchor of a whitespace-only composite.
- `@doenet/doenetml-worker`, `compositeListWrapping.test.ts`: 16 passing, including the string `trimEnd` and a whitespace-only composite left out of the wrapper.
- `@doenet/doenetml-worker-javascript`, the suites that touch lists, text, math, and copying (`compositeCommas`, `text`, `select`, `collect`, `repeat`, `group`, `numberlist`, `math`, `listoperators`, `unlinked copy`): 305 passing, 1 expected fail (#1811), 4 skipped. `compositeCommas.test.tsx` holds a `<cumulativeSum>` — #1824's list operators are composites with `asList` of their own — used directly, with `asList` off, through a reference, an index, and `extend`, and inside a list group, to one expectation in both pathways.
- `renderCommas.cy.js` in the real DOM, on a fresh `test-cypress` build of the final tree: 11 passing, including `$g`, `$r[1]`, and #596's `$a[1]`.
- `build:schema` leaves `generated/` unchanged; prettier clean; `tsc` in `@doenet/utils` reports nothing in `compositeLists.ts` (its two errors are in files outside this diff), and the six errors it reports in `CompositeExpander.ts` are all in lines outside this diff.

The full worker-javascript suite (3613 passing) and the wider Cypress groups were run on the tree before the between-items fix and the review tidy-ups that follow it; CI covers them on this one.

The four Copilot reviews' points are addressed: comma placement is one pass over a list's items; a whitespace-only composite keeps its anchor but not its whitespace whether it sits between two items or at the end of one; the tree is built in one pass over the ordered ranges rather than by recursing over suffixes of the array; the FlatDast bridge trims a string that ends an item as the React renderers do; and the changeset and doc comments no longer claim the rendered list and `text` cannot differ at all.

## Follow-ups

- #1810 — `EssentialValueWriter`'s defining-child index double-counts nested ranges and skips sibling ones. Latent today; found while tracing the places that reindex the ranges.
- #1811 — whitespace inside a child component's own text, as above.
- #1812 — per-child composite provenance in place of index ranges into the parent's children, which would make the three reindexing sites one array operation and retire the sentinel for an empty composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqQEbokFDiDUN57722Ah8r
