### PR TITLE
fix: visit each component once in two traversals that follow composite links

### DIFF
--- a/.changeset/nested-composite-chain-exponential-traversals.md
+++ b/.changeset/nested-composite-chain-exponential-traversals.md
@@ -28,6 +28,6 @@ The cost was not in evaluating the recurrence. Components form a directed acycli
 - `allPotentialRendererTypes`, which collects the renderers a document may need to load, recursed into children and into replacements. It now walks each component once, which loses nothing because every path contributed to the same set of renderer types.
 - `ancestorsIncludingComposites`, used when propagating dependency blockers, walked up both the parent chain and the chain of the composite a replacement came from — chains that converge on the same ancestors. It now remembers the ancestors it has already worked out for a component.
 
-The renderer types collected are unchanged. The example above loads in 3 seconds, and cost now grows with the number of components rather than exponentially.
+The renderer types collected are unchanged. The example above loads in a few seconds, and cost now grows with the number of components rather than exponentially.
 
 Documents that nest composites only a few deep — the overwhelming majority — were never affected and are unchanged.

--- a/.changeset/nested-composite-chain-exponential-traversals.md
+++ b/.changeset/nested-composite-chain-exponential-traversals.md
@@ -11,21 +11,23 @@ Stop two core traversals from taking exponential time when composites nest insid
 A repeat whose iterations refer to the previous iteration, as in
 
 ```xml
+<numberList name="vals"><sequence from="1" to="16" /></numberList>
+
 <repeatForSequence from="1" to="16" valueName="i" name="cumSums">
   <number><conditionalContent>
-    <case condition="$i=1">$values[1]</case>
-    <else>$cumSums[$i-1] + $values[$i]</else>
+    <case condition="$i=1">$vals[1]</case>
+    <else>$cumSums[$i-1] + $vals[$i]</else>
   </conditionalContent></number>
 </repeatForSequence>
 ```
 
-hung the document rather than loading it. At 8 iterations it took 4 seconds, at 10 it took 3 minutes, and each further iteration multiplied that by about four, so the 16 iterations above would have needed several days.
+hung the document rather than loading it. At 8 iterations it took 4 seconds and at 10 it took 3 minutes, with each further iteration multiplying the cost by about four, so the 16 iterations above would have needed several days.
 
 The cost was not in evaluating the recurrence. Components form a directed acyclic graph rather than a tree: a composite's replacements are spliced in as children of the composite's parent while the composite goes on pointing at them as replacements, so the same component is reachable along several paths. Each iteration of the repeat above adds a `<conditionalContent>` → `<group>` → copy chain, which makes the previous iteration reachable four ways, and two traversals walked every path separately:
 
-- `allPotentialRendererTypes`, which collects the renderers a document may need to load, recursed into children and into replacements.
-- `ancestorsIncludingComposites`, used when propagating dependency blockers, walked up both the parent chain and the chain of the composite a replacement came from — chains that converge on the same ancestors.
+- `allPotentialRendererTypes`, which collects the renderers a document may need to load, recursed into children and into replacements. It now walks each component once, which loses nothing because every path contributed to the same set of renderer types.
+- `ancestorsIncludingComposites`, used when propagating dependency blockers, walked up both the parent chain and the chain of the composite a replacement came from — chains that converge on the same ancestors. It now remembers the ancestors it has already worked out for a component.
 
-Both now visit each component once per traversal, which is enough because both accumulate a set. The renderer types collected are unchanged. The example above loads in 3 seconds, and cost grows with the number of components instead of exponentially.
+The renderer types collected are unchanged. The example above loads in 3 seconds, and cost now grows with the number of components rather than exponentially.
 
 Documents that nest composites only a few deep — the overwhelming majority — were never affected and are unchanged.

--- a/.changeset/nested-composite-chain-exponential-traversals.md
+++ b/.changeset/nested-composite-chain-exponential-traversals.md
@@ -1,0 +1,31 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop two core traversals from taking exponential time when composites nest inside one another.
+
+A repeat whose iterations refer to the previous iteration, as in
+
+```xml
+<repeatForSequence from="1" to="16" valueName="i" name="cumSums">
+  <number><conditionalContent>
+    <case condition="$i=1">$values[1]</case>
+    <else>$cumSums[$i-1] + $values[$i]</else>
+  </conditionalContent></number>
+</repeatForSequence>
+```
+
+hung the document rather than loading it. At 8 iterations it took 4 seconds, at 10 it took 3 minutes, and each further iteration multiplied that by about four, so the 16 iterations above would have needed several days.
+
+The cost was not in evaluating the recurrence. Components form a directed acyclic graph rather than a tree: a composite's replacements are spliced in as children of the composite's parent while the composite goes on pointing at them as replacements, so the same component is reachable along several paths. Each iteration of the repeat above adds a `<conditionalContent>` → `<group>` → copy chain, which makes the previous iteration reachable four ways, and two traversals walked every path separately:
+
+- `allPotentialRendererTypes`, which collects the renderers a document may need to load, recursed into children and into replacements.
+- `ancestorsIncludingComposites`, used when propagating dependency blockers, walked up both the parent chain and the chain of the composite a replacement came from — chains that converge on the same ancestors.
+
+Both now visit each component once per traversal, which is enough because both accumulate a set. The renderer types collected are unchanged. The example above loads in 3 seconds, and cost grows with the number of components instead of exponentially.
+
+Documents that nest composites only a few deep — the overwhelming majority — were never affected and are unchanged.

