### PR TITLE
Add sampleMultivariateRandomNumber for vector-valued sampling

### DIFF
--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -1,0 +1,19 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Add `<sampleMultivariateRandomNumber>`, which draws a vector-valued random number.
+
+Every existing sampling component produces numbers that are independent of one another. This one draws a single sample whose numbers are drawn *together*: `numInCategories` describes a population split into categories, `numDraws` items are drawn from it without replacement, and the component expands to one number per category giving how many of the drawn items came from each. The counts always sum to `numDraws`.
+
+```doenet
+<p>An urn holds 5 red, 3 blue, and 2 green marbles. Draw 4 without replacement:</p>
+<p><sampleMultivariateRandomNumber name="draw" numInCategories="5 3 2" numDraws="4" /></p>
+<p>Red: $draw[1], blue: $draw[2], green: $draw[3]</p>
+```
+
+The `numCategories`, `numTotal`, `means`, and `variances` properties describe the distribution, and the `resample` action draws a fresh set. `type` currently accepts only `hypergeometric`, leaving room for other multivariate distributions later.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -19,3 +19,5 @@ Every existing sampling component produces numbers that are independent of one a
 The `numCategories`, `numTotal`, `means`, and `variances` properties describe the distribution, and the `resample` action draws a fresh set. `type` currently accepts only `hypergeometric`, leaving room for other multivariate distributions later.
 
 Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what is wrong.
+
+Unusable parameters give `NaN` samples and statistics, and say so where the document's other warnings appear rather than only in the browser console. Because each category is drawn in turn, parameters needing more than ten million draws for a sample are refused the same way impossible ones are, instead of leaving the page unresponsive while they ran.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -12,7 +12,7 @@ Every existing sampling component produces numbers that are independent of one a
 
 ```doenet
 <p>An urn holds 5 red, 3 blue, and 2 green marbles. Draw 4 without replacement:</p>
-<p><sampleMultivariateRandomNumber name="draw" numInCategories="5 3 2" numDraws="4" /></p>
+<p><sampleMultivariateRandomNumber name="draw" type="hypergeometric" numInCategories="5 3 2" numDraws="4" /></p>
 <p>Red: $draw[1], blue: $draw[2], green: $draw[3]</p>
 ```
 

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -17,3 +17,5 @@ Every existing sampling component produces numbers that are independent of one a
 ```
 
 The `numCategories`, `numTotal`, `means`, and `variances` properties describe the distribution, and the `resample` action draws a fresh set. `type` currently accepts only `hypergeometric`, leaving room for other multivariate distributions later.
+
+Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what is wrong.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -23,3 +23,5 @@ The `numCategories`, `numTotal`, `means`, and `variances` properties describe th
 Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what to change. Because each category is drawn in turn, parameters that would need more than ten million random draws for a single sample are refused the same way, instead of leaving the page unresponsive while they ran.
 
 Counts must be whole numbers small enough to stay exact — up to about nine quadrillion. Past that the arithmetic behind the reported means overflows to infinity, so such a population is refused rather than sampled.
+
+Each category's count is drawn as a hypergeometric against the part of the population not yet accounted for, so the whole vector is drawn exactly, with no smallest probability it rounds away, for every population accepted.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -21,3 +21,5 @@ The `numCategories`, `numTotal`, `means`, and `variances` properties describe th
 `type` accepts only `hypergeometric` so far, and is required rather than defaulting to it. It is unlikely to remain the most natural default — a joint normal distribution is the more usual multivariate one — so naming the distribution in every document means adding others later cannot change what an existing document does.
 
 Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what to change. Because each category is drawn in turn, parameters that would need more than ten million random draws for a single sample are refused the same way, instead of leaving the page unresponsive while they ran.
+
+Counts must be whole numbers small enough to stay exact — up to about nine quadrillion. Past that the arithmetic behind the reported means overflows to infinity, so such a population is refused rather than sampled.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -18,6 +18,4 @@ Every existing sampling component produces numbers that are independent of one a
 
 The `numCategories`, `numTotal`, `means`, and `variances` properties describe the distribution, and the `resample` action draws a fresh set. `type` currently accepts only `hypergeometric`, leaving room for other multivariate distributions later.
 
-Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what is wrong.
-
-Unusable parameters give `NaN` samples and statistics, and say so where the document's other warnings appear rather than only in the browser console. Because each category is drawn in turn, parameters needing more than ten million draws for a sample are refused the same way impossible ones are, instead of leaving the page unresponsive while they ran.
+Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what to change. Because each category is drawn in turn, parameters that would need more than ten million random draws for a single sample are refused the same way, instead of leaving the page unresponsive while they ran.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -16,6 +16,8 @@ Every existing sampling component produces numbers that are independent of one a
 <p>Red: $draw[1], blue: $draw[2], green: $draw[3]</p>
 ```
 
-The `numCategories`, `numTotal`, `means`, and `variances` properties describe the distribution, and the `resample` action draws a fresh set. `type` currently accepts only `hypergeometric`, leaving room for other multivariate distributions later.
+The `numCategories`, `numTotal`, `means`, and `variances` properties describe the distribution, and the `resample` action draws a fresh set.
+
+`type` accepts only `hypergeometric` so far, and is required rather than defaulting to it. It is unlikely to remain the most natural default — a joint normal distribution is the more usual multivariate one — so naming the distribution in every document means adding others later cannot change what an existing document does.
 
 Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what to change. Because each category is drawn in turn, parameters that would need more than ten million random draws for a single sample are refused the same way, instead of leaving the page unresponsive while they ran.

--- a/.changeset/multivariate-random-number.md
+++ b/.changeset/multivariate-random-number.md
@@ -20,8 +20,8 @@ The `numCategories`, `numTotal`, `means`, and `variances` properties describe th
 
 `type` accepts only `hypergeometric` so far, and is required rather than defaulting to it. It is unlikely to remain the most natural default — a joint normal distribution is the more usual multivariate one — so naming the distribution in every document means adding others later cannot change what an existing document does.
 
-Invalid parameters produce `NaN` for both the samples and those properties, along with a warning describing what to change. Because each category is drawn in turn, parameters that would need more than ten million random draws for a single sample are refused the same way, instead of leaving the page unresponsive while they ran.
+Invalid parameters produce `NaN` for the samples and for `means` and `variances`, along with a warning describing what to change; `numCategories` and `numTotal` go on reporting the population the component read. Because each category is drawn in turn, parameters that could need more than ten million random draws for a single sample are refused the same way, instead of leaving the page unresponsive while they ran.
 
-Counts must be whole numbers small enough to stay exact — up to about nine quadrillion. Past that the arithmetic behind the reported means overflows to infinity, so such a population is refused rather than sampled.
+Counts must be whole numbers small enough to stay exact — each category, the population they add up to, and `numDraws` all up to about nine quadrillion. Past that, neighboring whole numbers stop being distinguishable, so drawing from such a population would not do what it says; it is refused rather than sampled.
 
 Each category's count is drawn as a hypergeometric against the part of the population not yet accounted for, so the whole vector is drawn exactly, with no smallest probability it rounds away, for every population accepted.

--- a/packages/docs-nextra/pages/reference/_meta.ts
+++ b/packages/docs-nextra/pages/reference/_meta.ts
@@ -212,6 +212,9 @@ export default {
     row_table: { title: "row (for table)" },
     rq: { title: "rq" },
     rsq: { title: "rsq" },
+    sampleMultivariateRandomNumber: {
+        title: "sampleMultivariateRandomNumber",
+    },
     samplePrimeNumbers: { title: "samplePrimeNumbers" },
     sampleRandomNumbers: { title: "sampleRandomNumbers" },
     sbsGroup: { title: "sbsGroup" },

--- a/packages/docs-nextra/pages/reference/componentTypes.mdx
+++ b/packages/docs-nextra/pages/reference/componentTypes.mdx
@@ -198,6 +198,7 @@ Mathematical content can be defined and rendered with Math Components. These com
     "periodicSet",
     "rightHandSide",
     "row (in a matrix)",
+    "sampleMultivariateRandomNumber",
     "samplePrimeNumbers",
     "sampleRandomNumbers",
     "selectFromSequence",

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -162,11 +162,17 @@ available as `means[1]`, `variances[1]`, and so on.
 ## Limits on the sample
 
 Each category is drawn in turn, so a very large draw would take a long time and leave 
-the page unresponsive while it ran. Parameters that would need more than ten million 
-random draws for a single sample are therefore treated as unusable, giving `NaN` 
-counts and statistics along with a warning explaining what to change. The limit is far 
-above the populations that arise in practice; it is there so that mistyping an extra 
-digit reports a problem instead of freezing the activity.
+the page unresponsive while it ran. Parameters that could need more than ten million 
+random draws for a single sample &mdash; counting each category at the most its draw 
+could cost &mdash; are therefore treated as unusable, giving `NaN` counts and 
+statistics along with a warning explaining what to change. The limit is far above the 
+populations that arise in practice; it is there so that mistyping an extra digit 
+reports a problem instead of freezing the activity.
+
+Counts must also stay exact. Each category, the population they add up to, and 
+`numDraws` must all be below about nine quadrillion, past which neighboring whole 
+numbers can no longer be told apart; a larger population is treated as unusable in 
+the same way.
 
 `type`, `numInCategories`, and `numDraws` have no defaults to fall back on. If any is 
 omitted, if `type` names a distribution that does not exist, or if the other two do not 

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -9,8 +9,8 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 
 <ComponentDisplay name='sampleMultivariateRandomNumber'/>
 
-`<sampleMultivariateRandomNumber/>{:dn}` draws a single *vector-valued* random number and 
-expands to one [Number](../concepts/essentialConcepts#component-types) per category. 
+`<sampleMultivariateRandomNumber/>{:dn}` draws a single *vector-valued* random number, 
+producing one [Number](../concepts/essentialConcepts#component-types) per category. 
 It differs from `<sampleRandomNumbers/>{:dn}`, where each sample is a single number drawn 
 independently of the others: here the numbers within one sample are drawn together and are 
 *not* independent of each other, since they describe how one set of draws was divided 
@@ -158,6 +158,12 @@ $n \frac{K_i}{N}\left(1 - \frac{K_i}{N}\right)\frac{N-n}{N-1}$, where $N$ is `nu
 $K_i$ is the size of category $i$, and $n$ is `numDraws`. Individual entries are 
 available as `means[1]`, `variances[1]`, and so on.
 
+Two populations are small enough that those formulas divide by zero, and both are 
+reported as the zero they describe rather than as `NaN`. A population with nothing in 
+it ($N = 0$) has every count, mean, and variance equal to zero, since there is nothing 
+to draw. A population holding a single item ($N = 1$) has zero variance, because the 
+one draw available always finds that item in the same category.
+
 
 ## Limits on the sample
 
@@ -174,11 +180,16 @@ Counts must also stay exact. Each category, the population they add up to, and
 numbers can no longer be told apart; a larger population is treated as unusable in 
 the same way.
 
-`type`, `numInCategories`, and `numDraws` have no defaults to fall back on. If any is 
-omitted, if `type` names a distribution that does not exist, or if the other two do not 
-describe a population &mdash; a category that is not a whole number, or more draws than 
-there are items &mdash; every count is `NaN`, as are the reported `means` and 
-`variances`.
+`type` and `numDraws` have no defaults to fall back on. If either is omitted, if `type` 
+names a distribution that does not exist, or if the population is not one that can be 
+drawn from &mdash; a category that is not a whole number, or more draws than there are 
+items &mdash; every count is `NaN`, as are the reported `means` and `variances`.
+
+Omitting `numInCategories` behaves differently, because the length of that list is what 
+decides how many numbers there are to report. With no categories given there is nothing 
+to sample and nothing to sample it from, so the component produces no numbers at all and 
+`means` and `variances` are both empty &mdash; not a list of `NaN`. A warning still 
+explains that the population is missing.
 
 `type` is required rather than defaulting to `hypergeometric` on purpose. It is the 
 only multivariate distribution available so far, but it is unlikely to remain the most 

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -44,10 +44,11 @@ The three numbers are the counts of each category among the drawn items, so they
 sum to `numDraws`. The number of categories &mdash; and therefore how many numbers are 
 produced &mdash; comes from the length of `numInCategories`.
 
-All three attributes are required, and the latter two must describe a population that 
-can actually be drawn from: `numInCategories` a list of non-negative whole numbers and `numDraws` a 
-non-negative whole number no larger than their sum. Anything else samples `NaN` for 
-every category, as do the `means` and `variances` properties below.
+`type`, `numInCategories`, and `numDraws` are all required, and the latter two must 
+describe a population that can actually be drawn from: `numInCategories` a list of 
+non-negative whole numbers and `numDraws` a non-negative whole number no larger than 
+their sum. Anything else samples `NaN` for every category, as do the `means` and 
+`variances` properties below.
 
 
 
@@ -168,9 +169,10 @@ above the populations that arise in practice; it is there so that mistyping an e
 digit reports a problem instead of freezing the activity.
 
 `type`, `numInCategories`, and `numDraws` have no defaults to fall back on. If any is 
-omitted, or the latter two do not describe a population &mdash; a category that is not 
-a whole number, or more draws than there are items &mdash; every count is `NaN`, as are 
-the reported `means` and `variances`.
+omitted, if `type` names a distribution that does not exist, or if the other two do not 
+describe a population &mdash; a category that is not a whole number, or more draws than 
+there are items &mdash; every count is `NaN`, as are the reported `means` and 
+`variances`.
 
 `type` is required rather than defaulting to `hypergeometric` on purpose. It is the 
 only multivariate distribution available so far, but it is unlikely to remain the most 

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -1,0 +1,148 @@
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+import { ComponentDisplay, AttrPropDisplay } from "../../components"
+
+
+
+# `<sampleMultivariateRandomNumber/>{:dn}`
+
+
+<ComponentDisplay name='sampleMultivariateRandomNumber'/>
+
+`<sampleMultivariateRandomNumber/>{:dn}` draws a single *vector-valued* random number and 
+expands to one [Number](../concepts/essentialConcepts#component-types) per category. 
+It differs from `<sampleRandomNumbers/>{:dn}`, where each sample is a single number drawn 
+independently of the others: here the numbers within one sample are drawn together and are 
+*not* independent of each other, since they describe how one set of draws was divided 
+among the categories.
+
+
+<AttrPropDisplay name='sampleMultivariateRandomNumber'/>
+
+
+## Examples
+
+### Example: Default `<sampleMultivariateRandomNumber/>{:dn}`
+
+
+```doenet-editor-horiz
+<p>An urn holds 5 red, 3 blue, and 2 green marbles. 
+  Draw 4 of them without replacement:</p>
+
+<p><sampleMultivariateRandomNumber name="draw" 
+  numInCategories="5 3 2" 
+  numDraws="4" 
+/></p>
+
+<p>Red: $draw[1], blue: $draw[2], green: $draw[3]</p>
+```
+
+
+
+The three numbers are the counts of each category among the drawn items, so they always 
+sum to `numDraws`. The number of categories &mdash; and therefore how many numbers are 
+produced &mdash; comes from the length of `numInCategories`.
+
+
+
+---
+
+### Example: Using a re-sampling button
+
+
+```doenet-editor-horiz
+<p><sampleMultivariateRandomNumber name="draw" 
+  numInCategories="5 3 2" 
+  numDraws="4" 
+/></p>
+
+<callAction actionName="resample" target="$draw">
+  <label>Draw Again</label>
+</callAction>
+```
+
+
+
+The `<callAction>{:dn}` button draws a fresh set of items from the same population.
+
+
+
+## Attribute Examples
+
+### Attribute Example: numInCategories
+
+
+```doenet-example
+<p>A committee of 3 is chosen from 4 seniors, 5 juniors, 
+  6 sophomores, and 2 first-years:</p>
+
+<p><sampleMultivariateRandomNumber name="committee" 
+  numInCategories="4 5 6 2" 
+  numDraws="3" 
+/></p>
+
+<callAction actionName="resample" target="$committee">
+  <label>Choose Again</label>
+</callAction>
+```
+
+
+
+The `numInCategories` attribute gives the number of items of each category in the 
+population. Its length determines how many numbers are sampled, so this example 
+produces four numbers.
+
+
+
+---
+
+### Attribute Example: numDraws
+
+
+```doenet-example
+<p>Draw 8 of the 10 marbles:</p>
+
+<p><sampleMultivariateRandomNumber name="draw" 
+  numInCategories="5 3 2" 
+  numDraws="8" 
+/></p>
+
+<callAction actionName="resample" target="$draw">
+  <label>Draw Again</label>
+</callAction>
+```
+
+
+
+The `numDraws` attribute sets how many items are drawn, without replacement, from the 
+whole population. Drawing all of them would always return `numInCategories` itself.
+
+
+
+## Property Examples
+
+### Property Example: means, variances
+
+
+```doenet-example
+<p><sampleMultivariateRandomNumber name="draw" 
+  numInCategories="5 3 2" 
+  numDraws="4" 
+/></p>
+
+<callAction actionName="resample" target="$draw">
+  <label>Draw Again</label>
+</callAction>
+
+<p>Expected counts: $draw.means</p>
+<p>Variances: $draw.variances</p>
+<p>Population size: $draw.numTotal, in $draw.numCategories categories</p>
+```
+
+
+
+Each category's count on its own follows a hypergeometric distribution, so `means` 
+reports $n K_i / N$ and `variances` reports 
+$n \frac{K_i}{N}\left(1 - \frac{K_i}{N}\right)\frac{N-n}{N-1}$, where $N$ is `numTotal`, 
+$K_i$ is the size of category $i$, and $n$ is `numDraws`. Individual entries are 
+available as `means[1]`, `variances[1]`, and so on.

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -22,7 +22,7 @@ among the categories.
 
 ## Examples
 
-### Example: Default `<sampleMultivariateRandomNumber/>{:dn}`
+### Example: Basic use
 
 
 ```doenet-editor-horiz
@@ -42,6 +42,11 @@ among the categories.
 The three numbers are the counts of each category among the drawn items, so they always 
 sum to `numDraws`. The number of categories &mdash; and therefore how many numbers are 
 produced &mdash; comes from the length of `numInCategories`.
+
+Both attributes are required, and they must describe a population that can actually be 
+drawn from: `numInCategories` a list of non-negative whole numbers and `numDraws` a 
+non-negative whole number no larger than their sum. Anything else samples `NaN` for 
+every category, as do the `means` and `variances` properties below.
 
 
 

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -173,7 +173,12 @@ random draws for a single sample &mdash; counting each category at the most its 
 could cost &mdash; are therefore treated as unusable, giving `NaN` counts and 
 statistics along with a warning explaining what to change. The limit is far above the 
 populations that arise in practice; it is there so that mistyping an extra digit 
-reports a problem instead of freezing the activity.
+reports a problem instead of freezing the activity. An order of magnitude below that, 
+from a million draws for a single sample, the sample is still drawn as asked, but a 
+warning notes that sampling may be slow. The two figures are the same ones 
+`<sampleRandomNumbers/>{:dn}` applies to its discrete distributions, and the estimate 
+they are compared against counts each category at the most its draw could cost, so a 
+sample that turns out cheaper than feared can still be the one warned about.
 
 Counts must also stay exact. Each category, the population they add up to, and 
 `numDraws` must all be below about nine quadrillion, past which neighboring whole 

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -30,6 +30,7 @@ among the categories.
   Draw 4 of them without replacement:</p>
 
 <p><sampleMultivariateRandomNumber name="draw" 
+  type="hypergeometric"
   numInCategories="5 3 2" 
   numDraws="4" 
 /></p>
@@ -43,8 +44,8 @@ The three numbers are the counts of each category among the drawn items, so they
 sum to `numDraws`. The number of categories &mdash; and therefore how many numbers are 
 produced &mdash; comes from the length of `numInCategories`.
 
-Both attributes are required, and they must describe a population that can actually be 
-drawn from: `numInCategories` a list of non-negative whole numbers and `numDraws` a 
+All three attributes are required, and the latter two must describe a population that 
+can actually be drawn from: `numInCategories` a list of non-negative whole numbers and `numDraws` a 
 non-negative whole number no larger than their sum. Anything else samples `NaN` for 
 every category, as do the `means` and `variances` properties below.
 
@@ -57,6 +58,7 @@ every category, as do the `means` and `variances` properties below.
 
 ```doenet-editor-horiz
 <p><sampleMultivariateRandomNumber name="draw" 
+  type="hypergeometric"
   numInCategories="5 3 2" 
   numDraws="4" 
 /></p>
@@ -82,6 +84,7 @@ The `<callAction>{:dn}` button draws a fresh set of items from the same populati
   6 sophomores, and 2 first-years:</p>
 
 <p><sampleMultivariateRandomNumber name="committee" 
+  type="hypergeometric"
   numInCategories="4 5 6 2" 
   numDraws="3" 
 /></p>
@@ -108,6 +111,7 @@ produces four numbers.
 <p>Draw 8 of the 10 marbles:</p>
 
 <p><sampleMultivariateRandomNumber name="draw" 
+  type="hypergeometric"
   numInCategories="5 3 2" 
   numDraws="8" 
 /></p>
@@ -131,6 +135,7 @@ whole population. Drawing all of them would always return `numInCategories` itse
 
 ```doenet-example
 <p><sampleMultivariateRandomNumber name="draw" 
+  type="hypergeometric"
   numInCategories="5 3 2" 
   numDraws="4" 
 /></p>
@@ -162,7 +167,13 @@ counts and statistics along with a warning explaining what to change. The limit 
 above the populations that arise in practice; it is there so that mistyping an extra 
 digit reports a problem instead of freezing the activity.
 
-`numInCategories` and `numDraws` have no defaults to fall back on. If either is 
-omitted, or they do not describe a population &mdash; a category that is not a whole 
-number, or more draws than there are items &mdash; every count is `NaN`, as are the 
-reported `means` and `variances`.
+`type`, `numInCategories`, and `numDraws` have no defaults to fall back on. If any is 
+omitted, or the latter two do not describe a population &mdash; a category that is not 
+a whole number, or more draws than there are items &mdash; every count is `NaN`, as are 
+the reported `means` and `variances`.
+
+`type` is required rather than defaulting to `hypergeometric` on purpose. It is the 
+only multivariate distribution available so far, but it is unlikely to remain the most 
+natural default &mdash; a joint normal distribution is the more usual multivariate one. 
+Naming the distribution in every document means adding others later cannot change what 
+an existing document does.

--- a/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
+++ b/packages/docs-nextra/pages/reference/sampleMultivariateRandomNumber.mdx
@@ -151,3 +151,18 @@ reports $n K_i / N$ and `variances` reports
 $n \frac{K_i}{N}\left(1 - \frac{K_i}{N}\right)\frac{N-n}{N-1}$, where $N$ is `numTotal`, 
 $K_i$ is the size of category $i$, and $n$ is `numDraws`. Individual entries are 
 available as `means[1]`, `variances[1]`, and so on.
+
+
+## Limits on the sample
+
+Each category is drawn in turn, so a very large draw would take a long time and leave 
+the page unresponsive while it ran. Parameters that would need more than ten million 
+random draws for a single sample are therefore treated as unusable, giving `NaN` 
+counts and statistics along with a warning explaining what to change. The limit is far 
+above the populations that arise in practice; it is there so that mistyping an extra 
+digit reports a problem instead of freezing the activity.
+
+`numInCategories` and `numDraws` have no defaults to fall back on. If either is 
+omitted, or they do not describe a population &mdash; a category that is not a whole 
+number, or more draws than there are items &mdash; every count is `NaN`, as are the 
+reported `means` and `variances`.

--- a/packages/doenetml-worker-javascript/src/ComponentTypes.js
+++ b/packages/doenetml-worker-javascript/src/ComponentTypes.js
@@ -121,6 +121,7 @@ import AnimateFromSequence from "./components/AnimateFromSequence";
 import Evaluate from "./components/Evaluate";
 import SelectRandomNumbers from "./components/SelectRandomNumbers";
 import SampleRandomNumbers from "./components/SampleRandomNumbers";
+import SampleMultivariateRandomNumber from "./components/SampleMultivariateRandomNumber";
 import SelectPrimeNumbers from "./components/SelectPrimeNumbers";
 import SamplePrimeNumbers from "./components/SamplePrimeNumbers";
 import Substitute from "./components/Substitute";
@@ -329,6 +330,7 @@ const componentTypeArray = [
     Evaluate,
     SelectRandomNumbers,
     SampleRandomNumbers,
+    SampleMultivariateRandomNumber,
     SelectPrimeNumbers,
     SamplePrimeNumbers,
     Substitute,

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -1,4 +1,5 @@
 import {
+    multivariateSamplingDiagnostics,
     sampleFromMultivariateDistribution,
     validMultivariateHypergeometricParameters,
 } from "../utils/randomNumbers";
@@ -340,8 +341,15 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                     Object.keys(changes).length === 0 ||
                     justUpdatedForNewComponent
                 ) {
+                    // Keep the counts, but re-check the parameters: they have not
+                    // changed, so whatever was wrong with them still is, and an
+                    // author who reloads a document should not lose the explanation
+                    // for why its counts are NaN. This draws nothing, so a variant
+                    // stays reproducible.
                     return {
                         useEssentialOrDefaultValue: { sampledValues: true },
+                        sendDiagnostics:
+                            multivariateSamplingDiagnostics(dependencyValues),
                     };
                 }
 

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -40,11 +40,18 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
         // possible types
         // hypergeometric: determined by numInCategories and numDraws
 
+        // Deliberately has no default. `hypergeometric` is the only distribution
+        // implemented so far, but it is unlikely to stay the most natural default —
+        // a joint gaussian is the more usual multivariate distribution. Defaulting
+        // to one now would let documents come to rely on it, and any later change
+        // would silently reinterpret them. Requiring the attribute keeps that door
+        // open at the cost of one word in every document.
         attributes.type = {
-            description: "Multivariate distribution from which to sample.",
+            description:
+                "Multivariate distribution from which to sample. Required; there is no default.",
             createComponentOfType: "text",
             createStateVariable: "type",
-            defaultValue: "hypergeometric",
+            defaultValue: null,
             public: true,
             toLowerCase: true,
             validValues: [
@@ -163,6 +170,10 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             returnArrayDependenciesByKey() {
                 return {
                     globalDependencies: {
+                        type: {
+                            dependencyType: "stateVariable",
+                            variableName: "type",
+                        },
                         numInCategories: {
                             dependencyType: "stateVariable",
                             variableName: "numInCategories",
@@ -185,10 +196,14 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                 const n = globalDependencyValues.numDraws;
 
                 // parameters that describe no distribution have no moments either,
-                // so report the NaN that their samples report
-                const valid = validMultivariateHypergeometricParameters(
-                    globalDependencyValues,
-                );
+                // so report the NaN that their samples report. These formulas are
+                // the hypergeometric's; with no distribution named there is nothing
+                // to compute, and another distribution will bring its own branch.
+                const valid =
+                    globalDependencyValues.type === "hypergeometric" &&
+                    validMultivariateHypergeometricParameters(
+                        globalDependencyValues,
+                    );
 
                 for (let arrayKey of arrayKeys) {
                     if (!valid) {
@@ -233,6 +248,10 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             returnArrayDependenciesByKey() {
                 return {
                     globalDependencies: {
+                        type: {
+                            dependencyType: "stateVariable",
+                            variableName: "type",
+                        },
                         numInCategories: {
                             dependencyType: "stateVariable",
                             variableName: "numInCategories",
@@ -254,9 +273,11 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                 const N = globalDependencyValues.numTotal;
                 const n = globalDependencyValues.numDraws;
 
-                const valid = validMultivariateHypergeometricParameters(
-                    globalDependencyValues,
-                );
+                const valid =
+                    globalDependencyValues.type === "hypergeometric" &&
+                    validMultivariateHypergeometricParameters(
+                        globalDependencyValues,
+                    );
 
                 for (let arrayKey of arrayKeys) {
                     if (!valid) {

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -1,0 +1,675 @@
+import { sampleMultivariateHypergeometric } from "../utils/randomNumbers";
+import { returnNumberDisplayAttributes } from "../utils/numberDisplay";
+import { setUpVariantSeedAndRng } from "../utils/variants";
+import CompositeComponent from "./abstract/CompositeComponent";
+import { convertUnresolvedAttributesForComponentType } from "../utils/dast/convertNormalizedDast";
+
+export default class SampleMultivariateRandomNumber extends CompositeComponent {
+    constructor(args) {
+        super(args);
+
+        Object.assign(this.actions, {
+            resample: this.resample.bind(this),
+        });
+    }
+
+    static componentType = "sampleMultivariateRandomNumber";
+
+    static componentDocs = {
+        summary:
+            "Samples a single vector-valued random number from a multivariate distribution, expanding to one number per category",
+    };
+
+    static takesIndex = true;
+
+    static allowInSchemaAsComponent = ["number"];
+
+    static createsVariants = true;
+
+    static stateVariableToEvaluateAfterReplacements =
+        "readyToExpandWhenResolved";
+
+    static processWhenJustUpdatedForNewComponent = true;
+
+    static createAttributesObject() {
+        let attributes = super.createAttributesObject();
+
+        // possible types
+        // hypergeometric: determined by numInCategories and numDraws
+
+        attributes.type = {
+            description: "Multivariate distribution from which to sample.",
+            createComponentOfType: "text",
+            createStateVariable: "type",
+            defaultValue: "hypergeometric",
+            public: true,
+            toLowerCase: true,
+            validValues: [
+                {
+                    value: "hypergeometric",
+                    description:
+                        "Number of items of each category obtained when drawing `numDraws` items without replacement from a population partitioned into categories of the sizes given by `numInCategories`.",
+                },
+            ],
+        };
+
+        attributes.numInCategories = {
+            createComponentOfType: "numberList",
+            createStateVariable: "numInCategories",
+            defaultValue: [],
+            public: true,
+            description:
+                "Number of items of each category in the population drawn from. Its length determines how many numbers are sampled.",
+        };
+
+        attributes.numDraws = {
+            createComponentOfType: "number",
+            createStateVariable: "numDraws",
+            defaultValue: null,
+            public: true,
+            description:
+                "Number of items drawn without replacement from the population.",
+        };
+
+        const numberDisplayAttrs = returnNumberDisplayAttributes();
+        for (let attrName in numberDisplayAttrs) {
+            attributes[attrName] = {
+                leaveRaw: true,
+                description: numberDisplayAttrs[attrName].description,
+            };
+        }
+
+        attributes.variantDeterminesSeed = {
+            description:
+                "Whether the document's variant index determines the random seed.",
+            createPrimitiveOfType: "boolean",
+            createStateVariable: "variantDeterminesSeed",
+            defaultPrimitiveValue: false,
+            public: true,
+        };
+
+        attributes.asList = {
+            createPrimitiveOfType: "boolean",
+            createStateVariable: "asList",
+            defaultValue: true,
+            description:
+                "Whether to render the items separated by commas (true) or with no separator (false).",
+        };
+
+        return attributes;
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        stateVariableDefinitions.numCategories = {
+            description:
+                "Number of categories the population is partitioned into, which is how many numbers are sampled.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "integer",
+            },
+            additionalStateVariablesDefined: [
+                {
+                    variableName: "numTotal",
+                    public: true,
+                    shadowingInstructions: {
+                        createComponentOfType: "number",
+                    },
+                    description:
+                        "Total number of items in the population drawn from, i.e. the sum of `numInCategories`.",
+                },
+            ],
+            returnDependencies: () => ({
+                numInCategories: {
+                    dependencyType: "stateVariable",
+                    variableName: "numInCategories",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        numCategories: dependencyValues.numInCategories.length,
+                        numTotal: dependencyValues.numInCategories.reduce(
+                            (a, c) => a + c,
+                            0,
+                        ),
+                    },
+                };
+            },
+        };
+
+        // Whether the parameters describe a distribution we can actually sample
+        // from. Computed once here so that the sampler, the statistics, and the
+        // replacements all agree on what counts as valid.
+        stateVariableDefinitions.validParameters = {
+            returnDependencies: () => ({
+                type: {
+                    dependencyType: "stateVariable",
+                    variableName: "type",
+                },
+                numInCategories: {
+                    dependencyType: "stateVariable",
+                    variableName: "numInCategories",
+                },
+                numDraws: {
+                    dependencyType: "stateVariable",
+                    variableName: "numDraws",
+                },
+                numTotal: {
+                    dependencyType: "stateVariable",
+                    variableName: "numTotal",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const validParameters =
+                    dependencyValues.numInCategories.length > 0 &&
+                    dependencyValues.numInCategories.every(
+                        (x) => Number.isInteger(x) && x >= 0,
+                    ) &&
+                    Number.isInteger(dependencyValues.numDraws) &&
+                    dependencyValues.numDraws >= 0 &&
+                    dependencyValues.numDraws <= dependencyValues.numTotal;
+
+                return { setValue: { validParameters } };
+            },
+        };
+
+        stateVariableDefinitions.means = {
+            description:
+                "Expected number of items sampled from each category, i.e. `numDraws * numInCategories[i] / numTotal`.",
+            isArray: true,
+            entryPrefixes: ["mean"],
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "number",
+            },
+            returnArraySizeDependencies: () => ({
+                numCategories: {
+                    dependencyType: "stateVariable",
+                    variableName: "numCategories",
+                },
+            }),
+            returnArraySize({ dependencyValues }) {
+                return [dependencyValues.numCategories];
+            },
+            returnArrayDependenciesByKey() {
+                return {
+                    globalDependencies: {
+                        numInCategories: {
+                            dependencyType: "stateVariable",
+                            variableName: "numInCategories",
+                        },
+                        numDraws: {
+                            dependencyType: "stateVariable",
+                            variableName: "numDraws",
+                        },
+                        numTotal: {
+                            dependencyType: "stateVariable",
+                            variableName: "numTotal",
+                        },
+                        validParameters: {
+                            dependencyType: "stateVariable",
+                            variableName: "validParameters",
+                        },
+                    },
+                };
+            },
+            arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
+                let means = {};
+
+                for (let arrayKey of arrayKeys) {
+                    if (!globalDependencyValues.validParameters) {
+                        means[arrayKey] = NaN;
+                        continue;
+                    }
+                    means[arrayKey] =
+                        (globalDependencyValues.numDraws *
+                            globalDependencyValues.numInCategories[arrayKey]) /
+                        globalDependencyValues.numTotal;
+                }
+
+                return { setValue: { means } };
+            },
+        };
+
+        stateVariableDefinitions.variances = {
+            description:
+                "Variance of the number of items sampled from each category.",
+            isArray: true,
+            entryPrefixes: ["variance"],
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "number",
+            },
+            returnArraySizeDependencies: () => ({
+                numCategories: {
+                    dependencyType: "stateVariable",
+                    variableName: "numCategories",
+                },
+            }),
+            returnArraySize({ dependencyValues }) {
+                return [dependencyValues.numCategories];
+            },
+            returnArrayDependenciesByKey() {
+                return {
+                    globalDependencies: {
+                        numInCategories: {
+                            dependencyType: "stateVariable",
+                            variableName: "numInCategories",
+                        },
+                        numDraws: {
+                            dependencyType: "stateVariable",
+                            variableName: "numDraws",
+                        },
+                        numTotal: {
+                            dependencyType: "stateVariable",
+                            variableName: "numTotal",
+                        },
+                        validParameters: {
+                            dependencyType: "stateVariable",
+                            variableName: "validParameters",
+                        },
+                    },
+                };
+            },
+            arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
+                let variances = {};
+
+                const N = globalDependencyValues.numTotal;
+                const n = globalDependencyValues.numDraws;
+
+                for (let arrayKey of arrayKeys) {
+                    if (!globalDependencyValues.validParameters) {
+                        variances[arrayKey] = NaN;
+                        continue;
+                    }
+
+                    // each category's marginal count is univariate hypergeometric,
+                    // so it carries the same finite population correction;
+                    // a population of one item leaves nothing to vary
+                    if (N > 1) {
+                        const p =
+                            globalDependencyValues.numInCategories[arrayKey] /
+                            N;
+                        variances[arrayKey] =
+                            (n * p * (1 - p) * (N - n)) / (N - 1);
+                    } else {
+                        variances[arrayKey] = 0;
+                    }
+                }
+
+                return { setValue: { variances } };
+            },
+        };
+
+        stateVariableDefinitions.sampledValues = {
+            shadowVariable: true,
+            hasEssential: true,
+            stateVariablesDeterminingDependencies: ["variantDeterminesSeed"],
+            returnDependencies({ stateValues, sharedParameters }) {
+                let dependencies = {
+                    type: {
+                        dependencyType: "stateVariable",
+                        variableName: "type",
+                    },
+                    numInCategories: {
+                        dependencyType: "stateVariable",
+                        variableName: "numInCategories",
+                    },
+                    numDraws: {
+                        dependencyType: "stateVariable",
+                        variableName: "numDraws",
+                    },
+                    numCategories: {
+                        dependencyType: "stateVariable",
+                        variableName: "numCategories",
+                    },
+                    validParameters: {
+                        dependencyType: "stateVariable",
+                        variableName: "validParameters",
+                    },
+                };
+                if (stateValues.variantDeterminesSeed) {
+                    dependencies.rng = {
+                        dependencyType: "value",
+                        value: sharedParameters.variantRng,
+                        doNotProxy: true,
+                    };
+                } else {
+                    dependencies.rng = {
+                        dependencyType: "value",
+                        value: sharedParameters.rngWithDateSeed,
+                        doNotProxy: true,
+                    };
+                }
+                return dependencies;
+            },
+            definition({
+                dependencyValues,
+                changes,
+                justUpdatedForNewComponent,
+            }) {
+                // if loaded in values from database (justUpdatedForNewComponent)
+                // or just resampled values from action (in which case there will be no changes)
+                // then don't resample the values but just use the current ones
+                if (
+                    Object.keys(changes).length === 0 ||
+                    justUpdatedForNewComponent
+                ) {
+                    return {
+                        useEssentialOrDefaultValue: { sampledValues: true },
+                    };
+                }
+
+                let sampledValues =
+                    sampleFromMultivariateDistribution(dependencyValues);
+
+                return {
+                    setEssentialValue: { sampledValues },
+                    setValue: { sampledValues },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "sampledValues",
+                            value: desiredStateVariableValues.sampledValues,
+                        },
+                    ],
+                };
+            },
+        };
+
+        stateVariableDefinitions.readyToExpandWhenResolved = {
+            returnDependencies: () => ({
+                sampledValues: {
+                    dependencyType: "stateVariable",
+                    variableName: "sampledValues",
+                },
+            }),
+            markStale: () => ({ updateReplacements: true }),
+            definition: function () {
+                return { setValue: { readyToExpandWhenResolved: true } };
+            },
+        };
+
+        stateVariableDefinitions.isVariantComponent = {
+            returnDependencies: () => ({}),
+            definition: () => ({ setValue: { isVariantComponent: true } }),
+        };
+
+        stateVariableDefinitions.generatedVariantInfo = {
+            returnDependencies: ({ sharedParameters }) => ({
+                variantSeed: {
+                    dependencyType: "value",
+                    value: sharedParameters.variantSeed,
+                },
+            }),
+            definition({ dependencyValues, componentIdx }) {
+                let generatedVariantInfo = {
+                    seed: dependencyValues.variantSeed,
+                    meta: {
+                        createdBy: componentIdx,
+                    },
+                };
+
+                return {
+                    setValue: {
+                        generatedVariantInfo,
+                    },
+                };
+            },
+        };
+
+        return stateVariableDefinitions;
+    }
+
+    static async createSerializedReplacements({
+        component,
+        componentInfoObjects,
+        startNum = 0,
+        nComponents,
+        workspace,
+    }) {
+        if (workspace.replacementsCreated === undefined) {
+            workspace.replacementsCreated = 0;
+        }
+
+        const stateIdInfo = {
+            prefix: `${component.stateId}|`,
+            num: workspace.replacementsCreated,
+        };
+
+        let diagnostics = [];
+
+        let attributesToConvert = {};
+        for (let attr of Object.keys(returnNumberDisplayAttributes())) {
+            if (attr in component.attributes) {
+                attributesToConvert[attr] = component.attributes[attr];
+            }
+        }
+
+        let replacements = [];
+
+        for (let value of (await component.stateValues.sampledValues).slice(
+            startNum,
+        )) {
+            let attributesFromComposite = {};
+
+            if (Object.keys(attributesToConvert).length > 0) {
+                const res = convertUnresolvedAttributesForComponentType({
+                    attributes: attributesToConvert,
+                    componentType: "number",
+                    componentInfoObjects,
+                    nComponents,
+                    stateIdInfo,
+                });
+
+                attributesFromComposite = res.attributes;
+                nComponents = res.nComponents;
+            }
+
+            replacements.push({
+                type: "serialized",
+                componentType: "number",
+                componentIdx: nComponents++,
+                stateId: `${stateIdInfo.prefix}${stateIdInfo.num++}`,
+                attributes: attributesFromComposite,
+                state: { value, fixed: true },
+                doenetAttributes: {},
+                children: [],
+            });
+        }
+
+        workspace.replacementsCreated = stateIdInfo.num;
+
+        return {
+            replacements,
+            diagnostics,
+            nComponents,
+        };
+    }
+
+    static async calculateReplacementChanges({
+        component,
+        componentInfoObjects,
+        nComponents,
+        workspace,
+    }) {
+        let diagnostics = [];
+
+        let replacementChanges = [];
+
+        let sampledValues = await component.stateValues.sampledValues;
+
+        // if have fewer results than replacements, adjust replacementsToWithhold
+        if (sampledValues.length < component.replacements.length) {
+            let numberToWithhold =
+                component.replacements.length - sampledValues.length;
+
+            if (numberToWithhold !== component.replacementsToWithhold) {
+                let replacementInstruction = {
+                    changeType: "changeReplacementsToWithhold",
+                    replacementsToWithhold: numberToWithhold,
+                };
+                replacementChanges.push(replacementInstruction);
+            }
+        } else {
+            // need to reuse all previous samples, don't withhold any
+            if (component.replacementsToWithhold > 0) {
+                let replacementInstruction = {
+                    changeType: "changeReplacementsToWithhold",
+                    replacementsToWithhold: 0,
+                };
+                replacementChanges.push(replacementInstruction);
+            }
+
+            if (sampledValues.length > component.replacements.length) {
+                let result = await this.createSerializedReplacements({
+                    component,
+                    componentInfoObjects,
+                    startNum: component.replacements.length,
+                    nComponents,
+                    workspace,
+                });
+                diagnostics.push(...result.diagnostics);
+                nComponents = result.nComponents;
+
+                let replacementInstruction = {
+                    changeType: "add",
+                    changeTopLevelReplacements: true,
+                    firstReplacementInd: component.replacements.length,
+                    numberReplacementsToReplace: 0,
+                    serializedReplacements: result.replacements,
+                };
+                replacementChanges.push(replacementInstruction);
+            }
+        }
+
+        // update values of the remainder of the replacements
+        let numUpdate = Math.min(
+            component.replacements.length,
+            sampledValues.length,
+        );
+
+        for (let ind = 0; ind < numUpdate; ind++) {
+            let replacementInstruction = {
+                changeType: "updateStateVariables",
+                component: component.replacements[ind],
+                stateChanges: { value: sampledValues[ind] },
+            };
+            replacementChanges.push(replacementInstruction);
+        }
+
+        return { replacementChanges, diagnostics, nComponents };
+    }
+
+    static setUpVariant({
+        serializedComponent,
+        sharedParameters,
+        descendantVariantComponents,
+    }) {
+        setUpVariantSeedAndRng({
+            serializedComponent,
+            sharedParameters,
+            descendantVariantComponents,
+        });
+
+        // seed from date plus a few digits from variant
+        let seedForRandomNumbers =
+            sharedParameters.variantRng().toString().slice(2, 8) + +new Date();
+        sharedParameters.rngWithDateSeed = new sharedParameters.rngClass(
+            seedForRandomNumbers,
+        );
+    }
+
+    static determineNumberOfUniqueVariants({
+        serializedComponent,
+        componentInfoObjects,
+        infoDiagnostics,
+    }) {
+        let variantDeterminesSeed =
+            serializedComponent.attributes.variantDeterminesSeed.primitive
+                .value;
+
+        if (variantDeterminesSeed) {
+            return { success: false };
+        } else {
+            return super.determineNumberOfUniqueVariants({
+                serializedComponent,
+                componentInfoObjects,
+                infoDiagnostics,
+            });
+        }
+    }
+
+    async resample({
+        actionId,
+        sourceInformation = {},
+        skipRendererUpdate = false,
+    }) {
+        let sampledValues = sampleFromMultivariateDistribution({
+            type: await this.stateValues.type,
+            numInCategories: await this.stateValues.numInCategories,
+            numDraws: await this.stateValues.numDraws,
+            numCategories: await this.stateValues.numCategories,
+            validParameters: await this.stateValues.validParameters,
+            rng: (await this.stateValues.variantDeterminesSeed)
+                ? this.sharedParameters.variantRng
+                : this.sharedParameters.rngWithDateSeed,
+        });
+
+        return await this.coreFunctions.performUpdate({
+            updateInstructions: [
+                {
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "sampledValues",
+                    value: sampledValues,
+                },
+            ],
+            actionId,
+            sourceInformation,
+            skipRendererUpdate,
+        });
+    }
+}
+
+/**
+ * Dispatch on `type` to draw one vector-valued sample, returning one number per
+ * category. Kept beside the component rather than in `utils/randomNumbers.js` because
+ * it deals in resolved state-variable values; the distributions themselves live there.
+ */
+function sampleFromMultivariateDistribution({
+    type,
+    numInCategories,
+    numDraws,
+    numCategories,
+    validParameters,
+    rng,
+}) {
+    if (!validParameters) {
+        console.warn(
+            "Invalid numInCategories (" +
+                numInCategories +
+                ") or numDraws (" +
+                numDraws +
+                ") for a multivariate " +
+                type +
+                " random variable. numInCategories must be a non-empty list of non-negative integers, and numDraws must be a non-negative integer no larger than their sum.",
+        );
+
+        return Array(numCategories).fill(NaN);
+    }
+
+    // only "hypergeometric" is currently offered, and the attribute's validValues
+    // keep any other type from reaching here
+    return sampleMultivariateHypergeometric({
+        numInCategories,
+        numDraws,
+        rng,
+    });
+}

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -181,6 +181,9 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
                 let means = {};
 
+                const N = globalDependencyValues.numTotal;
+                const n = globalDependencyValues.numDraws;
+
                 // parameters that describe no distribution have no moments either,
                 // so report the NaN that their samples report
                 const valid = validMultivariateHypergeometricParameters(
@@ -188,13 +191,21 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                 );
 
                 for (let arrayKey of arrayKeys) {
-                    means[arrayKey] = valid
-                        ? (globalDependencyValues.numDraws *
-                              globalDependencyValues.numInCategories[
-                                  arrayKey
-                              ]) /
-                          globalDependencyValues.numTotal
-                        : NaN;
+                    if (!valid) {
+                        means[arrayKey] = NaN;
+                    } else if (N > 0) {
+                        means[arrayKey] =
+                            (n *
+                                globalDependencyValues.numInCategories[
+                                    arrayKey
+                                ]) /
+                            N;
+                    } else {
+                        // every category of an empty population is empty, and the
+                        // only valid draw from it is the empty one, so `n K_i / N`
+                        // is 0/0 for a count that is determined to be zero
+                        means[arrayKey] = 0;
+                    }
                 }
 
                 return { setValue: { means } };
@@ -254,8 +265,9 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                     }
 
                     // each category's marginal count is univariate hypergeometric,
-                    // so it carries the same finite population correction;
-                    // a population of one item leaves nothing to vary
+                    // so it carries the same finite population correction, whose
+                    // (N - n) / (N - 1) is 0/0 for a population of at most one
+                    // item — which is determined, and so has variance 0
                     if (N > 1) {
                         const p =
                             globalDependencyValues.numInCategories[arrayKey] /

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -1,4 +1,7 @@
-import { sampleMultivariateHypergeometric } from "../utils/randomNumbers";
+import {
+    sampleFromMultivariateDistribution,
+    validMultivariateHypergeometricParameters,
+} from "../utils/randomNumbers";
 import { returnNumberDisplayAttributes } from "../utils/numberDisplay";
 import { setUpVariantSeedAndRng } from "../utils/variants";
 import CompositeComponent from "./abstract/CompositeComponent";
@@ -139,42 +142,6 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             },
         };
 
-        // Whether the parameters describe a distribution we can actually sample
-        // from. Computed once here so that the sampler, the statistics, and the
-        // replacements all agree on what counts as valid.
-        stateVariableDefinitions.validParameters = {
-            returnDependencies: () => ({
-                type: {
-                    dependencyType: "stateVariable",
-                    variableName: "type",
-                },
-                numInCategories: {
-                    dependencyType: "stateVariable",
-                    variableName: "numInCategories",
-                },
-                numDraws: {
-                    dependencyType: "stateVariable",
-                    variableName: "numDraws",
-                },
-                numTotal: {
-                    dependencyType: "stateVariable",
-                    variableName: "numTotal",
-                },
-            }),
-            definition({ dependencyValues }) {
-                const validParameters =
-                    dependencyValues.numInCategories.length > 0 &&
-                    dependencyValues.numInCategories.every(
-                        (x) => Number.isInteger(x) && x >= 0,
-                    ) &&
-                    Number.isInteger(dependencyValues.numDraws) &&
-                    dependencyValues.numDraws >= 0 &&
-                    dependencyValues.numDraws <= dependencyValues.numTotal;
-
-                return { setValue: { validParameters } };
-            },
-        };
-
         stateVariableDefinitions.means = {
             description:
                 "Expected number of items sampled from each category, i.e. `numDraws * numInCategories[i] / numTotal`.",
@@ -208,25 +175,26 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                             dependencyType: "stateVariable",
                             variableName: "numTotal",
                         },
-                        validParameters: {
-                            dependencyType: "stateVariable",
-                            variableName: "validParameters",
-                        },
                     },
                 };
             },
             arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
                 let means = {};
 
+                // parameters that describe no distribution have no moments either,
+                // so report the NaN that their samples report
+                const valid = validMultivariateHypergeometricParameters(
+                    globalDependencyValues,
+                );
+
                 for (let arrayKey of arrayKeys) {
-                    if (!globalDependencyValues.validParameters) {
-                        means[arrayKey] = NaN;
-                        continue;
-                    }
-                    means[arrayKey] =
-                        (globalDependencyValues.numDraws *
-                            globalDependencyValues.numInCategories[arrayKey]) /
-                        globalDependencyValues.numTotal;
+                    means[arrayKey] = valid
+                        ? (globalDependencyValues.numDraws *
+                              globalDependencyValues.numInCategories[
+                                  arrayKey
+                              ]) /
+                          globalDependencyValues.numTotal
+                        : NaN;
                 }
 
                 return { setValue: { means } };
@@ -266,10 +234,6 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                             dependencyType: "stateVariable",
                             variableName: "numTotal",
                         },
-                        validParameters: {
-                            dependencyType: "stateVariable",
-                            variableName: "validParameters",
-                        },
                     },
                 };
             },
@@ -279,8 +243,12 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                 const N = globalDependencyValues.numTotal;
                 const n = globalDependencyValues.numDraws;
 
+                const valid = validMultivariateHypergeometricParameters(
+                    globalDependencyValues,
+                );
+
                 for (let arrayKey of arrayKeys) {
-                    if (!globalDependencyValues.validParameters) {
+                    if (!valid) {
                         variances[arrayKey] = NaN;
                         continue;
                     }
@@ -320,14 +288,6 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                     numDraws: {
                         dependencyType: "stateVariable",
                         variableName: "numDraws",
-                    },
-                    numCategories: {
-                        dependencyType: "stateVariable",
-                        variableName: "numCategories",
-                    },
-                    validParameters: {
-                        dependencyType: "stateVariable",
-                        variableName: "validParameters",
                     },
                 };
                 if (stateValues.variantDeterminesSeed) {
@@ -615,8 +575,6 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             type: await this.stateValues.type,
             numInCategories: await this.stateValues.numInCategories,
             numDraws: await this.stateValues.numDraws,
-            numCategories: await this.stateValues.numCategories,
-            validParameters: await this.stateValues.validParameters,
             rng: (await this.stateValues.variantDeterminesSeed)
                 ? this.sharedParameters.variantRng
                 : this.sharedParameters.rngWithDateSeed,
@@ -636,40 +594,4 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             skipRendererUpdate,
         });
     }
-}
-
-/**
- * Dispatch on `type` to draw one vector-valued sample, returning one number per
- * category. Kept beside the component rather than in `utils/randomNumbers.js` because
- * it deals in resolved state-variable values; the distributions themselves live there.
- */
-function sampleFromMultivariateDistribution({
-    type,
-    numInCategories,
-    numDraws,
-    numCategories,
-    validParameters,
-    rng,
-}) {
-    if (!validParameters) {
-        console.warn(
-            "Invalid numInCategories (" +
-                numInCategories +
-                ") or numDraws (" +
-                numDraws +
-                ") for a multivariate " +
-                type +
-                " random variable. numInCategories must be a non-empty list of non-negative integers, and numDraws must be a non-negative integer no larger than their sum.",
-        );
-
-        return Array(numCategories).fill(NaN);
-    }
-
-    // only "hypergeometric" is currently offered, and the attribute's validValues
-    // keep any other type from reaching here
-    return sampleMultivariateHypergeometric({
-        numInCategories,
-        numDraws,
-        rng,
-    });
 }

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -334,12 +334,13 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                     };
                 }
 
-                let sampledValues =
+                const { sampledValues, diagnostics } =
                     sampleFromMultivariateDistribution(dependencyValues);
 
                 return {
                     setEssentialValue: { sampledValues },
                     setValue: { sampledValues },
+                    sendDiagnostics: diagnostics,
                 };
             },
             inverseDefinition({ desiredStateVariableValues }) {
@@ -583,7 +584,10 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
         sourceInformation = {},
         skipRendererUpdate = false,
     }) {
-        let sampledValues = sampleFromMultivariateDistribution({
+        // Any diagnostic these parameters raise was already sent when `sampledValues`
+        // was first computed, and resampling cannot change them, so there is nothing
+        // new to report here — and an action has no `sendDiagnostics` in any case.
+        const { sampledValues } = sampleFromMultivariateDistribution({
             type: await this.stateValues.type,
             numInCategories: await this.stateValues.numInCategories,
             numDraws: await this.stateValues.numDraws,

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -7,6 +7,50 @@ import { setUpVariantSeedAndRng } from "../utils/variants";
 import CompositeComponent from "./abstract/CompositeComponent";
 import { convertUnresolvedAttributesForComponentType } from "../utils/dast/convertNormalizedDast";
 
+/**
+ * The parameters the `means` and `variances` arrays are computed from. They are
+ * global rather than per-key because every category's moment is determined by the
+ * whole population, not just by its own entry — and both arrays read exactly the
+ * same ones, so a distribution added later adds its parameters here once.
+ */
+function returnMomentDependencies() {
+    return {
+        globalDependencies: {
+            type: {
+                dependencyType: "stateVariable",
+                variableName: "type",
+            },
+            numInCategories: {
+                dependencyType: "stateVariable",
+                variableName: "numInCategories",
+            },
+            numDraws: {
+                dependencyType: "stateVariable",
+                variableName: "numDraws",
+            },
+            numTotal: {
+                dependencyType: "stateVariable",
+                variableName: "numTotal",
+            },
+        },
+    };
+}
+
+/**
+ * Whether the closed forms the `means` and `variances` arrays use apply to what
+ * the author asked for. Those formulas are the multivariate hypergeometric's, so
+ * they describe a distribution only when that is the one named and its parameters
+ * are ones it can be sampled from. Anything else — no `type` at all, or parameters
+ * that describe no population — has no moments to report and gets the NaN its
+ * samples get; another distribution will bring its own branch.
+ */
+function hasHypergeometricMoments(globalDependencyValues) {
+    return (
+        globalDependencyValues.type === "hypergeometric" &&
+        validMultivariateHypergeometricParameters(globalDependencyValues)
+    );
+}
+
 export default class SampleMultivariateRandomNumber extends CompositeComponent {
     constructor(args) {
         super(args);
@@ -167,43 +211,14 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             returnArraySize({ dependencyValues }) {
                 return [dependencyValues.numCategories];
             },
-            returnArrayDependenciesByKey() {
-                return {
-                    globalDependencies: {
-                        type: {
-                            dependencyType: "stateVariable",
-                            variableName: "type",
-                        },
-                        numInCategories: {
-                            dependencyType: "stateVariable",
-                            variableName: "numInCategories",
-                        },
-                        numDraws: {
-                            dependencyType: "stateVariable",
-                            variableName: "numDraws",
-                        },
-                        numTotal: {
-                            dependencyType: "stateVariable",
-                            variableName: "numTotal",
-                        },
-                    },
-                };
-            },
+            returnArrayDependenciesByKey: returnMomentDependencies,
             arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
                 let means = {};
 
                 const N = globalDependencyValues.numTotal;
                 const n = globalDependencyValues.numDraws;
 
-                // parameters that describe no distribution have no moments either,
-                // so report the NaN that their samples report. These formulas are
-                // the hypergeometric's; with no distribution named there is nothing
-                // to compute, and another distribution will bring its own branch.
-                const valid =
-                    globalDependencyValues.type === "hypergeometric" &&
-                    validMultivariateHypergeometricParameters(
-                        globalDependencyValues,
-                    );
+                const valid = hasHypergeometricMoments(globalDependencyValues);
 
                 for (let arrayKey of arrayKeys) {
                     if (!valid) {
@@ -245,39 +260,14 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
             returnArraySize({ dependencyValues }) {
                 return [dependencyValues.numCategories];
             },
-            returnArrayDependenciesByKey() {
-                return {
-                    globalDependencies: {
-                        type: {
-                            dependencyType: "stateVariable",
-                            variableName: "type",
-                        },
-                        numInCategories: {
-                            dependencyType: "stateVariable",
-                            variableName: "numInCategories",
-                        },
-                        numDraws: {
-                            dependencyType: "stateVariable",
-                            variableName: "numDraws",
-                        },
-                        numTotal: {
-                            dependencyType: "stateVariable",
-                            variableName: "numTotal",
-                        },
-                    },
-                };
-            },
+            returnArrayDependenciesByKey: returnMomentDependencies,
             arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
                 let variances = {};
 
                 const N = globalDependencyValues.numTotal;
                 const n = globalDependencyValues.numDraws;
 
-                const valid =
-                    globalDependencyValues.type === "hypergeometric" &&
-                    validMultivariateHypergeometricParameters(
-                        globalDependencyValues,
-                    );
+                const valid = hasHypergeometricMoments(globalDependencyValues);
 
                 for (let arrayKey of arrayKeys) {
                     if (!valid) {

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -66,7 +66,7 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
 
     static componentDocs = {
         summary:
-            "Samples a single vector-valued random number from a multivariate distribution, expanding to one number per category",
+            "Samples one number per category from a multivariate distribution, drawn together rather than independently",
     };
 
     static takesIndex = true;

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -41,9 +41,10 @@ function returnMomentDependencies() {
  * Whether the closed forms the `means` and `variances` arrays use apply to what
  * the author asked for. Those formulas are the multivariate hypergeometric's, so
  * they describe a distribution only when that is the one named and its parameters
- * are ones it can be sampled from. Anything else — no `type` at all, or parameters
- * that describe no population — has no moments to report and gets the NaN its
- * samples get; another distribution will bring its own branch.
+ * are ones it can be sampled from. Anything else — no `type` at all, parameters
+ * that describe no population, or a population refused as too slow to draw from —
+ * has no moments to report and gets the NaN its samples get; another distribution
+ * will bring its own branch.
  */
 function hasHypergeometricMoments(globalDependencyValues) {
     return (

--- a/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleMultivariateRandomNumber.js
@@ -277,9 +277,10 @@ export default class SampleMultivariateRandomNumber extends CompositeComponent {
                     }
 
                     // each category's marginal count is univariate hypergeometric,
-                    // so it carries the same finite population correction, whose
-                    // (N - n) / (N - 1) is 0/0 for a population of at most one
-                    // item — which is determined, and so has variance 0
+                    // so it carries the same closed form — which divides by N - 1
+                    // in its finite population correction, and by N in p, so it is
+                    // undefined for a population of at most one item. Such a draw
+                    // is determined, and so has variance 0.
                     if (N > 1) {
                         const p =
                             globalDependencyValues.numInCategories[arrayKey] /

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -465,6 +465,20 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
                 numDraws: 4,
             }),
         ).eqls([]);
+
+        // Drawing nearly the whole population is as cheap as drawing almost
+        // none of it, since each category draws whichever of the taken and
+        // left-behind groups is smaller — which is why the message for a
+        // refused draw offers raising numDraws as a fix alongside lowering it.
+        // Half this population would need three billion draws and is refused;
+        // all but ten of it needs twenty and is not.
+        expect(
+            multivariateSamplingDiagnostics({
+                type: "hypergeometric",
+                numInCategories: [1000000000, 1000000000, 1000000000],
+                numDraws: 3000000000 - 10,
+            }),
+        ).eqls([]);
     });
 
     it("a population too large to count exactly is refused", async () => {
@@ -499,10 +513,10 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     it("a population whose total is too large to count exactly is refused", async () => {
         // Each category here is exact on its own, and few enough items are drawn
         // to be well under the work limit, but the population they add up to is
-        // past 2^53 — and that total is the bound every category's draw is taken
-        // against, so the sampler would reject every draw it made and never
-        // return. Asked of the shared entry point first, because a document that
-        // reached the sampler would hang rather than fail.
+        // past 2^53 — and that total is the population the first category's draw
+        // is taken against, so the sampler would reject every draw it made and
+        // never return. Asked of the shared entry point first, because a document
+        // that reached the sampler would hang rather than fail.
         const numInCategories = [2 ** 53 - 1, 2 ** 53 - 1];
         expect(
             multivariateSamplingDiagnostics({

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -158,7 +158,10 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
 
     it("reports numCategories, numTotal, means, and variances", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+            doenetML: `
+    <sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />
+    <p name="pSecondMean">$s.means[2]</p>
+    `,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
@@ -180,11 +183,24 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         for (const [i, p] of [0.5, 0.3, 0.2].entries()) {
             expect(variances[i]).closeTo((4 * p * (1 - p) * 6) / 9, 1e-10);
         }
+
+        // a single entry of the array is reachable by indexing
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pSecondMean")]
+                .stateValues.text,
+        ).eq("1.2");
     });
 
     it("marginal means match the reported means", async () => {
-        // 200 draws is enough to catch a sampler whose marginals are wrong,
-        // without the cost of creating many cores.
+        // Cross-checks the closed-form `means` against the sampler, which the
+        // joint-pmf cases above cannot do: they only test the sampler.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const reportedMeans =
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.means;
+
         const rng = seedrandom.alea("marginal-means");
         const numInCategories = [5, 3, 2];
         const sums = [0, 0, 0];
@@ -201,8 +217,8 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
             }
         }
 
-        for (const [j, expected] of [2, 1.2, 0.8].entries()) {
-            expect(sums[j] / trials).closeTo(expected, 0.02);
+        for (let j = 0; j < 3; j++) {
+            expect(sums[j] / trials).closeTo(reportedMeans[j], 0.02);
         }
     });
 
@@ -263,6 +279,14 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
                 expect(Number.isNaN(value)).eq(true);
             }
         }
+
+        // with no categories at all there is nothing to sample, so no replacements
+        expect(
+            await get_sampled_values(
+                `<sampleMultivariateRandomNumber name="s" numDraws="0" />`,
+                "s",
+            ),
+        ).eqls([]);
     });
 
     it("invalid parameters give NaN statistics too", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -474,6 +474,46 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
+    it("a population whose total is too large to count exactly is refused", async () => {
+        // Each category here is exact on its own, and few enough items are drawn
+        // to be well under the work limit, but the population they add up to is
+        // past 2^53 — and that total is the bound every category's draw is taken
+        // against, so the sampler would reject every draw it made and never
+        // return. Asked of the shared entry point first, because a document that
+        // reached the sampler would hang rather than fail.
+        const numInCategories = [2 ** 53 - 1, 2 ** 53 - 1];
+        expect(
+            multivariateSamplingDiagnostics({
+                type: "hypergeometric",
+                numInCategories,
+                numDraws: 10,
+            }).map((d) => d.code),
+        ).eqls(["doenet-w0134"]);
+
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="${numInCategories.join(" ")}" numDraws="10" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        expect(
+            getDiagnosticsByType(core).warnings.filter(
+                (w) => w.code === "doenet-w0134",
+            ).length,
+        ).eq(1);
+
+        for (const replacement of stateVariables[componentIdx].replacements!) {
+            expect(
+                Number.isNaN(
+                    stateVariables[replacement.componentIdx].stateValues.value,
+                ),
+            ).eq(true);
+        }
+        for (const value of stateVariables[componentIdx].stateValues.means) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+    });
+
     it("a draw too large to sample promptly is refused, not attempted", async () => {
         // Drawing each category costs a univariate hypergeometric draw, so this would
         // otherwise run for minutes rather than returning.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createTestCore } from "../utils/test-core";
+import { getDiagnosticsByType } from "../utils/diagnostics";
 import { callAction } from "../utils/actions";
 import { sampleMultivariateHypergeometric } from "../../utils/randomNumbers";
 import seedrandom from "seedrandom";
@@ -334,6 +335,88 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         for (let value of stateVariables[componentIdx].stateValues.variances) {
             expect(value).closeTo(0, 1e-10);
         }
+    });
+
+    it("unusable parameters are reported to the author, not just the console", async () => {
+        // A console warning is invisible to someone authoring a document, so the
+        // reason has to arrive as a diagnostic the surrounding tooling can show.
+        const cases: [string, Record<string, unknown>][] = [
+            [
+                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="11" />`,
+                { numInCategories: "5, 3, 2", numDraws: 11 },
+            ],
+            [
+                // numDraws left off entirely, which has no default to fall back on
+                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" />`,
+                { numInCategories: "5, 3, 2", numDraws: "not-set" },
+            ],
+            [
+                // and with no categories either
+                `<sampleMultivariateRandomNumber name="s" />`,
+                { numInCategories: "not-set", numDraws: "not-set" },
+            ],
+            [
+                `<sampleMultivariateRandomNumber name="s" numInCategories="5.5 3" numDraws="2" />`,
+                { numInCategories: "5.5, 3", numDraws: 2 },
+            ],
+        ];
+
+        for (const [doenetML, args] of cases) {
+            const { core } = await createTestCore({ doenetML });
+            await core.returnAllStateVariables(false, true);
+
+            const warnings = getDiagnosticsByType(core).warnings.filter(
+                (w) => w.code === "doenet-w0135",
+            );
+            expect(warnings.length, doenetML).eq(1);
+            expect(warnings[0].args).eqls(args);
+            // the reader should never be shown a raw JavaScript value
+            expect(warnings[0].message).not.toContain("null");
+            expect(warnings[0].message).not.toContain("undefined");
+        }
+    });
+
+    it("a draw too large to sample promptly is refused, not attempted", async () => {
+        // Drawing each category costs a univariate hypergeometric draw, so this would
+        // otherwise run for minutes rather than returning.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="1000000000 1000000000 1000000000" numDraws="1500000000" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        const warnings = getDiagnosticsByType(core).warnings.filter(
+            (w) => w.code === "doenet-w0136",
+        );
+        expect(warnings.length).eq(1);
+        expect(warnings[0].args).eqls({
+            numDraws: 1500000000,
+            numTotal: 3000000000,
+            numCategories: 3,
+            maxDraws: 1e7,
+        });
+
+        for (const replacement of stateVariables[componentIdx].replacements!) {
+            expect(
+                Number.isNaN(
+                    stateVariables[replacement.componentIdx].stateValues.value,
+                ),
+            ).eq(true);
+        }
+        for (const value of stateVariables[componentIdx].stateValues.means) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+    });
+
+    it("valid parameters raise no diagnostics", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+        });
+        await core.returnAllStateVariables(false, true);
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.warnings.length).eq(0);
+        expect(diagnostics.errors.length).eq(0);
     });
 
     it("resample draws a new vector", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -160,6 +160,28 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         ).eq(values[0].toString());
     });
 
+    it("number display attributes and asList reach the numbers produced", async () => {
+        // The component makes its own `<number>` replacements, so anything the
+        // author writes about how a number is shown has to be copied onto them;
+        // nothing downstream would do it. Drawing the whole population makes the
+        // counts deterministic, so the rendered text can be compared exactly.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="10" displayDecimals="2" padZeros /></p>
+    <p name="pRun"><sampleMultivariateRandomNumber name="s2" type="hypergeometric" numInCategories="5 3 2" numDraws="10" displayDecimals="2" padZeros asList="false" /></p>
+    `,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pList")].stateValues
+                .text,
+        ).eq("5.00, 3.00, 2.00");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pRun")].stateValues.text,
+        ).eq("5.003.002.00");
+    });
+
     it("reports numCategories, numTotal, means, and variances", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -530,6 +530,46 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
+    it("resampling keeps reporting why the parameters are unusable", async () => {
+        // Reusing counts rather than drawing them — after a resample, or when saved
+        // values are loaded back — takes a branch that never reached the sampler, so
+        // the explanation used to disappear while the NaN it explained remained.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p><sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="11" /></p>
+    <callAction name="again" target="$s" actionName="resample"><label>Resample</label></callAction>
+    `,
+        });
+        await core.returnAllStateVariables(false, true);
+        expect(
+            getDiagnosticsByType(core).warnings.filter(
+                (w) => w.code === "doenet-w0134",
+            ).length,
+        ).eq(1);
+
+        await callAction({
+            core,
+            componentIdx: await resolvePathToNodeIdx("again"),
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        // still explained, and still not doubled up
+        expect(
+            getDiagnosticsByType(core).warnings.filter(
+                (w) => w.code === "doenet-w0134",
+            ).length,
+        ).eq(1);
+        for (const replacement of stateVariables[
+            await resolvePathToNodeIdx("s")
+        ].replacements!) {
+            expect(
+                Number.isNaN(
+                    stateVariables[replacement.componentIdx].stateValues.value,
+                ),
+            ).eq(true);
+        }
+    });
+
     it("valid parameters raise no diagnostics", async () => {
         const { core } = await createTestCore({
             doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="4" />`,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -4,6 +4,7 @@ import { getDiagnosticsByType } from "../utils/diagnostics";
 import { callAction } from "../utils/actions";
 import {
     multivariateSamplingDiagnostics,
+    sampleFromMultivariateDistribution,
     sampleMultivariateHypergeometric,
 } from "../../utils/randomNumbers";
 import seedrandom from "seedrandom";
@@ -299,6 +300,29 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         ).eqls([0, 0]);
         expect(stateVariables[componentIdx].stateValues.means).eqls([0, 0]);
         expect(stateVariables[componentIdx].stateValues.variances).eqls([0, 0]);
+    });
+
+    it("no categories at all produces no numbers rather than NaN", async () => {
+        // `numInCategories` is the one parameter with a default, and the length of
+        // that list is what decides how many numbers there are to report. Leaving it
+        // off therefore does not behave like leaving off `type` or `numDraws`, which
+        // give a full-length list of NaN: there is nothing to report at all. The
+        // reason is still explained, so the emptiness is not silent.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numDraws="0" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        expect(stateVariables[componentIdx].replacements!.length).eq(0);
+        expect(stateVariables[componentIdx].stateValues.means).eqls([]);
+        expect(stateVariables[componentIdx].stateValues.variances).eqls([]);
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+        expect(diagnostics.warnings.map((w: any) => w.code)).eqls([
+            "doenet-w0135",
+        ]);
     });
 
     it("invalid parameters give NaN", async () => {
@@ -676,6 +700,51 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         for (const value of stateVariables[componentIdx].stateValues.means) {
             expect(Number.isNaN(value)).eq(true);
         }
+    });
+
+    it("the sampler refuses a type it has no distribution for", () => {
+        // The `type` attribute rejects an unknown name before a document can reach
+        // the sampler, but the sampler is exported and other code calls it directly.
+        // An unrecognized name has to refuse there too, rather than falling through
+        // to whichever distribution the code happened to try first — otherwise
+        // adding a second distribution to `validValues` without wiring up its
+        // sampler would quietly hand back hypergeometric counts.
+        const rng = seedrandom.alea("refuses-unknown-type");
+        const parameters = { numInCategories: [5, 3, 2], numDraws: 4 };
+
+        for (const type of [
+            null,
+            "gaussian",
+            // a property every object inherits: reachable through the prototype
+            // chain, so a membership test that walks it would call `Object` here
+            "constructor",
+        ]) {
+            const { sampledValues, diagnostics } =
+                sampleFromMultivariateDistribution({
+                    ...parameters,
+                    type,
+                    rng,
+                });
+
+            expect(sampledValues.length, String(type)).eq(3);
+            for (const value of sampledValues) {
+                expect(Number.isNaN(value), String(type)).eq(true);
+            }
+            expect(
+                diagnostics.map((d: any) => d.code),
+                String(type),
+            ).eqls(["doenet-w0137"]);
+        }
+
+        // and the one name it does answer to still draws
+        const { sampledValues, diagnostics } =
+            sampleFromMultivariateDistribution({
+                ...parameters,
+                type: "hypergeometric",
+                rng,
+            });
+        expect(sampledValues.reduce((a: number, b: number) => a + b, 0)).eq(4);
+        expect(diagnostics).eqls([]);
     });
 
     it("resampling and reloading keep reporting why the parameters are unusable", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -530,35 +530,55 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
-    it("resampling keeps reporting why the parameters are unusable", async () => {
+    it("resampling and reloading keep reporting why the parameters are unusable", async () => {
         // Reusing counts rather than drawing them — after a resample, or when saved
         // values are loaded back — takes a branch that never reached the sampler, so
         // the explanation used to disappear while the NaN it explained remained.
-        const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
+        const doenetML = `
     <p><sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="11" /></p>
     <callAction name="again" target="$s" actionName="resample"><label>Resample</label></callAction>
-    `,
-        });
-        await core.returnAllStateVariables(false, true);
-        expect(
-            getDiagnosticsByType(core).warnings.filter(
+    `;
+        function numExplanations(core: any) {
+            return getDiagnosticsByType(core).warnings.filter(
                 (w) => w.code === "doenet-w0134",
-            ).length,
-        ).eq(1);
+            ).length;
+        }
+
+        let { core, resolvePathToNodeIdx, scoreState } = await createTestCore({
+            doenetML,
+        });
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(numExplanations(core)).eq(1);
 
         await callAction({
             core,
             componentIdx: await resolvePathToNodeIdx("again"),
         });
-        const stateVariables = await core.returnAllStateVariables(false, true);
+        stateVariables = await core.returnAllStateVariables(false, true);
 
         // still explained, and still not doubled up
-        expect(
-            getDiagnosticsByType(core).warnings.filter(
-                (w) => w.code === "doenet-w0134",
-            ).length,
-        ).eq(1);
+        expect(numExplanations(core)).eq(1);
+        for (const replacement of stateVariables[
+            await resolvePathToNodeIdx("s")
+        ].replacements!) {
+            expect(
+                Number.isNaN(
+                    stateVariables[replacement.componentIdx].stateValues.value,
+                ),
+            ).eq(true);
+        }
+
+        // A reload begins with no diagnostics at all, so it is where an unexplained
+        // NaN would actually reach the author: the counts come back from the saved
+        // state without the sampler ever being asked for them.
+        await core.saveImmediately();
+        ({ core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+            initialState: scoreState.state,
+        }));
+        stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(numExplanations(core)).eq(1);
         for (const replacement of stateVariables[
             await resolvePathToNodeIdx("s")
         ].replacements!) {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -131,7 +131,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     it("expands to one number per category, summing to numDraws", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p><sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" /></p>
+    <p><sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="4" /></p>
     <p name="pFirst">$s[1]</p>
     `,
         });
@@ -160,7 +160,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     it("reports numCategories, numTotal, means, and variances", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />
+    <sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="4" />
     <p name="pSecondMean">$s.means[2]</p>
     `,
         });
@@ -196,7 +196,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // Cross-checks the closed-form `means` against the sampler, which the
         // joint-pmf cases above cannot do: they only test the sampler.
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="4" />`,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const reportedMeans =
@@ -227,7 +227,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // drawing the whole population takes every item of every category
         expect(
             await get_sampled_values(
-                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="10" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="10" />`,
                 "s",
             ),
         ).eqls([5, 3, 2]);
@@ -235,14 +235,14 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // drawing nothing takes nothing from any category
         expect(
             await get_sampled_values(
-                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="0" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="0" />`,
                 "s",
             ),
         ).eqls([0, 0, 0]);
 
         // an empty category can never be drawn from
         const withEmpty = await get_sampled_values(
-            `<sampleMultivariateRandomNumber name="s" numInCategories="6 0 4" numDraws="3" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="6 0 4" numDraws="3" />`,
             "s",
         );
         expect(withEmpty[1]).eq(0);
@@ -251,7 +251,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // a single category takes all the draws
         expect(
             await get_sampled_values(
-                `<sampleMultivariateRandomNumber name="s" numInCategories="7" numDraws="3" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="7" numDraws="3" />`,
                 "s",
             ),
         ).eqls([3]);
@@ -262,7 +262,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // so the counts and their moments are zero rather than the NaN that the
         // 0/0 in `n * numInCategories[i] / numTotal` would otherwise give
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="0 0" numDraws="0" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="0 0" numDraws="0" />`,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
@@ -279,17 +279,17 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     it("invalid parameters give NaN", async () => {
         const doenetMLs = [
             // numDraws unspecified
-            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" />`,
             // more draws than the population holds
-            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="11" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="11" />`,
             // negative draws
-            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="-1" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="-1" />`,
             // non-integer draws
-            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="2.5" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="2.5" />`,
             // non-integer category size
-            `<sampleMultivariateRandomNumber name="s" numInCategories="5.5 3 2" numDraws="4" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5.5 3 2" numDraws="4" />`,
             // negative category size
-            `<sampleMultivariateRandomNumber name="s" numInCategories="5 -3 2" numDraws="4" />`,
+            `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 -3 2" numDraws="4" />`,
         ];
 
         for (let doenetML of doenetMLs) {
@@ -303,7 +303,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // with no categories at all there is nothing to sample, so no replacements
         expect(
             await get_sampled_values(
-                `<sampleMultivariateRandomNumber name="s" numDraws="0" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numDraws="0" />`,
                 "s",
             ),
         ).eqls([]);
@@ -311,7 +311,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
 
     it("invalid parameters give NaN statistics too", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="11" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="11" />`,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
@@ -327,7 +327,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     it("a one-item population has zero variance", async () => {
         // the finite population correction divides by numTotal - 1
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="1 0" numDraws="1" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="1 0" numDraws="1" />`,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
@@ -342,21 +342,21 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // reason has to arrive as a diagnostic the surrounding tooling can show.
         const cases: [string, Record<string, unknown>][] = [
             [
-                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="11" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="11" />`,
                 { numInCategories: "5, 3, 2", numDraws: 11 },
             ],
             [
                 // numDraws left off entirely, which has no default to fall back on
-                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" />`,
                 { numInCategories: "5, 3, 2", numDraws: "not-set" },
             ],
             [
                 // and with no categories either
-                `<sampleMultivariateRandomNumber name="s" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" />`,
                 { numInCategories: "not-set", numDraws: "not-set" },
             ],
             [
-                `<sampleMultivariateRandomNumber name="s" numInCategories="5.5 3" numDraws="2" />`,
+                `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5.5 3" numDraws="2" />`,
                 { numInCategories: "5.5, 3", numDraws: 2 },
             ],
         ];
@@ -380,13 +380,13 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // Drawing each category costs a univariate hypergeometric draw, so this would
         // otherwise run for minutes rather than returning.
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="1000000000 1000000000 1000000000" numDraws="1500000000" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="1000000000 1000000000 1000000000" numDraws="1500000000" />`,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
 
         const warnings = getDiagnosticsByType(core).warnings.filter(
-            (w) => w.code === "doenet-w0136",
+            (w) => w.code === "doenet-w0137",
         );
         expect(warnings.length).eq(1);
         expect(warnings[0].args).eqls({
@@ -413,7 +413,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // draw is refused, the sample is taken as asked and the author is told why
         // the page feels slow — something no other part of the document can tell them.
         const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="3000000 3000000" numDraws="3000000" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="3000000 3000000" numDraws="3000000" />`,
         });
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
@@ -435,9 +435,49 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
+    it("an unspecified type samples nothing and says so", async () => {
+        // `type` deliberately has no default: `hypergeometric` is unlikely to stay
+        // the most natural one, and defaulting to it now would let documents come to
+        // rely on it, so that changing the default later would silently reinterpret
+        // them. Requiring the attribute keeps that door open.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        const warnings = getDiagnosticsByType(core).warnings.filter(
+            (w) => w.code === "doenet-w0137",
+        );
+        expect(warnings.length).eq(1);
+        expect(warnings[0].message).toContain(`type="hypergeometric"`);
+
+        // nothing is guessed: the counts and both sets of moments are NaN, even
+        // though the remaining parameters would describe a usable population
+        for (const replacement of stateVariables[componentIdx].replacements!) {
+            expect(
+                Number.isNaN(
+                    stateVariables[replacement.componentIdx].stateValues.value,
+                ),
+            ).eq(true);
+        }
+        for (const value of stateVariables[componentIdx].stateValues.means) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+        for (const value of stateVariables[componentIdx].stateValues
+            .variances) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+
+        // the parameters themselves are still reported, so an author can see what
+        // the component did read
+        expect(stateVariables[componentIdx].stateValues.numCategories).eq(3);
+        expect(stateVariables[componentIdx].stateValues.numTotal).eq(10);
+    });
+
     it("valid parameters raise no diagnostics", async () => {
         const { core } = await createTestCore({
-            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="5 3 2" numDraws="4" />`,
         });
         await core.returnAllStateVariables(false, true);
 
@@ -449,7 +489,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     it("resample draws a new vector", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p><sampleMultivariateRandomNumber name="s" numInCategories="40 30 30" numDraws="30" /></p>
+    <p><sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="40 30 30" numDraws="30" /></p>
     <callAction name="resample" target="$s" actionName="resample"><label>Resample</label></callAction>
     `,
         });
@@ -489,7 +529,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     });
 
     it("same values for given variant if variantDeterminesSeed", async () => {
-        const doenetML = `<sampleMultivariateRandomNumber name="s" numInCategories="40 30 30" numDraws="30" variantDeterminesSeed />`;
+        const doenetML = `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="40 30 30" numDraws="30" variantDeterminesSeed />`;
 
         async function values_for_variant(requestedVariantIndex: number) {
             const { core, resolvePathToNodeIdx } = await createTestCore({

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import { callAction } from "../utils/actions";
+import { sampleMultivariateHypergeometric } from "../../utils/randomNumbers";
+import seedrandom from "seedrandom";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
+    /** log of "n choose k" */
+    function logBinomial(n: number, k: number) {
+        let result = 0;
+        for (let i = 0; i < k; i++) {
+            result += Math.log(n - i) - Math.log(i + 1);
+        }
+        return result;
+    }
+
+    /**
+     * The exact multivariate hypergeometric probability of drawing `x` from a
+     * population partitioned as `numInCategories`: prod(C(K_i, x_i)) / C(N, n).
+     */
+    function exactProbability(
+        numInCategories: number[],
+        x: number[],
+        numDraws: number,
+    ) {
+        const numTotal = numInCategories.reduce((a, c) => a + c, 0);
+        let logProbability = 0;
+        for (let i = 0; i < numInCategories.length; i++) {
+            if (x[i] < 0 || x[i] > numInCategories[i]) {
+                return 0;
+            }
+            logProbability += logBinomial(numInCategories[i], x[i]);
+        }
+        return Math.exp(logProbability - logBinomial(numTotal, numDraws));
+    }
+
+    async function get_sampled_values(doenetML: string, name: string) {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx(name);
+        return stateVariables[componentIdx].replacements!.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+    }
+
+    // The joint distribution is checked directly against its exact pmf, since
+    // marginal means alone would not catch a sampler that got the dependence
+    // between categories wrong.
+    const distributionCases: [number[], number][] = [
+        [[5, 3, 2], 4],
+        [[5, 3, 2], 8], // draws most of the population
+        [[1, 1, 1, 1], 2],
+        [[10, 1], 3], // effectively univariate
+        [[4, 4], 8], // draws everything
+        [[4, 4], 0], // draws nothing
+        [[6, 0, 4], 3], // an empty category
+    ];
+
+    for (const [numInCategories, numDraws] of distributionCases) {
+        it(`joint distribution for numInCategories=[${numInCategories}], numDraws=${numDraws}`, () => {
+            const rng = seedrandom.alea(
+                `mvh-${numInCategories.join("_")}-${numDraws}`,
+            );
+            const trials = 100000;
+            const observed = new Map<string, number>();
+            let brokenInvariant: string | null = null;
+
+            for (let i = 0; i < trials; i++) {
+                const counts = sampleMultivariateHypergeometric({
+                    numInCategories,
+                    numDraws,
+                    rng,
+                });
+
+                // Checked with plain conditionals rather than expect() so the
+                // assertion machinery doesn't dominate a 100k-iteration loop.
+                if (brokenInvariant === null) {
+                    if (counts.length !== numInCategories.length) {
+                        brokenInvariant = `[${counts}] has the wrong number of categories`;
+                    }
+                    let sum = 0;
+                    for (let j = 0; j < counts.length; j++) {
+                        sum += counts[j];
+                        if (
+                            !Number.isInteger(counts[j]) ||
+                            counts[j] < 0 ||
+                            counts[j] > numInCategories[j]
+                        ) {
+                            brokenInvariant = `category ${j} of [${counts}] is outside 0..${numInCategories[j]}`;
+                        }
+                    }
+                    if (sum !== numDraws) {
+                        brokenInvariant = `[${counts}] sums to ${sum}, not ${numDraws}`;
+                    }
+                }
+
+                const key = counts.join(",");
+                observed.set(key, (observed.get(key) ?? 0) + 1);
+            }
+
+            expect(brokenInvariant).eq(null);
+
+            let massObserved = 0;
+            let worstDeviation = 0;
+            for (const [key, count] of observed) {
+                const x = key.split(",").map(Number);
+                const exact = exactProbability(numInCategories, x, numDraws);
+                worstDeviation = Math.max(
+                    worstDeviation,
+                    Math.abs(count / trials - exact),
+                );
+                massObserved += exact;
+            }
+
+            expect(worstDeviation, "worst joint-pmf deviation").lessThan(0.01);
+            // every outcome seen is in the support, and together they are all of it
+            expect(massObserved, "observed outcomes cover the support").closeTo(
+                1,
+                1e-6,
+            );
+        });
+    }
+
+    it("expands to one number per category, summing to numDraws", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p><sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" /></p>
+    <p name="pFirst">$s[1]</p>
+    `,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        const values = stateVariables[componentIdx].replacements!.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        expect(values.length).eq(3);
+        expect(values.reduce((a, c) => a + c, 0)).eq(4);
+        for (let i = 0; i < 3; i++) {
+            expect(Number.isInteger(values[i])).eq(true);
+            expect(values[i]).gte(0);
+            expect(values[i]).lte([5, 3, 2][i]);
+        }
+
+        // indexing into the composite picks out a single category
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pFirst")].stateValues
+                .text,
+        ).eq(values[0].toString());
+    });
+
+    it("reports numCategories, numTotal, means, and variances", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        expect(stateVariables[componentIdx].stateValues.numCategories).eq(3);
+        expect(stateVariables[componentIdx].stateValues.numTotal).eq(10);
+
+        // mean = numDraws * numInCategories[i] / numTotal
+        const means = stateVariables[componentIdx].stateValues.means;
+        expect(means.length).eq(3);
+        for (const [i, expected] of [2, 1.2, 0.8].entries()) {
+            expect(means[i]).closeTo(expected, 1e-10);
+        }
+
+        // each marginal is univariate hypergeometric, so it carries the same
+        // finite population correction: n*p*(1-p)*(N-n)/(N-1)
+        const variances = stateVariables[componentIdx].stateValues.variances;
+        expect(variances.length).eq(3);
+        for (const [i, p] of [0.5, 0.3, 0.2].entries()) {
+            expect(variances[i]).closeTo((4 * p * (1 - p) * 6) / 9, 1e-10);
+        }
+    });
+
+    it("marginal means match the reported means", async () => {
+        // 200 draws is enough to catch a sampler whose marginals are wrong,
+        // without the cost of creating many cores.
+        const rng = seedrandom.alea("marginal-means");
+        const numInCategories = [5, 3, 2];
+        const sums = [0, 0, 0];
+        const trials = 100000;
+
+        for (let i = 0; i < trials; i++) {
+            const counts = sampleMultivariateHypergeometric({
+                numInCategories,
+                numDraws: 4,
+                rng,
+            });
+            for (let j = 0; j < 3; j++) {
+                sums[j] += counts[j];
+            }
+        }
+
+        for (const [j, expected] of [2, 1.2, 0.8].entries()) {
+            expect(sums[j] / trials).closeTo(expected, 0.02);
+        }
+    });
+
+    it("degenerate populations", async () => {
+        // drawing the whole population takes every item of every category
+        expect(
+            await get_sampled_values(
+                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="10" />`,
+                "s",
+            ),
+        ).eqls([5, 3, 2]);
+
+        // drawing nothing takes nothing from any category
+        expect(
+            await get_sampled_values(
+                `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="0" />`,
+                "s",
+            ),
+        ).eqls([0, 0, 0]);
+
+        // an empty category can never be drawn from
+        const withEmpty = await get_sampled_values(
+            `<sampleMultivariateRandomNumber name="s" numInCategories="6 0 4" numDraws="3" />`,
+            "s",
+        );
+        expect(withEmpty[1]).eq(0);
+        expect(withEmpty.reduce((a, c) => a + c, 0)).eq(3);
+
+        // a single category takes all the draws
+        expect(
+            await get_sampled_values(
+                `<sampleMultivariateRandomNumber name="s" numInCategories="7" numDraws="3" />`,
+                "s",
+            ),
+        ).eqls([3]);
+    });
+
+    it("invalid parameters give NaN", async () => {
+        const doenetMLs = [
+            // numDraws unspecified
+            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" />`,
+            // more draws than the population holds
+            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="11" />`,
+            // negative draws
+            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="-1" />`,
+            // non-integer draws
+            `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="2.5" />`,
+            // non-integer category size
+            `<sampleMultivariateRandomNumber name="s" numInCategories="5.5 3 2" numDraws="4" />`,
+            // negative category size
+            `<sampleMultivariateRandomNumber name="s" numInCategories="5 -3 2" numDraws="4" />`,
+        ];
+
+        for (let doenetML of doenetMLs) {
+            const values = await get_sampled_values(doenetML, "s");
+            expect(values.length).eq(3);
+            for (let value of values) {
+                expect(Number.isNaN(value)).eq(true);
+            }
+        }
+    });
+
+    it("invalid parameters give NaN statistics too", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="11" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        for (let value of stateVariables[componentIdx].stateValues.means) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+        for (let value of stateVariables[componentIdx].stateValues.variances) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+    });
+
+    it("a one-item population has zero variance", async () => {
+        // the finite population correction divides by numTotal - 1
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="1 0" numDraws="1" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        for (let value of stateVariables[componentIdx].stateValues.variances) {
+            expect(value).closeTo(0, 1e-10);
+        }
+    });
+
+    it("resample draws a new vector", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p><sampleMultivariateRandomNumber name="s" numInCategories="40 30 30" numDraws="30" /></p>
+    <callAction name="resample" target="$s" actionName="resample"><label>Resample</label></callAction>
+    `,
+        });
+
+        async function current_values() {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const componentIdx = await resolvePathToNodeIdx("s");
+            return stateVariables[componentIdx].replacements!.map(
+                (x) => stateVariables[x.componentIdx].stateValues.value,
+            );
+        }
+
+        // Resampling repeatedly: with this population an identical vector is
+        // unlikely, so requiring one change across several tries is robust.
+        const before = await current_values();
+        expect(before.reduce((a, c) => a + c, 0)).eq(30);
+
+        let changed = false;
+        for (let attempt = 0; attempt < 10 && !changed; attempt++) {
+            await callAction({
+                core,
+                componentIdx: await resolvePathToNodeIdx("resample"),
+            });
+            const after = await current_values();
+            expect(after.length).eq(3);
+            expect(after.reduce((a, c) => a + c, 0)).eq(30);
+            if (after.some((v, i) => v !== before[i])) {
+                changed = true;
+            }
+        }
+        expect(changed, "resample should eventually change the counts").eq(
+            true,
+        );
+    });
+
+    it("same values for given variant if variantDeterminesSeed", async () => {
+        const doenetML = `<sampleMultivariateRandomNumber name="s" numInCategories="40 30 30" numDraws="30" variantDeterminesSeed />`;
+
+        async function values_for_variant(requestedVariantIndex: number) {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML,
+                requestedVariantIndex,
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const componentIdx = await resolvePathToNodeIdx("s");
+            return stateVariables[componentIdx].replacements!.map(
+                (x) => stateVariables[x.componentIdx].stateValues.value,
+            );
+        }
+
+        const first = await values_for_variant(1);
+        const firstAgain = await values_for_variant(1);
+        const second = await values_for_variant(2);
+
+        expect(firstAgain).eqls(first);
+        expect(second).not.eqls(first);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -417,7 +417,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
             // no distribution named
             [
                 { type: null, numInCategories: [5, 3, 2], numDraws: 4 },
-                "doenet-w0136",
+                "doenet-w0137",
             ],
             // more draws than the population holds
             [
@@ -426,7 +426,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
                     numInCategories: [5, 3, 2],
                     numDraws: 11,
                 },
-                "doenet-w0134",
+                "doenet-w0135",
             ],
             // Too slow to draw: one category on its own costs 6e6 draws, which
             // is under the ten-million limit, and only the two such draws the
@@ -438,7 +438,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
                     numInCategories: [6000000, 6000000, 6000000],
                     numDraws: 6000000,
                 },
-                "doenet-w0135",
+                "doenet-w0136",
             ],
             // slow enough to be worth saying so, but still sampled
             [
@@ -494,7 +494,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         const componentIdx = await resolvePathToNodeIdx("s");
 
         const warnings = getDiagnosticsByType(core).warnings.filter(
-            (w) => w.code === "doenet-w0134",
+            (w) => w.code === "doenet-w0135",
         );
         expect(warnings.length).eq(1);
 
@@ -524,7 +524,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
                 numInCategories,
                 numDraws: 10,
             }).map((d) => d.code),
-        ).eqls(["doenet-w0134"]);
+        ).eqls(["doenet-w0135"]);
 
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="${numInCategories.join(" ")}" numDraws="10" />`,
@@ -534,7 +534,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
 
         expect(
             getDiagnosticsByType(core).warnings.filter(
-                (w) => w.code === "doenet-w0134",
+                (w) => w.code === "doenet-w0135",
             ).length,
         ).eq(1);
 
@@ -560,7 +560,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         const componentIdx = await resolvePathToNodeIdx("s");
 
         const warnings = getDiagnosticsByType(core).warnings.filter(
-            (w) => w.code === "doenet-w0137",
+            (w) => w.code === "doenet-w0136",
         );
         expect(warnings.length).eq(1);
         expect(warnings[0].args).eqls({
@@ -668,7 +668,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         const diagnostics = getDiagnosticsByType(core);
         expect(diagnostics.errors.length).eq(0);
         expect(diagnostics.warnings.length).eq(1);
-        expect(diagnostics.warnings[0].code).eq("doenet-w0136");
+        expect(diagnostics.warnings[0].code).eq("doenet-w0137");
         expect(diagnostics.infos.length).eq(1);
         expect(diagnostics.infos[0].message).toContain("gaussian");
 
@@ -688,7 +688,7 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
     `;
         function numExplanations(core: any) {
             return getDiagnosticsByType(core).warnings.filter(
-                (w) => w.code === "doenet-w0134",
+                (w) => w.code === "doenet-w0135",
             ).length;
         }
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -408,6 +408,33 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
+    it("a draw below the limit but slow to make is still sampled, with a notice", async () => {
+        // Between the point where a document turns sluggish and the point where the
+        // draw is refused, the sample is taken as asked and the author is told why
+        // the page feels slow — something no other part of the document can tell them.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="3000000 3000000" numDraws="3000000" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        const warnings = getDiagnosticsByType(core).warnings;
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0133");
+        expect(warnings[0].args).eqls({
+            distribution: "multivariate hypergeometric",
+            draws: 3000000,
+        });
+
+        const values = stateVariables[componentIdx].replacements!.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        expect(values.reduce((a, c) => a + c, 0)).eq(3000000);
+        for (const value of values) {
+            expect(value).closeTo(1500000, 20000);
+        }
+    });
+
     it("valid parameters raise no diagnostics", async () => {
         const { core } = await createTestCore({
             doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="5 3 2" numDraws="4" />`,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -256,6 +256,25 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         ).eqls([3]);
     });
 
+    it("an empty population is sampled, not rejected", async () => {
+        // categories that are all empty are a valid (if degenerate) population,
+        // so the counts and their moments are zero rather than the NaN that the
+        // 0/0 in `n * numInCategories[i] / numTotal` would otherwise give
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" numInCategories="0 0" numDraws="0" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        expect(
+            stateVariables[componentIdx].replacements!.map(
+                (x) => stateVariables[x.componentIdx].stateValues.value,
+            ),
+        ).eqls([0, 0]);
+        expect(stateVariables[componentIdx].stateValues.means).eqls([0, 0]);
+        expect(stateVariables[componentIdx].stateValues.variances).eqls([0, 0]);
+    });
+
     it("invalid parameters give NaN", async () => {
         const doenetMLs = [
             // numDraws unspecified

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -376,6 +376,33 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
+    it("a population too large to count exactly is refused", async () => {
+        // `Number.isInteger(1e308)` is true, so such a population would otherwise
+        // be accepted whenever the draws are few — and then the arithmetic behind
+        // `means` overflows to Infinity while the sampler's urn never shrinks.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="1e308 5e307" numDraws="10" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        const warnings = getDiagnosticsByType(core).warnings.filter(
+            (w) => w.code === "doenet-w0134",
+        );
+        expect(warnings.length).eq(1);
+
+        for (const replacement of stateVariables[componentIdx].replacements!) {
+            expect(
+                Number.isNaN(
+                    stateVariables[replacement.componentIdx].stateValues.value,
+                ),
+            ).eq(true);
+        }
+        for (const value of stateVariables[componentIdx].stateValues.means) {
+            expect(Number.isNaN(value)).eq(true);
+        }
+    });
+
     it("a draw too large to sample promptly is refused, not attempted", async () => {
         // Drawing each category costs a univariate hypergeometric draw, so this would
         // otherwise run for minutes rather than returning.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createTestCore } from "../utils/test-core";
 import { getDiagnosticsByType } from "../utils/diagnostics";
 import { callAction } from "../utils/actions";
-import { sampleMultivariateHypergeometric } from "../../utils/randomNumbers";
+import {
+    multivariateSamplingDiagnostics,
+    sampleMultivariateHypergeometric,
+} from "../../utils/randomNumbers";
 import seedrandom from "seedrandom";
 
 const Mock = vi.fn();
@@ -376,10 +379,78 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         }
     });
 
+    it("every situation raises exactly one diagnostic, and a usable one raises none", () => {
+        // Asked of the shared entry point rather than through a document, because
+        // a core deduplicates diagnostics by message: the same explanation sent
+        // twice is indistinguishable there from the same explanation sent once, so
+        // no component-level count can pin down how many were raised.
+        const cases: [
+            {
+                type: string | null;
+                numInCategories: number[];
+                numDraws: number;
+            },
+            string,
+        ][] = [
+            // no distribution named
+            [
+                { type: null, numInCategories: [5, 3, 2], numDraws: 4 },
+                "doenet-w0136",
+            ],
+            // more draws than the population holds
+            [
+                {
+                    type: "hypergeometric",
+                    numInCategories: [5, 3, 2],
+                    numDraws: 11,
+                },
+                "doenet-w0134",
+            ],
+            // Too slow to draw: one category on its own costs 6e6 draws, which
+            // is under the ten-million limit, and only the two such draws the
+            // three categories need between them exceed it — so this is refused
+            // solely because the cost is counted per category.
+            [
+                {
+                    type: "hypergeometric",
+                    numInCategories: [6000000, 6000000, 6000000],
+                    numDraws: 6000000,
+                },
+                "doenet-w0135",
+            ],
+            // slow enough to be worth saying so, but still sampled
+            [
+                {
+                    type: "hypergeometric",
+                    numInCategories: [3000000, 3000000],
+                    numDraws: 3000000,
+                },
+                "doenet-w0133",
+            ],
+        ];
+
+        for (const [parameters, code] of cases) {
+            const diagnostics = multivariateSamplingDiagnostics(parameters);
+            expect(diagnostics.length, code).eq(1);
+            expect(diagnostics[0].code).eq(code);
+        }
+
+        // and parameters with nothing wrong with them say nothing at all
+        expect(
+            multivariateSamplingDiagnostics({
+                type: "hypergeometric",
+                numInCategories: [5, 3, 2],
+                numDraws: 4,
+            }),
+        ).eqls([]);
+    });
+
     it("a population too large to count exactly is refused", async () => {
         // `Number.isInteger(1e308)` is true, so such a population would otherwise
         // be accepted whenever the draws are few — and then the arithmetic behind
-        // `means` overflows to Infinity while the sampler's urn never shrinks.
+        // `means` overflows to Infinity, while the sampler asks for a whole number
+        // below a bound that has no representable multiple on the 2^53 grid and
+        // rejects every draw it makes, so it never returns at all.
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `<sampleMultivariateRandomNumber name="s" type="hypergeometric" numInCategories="1e308 5e307" numDraws="10" />`,
         });
@@ -473,9 +544,10 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
 
-        // exactly one warning, raised once: the missing type is reported on its
-        // own rather than also as unusable parameters, and neither the moments
-        // nor the samples repeat it
+        // one warning and no other: the missing type is reported on its own
+        // rather than also as unusable parameters. That it is raised only once is
+        // not something a count here can see — a core deduplicates identical
+        // messages — and is checked against the diagnostics themselves above.
         const diagnostics = getDiagnosticsByType(core);
         expect(diagnostics.errors.length).eq(0);
         expect(diagnostics.warnings.length).eq(1);
@@ -556,7 +628,11 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         });
         stateVariables = await core.returnAllStateVariables(false, true);
 
-        // still explained, and still not doubled up
+        // The explanation from the first computation is still in this core's
+        // accumulated list, and one sent again would be deduplicated away, so this
+        // says only that resampling did not add a *different* explanation — not
+        // that the reuse branch said anything. The reload below is what fails when
+        // it says nothing.
         expect(numExplanations(core)).eq(1);
         for (const replacement of stateVariables[
             await resolvePathToNodeIdx("s")

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/samplemultivariaterandomnumber.test.ts
@@ -446,11 +446,16 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
         const componentIdx = await resolvePathToNodeIdx("s");
 
-        const warnings = getDiagnosticsByType(core).warnings.filter(
-            (w) => w.code === "doenet-w0137",
+        // exactly one warning, raised once: the missing type is reported on its
+        // own rather than also as unusable parameters, and neither the moments
+        // nor the samples repeat it
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+        expect(diagnostics.warnings.length).eq(1);
+        expect(diagnostics.warnings[0].code).eq("doenet-w0137");
+        expect(diagnostics.warnings[0].message).toContain(
+            `type="hypergeometric"`,
         );
-        expect(warnings.length).eq(1);
-        expect(warnings[0].message).toContain(`type="hypergeometric"`);
 
         // nothing is guessed: the counts and both sets of moments are NaN, even
         // though the remaining parameters would describe a usable population
@@ -473,6 +478,29 @@ describe("SampleMultivariateRandomNumber tag tests @group4", async () => {
         // the component did read
         expect(stateVariables[componentIdx].stateValues.numCategories).eq(3);
         expect(stateVariables[componentIdx].stateValues.numTotal).eq(10);
+    });
+
+    it("a type the attribute does not recognize samples nothing either", async () => {
+        // An unrecognized value falls back to the attribute's default, which is
+        // no type at all, so it lands in the same refusal — reported as the value
+        // that was rejected and then as the distribution that is now missing.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<sampleMultivariateRandomNumber name="s" type="gaussian" numInCategories="5 3 2" numDraws="4" />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const componentIdx = await resolvePathToNodeIdx("s");
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+        expect(diagnostics.warnings.length).eq(1);
+        expect(diagnostics.warnings[0].code).eq("doenet-w0136");
+        expect(diagnostics.infos.length).eq(1);
+        expect(diagnostics.infos[0].message).toContain("gaussian");
+
+        expect(stateVariables[componentIdx].stateValues.type).eq(null);
+        for (const value of stateVariables[componentIdx].stateValues.means) {
+            expect(Number.isNaN(value)).eq(true);
+        }
     });
 
     it("valid parameters raise no diagnostics", async () => {

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -414,6 +414,30 @@ export function validPoissonMean(mean) {
 }
 
 /**
+ * Whether `numInCategories` and `numDraws` describe a multivariate hypergeometric
+ * distribution: a population split into at least one category of a non-negative whole
+ * number of items, from which a non-negative whole number of items no larger than the
+ * whole population is drawn.
+ *
+ * Shared with the component so that the reported means and variances are NaN for
+ * exactly the parameters whose samples are NaN. Insisting on at least one category
+ * also keeps `sampleMultivariateHypergeometric` from being handed an empty partition,
+ * which has no final category to absorb the remaining draws.
+ */
+export function validMultivariateHypergeometricParameters({
+    numInCategories,
+    numDraws,
+}) {
+    return (
+        numInCategories.length > 0 &&
+        numInCategories.every((num) => Number.isInteger(num) && num >= 0) &&
+        Number.isInteger(numDraws) &&
+        numDraws >= 0 &&
+        numDraws <= numInCategories.reduce((a, c) => a + c, 0)
+    );
+}
+
+/**
  * A notice that a document will be sluggish, or nothing when it will not. Below the
  * hard limit the samples are still drawn; this only tells the author why the page
  * feels slow, which they cannot learn from anywhere else.
@@ -591,6 +615,45 @@ export function sampleFromRandomNumbers({
 
         return { sampledValues, diagnostics: [] };
     }
+}
+
+/**
+ * Draw one vector-valued sample from the multivariate distribution named by `type`,
+ * returning one number per category — or one NaN per category, with a warning, when
+ * the parameters describe no such distribution.
+ */
+export function sampleFromMultivariateDistribution({
+    type,
+    numInCategories,
+    numDraws,
+    rng,
+}) {
+    // "hypergeometric" is the only type currently offered, and the `type` attribute's
+    // validValues keep any other from reaching here
+    if (
+        !validMultivariateHypergeometricParameters({
+            numInCategories,
+            numDraws,
+        })
+    ) {
+        console.warn(
+            `Invalid numInCategories (${numInCategories}) or numDraws (${numDraws}) for a multivariate ${type} random variable. numInCategories must be a non-empty list of non-negative integers, and numDraws must be a non-negative integer no larger than their sum.`,
+        );
+
+        return Array(numInCategories.length).fill(NaN);
+    }
+
+    const numTotal = numInCategories.reduce((a, c) => a + c, 0);
+
+    // Upper bound on the work: every category but the last costs a univariate
+    // hypergeometric draw against the part of the population not yet accounted for,
+    // and none of those is more work than a draw against the whole population.
+    warnSlowSampling(
+        "multivariate hypergeometric",
+        (numInCategories.length - 1) * Math.min(numDraws, numTotal - numDraws),
+    );
+
+    return sampleMultivariateHypergeometric({ numInCategories, numDraws, rng });
 }
 
 export function sampleFromNumberList({

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -676,29 +676,21 @@ export function sampleFromRandomNumbers({
 }
 
 /**
- * Draw one vector-valued sample from the multivariate distribution named by `type`,
- * returning one number per category alongside any diagnostics it raised — or one NaN
- * per category when the parameters describe no distribution this can sample from.
+ * What these parameters have to say for themselves, drawing nothing: whether they can
+ * be sampled from at all, and either the reason they cannot or a notice that sampling
+ * them will be slow.
  *
- * As with `sampleFromRandomNumbers`, the diagnostics come back rather than being
- * logged, so the state variable that calls this can pass them on to the reader.
+ * Both the draw and the diagnostics-only entry point below read this one answer, so
+ * the decision to sample and the explanation given to the author cannot drift apart.
  */
-/**
- * What these parameters have to say for themselves, drawing nothing: the reason
- * they cannot be sampled from, or a notice that sampling them will be slow, or
- * neither.
- *
- * Separate from the draw so that a component reusing values it already has — from
- * saved state, or from a resample — can still tell the author why they are NaN,
- * without consuming any randomness and so without disturbing a variant.
- */
-export function multivariateSamplingDiagnostics({
-    type,
-    numInCategories,
-    numDraws,
-}) {
+function inspectMultivariateParameters({ type, numInCategories, numDraws }) {
     if (type == null) {
-        return [codedDiagnostic({ type: "warning", code: "doenet-w0137" })];
+        return {
+            sampleable: false,
+            diagnostics: [
+                codedDiagnostic({ type: "warning", code: "doenet-w0137" }),
+            ],
+        };
     }
 
     const problem = multivariateHypergeometricProblem({
@@ -706,22 +698,45 @@ export function multivariateSamplingDiagnostics({
         numDraws,
     });
     if (problem) {
-        return [problem];
+        return { sampleable: false, diagnostics: [problem] };
     }
 
-    return slowSamplingDiagnostics(
-        `multivariate ${type}`,
-        multivariateHypergeometricWork({ numInCategories, numDraws }),
-    );
+    return {
+        sampleable: true,
+        diagnostics: slowSamplingDiagnostics(
+            `multivariate ${type}`,
+            multivariateHypergeometricWork({ numInCategories, numDraws }),
+        ),
+    };
 }
 
+/**
+ * The diagnostics these parameters raise, drawing nothing: the reason they cannot be
+ * sampled from, or a notice that sampling them will be slow, or neither.
+ *
+ * Separate from the draw so that a component reusing values it already has — from
+ * saved state, or from a resample — can still tell the author why they are NaN,
+ * without consuming any randomness and so without disturbing a variant.
+ */
+export function multivariateSamplingDiagnostics(parameters) {
+    return inspectMultivariateParameters(parameters).diagnostics;
+}
+
+/**
+ * Draw one vector-valued sample from the multivariate distribution named by `type`,
+ * returning one number per category alongside any diagnostics it raised — or one NaN
+ * per category when the parameters describe no distribution this can sample from.
+ *
+ * As with `sampleFromRandomNumbers`, the diagnostics come back rather than being
+ * logged, so the state variable that calls this can pass them on to the reader.
+ */
 export function sampleFromMultivariateDistribution({
     type,
     numInCategories,
     numDraws,
     rng,
 }) {
-    const diagnostics = multivariateSamplingDiagnostics({
+    const { sampleable, diagnostics } = inspectMultivariateParameters({
         type,
         numInCategories,
         numDraws,
@@ -729,10 +744,7 @@ export function sampleFromMultivariateDistribution({
 
     // anything that stopped it being sampled leaves one NaN per category, so a
     // caller never has to special-case the failure
-    if (
-        type == null ||
-        multivariateHypergeometricProblem({ numInCategories, numDraws })
-    ) {
+    if (!sampleable) {
         return {
             sampledValues: Array(numInCategories.length).fill(NaN),
             diagnostics,

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -70,6 +70,44 @@ export function sampleHypergeometric({
 }
 
 /**
+ * Sample a single multivariate hypergeometric variate: the vector of per-category
+ * counts obtained when drawing `numDraws` items without replacement from a population
+ * partitioned into categories of sizes `numInCategories`.
+ *
+ * Draws each category's count in turn as a univariate hypergeometric against the part
+ * of the population not yet accounted for, which is exact rather than an approximation.
+ * The last category takes whatever draws remain, so the counts always sum to `numDraws`.
+ */
+export function sampleMultivariateHypergeometric({
+    numInCategories,
+    numDraws,
+    rng,
+}) {
+    const counts = [];
+
+    let remainingInPopulation = numInCategories.reduce((a, c) => a + c, 0);
+    let remainingDraws = numDraws;
+
+    for (let i = 0; i < numInCategories.length - 1; i++) {
+        const count = sampleHypergeometric({
+            numTotal: remainingInPopulation,
+            numSuccesses: numInCategories[i],
+            numDraws: remainingDraws,
+            rng,
+        });
+
+        counts.push(count);
+        remainingInPopulation -= numInCategories[i];
+        remainingDraws -= count;
+    }
+
+    // whatever is left must come from the final category
+    counts.push(remainingDraws);
+
+    return counts;
+}
+
+/**
  * Sample a single binomial variate: the number of successes in `numTrials` independent
  * trials that each succeed with probability `probability`. Runs the trials directly,
  * which is O(numTrials).

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -684,6 +684,13 @@ export function sampleFromMultivariateDistribution({
     numDraws,
     rng,
 }) {
+    if (type == null) {
+        return unsampleable(
+            numInCategories.length,
+            codedDiagnostic({ type: "warning", code: "doenet-w0137" }),
+        );
+    }
+
     const problem = multivariateHypergeometricProblem({
         numInCategories,
         numDraws,
@@ -694,7 +701,7 @@ export function sampleFromMultivariateDistribution({
 
     return {
         // "hypergeometric" is the only type currently offered, and the `type`
-        // attribute's validValues keep any other from reaching here
+        // attribute's validValues keep any other named one from reaching here
         sampledValues: sampleMultivariateHypergeometric({
             numInCategories,
             numDraws,

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -453,10 +453,11 @@ function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
         !numInCategories.every(
             (num) => Number.isSafeInteger(num) && num >= 0,
         ) ||
-        // and the total as well as each category, since that total is the
-        // population every per-category draw is made against: past 2^53 it has
-        // no whole multiple of itself left below 2^53, so `uniformBelow` rejects
-        // every draw it makes and never returns
+        // and the total as well as each category, since that total — not any
+        // one category — is the largest population a draw is ever made against:
+        // the first category's is made against it, and each later one against a
+        // part of it. Past 2^53 it has no whole multiple of itself left below
+        // 2^53, so `uniformBelow` rejects every draw it makes and never returns
         !Number.isSafeInteger(numTotal) ||
         !Number.isSafeInteger(numDraws) ||
         numDraws < 0 ||

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -685,6 +685,18 @@ export function sampleFromRandomNumbers({
 }
 
 /**
+ * The multivariate distributions that can be sampled from, each mapped to the function
+ * that draws one vector-valued variate from it.
+ *
+ * Adding a distribution here and to the `type` attribute's `validValues` is all it
+ * takes; a name in one list but not the other refuses to sample rather than quietly
+ * drawing from whichever distribution happened to be first.
+ */
+const MULTIVARIATE_SAMPLERS = {
+    hypergeometric: sampleMultivariateHypergeometric,
+};
+
+/**
  * What these parameters have to say for themselves, drawing nothing: whether they can
  * be sampled from at all, and either the reason they cannot or a notice that sampling
  * them will be slow.
@@ -693,7 +705,11 @@ export function sampleFromRandomNumbers({
  * the decision to sample and the explanation given to the author cannot drift apart.
  */
 function inspectMultivariateParameters({ type, numInCategories, numDraws }) {
-    if (type == null) {
+    // A name no sampler answers to is treated exactly as no name at all, which is
+    // what the `type` attribute already does with one: it rejects the value and falls
+    // back to its `null` default. Matching that here keeps a direct caller of this
+    // helper from getting a draw that a document with the same `type` would refuse.
+    if (type == null || !Object.hasOwn(MULTIVARIATE_SAMPLERS, type)) {
         return {
             sampleable: false,
             diagnostics: [
@@ -761,9 +777,7 @@ export function sampleFromMultivariateDistribution({
     }
 
     return {
-        // "hypergeometric" is the only type currently offered, and the `type`
-        // attribute's validValues keep any other named one from reaching here
-        sampledValues: sampleMultivariateHypergeometric({
+        sampledValues: MULTIVARIATE_SAMPLERS[type]({
             numInCategories,
             numDraws,
             rng,

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -262,11 +262,11 @@ function hypergeometricWork({ numTotal, numDraws }) {
  * How a parameter is written into a diagnostic: the number the author gave, or the
  * sentinel `"not-set"` for one they left off.
  *
- * The hypergeometric parameters are the only ones with no default, so an omitted
- * one reaches a message as `null` — a word out of the implementation rather than
- * anything the author typed, and omitting one is the first way most authors reach
- * that message. The catalog selects on the sentinel and says "not set" in the
- * reader's language instead.
+ * The hypergeometric parameters, and the multivariate `numDraws`, are the only
+ * ones with no default, so an omitted one reaches a message as `null` — a word out
+ * of the implementation rather than anything the author typed, and omitting one is
+ * the first way most authors reach those messages. The catalog selects on the
+ * sentinel and says "not set" in the reader's language instead.
  */
 function reportedValue(value) {
     return value == null ? "not-set" : value;
@@ -419,15 +419,27 @@ export function validPoissonMean(mean) {
 }
 
 /**
- * Whether `numInCategories` and `numDraws` describe a multivariate hypergeometric
- * distribution: a population split into at least one category of a non-negative whole
- * number of items, from which a non-negative whole number of items no larger than the
- * whole population is drawn.
+ * An upper bound on the draws one multivariate variate costs. Every category but the
+ * last is a univariate hypergeometric draw against the part of the population not yet
+ * accounted for; neither the draws remaining nor the items left behind ever grows as
+ * that part shrinks, so no such draw costs more than one against the whole population.
+ */
+function multivariateHypergeometricWork({ numInCategories, numDraws }) {
+    const numTotal = sumOf(numInCategories);
+    return (
+        (numInCategories.length - 1) * Math.min(numDraws, numTotal - numDraws)
+    );
+}
+
+/**
+ * Why `numInCategories` and `numDraws` cannot be sampled from, or `null` if they can.
+ * A usable set is a population split into at least one category of a non-negative
+ * whole number of items, from which a non-negative whole number of items no larger
+ * than the whole population is drawn few enough times to finish promptly.
  *
- * Shared with the component so that the reported means and variances are NaN for
- * exactly the parameters whose samples are NaN. Insisting on at least one category
- * also keeps `sampleMultivariateHypergeometric` from being handed an empty partition,
- * which has no final category to absorb the remaining draws.
+ * Insisting on at least one category also keeps `sampleMultivariateHypergeometric`
+ * from being handed an empty partition, which has no final category to absorb the
+ * remaining draws.
  */
 function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
     if (
@@ -471,22 +483,8 @@ function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
 }
 
 /**
- * An upper bound on the draws one multivariate variate costs. Every category but the
- * last is a univariate hypergeometric draw against the part of the population not yet
- * accounted for; neither the draws remaining nor the items left behind ever grows as
- * that part shrinks, so no such draw costs more than one against the whole population.
- */
-function multivariateHypergeometricWork({ numInCategories, numDraws }) {
-    const numTotal = sumOf(numInCategories);
-    return (
-        (numInCategories.length - 1) * Math.min(numDraws, numTotal - numDraws)
-    );
-}
-
-/**
  * Whether `numInCategories` and `numDraws` describe a multivariate hypergeometric
- * distribution this can actually sample from. Shared with the component so that the
- * reported means and variances are NaN for exactly the parameters whose samples are.
+ * distribution this can actually sample from. Shared with the component, as above.
  */
 export function validMultivariateHypergeometricParameters(parameters) {
     return multivariateHypergeometricProblem(parameters) === null;

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -683,17 +683,22 @@ export function sampleFromRandomNumbers({
  * As with `sampleFromRandomNumbers`, the diagnostics come back rather than being
  * logged, so the state variable that calls this can pass them on to the reader.
  */
-export function sampleFromMultivariateDistribution({
+/**
+ * What these parameters have to say for themselves, drawing nothing: the reason
+ * they cannot be sampled from, or a notice that sampling them will be slow, or
+ * neither.
+ *
+ * Separate from the draw so that a component reusing values it already has — from
+ * saved state, or from a resample — can still tell the author why they are NaN,
+ * without consuming any randomness and so without disturbing a variant.
+ */
+export function multivariateSamplingDiagnostics({
     type,
     numInCategories,
     numDraws,
-    rng,
 }) {
     if (type == null) {
-        return unsampleable(
-            numInCategories.length,
-            codedDiagnostic({ type: "warning", code: "doenet-w0137" }),
-        );
+        return [codedDiagnostic({ type: "warning", code: "doenet-w0137" })];
     }
 
     const problem = multivariateHypergeometricProblem({
@@ -701,7 +706,37 @@ export function sampleFromMultivariateDistribution({
         numDraws,
     });
     if (problem) {
-        return unsampleable(numInCategories.length, problem);
+        return [problem];
+    }
+
+    return slowSamplingDiagnostics(
+        `multivariate ${type}`,
+        multivariateHypergeometricWork({ numInCategories, numDraws }),
+    );
+}
+
+export function sampleFromMultivariateDistribution({
+    type,
+    numInCategories,
+    numDraws,
+    rng,
+}) {
+    const diagnostics = multivariateSamplingDiagnostics({
+        type,
+        numInCategories,
+        numDraws,
+    });
+
+    // anything that stopped it being sampled leaves one NaN per category, so a
+    // caller never has to special-case the failure
+    if (
+        type == null ||
+        multivariateHypergeometricProblem({ numInCategories, numDraws })
+    ) {
+        return {
+            sampledValues: Array(numInCategories.length).fill(NaN),
+            diagnostics,
+        };
     }
 
     return {
@@ -712,10 +747,7 @@ export function sampleFromMultivariateDistribution({
             numDraws,
             rng,
         }),
-        diagnostics: slowSamplingDiagnostics(
-            `multivariate ${type}`,
-            multivariateHypergeometricWork({ numInCategories, numDraws }),
-        ),
+        diagnostics,
     };
 }
 

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -444,8 +444,13 @@ function multivariateHypergeometricWork({ numInCategories, numDraws }) {
 function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
     if (
         numInCategories.length === 0 ||
-        !numInCategories.every((num) => Number.isInteger(num) && num >= 0) ||
-        !Number.isInteger(numDraws) ||
+        // safe integers, for the reason given on the univariate hypergeometric
+        // above: `numDraws * numInCategories[i]` backs the reported means, and a
+        // merely-whole population large enough overflows it to Infinity
+        !numInCategories.every(
+            (num) => Number.isSafeInteger(num) && num >= 0,
+        ) ||
+        !Number.isSafeInteger(numDraws) ||
         numDraws < 0 ||
         numDraws > sumOf(numInCategories)
     ) {

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -434,14 +434,17 @@ function multivariateHypergeometricWork({ numInCategories, numDraws }) {
 /**
  * Why `numInCategories` and `numDraws` cannot be sampled from, or `null` if they can.
  * A usable set is a population split into at least one category of a non-negative
- * whole number of items, from which a non-negative whole number of items no larger
- * than the whole population is drawn few enough times to finish promptly.
+ * whole number of items, counting exactly both category by category and in total,
+ * from which a non-negative whole number of items no larger than the whole population
+ * is drawn few enough times to finish promptly.
  *
  * Insisting on at least one category also keeps `sampleMultivariateHypergeometric`
  * from being handed an empty partition, which has no final category to absorb the
  * remaining draws.
  */
 function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
+    const numTotal = sumOf(numInCategories);
+
     if (
         numInCategories.length === 0 ||
         // safe integers, for the reason given on the univariate hypergeometric
@@ -450,9 +453,14 @@ function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
         !numInCategories.every(
             (num) => Number.isSafeInteger(num) && num >= 0,
         ) ||
+        // and the total as well as each category, since that total is the
+        // population every per-category draw is made against: past 2^53 it has
+        // no whole multiple of itself left below 2^53, so `uniformBelow` rejects
+        // every draw it makes and never returns
+        !Number.isSafeInteger(numTotal) ||
         !Number.isSafeInteger(numDraws) ||
         numDraws < 0 ||
-        numDraws > sumOf(numInCategories)
+        numDraws > numTotal
     ) {
         return codedDiagnostic({
             type: "warning",
@@ -477,7 +485,7 @@ function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
             code: "doenet-w0136",
             args: {
                 numDraws,
-                numTotal: sumOf(numInCategories),
+                numTotal,
                 numCategories: numInCategories.length,
                 maxDraws: MAX_WORK_PER_VARIATE,
             },

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -429,17 +429,67 @@ export function validPoissonMean(mean) {
  * also keeps `sampleMultivariateHypergeometric` from being handed an empty partition,
  * which has no final category to absorb the remaining draws.
  */
-export function validMultivariateHypergeometricParameters({
-    numInCategories,
-    numDraws,
-}) {
+function multivariateHypergeometricProblem({ numInCategories, numDraws }) {
+    if (
+        numInCategories.length === 0 ||
+        !numInCategories.every((num) => Number.isInteger(num) && num >= 0) ||
+        !Number.isInteger(numDraws) ||
+        numDraws < 0 ||
+        numDraws > sumOf(numInCategories)
+    ) {
+        return codedDiagnostic({
+            type: "warning",
+            code: "doenet-w0135",
+            args: {
+                // an omitted numberList arrives empty rather than as null
+                numInCategories:
+                    numInCategories.length === 0
+                        ? "not-set"
+                        : numInCategories.join(", "),
+                numDraws: reportedValue(numDraws),
+            },
+        });
+    }
+
+    if (
+        multivariateHypergeometricWork({ numInCategories, numDraws }) >
+        MAX_WORK_PER_VARIATE
+    ) {
+        return codedDiagnostic({
+            type: "warning",
+            code: "doenet-w0136",
+            args: {
+                numDraws,
+                numTotal: sumOf(numInCategories),
+                numCategories: numInCategories.length,
+                maxDraws: MAX_WORK_PER_VARIATE,
+            },
+        });
+    }
+
+    return null;
+}
+
+/**
+ * An upper bound on the draws one multivariate variate costs. Every category but the
+ * last is a univariate hypergeometric draw against the part of the population not yet
+ * accounted for; neither the draws remaining nor the items left behind ever grows as
+ * that part shrinks, so no such draw costs more than one against the whole population.
+ */
+function multivariateHypergeometricWork({ numInCategories, numDraws }) {
+    const numTotal = sumOf(numInCategories);
     return (
-        numInCategories.length > 0 &&
-        numInCategories.every((num) => Number.isInteger(num) && num >= 0) &&
-        Number.isInteger(numDraws) &&
-        numDraws >= 0 &&
-        numDraws <= sumOf(numInCategories)
+        (numInCategories.length - 1) * Math.min(numDraws, numTotal - numDraws)
     );
+}
+
+/**
+ * Whether `numInCategories` and `numDraws` describe a multivariate hypergeometric
+ * distribution this can actually sample from. Shared with the component so that the
+ * reported means and variances are NaN for exactly the parameters whose samples are.
+ */
+export function validMultivariateHypergeometricParameters(parameters) {
+    return multivariateHypergeometricProblem(parameters) === null;
 }
 
 /**
@@ -624,8 +674,11 @@ export function sampleFromRandomNumbers({
 
 /**
  * Draw one vector-valued sample from the multivariate distribution named by `type`,
- * returning one number per category — or one NaN per category, with a warning, when
- * the parameters describe no such distribution.
+ * returning one number per category alongside any diagnostics it raised — or one NaN
+ * per category when the parameters describe no distribution this can sample from.
+ *
+ * As with `sampleFromRandomNumbers`, the diagnostics come back rather than being
+ * logged, so the state variable that calls this can pass them on to the reader.
  */
 export function sampleFromMultivariateDistribution({
     type,
@@ -633,33 +686,27 @@ export function sampleFromMultivariateDistribution({
     numDraws,
     rng,
 }) {
-    if (
-        !validMultivariateHypergeometricParameters({
-            numInCategories,
-            numDraws,
-        })
-    ) {
-        console.warn(
-            `Invalid numInCategories (${numInCategories}) or numDraws (${numDraws}) for a multivariate ${type} random variable. numInCategories must be a non-empty list of non-negative integers, and numDraws must be a non-negative integer no larger than their sum.`,
-        );
-
-        return Array(numInCategories.length).fill(NaN);
+    const problem = multivariateHypergeometricProblem({
+        numInCategories,
+        numDraws,
+    });
+    if (problem) {
+        return unsampleable(numInCategories.length, problem);
     }
 
-    const numTotal = sumOf(numInCategories);
-
-    // Upper bound on the work: every category but the last costs a univariate
-    // hypergeometric draw against the part of the population not yet accounted for.
-    // Neither the draws remaining nor the items left behind ever grows as that part
-    // shrinks, so no such draw is more work than one against the whole population.
-    warnSlowSampling(
-        "multivariate hypergeometric",
-        (numInCategories.length - 1) * Math.min(numDraws, numTotal - numDraws),
-    );
-
-    // "hypergeometric" is the only type currently offered, and the `type` attribute's
-    // validValues keep any other from reaching here
-    return sampleMultivariateHypergeometric({ numInCategories, numDraws, rng });
+    return {
+        // "hypergeometric" is the only type currently offered, and the `type`
+        // attribute's validValues keep any other from reaching here
+        sampledValues: sampleMultivariateHypergeometric({
+            numInCategories,
+            numDraws,
+            rng,
+        }),
+        diagnostics: slowSamplingDiagnostics(
+            `multivariate ${type}`,
+            multivariateHypergeometricWork({ numInCategories, numDraws }),
+        ),
+    };
 }
 
 export function sampleFromNumberList({

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -688,9 +688,17 @@ export function sampleFromRandomNumbers({
  * The multivariate distributions that can be sampled from, each mapped to the function
  * that draws one vector-valued variate from it.
  *
- * Adding a distribution here and to the `type` attribute's `validValues` is all it
- * takes; a name in one list but not the other refuses to sample rather than quietly
- * drawing from whichever distribution happened to be first.
+ * A name in this map but not in the `type` attribute's `validValues`, or the reverse,
+ * refuses to sample rather than quietly drawing from whichever distribution happened to
+ * be first. That refusal is all this map buys, and registering a second distribution
+ * takes considerably more than adding it to the two lists: everything below is still
+ * written for the hypergeometric alone. The parameters describe an urn rather than any
+ * multivariate distribution — a joint gaussian would be given means and covariances,
+ * not `numInCategories` and `numDraws` — and the validity check, the cost estimate, and
+ * the two diagnostics reporting on them are all specific to that urn, down to the
+ * message text, which names the multivariate hypergeometric outright. A second
+ * distribution needs its own parameters, validation, cost estimate, and messages; what
+ * it inherits from here is only that forgetting them cannot pass for a working draw.
  */
 const MULTIVARIATE_SAMPLERS = {
     hypergeometric: sampleMultivariateHypergeometric,
@@ -718,6 +726,8 @@ function inspectMultivariateParameters({ type, numInCategories, numDraws }) {
         };
     }
 
+    // Hypergeometric-specific, as is the cost estimate below — see the note on
+    // MULTIVARIATE_SAMPLERS for what a second distribution would have to bring.
     const problem = multivariateHypergeometricProblem({
         numInCategories,
         numDraws,

--- a/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/utils/randomNumbers.js
@@ -20,6 +20,11 @@ const TWO_TO_THE_53 = 0x20000000000000;
 // worth saying but not worth refusing.
 const WORK_PER_VARIATE_WARNING_THRESHOLD = 1e6;
 
+/** Total of a list of numbers, e.g. the population size a partition adds up to. */
+function sumOf(nums) {
+    return nums.reduce((a, c) => a + c, 0);
+}
+
 /**
  * Sample a single hypergeometric variate: the number of successes obtained when drawing
  * `numDraws` items without replacement from a population of `numTotal` items, of which
@@ -85,7 +90,7 @@ export function sampleMultivariateHypergeometric({
 }) {
     const counts = [];
 
-    let remainingInPopulation = numInCategories.reduce((a, c) => a + c, 0);
+    let remainingInPopulation = sumOf(numInCategories);
     let remainingDraws = numDraws;
 
     for (let i = 0; i < numInCategories.length - 1; i++) {
@@ -433,7 +438,7 @@ export function validMultivariateHypergeometricParameters({
         numInCategories.every((num) => Number.isInteger(num) && num >= 0) &&
         Number.isInteger(numDraws) &&
         numDraws >= 0 &&
-        numDraws <= numInCategories.reduce((a, c) => a + c, 0)
+        numDraws <= sumOf(numInCategories)
     );
 }
 
@@ -628,8 +633,6 @@ export function sampleFromMultivariateDistribution({
     numDraws,
     rng,
 }) {
-    // "hypergeometric" is the only type currently offered, and the `type` attribute's
-    // validValues keep any other from reaching here
     if (
         !validMultivariateHypergeometricParameters({
             numInCategories,
@@ -643,16 +646,19 @@ export function sampleFromMultivariateDistribution({
         return Array(numInCategories.length).fill(NaN);
     }
 
-    const numTotal = numInCategories.reduce((a, c) => a + c, 0);
+    const numTotal = sumOf(numInCategories);
 
     // Upper bound on the work: every category but the last costs a univariate
-    // hypergeometric draw against the part of the population not yet accounted for,
-    // and none of those is more work than a draw against the whole population.
+    // hypergeometric draw against the part of the population not yet accounted for.
+    // Neither the draws remaining nor the items left behind ever grows as that part
+    // shrinks, so no such draw is more work than one against the whole population.
     warnSlowSampling(
         "multivariate hypergeometric",
         (numInCategories.length - 1) * Math.min(numDraws, numTotal - numDraws),
     );
 
+    // "hypergeometric" is the only type currently offered, and the `type` attribute's
+    // validValues keep any other from reaching here
     return sampleMultivariateHypergeometric({ numInCategories, numDraws, rng });
 }
 

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -96,6 +96,7 @@
     "doenet-i0033": "variant-math-exclude-not-implemented",
     "doenet-i0034": "variant-non-constant-exclude-not-implemented",
     "doenet-i0048": "attribute-value-invalid-using-default",
+    "doenet-i0049": "index-operator-no-values",
     "doenet-w0001": "line-points-undetermined-dimensions",
     "doenet-w0002": "line-points-too-few-dimensions",
     "doenet-w0003": "line-points-depend-on-variables",
@@ -227,7 +228,8 @@
     "doenet-w0131": "sample-poisson-mean-invalid",
     "doenet-w0132": "sample-poisson-mean-too-large",
     "doenet-w0133": "sample-distribution-slow",
-    "doenet-w0134": "sample-multivariate-parameters-invalid",
-    "doenet-w0135": "sample-multivariate-draws-too-many",
-    "doenet-w0136": "sample-multivariate-type-not-specified"
+    "doenet-w0134": "index-operator-missing-target",
+    "doenet-w0135": "sample-multivariate-parameters-invalid",
+    "doenet-w0136": "sample-multivariate-draws-too-many",
+    "doenet-w0137": "sample-multivariate-type-not-specified"
 }

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -96,7 +96,6 @@
     "doenet-i0033": "variant-math-exclude-not-implemented",
     "doenet-i0034": "variant-non-constant-exclude-not-implemented",
     "doenet-i0048": "attribute-value-invalid-using-default",
-    "doenet-i0049": "index-operator-no-values",
     "doenet-w0001": "line-points-undetermined-dimensions",
     "doenet-w0002": "line-points-too-few-dimensions",
     "doenet-w0003": "line-points-depend-on-variables",
@@ -228,5 +227,6 @@
     "doenet-w0131": "sample-poisson-mean-invalid",
     "doenet-w0132": "sample-poisson-mean-too-large",
     "doenet-w0133": "sample-distribution-slow",
-    "doenet-w0134": "index-operator-missing-target"
+    "doenet-w0134": "sample-multivariate-parameters-invalid",
+    "doenet-w0135": "sample-multivariate-draws-too-many"
 }

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -228,5 +228,6 @@
     "doenet-w0132": "sample-poisson-mean-too-large",
     "doenet-w0133": "sample-distribution-slow",
     "doenet-w0134": "sample-multivariate-parameters-invalid",
-    "doenet-w0135": "sample-multivariate-draws-too-many"
+    "doenet-w0135": "sample-multivariate-draws-too-many",
+    "doenet-w0136": "sample-multivariate-type-not-specified"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -1021,10 +1021,13 @@ index-operator-no-values =
 ## written. Each names the attribute the author has to change, so a message that
 ## translated one would point at an attribute that does not exist.
 
-# Neither attribute has a default, so leaving one out is the commonest way to reach
-# this message. Each arrives either as the value the author wrote or as `not-set`
-# for an attribute they left off entirely; translate the "not set" wording, but
-# leave the `not-set` key that selects it untouched.
+# Neither attribute has a default that names a population — numDraws has none at
+# all, and numInCategories falls back to a list with no categories in it — so
+# leaving one out is the commonest way to reach this message. Each arrives either
+# as the value the author wrote or as `not-set`: for numDraws when it is missing,
+# and for numInCategories when it names no categories, whether it was left off or
+# written empty. Translate the "not set" wording, but leave the `not-set` key that
+# selects it untouched.
 sample-multivariate-parameters-invalid =
     Invalid numInCategories ({ $numInCategories ->
         [not-set] not set

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -1032,13 +1032,15 @@ sample-multivariate-parameters-invalid =
     }) or numDraws ({ $numDraws ->
         [not-set] not set
        *[other] { $numDraws }
-    }) for a multivariate hypergeometric random variable. numInCategories must list at least one category, each a non-negative whole number, and numDraws must be a non-negative whole number no larger than their total.
+    }) for a multivariate hypergeometric random variable. numInCategories must list at least one category, each a non-negative whole number, and numDraws must be a non-negative whole number no larger than their total. Each category, that total, and numDraws must also stay below about nine quadrillion, past which whole numbers can no longer be counted exactly.
 
 # $maxDraws is the largest number of random draws allowed for a single sample.
 # Drawing nearly the whole population is as cheap as drawing almost none of it, so
-# raising numDraws is a fix as well as lowering it.
+# raising numDraws is a fix as well as lowering it. "could need" rather than "would
+# need": each category is counted at the most its draw could cost, so the count
+# these parameters are refused on is an upper bound on the work they really take.
 sample-multivariate-draws-too-many =
-    Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, bring it closer to numTotal, or use fewer categories.
+    Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories could need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, bring it closer to numTotal, or use fewer categories.
 
 # `type` has no default, so this is what leaving it off gets. A type the attribute
 # does not recognize falls back to no type at all and reaches this message too,

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -1038,3 +1038,9 @@ sample-multivariate-parameters-invalid =
 # raising numDraws is a fix as well as lowering it.
 sample-multivariate-draws-too-many =
     Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, bring it closer to numTotal, or use fewer categories.
+
+# Deliberately has no default: which multivariate distribution is meant is not
+# something to guess on the author's behalf, and defaulting to one would make any
+# later change of default silently reinterpret documents that relied on it.
+sample-multivariate-type-not-specified =
+    No type was given for this multivariate random variable, so nothing was sampled. Add a type attribute naming the distribution, such as `type="hypergeometric"`.

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -1015,10 +1015,11 @@ index-operator-no-values =
     `{ $component }` has no values to look through, so it gives 0, which is not the index of any item.
 ## `<sampleMultivariateRandomNumber>`
 ##
-## Translators: `numInCategories` and `numDraws` are DoenetML attribute names.
-## They are written into these messages as they stand and must be left in English
-## exactly as written. Each names the attribute the author has to change, so a
-## message that translated one would point at an attribute that does not exist.
+## Translators: `type`, `numInCategories` and `numDraws` are DoenetML attribute
+## names, and `hypergeometric` is one of the values `type` takes. They are written
+## into these messages as they stand and must be left in English exactly as
+## written. Each names the attribute the author has to change, so a message that
+## translated one would point at an attribute that does not exist.
 
 # Neither attribute has a default, so leaving one out is the commonest way to reach
 # this message. Each arrives either as the value the author wrote or as `not-set`
@@ -1039,8 +1040,9 @@ sample-multivariate-parameters-invalid =
 sample-multivariate-draws-too-many =
     Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, bring it closer to numTotal, or use fewer categories.
 
-# Deliberately has no default: which multivariate distribution is meant is not
-# something to guess on the author's behalf, and defaulting to one would make any
-# later change of default silently reinterpret documents that relied on it.
+# `type` has no default, so this is what leaving it off gets. A type the attribute
+# does not recognize falls back to no type at all and reaches this message too,
+# after a separate one naming the value that was rejected — hence "no distribution
+# was named" rather than wording that assumes the attribute is missing.
 sample-multivariate-type-not-specified =
-    No type was given for this multivariate random variable, so nothing was sampled. Add a type attribute naming the distribution, such as `type="hypergeometric"`.
+    No multivariate distribution was named for this random variable, so nothing was sampled. Give the type attribute the name of a distribution, such as `type="hypergeometric"`.

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -994,10 +994,11 @@ sample-poisson-mean-invalid =
 sample-poisson-mean-too-large =
     A poisson mean of { $mean } would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce the mean.
 
-# $distribution names the distribution, e.g. "binomial"; $draws is roughly how many
-# random draws each value needs. Raised by both `<sampleRandomNumbers>` and
-# `<selectRandomNumbers>`, which count values with `numSamples` and `numToSelect`
-# respectively, so the wording names neither.
+# $distribution names the distribution being sampled, e.g. "binomial" or
+# "multivariate hypergeometric"; $draws is roughly how many random draws each value
+# needs. Raised by `<sampleRandomNumbers>`, `<selectRandomNumbers>` and
+# `<sampleMultivariateRandomNumber>`, which count values with `numSamples`,
+# `numToSelect` and one vector respectively, so the wording names no attribute.
 sample-distribution-slow =
     Each value from this { $distribution } distribution needs about { $draws } random draws, so sampling may be slow. Reduce the distribution's parameters, or ask for fewer values, if the page feels sluggish.
 
@@ -1013,11 +1014,16 @@ index-operator-missing-target =
 index-operator-no-values =
     `{ $component }` has no values to look through, so it gives 0, which is not the index of any item.
 ## `<sampleMultivariateRandomNumber>`
+##
+## Translators: `numInCategories` and `numDraws` are DoenetML attribute names.
+## They are written into these messages as they stand and must be left in English
+## exactly as written. Each names the attribute the author has to change, so a
+## message that translated one would point at an attribute that does not exist.
 
-# Translators: `numInCategories` and `numDraws` are DoenetML attribute names. Leave
-# them in English exactly as written. `not-set` marks an attribute the author left
-# off altogether, as opposed to one holding an unusable value.
-
+# Neither attribute has a default, so leaving one out is the commonest way to reach
+# this message. Each arrives either as the value the author wrote or as `not-set`
+# for an attribute they left off entirely; translate the "not set" wording, but
+# leave the `not-set` key that selects it untouched.
 sample-multivariate-parameters-invalid =
     Invalid numInCategories ({ $numInCategories ->
         [not-set] not set
@@ -1025,8 +1031,10 @@ sample-multivariate-parameters-invalid =
     }) or numDraws ({ $numDraws ->
         [not-set] not set
        *[other] { $numDraws }
-    }) for a multivariate random variable. numInCategories must list at least one category, each a non-negative whole number, and numDraws must be a non-negative whole number no larger than their total.
+    }) for a multivariate hypergeometric random variable. numInCategories must list at least one category, each a non-negative whole number, and numDraws must be a non-negative whole number no larger than their total.
 
 # $maxDraws is the largest number of random draws allowed for a single sample.
+# Drawing nearly the whole population is as cheap as drawing almost none of it, so
+# raising numDraws is a fix as well as lowering it.
 sample-multivariate-draws-too-many =
-    Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, or use fewer categories.
+    Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, bring it closer to numTotal, or use fewer categories.

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -1012,3 +1012,21 @@ index-operator-missing-target =
 # whose only children were references that produced nothing.
 index-operator-no-values =
     `{ $component }` has no values to look through, so it gives 0, which is not the index of any item.
+## `<sampleMultivariateRandomNumber>`
+
+# Translators: `numInCategories` and `numDraws` are DoenetML attribute names. Leave
+# them in English exactly as written. `not-set` marks an attribute the author left
+# off altogether, as opposed to one holding an unusable value.
+
+sample-multivariate-parameters-invalid =
+    Invalid numInCategories ({ $numInCategories ->
+        [not-set] not set
+       *[other] { $numInCategories }
+    }) or numDraws ({ $numDraws ->
+        [not-set] not set
+       *[other] { $numDraws }
+    }) for a multivariate random variable. numInCategories must list at least one category, each a non-negative whole number, and numDraws must be a non-negative whole number no larger than their total.
+
+# $maxDraws is the largest number of random draws allowed for a single sample.
+sample-multivariate-draws-too-many =
+    Drawing { $numDraws } items from a population of { $numTotal } split into { $numCategories } categories would need more than { $maxDraws } random draws for each sample, which would stop the page from responding. Reduce numDraws, or use fewer categories.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -220,6 +220,8 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0132": "sample-poisson-mean-too-large",
     "doenet-w0133": "sample-distribution-slow",
     "doenet-w0134": "index-operator-missing-target",
+    "doenet-w0135": "sample-multivariate-parameters-invalid",
+    "doenet-w0136": "sample-multivariate-draws-too-many",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -222,6 +222,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0134": "index-operator-missing-target",
     "doenet-w0135": "sample-multivariate-parameters-invalid",
     "doenet-w0136": "sample-multivariate-draws-too-many",
+    "doenet-w0137": "sample-multivariate-type-not-specified",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -532,7 +532,11 @@ export type MessageKey =
 =======
     | "sample-multivariate-parameters-invalid"
     | "sample-multivariate-draws-too-many"
+<<<<<<< HEAD
 >>>>>>> 722b980f4 (fix(sampling): bound the multivariate draw and report to the author)
+=======
+    | "sample-multivariate-type-not-specified"
+>>>>>>> bfd4488c7 (feat(sampling): require a type on the multivariate sampler)
     | "editor-update-viewer"
     | "editor-update-viewer-title"
     | "editor-variant"
@@ -1131,7 +1135,11 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
 =======
     "sample-multivariate-parameters-invalid",
     "sample-multivariate-draws-too-many",
+<<<<<<< HEAD
 >>>>>>> 722b980f4 (fix(sampling): bound the multivariate draw and report to the author)
+=======
+    "sample-multivariate-type-not-specified",
+>>>>>>> bfd4488c7 (feat(sampling): require a type on the multivariate sampler)
     "editor-update-viewer",
     "editor-update-viewer-title",
     "editor-variant",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -526,17 +526,11 @@ export type MessageKey =
     | "sample-poisson-mean-invalid"
     | "sample-poisson-mean-too-large"
     | "sample-distribution-slow"
-<<<<<<< HEAD
     | "index-operator-missing-target"
     | "index-operator-no-values"
-=======
     | "sample-multivariate-parameters-invalid"
     | "sample-multivariate-draws-too-many"
-<<<<<<< HEAD
->>>>>>> 722b980f4 (fix(sampling): bound the multivariate draw and report to the author)
-=======
     | "sample-multivariate-type-not-specified"
->>>>>>> bfd4488c7 (feat(sampling): require a type on the multivariate sampler)
     | "editor-update-viewer"
     | "editor-update-viewer-title"
     | "editor-variant"
@@ -1129,17 +1123,11 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "sample-poisson-mean-invalid",
     "sample-poisson-mean-too-large",
     "sample-distribution-slow",
-<<<<<<< HEAD
     "index-operator-missing-target",
     "index-operator-no-values",
-=======
     "sample-multivariate-parameters-invalid",
     "sample-multivariate-draws-too-many",
-<<<<<<< HEAD
->>>>>>> 722b980f4 (fix(sampling): bound the multivariate draw and report to the author)
-=======
     "sample-multivariate-type-not-specified",
->>>>>>> bfd4488c7 (feat(sampling): require a type on the multivariate sampler)
     "editor-update-viewer",
     "editor-update-viewer-title",
     "editor-variant",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -526,8 +526,13 @@ export type MessageKey =
     | "sample-poisson-mean-invalid"
     | "sample-poisson-mean-too-large"
     | "sample-distribution-slow"
+<<<<<<< HEAD
     | "index-operator-missing-target"
     | "index-operator-no-values"
+=======
+    | "sample-multivariate-parameters-invalid"
+    | "sample-multivariate-draws-too-many"
+>>>>>>> 722b980f4 (fix(sampling): bound the multivariate draw and report to the author)
     | "editor-update-viewer"
     | "editor-update-viewer-title"
     | "editor-variant"
@@ -1120,8 +1125,13 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "sample-poisson-mean-invalid",
     "sample-poisson-mean-too-large",
     "sample-distribution-slow",
+<<<<<<< HEAD
     "index-operator-missing-target",
     "index-operator-no-values",
+=======
+    "sample-multivariate-parameters-invalid",
+    "sample-multivariate-draws-too-many",
+>>>>>>> 722b980f4 (fix(sampling): bound the multivariate draw and report to the author)
     "editor-update-viewer",
     "editor-update-viewer-title",
     "editor-variant",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -135586,7 +135586,7 @@
                     "name": "type",
                     "type": "text",
                     "isArray": false,
-                    "description": "Multivariate distribution from which to sample.",
+                    "description": "Multivariate distribution from which to sample. Required; there is no default.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -192,6 +192,7 @@
         "evaluate",
         "selectRandomNumbers",
         "sampleRandomNumbers",
+        "sampleMultivariateRandomNumber",
         "selectPrimeNumbers",
         "samplePrimeNumbers",
         "substitute",
@@ -679,6 +680,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -1276,6 +1280,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -2191,6 +2198,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -2897,6 +2907,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -3813,6 +3826,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -4797,6 +4813,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -5777,6 +5796,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -6806,6 +6828,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -7682,6 +7707,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -8361,6 +8389,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -9037,6 +9068,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -9711,6 +9745,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -10836,6 +10873,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -11416,6 +11456,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -13782,6 +13825,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -14350,6 +14396,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -14933,6 +14982,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -15603,6 +15655,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -16499,6 +16554,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -17389,6 +17447,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -18283,6 +18344,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -19175,6 +19239,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -20061,6 +20128,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -20927,6 +20997,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -21785,6 +21858,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -22653,6 +22729,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -23519,6 +23598,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -24383,6 +24465,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -25263,6 +25348,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -26157,6 +26245,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -27058,6 +27149,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -27968,6 +28062,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -28869,6 +28966,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -29761,6 +29861,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -30657,6 +30760,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -31549,6 +31655,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -32445,6 +32554,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -33337,6 +33449,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -34239,6 +34354,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -42589,6 +42707,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -43598,6 +43719,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -44611,6 +44735,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -45472,6 +45599,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -46149,6 +46279,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -46733,6 +46866,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -47321,6 +47457,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -47905,6 +48044,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -48493,6 +48635,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -49077,6 +49222,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -49665,6 +49813,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -50249,6 +50400,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -50837,6 +50991,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -51421,6 +51578,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -53411,6 +53571,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -54608,6 +54771,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -55809,6 +55975,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -57006,6 +57175,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -58214,6 +58386,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -59411,6 +59586,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -60619,6 +60797,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -61823,6 +62004,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -63031,6 +63215,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -64237,6 +64424,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -65434,6 +65624,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -66635,6 +66828,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -67832,6 +68028,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -69033,6 +69232,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -70232,6 +70434,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -71429,6 +71634,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -72636,6 +72844,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -73827,6 +74038,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -75016,6 +75230,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -76648,6 +76865,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -78470,6 +78690,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -79257,6 +79480,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -80087,6 +80313,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -81769,6 +81998,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -82484,6 +82716,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -84631,6 +84866,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -85529,6 +85767,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -86513,6 +86754,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -87430,6 +87674,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -88263,6 +88510,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -89128,6 +89378,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -90397,6 +90650,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -91089,6 +91345,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -91830,6 +92089,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -92816,6 +93078,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -93392,6 +93657,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -93979,6 +94247,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -94577,6 +94848,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -95184,6 +95458,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -96061,6 +96338,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -96850,6 +97130,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -97340,6 +97623,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -97729,6 +98015,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -98619,6 +98908,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -99297,6 +99589,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -100078,6 +100373,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -100924,6 +101222,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -105600,6 +105901,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -106430,6 +106734,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -107245,6 +107552,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -108012,6 +108322,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -108487,6 +108800,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -109023,6 +109339,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -109766,6 +110085,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -110647,6 +110969,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -111580,6 +111905,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -112295,6 +112623,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -113042,6 +113373,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -113853,6 +114187,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -114527,6 +114864,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -115778,6 +116118,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -116333,6 +116676,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -116963,6 +117309,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -117970,6 +118319,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -119153,6 +119505,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -120793,6 +121148,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -121860,6 +122218,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -122579,6 +122940,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -123635,6 +123999,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -125524,6 +125891,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -126293,6 +126663,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -127271,6 +127644,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -128129,6 +128505,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -131399,6 +131778,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -132016,6 +132398,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -133362,6 +133747,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -135044,6 +135432,232 @@
                 }
             ]
         },
+        "sampleMultivariateRandomNumber": {
+            "type": "element",
+            "name": "sampleMultivariateRandomNumber",
+            "attributes": {
+                "name": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "hide": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "disabled": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "fixed": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "fixLocation": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "styleNumber": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "type": {
+                    "optional": true,
+                    "type": [
+                        "hypergeometric"
+                    ]
+                },
+                "numInCategories": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "numDraws": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "displayDigits": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "displayDecimals": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "displaySmallAsZero": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "padZeros": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "avoidScientificNotation": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "variantDeterminesSeed": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "asList": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                }
+            },
+            "children": [],
+            "textChildrenAllowed": false,
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "type",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Multivariate distribution from which to sample.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "numInCategories",
+                    "type": "numberList",
+                    "isArray": false,
+                    "description": "Number of items of each category in the population drawn from. Its length determines how many numbers are sampled.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "numDraws",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Number of items drawn without replacement from the population.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "variantDeterminesSeed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the document's variant index determines the random seed.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "numCategories",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of categories the population is partitioned into, which is how many numbers are sampled."
+                },
+                {
+                    "name": "numTotal",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Total number of items in the population drawn from, i.e. the sum of `numInCategories`."
+                },
+                {
+                    "name": "means",
+                    "type": "number",
+                    "isArray": true,
+                    "description": "Expected number of items sampled from each category, i.e. `numDraws * numInCategories[i] / numTotal`.",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "number",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "variances",
+                    "type": "number",
+                    "isArray": true,
+                    "description": "Variance of the number of items sampled from each category.",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "number",
+                            "numDimensions": 1
+                        }
+                    ]
+                }
+            ]
+        },
         "selectPrimeNumbers": {
             "type": "element",
             "name": "selectPrimeNumbers",
@@ -136120,6 +136734,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -138396,6 +139013,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -138927,6 +139547,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -139548,6 +140171,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -140493,6 +141119,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -141319,6 +141948,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -142161,6 +142793,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -143519,6 +144154,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -144916,6 +145554,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -145718,6 +146359,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -146540,6 +147184,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -147156,6 +147803,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -147746,6 +148396,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -148508,6 +149161,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -149535,6 +150191,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -151238,6 +151897,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -151723,6 +152385,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -152557,6 +153222,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -153697,6 +154365,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -155214,6 +155885,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -155730,6 +156404,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -156855,6 +157532,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -157539,6 +158219,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -158468,6 +159151,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -159108,6 +159794,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -160314,6 +161003,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -160810,6 +161502,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -161804,6 +162499,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -162637,6 +163335,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -164570,6 +165271,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -165380,6 +166084,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -165891,6 +166598,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -166298,6 +167008,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -166743,6 +167456,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -35131,6 +35131,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -35557,6 +35560,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -35987,6 +35993,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -36415,6 +36424,9 @@
                     "ref": "sampleRandomNumbers"
                 },
                 {
+                    "ref": "sampleMultivariateRandomNumber"
+                },
+                {
                     "ref": "selectPrimeNumbers"
                 },
                 {
@@ -36841,6 +36853,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -37734,6 +37749,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -39050,6 +39068,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -40372,6 +40393,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -41701,6 +41725,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"
@@ -151054,6 +151081,9 @@
                 },
                 {
                     "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "sampleMultivariateRandomNumber"
                 },
                 {
                     "ref": "selectPrimeNumbers"

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -109767,7 +109767,7 @@
             "acceptsStringChildren": false,
             "takesIndex": true,
             "docsSlug": "sampleMultivariateRandomNumber",
-            "summary": "Samples a single vector-valued random number from a multivariate distribution, expanding to one number per category",
+            "summary": "Samples one number per category from a multivariate distribution, drawn together rather than independently",
             "layoutCategory": "other"
         },
         {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -45,6 +45,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -134,6 +143,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -148,7 +158,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_textOrInline",
                 "_inline",
@@ -329,6 +339,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -375,6 +394,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -383,7 +403,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -1189,6 +1209,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -1278,6 +1307,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -1292,7 +1322,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -1655,6 +1685,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -1744,6 +1783,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -1758,7 +1798,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -2125,6 +2165,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -2282,6 +2331,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -2309,7 +2359,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -2672,6 +2722,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -2829,6 +2888,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -2856,7 +2916,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -3219,6 +3279,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -3376,6 +3445,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -3403,7 +3473,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -4044,6 +4114,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -4133,6 +4212,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -4149,7 +4229,7 @@
                 "ol",
                 "ul"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122211221111122200",
+            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222211221111122200",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -4518,6 +4598,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -4675,6 +4764,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -4702,7 +4792,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -4899,6 +4989,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -4988,6 +5087,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -5002,7 +5102,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -5332,6 +5432,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -5421,6 +5530,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -5435,7 +5545,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -5765,6 +5875,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -5854,6 +5973,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -5868,7 +5988,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -6774,6 +6894,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -6863,6 +6992,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -6877,7 +7007,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -7207,6 +7337,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -7253,6 +7392,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -7279,7 +7419,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "12222111111111111111111111122212222212202022221222220122122221222222111221211222221111111110212120",
+            "childBuckets": "122221111111111111111111111222221111222122222122020222212222201221222212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_booleanOperatorOneInput",
                 "_inline",
@@ -9624,6 +9764,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -9670,6 +9819,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -9678,7 +9828,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -10078,6 +10228,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -10124,6 +10283,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -10132,7 +10292,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -10532,6 +10692,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -10578,6 +10747,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -10586,7 +10756,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -11016,6 +11186,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -11062,6 +11241,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -11070,7 +11250,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -11896,6 +12076,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -11942,6 +12131,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -11950,7 +12140,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -12776,6 +12966,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -12822,6 +13021,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -12830,7 +13030,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -13648,6 +13848,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -13694,6 +13903,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -13702,7 +13912,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -14520,6 +14730,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -14566,6 +14785,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -14574,7 +14794,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -15392,6 +15612,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -15438,6 +15667,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -15446,7 +15676,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -16251,6 +16481,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -16297,6 +16536,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -16305,7 +16545,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -17081,6 +17321,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -17127,6 +17376,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -17135,7 +17385,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -17927,6 +18177,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -17973,6 +18232,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -17981,7 +18241,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -18773,6 +19033,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -18819,6 +19088,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -18827,7 +19097,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -19619,6 +19889,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -19665,6 +19944,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -19673,7 +19953,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -20465,6 +20745,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -20511,6 +20800,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -20519,7 +20809,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -21345,6 +21635,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -21391,6 +21690,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -21399,7 +21699,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -22225,6 +22525,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -22271,6 +22580,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -22279,7 +22589,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -23122,6 +23432,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -23168,6 +23487,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -23176,7 +23496,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -24019,6 +24339,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -24065,6 +24394,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -24073,7 +24403,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -24899,6 +25229,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -24945,6 +25284,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -24953,7 +25293,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -25779,6 +26119,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -25825,6 +26174,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -25833,7 +26183,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -26659,6 +27009,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -26705,6 +27064,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -26713,7 +27073,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -27539,6 +27899,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -27585,6 +27954,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -27593,7 +27963,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -28419,6 +28789,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -28465,6 +28844,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -28473,7 +28853,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -29299,6 +29679,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -29345,6 +29734,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -29353,7 +29743,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -30177,7 +30567,7 @@
             "layoutCategory": "inline"
         },
         {
-            "name": "clampFunction",
+            "name": "cumulativeSum",
             "children": [
                 "rightHandSide",
                 "m",
@@ -30206,6 +30596,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -30252,6 +30651,5511 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
+                "subsetOfReals",
+                "bestFitLine",
+                "matrix",
+                "latex",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "abstractAncestors": [
+                "_mathListOperator",
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "forceSymbolic",
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "forceNumeric",
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": true,
+            "docsSlug": "cumulativeSum",
+            "summary": "Running total of the child math or number values: the list of partial sums",
+            "layoutCategory": "other"
+        },
+        {
+            "name": "cumulativeProduct",
+            "children": [
+                "rightHandSide",
+                "m",
+                "me",
+                "men",
+                "mrow",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "matrixInput",
+                "fractionInput",
+                "text",
+                "textList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "point",
+                "coords",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "number",
+                "integer",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "cell",
+                "conditionalContent",
+                "selectFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "intComma",
+                "pluralize",
+                "lorem",
+                "endpoint",
+                "sortIndices",
+                "subsetOfReals",
+                "bestFitLine",
+                "matrix",
+                "latex",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "abstractAncestors": [
+                "_mathListOperator",
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "forceSymbolic",
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "forceNumeric",
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": true,
+            "docsSlug": "cumulativeProduct",
+            "summary": "Running product of the child math or number values: the list of partial products",
+            "layoutCategory": "other"
+        },
+        {
+            "name": "cumulativeMin",
+            "children": [
+                "rightHandSide",
+                "m",
+                "me",
+                "men",
+                "mrow",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "matrixInput",
+                "fractionInput",
+                "text",
+                "textList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "point",
+                "coords",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "number",
+                "integer",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "cell",
+                "conditionalContent",
+                "selectFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "intComma",
+                "pluralize",
+                "lorem",
+                "endpoint",
+                "sortIndices",
+                "subsetOfReals",
+                "bestFitLine",
+                "matrix",
+                "latex",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "abstractAncestors": [
+                "_mathListOperator",
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "forceSymbolic",
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "forceNumeric",
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": true,
+            "docsSlug": "cumulativeMin",
+            "summary": "Running minimum of the child math or number values",
+            "layoutCategory": "other"
+        },
+        {
+            "name": "cumulativeMax",
+            "children": [
+                "rightHandSide",
+                "m",
+                "me",
+                "men",
+                "mrow",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "matrixInput",
+                "fractionInput",
+                "text",
+                "textList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "point",
+                "coords",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "number",
+                "integer",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "cell",
+                "conditionalContent",
+                "selectFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "intComma",
+                "pluralize",
+                "lorem",
+                "endpoint",
+                "sortIndices",
+                "subsetOfReals",
+                "bestFitLine",
+                "matrix",
+                "latex",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "abstractAncestors": [
+                "_mathListOperator",
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "forceSymbolic",
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "forceNumeric",
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": true,
+            "docsSlug": "cumulativeMax",
+            "summary": "Running maximum of the child math or number values",
+            "layoutCategory": "other"
+        },
+        {
+            "name": "differences",
+            "children": [
+                "rightHandSide",
+                "m",
+                "me",
+                "men",
+                "mrow",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "matrixInput",
+                "fractionInput",
+                "text",
+                "textList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "point",
+                "coords",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "number",
+                "integer",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "cell",
+                "conditionalContent",
+                "selectFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "intComma",
+                "pluralize",
+                "lorem",
+                "endpoint",
+                "sortIndices",
+                "subsetOfReals",
+                "bestFitLine",
+                "matrix",
+                "latex",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "abstractAncestors": [
+                "_mathListOperator",
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "forceSymbolic",
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "forceNumeric",
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "highlighted": true,
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": true,
+            "docsSlug": "differences",
+            "summary": "Differences between successive child math or number values; one shorter than the input",
+            "layoutCategory": "other"
+        },
+        {
+            "name": "argMin",
+            "children": [
+                "title",
+                "rightHandSide",
+                "xLabel",
+                "yLabel",
+                "statement",
+                "introduction",
+                "conclusion",
+                "br",
+                "hr",
+                "m",
+                "me",
+                "men",
+                "md",
+                "mdn",
+                "mrow",
+                "not",
+                "and",
+                "or",
+                "xor",
+                "iff",
+                "implies",
+                "isInteger",
+                "isNumber",
+                "isBetween",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "em",
+                "alert",
+                "q",
+                "sq",
+                "term",
+                "c",
+                "tag",
+                "tage",
+                "tagc",
+                "attr",
+                "ndash",
+                "mdash",
+                "nbsp",
+                "ellipsis",
+                "lq",
+                "rq",
+                "lsq",
+                "rsq",
+                "section",
+                "subsection",
+                "subsubsection",
+                "paragraphs",
+                "aside",
+                "objectives",
+                "problem",
+                "exercise",
+                "question",
+                "activity",
+                "example",
+                "definition",
+                "note",
+                "theorem",
+                "part",
+                "task",
+                "proof",
+                "problems",
+                "exercises",
+                "ol",
+                "ul",
+                "odeSystem",
+                "cobwebPolyline",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "equilibriumCurve",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "orbitalDiagram",
+                "orbitalDiagramInput",
+                "sideBySide",
+                "sbsGroup",
+                "stack",
+                "div",
+                "span",
+                "pre",
+                "displayDoenetML",
+                "paginator",
+                "paginatorControls",
+                "matrixInput",
+                "fractionInput",
+                "solution",
+                "givenAnswer",
+                "document",
+                "text",
+                "textList",
+                "p",
+                "boolean",
+                "booleanList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "collect",
+                "ref",
+                "point",
+                "coords",
+                "line",
+                "lineSegment",
+                "ray",
+                "polyline",
+                "polygon",
+                "triangle",
+                "rectangle",
+                "regularPolygon",
+                "circle",
+                "parabola",
+                "curve",
+                "bezierControls",
+                "vector",
+                "angle",
+                "answer",
+                "award",
+                "mathInput",
+                "textInput",
+                "booleanInput",
+                "choiceInput",
+                "choice",
+                "number",
+                "integer",
+                "graph",
+                "annotations",
+                "annotation",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "slider",
+                "spreadsheet",
+                "cell",
+                "row",
+                "column",
+                "cellBlock",
+                "tabular",
+                "table",
+                "figure",
+                "repeat",
+                "repeatForSequence",
+                "pegboard",
+                "intersection",
+                "conditionalContent",
+                "asList",
+                "variantControl",
+                "selectFromSequence",
+                "select",
+                "group",
+                "animateFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "image",
+                "video",
+                "hint",
+                "intComma",
+                "pluralize",
+                "feedback",
+                "lorem",
+                "updateValue",
+                "callAction",
+                "triggerSet",
+                "functionIterates",
+                "module",
+                "moduleAttributes",
+                "setup",
+                "footnote",
+                "caption",
+                "endpoint",
+                "sort",
+                "sortIndices",
+                "shuffle",
+                "solveEquations",
+                "subsetOfRealsInput",
+                "subsetOfReals",
+                "split",
+                "bestFitLine",
+                "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
+                "slopeField",
+                "vectorField",
+                "regionHalfPlane",
+                "codeEditor",
+                "hasSameFactoring",
+                "legend",
+                "label",
+                "matchesPattern",
+                "matrix",
+                "eigenDecomposition",
+                "latex",
+                "blockQuote",
+                "stickyGroup",
+                "pretzel",
+                "cascade",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "abstractAncestors": [
+                "_listIndexOperator",
+                "_inline",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "format",
+                    "description": "Input format.",
+                    "defaultValue": "text",
+                    "values": [
+                        "text",
+                        "latex"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "text",
+                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
+                        },
+                        {
+                            "value": "latex",
+                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "simplify",
+                    "description": "Level of simplification applied to the expression.",
+                    "defaultValue": "none",
+                    "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "none",
+                            "description": "No simplification is applied."
+                        },
+                        {
+                            "value": "full",
+                            "description": "Fully simplify the expression."
+                        },
+                        {
+                            "value": "numbers",
+                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
+                        },
+                        {
+                            "value": "numbersPreserveOrder",
+                            "description": "Like `numbers`, but does not reorder commutative operands."
+                        },
+                        {
+                            "value": "normalizeOrder",
+                            "description": "Reorder commutative operands into a canonical form without simplifying values."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "expand",
+                    "description": "Whether to expand the expression.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 3,
+                    "type": "integer"
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 2,
+                    "type": "integer"
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero.",
+                    "groupName": "number-display",
+                    "defaultValue": 1e-14,
+                    "type": "number"
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "renderMode",
+                    "description": "How the math is rendered.",
+                    "defaultValue": "inline",
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "unordered",
+                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createVectors",
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createIntervals",
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "functionSymbols",
+                    "description": "Symbols treated as function names when parsing.",
+                    "defaultValue": [
+                        "f",
+                        "g"
+                    ],
+                    "type": "textList"
+                },
+                {
+                    "name": "referencesAreFunctionSymbols",
+                    "description": "References whose names should be treated as function symbols when parsing.",
+                    "defaultValue": [],
+                    "type": "reference"
+                },
+                {
+                    "name": "splitSymbols",
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayBlanks",
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "assumptions",
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "＿"
+                    },
+                    "type": "math"
+                },
+                {
+                    "name": "draggable",
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "layer",
+                    "description": "Z-order layer index when shown on a graph.",
+                    "defaultValue": 0,
+                    "type": "number"
+                },
+                {
+                    "name": "anchor",
+                    "description": "Coordinates of the anchor point used to position this component on a graph.",
+                    "groupName": "positioning",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "\\left( 0, 0 \\right)"
+                    },
+                    "type": "point"
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "description": "Where this component sits relative to its anchor point.",
+                    "groupName": "positioning",
+                    "defaultValue": "center",
+                    "values": [
+                        "upperRight",
+                        "upperLeft",
+                        "lowerRight",
+                        "lowerLeft",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                        "center"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "upperRight",
+                            "description": "Place the component above and to the right of the anchor point."
+                        },
+                        {
+                            "value": "upperLeft",
+                            "description": "Place the component above and to the left of the anchor point."
+                        },
+                        {
+                            "value": "lowerRight",
+                            "description": "Place the component below and to the right of the anchor point."
+                        },
+                        {
+                            "value": "lowerLeft",
+                            "description": "Place the component below and to the left of the anchor point."
+                        },
+                        {
+                            "value": "top",
+                            "description": "Place the component directly above the anchor point."
+                        },
+                        {
+                            "value": "bottom",
+                            "description": "Place the component directly below the anchor point."
+                        },
+                        {
+                            "value": "left",
+                            "description": "Place the component directly to the left of the anchor point."
+                        },
+                        {
+                            "value": "right",
+                            "description": "Place the component directly to the right of the anchor point."
+                        },
+                        {
+                            "value": "center",
+                            "description": "Center the component on the anchor point."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "type",
+                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers, ordered by value."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions, ordered by value."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text, ordered alphabetically."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans, ordered with false before true."
+                        }
+                    ],
+                    "type": "keyword"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "format",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Input format.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "simplify",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Level of simplification applied to the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "expand",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to expand the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "renderMode",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "How the math is rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createVectors",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createIntervals",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "functionSymbols",
+                    "type": "textList",
+                    "isArray": false,
+                    "description": "Symbols treated as function names when parsing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "splitSymbols",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "displayBlanks",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "assumptions",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "draggable",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "layer",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Z-order layer index when shown on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Where this component sits relative to its anchor point.",
+                    "fromAttribute": true,
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is hidden from the rendered output."
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is disabled and cannot be interacted with."
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's value is fixed and cannot be modified."
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "textColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
+                },
+                {
+                    "name": "backgroundColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
+                },
+                {
+                    "name": "textStyleDescription",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable description of this component's text styling (color and any background color)."
+                },
+                {
+                    "name": "anchor",
+                    "type": "point",
+                    "isArray": false,
+                    "description": "The coordinates where this component is anchored on the graph.",
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "displayDigits",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "value",
+                    "type": "argMin",
+                    "isArray": false,
+                    "description": "The 1-based index the operator found, or 0 if there is none.",
+                    "highlighted": true
+                },
+                {
+                    "name": "number",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The numeric value of the expression (NaN if not a number)."
+                },
+                {
+                    "name": "isNumber",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "isNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "latex",
+                    "type": "latex",
+                    "isArray": false,
+                    "description": "The expression rendered as a LaTeX string."
+                },
+                {
+                    "name": "text",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The expression rendered as a plain text string."
+                },
+                {
+                    "name": "numDimensions",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
+                },
+                {
+                    "name": "vector",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a vector (its components).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "vector"
+                        }
+                    ]
+                },
+                {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a list (its elements).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "matrixSize",
+                    "type": "numberList",
+                    "isArray": false,
+                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
+                },
+                {
+                    "name": "numRows",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of rows when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "numColumns",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of columns when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "matrix",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "rows",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by row.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "columns",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by column.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "x",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The first component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "y",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The second component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "z",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The third component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of items when the math expression is interpreted as a list."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": false,
+            "docsSlug": "argMin",
+            "summary": "The index of the smallest value in a list",
+            "layoutCategory": "inline"
+        },
+        {
+            "name": "argMax",
+            "children": [
+                "title",
+                "rightHandSide",
+                "xLabel",
+                "yLabel",
+                "statement",
+                "introduction",
+                "conclusion",
+                "br",
+                "hr",
+                "m",
+                "me",
+                "men",
+                "md",
+                "mdn",
+                "mrow",
+                "not",
+                "and",
+                "or",
+                "xor",
+                "iff",
+                "implies",
+                "isInteger",
+                "isNumber",
+                "isBetween",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "em",
+                "alert",
+                "q",
+                "sq",
+                "term",
+                "c",
+                "tag",
+                "tage",
+                "tagc",
+                "attr",
+                "ndash",
+                "mdash",
+                "nbsp",
+                "ellipsis",
+                "lq",
+                "rq",
+                "lsq",
+                "rsq",
+                "section",
+                "subsection",
+                "subsubsection",
+                "paragraphs",
+                "aside",
+                "objectives",
+                "problem",
+                "exercise",
+                "question",
+                "activity",
+                "example",
+                "definition",
+                "note",
+                "theorem",
+                "part",
+                "task",
+                "proof",
+                "problems",
+                "exercises",
+                "ol",
+                "ul",
+                "odeSystem",
+                "cobwebPolyline",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "equilibriumCurve",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "orbitalDiagram",
+                "orbitalDiagramInput",
+                "sideBySide",
+                "sbsGroup",
+                "stack",
+                "div",
+                "span",
+                "pre",
+                "displayDoenetML",
+                "paginator",
+                "paginatorControls",
+                "matrixInput",
+                "fractionInput",
+                "solution",
+                "givenAnswer",
+                "document",
+                "text",
+                "textList",
+                "p",
+                "boolean",
+                "booleanList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "collect",
+                "ref",
+                "point",
+                "coords",
+                "line",
+                "lineSegment",
+                "ray",
+                "polyline",
+                "polygon",
+                "triangle",
+                "rectangle",
+                "regularPolygon",
+                "circle",
+                "parabola",
+                "curve",
+                "bezierControls",
+                "vector",
+                "angle",
+                "answer",
+                "award",
+                "mathInput",
+                "textInput",
+                "booleanInput",
+                "choiceInput",
+                "choice",
+                "number",
+                "integer",
+                "graph",
+                "annotations",
+                "annotation",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "slider",
+                "spreadsheet",
+                "cell",
+                "row",
+                "column",
+                "cellBlock",
+                "tabular",
+                "table",
+                "figure",
+                "repeat",
+                "repeatForSequence",
+                "pegboard",
+                "intersection",
+                "conditionalContent",
+                "asList",
+                "variantControl",
+                "selectFromSequence",
+                "select",
+                "group",
+                "animateFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "image",
+                "video",
+                "hint",
+                "intComma",
+                "pluralize",
+                "feedback",
+                "lorem",
+                "updateValue",
+                "callAction",
+                "triggerSet",
+                "functionIterates",
+                "module",
+                "moduleAttributes",
+                "setup",
+                "footnote",
+                "caption",
+                "endpoint",
+                "sort",
+                "sortIndices",
+                "shuffle",
+                "solveEquations",
+                "subsetOfRealsInput",
+                "subsetOfReals",
+                "split",
+                "bestFitLine",
+                "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
+                "slopeField",
+                "vectorField",
+                "regionHalfPlane",
+                "codeEditor",
+                "hasSameFactoring",
+                "legend",
+                "label",
+                "matchesPattern",
+                "matrix",
+                "eigenDecomposition",
+                "latex",
+                "blockQuote",
+                "stickyGroup",
+                "pretzel",
+                "cascade",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "abstractAncestors": [
+                "_listIndexOperator",
+                "_inline",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "format",
+                    "description": "Input format.",
+                    "defaultValue": "text",
+                    "values": [
+                        "text",
+                        "latex"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "text",
+                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
+                        },
+                        {
+                            "value": "latex",
+                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "simplify",
+                    "description": "Level of simplification applied to the expression.",
+                    "defaultValue": "none",
+                    "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "none",
+                            "description": "No simplification is applied."
+                        },
+                        {
+                            "value": "full",
+                            "description": "Fully simplify the expression."
+                        },
+                        {
+                            "value": "numbers",
+                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
+                        },
+                        {
+                            "value": "numbersPreserveOrder",
+                            "description": "Like `numbers`, but does not reorder commutative operands."
+                        },
+                        {
+                            "value": "normalizeOrder",
+                            "description": "Reorder commutative operands into a canonical form without simplifying values."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "expand",
+                    "description": "Whether to expand the expression.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 3,
+                    "type": "integer"
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 2,
+                    "type": "integer"
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero.",
+                    "groupName": "number-display",
+                    "defaultValue": 1e-14,
+                    "type": "number"
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "renderMode",
+                    "description": "How the math is rendered.",
+                    "defaultValue": "inline",
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "unordered",
+                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createVectors",
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createIntervals",
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "functionSymbols",
+                    "description": "Symbols treated as function names when parsing.",
+                    "defaultValue": [
+                        "f",
+                        "g"
+                    ],
+                    "type": "textList"
+                },
+                {
+                    "name": "referencesAreFunctionSymbols",
+                    "description": "References whose names should be treated as function symbols when parsing.",
+                    "defaultValue": [],
+                    "type": "reference"
+                },
+                {
+                    "name": "splitSymbols",
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayBlanks",
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "assumptions",
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "＿"
+                    },
+                    "type": "math"
+                },
+                {
+                    "name": "draggable",
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "layer",
+                    "description": "Z-order layer index when shown on a graph.",
+                    "defaultValue": 0,
+                    "type": "number"
+                },
+                {
+                    "name": "anchor",
+                    "description": "Coordinates of the anchor point used to position this component on a graph.",
+                    "groupName": "positioning",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "\\left( 0, 0 \\right)"
+                    },
+                    "type": "point"
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "description": "Where this component sits relative to its anchor point.",
+                    "groupName": "positioning",
+                    "defaultValue": "center",
+                    "values": [
+                        "upperRight",
+                        "upperLeft",
+                        "lowerRight",
+                        "lowerLeft",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                        "center"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "upperRight",
+                            "description": "Place the component above and to the right of the anchor point."
+                        },
+                        {
+                            "value": "upperLeft",
+                            "description": "Place the component above and to the left of the anchor point."
+                        },
+                        {
+                            "value": "lowerRight",
+                            "description": "Place the component below and to the right of the anchor point."
+                        },
+                        {
+                            "value": "lowerLeft",
+                            "description": "Place the component below and to the left of the anchor point."
+                        },
+                        {
+                            "value": "top",
+                            "description": "Place the component directly above the anchor point."
+                        },
+                        {
+                            "value": "bottom",
+                            "description": "Place the component directly below the anchor point."
+                        },
+                        {
+                            "value": "left",
+                            "description": "Place the component directly to the left of the anchor point."
+                        },
+                        {
+                            "value": "right",
+                            "description": "Place the component directly to the right of the anchor point."
+                        },
+                        {
+                            "value": "center",
+                            "description": "Center the component on the anchor point."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "type",
+                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers, ordered by value."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions, ordered by value."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text, ordered alphabetically."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans, ordered with false before true."
+                        }
+                    ],
+                    "type": "keyword"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "format",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Input format.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "simplify",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Level of simplification applied to the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "expand",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to expand the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "renderMode",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "How the math is rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createVectors",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createIntervals",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "functionSymbols",
+                    "type": "textList",
+                    "isArray": false,
+                    "description": "Symbols treated as function names when parsing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "splitSymbols",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "displayBlanks",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "assumptions",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "draggable",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "layer",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Z-order layer index when shown on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Where this component sits relative to its anchor point.",
+                    "fromAttribute": true,
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is hidden from the rendered output."
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is disabled and cannot be interacted with."
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's value is fixed and cannot be modified."
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "textColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
+                },
+                {
+                    "name": "backgroundColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
+                },
+                {
+                    "name": "textStyleDescription",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable description of this component's text styling (color and any background color)."
+                },
+                {
+                    "name": "anchor",
+                    "type": "point",
+                    "isArray": false,
+                    "description": "The coordinates where this component is anchored on the graph.",
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "displayDigits",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "value",
+                    "type": "argMax",
+                    "isArray": false,
+                    "description": "The 1-based index the operator found, or 0 if there is none.",
+                    "highlighted": true
+                },
+                {
+                    "name": "number",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The numeric value of the expression (NaN if not a number)."
+                },
+                {
+                    "name": "isNumber",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "isNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "latex",
+                    "type": "latex",
+                    "isArray": false,
+                    "description": "The expression rendered as a LaTeX string."
+                },
+                {
+                    "name": "text",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The expression rendered as a plain text string."
+                },
+                {
+                    "name": "numDimensions",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
+                },
+                {
+                    "name": "vector",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a vector (its components).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "vector"
+                        }
+                    ]
+                },
+                {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a list (its elements).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "matrixSize",
+                    "type": "numberList",
+                    "isArray": false,
+                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
+                },
+                {
+                    "name": "numRows",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of rows when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "numColumns",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of columns when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "matrix",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "rows",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by row.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "columns",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by column.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "x",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The first component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "y",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The second component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "z",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The third component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of items when the math expression is interpreted as a list."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": false,
+            "docsSlug": "argMax",
+            "summary": "The index of the largest value in a list",
+            "layoutCategory": "inline"
+        },
+        {
+            "name": "indexOf",
+            "children": [
+                "title",
+                "rightHandSide",
+                "xLabel",
+                "yLabel",
+                "statement",
+                "introduction",
+                "conclusion",
+                "br",
+                "hr",
+                "m",
+                "me",
+                "men",
+                "md",
+                "mdn",
+                "mrow",
+                "not",
+                "and",
+                "or",
+                "xor",
+                "iff",
+                "implies",
+                "isInteger",
+                "isNumber",
+                "isBetween",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "em",
+                "alert",
+                "q",
+                "sq",
+                "term",
+                "c",
+                "tag",
+                "tage",
+                "tagc",
+                "attr",
+                "ndash",
+                "mdash",
+                "nbsp",
+                "ellipsis",
+                "lq",
+                "rq",
+                "lsq",
+                "rsq",
+                "section",
+                "subsection",
+                "subsubsection",
+                "paragraphs",
+                "aside",
+                "objectives",
+                "problem",
+                "exercise",
+                "question",
+                "activity",
+                "example",
+                "definition",
+                "note",
+                "theorem",
+                "part",
+                "task",
+                "proof",
+                "problems",
+                "exercises",
+                "ol",
+                "ul",
+                "odeSystem",
+                "cobwebPolyline",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "equilibriumCurve",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "orbitalDiagram",
+                "orbitalDiagramInput",
+                "sideBySide",
+                "sbsGroup",
+                "stack",
+                "div",
+                "span",
+                "pre",
+                "displayDoenetML",
+                "paginator",
+                "paginatorControls",
+                "matrixInput",
+                "fractionInput",
+                "solution",
+                "givenAnswer",
+                "document",
+                "text",
+                "textList",
+                "p",
+                "boolean",
+                "booleanList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "collect",
+                "ref",
+                "point",
+                "coords",
+                "line",
+                "lineSegment",
+                "ray",
+                "polyline",
+                "polygon",
+                "triangle",
+                "rectangle",
+                "regularPolygon",
+                "circle",
+                "parabola",
+                "curve",
+                "bezierControls",
+                "vector",
+                "angle",
+                "answer",
+                "award",
+                "mathInput",
+                "textInput",
+                "booleanInput",
+                "choiceInput",
+                "choice",
+                "number",
+                "integer",
+                "graph",
+                "annotations",
+                "annotation",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "slider",
+                "spreadsheet",
+                "cell",
+                "row",
+                "column",
+                "cellBlock",
+                "tabular",
+                "table",
+                "figure",
+                "repeat",
+                "repeatForSequence",
+                "pegboard",
+                "intersection",
+                "conditionalContent",
+                "asList",
+                "variantControl",
+                "selectFromSequence",
+                "select",
+                "group",
+                "animateFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "image",
+                "video",
+                "hint",
+                "intComma",
+                "pluralize",
+                "feedback",
+                "lorem",
+                "updateValue",
+                "callAction",
+                "triggerSet",
+                "functionIterates",
+                "module",
+                "moduleAttributes",
+                "setup",
+                "footnote",
+                "caption",
+                "endpoint",
+                "sort",
+                "sortIndices",
+                "shuffle",
+                "solveEquations",
+                "subsetOfRealsInput",
+                "subsetOfReals",
+                "split",
+                "bestFitLine",
+                "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
+                "slopeField",
+                "vectorField",
+                "regionHalfPlane",
+                "codeEditor",
+                "hasSameFactoring",
+                "legend",
+                "label",
+                "matchesPattern",
+                "matrix",
+                "eigenDecomposition",
+                "latex",
+                "blockQuote",
+                "stickyGroup",
+                "pretzel",
+                "cascade",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "abstractAncestors": [
+                "_listIndexOperator",
+                "_inline",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "format",
+                    "description": "Input format.",
+                    "defaultValue": "text",
+                    "values": [
+                        "text",
+                        "latex"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "text",
+                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
+                        },
+                        {
+                            "value": "latex",
+                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "simplify",
+                    "description": "Level of simplification applied to the expression.",
+                    "defaultValue": "none",
+                    "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "none",
+                            "description": "No simplification is applied."
+                        },
+                        {
+                            "value": "full",
+                            "description": "Fully simplify the expression."
+                        },
+                        {
+                            "value": "numbers",
+                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
+                        },
+                        {
+                            "value": "numbersPreserveOrder",
+                            "description": "Like `numbers`, but does not reorder commutative operands."
+                        },
+                        {
+                            "value": "normalizeOrder",
+                            "description": "Reorder commutative operands into a canonical form without simplifying values."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "expand",
+                    "description": "Whether to expand the expression.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 3,
+                    "type": "integer"
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 2,
+                    "type": "integer"
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero.",
+                    "groupName": "number-display",
+                    "defaultValue": 1e-14,
+                    "type": "number"
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "renderMode",
+                    "description": "How the math is rendered.",
+                    "defaultValue": "inline",
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "unordered",
+                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createVectors",
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createIntervals",
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "functionSymbols",
+                    "description": "Symbols treated as function names when parsing.",
+                    "defaultValue": [
+                        "f",
+                        "g"
+                    ],
+                    "type": "textList"
+                },
+                {
+                    "name": "referencesAreFunctionSymbols",
+                    "description": "References whose names should be treated as function symbols when parsing.",
+                    "defaultValue": [],
+                    "type": "reference"
+                },
+                {
+                    "name": "splitSymbols",
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayBlanks",
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "assumptions",
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "＿"
+                    },
+                    "type": "math"
+                },
+                {
+                    "name": "draggable",
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "layer",
+                    "description": "Z-order layer index when shown on a graph.",
+                    "defaultValue": 0,
+                    "type": "number"
+                },
+                {
+                    "name": "anchor",
+                    "description": "Coordinates of the anchor point used to position this component on a graph.",
+                    "groupName": "positioning",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "\\left( 0, 0 \\right)"
+                    },
+                    "type": "point"
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "description": "Where this component sits relative to its anchor point.",
+                    "groupName": "positioning",
+                    "defaultValue": "center",
+                    "values": [
+                        "upperRight",
+                        "upperLeft",
+                        "lowerRight",
+                        "lowerLeft",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                        "center"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "upperRight",
+                            "description": "Place the component above and to the right of the anchor point."
+                        },
+                        {
+                            "value": "upperLeft",
+                            "description": "Place the component above and to the left of the anchor point."
+                        },
+                        {
+                            "value": "lowerRight",
+                            "description": "Place the component below and to the right of the anchor point."
+                        },
+                        {
+                            "value": "lowerLeft",
+                            "description": "Place the component below and to the left of the anchor point."
+                        },
+                        {
+                            "value": "top",
+                            "description": "Place the component directly above the anchor point."
+                        },
+                        {
+                            "value": "bottom",
+                            "description": "Place the component directly below the anchor point."
+                        },
+                        {
+                            "value": "left",
+                            "description": "Place the component directly to the left of the anchor point."
+                        },
+                        {
+                            "value": "right",
+                            "description": "Place the component directly to the right of the anchor point."
+                        },
+                        {
+                            "value": "center",
+                            "description": "Center the component on the anchor point."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "type",
+                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers, ordered by value."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions, ordered by value."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text, ordered alphabetically."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans, ordered with false before true."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "target",
+                    "description": "The value to look for.",
+                    "highlighted": true,
+                    "defaultValue": null,
+                    "type": "_componentWithSelectableType"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "format",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Input format.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "simplify",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Level of simplification applied to the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "expand",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to expand the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "renderMode",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "How the math is rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createVectors",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createIntervals",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "functionSymbols",
+                    "type": "textList",
+                    "isArray": false,
+                    "description": "Symbols treated as function names when parsing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "splitSymbols",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "displayBlanks",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "assumptions",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "draggable",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "layer",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Z-order layer index when shown on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Where this component sits relative to its anchor point.",
+                    "fromAttribute": true,
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is hidden from the rendered output."
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is disabled and cannot be interacted with."
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's value is fixed and cannot be modified."
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "textColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
+                },
+                {
+                    "name": "backgroundColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
+                },
+                {
+                    "name": "textStyleDescription",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable description of this component's text styling (color and any background color)."
+                },
+                {
+                    "name": "anchor",
+                    "type": "point",
+                    "isArray": false,
+                    "description": "The coordinates where this component is anchored on the graph.",
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "displayDigits",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "value",
+                    "type": "indexOf",
+                    "isArray": false,
+                    "description": "The 1-based index the operator found, or 0 if there is none.",
+                    "highlighted": true
+                },
+                {
+                    "name": "number",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The numeric value of the expression (NaN if not a number)."
+                },
+                {
+                    "name": "isNumber",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "isNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "latex",
+                    "type": "latex",
+                    "isArray": false,
+                    "description": "The expression rendered as a LaTeX string."
+                },
+                {
+                    "name": "text",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The expression rendered as a plain text string."
+                },
+                {
+                    "name": "numDimensions",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
+                },
+                {
+                    "name": "vector",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a vector (its components).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "vector"
+                        }
+                    ]
+                },
+                {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a list (its elements).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "matrixSize",
+                    "type": "numberList",
+                    "isArray": false,
+                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
+                },
+                {
+                    "name": "numRows",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of rows when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "numColumns",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of columns when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "matrix",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "rows",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by row.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "columns",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by column.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "x",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The first component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "y",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The second component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "z",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The third component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of items when the math expression is interpreted as a list."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": false,
+            "docsSlug": "indexOf",
+            "summary": "The index of the first value in a list equal to a target, or 0 if there is none",
+            "layoutCategory": "inline"
+        },
+        {
+            "name": "searchSorted",
+            "children": [
+                "title",
+                "rightHandSide",
+                "xLabel",
+                "yLabel",
+                "statement",
+                "introduction",
+                "conclusion",
+                "br",
+                "hr",
+                "m",
+                "me",
+                "men",
+                "md",
+                "mdn",
+                "mrow",
+                "not",
+                "and",
+                "or",
+                "xor",
+                "iff",
+                "implies",
+                "isInteger",
+                "isNumber",
+                "isBetween",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "em",
+                "alert",
+                "q",
+                "sq",
+                "term",
+                "c",
+                "tag",
+                "tage",
+                "tagc",
+                "attr",
+                "ndash",
+                "mdash",
+                "nbsp",
+                "ellipsis",
+                "lq",
+                "rq",
+                "lsq",
+                "rsq",
+                "section",
+                "subsection",
+                "subsubsection",
+                "paragraphs",
+                "aside",
+                "objectives",
+                "problem",
+                "exercise",
+                "question",
+                "activity",
+                "example",
+                "definition",
+                "note",
+                "theorem",
+                "part",
+                "task",
+                "proof",
+                "problems",
+                "exercises",
+                "ol",
+                "ul",
+                "odeSystem",
+                "cobwebPolyline",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "equilibriumCurve",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "orbitalDiagram",
+                "orbitalDiagramInput",
+                "sideBySide",
+                "sbsGroup",
+                "stack",
+                "div",
+                "span",
+                "pre",
+                "displayDoenetML",
+                "paginator",
+                "paginatorControls",
+                "matrixInput",
+                "fractionInput",
+                "solution",
+                "givenAnswer",
+                "document",
+                "text",
+                "textList",
+                "p",
+                "boolean",
+                "booleanList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "collect",
+                "ref",
+                "point",
+                "coords",
+                "line",
+                "lineSegment",
+                "ray",
+                "polyline",
+                "polygon",
+                "triangle",
+                "rectangle",
+                "regularPolygon",
+                "circle",
+                "parabola",
+                "curve",
+                "bezierControls",
+                "vector",
+                "angle",
+                "answer",
+                "award",
+                "mathInput",
+                "textInput",
+                "booleanInput",
+                "choiceInput",
+                "choice",
+                "number",
+                "integer",
+                "graph",
+                "annotations",
+                "annotation",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "slider",
+                "spreadsheet",
+                "cell",
+                "row",
+                "column",
+                "cellBlock",
+                "tabular",
+                "table",
+                "figure",
+                "repeat",
+                "repeatForSequence",
+                "pegboard",
+                "intersection",
+                "conditionalContent",
+                "asList",
+                "variantControl",
+                "selectFromSequence",
+                "select",
+                "group",
+                "animateFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "image",
+                "video",
+                "hint",
+                "intComma",
+                "pluralize",
+                "feedback",
+                "lorem",
+                "updateValue",
+                "callAction",
+                "triggerSet",
+                "functionIterates",
+                "module",
+                "moduleAttributes",
+                "setup",
+                "footnote",
+                "caption",
+                "endpoint",
+                "sort",
+                "sortIndices",
+                "shuffle",
+                "solveEquations",
+                "subsetOfRealsInput",
+                "subsetOfReals",
+                "split",
+                "bestFitLine",
+                "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
+                "slopeField",
+                "vectorField",
+                "regionHalfPlane",
+                "codeEditor",
+                "hasSameFactoring",
+                "legend",
+                "label",
+                "matchesPattern",
+                "matrix",
+                "eigenDecomposition",
+                "latex",
+                "blockQuote",
+                "stickyGroup",
+                "pretzel",
+                "cascade",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "abstractAncestors": [
+                "_listIndexOperator",
+                "_inline",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "format",
+                    "description": "Input format.",
+                    "defaultValue": "text",
+                    "values": [
+                        "text",
+                        "latex"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "text",
+                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
+                        },
+                        {
+                            "value": "latex",
+                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "simplify",
+                    "description": "Level of simplification applied to the expression.",
+                    "defaultValue": "none",
+                    "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "none",
+                            "description": "No simplification is applied."
+                        },
+                        {
+                            "value": "full",
+                            "description": "Fully simplify the expression."
+                        },
+                        {
+                            "value": "numbers",
+                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
+                        },
+                        {
+                            "value": "numbersPreserveOrder",
+                            "description": "Like `numbers`, but does not reorder commutative operands."
+                        },
+                        {
+                            "value": "normalizeOrder",
+                            "description": "Reorder commutative operands into a canonical form without simplifying values."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "expand",
+                    "description": "Whether to expand the expression.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 3,
+                    "type": "integer"
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number.",
+                    "groupName": "number-display",
+                    "defaultValue": 2,
+                    "type": "integer"
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero.",
+                    "groupName": "number-display",
+                    "defaultValue": 1e-14,
+                    "type": "number"
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
+                    "groupName": "number-display",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "renderMode",
+                    "description": "How the math is rendered.",
+                    "defaultValue": "inline",
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "unordered",
+                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createVectors",
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "createIntervals",
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "functionSymbols",
+                    "description": "Symbols treated as function names when parsing.",
+                    "defaultValue": [
+                        "f",
+                        "g"
+                    ],
+                    "type": "textList"
+                },
+                {
+                    "name": "referencesAreFunctionSymbols",
+                    "description": "References whose names should be treated as function symbols when parsing.",
+                    "defaultValue": [],
+                    "type": "reference"
+                },
+                {
+                    "name": "splitSymbols",
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "displayBlanks",
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "assumptions",
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "＿"
+                    },
+                    "type": "math"
+                },
+                {
+                    "name": "draggable",
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "layer",
+                    "description": "Z-order layer index when shown on a graph.",
+                    "defaultValue": 0,
+                    "type": "number"
+                },
+                {
+                    "name": "anchor",
+                    "description": "Coordinates of the anchor point used to position this component on a graph.",
+                    "groupName": "positioning",
+                    "defaultValue": {
+                        "type": "math",
+                        "latex": "\\left( 0, 0 \\right)"
+                    },
+                    "type": "point"
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "description": "Where this component sits relative to its anchor point.",
+                    "groupName": "positioning",
+                    "defaultValue": "center",
+                    "values": [
+                        "upperRight",
+                        "upperLeft",
+                        "lowerRight",
+                        "lowerLeft",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                        "center"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "upperRight",
+                            "description": "Place the component above and to the right of the anchor point."
+                        },
+                        {
+                            "value": "upperLeft",
+                            "description": "Place the component above and to the left of the anchor point."
+                        },
+                        {
+                            "value": "lowerRight",
+                            "description": "Place the component below and to the right of the anchor point."
+                        },
+                        {
+                            "value": "lowerLeft",
+                            "description": "Place the component below and to the left of the anchor point."
+                        },
+                        {
+                            "value": "top",
+                            "description": "Place the component directly above the anchor point."
+                        },
+                        {
+                            "value": "bottom",
+                            "description": "Place the component directly below the anchor point."
+                        },
+                        {
+                            "value": "left",
+                            "description": "Place the component directly to the left of the anchor point."
+                        },
+                        {
+                            "value": "right",
+                            "description": "Place the component directly to the right of the anchor point."
+                        },
+                        {
+                            "value": "center",
+                            "description": "Center the component on the anchor point."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "type",
+                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers, ordered by value."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions, ordered by value."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text, ordered alphabetically."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans, ordered with false before true."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "target",
+                    "description": "The value to locate within the sorted list.",
+                    "highlighted": true,
+                    "defaultValue": null,
+                    "type": "_componentWithSelectableType"
+                },
+                {
+                    "name": "side",
+                    "description": "Which end of a run of equal values the target is placed at.",
+                    "highlighted": true,
+                    "defaultValue": "left",
+                    "values": [
+                        "left",
+                        "right"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "left",
+                            "description": "Insert before any equal values, so the result is the index of the first entry greater than or equal to the target."
+                        },
+                        {
+                            "value": "right",
+                            "description": "Insert after any equal values, so the result is the index of the first entry strictly greater than the target."
+                        }
+                    ],
+                    "type": "keyword"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "format",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Input format.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "simplify",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Level of simplification applied to the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "expand",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to expand the expression.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "renderMode",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "How the math is rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createVectors",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether tuple-like expressions are interpreted as vectors.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "createIntervals",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether range expressions are interpreted as intervals.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "functionSymbols",
+                    "type": "textList",
+                    "isArray": false,
+                    "description": "Symbols treated as function names when parsing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "splitSymbols",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether multi-character symbols are split into a product of variables.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "displayBlanks",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether blanks (placeholders) are visibly rendered.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "assumptions",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "Assumptions applied when simplifying or comparing.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "draggable",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the math component can be dragged on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "layer",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Z-order layer index when shown on a graph.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Where this component sits relative to its anchor point.",
+                    "fromAttribute": true,
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "side",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Which end of a run of equal values the target is placed at.",
+                    "fromAttribute": true,
+                    "highlighted": true
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is hidden from the rendered output."
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is disabled and cannot be interacted with."
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's value is fixed and cannot be modified."
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "textColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
+                },
+                {
+                    "name": "backgroundColor",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
+                },
+                {
+                    "name": "textStyleDescription",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Human-readable description of this component's text styling (color and any background color)."
+                },
+                {
+                    "name": "anchor",
+                    "type": "point",
+                    "isArray": false,
+                    "description": "The coordinates where this component is anchored on the graph.",
+                    "groupName": "positioning"
+                },
+                {
+                    "name": "displayDigits",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "value",
+                    "type": "searchSorted",
+                    "isArray": false,
+                    "description": "The 1-based index the operator found, or 0 if there is none.",
+                    "highlighted": true
+                },
+                {
+                    "name": "number",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The numeric value of the expression (NaN if not a number)."
+                },
+                {
+                    "name": "isNumber",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to a finite number."
+                },
+                {
+                    "name": "isNumeric",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the expression evaluates to any number (including infinities)."
+                },
+                {
+                    "name": "latex",
+                    "type": "latex",
+                    "isArray": false,
+                    "description": "The expression rendered as a LaTeX string."
+                },
+                {
+                    "name": "text",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The expression rendered as a plain text string."
+                },
+                {
+                    "name": "numDimensions",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
+                },
+                {
+                    "name": "vector",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a vector (its components).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "vector"
+                        }
+                    ]
+                },
+                {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a list (its elements).",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "matrixSize",
+                    "type": "numberList",
+                    "isArray": false,
+                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
+                },
+                {
+                    "name": "numRows",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of rows when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "numColumns",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of columns when the math expression is interpreted as a matrix."
+                },
+                {
+                    "name": "matrix",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "rows",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by row.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "columns",
+                    "type": "math",
+                    "isArray": true,
+                    "description": "The matrix's entries grouped by column.",
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "x",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The first component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "y",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The second component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "z",
+                    "type": "math",
+                    "isArray": false,
+                    "description": "The third component of the math expression when interpreted as a vector."
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The number of items when the math expression is interpreted as a list."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": false,
+            "docsSlug": "searchSorted",
+            "summary": "The position at which a target would be inserted to keep a sorted list sorted",
+            "layoutCategory": "inline"
+        },
+        {
+            "name": "clampFunction",
+            "children": [
+                "rightHandSide",
+                "m",
+                "me",
+                "men",
+                "mrow",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "matrixInput",
+                "fractionInput",
+                "text",
+                "textList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "point",
+                "coords",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "number",
+                "integer",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "cell",
+                "conditionalContent",
+                "selectFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "intComma",
+                "pluralize",
+                "lorem",
+                "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -30263,7 +36167,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
+            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -31143,6 +37047,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -31189,6 +37102,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -31200,7 +37114,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
+            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -32080,6 +37994,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -32126,6 +38049,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -32137,7 +38061,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
+            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -33021,6 +38945,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -33067,6 +39000,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -33075,7 +39009,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_textOperatorOfMath",
                 "_inline",
@@ -33489,6 +39423,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -33578,6 +39521,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -33592,7 +39536,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -33782,6 +39726,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -33871,6 +39824,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -33885,7 +39839,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -34075,6 +40029,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -34164,6 +40127,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -34178,7 +40142,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -34368,6 +40332,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -34457,6 +40430,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -34471,7 +40445,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -34661,6 +40635,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -34750,6 +40733,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -34764,7 +40748,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -34954,6 +40938,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -35043,6 +41036,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -35057,7 +41051,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -35247,6 +41241,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -35336,6 +41339,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -35350,7 +41354,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -35540,6 +41544,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -35629,6 +41642,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -35643,7 +41657,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -35833,6 +41847,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -35922,6 +41945,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -35936,7 +41960,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -36126,6 +42150,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -36215,6 +42248,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -36229,7 +42263,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -37614,6 +43648,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -37768,6 +43811,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -37795,7 +43839,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -38404,6 +44448,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -38558,6 +44611,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -38585,7 +44639,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -39194,6 +45248,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -39348,6 +45411,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -39375,7 +45439,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -39984,6 +46048,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -40138,6 +46211,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -40165,7 +46239,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -40774,6 +46848,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -40928,6 +47011,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -40955,7 +47039,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -41573,6 +47657,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -41727,6 +47820,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -41754,7 +47848,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -42363,6 +48457,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -42517,6 +48620,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -42544,7 +48648,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -43162,6 +49266,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -43316,6 +49429,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -43343,7 +49457,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -43961,6 +50075,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -44115,6 +50238,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -44142,7 +50266,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -44760,6 +50884,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -44914,6 +51047,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -44941,7 +51075,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -45559,6 +51693,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -45713,6 +51856,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -45740,7 +51884,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -46349,6 +52493,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -46503,6 +52656,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -46530,7 +52684,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -47139,6 +53293,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -47293,6 +53456,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -47320,7 +53484,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -47929,6 +54093,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -48083,6 +54256,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -48110,7 +54284,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -48719,6 +54893,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -48873,6 +55056,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -48900,7 +55084,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -49509,6 +55693,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -49663,6 +55856,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -49690,7 +55884,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -50299,6 +56493,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -50453,6 +56656,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -50480,7 +56684,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_unnumberedSectioningComponent",
                 "_sectioningComponent",
@@ -51086,6 +57290,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -51240,6 +57453,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -51267,7 +57481,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponent",
                 "_block",
@@ -51863,6 +58077,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -52017,6 +58240,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -52044,7 +58268,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponent",
                 "_block",
@@ -53337,6 +59561,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -53494,6 +59727,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -53521,7 +59755,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -55078,6 +61312,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -55121,6 +61364,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -55143,7 +61387,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "1120111111111111111111111111102201012212111122211111111222201222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111122222111111022010122121111222111111112222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -55836,6 +62080,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -55881,6 +62134,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -55889,7 +62143,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
+            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -56491,6 +62745,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -56531,6 +62794,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -56539,7 +62803,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112011101012222111111111111111111111122222212222022221222220112221222222122221212222",
+            "childBuckets": "1120111010122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -58234,6 +64498,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -58280,6 +64553,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -58288,7 +64562,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -59082,6 +65356,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -59126,6 +65409,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -59134,7 +65418,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "020122221111111111111111111111222222222122220222122222012212221222222122221212222",
+            "childBuckets": "0201222211111111111111111111112222211112222222221222202221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -60886,6 +67170,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -61043,6 +67336,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -61070,7 +67364,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -61257,6 +67551,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -61414,6 +67717,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -61441,7 +67745,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -61804,6 +68108,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -61961,6 +68274,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -61988,7 +68302,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -62351,6 +68665,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -62508,6 +68831,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -62535,7 +68859,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -62722,6 +69046,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -62879,6 +69212,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -62906,7 +69240,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -63117,6 +69451,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -63274,6 +69617,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -63301,7 +69645,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -64226,6 +70570,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -64271,6 +70624,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -64279,7 +70633,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120001222211111111111111111111112222222221222202222122222222212221222222122221212222",
+            "childBuckets": "11200012222111111111111111111111122222111122222222212222022221222222222122212222221222221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -64785,6 +71139,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -64874,6 +71237,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -64940,7 +71304,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -65128,6 +71492,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -65217,6 +71590,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -65283,7 +71657,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -65481,6 +71855,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -65635,6 +72018,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -65662,7 +72046,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -67339,6 +73723,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -67371,6 +73764,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -67397,7 +73791,7 @@
                 "tagc",
                 "attr"
             ],
-            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212111111111111111111",
+            "childBuckets": "222222222222222222222222222222222222222222222221222022222222222222222222222211222222212111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -67806,6 +74200,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -67838,6 +74241,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -67846,7 +74250,7 @@
                 "latex",
                 "intervalList"
             ],
-            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212",
+            "childBuckets": "222222222222222222222222222222222222222222222221222022222222222222222222222211222222212",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -68039,6 +74443,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -68128,6 +74541,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -68144,7 +74558,7 @@
                 "ol",
                 "ul"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122211221111122200",
+            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222211221111122200",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -68494,6 +74908,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -68540,6 +74963,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -68566,7 +74990,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "12222111111111111111111111122212222212202022221222220122122221222222111221211222221111111110212120",
+            "childBuckets": "122221111111111111111111111222221111222122222122020222212222201221222212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -69132,6 +75556,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -69178,6 +75611,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -69186,7 +75620,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -69977,6 +76411,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -70023,6 +76466,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -70031,7 +76475,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -70299,6 +76743,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -70345,6 +76798,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -70353,7 +76807,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -70617,6 +77071,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -70644,6 +77107,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -70675,7 +77139,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "11111111111111111111111212202221011222212222221222112222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211112122022210112222122222212222112222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -70974,6 +77438,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -71131,6 +77604,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -71158,7 +77632,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -71372,6 +77846,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -71415,6 +77898,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -71437,7 +77921,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "1120111111111111111111111111102201012212111122211111111222201222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111122222111111022010122121111222111111112222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -72111,6 +78595,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -72157,6 +78650,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -72165,7 +78659,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -72949,6 +79443,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -72994,6 +79497,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -73002,7 +79506,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
+            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -78291,6 +84795,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -78336,6 +84849,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -78344,7 +84858,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
+            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -79172,6 +85686,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -79217,6 +85740,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -79225,7 +85749,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
+            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -79890,6 +86414,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -79930,6 +86463,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -79938,7 +86472,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112011101012222111111111111111111111122222212222022221222220112221222222122221212222",
+            "childBuckets": "1120111010122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -80818,6 +87352,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -80863,6 +87406,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -80871,7 +87415,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "021222211111111111111111111112222222221222202222122222012212221222222122221212222",
+            "childBuckets": "0212222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -81052,6 +87596,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "electronConfiguration",
                 "math",
                 "mathList",
@@ -81106,11 +87659,12 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "bestFitLine",
                 "latex",
                 "pointList"
             ],
-            "childBuckets": "11111111111111111111111102210122212111222222222222222222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211111022101222121112222222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -81362,6 +87916,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -81397,6 +87960,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -81419,7 +87983,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "11201111111111111111111111111022010122121111222222201222222222222222222222222222222",
+            "childBuckets": "112011111111111111111111111222221111110220101221211112222222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -82123,6 +88687,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -82149,6 +88722,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -82180,7 +88754,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "11201111111111111111111111121220222101122212222221222112222222222222222222222222222",
+            "childBuckets": "112011111111111111111111111222221111212202221011222122222212222112222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -82688,6 +89262,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -82730,6 +89313,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -82751,7 +89335,7 @@
                 "hasSameFactoring",
                 "matchesPattern"
             ],
-            "childBuckets": "0211111101100012222111111111111111111111122212222210000102122200122122212222221112212112221111111110011",
+            "childBuckets": "02111111011000122221111111111111111111111222221111222122222100001021222001221222122222211122212112221111111110011",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -83719,6 +90303,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -83764,6 +90357,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -83790,7 +90384,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "021222211111111111111111111112221222221220202222122222012212221222222111221211222221111111110212120",
+            "childBuckets": "0212222111111111111111111111122222111122212222212202022221222220122122212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_base"
             ],
@@ -84327,6 +90921,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -84373,6 +90976,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -84399,7 +91003,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "12222111111111111111111111122212222212202022221222220122122221222222111221211222221111111110212120",
+            "childBuckets": "122221111111111111111111111222221111222122222122020222212222201221222212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -84833,6 +91437,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -84878,6 +91491,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -84886,7 +91500,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120001222211111111111111111111112222222221222202222122222222212221222222122221212222",
+            "childBuckets": "11200012222111111111111111111111122222111122222222212222022221222222222122212222221222221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -85698,6 +92312,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -85729,6 +92352,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "matchesPattern",
@@ -85736,7 +92360,7 @@
                 "latex",
                 "intervalList"
             ],
-            "childBuckets": "1120002222222222222222222222222222222222221222022222222222222222222222112222212",
+            "childBuckets": "11200022222222222222222222222222222222222222222222212220222222222222222222222221122222212",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -86245,6 +92869,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -86290,6 +92923,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -86298,7 +92932,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112000111111111022111222211111111111111111111112222222221222202222122222012212221222222122221212222",
+            "childBuckets": "1120001111111110221112222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -87159,6 +93793,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -87316,6 +93959,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -87343,7 +93987,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -87586,6 +94230,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -87613,6 +94266,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -87661,7 +94315,7 @@
                 "matchesPattern",
                 "booleanInput"
             ],
-            "childBuckets": "1111111111111111111111111020222101122221222222111211122222222222222222222222222222111111111021212",
+            "childBuckets": "11111111111111111111111222221111110202221011222212222221112211122222222222222222222222222222111111111021212",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -88084,6 +94738,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -88111,6 +94774,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -88159,7 +94823,7 @@
                 "matchesPattern",
                 "booleanInput"
             ],
-            "childBuckets": "1111111111111111111111111020222101122221222222111211122222222222222222222222222222111111111021212",
+            "childBuckets": "11111111111111111111111222221111110202221011222212222221112211122222222222222222222222222222111111111021212",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -88587,6 +95251,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -88680,6 +95353,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "hasSameFactoring",
                 "label",
                 "matchesPattern",
@@ -88698,7 +95372,7 @@
                 "graph",
                 "annotations"
             ],
-            "childBuckets": "020001111111111111111111111122211111022211111111111111122122212222121212212111111111222001112222222221220222220122222211220212220010000000",
+            "childBuckets": "0200011111111111111111111111222221111222111110222111111111111111221222122221212122121111111112220011122222222212202222201222222112220212220010000000",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -89953,6 +96627,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -89999,6 +96682,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -90010,7 +96694,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
+            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -91654,6 +98338,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -91700,6 +98393,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -91708,7 +98402,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -92507,6 +99201,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -92664,6 +99367,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -92691,7 +99395,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -92952,6 +99656,7 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
+                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -92976,21 +99681,25 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
+                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
+                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -93071,6 +99780,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -93098,6 +99816,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -93126,7 +99845,7 @@
                 "label",
                 "matchesPattern"
             ],
-            "childBuckets": "22222222222222222222222120222222012222222222222112221211222222222222222222202",
+            "childBuckets": "222222222222222222222222222222221202222220122222222222221122221211222222222222222222202",
             "abstractAncestors": [
                 "_base"
             ],
@@ -94042,6 +100761,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -94088,6 +100816,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -94245,7 +100974,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -95700,6 +102429,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -95788,6 +102526,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -95854,7 +102593,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "0211111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "02111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -96077,6 +102816,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -96165,6 +102913,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -96230,7 +102979,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "2011111111111111111111111111111111111111111111111111111111111111111221111111112121222212121221111111111122222122212222221112111121222112211111222111111111111111111111111111111111111111111111111111",
+            "childBuckets": "20111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222221222122222211121111212222112211111222111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -96455,6 +103204,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -96612,6 +103370,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -96639,7 +103398,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -96821,6 +103580,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -96978,6 +103746,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -97005,7 +103774,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -97079,6 +103848,7 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
+                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -97103,21 +103873,25 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
+                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
+                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -98057,6 +104831,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -98118,7 +104901,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "22222222222222222222222222111122222121111111111111222222122222222212222111111121222",
+            "childBuckets": "22222222222222222222222222222222222111122222121111111111111222222122222222212222111111121222",
             "abstractAncestors": [
                 "_constraint",
                 "_base"
@@ -98299,6 +105082,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -98360,7 +105152,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "22222222222222222222222222111122222121111111111111222222122222222212222111111121222",
+            "childBuckets": "22222222222222222222222222222222222111122222121111111111111222222122222222212222111111121222",
             "abstractAncestors": [
                 "_constraint",
                 "_base"
@@ -98867,6 +105659,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -98928,7 +105729,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "22222222222222222222222222111122222121111111111111222222122222222212222111111121222",
+            "childBuckets": "22222222222222222222222222222222222111122222121111111111111222222122222222212222111111121222",
             "abstractAncestors": [
                 "_constraint",
                 "_base"
@@ -99265,6 +106066,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -99421,6 +106231,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -99449,7 +106260,7 @@
                 "vectorList",
                 "else"
             ],
-            "childBuckets": "101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110",
+            "childBuckets": "1011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -99617,6 +106428,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -99706,6 +106526,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -99720,7 +106541,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -100142,6 +106963,7 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
+                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -100166,21 +106988,25 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
+                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
+                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -100535,6 +107361,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -100692,6 +107527,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -100719,7 +107555,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -100939,6 +107775,7 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
+                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -100963,21 +107800,25 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
+                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
+                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
+                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -103408,6 +110249,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -103565,6 +110415,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -103592,7 +110443,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -105801,6 +112652,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -105957,6 +112817,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -105984,7 +112845,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "0111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "01111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -106175,6 +113036,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -106207,6 +113077,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -106233,7 +113104,7 @@
                 "tagc",
                 "attr"
             ],
-            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212111111111111111111",
+            "childBuckets": "222222222222222222222222222222222222222222222221222022222222222222222222222211222222212111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -106642,6 +113513,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -106674,6 +113554,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -106700,7 +113581,7 @@
                 "tagc",
                 "attr"
             ],
-            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212111111111111111111",
+            "childBuckets": "222222222222222222222222222222222222222222222221222022222222222222222222222211222222212111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -107143,6 +114024,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -107300,6 +114190,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -107327,7 +114218,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -107511,6 +114402,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -107668,6 +114568,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -107695,7 +114596,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -107881,6 +114782,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -108038,6 +114948,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -108065,7 +114976,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -108837,6 +115748,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -108993,6 +115913,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -109019,7 +115940,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1110111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -110001,6 +116922,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -110158,6 +117088,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -110185,7 +117116,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -110359,6 +117290,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -110516,6 +117456,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -110543,7 +117484,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -110710,6 +117651,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -110866,6 +117816,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -110893,7 +117844,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "0100111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "01001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -111052,6 +118003,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -111141,6 +118101,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -111155,7 +118116,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -111350,6 +118311,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -111439,6 +118409,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -111505,7 +118476,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -111679,6 +118650,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -111722,6 +118702,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -111744,7 +118725,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "1120111111111111111111111111102201012212111122211111111222201222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111122222111111022010122121111222111111112222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -112452,6 +119433,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -112609,6 +119599,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -112636,7 +119627,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -112716,6 +119707,7 @@
                 {
                     "name": "sortVectorsBy",
                     "description": "Whether to sort vectors by component or by magnitude.",
+                    "groupName": "sorting",
                     "defaultValue": "displacement",
                     "values": [
                         "displacement",
@@ -112736,22 +119728,51 @@
                 {
                     "name": "sortByComponent",
                     "description": "Index of the component to sort by (when sorting vectors).",
+                    "groupName": "sorting",
                     "defaultValue": "1",
                     "type": "integer"
                 },
                 {
                     "name": "sortByProp",
                     "description": "Name of a property to sort by (e.g. \"x\" for sorting points by x-coordinate).",
+                    "groupName": "sorting",
+                    "highlighted": true,
                     "type": "text"
                 },
                 {
                     "name": "type",
                     "description": "Component type to sort children as.",
-                    "type": "text"
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers, ordered by value."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions, ordered by value."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text, ordered alphabetically."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans, ordered with false before true."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "asList",
                     "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
                     "defaultValue": true,
                     "values": [
                         "true",
@@ -112787,14 +119808,16 @@
                     "type": "text",
                     "isArray": false,
                     "description": "Whether to sort vectors by component or by magnitude.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "groupName": "sorting"
                 },
                 {
                     "name": "sortByComponent",
                     "type": "integer",
                     "isArray": false,
                     "description": "Index of the component to sort by (when sorting vectors).",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "groupName": "sorting"
                 },
                 {
                     "name": "doenetML",
@@ -112811,7 +119834,7 @@
             "layoutCategory": "other"
         },
         {
-            "name": "shuffle",
+            "name": "sortIndices",
             "children": [
                 "title",
                 "rightHandSide",
@@ -112859,6 +119882,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -113016,6 +120048,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -113043,7 +120076,456 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "abstractAncestors": [
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "sortVectorsBy",
+                    "description": "Whether to sort vectors by component or by magnitude.",
+                    "groupName": "sorting",
+                    "defaultValue": "displacement",
+                    "values": [
+                        "displacement",
+                        "tail"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "displacement",
+                            "description": "Sort vectors by their displacement components."
+                        },
+                        {
+                            "value": "tail",
+                            "description": "Sort vectors by the position of their tail point."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "sortByComponent",
+                    "description": "Index of the component to sort by (when sorting vectors).",
+                    "groupName": "sorting",
+                    "defaultValue": "1",
+                    "type": "integer"
+                },
+                {
+                    "name": "sortByProp",
+                    "description": "Name of a property to sort by (e.g. \"x\" for sorting points by x-coordinate).",
+                    "groupName": "sorting",
+                    "highlighted": true,
+                    "type": "text"
+                },
+                {
+                    "name": "type",
+                    "description": "Component type to sort children as.",
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers, ordered by value."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions, ordered by value."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text, ordered alphabetically."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans, ordered with false before true."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "sortVectorsBy",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Whether to sort vectors by component or by magnitude.",
+                    "fromAttribute": true,
+                    "groupName": "sorting"
+                },
+                {
+                    "name": "sortByComponent",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Index of the component to sort by (when sorting vectors).",
+                    "fromAttribute": true,
+                    "groupName": "sorting"
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true,
+            "takesIndex": true,
+            "docsSlug": "sortIndices",
+            "summary": "The indices that put a list in sorted order, rather than the sorted values",
+            "layoutCategory": "other"
+        },
+        {
+            "name": "shuffle",
+            "children": [
+                "title",
+                "rightHandSide",
+                "xLabel",
+                "yLabel",
+                "statement",
+                "introduction",
+                "conclusion",
+                "br",
+                "hr",
+                "m",
+                "me",
+                "men",
+                "md",
+                "mdn",
+                "mrow",
+                "not",
+                "and",
+                "or",
+                "xor",
+                "iff",
+                "implies",
+                "isInteger",
+                "isNumber",
+                "isBetween",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "em",
+                "alert",
+                "q",
+                "sq",
+                "term",
+                "c",
+                "tag",
+                "tage",
+                "tagc",
+                "attr",
+                "ndash",
+                "mdash",
+                "nbsp",
+                "ellipsis",
+                "lq",
+                "rq",
+                "lsq",
+                "rsq",
+                "section",
+                "subsection",
+                "subsubsection",
+                "paragraphs",
+                "aside",
+                "objectives",
+                "problem",
+                "exercise",
+                "question",
+                "activity",
+                "example",
+                "definition",
+                "note",
+                "theorem",
+                "part",
+                "task",
+                "proof",
+                "problems",
+                "exercises",
+                "ol",
+                "ul",
+                "odeSystem",
+                "cobwebPolyline",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "equilibriumCurve",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "orbitalDiagram",
+                "orbitalDiagramInput",
+                "sideBySide",
+                "sbsGroup",
+                "stack",
+                "div",
+                "span",
+                "pre",
+                "displayDoenetML",
+                "paginator",
+                "paginatorControls",
+                "matrixInput",
+                "fractionInput",
+                "solution",
+                "givenAnswer",
+                "document",
+                "text",
+                "textList",
+                "p",
+                "boolean",
+                "booleanList",
+                "math",
+                "mathList",
+                "tupleList",
+                "numberList",
+                "collect",
+                "ref",
+                "point",
+                "coords",
+                "line",
+                "lineSegment",
+                "ray",
+                "polyline",
+                "polygon",
+                "triangle",
+                "rectangle",
+                "regularPolygon",
+                "circle",
+                "parabola",
+                "curve",
+                "bezierControls",
+                "vector",
+                "angle",
+                "answer",
+                "award",
+                "mathInput",
+                "textInput",
+                "booleanInput",
+                "choiceInput",
+                "choice",
+                "number",
+                "integer",
+                "graph",
+                "annotations",
+                "annotation",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "slider",
+                "spreadsheet",
+                "cell",
+                "row",
+                "column",
+                "cellBlock",
+                "tabular",
+                "table",
+                "figure",
+                "repeat",
+                "repeatForSequence",
+                "pegboard",
+                "intersection",
+                "conditionalContent",
+                "asList",
+                "variantControl",
+                "selectFromSequence",
+                "select",
+                "group",
+                "animateFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "image",
+                "video",
+                "hint",
+                "intComma",
+                "pluralize",
+                "feedback",
+                "lorem",
+                "updateValue",
+                "callAction",
+                "triggerSet",
+                "functionIterates",
+                "module",
+                "moduleAttributes",
+                "setup",
+                "footnote",
+                "caption",
+                "endpoint",
+                "sort",
+                "sortIndices",
+                "shuffle",
+                "solveEquations",
+                "subsetOfRealsInput",
+                "subsetOfReals",
+                "split",
+                "bestFitLine",
+                "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
+                "slopeField",
+                "vectorField",
+                "regionHalfPlane",
+                "codeEditor",
+                "hasSameFactoring",
+                "legend",
+                "label",
+                "matchesPattern",
+                "matrix",
+                "eigenDecomposition",
+                "latex",
+                "blockQuote",
+                "stickyGroup",
+                "pretzel",
+                "cascade",
+                "pointList",
+                "intervalList",
+                "vectorList"
+            ],
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -113123,11 +120605,37 @@
                 {
                     "name": "type",
                     "description": "Component type to shuffle children as.",
-                    "type": "text"
+                    "highlighted": true,
+                    "values": [
+                        "number",
+                        "math",
+                        "text",
+                        "boolean"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "number",
+                            "description": "Read bare strings as numbers."
+                        },
+                        {
+                            "value": "math",
+                            "description": "Read bare strings as math expressions."
+                        },
+                        {
+                            "value": "text",
+                            "description": "Read bare strings as text."
+                        },
+                        {
+                            "value": "boolean",
+                            "description": "Read bare strings as booleans."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "asList",
                     "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
                     "defaultValue": true,
                     "values": [
                         "true",
@@ -113202,6 +120710,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -113248,6 +120765,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -113256,7 +120774,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -113758,6 +121276,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -113804,6 +121331,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -113812,7 +121340,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -114714,6 +122242,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -114871,6 +122408,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -114898,7 +122436,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -116283,6 +123821,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -116323,6 +123870,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -116331,7 +123879,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11101212222111111111111111111111122222212222022221222220112221222222122221212222",
+            "childBuckets": "111012122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -116642,6 +124190,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -116682,6 +124239,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -116690,7 +124248,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11101212222111111111111111111111122222212222022221222220112221222222122221212222",
+            "childBuckets": "111012122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -117297,6 +124855,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -117454,6 +125021,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -117481,7 +125049,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -117884,6 +125452,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -117930,6 +125507,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -117938,7 +125516,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -118681,6 +126259,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -118770,6 +126357,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -118784,7 +126372,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -119132,6 +126720,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -119178,6 +126775,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -119186,7 +126784,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -120520,6 +128118,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -120566,6 +128173,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -120574,7 +128182,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_base"
             ],
@@ -120871,6 +128479,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -120903,6 +128520,7 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -120950,7 +128568,7 @@
                 "md",
                 "mdn"
             ],
-            "childBuckets": "12201112222222221111111111111111111111122102220222122212222122222211121222112111111111111111111222222222222222222201",
+            "childBuckets": "122011122222222211111111111111111111112222211111221022202221222122221222222111221222112111111111111111111222222222222222222201",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -121373,6 +128991,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -121530,6 +129157,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -121557,7 +129185,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -121744,6 +129372,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -121901,6 +129538,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -121928,7 +129566,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -122096,6 +129734,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -122156,7 +129803,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11202222222222222222222222222211112222212111111111111122222212222222212222111111121222",
+            "childBuckets": "11202222222222222222222222222222222222211112222212111111111111122222212222222212222111111121222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -122901,6 +130548,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -123055,6 +130711,7 @@
                 "caption",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -123082,7 +130739,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "100000001111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponent",
                 "_block",
@@ -123709,6 +131366,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -123798,6 +131464,7 @@
                 "footnote",
                 "endpoint",
                 "sort",
+                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -123812,7 +131479,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_textOrInline",
                 "_inline",
@@ -123989,6 +131656,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -124044,10 +131720,11 @@
                 "intComma",
                 "pluralize",
                 "lorem",
+                "sortIndices",
                 "bestFitLine",
                 "latex"
             ],
-            "childBuckets": "11111111111111111111111110220121222121111222222222222222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211111102201212221211112222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -124247,6 +131924,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -124291,6 +131977,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -124298,7 +131985,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "02212222111111111111111111111122222222212222022221222222222222122222212222121222",
+            "childBuckets": "022122221111111111111111111111222221111222222222122220222212222222222221222222122222121222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -124491,6 +132178,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "electronConfiguration",
                 "math",
                 "mathList",
@@ -124545,11 +132241,12 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "bestFitLine",
                 "latex",
                 "pointList"
             ],
-            "childBuckets": "11111111111111111111111102210122212111222222222222222222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211111022101222121112222222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -124976,6 +132673,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -125022,6 +132728,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -125030,7 +132737,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -125297,6 +133004,15 @@
                 "gcd",
                 "lcm",
                 "extractMath",
+                "cumulativeSum",
+                "cumulativeProduct",
+                "cumulativeMin",
+                "cumulativeMax",
+                "differences",
+                "argMin",
+                "argMax",
+                "indexOf",
+                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -125343,6 +133059,7 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
+                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -125351,7 +133068,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
+            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -102760,8 +102760,8 @@
                 },
                 {
                     "name": "type",
-                    "description": "Multivariate distribution from which to sample.",
-                    "defaultValue": "hypergeometric",
+                    "description": "Multivariate distribution from which to sample. Required; there is no default.",
+                    "defaultValue": null,
                     "values": [
                         "hypergeometric"
                     ],
@@ -102851,7 +102851,7 @@
                     "name": "type",
                     "type": "text",
                     "isArray": false,
-                    "description": "Multivariate distribution from which to sample.",
+                    "description": "Multivariate distribution from which to sample. Required; there is no default.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -45,15 +45,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -127,6 +118,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -142,7 +134,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -157,7 +148,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_textOrInline",
                 "_inline",
@@ -338,15 +329,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -384,6 +366,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -392,7 +375,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -401,7 +383,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -1207,15 +1189,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -1289,6 +1262,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -1304,7 +1278,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -1319,7 +1292,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -1682,15 +1655,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -1764,6 +1728,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -1779,7 +1744,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -1794,7 +1758,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -2161,15 +2125,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -2304,6 +2259,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -2326,7 +2282,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -2354,7 +2309,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -2717,15 +2672,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -2860,6 +2806,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -2882,7 +2829,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -2910,7 +2856,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -3273,15 +3219,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -3416,6 +3353,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -3438,7 +3376,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -3466,7 +3403,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -4107,15 +4044,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -4189,6 +4117,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -4204,7 +4133,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -4221,7 +4149,7 @@
                 "ol",
                 "ul"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222221112111121222211221111122200",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122211221111122200",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -4590,15 +4518,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -4733,6 +4652,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -4755,7 +4675,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -4783,7 +4702,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -4980,15 +4899,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -5062,6 +4972,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -5077,7 +4988,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -5092,7 +5002,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -5422,15 +5332,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -5504,6 +5405,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -5519,7 +5421,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -5534,7 +5435,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -5864,15 +5765,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -5946,6 +5838,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -5961,7 +5854,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -5976,7 +5868,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -6882,15 +6774,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -6964,6 +6847,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -6979,7 +6863,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -6994,7 +6877,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -7324,15 +7207,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -7370,6 +7244,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -7378,7 +7253,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -7405,7 +7279,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "12222111111111111111111111122222111122212222212202022221222220122122221222221112221211222221111111110212120",
+            "childBuckets": "12222111111111111111111111122212222212202022221222220122122221222222111221211222221111111110212120",
             "abstractAncestors": [
                 "_booleanOperatorOneInput",
                 "_inline",
@@ -9750,15 +9624,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -9796,6 +9661,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -9804,7 +9670,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -9813,7 +9678,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -10213,15 +10078,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -10259,6 +10115,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -10267,7 +10124,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -10276,7 +10132,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -10676,15 +10532,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -10722,6 +10569,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -10730,7 +10578,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -10739,7 +10586,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -11169,15 +11016,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -11215,6 +11053,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -11223,7 +11062,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -11232,7 +11070,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -12058,15 +11896,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -12104,6 +11933,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -12112,7 +11942,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -12121,7 +11950,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -12947,15 +12776,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -12993,6 +12813,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -13001,7 +12822,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -13010,7 +12830,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -13828,15 +13648,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -13874,6 +13685,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -13882,7 +13694,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -13891,7 +13702,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -14709,15 +14520,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -14755,6 +14557,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -14763,7 +14566,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -14772,7 +14574,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -15590,15 +15392,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -15636,6 +15429,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -15644,7 +15438,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -15653,7 +15446,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -16458,15 +16251,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -16504,6 +16288,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -16512,7 +16297,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -16521,7 +16305,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -17297,15 +17081,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -17343,6 +17118,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -17351,7 +17127,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -17360,7 +17135,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -18152,15 +17927,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -18198,6 +17964,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -18206,7 +17973,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -18215,7 +17981,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -19007,15 +18773,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -19053,6 +18810,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -19061,7 +18819,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -19070,7 +18827,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -19862,15 +19619,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -19908,6 +19656,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -19916,7 +19665,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -19925,7 +19673,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -20717,15 +20465,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -20763,6 +20502,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -20771,7 +20511,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -20780,7 +20519,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -21606,15 +21345,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -21652,6 +21382,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -21660,7 +21391,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -21669,7 +21399,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -22495,15 +22225,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -22541,6 +22262,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -22549,7 +22271,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -22558,7 +22279,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -23401,15 +23122,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -23447,6 +23159,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -23455,7 +23168,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -23464,7 +23176,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -24307,15 +24019,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -24353,6 +24056,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -24361,7 +24065,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -24370,7 +24073,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -25196,15 +24899,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -25242,6 +24936,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -25250,7 +24945,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -25259,7 +24953,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -26085,15 +25779,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -26131,6 +25816,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -26139,7 +25825,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -26148,7 +25833,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -26974,15 +26659,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -27020,6 +26696,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -27028,7 +26705,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -27037,7 +26713,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -27863,15 +27539,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -27909,6 +27576,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -27917,7 +27585,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -27926,7 +27593,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -28752,15 +28419,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -28798,6 +28456,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -28806,7 +28465,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -28815,7 +28473,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222220122122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -29641,15 +29299,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -29687,6 +29336,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -29695,7 +29345,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -29704,7 +29353,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -30528,5501 +30177,6 @@
             "layoutCategory": "inline"
         },
         {
-            "name": "cumulativeSum",
-            "children": [
-                "rightHandSide",
-                "m",
-                "me",
-                "men",
-                "mrow",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "matrixInput",
-                "fractionInput",
-                "text",
-                "textList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "point",
-                "coords",
-                "line",
-                "vector",
-                "angle",
-                "mathInput",
-                "choice",
-                "number",
-                "integer",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "cell",
-                "conditionalContent",
-                "selectFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "intComma",
-                "pluralize",
-                "lorem",
-                "endpoint",
-                "sortIndices",
-                "subsetOfReals",
-                "bestFitLine",
-                "matrix",
-                "latex",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
-            "abstractAncestors": [
-                "_mathListOperator",
-                "_composite",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "forceSymbolic",
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "forceNumeric",
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "asList",
-                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "forceSymbolic",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "forceNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": true,
-            "docsSlug": "cumulativeSum",
-            "summary": "Running total of the child math or number values: the list of partial sums",
-            "layoutCategory": "other"
-        },
-        {
-            "name": "cumulativeProduct",
-            "children": [
-                "rightHandSide",
-                "m",
-                "me",
-                "men",
-                "mrow",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "matrixInput",
-                "fractionInput",
-                "text",
-                "textList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "point",
-                "coords",
-                "line",
-                "vector",
-                "angle",
-                "mathInput",
-                "choice",
-                "number",
-                "integer",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "cell",
-                "conditionalContent",
-                "selectFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "intComma",
-                "pluralize",
-                "lorem",
-                "endpoint",
-                "sortIndices",
-                "subsetOfReals",
-                "bestFitLine",
-                "matrix",
-                "latex",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
-            "abstractAncestors": [
-                "_mathListOperator",
-                "_composite",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "forceSymbolic",
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "forceNumeric",
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "asList",
-                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "forceSymbolic",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "forceNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": true,
-            "docsSlug": "cumulativeProduct",
-            "summary": "Running product of the child math or number values: the list of partial products",
-            "layoutCategory": "other"
-        },
-        {
-            "name": "cumulativeMin",
-            "children": [
-                "rightHandSide",
-                "m",
-                "me",
-                "men",
-                "mrow",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "matrixInput",
-                "fractionInput",
-                "text",
-                "textList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "point",
-                "coords",
-                "line",
-                "vector",
-                "angle",
-                "mathInput",
-                "choice",
-                "number",
-                "integer",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "cell",
-                "conditionalContent",
-                "selectFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "intComma",
-                "pluralize",
-                "lorem",
-                "endpoint",
-                "sortIndices",
-                "subsetOfReals",
-                "bestFitLine",
-                "matrix",
-                "latex",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
-            "abstractAncestors": [
-                "_mathListOperator",
-                "_composite",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "forceSymbolic",
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "forceNumeric",
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "asList",
-                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "forceSymbolic",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "forceNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": true,
-            "docsSlug": "cumulativeMin",
-            "summary": "Running minimum of the child math or number values",
-            "layoutCategory": "other"
-        },
-        {
-            "name": "cumulativeMax",
-            "children": [
-                "rightHandSide",
-                "m",
-                "me",
-                "men",
-                "mrow",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "matrixInput",
-                "fractionInput",
-                "text",
-                "textList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "point",
-                "coords",
-                "line",
-                "vector",
-                "angle",
-                "mathInput",
-                "choice",
-                "number",
-                "integer",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "cell",
-                "conditionalContent",
-                "selectFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "intComma",
-                "pluralize",
-                "lorem",
-                "endpoint",
-                "sortIndices",
-                "subsetOfReals",
-                "bestFitLine",
-                "matrix",
-                "latex",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
-            "abstractAncestors": [
-                "_mathListOperator",
-                "_composite",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "forceSymbolic",
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "forceNumeric",
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "asList",
-                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "forceSymbolic",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "forceNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": true,
-            "docsSlug": "cumulativeMax",
-            "summary": "Running maximum of the child math or number values",
-            "layoutCategory": "other"
-        },
-        {
-            "name": "differences",
-            "children": [
-                "rightHandSide",
-                "m",
-                "me",
-                "men",
-                "mrow",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "matrixInput",
-                "fractionInput",
-                "text",
-                "textList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "point",
-                "coords",
-                "line",
-                "vector",
-                "angle",
-                "mathInput",
-                "choice",
-                "number",
-                "integer",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "cell",
-                "conditionalContent",
-                "selectFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "intComma",
-                "pluralize",
-                "lorem",
-                "endpoint",
-                "sortIndices",
-                "subsetOfReals",
-                "bestFitLine",
-                "matrix",
-                "latex",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222220122122221222221222221212222",
-            "abstractAncestors": [
-                "_mathListOperator",
-                "_composite",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "forceSymbolic",
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "forceNumeric",
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "highlighted": true,
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "asList",
-                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "forceSymbolic",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate symbolically rather than numerically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "forceNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to force the operator to evaluate numerically rather than symbolically.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": true,
-            "docsSlug": "differences",
-            "summary": "Differences between successive child math or number values; one shorter than the input",
-            "layoutCategory": "other"
-        },
-        {
-            "name": "argMin",
-            "children": [
-                "title",
-                "rightHandSide",
-                "xLabel",
-                "yLabel",
-                "statement",
-                "introduction",
-                "conclusion",
-                "br",
-                "hr",
-                "m",
-                "me",
-                "men",
-                "md",
-                "mdn",
-                "mrow",
-                "not",
-                "and",
-                "or",
-                "xor",
-                "iff",
-                "implies",
-                "isInteger",
-                "isNumber",
-                "isBetween",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "em",
-                "alert",
-                "q",
-                "sq",
-                "term",
-                "c",
-                "tag",
-                "tage",
-                "tagc",
-                "attr",
-                "ndash",
-                "mdash",
-                "nbsp",
-                "ellipsis",
-                "lq",
-                "rq",
-                "lsq",
-                "rsq",
-                "section",
-                "subsection",
-                "subsubsection",
-                "paragraphs",
-                "aside",
-                "objectives",
-                "problem",
-                "exercise",
-                "question",
-                "activity",
-                "example",
-                "definition",
-                "note",
-                "theorem",
-                "part",
-                "task",
-                "proof",
-                "problems",
-                "exercises",
-                "ol",
-                "ul",
-                "odeSystem",
-                "cobwebPolyline",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "equilibriumCurve",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "orbitalDiagram",
-                "orbitalDiagramInput",
-                "sideBySide",
-                "sbsGroup",
-                "stack",
-                "div",
-                "span",
-                "pre",
-                "displayDoenetML",
-                "paginator",
-                "paginatorControls",
-                "matrixInput",
-                "fractionInput",
-                "solution",
-                "givenAnswer",
-                "document",
-                "text",
-                "textList",
-                "p",
-                "boolean",
-                "booleanList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "collect",
-                "ref",
-                "point",
-                "coords",
-                "line",
-                "lineSegment",
-                "ray",
-                "polyline",
-                "polygon",
-                "triangle",
-                "rectangle",
-                "regularPolygon",
-                "circle",
-                "parabola",
-                "curve",
-                "bezierControls",
-                "vector",
-                "angle",
-                "answer",
-                "award",
-                "mathInput",
-                "textInput",
-                "booleanInput",
-                "choiceInput",
-                "choice",
-                "number",
-                "integer",
-                "graph",
-                "annotations",
-                "annotation",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "slider",
-                "spreadsheet",
-                "cell",
-                "row",
-                "column",
-                "cellBlock",
-                "tabular",
-                "table",
-                "figure",
-                "repeat",
-                "repeatForSequence",
-                "pegboard",
-                "intersection",
-                "conditionalContent",
-                "asList",
-                "variantControl",
-                "selectFromSequence",
-                "select",
-                "group",
-                "animateFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "image",
-                "video",
-                "hint",
-                "intComma",
-                "pluralize",
-                "feedback",
-                "lorem",
-                "updateValue",
-                "callAction",
-                "triggerSet",
-                "functionIterates",
-                "module",
-                "moduleAttributes",
-                "setup",
-                "footnote",
-                "caption",
-                "endpoint",
-                "sort",
-                "sortIndices",
-                "shuffle",
-                "solveEquations",
-                "subsetOfRealsInput",
-                "subsetOfReals",
-                "split",
-                "bestFitLine",
-                "regionBetweenCurveXAxis",
-                "regionBetweenCurves",
-                "slopeField",
-                "vectorField",
-                "regionHalfPlane",
-                "codeEditor",
-                "hasSameFactoring",
-                "legend",
-                "label",
-                "matchesPattern",
-                "matrix",
-                "eigenDecomposition",
-                "latex",
-                "blockQuote",
-                "stickyGroup",
-                "pretzel",
-                "cascade",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "abstractAncestors": [
-                "_listIndexOperator",
-                "_inline",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "format",
-                    "description": "Input format.",
-                    "defaultValue": "text",
-                    "values": [
-                        "text",
-                        "latex"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "text",
-                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
-                        },
-                        {
-                            "value": "latex",
-                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "simplify",
-                    "description": "Level of simplification applied to the expression.",
-                    "defaultValue": "none",
-                    "values": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "none",
-                            "description": "No simplification is applied."
-                        },
-                        {
-                            "value": "full",
-                            "description": "Fully simplify the expression."
-                        },
-                        {
-                            "value": "numbers",
-                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
-                        },
-                        {
-                            "value": "numbersPreserveOrder",
-                            "description": "Like `numbers`, but does not reorder commutative operands."
-                        },
-                        {
-                            "value": "normalizeOrder",
-                            "description": "Reorder commutative operands into a canonical form without simplifying values."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "expand",
-                    "description": "Whether to expand the expression.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 3,
-                    "type": "integer"
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 2,
-                    "type": "integer"
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero.",
-                    "groupName": "number-display",
-                    "defaultValue": 1e-14,
-                    "type": "number"
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "renderMode",
-                    "description": "How the math is rendered.",
-                    "defaultValue": "inline",
-                    "values": [
-                        "inline",
-                        "display"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "inline",
-                            "description": "Render inline with the surrounding text."
-                        },
-                        {
-                            "value": "display",
-                            "description": "Render as a centered equation on its own line."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "unordered",
-                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createVectors",
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createIntervals",
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "functionSymbols",
-                    "description": "Symbols treated as function names when parsing.",
-                    "defaultValue": [
-                        "f",
-                        "g"
-                    ],
-                    "type": "textList"
-                },
-                {
-                    "name": "referencesAreFunctionSymbols",
-                    "description": "References whose names should be treated as function symbols when parsing.",
-                    "defaultValue": [],
-                    "type": "reference"
-                },
-                {
-                    "name": "splitSymbols",
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayBlanks",
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumptions",
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "＿"
-                    },
-                    "type": "math"
-                },
-                {
-                    "name": "draggable",
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "layer",
-                    "description": "Z-order layer index when shown on a graph.",
-                    "defaultValue": 0,
-                    "type": "number"
-                },
-                {
-                    "name": "anchor",
-                    "description": "Coordinates of the anchor point used to position this component on a graph.",
-                    "groupName": "positioning",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "\\left( 0, 0 \\right)"
-                    },
-                    "type": "point"
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "description": "Where this component sits relative to its anchor point.",
-                    "groupName": "positioning",
-                    "defaultValue": "center",
-                    "values": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "upperRight",
-                            "description": "Place the component above and to the right of the anchor point."
-                        },
-                        {
-                            "value": "upperLeft",
-                            "description": "Place the component above and to the left of the anchor point."
-                        },
-                        {
-                            "value": "lowerRight",
-                            "description": "Place the component below and to the right of the anchor point."
-                        },
-                        {
-                            "value": "lowerLeft",
-                            "description": "Place the component below and to the left of the anchor point."
-                        },
-                        {
-                            "value": "top",
-                            "description": "Place the component directly above the anchor point."
-                        },
-                        {
-                            "value": "bottom",
-                            "description": "Place the component directly below the anchor point."
-                        },
-                        {
-                            "value": "left",
-                            "description": "Place the component directly to the left of the anchor point."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Place the component directly to the right of the anchor point."
-                        },
-                        {
-                            "value": "center",
-                            "description": "Center the component on the anchor point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers, ordered by value."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions, ordered by value."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text, ordered alphabetically."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans, ordered with false before true."
-                        }
-                    ],
-                    "type": "keyword"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true,
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph.",
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "argMin",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none.",
-                    "highlighted": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": false,
-            "docsSlug": "argMin",
-            "summary": "The index of the smallest value in a list",
-            "layoutCategory": "inline"
-        },
-        {
-            "name": "argMax",
-            "children": [
-                "title",
-                "rightHandSide",
-                "xLabel",
-                "yLabel",
-                "statement",
-                "introduction",
-                "conclusion",
-                "br",
-                "hr",
-                "m",
-                "me",
-                "men",
-                "md",
-                "mdn",
-                "mrow",
-                "not",
-                "and",
-                "or",
-                "xor",
-                "iff",
-                "implies",
-                "isInteger",
-                "isNumber",
-                "isBetween",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "em",
-                "alert",
-                "q",
-                "sq",
-                "term",
-                "c",
-                "tag",
-                "tage",
-                "tagc",
-                "attr",
-                "ndash",
-                "mdash",
-                "nbsp",
-                "ellipsis",
-                "lq",
-                "rq",
-                "lsq",
-                "rsq",
-                "section",
-                "subsection",
-                "subsubsection",
-                "paragraphs",
-                "aside",
-                "objectives",
-                "problem",
-                "exercise",
-                "question",
-                "activity",
-                "example",
-                "definition",
-                "note",
-                "theorem",
-                "part",
-                "task",
-                "proof",
-                "problems",
-                "exercises",
-                "ol",
-                "ul",
-                "odeSystem",
-                "cobwebPolyline",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "equilibriumCurve",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "orbitalDiagram",
-                "orbitalDiagramInput",
-                "sideBySide",
-                "sbsGroup",
-                "stack",
-                "div",
-                "span",
-                "pre",
-                "displayDoenetML",
-                "paginator",
-                "paginatorControls",
-                "matrixInput",
-                "fractionInput",
-                "solution",
-                "givenAnswer",
-                "document",
-                "text",
-                "textList",
-                "p",
-                "boolean",
-                "booleanList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "collect",
-                "ref",
-                "point",
-                "coords",
-                "line",
-                "lineSegment",
-                "ray",
-                "polyline",
-                "polygon",
-                "triangle",
-                "rectangle",
-                "regularPolygon",
-                "circle",
-                "parabola",
-                "curve",
-                "bezierControls",
-                "vector",
-                "angle",
-                "answer",
-                "award",
-                "mathInput",
-                "textInput",
-                "booleanInput",
-                "choiceInput",
-                "choice",
-                "number",
-                "integer",
-                "graph",
-                "annotations",
-                "annotation",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "slider",
-                "spreadsheet",
-                "cell",
-                "row",
-                "column",
-                "cellBlock",
-                "tabular",
-                "table",
-                "figure",
-                "repeat",
-                "repeatForSequence",
-                "pegboard",
-                "intersection",
-                "conditionalContent",
-                "asList",
-                "variantControl",
-                "selectFromSequence",
-                "select",
-                "group",
-                "animateFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "image",
-                "video",
-                "hint",
-                "intComma",
-                "pluralize",
-                "feedback",
-                "lorem",
-                "updateValue",
-                "callAction",
-                "triggerSet",
-                "functionIterates",
-                "module",
-                "moduleAttributes",
-                "setup",
-                "footnote",
-                "caption",
-                "endpoint",
-                "sort",
-                "sortIndices",
-                "shuffle",
-                "solveEquations",
-                "subsetOfRealsInput",
-                "subsetOfReals",
-                "split",
-                "bestFitLine",
-                "regionBetweenCurveXAxis",
-                "regionBetweenCurves",
-                "slopeField",
-                "vectorField",
-                "regionHalfPlane",
-                "codeEditor",
-                "hasSameFactoring",
-                "legend",
-                "label",
-                "matchesPattern",
-                "matrix",
-                "eigenDecomposition",
-                "latex",
-                "blockQuote",
-                "stickyGroup",
-                "pretzel",
-                "cascade",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "abstractAncestors": [
-                "_listIndexOperator",
-                "_inline",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "format",
-                    "description": "Input format.",
-                    "defaultValue": "text",
-                    "values": [
-                        "text",
-                        "latex"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "text",
-                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
-                        },
-                        {
-                            "value": "latex",
-                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "simplify",
-                    "description": "Level of simplification applied to the expression.",
-                    "defaultValue": "none",
-                    "values": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "none",
-                            "description": "No simplification is applied."
-                        },
-                        {
-                            "value": "full",
-                            "description": "Fully simplify the expression."
-                        },
-                        {
-                            "value": "numbers",
-                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
-                        },
-                        {
-                            "value": "numbersPreserveOrder",
-                            "description": "Like `numbers`, but does not reorder commutative operands."
-                        },
-                        {
-                            "value": "normalizeOrder",
-                            "description": "Reorder commutative operands into a canonical form without simplifying values."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "expand",
-                    "description": "Whether to expand the expression.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 3,
-                    "type": "integer"
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 2,
-                    "type": "integer"
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero.",
-                    "groupName": "number-display",
-                    "defaultValue": 1e-14,
-                    "type": "number"
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "renderMode",
-                    "description": "How the math is rendered.",
-                    "defaultValue": "inline",
-                    "values": [
-                        "inline",
-                        "display"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "inline",
-                            "description": "Render inline with the surrounding text."
-                        },
-                        {
-                            "value": "display",
-                            "description": "Render as a centered equation on its own line."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "unordered",
-                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createVectors",
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createIntervals",
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "functionSymbols",
-                    "description": "Symbols treated as function names when parsing.",
-                    "defaultValue": [
-                        "f",
-                        "g"
-                    ],
-                    "type": "textList"
-                },
-                {
-                    "name": "referencesAreFunctionSymbols",
-                    "description": "References whose names should be treated as function symbols when parsing.",
-                    "defaultValue": [],
-                    "type": "reference"
-                },
-                {
-                    "name": "splitSymbols",
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayBlanks",
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumptions",
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "＿"
-                    },
-                    "type": "math"
-                },
-                {
-                    "name": "draggable",
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "layer",
-                    "description": "Z-order layer index when shown on a graph.",
-                    "defaultValue": 0,
-                    "type": "number"
-                },
-                {
-                    "name": "anchor",
-                    "description": "Coordinates of the anchor point used to position this component on a graph.",
-                    "groupName": "positioning",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "\\left( 0, 0 \\right)"
-                    },
-                    "type": "point"
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "description": "Where this component sits relative to its anchor point.",
-                    "groupName": "positioning",
-                    "defaultValue": "center",
-                    "values": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "upperRight",
-                            "description": "Place the component above and to the right of the anchor point."
-                        },
-                        {
-                            "value": "upperLeft",
-                            "description": "Place the component above and to the left of the anchor point."
-                        },
-                        {
-                            "value": "lowerRight",
-                            "description": "Place the component below and to the right of the anchor point."
-                        },
-                        {
-                            "value": "lowerLeft",
-                            "description": "Place the component below and to the left of the anchor point."
-                        },
-                        {
-                            "value": "top",
-                            "description": "Place the component directly above the anchor point."
-                        },
-                        {
-                            "value": "bottom",
-                            "description": "Place the component directly below the anchor point."
-                        },
-                        {
-                            "value": "left",
-                            "description": "Place the component directly to the left of the anchor point."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Place the component directly to the right of the anchor point."
-                        },
-                        {
-                            "value": "center",
-                            "description": "Center the component on the anchor point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers, ordered by value."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions, ordered by value."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text, ordered alphabetically."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans, ordered with false before true."
-                        }
-                    ],
-                    "type": "keyword"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true,
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph.",
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "argMax",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none.",
-                    "highlighted": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": false,
-            "docsSlug": "argMax",
-            "summary": "The index of the largest value in a list",
-            "layoutCategory": "inline"
-        },
-        {
-            "name": "indexOf",
-            "children": [
-                "title",
-                "rightHandSide",
-                "xLabel",
-                "yLabel",
-                "statement",
-                "introduction",
-                "conclusion",
-                "br",
-                "hr",
-                "m",
-                "me",
-                "men",
-                "md",
-                "mdn",
-                "mrow",
-                "not",
-                "and",
-                "or",
-                "xor",
-                "iff",
-                "implies",
-                "isInteger",
-                "isNumber",
-                "isBetween",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "em",
-                "alert",
-                "q",
-                "sq",
-                "term",
-                "c",
-                "tag",
-                "tage",
-                "tagc",
-                "attr",
-                "ndash",
-                "mdash",
-                "nbsp",
-                "ellipsis",
-                "lq",
-                "rq",
-                "lsq",
-                "rsq",
-                "section",
-                "subsection",
-                "subsubsection",
-                "paragraphs",
-                "aside",
-                "objectives",
-                "problem",
-                "exercise",
-                "question",
-                "activity",
-                "example",
-                "definition",
-                "note",
-                "theorem",
-                "part",
-                "task",
-                "proof",
-                "problems",
-                "exercises",
-                "ol",
-                "ul",
-                "odeSystem",
-                "cobwebPolyline",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "equilibriumCurve",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "orbitalDiagram",
-                "orbitalDiagramInput",
-                "sideBySide",
-                "sbsGroup",
-                "stack",
-                "div",
-                "span",
-                "pre",
-                "displayDoenetML",
-                "paginator",
-                "paginatorControls",
-                "matrixInput",
-                "fractionInput",
-                "solution",
-                "givenAnswer",
-                "document",
-                "text",
-                "textList",
-                "p",
-                "boolean",
-                "booleanList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "collect",
-                "ref",
-                "point",
-                "coords",
-                "line",
-                "lineSegment",
-                "ray",
-                "polyline",
-                "polygon",
-                "triangle",
-                "rectangle",
-                "regularPolygon",
-                "circle",
-                "parabola",
-                "curve",
-                "bezierControls",
-                "vector",
-                "angle",
-                "answer",
-                "award",
-                "mathInput",
-                "textInput",
-                "booleanInput",
-                "choiceInput",
-                "choice",
-                "number",
-                "integer",
-                "graph",
-                "annotations",
-                "annotation",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "slider",
-                "spreadsheet",
-                "cell",
-                "row",
-                "column",
-                "cellBlock",
-                "tabular",
-                "table",
-                "figure",
-                "repeat",
-                "repeatForSequence",
-                "pegboard",
-                "intersection",
-                "conditionalContent",
-                "asList",
-                "variantControl",
-                "selectFromSequence",
-                "select",
-                "group",
-                "animateFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "image",
-                "video",
-                "hint",
-                "intComma",
-                "pluralize",
-                "feedback",
-                "lorem",
-                "updateValue",
-                "callAction",
-                "triggerSet",
-                "functionIterates",
-                "module",
-                "moduleAttributes",
-                "setup",
-                "footnote",
-                "caption",
-                "endpoint",
-                "sort",
-                "sortIndices",
-                "shuffle",
-                "solveEquations",
-                "subsetOfRealsInput",
-                "subsetOfReals",
-                "split",
-                "bestFitLine",
-                "regionBetweenCurveXAxis",
-                "regionBetweenCurves",
-                "slopeField",
-                "vectorField",
-                "regionHalfPlane",
-                "codeEditor",
-                "hasSameFactoring",
-                "legend",
-                "label",
-                "matchesPattern",
-                "matrix",
-                "eigenDecomposition",
-                "latex",
-                "blockQuote",
-                "stickyGroup",
-                "pretzel",
-                "cascade",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "abstractAncestors": [
-                "_listIndexOperator",
-                "_inline",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "format",
-                    "description": "Input format.",
-                    "defaultValue": "text",
-                    "values": [
-                        "text",
-                        "latex"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "text",
-                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
-                        },
-                        {
-                            "value": "latex",
-                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "simplify",
-                    "description": "Level of simplification applied to the expression.",
-                    "defaultValue": "none",
-                    "values": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "none",
-                            "description": "No simplification is applied."
-                        },
-                        {
-                            "value": "full",
-                            "description": "Fully simplify the expression."
-                        },
-                        {
-                            "value": "numbers",
-                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
-                        },
-                        {
-                            "value": "numbersPreserveOrder",
-                            "description": "Like `numbers`, but does not reorder commutative operands."
-                        },
-                        {
-                            "value": "normalizeOrder",
-                            "description": "Reorder commutative operands into a canonical form without simplifying values."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "expand",
-                    "description": "Whether to expand the expression.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 3,
-                    "type": "integer"
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 2,
-                    "type": "integer"
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero.",
-                    "groupName": "number-display",
-                    "defaultValue": 1e-14,
-                    "type": "number"
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "renderMode",
-                    "description": "How the math is rendered.",
-                    "defaultValue": "inline",
-                    "values": [
-                        "inline",
-                        "display"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "inline",
-                            "description": "Render inline with the surrounding text."
-                        },
-                        {
-                            "value": "display",
-                            "description": "Render as a centered equation on its own line."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "unordered",
-                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createVectors",
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createIntervals",
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "functionSymbols",
-                    "description": "Symbols treated as function names when parsing.",
-                    "defaultValue": [
-                        "f",
-                        "g"
-                    ],
-                    "type": "textList"
-                },
-                {
-                    "name": "referencesAreFunctionSymbols",
-                    "description": "References whose names should be treated as function symbols when parsing.",
-                    "defaultValue": [],
-                    "type": "reference"
-                },
-                {
-                    "name": "splitSymbols",
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayBlanks",
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumptions",
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "＿"
-                    },
-                    "type": "math"
-                },
-                {
-                    "name": "draggable",
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "layer",
-                    "description": "Z-order layer index when shown on a graph.",
-                    "defaultValue": 0,
-                    "type": "number"
-                },
-                {
-                    "name": "anchor",
-                    "description": "Coordinates of the anchor point used to position this component on a graph.",
-                    "groupName": "positioning",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "\\left( 0, 0 \\right)"
-                    },
-                    "type": "point"
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "description": "Where this component sits relative to its anchor point.",
-                    "groupName": "positioning",
-                    "defaultValue": "center",
-                    "values": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "upperRight",
-                            "description": "Place the component above and to the right of the anchor point."
-                        },
-                        {
-                            "value": "upperLeft",
-                            "description": "Place the component above and to the left of the anchor point."
-                        },
-                        {
-                            "value": "lowerRight",
-                            "description": "Place the component below and to the right of the anchor point."
-                        },
-                        {
-                            "value": "lowerLeft",
-                            "description": "Place the component below and to the left of the anchor point."
-                        },
-                        {
-                            "value": "top",
-                            "description": "Place the component directly above the anchor point."
-                        },
-                        {
-                            "value": "bottom",
-                            "description": "Place the component directly below the anchor point."
-                        },
-                        {
-                            "value": "left",
-                            "description": "Place the component directly to the left of the anchor point."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Place the component directly to the right of the anchor point."
-                        },
-                        {
-                            "value": "center",
-                            "description": "Center the component on the anchor point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers, ordered by value."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions, ordered by value."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text, ordered alphabetically."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans, ordered with false before true."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "target",
-                    "description": "The value to look for.",
-                    "highlighted": true,
-                    "defaultValue": null,
-                    "type": "_componentWithSelectableType"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true,
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph.",
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "indexOf",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none.",
-                    "highlighted": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": false,
-            "docsSlug": "indexOf",
-            "summary": "The index of the first value in a list equal to a target, or 0 if there is none",
-            "layoutCategory": "inline"
-        },
-        {
-            "name": "searchSorted",
-            "children": [
-                "title",
-                "rightHandSide",
-                "xLabel",
-                "yLabel",
-                "statement",
-                "introduction",
-                "conclusion",
-                "br",
-                "hr",
-                "m",
-                "me",
-                "men",
-                "md",
-                "mdn",
-                "mrow",
-                "not",
-                "and",
-                "or",
-                "xor",
-                "iff",
-                "implies",
-                "isInteger",
-                "isNumber",
-                "isBetween",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "em",
-                "alert",
-                "q",
-                "sq",
-                "term",
-                "c",
-                "tag",
-                "tage",
-                "tagc",
-                "attr",
-                "ndash",
-                "mdash",
-                "nbsp",
-                "ellipsis",
-                "lq",
-                "rq",
-                "lsq",
-                "rsq",
-                "section",
-                "subsection",
-                "subsubsection",
-                "paragraphs",
-                "aside",
-                "objectives",
-                "problem",
-                "exercise",
-                "question",
-                "activity",
-                "example",
-                "definition",
-                "note",
-                "theorem",
-                "part",
-                "task",
-                "proof",
-                "problems",
-                "exercises",
-                "ol",
-                "ul",
-                "odeSystem",
-                "cobwebPolyline",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "equilibriumCurve",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "orbitalDiagram",
-                "orbitalDiagramInput",
-                "sideBySide",
-                "sbsGroup",
-                "stack",
-                "div",
-                "span",
-                "pre",
-                "displayDoenetML",
-                "paginator",
-                "paginatorControls",
-                "matrixInput",
-                "fractionInput",
-                "solution",
-                "givenAnswer",
-                "document",
-                "text",
-                "textList",
-                "p",
-                "boolean",
-                "booleanList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "collect",
-                "ref",
-                "point",
-                "coords",
-                "line",
-                "lineSegment",
-                "ray",
-                "polyline",
-                "polygon",
-                "triangle",
-                "rectangle",
-                "regularPolygon",
-                "circle",
-                "parabola",
-                "curve",
-                "bezierControls",
-                "vector",
-                "angle",
-                "answer",
-                "award",
-                "mathInput",
-                "textInput",
-                "booleanInput",
-                "choiceInput",
-                "choice",
-                "number",
-                "integer",
-                "graph",
-                "annotations",
-                "annotation",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "slider",
-                "spreadsheet",
-                "cell",
-                "row",
-                "column",
-                "cellBlock",
-                "tabular",
-                "table",
-                "figure",
-                "repeat",
-                "repeatForSequence",
-                "pegboard",
-                "intersection",
-                "conditionalContent",
-                "asList",
-                "variantControl",
-                "selectFromSequence",
-                "select",
-                "group",
-                "animateFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "image",
-                "video",
-                "hint",
-                "intComma",
-                "pluralize",
-                "feedback",
-                "lorem",
-                "updateValue",
-                "callAction",
-                "triggerSet",
-                "functionIterates",
-                "module",
-                "moduleAttributes",
-                "setup",
-                "footnote",
-                "caption",
-                "endpoint",
-                "sort",
-                "sortIndices",
-                "shuffle",
-                "solveEquations",
-                "subsetOfRealsInput",
-                "subsetOfReals",
-                "split",
-                "bestFitLine",
-                "regionBetweenCurveXAxis",
-                "regionBetweenCurves",
-                "slopeField",
-                "vectorField",
-                "regionHalfPlane",
-                "codeEditor",
-                "hasSameFactoring",
-                "legend",
-                "label",
-                "matchesPattern",
-                "matrix",
-                "eigenDecomposition",
-                "latex",
-                "blockQuote",
-                "stickyGroup",
-                "pretzel",
-                "cascade",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "abstractAncestors": [
-                "_listIndexOperator",
-                "_inline",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "format",
-                    "description": "Input format.",
-                    "defaultValue": "text",
-                    "values": [
-                        "text",
-                        "latex"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "text",
-                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
-                        },
-                        {
-                            "value": "latex",
-                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "simplify",
-                    "description": "Level of simplification applied to the expression.",
-                    "defaultValue": "none",
-                    "values": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "none",
-                            "description": "No simplification is applied."
-                        },
-                        {
-                            "value": "full",
-                            "description": "Fully simplify the expression."
-                        },
-                        {
-                            "value": "numbers",
-                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
-                        },
-                        {
-                            "value": "numbersPreserveOrder",
-                            "description": "Like `numbers`, but does not reorder commutative operands."
-                        },
-                        {
-                            "value": "normalizeOrder",
-                            "description": "Reorder commutative operands into a canonical form without simplifying values."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "expand",
-                    "description": "Whether to expand the expression.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 3,
-                    "type": "integer"
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 2,
-                    "type": "integer"
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero.",
-                    "groupName": "number-display",
-                    "defaultValue": 1e-14,
-                    "type": "number"
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "renderMode",
-                    "description": "How the math is rendered.",
-                    "defaultValue": "inline",
-                    "values": [
-                        "inline",
-                        "display"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "inline",
-                            "description": "Render inline with the surrounding text."
-                        },
-                        {
-                            "value": "display",
-                            "description": "Render as a centered equation on its own line."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "unordered",
-                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createVectors",
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createIntervals",
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "functionSymbols",
-                    "description": "Symbols treated as function names when parsing.",
-                    "defaultValue": [
-                        "f",
-                        "g"
-                    ],
-                    "type": "textList"
-                },
-                {
-                    "name": "referencesAreFunctionSymbols",
-                    "description": "References whose names should be treated as function symbols when parsing.",
-                    "defaultValue": [],
-                    "type": "reference"
-                },
-                {
-                    "name": "splitSymbols",
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayBlanks",
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumptions",
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "＿"
-                    },
-                    "type": "math"
-                },
-                {
-                    "name": "draggable",
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "layer",
-                    "description": "Z-order layer index when shown on a graph.",
-                    "defaultValue": 0,
-                    "type": "number"
-                },
-                {
-                    "name": "anchor",
-                    "description": "Coordinates of the anchor point used to position this component on a graph.",
-                    "groupName": "positioning",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "\\left( 0, 0 \\right)"
-                    },
-                    "type": "point"
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "description": "Where this component sits relative to its anchor point.",
-                    "groupName": "positioning",
-                    "defaultValue": "center",
-                    "values": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "upperRight",
-                            "description": "Place the component above and to the right of the anchor point."
-                        },
-                        {
-                            "value": "upperLeft",
-                            "description": "Place the component above and to the left of the anchor point."
-                        },
-                        {
-                            "value": "lowerRight",
-                            "description": "Place the component below and to the right of the anchor point."
-                        },
-                        {
-                            "value": "lowerLeft",
-                            "description": "Place the component below and to the left of the anchor point."
-                        },
-                        {
-                            "value": "top",
-                            "description": "Place the component directly above the anchor point."
-                        },
-                        {
-                            "value": "bottom",
-                            "description": "Place the component directly below the anchor point."
-                        },
-                        {
-                            "value": "left",
-                            "description": "Place the component directly to the left of the anchor point."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Place the component directly to the right of the anchor point."
-                        },
-                        {
-                            "value": "center",
-                            "description": "Center the component on the anchor point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers, ordered by value."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions, ordered by value."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text, ordered alphabetically."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans, ordered with false before true."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "target",
-                    "description": "The value to locate within the sorted list.",
-                    "highlighted": true,
-                    "defaultValue": null,
-                    "type": "_componentWithSelectableType"
-                },
-                {
-                    "name": "side",
-                    "description": "Which end of a run of equal values the target is placed at.",
-                    "highlighted": true,
-                    "defaultValue": "left",
-                    "values": [
-                        "left",
-                        "right"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "left",
-                            "description": "Insert before any equal values, so the result is the index of the first entry greater than or equal to the target."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Insert after any equal values, so the result is the index of the first entry strictly greater than the target."
-                        }
-                    ],
-                    "type": "keyword"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true,
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "side",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Which end of a run of equal values the target is placed at.",
-                    "fromAttribute": true,
-                    "highlighted": true
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph.",
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "searchSorted",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none.",
-                    "highlighted": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": false,
-            "docsSlug": "searchSorted",
-            "summary": "The position at which a target would be inserted to keep a sorted list sorted",
-            "layoutCategory": "inline"
-        },
-        {
             "name": "clampFunction",
             "children": [
                 "rightHandSide",
@@ -36052,15 +30206,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -36098,6 +30243,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -36106,7 +30252,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -36118,7 +30263,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111122222111111122222212222022221222222201122221222221222221212222110",
+            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -36998,15 +31143,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -37044,6 +31180,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -37052,7 +31189,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -37064,7 +31200,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111122222111111122222212222022221222222201122221222221222221212222110",
+            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -37944,15 +32080,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -37990,6 +32117,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -37998,7 +32126,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -38010,7 +32137,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111122222111111122222212222022221222222201122221222221222221212222110",
+            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -38894,15 +33021,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -38940,6 +33058,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -38948,7 +33067,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -38957,7 +33075,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_textOperatorOfMath",
                 "_inline",
@@ -39371,15 +33489,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -39453,6 +33562,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -39468,7 +33578,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -39483,7 +33592,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -39673,15 +33782,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -39755,6 +33855,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -39770,7 +33871,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -39785,7 +33885,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -39975,15 +34075,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -40057,6 +34148,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -40072,7 +34164,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -40087,7 +34178,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -40277,15 +34368,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -40359,6 +34441,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -40374,7 +34457,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -40389,7 +34471,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -40579,15 +34661,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -40661,6 +34734,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -40676,7 +34750,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -40691,7 +34764,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -40881,15 +34954,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -40963,6 +35027,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -40978,7 +35043,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -40993,7 +35057,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41183,15 +35247,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -41265,6 +35320,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -41280,7 +35336,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -41295,7 +35350,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41485,15 +35540,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -41567,6 +35613,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -41582,7 +35629,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -41597,7 +35643,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41787,15 +35833,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -41869,6 +35906,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -41884,7 +35922,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -41899,7 +35936,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -42089,15 +36126,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -42171,6 +36199,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -42186,7 +36215,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -42201,7 +36229,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -43586,15 +37614,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -43727,6 +37746,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -43748,7 +37768,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -43776,7 +37795,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -44385,15 +38404,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -44526,6 +38536,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -44547,7 +38558,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -44575,7 +38585,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -45184,15 +39194,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -45325,6 +39326,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -45346,7 +39348,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -45374,7 +39375,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -45983,15 +39984,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -46124,6 +40116,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -46145,7 +40138,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -46173,7 +40165,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -46782,15 +40774,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -46923,6 +40906,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -46944,7 +40928,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -46972,7 +40955,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -47590,15 +41573,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -47731,6 +41705,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -47752,7 +41727,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -47780,7 +41754,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -48389,15 +42363,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -48530,6 +42495,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -48551,7 +42517,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -48579,7 +42544,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -49197,15 +43162,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -49338,6 +43294,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -49359,7 +43316,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -49387,7 +43343,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -50005,15 +43961,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -50146,6 +44093,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -50167,7 +44115,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -50195,7 +44142,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -50813,15 +44760,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -50954,6 +44892,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -50975,7 +44914,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -51003,7 +44941,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -51621,15 +45559,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -51762,6 +45691,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -51783,7 +45713,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -51811,7 +45740,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -52420,15 +46349,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -52561,6 +46481,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -52582,7 +46503,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -52610,7 +46530,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -53219,15 +47139,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -53360,6 +47271,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -53381,7 +47293,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -53409,7 +47320,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -54018,15 +47929,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -54159,6 +48061,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -54180,7 +48083,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -54208,7 +48110,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -54817,15 +48719,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -54958,6 +48851,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -54979,7 +48873,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -55007,7 +48900,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -55616,15 +49509,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -55757,6 +49641,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -55778,7 +49663,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -55806,7 +49690,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponentNumberWithSiblings",
                 "_sectioningComponent",
@@ -56415,15 +50299,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -56556,6 +50431,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -56577,7 +50453,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -56605,7 +50480,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_unnumberedSectioningComponent",
                 "_sectioningComponent",
@@ -57211,15 +51086,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -57352,6 +51218,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -57373,7 +51240,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -57401,7 +51267,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponent",
                 "_block",
@@ -57997,15 +51863,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -58138,6 +51995,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -58159,7 +52017,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -58187,7 +52044,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponent",
                 "_block",
@@ -59480,15 +53337,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -59623,6 +53471,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -59645,7 +53494,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -59673,7 +53521,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -61230,15 +55078,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -61276,12 +55115,12 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -61304,7 +55143,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "1120111111111111111111111112222211111102201012212111122211111111222201222222222222222222222222222222",
+            "childBuckets": "1120111111111111111111111111102201012212111122211111111222201222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -61997,15 +55836,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -62042,6 +55872,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -62050,7 +55881,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -62059,7 +55889,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222211112222222221222202222122222012212221222221222221212222",
+            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -62661,15 +56491,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -62701,6 +56522,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -62709,7 +56531,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -62718,7 +56539,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112011101012222111111111111111111111122222111122222212222022221222220112221222221222221212222",
+            "childBuckets": "112011101012222111111111111111111111122222212222022221222220112221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -64413,15 +58234,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -64459,6 +58271,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -64467,7 +58280,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -64476,7 +58288,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -65270,15 +59082,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -65314,6 +59117,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -65322,7 +59126,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -65331,7 +59134,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "020122221111111111111111111111222221111222222222122220222122222012212221222221222221212222",
+            "childBuckets": "020122221111111111111111111111222222222122220222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -67083,15 +60886,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -67226,6 +61020,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -67248,7 +61043,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -67276,7 +61070,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -67463,15 +61257,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -67606,6 +61391,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -67628,7 +61414,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -67656,7 +61441,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -68019,15 +61804,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -68162,6 +61938,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -68184,7 +61961,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -68212,7 +61988,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -68575,15 +62351,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -68718,6 +62485,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -68740,7 +62508,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -68768,7 +62535,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -68955,15 +62722,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -69098,6 +62856,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -69120,7 +62879,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -69148,7 +62906,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -69359,15 +63117,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -69502,6 +63251,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -69524,7 +63274,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -69552,7 +63301,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -70477,15 +64226,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -70522,6 +64262,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -70530,7 +64271,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -70539,7 +64279,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120001222211111111111111111111112222211112222222221222202222122222222212221222221222221212222",
+            "childBuckets": "1120001222211111111111111111111112222222221222202222122222222212221222222122221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -71045,15 +64785,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -71127,6 +64858,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -71142,7 +64874,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -71209,7 +64940,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -71397,15 +65128,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -71479,6 +65201,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -71494,7 +65217,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -71561,7 +65283,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -71759,15 +65481,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -71900,6 +65613,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -71921,7 +65635,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -71949,7 +65662,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -73626,15 +67339,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -73659,6 +67363,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -73666,7 +67371,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -73693,7 +67397,7 @@
                 "tagc",
                 "attr"
             ],
-            "childBuckets": "22222222222222222222222222222222222222222222222122202222222222222222222222211222222212111111111111111111",
+            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -74102,15 +67806,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -74135,6 +67830,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -74142,7 +67838,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -74151,7 +67846,7 @@
                 "latex",
                 "intervalList"
             ],
-            "childBuckets": "22222222222222222222222222222222222222222222222122202222222222222222222222211222222212",
+            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -74344,15 +68039,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -74426,6 +68112,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -74441,7 +68128,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -74458,7 +68144,7 @@
                 "ol",
                 "ul"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222221112111121222211221111122200",
+            "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122211221111122200",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -74808,15 +68494,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -74854,6 +68531,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -74862,7 +68540,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -74889,7 +68566,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "12222111111111111111111111122222111122212222212202022221222220122122221222221112221211222221111111110212120",
+            "childBuckets": "12222111111111111111111111122212222212202022221222220122122221222222111221211222221111111110212120",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -75455,15 +69132,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -75501,6 +69169,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -75509,7 +69178,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -75518,7 +69186,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -76309,15 +69977,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -76355,6 +70014,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -76363,7 +70023,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -76372,7 +70031,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -76640,15 +70299,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -76686,6 +70336,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -76694,7 +70345,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -76703,7 +70353,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -76967,15 +70617,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -76995,6 +70636,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -77002,7 +70644,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -77034,7 +70675,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "11111111111111111111111222221111212202221011222212222212222112222222222222222222222222222",
+            "childBuckets": "11111111111111111111111212202221011222212222221222112222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -77333,15 +70974,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -77476,6 +71108,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -77498,7 +71131,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -77526,7 +71158,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -77740,15 +71372,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -77786,12 +71409,12 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -77814,7 +71437,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "1120111111111111111111111112222211111102201012212111122211111111222201222222222222222222222222222222",
+            "childBuckets": "1120111111111111111111111111102201012212111122211111111222201222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -78488,15 +72111,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -78534,6 +72148,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -78542,7 +72157,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -78551,7 +72165,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -79335,15 +72949,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -79380,6 +72985,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -79388,7 +72994,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -79397,7 +73002,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222211112222222221222202222122222012212221222221222221212222",
+            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -84686,15 +78291,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -84731,6 +78327,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -84739,7 +78336,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -84748,7 +78344,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222211112222222221222202222122222012212221222221222221212222",
+            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -85576,15 +79172,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -85621,6 +79208,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -85629,7 +79217,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -85638,7 +79225,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11201222211111111111111111111112222211112222222221222202222122222012212221222221222221212222",
+            "childBuckets": "11201222211111111111111111111112222222221222202222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -86303,15 +79890,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -86343,6 +79921,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -86351,7 +79930,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -86360,7 +79938,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112011101012222111111111111111111111122222111122222212222022221222220112221222221222221212222",
+            "childBuckets": "112011101012222111111111111111111111122222212222022221222220112221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -87240,15 +80818,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -87285,6 +80854,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -87293,7 +80863,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -87302,7 +80871,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "021222211111111111111111111112222211112222222221222202222122222012212221222221222221212222",
+            "childBuckets": "021222211111111111111111111112222222221222202222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -87483,15 +81052,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "electronConfiguration",
                 "math",
                 "mathList",
@@ -87539,18 +81099,18 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "bestFitLine",
                 "latex",
                 "pointList"
             ],
-            "childBuckets": "11111111111111111111111222221111102210122212111222222222222222222222222222222222222222222",
+            "childBuckets": "11111111111111111111111102210122212111222222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -87802,15 +81362,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -87840,12 +81391,12 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -87868,7 +81419,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "11201111111111111111111111122222111111022010122121111222222201222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111111022010122121111222222201222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -88572,15 +82123,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -88599,6 +82141,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -88606,7 +82149,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -88638,7 +82180,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "11201111111111111111111111122222111121220222101122212222212222112222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111121220222101122212222221222112222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -89146,15 +82688,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -89188,6 +82721,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -89196,7 +82730,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -89218,7 +82751,7 @@
                 "hasSameFactoring",
                 "matchesPattern"
             ],
-            "childBuckets": "0211111101100012222111111111111111111111122222111122212222210000102122200122122212222211122212112221111111110011",
+            "childBuckets": "0211111101100012222111111111111111111111122212222210000102122200122122212222221112212112221111111110011",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -90186,15 +83719,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -90231,6 +83755,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -90239,7 +83764,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -90266,7 +83790,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "021222211111111111111111111112222211112221222221220202222122222012212221222221112221211222221111111110212120",
+            "childBuckets": "021222211111111111111111111112221222221220202222122222012212221222222111221211222221111111110212120",
             "abstractAncestors": [
                 "_base"
             ],
@@ -90803,15 +84327,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -90849,6 +84364,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -90857,7 +84373,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -90884,7 +84399,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "12222111111111111111111111122222111122212222212202022221222220122122221222221112221211222221111111110212120",
+            "childBuckets": "12222111111111111111111111122212222212202022221222220122122221222222111221211222221111111110212120",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -91318,15 +84833,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -91363,6 +84869,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -91371,7 +84878,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -91380,7 +84886,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120001222211111111111111111111112222211112222222221222202222122222222212221222221222221212222",
+            "childBuckets": "1120001222211111111111111111111112222222221222202222122222222212221222222122221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -92192,15 +85698,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -92224,6 +85721,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -92231,7 +85729,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "matchesPattern",
@@ -92239,7 +85736,7 @@
                 "latex",
                 "intervalList"
             ],
-            "childBuckets": "1120002222222222222222222222222222222222222222222221222022222222222222222222221122222212",
+            "childBuckets": "1120002222222222222222222222222222222222221222022222222222222222222222112222212",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -92748,15 +86245,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -92793,6 +86281,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -92801,7 +86290,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -92810,7 +86298,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112000111111111022111222211111111111111111111112222211112222222221222202222122222012212221222221222221212222",
+            "childBuckets": "112000111111111022111222211111111111111111111112222222221222202222122222012212221222222122221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -93671,15 +87159,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -93814,6 +87293,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -93836,7 +87316,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -93864,7 +87343,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -94107,15 +87586,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -94135,6 +87605,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -94142,7 +87613,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -94191,7 +87661,7 @@
                 "matchesPattern",
                 "booleanInput"
             ],
-            "childBuckets": "1111111111111111111111122222111111020222101122221222221112211122222222222222222222222222222111111111021212",
+            "childBuckets": "1111111111111111111111111020222101122221222222111211122222222222222222222222222222111111111021212",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -94614,15 +88084,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -94642,6 +88103,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -94649,7 +88111,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -94698,7 +88159,7 @@
                 "matchesPattern",
                 "booleanInput"
             ],
-            "childBuckets": "1111111111111111111111122222111111020222101122221222221112211122222222222222222222222222222111111111021212",
+            "childBuckets": "1111111111111111111111111020222101122221222222111211122222222222222222222222222222111111111021212",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -95126,15 +88587,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -95222,12 +88674,12 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "hasSameFactoring",
                 "label",
                 "matchesPattern",
@@ -95246,7 +88698,7 @@
                 "graph",
                 "annotations"
             ],
-            "childBuckets": "020001111111111111111111111122222111122211111022211111111111111122122212222121212212111111111222001112222222221220222220122222112220212220010000000",
+            "childBuckets": "020001111111111111111111111122211111022211111111111111122122212222121212212111111111222001112222222221220222220122222211220212220010000000",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -96501,15 +89953,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -96547,6 +89990,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -96555,7 +89999,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -96567,7 +90010,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "12222111111111111111111111122222111111122222212222022221222222201122221222221222221212222110",
+            "childBuckets": "12222111111111111111111111111122222212222022221222222201122221222222122221212222110",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -98211,15 +91654,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -98257,6 +91691,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -98265,7 +91700,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -98274,7 +91708,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -99073,15 +92507,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -99216,6 +92641,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -99238,7 +92664,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -99266,7 +92691,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -99527,7 +92952,6 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
-                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -99552,25 +92976,21 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
-                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
-                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -99651,15 +93071,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "electronConfiguration",
                 "text",
@@ -99679,6 +93090,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -99686,7 +93098,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "matrix",
                 "latex",
@@ -99715,7 +93126,7 @@
                 "label",
                 "matchesPattern"
             ],
-            "childBuckets": "22222222222222222222222222222222120222222012222222222221122221211222222222222222222202",
+            "childBuckets": "22222222222222222222222120222222012222222222222112221211222222222222222222202",
             "abstractAncestors": [
                 "_base"
             ],
@@ -100631,15 +94042,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -100677,6 +94079,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -100685,7 +94088,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -100843,7 +94245,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -102298,15 +95700,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -102379,6 +95772,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -102394,7 +95788,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -102461,7 +95854,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "0211111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222221222122222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "0211111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -102684,15 +96077,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -102765,6 +96149,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -102780,7 +96165,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -102846,7 +96230,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "2011111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222122212222211121111212222112211111222111111111111111111111111111111111111111111111111111",
+            "childBuckets": "2011111111111111111111111111111111111111111111111111111111111111111221111111112121222212121221111111111122222122212222221112111121222112211111222111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -103071,15 +96455,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -103214,6 +96589,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -103236,7 +96612,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -103264,7 +96639,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -103446,15 +96821,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -103589,6 +96955,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -103611,7 +96978,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -103639,7 +97005,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -103713,7 +97079,6 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
-                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -103738,25 +97103,21 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
-                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
-                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -104696,15 +98057,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -104766,7 +98118,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "22222222222222222222222222222222222111122222121111111111111222222122222222212222111111121222",
+            "childBuckets": "22222222222222222222222222111122222121111111111111222222122222222212222111111121222",
             "abstractAncestors": [
                 "_constraint",
                 "_base"
@@ -104947,15 +98299,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -105017,7 +98360,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "22222222222222222222222222222222222111122222121111111111111222222122222222212222111111121222",
+            "childBuckets": "22222222222222222222222222111122222121111111111111222222122222222212222111111121222",
             "abstractAncestors": [
                 "_constraint",
                 "_base"
@@ -105524,15 +98867,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -105594,7 +98928,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "22222222222222222222222222222222222111122222121111111111111222222122222222212222111111121222",
+            "childBuckets": "22222222222222222222222222111122222121111111111111222222122222222212222111111121222",
             "abstractAncestors": [
                 "_constraint",
                 "_base"
@@ -105931,15 +99265,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -106073,6 +99398,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -106095,7 +99421,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -106124,7 +99449,7 @@
                 "vectorList",
                 "else"
             ],
-            "childBuckets": "101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110",
+            "childBuckets": "101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -106292,15 +99617,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -106374,6 +99690,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -106389,7 +99706,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -106404,7 +99720,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -106826,7 +100142,6 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
-                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -106851,25 +100166,21 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
-                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
-                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -107224,15 +100535,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -107367,6 +100669,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -107389,7 +100692,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -107417,7 +100719,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -107637,7 +100939,6 @@
                 {
                     "name": "type",
                     "description": "The kind of values in the sequence.",
-                    "highlighted": true,
                     "values": [
                         "number",
                         "math",
@@ -107662,25 +100963,21 @@
                 {
                     "name": "from",
                     "description": "The first value in the sequence.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "to",
                     "description": "The last value in the sequence. Used together with from to determine length when length is not specified.",
-                    "highlighted": true,
                     "type": "_componentWithSelectableType"
                 },
                 {
                     "name": "step",
                     "description": "The increment between successive values in the sequence.",
-                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "length",
                     "description": "The number of values in the sequence.",
-                    "highlighted": true,
                     "type": "integer"
                 },
                 {
@@ -109382,6 +102679,257 @@
             "layoutCategory": "other"
         },
         {
+            "name": "sampleMultivariateRandomNumber",
+            "children": [],
+            "childBuckets": "",
+            "abstractAncestors": [
+                "_composite",
+                "_base"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": "The name used to reference this component from elsewhere in the document.",
+                    "type": "text"
+                },
+                {
+                    "name": "hide",
+                    "description": "Whether to hide this component from the rendered output.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "disabled",
+                    "description": "Whether this component is disabled and cannot be interacted with.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixed",
+                    "description": "Whether this component's value is fixed and cannot be modified.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "fixLocation",
+                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "styleNumber",
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "defaultValue": 1,
+                    "type": "integer"
+                },
+                {
+                    "name": "isResponse",
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "defaultValue": false,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "extend",
+                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "copy",
+                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
+                    "type": "reference"
+                },
+                {
+                    "name": "type",
+                    "description": "Multivariate distribution from which to sample.",
+                    "defaultValue": "hypergeometric",
+                    "values": [
+                        "hypergeometric"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "hypergeometric",
+                            "description": "Number of items of each category obtained when drawing `numDraws` items without replacement from a population partitioned into categories of the sizes given by `numInCategories`."
+                        }
+                    ],
+                    "type": "keyword"
+                },
+                {
+                    "name": "numInCategories",
+                    "description": "Number of items of each category in the population drawn from. Its length determines how many numbers are sampled.",
+                    "defaultValue": [],
+                    "type": "numberList"
+                },
+                {
+                    "name": "numDraws",
+                    "description": "Number of items drawn without replacement from the population.",
+                    "defaultValue": null,
+                    "type": "number"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "variantDeterminesSeed",
+                    "description": "Whether the document's variant index determines the random seed.",
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether to hide this component from the rendered output.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "The style number used to select this component's visual styling from the available style definitions.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether this component is treated as a response for the purposes of assessment.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "type",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Multivariate distribution from which to sample.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "numInCategories",
+                    "type": "numberList",
+                    "isArray": false,
+                    "description": "Number of items of each category in the population drawn from. Its length determines how many numbers are sampled.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "numDraws",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Number of items drawn without replacement from the population.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "variantDeterminesSeed",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the document's variant index determines the random seed.",
+                    "fromAttribute": true
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "numCategories",
+                    "type": "integer",
+                    "isArray": false,
+                    "description": "Number of categories the population is partitioned into, which is how many numbers are sampled."
+                },
+                {
+                    "name": "numTotal",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "Total number of items in the population drawn from, i.e. the sum of `numInCategories`."
+                },
+                {
+                    "name": "means",
+                    "type": "number",
+                    "isArray": true,
+                    "description": "Expected number of items sampled from each category, i.e. `numDraws * numInCategories[i] / numTotal`.",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "number",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "variances",
+                    "type": "number",
+                    "isArray": true,
+                    "description": "Variance of the number of items sampled from each category.",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "number",
+                            "numDimensions": 1
+                        }
+                    ]
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": false,
+            "takesIndex": true,
+            "docsSlug": "sampleMultivariateRandomNumber",
+            "summary": "Samples a single vector-valued random number from a multivariate distribution, expanding to one number per category",
+            "layoutCategory": "other"
+        },
+        {
             "name": "selectPrimeNumbers",
             "children": [],
             "childBuckets": "",
@@ -109860,15 +103408,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -110003,6 +103542,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -110025,7 +103565,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -110053,7 +103592,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -112262,15 +105801,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -112404,6 +105934,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -112426,7 +105957,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -112454,7 +105984,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "0111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "0111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -112645,15 +106175,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -112678,6 +106199,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -112685,7 +106207,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -112712,7 +106233,7 @@
                 "tagc",
                 "attr"
             ],
-            "childBuckets": "22222222222222222222222222222222222222222222222122202222222222222222222222211222222212111111111111111111",
+            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -113121,15 +106642,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -113154,6 +106666,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -113161,7 +106674,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -113188,7 +106700,7 @@
                 "tagc",
                 "attr"
             ],
-            "childBuckets": "22222222222222222222222222222222222222222222222122202222222222222222222222211222222212111111111111111111",
+            "childBuckets": "22222222222222222222222222222222222222122202222222222222222222222221122222212111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -113631,15 +107143,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -113774,6 +107277,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -113796,7 +107300,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -113824,7 +107327,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -114008,15 +107511,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -114151,6 +107645,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -114173,7 +107668,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -114201,7 +107695,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -114387,15 +107881,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -114530,6 +108015,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -114552,7 +108038,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -114580,7 +108065,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_base"
             ],
@@ -115352,15 +108837,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -115494,6 +108970,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -115516,7 +108993,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -115543,7 +109019,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1110111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1110111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -116525,15 +110001,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -116668,6 +110135,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -116690,7 +110158,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -116718,7 +110185,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -116892,15 +110359,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -117035,6 +110493,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -117057,7 +110516,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -117085,7 +110543,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -117252,15 +110710,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -117394,6 +110843,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -117416,7 +110866,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -117444,7 +110893,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "0100111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "0100111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -117603,15 +111052,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -117685,6 +111125,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -117700,7 +111141,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -117715,7 +111155,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -117910,15 +111350,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -117992,6 +111423,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -118007,7 +111439,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -118074,7 +111505,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -118248,15 +111679,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -118294,12 +111716,12 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "latex",
                 "m",
                 "me",
@@ -118322,7 +111744,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "1120111111111111111111111112222211111102201012212111122211111111222201222222222222222222222222222222",
+            "childBuckets": "1120111111111111111111111111102201012212111122211111111222201222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -119030,15 +112452,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -119173,6 +112586,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -119195,7 +112609,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -119223,7 +112636,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -119303,7 +112716,6 @@
                 {
                     "name": "sortVectorsBy",
                     "description": "Whether to sort vectors by component or by magnitude.",
-                    "groupName": "sorting",
                     "defaultValue": "displacement",
                     "values": [
                         "displacement",
@@ -119324,51 +112736,22 @@
                 {
                     "name": "sortByComponent",
                     "description": "Index of the component to sort by (when sorting vectors).",
-                    "groupName": "sorting",
                     "defaultValue": "1",
                     "type": "integer"
                 },
                 {
                     "name": "sortByProp",
                     "description": "Name of a property to sort by (e.g. \"x\" for sorting points by x-coordinate).",
-                    "groupName": "sorting",
-                    "highlighted": true,
                     "type": "text"
                 },
                 {
                     "name": "type",
                     "description": "Component type to sort children as.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers, ordered by value."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions, ordered by value."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text, ordered alphabetically."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans, ordered with false before true."
-                        }
-                    ],
-                    "type": "keyword"
+                    "type": "text"
                 },
                 {
                     "name": "asList",
                     "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
                     "defaultValue": true,
                     "values": [
                         "true",
@@ -119404,16 +112787,14 @@
                     "type": "text",
                     "isArray": false,
                     "description": "Whether to sort vectors by component or by magnitude.",
-                    "fromAttribute": true,
-                    "groupName": "sorting"
+                    "fromAttribute": true
                 },
                 {
                     "name": "sortByComponent",
                     "type": "integer",
                     "isArray": false,
                     "description": "Index of the component to sort by (when sorting vectors).",
-                    "fromAttribute": true,
-                    "groupName": "sorting"
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -119427,454 +112808,6 @@
             "takesIndex": true,
             "docsSlug": "sort",
             "summary": "Sorts a list according to a comparison function",
-            "layoutCategory": "other"
-        },
-        {
-            "name": "sortIndices",
-            "children": [
-                "title",
-                "rightHandSide",
-                "xLabel",
-                "yLabel",
-                "statement",
-                "introduction",
-                "conclusion",
-                "br",
-                "hr",
-                "m",
-                "me",
-                "men",
-                "md",
-                "mdn",
-                "mrow",
-                "not",
-                "and",
-                "or",
-                "xor",
-                "iff",
-                "implies",
-                "isInteger",
-                "isNumber",
-                "isBetween",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "lcm",
-                "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "extractMathOperator",
-                "em",
-                "alert",
-                "q",
-                "sq",
-                "term",
-                "c",
-                "tag",
-                "tage",
-                "tagc",
-                "attr",
-                "ndash",
-                "mdash",
-                "nbsp",
-                "ellipsis",
-                "lq",
-                "rq",
-                "lsq",
-                "rsq",
-                "section",
-                "subsection",
-                "subsubsection",
-                "paragraphs",
-                "aside",
-                "objectives",
-                "problem",
-                "exercise",
-                "question",
-                "activity",
-                "example",
-                "definition",
-                "note",
-                "theorem",
-                "part",
-                "task",
-                "proof",
-                "problems",
-                "exercises",
-                "ol",
-                "ul",
-                "odeSystem",
-                "cobwebPolyline",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "equilibriumCurve",
-                "atom",
-                "ion",
-                "ionicCompound",
-                "electronConfiguration",
-                "orbitalDiagram",
-                "orbitalDiagramInput",
-                "sideBySide",
-                "sbsGroup",
-                "stack",
-                "div",
-                "span",
-                "pre",
-                "displayDoenetML",
-                "paginator",
-                "paginatorControls",
-                "matrixInput",
-                "fractionInput",
-                "solution",
-                "givenAnswer",
-                "document",
-                "text",
-                "textList",
-                "p",
-                "boolean",
-                "booleanList",
-                "math",
-                "mathList",
-                "tupleList",
-                "numberList",
-                "collect",
-                "ref",
-                "point",
-                "coords",
-                "line",
-                "lineSegment",
-                "ray",
-                "polyline",
-                "polygon",
-                "triangle",
-                "rectangle",
-                "regularPolygon",
-                "circle",
-                "parabola",
-                "curve",
-                "bezierControls",
-                "vector",
-                "angle",
-                "answer",
-                "award",
-                "mathInput",
-                "textInput",
-                "booleanInput",
-                "choiceInput",
-                "choice",
-                "number",
-                "integer",
-                "graph",
-                "annotations",
-                "annotation",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "slider",
-                "spreadsheet",
-                "cell",
-                "row",
-                "column",
-                "cellBlock",
-                "tabular",
-                "table",
-                "figure",
-                "repeat",
-                "repeatForSequence",
-                "pegboard",
-                "intersection",
-                "conditionalContent",
-                "asList",
-                "variantControl",
-                "selectFromSequence",
-                "select",
-                "group",
-                "animateFromSequence",
-                "evaluate",
-                "selectRandomNumbers",
-                "sampleRandomNumbers",
-                "selectPrimeNumbers",
-                "samplePrimeNumbers",
-                "substitute",
-                "periodicSet",
-                "image",
-                "video",
-                "hint",
-                "intComma",
-                "pluralize",
-                "feedback",
-                "lorem",
-                "updateValue",
-                "callAction",
-                "triggerSet",
-                "functionIterates",
-                "module",
-                "moduleAttributes",
-                "setup",
-                "footnote",
-                "caption",
-                "endpoint",
-                "sort",
-                "sortIndices",
-                "shuffle",
-                "solveEquations",
-                "subsetOfRealsInput",
-                "subsetOfReals",
-                "split",
-                "bestFitLine",
-                "regionBetweenCurveXAxis",
-                "regionBetweenCurves",
-                "slopeField",
-                "vectorField",
-                "regionHalfPlane",
-                "codeEditor",
-                "hasSameFactoring",
-                "legend",
-                "label",
-                "matchesPattern",
-                "matrix",
-                "eigenDecomposition",
-                "latex",
-                "blockQuote",
-                "stickyGroup",
-                "pretzel",
-                "cascade",
-                "pointList",
-                "intervalList",
-                "vectorList"
-            ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-            "abstractAncestors": [
-                "_composite",
-                "_base"
-            ],
-            "attributes": [
-                {
-                    "name": "name",
-                    "description": "The name used to reference this component from elsewhere in the document.",
-                    "type": "text"
-                },
-                {
-                    "name": "hide",
-                    "description": "Whether to hide this component from the rendered output.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "description": "Whether this component is disabled and cannot be interacted with.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixed",
-                    "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "fixLocation",
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications).",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "styleNumber",
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "defaultValue": 1,
-                    "type": "integer"
-                },
-                {
-                    "name": "isResponse",
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "extend",
-                    "description": "Extend another component by reference, inheriting its children and attributes. Enter a reference as `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "copy",
-                    "description": "Create an independent copy of another component by reference. Enter a references a `$name`.",
-                    "type": "reference"
-                },
-                {
-                    "name": "sortVectorsBy",
-                    "description": "Whether to sort vectors by component or by magnitude.",
-                    "groupName": "sorting",
-                    "defaultValue": "displacement",
-                    "values": [
-                        "displacement",
-                        "tail"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "displacement",
-                            "description": "Sort vectors by their displacement components."
-                        },
-                        {
-                            "value": "tail",
-                            "description": "Sort vectors by the position of their tail point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "sortByComponent",
-                    "description": "Index of the component to sort by (when sorting vectors).",
-                    "groupName": "sorting",
-                    "defaultValue": "1",
-                    "type": "integer"
-                },
-                {
-                    "name": "sortByProp",
-                    "description": "Name of a property to sort by (e.g. \"x\" for sorting points by x-coordinate).",
-                    "groupName": "sorting",
-                    "highlighted": true,
-                    "type": "text"
-                },
-                {
-                    "name": "type",
-                    "description": "Component type to sort children as.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers, ordered by value."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions, ordered by value."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text, ordered alphabetically."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans, ordered with false before true."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "asList",
-                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to hide this component from the rendered output.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "sortVectorsBy",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Whether to sort vectors by component or by magnitude.",
-                    "fromAttribute": true,
-                    "groupName": "sorting"
-                },
-                {
-                    "name": "sortByComponent",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Index of the component to sort by (when sorting vectors).",
-                    "fromAttribute": true,
-                    "groupName": "sorting"
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The DoenetML source code that produced this component."
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": true,
-            "takesIndex": true,
-            "docsSlug": "sortIndices",
-            "summary": "The indices that put a list in sorted order, rather than the sorted values",
             "layoutCategory": "other"
         },
         {
@@ -119926,15 +112859,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -120069,6 +112993,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -120091,7 +113016,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -120119,7 +113043,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -120199,37 +113123,11 @@
                 {
                     "name": "type",
                     "description": "Component type to shuffle children as.",
-                    "highlighted": true,
-                    "values": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "number",
-                            "description": "Read bare strings as numbers."
-                        },
-                        {
-                            "value": "math",
-                            "description": "Read bare strings as math expressions."
-                        },
-                        {
-                            "value": "text",
-                            "description": "Read bare strings as text."
-                        },
-                        {
-                            "value": "boolean",
-                            "description": "Read bare strings as booleans."
-                        }
-                    ],
-                    "type": "keyword"
+                    "type": "text"
                 },
                 {
                     "name": "asList",
                     "description": "Whether to render the items separated by commas (true) or with no separator (false).",
-                    "highlighted": true,
                     "defaultValue": true,
                     "values": [
                         "true",
@@ -120304,15 +113202,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -120350,6 +113239,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -120358,7 +113248,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -120367,7 +113256,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -120869,15 +113758,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -120915,6 +113795,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -120923,7 +113804,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -120932,7 +113812,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -121834,15 +114714,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -121977,6 +114848,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -121999,7 +114871,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -122027,7 +114898,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -123412,15 +116283,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -123452,6 +116314,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -123460,7 +116323,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -123469,7 +116331,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11101212222111111111111111111111122222111122222212222022221222220112221222221222221212222",
+            "childBuckets": "11101212222111111111111111111111122222212222022221222220112221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -123780,15 +116642,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "equilibriumPoint",
                 "equilibriumLine",
@@ -123820,6 +116673,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -123828,7 +116682,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -123837,7 +116690,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11101212222111111111111111111111122222111122222212222022221222220112221222221222221212222",
+            "childBuckets": "11101212222111111111111111111111122222212222022221222220112221222222122221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -124444,15 +117297,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -124587,6 +117431,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -124609,7 +117454,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -124637,7 +117481,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -125040,15 +117884,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -125086,6 +117921,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -125094,7 +117930,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -125103,7 +117938,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -125846,15 +118681,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -125928,6 +118754,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -125943,7 +118770,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -125958,7 +118784,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -126306,15 +119132,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -126352,6 +119169,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -126360,7 +119178,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -126369,7 +119186,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -127703,15 +120520,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -127749,6 +120557,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -127757,7 +120566,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -127766,7 +120574,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_base"
             ],
@@ -128063,15 +120871,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "extractMathOperator",
                 "atom",
                 "ion",
@@ -128096,6 +120895,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -128103,7 +120903,6 @@
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "subsetOfReals",
                 "hasSameFactoring",
                 "label",
@@ -128151,7 +120950,7 @@
                 "md",
                 "mdn"
             ],
-            "childBuckets": "12201112222222221111111111111111111111222221111122102220222122212222122222111221222112111111111111111111222222222222222222201",
+            "childBuckets": "12201112222222221111111111111111111111122102220222122212222122222211121222112111111111111111111222222222222222222201",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -128574,15 +121373,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -128717,6 +121507,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -128739,7 +121530,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -128767,7 +121557,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -128954,15 +121744,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -129097,6 +121878,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -129119,7 +121901,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -129147,7 +121928,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -129315,15 +122096,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -129384,7 +122156,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11202222222222222222222222222222222222211112222212111111111111122222212222222212222111111121222",
+            "childBuckets": "11202222222222222222222222222211112222212111111111111122222212222222212222111111121222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -130129,15 +122901,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -130270,6 +123033,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -130291,7 +123055,6 @@
                 "caption",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfRealsInput",
@@ -130319,7 +123082,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "childBuckets": "10000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_sectioningComponent",
                 "_block",
@@ -130946,15 +123709,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -131028,6 +123782,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -131043,7 +123798,6 @@
                 "footnote",
                 "endpoint",
                 "sort",
-                "sortIndices",
                 "shuffle",
                 "solveEquations",
                 "subsetOfReals",
@@ -131058,7 +123812,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222211121111212222112211111222",
+            "childBuckets": "111111111111111111111111111111111111111111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222112211111222",
             "abstractAncestors": [
                 "_textOrInline",
                 "_inline",
@@ -131235,15 +123989,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "equilibriumPoint",
                 "electronConfiguration",
                 "math",
@@ -131293,16 +124038,16 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
-                "sortIndices",
                 "bestFitLine",
                 "latex"
             ],
-            "childBuckets": "11111111111111111111111222221111110220121222121111222222222222222222222222222222222222222",
+            "childBuckets": "11111111111111111111111110220121222121111222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -131502,15 +124247,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -131546,6 +124282,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -131554,7 +124291,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -131562,7 +124298,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "02212222111111111111111111111122222111122222222212222022221222222222222122222122222121222",
+            "childBuckets": "02212222111111111111111111111122222222212222022221222222222222122222212222121222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -131755,15 +124491,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "electronConfiguration",
                 "math",
                 "mathList",
@@ -131811,18 +124538,18 @@
                 "cell",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "intComma",
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "bestFitLine",
                 "latex",
                 "pointList"
             ],
-            "childBuckets": "11111111111111111111111222221111102210122212111222222222222222222222222222222222222222222",
+            "childBuckets": "11111111111111111111111102210122212111222222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -132249,15 +124976,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -132295,6 +125013,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -132303,7 +125022,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -132312,7 +125030,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -132579,15 +125297,6 @@
                 "gcd",
                 "lcm",
                 "extractMath",
-                "cumulativeSum",
-                "cumulativeProduct",
-                "cumulativeMin",
-                "cumulativeMax",
-                "differences",
-                "argMin",
-                "argMax",
-                "indexOf",
-                "searchSorted",
                 "clampFunction",
                 "wrapFunctionPeriodic",
                 "derivative",
@@ -132625,6 +125334,7 @@
                 "evaluate",
                 "selectRandomNumbers",
                 "sampleRandomNumbers",
+                "sampleMultivariateRandomNumber",
                 "selectPrimeNumbers",
                 "samplePrimeNumbers",
                 "substitute",
@@ -132633,7 +125343,6 @@
                 "pluralize",
                 "lorem",
                 "endpoint",
-                "sortIndices",
                 "subsetOfReals",
                 "bestFitLine",
                 "matrix",
@@ -132642,7 +125351,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "12222111111111111111111111122222111122222222212222022221222222222122221222221222221212222",
+            "childBuckets": "12222111111111111111111111122222222212222022221222222222122221222222122221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"


### PR DESCRIPTION
## Why

Every sampling component in the codebase produces numbers that are independent of one another, so there was no way to express a draw whose parts constrain each other. `<sampleMultivariateRandomNumber>` draws a single *vector-valued* sample: `numDraws` items are taken without replacement from a population split by `numInCategories`, and the component expands to one number per category giving how many of the drawn items came from each. The counts always sum to `numDraws`.

```doenet
<p>An urn holds 5 red, 3 blue, and 2 green marbles. Draw 4 without replacement:</p>
<p><sampleMultivariateRandomNumber name="draw" type="hypergeometric" numInCategories="5 3 2" numDraws="4" /></p>
<p>Red: $draw[1], blue: $draw[2], green: $draw[3]</p>
```

It is named for the general case rather than the distribution, so multivariate Gaussian and multinomial can join later as further `type` values; `type` accepts only `hypergeometric` so far.

Also exposes `numCategories`, `numTotal`, `means`, `variances`, and a `resample` action.

## Why single-draw only

This was settled by measurement rather than argument, and the numbers were not what I expected. At 200 draws:

| scenario | time | components |
|---|---|---|
| composite ×200 via `<repeat>` | 13537 ms | 4003 |
| `<repeat>` of 3 plain numbers ×200 | 8616 ms | 2803 |
| `sampleRandomNumbers numSamples="600"` (same 600 numbers) | 1747 ms | 606 |
| single component, no replacements | 41 ms | 10 |

**Being a composite is cheap; iterating is not.** Of the composite's 4003 components and 13.5s, 2803 components and 8.6s are the `<repeat>` scaffolding alone — a composite emitting the same 600 numbers directly costs 606 components and 1.7s.

So the composite form is kept for the single-draw case it is genuinely good at (~6 components), and the simulation case is deliberately left out rather than paid for with a shape that serves neither well. If simulations are wanted later, the fix is a component that takes a sample count directly — not `<repeat>`. The sampling math is an exported pure function, so that component reuses it without touching any statistics.

## Notes for review

**The sampler is exact, not an approximation.** It draws each category in turn as a univariate hypergeometric against the part of the population not yet accounted for, reusing `sampleHypergeometric` from #1808; the final category takes whatever draws remain, which is what guarantees the counts sum to `numDraws`.

**Validity follows #1808's predicate/problem split.** `multivariateHypergeometricProblem` returns the coded diagnostic explaining why a set of parameters cannot be sampled, or `null` when it can, and `validMultivariateHypergeometricParameters` is the thin boolean wrapper over it — the same arrangement as the univariate hypergeometric, binomial, and Poisson predicates beside it in `randomNumbers.js`. The predicate is consulted by both the sampler dispatch and the `means`/`variances` definitions, so unusable parameters can never produce plausible-looking moments next to `NaN` samples. `sampleFromMultivariateDistribution` lives there too, next to its univariate counterpart, and guards itself rather than trusting the caller.

**`type` is required, with no default.** `hypergeometric` is the only multivariate distribution implemented, but it is unlikely to stay the most natural default — a joint gaussian is the more usual one. Defaulting to it now would let documents come to rely on it, so that adding other distributions later and changing the default would silently reinterpret them rather than fail. So the attribute has `defaultValue: null` and is simply the third of three required attributes, beside `numInCategories` and `numDraws`, which have no defaults either. A document that omits it samples nothing and says so: `NaN` counts, `NaN` moments, and `doenet-w0137` naming what to add. It is a warning rather than an error, matching how the component reports its other unusable parameters, and the cost — one word in every document — is paid now, while nothing has been released against the old default. A `type` the attribute does not recognize falls back to that same no-type state, so it lands in the same refusal after the generic invalid-value notice naming the value that was rejected. The sampler refuses an unrecognized name on its own account too, rather than relying on the attribute to have filtered it: it dispatches through a map of the distributions that exist, so a name absent from that map is treated exactly as no name at all. Otherwise adding a distribution to `validValues` without wiring up its sampler would have quietly returned hypergeometric counts. Membership is tested with `Object.hasOwn` rather than `in`, so an inherited name such as `constructor` is refused instead of calling `Object`.

**The moments gate on `type` too.** Their formulas are the hypergeometric's, so with no distribution named there is nothing for them to compute and `NaN` is the honest answer; another distribution will bring its own branch. `hasHypergeometricMoments` in the component pairs that check with the shared parameter predicate, and `returnMomentDependencies` gives `means` and `variances` their one shared dependency block, so a distribution added later adds its parameters and its branch in one place each.

**Unusable parameters are reported to the author, not logged.** `sampleFromMultivariateDistribution` returns the diagnostics it raised alongside the samples, exactly as `sampleFromRandomNumbers` does, and the `sampledValues` definition passes them on with `sendDiagnostics` — a browser console is not somewhere an author looks. Three new codes: `doenet-w0135` for parameters describing no distribution, `doenet-w0136` for a draw too large to make promptly, and `doenet-w0137` for no distribution named at all. An omitted `numDraws` reaches the message through #1808's `not-set` sentinel; an omitted `numInCategories` arrives as an *empty list* rather than `null`, so it selects the same sentinel from its own emptiness. The existing `doenet-w0133` slow-sampling notice is reused for draws that are merely sluggish. The `resample` action discards its diagnostics deliberately: the parameters cannot have changed since `sampledValues` was first computed, so anything they raise was already sent, and an action has no `sendDiagnostics` in any case.

**A reused draw still explains itself.** `sampledValues` keeps the counts it already has rather than drawing new ones in two situations — after a `resample`, and when saved values load back into a fresh document — and that branch never reached the sampler, so an author who reloaded a document was left with `NaN` counts and no reason for them. The checks are therefore their own function, `multivariateSamplingDiagnostics`, which both the sampler and that branch call; it consumes no randomness, so a variant stays reproducible. `inspectMultivariateParameters` behind it answers *whether* the parameters can be sampled and *what to say about them* in one pass, so the decision to draw and the explanation given to the author cannot drift apart. The univariate samplers solve the same problem by asking for zero samples, which has no equivalent when a draw is a single vector.

**Counts must stay exactly representable.** `numInCategories` and `numDraws` are required to be safe integers rather than merely whole ones, carrying across the requirement the univariate samplers took in #1808: `Number.isInteger(1e308)` is true, and `numDraws * numInCategories[i]` backs the reported `means`, so a population that large overflows the mean to `Infinity` — and the sampler, asking for a whole number below a bound that has no representable multiple on the 2^53 grid, rejects every draw it makes and never returns at all. **The population *total* is required to be a safe integer too, not just each category:** that total, not any one category, is the largest population a draw is ever made against (the first category's is made against it, and each later one against a part of it), so two categories of nine quadrillion each — both exact — drawn ten times passed every check and hung the worker in exactly that way. Such a population is refused through the same `doenet-w0135` path as any other unusable one, whose message now names the nine-quadrillion ceiling as the univariate one does; that ceiling is no real limit on a population.

**A draw too large to make promptly is refused, not attempted.** Each category costs a univariate hypergeometric draw, so a large population would otherwise run for minutes on the worker thread with no chance to warn first. `multivariateHypergeometricWork` bounds one sample above by `(numCategories - 1) * min(numDraws, numTotal - numDraws)`: each category draws against the part of the population not yet accounted for, and neither the draws remaining nor the items left behind ever grows as that part shrinks, so no category costs more than a draw against the whole population — including when an early category absorbs most of the draws. Above `MAX_WORK_PER_VARIATE` (the same 10 million limit #1808 set) the parameters are refused exactly as impossible ones are: `NaN` counts, `NaN` statistics, and a warning saying what to change. That warning says such a draw *could* need more than ten million draws rather than *would*: unlike the univariate cost, which is exact, this one counts every category at the most its draw could take and so can exceed what the sample really costs.

**`means`/`variances` are the marginals.** Each category's count on its own is univariate hypergeometric, so it carries the same finite population correction. The two degenerate populations that leave those formulas undefined — the correction divides by `N - 1`, and `p` by `N` — are answered directly instead: a population of at most one item has variance 0, and an empty population — whose only valid draw is the empty one — has mean 0. Both agree with what the sampler returns.

**`select-family.ts` deliberately gets no entry.** That table drives the `$s.prop` ≡ `$s[1].prop` shorthand, which applies only when a count attribute equals 1. Here the replacement count comes from `numInCategories.length` and is normally greater than 1, so the default `false` is correct.

**The `childBuckets` churn in the generated schema is expected** — registering a new component type shifts every bucket bitstring by one position.

## Testing

- The **joint** pmf is checked against the exact multivariate hypergeometric probability, not just marginal means — marginals alone would not catch a sampler that got the dependence between categories wrong. Every observed outcome set covered exactly 1.0 of the support mass.
- Per-draw invariants on 100k draws per case: correct length, counts within each category's size, and summing to `numDraws`.
- Cases: empty categories, drawing everything, drawing nothing, a single category, and the effectively-univariate two-category case.
- The reported `means` are cross-checked against the sampler's own marginal averages, which the joint-pmf cases cannot do — they exercise only the sampler.
- Component level: replacements, `$s[1]` indexing, all four properties, `$s.means[2]` array indexing, invalid parameters producing `NaN` samples *and* `NaN` statistics, no categories at all producing no replacements, an all-empty population sampling and reporting zeros, `resample`, and `variantDeterminesSeed` reproducibility.
- The `<number>` replacements the component makes itself are checked to carry the author's number-display attributes and the component's `asList`: drawing the whole population makes the counts deterministic, so `displayDecimals="2" padZeros` is asserted to render `5.00, 3.00, 2.00`, and `asList="false"` the same counts with no separator between them. Nothing downstream would copy those attributes onto replacements a composite builds, and no other test looked at them.
- An omitted `type` is asserted to sample nothing: `NaN` counts and `NaN` moments even though the remaining parameters describe a usable population, `numCategories`/`numTotal` still reporting what the component read, and one warning and no other — `doenet-w0137`, not also a parameters-invalid one. An unrecognized `type` is asserted to reach the same refusal alongside the invalid-value notice. Deleting either the sampler's refusal or the moments' `type` gate fails these tests.
- Reuse: a resample and then a save-and-reload of a document with unusable parameters are both asserted to still report `doenet-w0135` exactly once, with the counts still `NaN`. The reload leg is the one that discriminates — diagnostics accumulate for the life of a core, so only a fresh core proves the explanation is re-raised rather than left over.
- Every situation is also asked of `multivariateSamplingDiagnostics` directly, which is the only place the *number* of diagnostics is visible: a core deduplicates identical messages, so no component-level count can tell one explanation from the same explanation sent twice. Each of the four (no `type`, unusable parameters, too slow to draw, and merely sluggish) is asserted to raise exactly one diagnostic carrying the expected code, and usable parameters to raise none. Its too-slow case is one whose *per-category* cost is under the limit and only exceeds it once every category is counted, so dropping the `(numCategories - 1)` factor from the work bound fails it — no other test noticed that. Drawing all but ten of that same three-billion population is asserted to raise nothing, which is what the message's advice to *raise* `numDraws` rests on: replacing the work bound's `min(numDraws, numTotal - numDraws)` with `numDraws` passed every other test in the file.
- A population of `1e308` is asserted to be refused, since `Number.isInteger` accepts it; reverting the safe-integer check fails that test. A population of two exact categories whose *total* passes 2^53 is asserted to be refused as well — asked of `multivariateSamplingDiagnostics` first, because a document that reached the sampler would hang rather than fail; dropping the check on the total fails that assertion.
- Diagnostics: `doenet-w0135` is asserted with its exact arguments for four ways of reaching it — including both attributes omitted — and the rendered message is checked for not leaking `null`/`undefined`; `doenet-w0136` is asserted for a draw that would need billions of draws, together with the `NaN` counts and statistics that accompany it; a draw between the sluggish and the refused thresholds is checked to still be sampled, with `doenet-w0133`; and valid parameters are checked to raise nothing at all.
- Fourteen mutations of the component and the sampler were made to check the tests discriminate: not shrinking the population or the remaining draws between categories, giving the last category zero, dropping `numDraws` from the mean, dropping the finite population correction, removing each degenerate-population branch, zeroing `numTotal`, reusing the old counts on `resample`, ignoring `variantDeterminesSeed`, not copying the number-display attributes onto the replacements, not declaring `asList`, and dropping the complement symmetry from the work bound. Each fails a test that names the behavior. A fifteenth, `takesIndex = false`, does not, and cannot: the worker tests never see that flag — it is read by the LSP through the generated schema, which records it.

## Docs

New reference page `sampleMultivariateRandomNumber.mdx` (basic use, `resample` button, one example per attribute and for `means`/`variances`, and a section on the limits that make a draw unusable, including why `type` is required rather than defaulted), plus entries in the reference `_meta.ts` sidebar and the "Math components" list on the component-type index page. Its examples run through core to confirm they render.

`samplemultivariaterandomnumber.test.ts` (28) and `selectsamplerandomnumbers.test.ts` (74) pass locally, as does the `@doenet/i18n` lint; the generated schema is regenerated and current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVXbfUXJtSfPT7D7chwrWu