--- a/packages/doenetml-worker-javascript/src/components/Case.js
+++ b/packages/doenetml-worker-javascript/src/components/Case.js
@@ -87,10 +87,6 @@ export default class Case extends BaseComponent {
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
-            this.serializedChildren,
-        )) {
-            rendererTypes.add(rendererType);
-        }
+        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Case.js
+++ b/packages/doenetml-worker-javascript/src/components/Case.js
@@ -84,19 +84,13 @@ export default class Case extends BaseComponent {
         return stateVariableDefinitions;
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        let additionalRendererTypes =
-            this.potentialRendererTypesFromSerializedComponents(
-                this.serializedChildren,
-            );
-        for (let rendererType of additionalRendererTypes) {
-            if (!allPotentialRendererTypes.includes(rendererType)) {
-                allPotentialRendererTypes.push(rendererType);
-            }
+        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+            this.serializedChildren,
+        )) {
+            rendererTypes.add(rendererType);
         }
-
-        return allPotentialRendererTypes;
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
+++ b/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
@@ -383,9 +383,10 @@ export default class ConditionalContent extends CompositeComponent {
         });
     }
 
-    addOwnPotentialRendererTypes(rendererTypes, visited) {
-        super.addOwnPotentialRendererTypes(rendererTypes, visited);
-
-        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
-    }
+    // No `addOwnPotentialRendererTypes` override here, unlike the sibling
+    // composites that hold a template: this class defines no
+    // `keepChildrenSerialized`, so `ComponentBuilder` always gives it an empty
+    // `serializedChildren` and such an override could contribute nothing. The
+    // branches are covered by `Case`, which does keep its children serialized
+    // and does report their renderer types.
 }

--- a/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
+++ b/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
@@ -386,12 +386,6 @@ export default class ConditionalContent extends CompositeComponent {
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        if (this.serializedChildren) {
-            for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
-                this.serializedChildren,
-            )) {
-                rendererTypes.add(rendererType);
-            }
-        }
+        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
+++ b/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
@@ -383,21 +383,15 @@ export default class ConditionalContent extends CompositeComponent {
         });
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
         if (this.serializedChildren) {
-            let additionalRendererTypes =
-                this.potentialRendererTypesFromSerializedComponents(
-                    this.serializedChildren,
-                );
-            for (let rendererType of additionalRendererTypes) {
-                if (!allPotentialRendererTypes.includes(rendererType)) {
-                    allPotentialRendererTypes.push(rendererType);
-                }
+            for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+                this.serializedChildren,
+            )) {
+                rendererTypes.add(rendererType);
             }
         }
-
-        return allPotentialRendererTypes;
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Group.js
+++ b/packages/doenetml-worker-javascript/src/components/Group.js
@@ -406,19 +406,13 @@ export default class Group extends CompositeComponent {
         });
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        let additionalRendererTypes =
-            this.potentialRendererTypesFromSerializedComponents(
-                this.serializedChildren,
-            );
-        for (let rendererType of additionalRendererTypes) {
-            if (!allPotentialRendererTypes.includes(rendererType)) {
-                allPotentialRendererTypes.push(rendererType);
-            }
+        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+            this.serializedChildren,
+        )) {
+            rendererTypes.add(rendererType);
         }
-
-        return allPotentialRendererTypes;
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Group.js
+++ b/packages/doenetml-worker-javascript/src/components/Group.js
@@ -409,10 +409,6 @@ export default class Group extends CompositeComponent {
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
-            this.serializedChildren,
-        )) {
-            rendererTypes.add(rendererType);
-        }
+        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Option.js
+++ b/packages/doenetml-worker-javascript/src/components/Option.js
@@ -144,10 +144,6 @@ export default class Option extends BaseComponent {
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
-            this.serializedChildren,
-        )) {
-            rendererTypes.add(rendererType);
-        }
+        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Option.js
+++ b/packages/doenetml-worker-javascript/src/components/Option.js
@@ -141,19 +141,13 @@ export default class Option extends BaseComponent {
         });
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        let additionalRendererTypes =
-            this.potentialRendererTypesFromSerializedComponents(
-                this.serializedChildren,
-            );
-        for (let rendererType of additionalRendererTypes) {
-            if (!allPotentialRendererTypes.includes(rendererType)) {
-                allPotentialRendererTypes.push(rendererType);
-            }
+        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+            this.serializedChildren,
+        )) {
+            rendererTypes.add(rendererType);
         }
-
-        return allPotentialRendererTypes;
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Repeat.js
+++ b/packages/doenetml-worker-javascript/src/components/Repeat.js
@@ -742,11 +742,7 @@ export default class Repeat extends CompositeComponent {
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
-            this.serializedChildren,
-        )) {
-            rendererTypes.add(rendererType);
-        }
+        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
     }
 }
 

--- a/packages/doenetml-worker-javascript/src/components/Repeat.js
+++ b/packages/doenetml-worker-javascript/src/components/Repeat.js
@@ -739,20 +739,14 @@ export default class Repeat extends CompositeComponent {
         return { success: true, desiredVariant };
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        let additionalRendererTypes =
-            this.potentialRendererTypesFromSerializedComponents(
-                this.serializedChildren,
-            );
-        for (let rendererType of additionalRendererTypes) {
-            if (!allPotentialRendererTypes.includes(rendererType)) {
-                allPotentialRendererTypes.push(rendererType);
-            }
+        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+            this.serializedChildren,
+        )) {
+            rendererTypes.add(rendererType);
         }
-
-        return allPotentialRendererTypes;
     }
 }
 

--- a/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
@@ -728,20 +728,14 @@ export default class RepeatForSequence extends CompositeComponent {
         return { success: true, desiredVariant };
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        let additionalRendererTypes =
-            this.potentialRendererTypesFromSerializedComponents(
-                this.serializedChildren,
-            );
-        for (let rendererType of additionalRendererTypes) {
-            if (!allPotentialRendererTypes.includes(rendererType)) {
-                allPotentialRendererTypes.push(rendererType);
-            }
+        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+            this.serializedChildren,
+        )) {
+            rendererTypes.add(rendererType);
         }
-
-        return allPotentialRendererTypes;
     }
 }
 

--- a/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
@@ -731,11 +731,7 @@ export default class RepeatForSequence extends CompositeComponent {
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
-            this.serializedChildren,
-        )) {
-            rendererTypes.add(rendererType);
-        }
+        this.addPotentialRendererTypesFromSerializedChildren(rendererTypes);
     }
 }
 

--- a/packages/doenetml-worker-javascript/src/components/Sequence.js
+++ b/packages/doenetml-worker-javascript/src/components/Sequence.js
@@ -481,8 +481,8 @@ export default class Sequence extends CompositeComponent {
         return { replacementChanges, diagnostics, nComponents };
     }
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
         let type = "number";
         if (this.attributes.type && this.attributes.type.primitive) {
@@ -496,10 +496,6 @@ export default class Sequence extends CompositeComponent {
             this.componentInfoObjects.allComponentClasses[
                 type === "letters" ? "text" : type
             ].rendererType;
-        if (!allPotentialRendererTypes.includes(rendererType)) {
-            allPotentialRendererTypes.push(rendererType);
-        }
-
-        return allPotentialRendererTypes;
+        rendererTypes.add(rendererType);
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -157,6 +157,10 @@ export default class BaseComponent {
         return this.constructor.rendererType;
     }
 
+    /**
+     * The renderer types that this component and everything reachable from it
+     * could create, so the viewer knows which renderers to load.
+     */
     get allPotentialRendererTypes() {
         const rendererTypes = new Set();
         this.addPotentialRendererTypes(rendererTypes, new Set());
@@ -177,8 +181,9 @@ export default class BaseComponent {
      * a repeat whose iterations reference the previous iteration builds — is
      * traversed exponentially many times.
      *
-     * Subclasses extend `addOwnPotentialRendererTypes`; this method is the
-     * guarded entry point that recursion goes through.
+     * This is the guarded entry point that every step of the recursion goes
+     * through. Subclasses must not override it; they override
+     * `addOwnPotentialRendererTypes` instead.
      */
     addPotentialRendererTypes(rendererTypes, visited) {
         if (visited.has(this.componentIdx)) {
@@ -189,6 +194,14 @@ export default class BaseComponent {
         this.addOwnPotentialRendererTypes(rendererTypes, visited);
     }
 
+    /**
+     * The body of `addPotentialRendererTypes`, called once per component.
+     *
+     * Subclasses override this to contribute renderer types that the component
+     * graph alone does not reveal; an override must call `super` and must
+     * recurse through `addPotentialRendererTypes` (passing `visited` along)
+     * rather than calling this method directly, so the guard is not bypassed.
+     */
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         rendererTypes.add("_error");
         if (this.rendererType) {
@@ -261,6 +274,27 @@ export default class BaseComponent {
             } else {
                 child.addPotentialRendererTypes(rendererTypes, visited);
             }
+        }
+    }
+
+    /**
+     * Add to `rendererTypes` the renderer types that `this.serializedChildren`
+     * could create.
+     *
+     * Components that hold on to serialized children which are not (or not
+     * yet) part of the component graph — a repeat's template, the branches of
+     * a conditional — call this from `addOwnPotentialRendererTypes`, since
+     * walking the graph would not reach them.
+     */
+    addPotentialRendererTypesFromSerializedChildren(rendererTypes) {
+        if (!this.serializedChildren) {
+            return;
+        }
+
+        for (let rendererType of this.potentialRendererTypesFromSerializedComponents(
+            this.serializedChildren,
+        )) {
+            rendererTypes.add(rendererType);
         }
     }
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -296,9 +296,10 @@ export default class BaseComponent {
      * yet) part of the component graph — a repeat's template, a `<case>` of a
      * conditional — call this from `addOwnPotentialRendererTypes`, since
      * walking the graph would not reach them. Only classes with a static
-     * `keepChildrenSerialized` have anything here; `ComponentBuilder` gives
-     * every other component an empty array, and the field is optional on a
-     * component instance, hence the guard.
+     * `keepChildrenSerialized` have anything here: `ComponentBuilder` gives
+     * every other component an empty array. The guard below therefore does
+     * not fire for a component Core built; it is there because
+     * `ComponentInstance` declares the field optional.
      */
     addPotentialRendererTypesFromSerializedChildren(rendererTypes) {
         if (!this.serializedChildren) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -158,9 +158,41 @@ export default class BaseComponent {
     }
 
     get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = ["_error"];
+        const rendererTypes = new Set();
+        this.addPotentialRendererTypes(rendererTypes, new Set());
+        return [...rendererTypes];
+    }
+
+    /**
+     * Add to `rendererTypes` every renderer type that this component or its
+     * descendants could create.
+     *
+     * Components form a directed acyclic graph rather than a tree: a
+     * composite's replacements are spliced in as children of the composite's
+     * parent while the composite keeps pointing at them as replacements, so
+     * the same component is reachable along several paths. `visited` holds the
+     * components already accounted for, so each is walked once; since every
+     * path contributes to the same `rendererTypes` set, skipping a repeat
+     * visit loses nothing. Without it, a chain of `k` nested composites — what
+     * a repeat whose iterations reference the previous iteration builds — is
+     * traversed exponentially many times.
+     *
+     * Subclasses extend `addOwnPotentialRendererTypes`; this method is the
+     * guarded entry point that recursion goes through.
+     */
+    addPotentialRendererTypes(rendererTypes, visited) {
+        if (visited.has(this.componentIdx)) {
+            return;
+        }
+        visited.add(this.componentIdx);
+
+        this.addOwnPotentialRendererTypes(rendererTypes, visited);
+    }
+
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        rendererTypes.add("_error");
         if (this.rendererType) {
-            allPotentialRendererTypes.push(this.rendererType);
+            rendererTypes.add(this.rendererType);
         }
 
         // include any potential renderer type that could be
@@ -187,11 +219,8 @@ export default class BaseComponent {
                         ];
                     if (componentClass) {
                         let rendererType = componentClass.rendererType;
-                        if (
-                            rendererType &&
-                            !allPotentialRendererTypes.includes(rendererType)
-                        ) {
-                            allPotentialRendererTypes.push(rendererType);
+                        if (rendererType) {
+                            rendererTypes.add(rendererType);
                         }
                     }
                 }
@@ -213,18 +242,15 @@ export default class BaseComponent {
                     ];
                 if (componentClass) {
                     let rendererType = componentClass.rendererType;
-                    if (
-                        rendererType &&
-                        !allPotentialRendererTypes.includes(rendererType)
-                    ) {
-                        allPotentialRendererTypes.push(rendererType);
+                    if (rendererType) {
+                        rendererTypes.add(rendererType);
                     }
                 }
             }
         }
 
         if (!this.rendererType) {
-            return allPotentialRendererTypes;
+            return;
         }
 
         // recurse to all children
@@ -233,15 +259,9 @@ export default class BaseComponent {
             if (typeof child !== "object") {
                 continue;
             } else {
-                for (let rendererType of child.allPotentialRendererTypes) {
-                    if (!allPotentialRendererTypes.includes(rendererType)) {
-                        allPotentialRendererTypes.push(rendererType);
-                    }
-                }
+                child.addPotentialRendererTypes(rendererTypes, visited);
             }
         }
-
-        return allPotentialRendererTypes;
     }
 
     potentialRendererTypesFromSerializedComponents(serializedComponents) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -162,7 +162,9 @@ export default class BaseComponent {
      * could create, so the viewer knows which renderers to load.
      */
     get allPotentialRendererTypes() {
-        const rendererTypes = new Set();
+        // `_error` is seeded here rather than contributed by a component: the
+        // viewer needs the error renderer available for any document at all.
+        const rendererTypes = new Set(["_error"]);
         this.addPotentialRendererTypes(rendererTypes, new Set());
         return [...rendererTypes];
     }
@@ -197,7 +199,7 @@ export default class BaseComponent {
     /**
      * The body of `addPotentialRendererTypes`, called once per component.
      *
-     * Subclasses override this to reach what the walk below does not: further
+     * Subclasses override this to reach what the walk here does not: further
      * links out of the component (a composite's replacements) or renderer
      * types that no component reveals (a repeat's serialized template). An
      * override must call `super`, and must step to another component through
@@ -205,7 +207,6 @@ export default class BaseComponent {
      * calling this method directly, so the guard is not bypassed.
      */
     addOwnPotentialRendererTypes(rendererTypes, visited) {
-        rendererTypes.add("_error");
         if (this.rendererType) {
             rendererTypes.add(this.rendererType);
         }
@@ -292,9 +293,12 @@ export default class BaseComponent {
      * could create.
      *
      * Components that hold on to serialized children which are not (or not
-     * yet) part of the component graph — a repeat's template, the branches of
-     * a conditional — call this from `addOwnPotentialRendererTypes`, since
-     * walking the graph would not reach them.
+     * yet) part of the component graph — a repeat's template, a `<case>` of a
+     * conditional — call this from `addOwnPotentialRendererTypes`, since
+     * walking the graph would not reach them. Only classes with a static
+     * `keepChildrenSerialized` have anything here; `ComponentBuilder` gives
+     * every other component an empty array, and the field is optional on a
+     * component instance, hence the guard.
      */
     addPotentialRendererTypesFromSerializedChildren(rendererTypes) {
         if (!this.serializedChildren) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -197,10 +197,12 @@ export default class BaseComponent {
     /**
      * The body of `addPotentialRendererTypes`, called once per component.
      *
-     * Subclasses override this to contribute renderer types that the component
-     * graph alone does not reveal; an override must call `super` and must
-     * recurse through `addPotentialRendererTypes` (passing `visited` along)
-     * rather than calling this method directly, so the guard is not bypassed.
+     * Subclasses override this to reach what the walk below does not: further
+     * links out of the component (a composite's replacements) or renderer
+     * types that no component reveals (a repeat's serialized template). An
+     * override must call `super`, and must step to another component through
+     * `addPotentialRendererTypes` (passing `visited` along) rather than
+     * calling this method directly, so the guard is not bypassed.
      */
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         rendererTypes.add("_error");
@@ -266,12 +268,20 @@ export default class BaseComponent {
             return;
         }
 
-        // recurse to all children
+        this.addPotentialRendererTypesFromChildren(rendererTypes, visited);
+    }
+
+    /**
+     * Recurse into every child of this component.
+     *
+     * Split out because `CompositeComponent` has to run this walk itself: a
+     * composite has no `rendererType`, so `addOwnPotentialRendererTypes`
+     * returns above without reaching the children.
+     */
+    addPotentialRendererTypesFromChildren(rendererTypes, visited) {
         for (const childIdxStr in this.allChildren) {
-            let child = this.allChildren[childIdxStr].component;
-            if (typeof child !== "object") {
-                continue;
-            } else {
+            const child = this.allChildren[childIdxStr].component;
+            if (typeof child === "object") {
                 child.addPotentialRendererTypes(rendererTypes, visited);
             }
         }

--- a/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
@@ -120,32 +120,25 @@ export default class CompositeComponent extends BaseComponent {
     // the static function calculateReplacementChanges.
     replacementsToWithhold = 0;
 
-    get allPotentialRendererTypes() {
-        let allPotentialRendererTypes = super.allPotentialRendererTypes;
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
         // we still recurse to all children, even though was skipped at base component
         // due to not having a rendererType
         for (const childIdxStr in this.allChildren) {
             let child = this.allChildren[childIdxStr].component;
-            for (let rendererType of child.allPotentialRendererTypes) {
-                if (!allPotentialRendererTypes.includes(rendererType)) {
-                    allPotentialRendererTypes.push(rendererType);
-                }
-            }
+            child.addPotentialRendererTypes(rendererTypes, visited);
         }
 
         if (this.replacements) {
             for (let replacement of this.replacements) {
                 if (typeof replacement === "object") {
-                    for (let rendererType of replacement.allPotentialRendererTypes) {
-                        if (!allPotentialRendererTypes.includes(rendererType)) {
-                            allPotentialRendererTypes.push(rendererType);
-                        }
-                    }
+                    replacement.addPotentialRendererTypes(
+                        rendererTypes,
+                        visited,
+                    );
                 }
             }
         }
-
-        return allPotentialRendererTypes;
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
@@ -125,10 +125,7 @@ export default class CompositeComponent extends BaseComponent {
 
         // we still recurse to all children, even though was skipped at base component
         // due to not having a rendererType
-        for (const childIdxStr in this.allChildren) {
-            let child = this.allChildren[childIdxStr].component;
-            child.addPotentialRendererTypes(rendererTypes, visited);
-        }
+        this.addPotentialRendererTypesFromChildren(rendererTypes, visited);
 
         if (this.replacements) {
             for (let replacement of this.replacements) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
@@ -120,11 +120,16 @@ export default class CompositeComponent extends BaseComponent {
     // the static function calculateReplacementChanges.
     replacementsToWithhold = 0;
 
+    /**
+     * A composite reaches components along a second kind of link: its
+     * `replacements`, which are spliced in as children of the composite's own
+     * parent. Follow those as well as the children.
+     */
     addOwnPotentialRendererTypes(rendererTypes, visited) {
         super.addOwnPotentialRendererTypes(rendererTypes, visited);
 
-        // we still recurse to all children, even though was skipped at base component
-        // due to not having a rendererType
+        // Walk the children here: a composite has no `rendererType`, so the
+        // base implementation returned before reaching them.
         this.addPotentialRendererTypesFromChildren(rendererTypes, visited);
 
         if (this.replacements) {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2787,11 +2787,11 @@ describe("RepeatForSequence tag tests @group3", async () => {
         // reachable along many paths at once. Traversals that followed every path
         // separately took time exponential in the number of iterations, which turned
         // a recurrence like this cumulative sum into a hung document; twelve
-        // iterations took roughly an hour. Keep the assertion generous — this guards
-        // against exponential growth, not against a modest slowdown.
+        // iterations took roughly an hour. The test's timeout is what guards against
+        // that; it is deliberately far above the time this now takes, since we are
+        // catching exponential growth, not a modest slowdown.
         const numIterations = 12;
 
-        const t0 = Date.now();
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <numberList name="vals"><sequence from="1" to="${numIterations}" /></numberList>
@@ -2805,13 +2805,14 @@ describe("RepeatForSequence tag tests @group3", async () => {
         });
 
         const stateVariables = await core.returnAllStateVariables(false, true);
-        const elapsed = Date.now() - t0;
 
         // cumulative sums of 1..12
         expect(
             stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
         ).eq("1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78");
 
-        expect(elapsed).toBeLessThan(60000);
-    }, 90000);
+        // Not asserting on warnings here: this document also draws spurious
+        // "No referent found" warnings for the references inside the repeat's
+        // template, which is a separate, pre-existing issue.
+    }, 60000);
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2780,4 +2780,38 @@ describe("RepeatForSequence tag tests @group3", async () => {
 
         expect(getDiagnosticsByType(core).warnings).eqls([]);
     });
+
+    it("iterations referring to the previous iteration stay tractable", async () => {
+        // Each iteration wraps the previous one in a conditionalContent -> group ->
+        // copy chain, so iteration `n` sits under `n` nested composites and is
+        // reachable along many paths at once. Traversals that followed every path
+        // separately took time exponential in the number of iterations, which turned
+        // a recurrence like this cumulative sum into a hung document; twelve
+        // iterations took roughly an hour. Keep the assertion generous — this guards
+        // against exponential growth, not against a modest slowdown.
+        const numIterations = 12;
+
+        const t0 = Date.now();
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <numberList name="vals"><sequence from="1" to="${numIterations}" /></numberList>
+    <p name="p"><repeatForSequence from="1" to="${numIterations}" valueName="i" name="cumSums">
+      <number><conditionalContent>
+        <case condition="$i=1">$vals[1]</case>
+        <else>$cumSums[$i-1] + $vals[$i]</else>
+      </conditionalContent></number>
+    </repeatForSequence></p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const elapsed = Date.now() - t0;
+
+        // cumulative sums of 1..12
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
+        ).eq("1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78");
+
+        expect(elapsed).toBeLessThan(60000);
+    }, 90000);
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2793,8 +2793,8 @@ describe("RepeatForSequence tag tests @group3", async () => {
         // The blowup happens inside synchronous recursion, so vitest cannot preempt
         // it: a regression shows up as this test never finishing rather than as a
         // clean timeout failure. The timeout below is a backstop for a regression
-        // that does yield, and a record of the intended scale — this takes a couple
-        // of seconds today, so CI jitter comes nowhere near it.
+        // that does yield, and a record of the intended scale — this runs in about
+        // four seconds today, so CI jitter comes nowhere near it.
         const numIterations = 12;
 
         let { core, resolvePathToNodeIdx } = await createTestCore({
@@ -2818,6 +2818,8 @@ describe("RepeatForSequence tag tests @group3", async () => {
 
         // Not asserting on warnings here: this document also draws spurious
         // "No referent found" warnings for the references inside the repeat's
-        // template, which is a separate, pre-existing issue.
+        // template, which is a separate, pre-existing issue tracked as
+        // https://github.com/Doenet/DoenetML/issues/1822. Add a warning
+        // assertion here once that is fixed.
     }, 60000);
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeatForSequence.test.ts
@@ -2787,9 +2787,14 @@ describe("RepeatForSequence tag tests @group3", async () => {
         // reachable along many paths at once. Traversals that followed every path
         // separately took time exponential in the number of iterations, which turned
         // a recurrence like this cumulative sum into a hung document; twelve
-        // iterations took roughly an hour. The test's timeout is what guards against
-        // that; it is deliberately far above the time this now takes, since we are
-        // catching exponential growth, not a modest slowdown.
+        // iterations took roughly an hour, and reverting either half of the fix on
+        // its own still leaves this test running for many minutes.
+        //
+        // The blowup happens inside synchronous recursion, so vitest cannot preempt
+        // it: a regression shows up as this test never finishing rather than as a
+        // clean timeout failure. The timeout below is a backstop for a regression
+        // that does yield, and a record of the intended scale — this takes a couple
+        // of seconds today, so CI jitter comes nowhere near it.
         const numIterations = 12;
 
         let { core, resolvePathToNodeIdx } = await createTestCore({

--- a/packages/doenetml-worker-javascript/src/utils/descendants.js
+++ b/packages/doenetml-worker-javascript/src/utils/descendants.js
@@ -232,16 +232,40 @@ function replacementsForComposites({
     return replacements;
 }
 
-export function ancestorsIncludingComposites(comp, components) {
+/**
+ * Return the component indices of all ancestors of `comp`, following both the
+ * parent chain and, for a replacement, the chain of the composite that created
+ * it.
+ *
+ * Those two chains converge: a composite's replacements are placed under the
+ * composite's own parent, so `comp` and `comp.replacementOf` typically share
+ * ancestors. Without `memo`, a component sitting under `k` nested composites
+ * would walk the shared upper chain `2^k` times. `memo` holds the results
+ * computed so far in this call — the component graph does not change while we
+ * recurse, so a repeat visit can reuse the earlier answer.
+ *
+ * The arrays put in `memo` are returned directly to callers, so callers must
+ * not mutate what they get back.
+ */
+export function ancestorsIncludingComposites(
+    comp,
+    components,
+    memo = new Map(),
+) {
     if (comp.ancestors === undefined || comp.ancestors.length === 0) {
         return [];
+    }
+
+    const memoized = memo.get(comp.componentIdx);
+    if (memoized) {
+        return memoized;
     }
 
     let comps = [comp.ancestors[0].componentIdx];
 
     let parent = components[comp.ancestors[0].componentIdx];
     if (parent) {
-        comps.push(...ancestorsIncludingComposites(parent, components));
+        comps.push(...ancestorsIncludingComposites(parent, components, memo));
     }
 
     if (comp.replacementOf) {
@@ -249,6 +273,7 @@ export function ancestorsIncludingComposites(comp, components) {
         let replacementAs = ancestorsIncludingComposites(
             comp.replacementOf,
             components,
+            memo,
         );
         for (let a of replacementAs) {
             if (!comps.includes(a)) {
@@ -256,6 +281,8 @@ export function ancestorsIncludingComposites(comp, components) {
             }
         }
     }
+
+    memo.set(comp.componentIdx, comps);
 
     return comps;
 }

--- a/packages/doenetml-worker-javascript/src/utils/descendants.js
+++ b/packages/doenetml-worker-javascript/src/utils/descendants.js
@@ -236,22 +236,28 @@ function replacementsForComposites({
  * Return the component indices of all ancestors of `comp`, following both the
  * parent chain and, for a replacement, the chain of the composite that created
  * it.
- *
- * Those two chains converge: a composite's replacements are placed under the
- * composite's own parent, so `comp` and `comp.replacementOf` typically share
- * ancestors. Without `memo`, a component sitting under `k` nested composites
- * would walk the shared upper chain `2^k` times. `memo` holds the results
- * computed so far in this call — the component graph does not change while we
- * recurse, so a repeat visit can reuse the earlier answer.
- *
- * The arrays put in `memo` are returned directly to callers, so callers must
- * not mutate what they get back.
  */
-export function ancestorsIncludingComposites(
-    comp,
-    components,
-    memo = new Map(),
-) {
+export function ancestorsIncludingComposites(comp, components) {
+    return ancestorsIncludingCompositesMemoized(comp, components, new Map());
+}
+
+/**
+ * The recursion behind `ancestorsIncludingComposites`, with `memo` mapping a
+ * component index to the ancestors already computed for it in this call.
+ *
+ * The two chains we follow converge: a composite's replacements are placed
+ * under the composite's own parent, so `comp` and `comp.replacementOf`
+ * typically share ancestors. Without `memo`, a component sitting under `k`
+ * nested composites would walk the shared upper chain `2^k` times. The
+ * component graph does not change while we recurse, so a repeat visit can
+ * reuse the earlier answer.
+ *
+ * A memoized array can be handed back to more than one caller within the
+ * recursion, so it must not be mutated. `memo` is created fresh per top-level
+ * call and discarded with it, so the array that reaches the outside caller is
+ * unaliased.
+ */
+function ancestorsIncludingCompositesMemoized(comp, components, memo) {
     if (comp.ancestors === undefined || comp.ancestors.length === 0) {
         return [];
     }
@@ -265,12 +271,14 @@ export function ancestorsIncludingComposites(
 
     let parent = components[comp.ancestors[0].componentIdx];
     if (parent) {
-        comps.push(...ancestorsIncludingComposites(parent, components, memo));
+        comps.push(
+            ...ancestorsIncludingCompositesMemoized(parent, components, memo),
+        );
     }
 
     if (comp.replacementOf) {
         comps.push(comp.replacementOf.componentIdx);
-        let replacementAs = ancestorsIncludingComposites(
+        let replacementAs = ancestorsIncludingCompositesMemoized(
             comp.replacementOf,
             components,
             memo,

--- a/packages/doenetml-worker-javascript/src/utils/descendants.js
+++ b/packages/doenetml-worker-javascript/src/utils/descendants.js
@@ -263,7 +263,7 @@ function ancestorsIncludingCompositesMemoized(comp, components, memo) {
     }
 
     const memoized = memo.get(comp.componentIdx);
-    if (memoized) {
+    if (memoized !== undefined) {
         return memoized;
     }
 


### PR DESCRIPTION
## Problem

A repeat whose iterations reference the previous iteration hangs the document instead of loading it:

```xml
<numberList name="vals"><sequence from="1" to="16" /></numberList>

<repeatForSequence from="1" to="16" valueName="i" name="cumSums">
  <number><conditionalContent>
    <case condition="$i=1">$vals[1]</case>
    <else>$cumSums[$i-1] + $vals[$i]</else>
  </conditionalContent></number>
</repeatForSequence>
```

Not an infinite loop — exponential, roughly ×4 per added iteration. Load times measured before this change: 4 iterations 0.5 s, 8 → 4.3 s, 9 → 46 s, 10 → 3 min, 16 → several days (projected).

## Cause

Components form a directed acyclic graph, not a tree: a composite's replacements are spliced in as children of the composite's *parent*, while the composite goes on pointing at them through `replacements` / `replacementOf`. Each iteration adds a `conditionalContent` → `group` → copy chain, so the previous iteration's `<number>` becomes reachable four ways and the number of paths quadruples per iteration.

Two traversals followed every path separately, with no memoization:

- **`allPotentialRendererTypes`** (`BaseComponent.js`, `CompositeComponent.js`, seven subclass overrides) collects the renderers a document may need to load, recursing into `allChildren` *and* `replacements`. Instrumented visit counts for 2…8 iterations — `136, 567, 2294, 9205, 36852, 147443, 589810` — grew ×4 per step while the component count grew only quadratically. ~70 % of the runtime; called once, from `Core.rendererTypesInDocument`.
- **`ancestorsIncludingComposites`** (`utils/descendants.js`, three call sites in `DependencyHandler`) walks up the parent chain *and* the ancestors of `comp.replacementOf`; those two chains converge on the same ancestors. ~25 % of the runtime.

Both are exponential in how deeply composites nest, not in document size, so documents that nest composites only a few deep were never affected.

## Fix

Both traversals accumulate results that do not depend on the path taken to reach a component, so visiting each component once loses nothing.

- **`ancestorsIncludingComposites`** keeps its two-argument public signature and delegates to an internal helper threading a per-call `memo` Map. Keeping the cache inside the helper means the exported entry point cannot be handed a shared `memo`, and the array reaching an outside caller is never aliased by a still-live cache.
- **`allPotentialRendererTypes`** becomes a thin getter that seeds one shared `Set` plus a `visited` set and delegates to `addPotentialRendererTypes`, which does the visited check and calls an overridable `addOwnPotentialRendererTypes`. The guard lives in the wrapper, so a subclass calling `super` cannot bypass it. The seven remaining overrides add into the shared set instead of building and merging per-level arrays.

Along the way, two pieces of duplication collapse into shared `BaseComponent` helpers: `CompositeComponent`'s hand-copied child loop (which lacked the base's guard against a non-object child) becomes `addPotentialRendererTypesFromChildren`, and five hand-copied `serializedChildren` loops become `addPotentialRendererTypesFromSerializedChildren`. A sixth copy of that loop, in `ConditionalContent`, was dead and is dropped, with a comment in its place saying why: the class defines no `keepChildrenSerialized`, so `ComponentBuilder` always hands it the shared frozen empty array; `this.serializedChildren` is written in exactly one place (the `BaseComponent` constructor, from the single `new componentClass(...)` in `ComponentBuilder`); and the class has no subclass. Its `<case>` children are ordinary instantiated children, and `Case` does report their serialized grandchildren. Six other classes (`Copy`, `CallAction`, `CodeEditor`, `ModuleAttributes`, `PretzelArranger`, `Verbatim`) do keep children serialized and report no renderer types from them; whether that is a gap is a pre-existing question this PR does not answer, since changing it would change which renderers a document preloads.

## Results

The example above now loads in **about 4 s**, and growth is polynomial, tracking the component count. Load times on one developer machine (a single run; wall-clock here varies by ~30 % between runs, so read the shape, not the digits):

| iterations | 8 | 12 | 16 | 20 | 24 |
|---|---|---|---|---|---|
| before | 4.3 s | ~1 hr | ~days | — | — |
| after | 1.5 s | 2.6 s | 4.4 s | 5.8 s | 8.6 s |

The full activity this was found in — a sampling simulation with a sixteen-step cumulative sum, 4555 components — goes from a projected ~160 hours to **15 s**.

## Verification

- **Renderer types are unchanged.** Captured the sorted `rendererTypesInDocument` under `upstream/main` and under this branch on the same runner, for the reported activity and for synthetic documents exercising `group`, `select`/`option`, `conditionalContent`/`case`, `repeat`, `repeatForSequence`, `sequence`, `graph`, the inputs, `answer` and `matrix`, plus the nested-composite chain itself. Identical in every case, re-checked after each round of override deduplication.
- **Tests.** The full `@doenet/doenetml-worker-javascript` suite passes at this branch's head — 171 files (170 passed, 1 skipped), 3603 passed / 38 skipped / 1 todo / 0 failed — matching `upstream/main`. `npm run build:schema -w packages/static-assets` produces no diff.
- Nothing downstream depends on the returned order — `DocViewer` iterates the list to build renderer loaders.

## Test

`repeatForSequence.test.ts` gains a twelve-iteration cumulative sum that asserts the computed values — a document that could not be loaded at all before this change. It runs in about 4 s under a 60 s timeout (the file's default is 180 s).

One test guards both halves of the fix: reverting only the `visited` set leaves it running past 4 minutes, reverting only the `memo` past 6.5 minutes, and with both reverted twelve iterations took roughly an hour. The guard is "does this finish", not "does the timeout fire" — the blowup is synchronous recursion vitest cannot preempt, so a regression surfaces as a test file that never finishes and is ended by CI's job timeout rather than as a clean timeout failure.

The test deliberately does not assert on warnings, and its comment now says why: this document also draws spurious `No referent found` warnings for the references inside the repeat's template. That is [#1822](https://github.com/Doenet/DoenetML/issues/1822), a separate pre-existing issue confirmed there to predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wc9VV7AZRbh3criE985CKK

