### PR TITLE
Return one index per target from searchSorted and indexOf

### DIFF
--- a/.changeset/list-operators-scans-and-indices.md
+++ b/.changeset/list-operators-scans-and-indices.md
@@ -16,6 +16,8 @@ Ten new components, in two families.
 
 **Index-returning operators** report a position rather than a value: `<argMin>`, `<argMax>`, `<indexOf>`, `<searchSorted>` and `<sortIndices>`. Indices are 1-based to match `$list[1]`, and `0` means "no such element". These are not math-only — they order values exactly as `<sort>` does, comparing numerically when every value is numeric and alphabetically otherwise, so `<indexOf type="text" target="Cal">$names</indexOf>` searches a `<textList>` as readily as `<argMin>` scans a `<numberList>`.
 
+The `target` of `<indexOf>` and `<searchSorted>` is a *list*, and the result has one position per target, in the manner of `np.searchsorted(a, v)` with an array `v` and R's `match()`. A single target still reads as a single index — it renders inline and indexes another list, so `$pop[$which]` works as before — but a thousand targets are searched by one operator rather than a thousand. Each result is still its own `<math>`, so the results scale with the targets; what does not scale is the searching. That is what makes these usable on the output of `<sampleRandomNumbers>`: searching a large sample by wrapping it in a `<repeat>` builds a whole operator, with its own dependencies and its own result, for every draw, and stops being practical long before the sample is big enough to be interesting.
+
 The index family is worth more than its parts because DoenetML already indexes by reference, so a returned index composes with every list in the document:
 
 ```xml
@@ -27,14 +29,14 @@ The index family is worth more than its parts because DoenetML already indexes b
 
 `<sortIndices>` extends `<sort>` and accepts everything it accepts, including `sortByProp`, so `$names[$perm[1]]` sorts one list by another list's ordering — which `<sort>` alone cannot express, since it returns the values it sorted and discards where they came from.
 
-Together, the two families make sampling from a weighted population a matter of three lines: accumulate the weights, draw uniformly from the total, and look up which bucket the draw landed in.
+Together, the two families make sampling from a weighted population a matter of three lines: accumulate the weights, draw uniformly from the total, and look up which bucket each draw landed in. Raising `numSamples` here changes nothing but the number of results.
 
 ```xml
 <numberList name="pop">30 45 12 60</numberList>
 <cumulativeSum name="cum">$pop</cumulativeSum>
 <number name="total"><sum>$pop</sum></number>
-<sampleRandomNumbers name="u" type="discreteUniform" from="1" to="$total" numSamples="1" />
-<searchSorted name="which" target="$u">$cum</searchSorted>
+<sampleRandomNumbers name="draws" type="discreteUniform" from="1" to="$total" numSamples="500" />
+<searchSorted name="which" target="$draws">$cum</searchSorted>
 ```
 
 The value extraction that decides how `<sort>` compares its children now lives in one shared place, so `<sortIndices>` and the index operators agree with `<sort>` by construction rather than by coincidence.
@@ -43,10 +45,10 @@ Sharing it also fixes a second bug, in `<sort>` and `<shuffle>`: an explicit `ty
 
 Sharing it also fixes a bug in `<sort>` itself, so `<sort type="boolean">` now renders differently than before: `type="boolean"` has always been an accepted type, but a boolean child had no comparable value and was silently skipped, so `<sort type="boolean">true false</sort>` rendered nothing at all. Boolean children are now ordered as text, which puts `false` before `true` — the same order `<indexOf>` uses when its `target` is a boolean. `<shuffle type="boolean">` was never affected, since it rearranges its children without comparing them.
 
-Two ways of getting a 0 out of an index operator say so, since neither is a position and the result alone does not distinguish them. Omitting `target` on `<indexOf>` or `<searchSorted>` is a warning — no document written that way can ever produce an answer. Having no values at all to look through is an info message, since a list driven by an input can legitimately be empty for a while. A target that is simply absent from the list is *not* reported: that 0 is what `<indexOf>` is for, and a `target` bound to an input would otherwise raise one message for every value typed on the way to the right one.
+Two ways of getting a 0 out of an index operator say so, since neither is a position and the result alone does not distinguish them. Omitting `target` on `<indexOf>` or `<searchSorted>` is a warning — no document written that way can ever produce an answer. Having no values at all to look through is an info message, since a list driven by an input can legitimately be empty for a while. A target that is simply absent from the list is *not* reported: that 0 is what `<indexOf>` is for, and a `target` bound to an input would otherwise raise one message for every value typed on the way to the right one. Nor is an empty *list* of targets reported — it produces no positions, which is the honest answer to a question about nothing.
 
 The `type` attribute of `<sort>`, `<shuffle>` and the five index operators now declares the values it accepts — `number`, `math`, `text` and `boolean` — so the editor offers them, the reference pages list them with descriptions, and writing anything else is flagged rather than only warned about once the document runs. The set is unchanged; it was simply never declared.
 
 Finally, the reference pages for `<sort>`, `<shuffle>` and the sequence components (`<sequence>`, `<selectFromSequence>`, `<repeatForSequence>`, `<animateFromSequence>`) now open on the handful of attributes that actually define what the component does, rather than on an undifferentiated list. `<sort>`'s three ways of choosing what to compare are gathered under a "Sort order" heading of their own.
 
-Closes #1816. Closes #1817. Closes #1823.
+Closes #1816. Closes #1817. Closes #1823. Closes #1831.

--- a/packages/docs-nextra/pages/reference/indexOf.mdx
+++ b/packages/docs-nextra/pages/reference/indexOf.mdx
@@ -8,14 +8,19 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 <ComponentDisplay name='indexOf'/>
 
 `<indexOf>{:dn}` is a [General Operator](../concepts/essentialConcepts#component-types)
-component that renders the position of the first of its arguments equal to the value
-given by the `target` attribute. Indices start at 1, and a target that does not occur
-in the list gives 0.
+component that renders, for each value given by the `target` attribute, the position of
+the first of its arguments equal to that value. Indices start at 1, and a target that
+does not occur in the list gives 0.
+
+`target` may be a single value or a whole list of them, and the result has one position
+per target — so looking up twenty names against a roster takes one `<indexOf>{:dn}`
+rather than twenty. Each of the twenty positions is still a component of its own; what
+one operator replaces is the twenty operators.
 
 A 0 for a target that is not in the list is the answer, not a problem, so nothing is
 reported for it. Omitting `target` altogether is a warning, since nothing about that
 document could ever produce an answer, and a list with no values at all is an info
-message.
+message. (An empty *list of targets* is neither: it simply produces no positions.)
 
 Values are compared numerically when they are all numeric, and as text otherwise, so
 `<indexOf>{:dn}` searches a `<textList>{:dn}` as readily as a `<numberList>{:dn}`.
@@ -60,6 +65,27 @@ gives 0, which is a position no list entry has.
 
 `type="text"` tells `<indexOf>{:dn}` to read the target as text rather than as a
 number.
+
+
+
+---
+
+### Example: looking up several targets at once
+
+
+```doenet-editor-horiz
+<textList name="names">Ann Bob Cal Dee</textList>
+<textList name="wanted">Cal Ann Eve</textList>
+
+<p>Roster: $names</p>
+<p>Looking for: $wanted</p>
+<p>Positions: <indexOf type="text" target="$wanted">$names</indexOf></p>
+```
+
+
+
+There is one result per target, in the order the targets were given. Eve is not on the
+roster, so her slot is 0 while the others keep their positions.
 
 
 

--- a/packages/docs-nextra/pages/reference/searchSorted.mdx
+++ b/packages/docs-nextra/pages/reference/searchSorted.mdx
@@ -8,12 +8,17 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 <ComponentDisplay name='searchSorted'/>
 
 `<searchSorted>{:dn}` is a [General Operator](../concepts/essentialConcepts#component-types)
-component that locates a value within an **already sorted** list. It renders the
-position at which the `target` would have to be inserted for the list to stay sorted.
+component that locates values within an **already sorted** list. It renders the
+position at which each `target` would have to be inserted for the list to stay sorted.
 
 With the default `side="left"`, that position is the index of the first entry greater
 than or equal to the target. A target larger than every entry gives one past the end of
 the list.
+
+`target` may be a single value or a whole list of them, and the result has one position
+per target. One component maps a thousand samples onto their positions, which is what
+makes it usable on the output of `<sampleRandomNumbers>{:dn}` — see the sampling example
+below.
 
 Unlike [`<indexOf>{:dn}`](indexOf), the target need not appear in the list; this
 answers "where does it belong?", not "is it there?". Ordering is numeric when the list
@@ -22,7 +27,8 @@ is all numeric and alphabetical otherwise, so a sorted `<textList>{:dn}` works t
 Every position in a list is at least 1, so the result is 1 or more whenever there is a
 target to place and something to place it among. The two cases that give 0 instead are
 both reported: omitting `target` is a warning, since nothing about that document could
-ever produce an answer, and an empty list is an info message.
+ever produce an answer, and an empty list is an info message. (An empty *list of
+targets* is neither: it simply produces no positions.)
 
 <AttrPropDisplay name='searchSorted'/>
 
@@ -76,6 +82,40 @@ with [`<cumulativeSum>{:dn}`](cumulativeSum), draw uniformly from the total, the
 `<searchSorted>{:dn}` to find which bucket the draw landed in. Because every individual
 in the population is equally likely to be drawn, each subpopulation is selected in
 proportion to its size.
+
+
+
+---
+
+### Example: many draws at once
+
+
+```doenet-editor-horiz
+<setup>
+  <numberList name="pop">30 45 12 60</numberList>
+  <cumulativeSum name="cum">$pop</cumulativeSum>
+  <number name="total"><sum>$pop</sum></number>
+  <sampleRandomNumbers name="draws" type="discreteUniform"
+    from="1" to="$total" numSamples="20" />
+  <searchSorted name="which" target="$draws">$cum</searchSorted>
+</setup>
+
+<p>Individuals drawn: $draws</p>
+<p>Their subpopulations: $which</p>
+
+<callAction actionName="resample" target="$draws">
+  <label>Draw again</label>
+</callAction>
+```
+
+
+
+Raising `numSamples` here does not add searches: `target` takes the whole list of draws
+and one `<searchSorted>{:dn}` reports a subpopulation for each. Every result is still a
+component of its own, so the results grow with the sample — but wrapping the draws in a
+`<repeat>{:dn}` to search them one at a time would build a whole operator for every draw
+on top of that, which stops being practical long before the sample is large enough to be
+interesting.
 
 
 

--- a/packages/doenetml-worker-javascript/src/components/ListIndexOperators.js
+++ b/packages/doenetml-worker-javascript/src/components/ListIndexOperators.js
@@ -1,12 +1,15 @@
-import ListIndexBaseOperator, {
-    returnTargetAttribute,
-    returnTargetSearchingIndexOperator,
-    returnTargetStateVariableDefinition,
-} from "./abstract/ListIndexBaseOperator";
+import ListIndexBaseOperator from "./abstract/ListIndexBaseOperator";
+import ListIndexBaseListOperator from "./abstract/ListIndexBaseListOperator";
 import { compareExtractedValues } from "../utils/listValues";
 
 /**
- * Operators that report a position within a list. See `ListIndexBaseOperator`.
+ * Operators that report a position within a list.
+ *
+ * `<argMin>` and `<argMax>` need nothing but the list and report one index, so
+ * they are `<math>` components (`ListIndexBaseOperator`). `<indexOf>` and
+ * `<searchSorted>` search for a target, and since a target may be a list they
+ * report one index per target, so they are composites
+ * (`ListIndexBaseListOperator`).
  *
  * All indices are 1-based, matching `$list[1]`; `0` means "no such element".
  */
@@ -23,32 +26,20 @@ function returnConstantIndexOperatorDefinition(indexOperator) {
 }
 
 /**
- * The `indexOperator` state variable of an operator that searches the list for
- * the value of its `target` attribute — `<indexOf>` and `<searchSorted>`.
+ * The `locate` state variable of an operator that searches the list for one of
+ * the values of its `target` attribute — `<indexOf>` and `<searchSorted>`.
  *
- * `locate` is called with `{ values, target, numeric, dependencyValues }`;
- * `extraDependencies` names any further state variables it reads from the last
- * of those.
+ * `locate` is called with `{ values, target, numeric, dependencyValues }` once
+ * per target; `extraDependencies` names any further state variables it reads
+ * from the last of those.
  */
-function returnTargetSearchingIndexOperatorDefinition(
-    locate,
-    extraDependencies = {},
-) {
+function returnLocateDefinition(locate, extraDependencies = {}) {
     return {
-        returnDependencies: () => ({
-            comparableTarget: {
-                dependencyType: "stateVariable",
-                variableName: "comparableTarget",
-            },
-            ...extraDependencies,
-        }),
+        returnDependencies: () => ({ ...extraDependencies }),
         definition({ dependencyValues }) {
             return {
                 setValue: {
-                    indexOperator: returnTargetSearchingIndexOperator(
-                        dependencyValues.comparableTarget,
-                        (args) => locate({ ...args, dependencyValues }),
-                    ),
+                    locate: (args) => locate({ ...args, dependencyValues }),
                 },
             };
         },
@@ -114,65 +105,44 @@ export class ArgMax extends ListIndexBaseOperator {
     }
 }
 
-export class IndexOf extends ListIndexBaseOperator {
+export class IndexOf extends ListIndexBaseListOperator {
     static componentType = "indexOf";
 
     static componentDocs = {
         summary:
-            "The index of the first value in a list equal to a target, or 0 if there is none",
+            "The index of the first value in a list equal to each target, or 0 where there is none",
     };
 
-    static createAttributesObject() {
-        let attributes = super.createAttributesObject();
-
-        attributes.target = returnTargetAttribute("The value to look for.");
-
-        return attributes;
-    }
-
     static returnStateVariableDefinitions() {
-        return Object.assign(
-            super.returnStateVariableDefinitions(),
-            returnTargetStateVariableDefinition(),
-            {
-                indexOperator: returnTargetSearchingIndexOperatorDefinition(
-                    ({ values, target, numeric }) => {
-                        for (let [ind, value] of values.entries()) {
-                            if (
-                                compareExtractedValues(
-                                    value,
-                                    target,
-                                    numeric,
-                                ) === 0
-                            ) {
-                                return { index: ind + 1 };
-                            }
-                        }
-                        // A target that is not in the list is the documented
-                        // answer of `<indexOf>`, not a problem, so no reason
-                        // is attached and nothing is reported.
-                        return { index: 0 };
-                    },
-                ),
-            },
-        );
+        return Object.assign(super.returnStateVariableDefinitions(), {
+            locate: returnLocateDefinition(({ values, target, numeric }) => {
+                for (let [ind, value] of values.entries()) {
+                    if (compareExtractedValues(value, target, numeric) === 0) {
+                        return { index: ind + 1 };
+                    }
+                }
+                // A target that is not in the list is the documented answer of
+                // `<indexOf>`, not a problem, so no reason is attached and
+                // nothing is reported.
+                return { index: 0 };
+            }),
+        });
     }
 }
 
-export class SearchSorted extends ListIndexBaseOperator {
+export class SearchSorted extends ListIndexBaseListOperator {
     static componentType = "searchSorted";
 
     static componentDocs = {
         summary:
-            "The position at which a target would be inserted to keep a sorted list sorted",
+            "The position at which each target would be inserted to keep a sorted list sorted",
     };
+
+    static targetDescription =
+        "The value, or list of values, to locate within the sorted list.";
 
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
-
-        attributes.target = returnTargetAttribute(
-            "The value to locate within the sorted list.",
-        );
 
         attributes.side = {
             createComponentOfType: "text",
@@ -201,43 +171,38 @@ export class SearchSorted extends ListIndexBaseOperator {
     }
 
     static returnStateVariableDefinitions() {
-        return Object.assign(
-            super.returnStateVariableDefinitions(),
-            returnTargetStateVariableDefinition(),
-            {
-                indexOperator: returnTargetSearchingIndexOperatorDefinition(
-                    ({ values, target, numeric, dependencyValues }) => {
-                        // The number of entries that sort before the target,
-                        // plus one, is the 1-based position the target would
-                        // occupy. Counting rather than bisecting keeps the
-                        // result well defined even when the input is not
-                        // actually sorted.
-                        let count = 0;
-                        for (let value of values) {
-                            let comparison = compareExtractedValues(
-                                value,
-                                target,
-                                numeric,
-                            );
-                            if (
-                                comparison < 0 ||
-                                (dependencyValues.side === "right" &&
-                                    comparison === 0)
-                            ) {
-                                count++;
-                            }
+        return Object.assign(super.returnStateVariableDefinitions(), {
+            locate: returnLocateDefinition(
+                ({ values, target, numeric, dependencyValues }) => {
+                    // The number of entries that sort before the target, plus
+                    // one, is the 1-based position the target would occupy.
+                    // Counting rather than bisecting keeps the result well
+                    // defined even when the input is not actually sorted.
+                    let count = 0;
+                    for (let value of values) {
+                        let comparison = compareExtractedValues(
+                            value,
+                            target,
+                            numeric,
+                        );
+                        if (
+                            comparison < 0 ||
+                            (dependencyValues.side === "right" &&
+                                comparison === 0)
+                        ) {
+                            count++;
                         }
+                    }
 
-                        return { index: count + 1 };
+                    return { index: count + 1 };
+                },
+                {
+                    side: {
+                        dependencyType: "stateVariable",
+                        variableName: "side",
                     },
-                    {
-                        side: {
-                            dependencyType: "stateVariable",
-                            variableName: "side",
-                        },
-                    },
-                ),
-            },
-        );
+                },
+            ),
+        });
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/abstract/ListIndexBaseListOperator.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/ListIndexBaseListOperator.js
@@ -1,0 +1,266 @@
+import CompositeComponent from "./CompositeComponent";
+import me from "math-expressions";
+import {
+    returnBreakStringsIntoTypeSugarInstruction,
+    returnListValueStateVariableDefinitions,
+} from "../../utils/listValues";
+import {
+    diagnosticsForNoIndices,
+    locateEachTarget,
+    returnComparableTargetsStateVariableDefinition,
+    returnListTypeAttribute,
+    returnTargetAttribute,
+} from "../../utils/listIndexOperators";
+import {
+    addReplacementRendererType,
+    calculateValueListReplacementChanges,
+    createValueListReplacements,
+    returnPassThroughAttributeDeclarations,
+    returnPassThroughAttributes,
+} from "../../utils/valueListReplacements";
+
+/**
+ * Base class for the index-returning operators that search the list for a
+ * value the author supplies: `<indexOf>` and `<searchSorted>`.
+ *
+ * These take a *list* of targets and report one 1-based index per target, in
+ * the manner of `np.searchsorted(a, v)` with an array `v` and R's `match()`.
+ * One target in, one index out, so the common scalar reading still works; a
+ * hundred targets in, a hundred indices out of one operator rather than a
+ * hundred operators. The hundred indices are themselves a hundred `<math>`
+ * replacements — what one operator saves is the searching, not the results.
+ *
+ * Returning a list is what makes these composites rather than `<math>`
+ * components, so they follow `MathBaseListOperator` (fresh `<math>`
+ * replacements, in the manner of `<sequence>`) rather than
+ * `ListIndexBaseOperator`, which stays the home of the operators that report a
+ * single position and need no target — `<argMin>` and `<argMax>`.
+ *
+ * Being a composite is what makes `$which[2]`, `<sum>$which</sum>` and
+ * `<numberList>$which</numberList>` all work on the result, and a single-target
+ * operator still reads as one math wherever one is expected — including as a
+ * path index, so `$pop[$which]` keeps working now that `<searchSorted>` is a
+ * composite rather than a `<math>`.
+ *
+ * The replacements are `<math>` rather than the `<number>` that `<sortIndices>`
+ * creates: an index is an integer either way, but these operators rendered as
+ * `<math>` before they returned a list, and their `<argMin>` / `<argMax>` /
+ * `<count>` siblings still do, so `<math>` keeps one family rendering one way.
+ *
+ * Like `<sort>`, these accept anything with a comparable value, not only maths
+ * and numbers: finding the position of a name in a `<textList>` is at least as
+ * common as finding a value in a `<numberList>`. The shared extraction in
+ * `utils/listValues` is what keeps those comparisons identical to `<sort>`'s.
+ *
+ * Indices are 1-based, matching `$list[1]`, and `0` means "no such element" —
+ * consistent with `$list[0]` being empty.
+ *
+ * Subclasses supply `locate`, which receives `{ values, target, numeric }` for
+ * one target and returns `{ index, reason? }`.
+ */
+export default class ListIndexBaseListOperator extends CompositeComponent {
+    static componentType = "_listIndexListOperator";
+
+    static takesIndex = true;
+
+    static stateVariableToEvaluateAfterReplacements =
+        "readyToExpandWhenResolved";
+
+    static allowInSchemaAsComponent = ["math"];
+
+    // Since the operator treats each child as a separate argument,
+    // composites with no replacement should be ignored.
+    static descendantCompositesMustHaveAReplacement = false;
+
+    // The reference pages show this text, and the two operators do not mean
+    // the same thing by `target`: `<indexOf>` looks its target up in the list,
+    // which is the wording below, while `<searchSorted>` places a target that
+    // need not be in the list at all and overrides it.
+    static targetDescription = "The value, or list of values, to look for.";
+
+    static createAttributesObject() {
+        let attributes = super.createAttributesObject();
+
+        // `createStateVariable` matters here in a way it does not for the
+        // scalar operators. The `target` attribute is a
+        // `_componentListWithSelectableType`, whose own `type` falls back to a
+        // `parentStateVariable` named `type` — so without a `type` state
+        // variable on the operator, `<indexOf type="text" target="Cal">` would
+        // convert its target with the default numeric reading and compare NaN.
+        attributes.type = {
+            ...returnListTypeAttribute({ readsTarget: true }),
+            createStateVariable: "type",
+            defaultValue: null,
+        };
+
+        attributes.target = returnTargetAttribute(this.targetDescription);
+
+        // Not used by the composite itself; forwarded to each `<math>` it
+        // creates, so `displayDigits` on the operator rounds every index.
+        Object.assign(attributes, returnPassThroughAttributeDeclarations());
+
+        attributes.asList = {
+            createPrimitiveOfType: "boolean",
+            createStateVariable: "asList",
+            defaultValue: true,
+            highlighted: true,
+            description:
+                "Whether to render the items separated by commas (true) or with no separator (false).",
+        };
+
+        return attributes;
+    }
+
+    // Include children that can be added due to sugar
+    static additionalSchemaChildren = ["string"];
+
+    static returnSugarInstructions() {
+        let sugarInstructions = super.returnSugarInstructions();
+
+        sugarInstructions.push(
+            returnBreakStringsIntoTypeSugarInstruction(this.componentType),
+        );
+
+        return sugarInstructions;
+    }
+
+    static returnChildGroups() {
+        return [
+            {
+                group: "anything",
+                componentTypes: ["_base"],
+            },
+        ];
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        // `this` is the class here, so a subclass names itself in its own
+        // diagnostics; inside a `definition` it would not be.
+        const componentType = this.componentType;
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListValueStateVariableDefinitions({
+                componentName: this.componentType,
+                supportProps: false,
+            }),
+            returnComparableTargetsStateVariableDefinition(),
+        );
+
+        // Overridden by subclasses. Searches `values` for one `target` and
+        // returns `{ index, reason? }`; `reason` explains a zero so the base
+        // can raise the right diagnostic.
+        stateVariableDefinitions.locate = {
+            returnDependencies: () => ({}),
+            definition: () => ({
+                setValue: { locate: () => ({ index: 0 }) },
+            }),
+        };
+
+        stateVariableDefinitions.operatorResults = {
+            returnDependencies: () => ({
+                listValues: {
+                    dependencyType: "stateVariable",
+                    variableName: "listValues",
+                },
+                allAreNumeric: {
+                    dependencyType: "stateVariable",
+                    variableName: "allAreNumeric",
+                },
+                comparableTargets: {
+                    dependencyType: "stateVariable",
+                    variableName: "comparableTargets",
+                },
+                locate: {
+                    dependencyType: "stateVariable",
+                    variableName: "locate",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const results = locateEachTarget({
+                    values: dependencyValues.listValues,
+                    targets: dependencyValues.comparableTargets,
+                    numeric: dependencyValues.allAreNumeric,
+                    locate: dependencyValues.locate,
+                });
+
+                return {
+                    setValue: {
+                        operatorResults: results.map((result) =>
+                            me.fromAst(result.index),
+                        ),
+                    },
+                    sendDiagnostics: diagnosticsForNoIndices(
+                        results,
+                        componentType,
+                    ),
+                };
+            },
+        };
+
+        stateVariableDefinitions.readyToExpandWhenResolved = {
+            returnDependencies: () => ({
+                operatorResults: {
+                    dependencyType: "stateVariable",
+                    variableName: "operatorResults",
+                },
+            }),
+            // When this state variable is marked stale it indicates we should
+            // update replacements. For this to work, we must get its value in
+            // the replacement functions so that the variable is marked fresh.
+            markStale: () => ({ updateReplacements: true }),
+            definition: function () {
+                return { setValue: { readyToExpandWhenResolved: true } };
+            },
+        };
+
+        return stateVariableDefinitions;
+    }
+
+    static async createSerializedReplacements({
+        component,
+        componentInfoObjects,
+        workspace,
+        nComponents,
+    }) {
+        return createValueListReplacements({
+            component,
+            values: await component.stateValues.operatorResults,
+            componentType: "math",
+            attributesToConvert: returnPassThroughAttributes(component),
+            componentInfoObjects,
+            workspace,
+            nComponents,
+        });
+    }
+
+    static async calculateReplacementChanges({
+        component,
+        componentInfoObjects,
+        workspace,
+        nComponents,
+    }) {
+        return calculateValueListReplacementChanges({
+            component,
+            values: await component.stateValues.operatorResults,
+            componentType: "math",
+            attributesToConvert: returnPassThroughAttributes(component),
+            componentInfoObjects,
+            workspace,
+            nComponents,
+        });
+    }
+
+    addOwnPotentialRendererTypes(rendererTypes, visited) {
+        super.addOwnPotentialRendererTypes(rendererTypes, visited);
+
+        // The replacements are `<math>` components whatever the children are.
+        addReplacementRendererType({
+            component: this,
+            componentType: "math",
+            rendererTypes,
+        });
+    }
+}

--- a/packages/doenetml-worker-javascript/src/components/abstract/ListIndexBaseOperator.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/ListIndexBaseOperator.js
@@ -1,64 +1,29 @@
 import MathComponent from "../Math";
 import me from "math-expressions";
-import { codedDiagnostic } from "../../utils/diagnostics";
 import { returnNumberDisplayStateVariableDefinitions } from "../../utils/numberDisplay";
 import {
-    comparableValueFromRaw,
     returnBreakStringsIntoTypeSugarInstruction,
     returnListValueStateVariableDefinitions,
 } from "../../utils/listValues";
+import {
+    diagnosticsForNoIndex,
+    returnListTypeAttribute,
+} from "../../utils/listIndexOperators";
 
 /**
- * The reasons an index operator can come back with 0 — no position at all —
- * that are worth telling the author about, and the diagnostic each one gets.
+ * Base class for operators that report a single *position* within a list
+ * rather than a value from it: `<argMin>` and `<argMax>`.
  *
- * Not every 0 belongs here. `<indexOf>` answering 0 for a target that is not in
- * the list is its documented result, not a problem, and reporting it would fire
- * on ordinary correct documents — once per distinct value a student or author
- * types into an input bound to `target`. The diagnostics queue is append-only
- * and deduplicates by message, so anything that varies with a transient value
- * accumulates permanently; only reasons that stay true of a settled document
- * are reported.
+ * The result is one index, so — like `<count>` — these are math components
+ * whose value is computed from their children. The operators that search for a
+ * *target* report one index per target and so are composites; they live in
+ * `ListIndexBaseListOperator`. What the two bases share is in
+ * `utils/listIndexOperators`.
  *
- * Omitting `target` is one such: nothing about that document can ever produce
- * an answer, so it is a warning. Having no values at all is the other, and is
- * only info, since a list driven by an input can legitimately be empty for a
- * while.
- */
-function diagnosticsForNoIndex(result, componentType) {
-    switch (result.reason) {
-        case "noTarget":
-            return [
-                codedDiagnostic({
-                    type: "warning",
-                    code: "doenet-w0134",
-                    args: { component: componentType },
-                }),
-            ];
-        case "noValues":
-            return [
-                codedDiagnostic({
-                    type: "info",
-                    code: "doenet-i0049",
-                    args: { component: componentType },
-                }),
-            ];
-        default:
-            return [];
-    }
-}
-
-/**
- * Base class for operators that report a *position* within a list rather than
- * a value from it: `<argMin>`, `<argMax>`, `<indexOf>`, `<searchSorted>`.
- *
- * The result is an index, so — like `<count>` — these are math components whose
- * value is computed from their children. But unlike `MathBaseOperator`, which
- * only accepts math and number children, these accept anything `<sort>` accepts.
- * Finding the position of a name in a `<textList>` is at least as common as
- * finding a value in a `<numberList>`, and ordering comparisons on text are
- * perfectly well defined; the shared extraction in `utils/listValues` is what
- * keeps those comparisons identical to `<sort>`'s.
+ * Unlike `MathBaseOperator`, which only accepts math and number children, these
+ * accept anything `<sort>` accepts. Ordering comparisons on text are perfectly
+ * well defined, and the shared extraction in `utils/listValues` is what keeps
+ * those comparisons identical to `<sort>`'s.
  *
  * Indices are 1-based, matching `$list[1]`, and `0` means "no such element" —
  * consistent with `$list[0]` being empty.
@@ -78,34 +43,7 @@ export default class ListIndexBaseOperator extends MathComponent {
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
 
-        attributes.type = {
-            createPrimitiveOfType: "string",
-            description:
-                "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
-            highlighted: true,
-            validValues: [
-                {
-                    value: "number",
-                    description:
-                        "Read bare strings as numbers, ordered by value.",
-                },
-                {
-                    value: "math",
-                    description:
-                        "Read bare strings as math expressions, ordered by value.",
-                },
-                {
-                    value: "text",
-                    description:
-                        "Read bare strings as text, ordered alphabetically.",
-                },
-                {
-                    value: "boolean",
-                    description:
-                        "Read bare strings as booleans, ordered with false before true.",
-                },
-            ],
-        };
+        attributes.type = returnListTypeAttribute();
 
         // `<math>` highlights these because they shape the expression it parses
         // and renders. The value here is an integer index, so how the input is
@@ -225,12 +163,10 @@ export default class ListIndexBaseOperator extends MathComponent {
                     numeric: dependencyValues.allAreNumeric,
                 });
 
-                const index = result.index;
-
                 return {
-                    setValue: { unnormalizedValue: me.fromAst(index) },
+                    setValue: { unnormalizedValue: me.fromAst(result.index) },
                     sendDiagnostics: diagnosticsForNoIndex(
-                        result,
+                        result.reason,
                         componentType,
                     ),
                 };
@@ -239,66 +175,4 @@ export default class ListIndexBaseOperator extends MathComponent {
 
         return stateVariableDefinitions;
     }
-}
-
-/**
- * Shared pieces for the two operators that compare the list against a value
- * supplied by the author: `<indexOf>` and `<searchSorted>`.
- *
- * The target is a `_componentWithSelectableType`, so it follows the component's
- * own `type` attribute: `<indexOf type="text" target="Carol">` compares text.
- */
-export function returnTargetAttribute(description) {
-    return {
-        createComponentOfType: "_componentWithSelectableType",
-        createStateVariable: "target",
-        defaultValue: null,
-        description,
-        highlighted: true,
-    };
-}
-
-export function returnTargetStateVariableDefinition() {
-    return {
-        comparableTarget: {
-            returnDependencies: () => ({
-                target: {
-                    dependencyType: "stateVariable",
-                    variableName: "target",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        comparableTarget: comparableValueFromRaw(
-                            dependencyValues.target,
-                        ),
-                    },
-                };
-            },
-        },
-    };
-}
-
-/**
- * Turn `locate`, which searches `values` for `target`, into an `indexOperator`,
- * supplying the two things both target-taking operators need: no target means
- * no answer, so the result is 0; and the comparison is numeric only when the
- * target is numeric as well as the list, so that
- * `<indexOf target="b">a b c</indexOf>` compares as text.
- */
-export function returnTargetSearchingIndexOperator(target, locate) {
-    return ({ values, numeric }) => {
-        if (target === null) {
-            return { index: 0, reason: "noTarget" };
-        }
-        if (values.length === 0) {
-            return { index: 0, reason: "noValues" };
-        }
-        return locate({
-            values,
-            target,
-            numeric: numeric && target.isNumeric,
-        });
-    };
 }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/listoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/listoperators.test.ts
@@ -458,6 +458,36 @@ describe("List operator tag tests @group4", async () => {
             ).eq(true);
         });
 
+        it("many targets with nothing to look through report once", async () => {
+            // The reason is a property of the document, not of each target, so
+            // five targets say it once rather than five times.
+            const { infos } = await messagesFor(
+                `
+    <numberList name="targets">1 2 3 4 5</numberList>
+    <p><searchSorted target="$targets"></searchSorted></p>
+    `,
+            );
+            expect(
+                infos.filter((m) => m.includes("has no values to look through"))
+                    .length,
+            ).eq(1);
+        });
+
+        it("an empty list of targets is not reported", async () => {
+            // Unlike omitting `target`, which can never produce an answer, an
+            // empty list is a list: it asks about nothing and gets nothing, and
+            // a list driven by an input can legitimately be empty for a while.
+            const { warnings, infos } = await messagesFor(`
+    <numberList name="nl">10 20 30</numberList>
+    <numberList name="none" />
+    <p><indexOf target="$none">$nl</indexOf></p>
+    `);
+            const mine = (m: string) =>
+                m.includes("look for") || m.includes("look through");
+            expect(warnings.filter(mine)).eqls([]);
+            expect(infos.filter(mine)).eqls([]);
+        });
+
         it("an operator that finds an index reports nothing", async () => {
             const { warnings, infos } = await messagesFor(`
     <numberList name="nl">10 20 30</numberList>
@@ -731,6 +761,197 @@ describe("List operator tag tests @group4", async () => {
                 resolvePathToNodeIdx,
                 name: "p147",
                 text: "4",
+            });
+        });
+
+        it("a list of targets gives one index per target", async () => {
+            // The whole point of vectorizing `target`: mapping M draws onto
+            // their subpopulations takes one search operator, not M. The M
+            // results are still M `<math>` replacements.
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <numberList name="pop">30 45 12 60</numberList>
+    <cumulativeSum name="cum">$pop</cumulativeSum>
+    <numberList name="draws">1 30 31 88 147</numberList>
+    <searchSorted name="which" side="left" target="$draws">$cum</searchSorted>
+    <p name="pAll">$which</p>
+    <p name="pThird">$which[3]</p>
+    <p name="pSum"><sum>$which</sum></p>
+    <numberList name="asNumbers">$which</numberList>
+    `,
+            });
+
+            // individuals 1-30 are in subpopulation 1, 31-75 in 2,
+            // 76-87 in 3, 88-147 in 4
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pAll",
+                text: "1, 1, 2, 4, 4",
+            });
+
+            // The result is a composite, so it indexes and aggregates like any
+            // other list.
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pThird",
+                text: "2",
+            });
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pSum",
+                text: "12",
+            });
+
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("asNumbers")]
+                    .stateValues.numbers,
+            ).eqls([1, 1, 2, 4, 4]);
+        });
+
+        it("a single target still reads as one index", async () => {
+            // Returning a list made these composites, so the scalar reading —
+            // rendering inline, and indexing another list with the result —
+            // has to keep working.
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <numberList name="pop">30 45 12 60</numberList>
+    <cumulativeSum name="cum">$pop</cumulativeSum>
+    <searchSorted name="i" side="left" target="31">$cum</searchSorted>
+    <p name="pIndex">$i</p>
+    <p name="pIndexed">$pop[$i]</p>
+    <p name="pInline">Individual 31 is in subpopulation $i.</p>
+    `,
+            });
+
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pIndex",
+                text: "2",
+            });
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pIndexed",
+                text: "45",
+            });
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pInline",
+                text: "Individual 31 is in subpopulation 2.",
+            });
+        });
+
+        it("indexOf over a list of text targets", async () => {
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <textList name="names">Ann Bob Cal Dee</textList>
+    <textList name="wanted">Cal Ann Eve</textList>
+    <p name="pFound"><indexOf type="text" target="$wanted">$names</indexOf></p>
+    `,
+            });
+
+            // Eve is not in the list, so her slot is 0 while the others keep
+            // their positions — one index per target, absences included.
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pFound",
+                text: "3, 1, 0",
+            });
+        });
+
+        it("an empty list of targets gives no indices", async () => {
+            // Distinct from omitting `target` altogether, which gives a single
+            // 0 and a warning: an empty list is a list, and produces nothing.
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <numberList name="nl">10 20 30</numberList>
+    <numberList name="none" />
+    <p name="pEmpty"><indexOf target="$none">$nl</indexOf></p>
+    `,
+            });
+
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pEmpty",
+                text: "",
+            });
+        });
+
+        it("changing the number of targets adds and removes indices", async () => {
+            // The replacements have to be recalculated, not just revalued,
+            // when the number of targets changes — and a list that empties has
+            // to give nothing back rather than a stale index or a 0.
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <numberList name="cutoffs">10 20 30</numberList>
+    <mathInput name="n" prefill="2" />
+    <numberList name="targets">
+      <repeatForSequence from="1" to="$n" valueName="v"><number>$v * 12</number></repeatForSequence>
+    </numberList>
+    <p name="pWhich"><searchSorted target="$targets">$cutoffs</searchSorted></p>
+    `,
+            });
+
+            // 12 sorts after 10, 24 after 20
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pWhich",
+                text: "2, 3",
+            });
+
+            await updateMathInputValue({
+                latex: "4",
+                componentIdx: await resolvePathToNodeIdx("n"),
+                core,
+            });
+
+            // 36 is past every cutoff, so it would be inserted at position 4
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pWhich",
+                text: "2, 3, 4, 4",
+            });
+
+            // Emptying the list withholds every replacement: no targets, no
+            // positions — not a 0, which would claim to be an answer.
+            await updateMathInputValue({
+                latex: "0",
+                componentIdx: await resolvePathToNodeIdx("n"),
+                core,
+            });
+
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pWhich",
+                text: "",
+            });
+
+            // and the withheld replacements come back when it refills
+            await updateMathInputValue({
+                latex: "3",
+                componentIdx: await resolvePathToNodeIdx("n"),
+                core,
+            });
+
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pWhich",
+                text: "2, 3, 4",
             });
         });
 
@@ -1120,6 +1341,22 @@ describe("List operator tag tests @group4", async () => {
             });
 
             expect(core.core!.rendererTypesInDocument).toContain("number");
+        });
+
+        it("searchSorted declares the math renderer with no targets", async () => {
+            // An operator that searches for a list of targets starts with no
+            // replacements whenever that list is empty, so it too has to
+            // declare what its results will be rendered as. Nothing else here
+            // is a math, so the renderer can only have come from the operator.
+            let { core } = await createTestCore({
+                doenetML: `
+    <numberList name="cutoffs">10 20 30</numberList>
+    <numberList name="none" />
+    <searchSorted target="$none">$cutoffs</searchSorted>
+    `,
+            });
+
+            expect(core.core!.rendererTypesInDocument).toContain("math");
         });
     });
 });

--- a/packages/doenetml-worker-javascript/src/utils/listIndexOperators.js
+++ b/packages/doenetml-worker-javascript/src/utils/listIndexOperators.js
@@ -1,0 +1,208 @@
+import { codedDiagnostic } from "./diagnostics";
+import { comparableValueFromRaw } from "./listValues";
+
+/**
+ * Pieces shared by the two shapes of index-returning operator.
+ *
+ * `<argMin>` and `<argMax>` report a single position and stay `<math>`
+ * components (`abstract/ListIndexBaseOperator`). `<indexOf>` and
+ * `<searchSorted>` report one position per target and so are composites
+ * (`abstract/ListIndexBaseListOperator`). The two bases have different
+ * superclasses and cannot share code by inheritance, so what they genuinely
+ * have in common lives here — the same arrangement `utils/mathOperatorChildren`
+ * uses for `MathBaseOperator` and `MathBaseListOperator`.
+ */
+
+/**
+ * The `type` attribute both bases declare: which component type bare string
+ * children are read as.
+ *
+ * `readsTarget` adds the second half of the story, and only the operators that
+ * have a `target` may pass it: their target has no type of its own, so it is
+ * read as this `type` too. Saying that on `<argMin>`, which takes no target,
+ * would point the author at an attribute the component does not have.
+ */
+export function returnListTypeAttribute({ readsTarget = false } = {}) {
+    return {
+        createPrimitiveOfType: "string",
+        description: readsTarget
+            ? "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own."
+            : "Component type to interpret bare string children as.",
+        highlighted: true,
+        validValues: [
+            {
+                value: "number",
+                description: "Read bare strings as numbers, ordered by value.",
+            },
+            {
+                value: "math",
+                description:
+                    "Read bare strings as math expressions, ordered by value.",
+            },
+            {
+                value: "text",
+                description:
+                    "Read bare strings as text, ordered alphabetically.",
+            },
+            {
+                value: "boolean",
+                description:
+                    "Read bare strings as booleans, ordered with false before true.",
+            },
+        ],
+    };
+}
+
+/**
+ * The reasons an index operator can come back with 0 — no position at all —
+ * that are worth telling the author about, and the diagnostic each one gets.
+ *
+ * Not every 0 belongs here. `<indexOf>` answering 0 for a target that is not in
+ * the list is its documented result, not a problem, and reporting it would fire
+ * on ordinary correct documents — once per distinct value a student or author
+ * types into an input bound to `target`. The diagnostics queue is append-only
+ * and deduplicates by message, so anything that varies with a transient value
+ * accumulates permanently; only reasons that stay true of a settled document
+ * are reported.
+ *
+ * Omitting `target` is one such: nothing about that document can ever produce
+ * an answer, so it is a warning. Having no values at all is the other, and is
+ * only info, since a list driven by an input can legitimately be empty for a
+ * while.
+ *
+ * An empty *list* of targets is a third case, and gets no message at all: it
+ * produces no indices rather than a 0, so there is no misleading result to
+ * explain, and a list driven by an input is empty on the way to being filled.
+ */
+export function diagnosticsForNoIndex(reason, componentType) {
+    switch (reason) {
+        case "noTarget":
+            return [
+                codedDiagnostic({
+                    type: "warning",
+                    code: "doenet-w0134",
+                    args: { component: componentType },
+                }),
+            ];
+        case "noValues":
+            return [
+                codedDiagnostic({
+                    type: "info",
+                    code: "doenet-i0049",
+                    args: { component: componentType },
+                }),
+            ];
+        default:
+            return [];
+    }
+}
+
+/**
+ * Collapse the per-target diagnostics of a whole run into one set.
+ *
+ * The reasons are properties of the document, not of individual targets — an
+ * absent `target` attribute or an empty list is the same fact however many
+ * targets there are — so reporting one diagnostic per target would say the
+ * same thing N times. `codedDiagnostic` dedupes by message downstream, but
+ * building N of them to throw N-1 away is wasteful when N is the sample size.
+ */
+export function diagnosticsForNoIndices(results, componentType) {
+    const reasons = new Set();
+    for (const result of results) {
+        if (result?.reason) {
+            reasons.add(result.reason);
+        }
+    }
+
+    return [...reasons].flatMap((reason) =>
+        diagnosticsForNoIndex(reason, componentType),
+    );
+}
+
+/**
+ * The `target` attribute of `<indexOf>` and `<searchSorted>`.
+ *
+ * It is a `_componentListWithSelectableType`, so it follows the component's own
+ * `type` attribute (`<indexOf type="text" target="Carol">` compares text) and
+ * accepts either one value or a list of them. One target in, one index out;
+ * a hundred targets in, a hundred indices out.
+ */
+export function returnTargetAttribute(description) {
+    return {
+        createComponentOfType: "_componentListWithSelectableType",
+        description,
+        highlighted: true,
+    };
+}
+
+/**
+ * `comparableTargets` — the target attribute's values in the same comparable
+ * form `utils/listValues` puts the list's own children into, so the comparison
+ * between a target and a list entry is the one `<sort>` would make.
+ *
+ * `null` (rather than an empty array) means the attribute was not given at all,
+ * which is the case that earns a warning; an empty array means it was given and
+ * is currently empty, which does not.
+ */
+export function returnComparableTargetsStateVariableDefinition() {
+    return {
+        comparableTargets: {
+            returnDependencies: () => ({
+                targetAttr: {
+                    dependencyType: "attributeComponent",
+                    attributeName: "target",
+                    variableNames: ["values"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                if (dependencyValues.targetAttr === null) {
+                    return { setValue: { comparableTargets: null } };
+                }
+
+                return {
+                    setValue: {
+                        comparableTargets:
+                            dependencyValues.targetAttr.stateValues.values.map(
+                                comparableValueFromRaw,
+                            ),
+                    },
+                };
+            },
+        },
+    };
+}
+
+/**
+ * Run `locate` once per target, supplying the two guards both target-taking
+ * operators need: nothing to look for means no answer, so the result is 0; and
+ * the comparison is numeric only when the target is numeric as well as the
+ * list, so that `<indexOf target="b">a b c</indexOf>` compares as text.
+ *
+ * The three arities are distinct. No `target` attribute at all (`null`) is one
+ * unanswerable question, so it gets one 0 and one warning — the same result the
+ * operator gave before `target` became a list. An empty list of targets asks
+ * nothing and gets nothing: no indices, and no message. Otherwise there is one
+ * result per target, whether or not each target turns out to be in the list.
+ */
+export function locateEachTarget({ values, targets, numeric, locate }) {
+    if (targets === null) {
+        return [{ index: 0, reason: "noTarget" }];
+    }
+
+    return targets.map((target) => {
+        // A target whose value came to nothing — a reference that resolved to
+        // no component — is nothing to look for, so it reads as a missing
+        // target rather than as a value absent from the list.
+        if (target === null) {
+            return { index: 0, reason: "noTarget" };
+        }
+        if (values.length === 0) {
+            return { index: 0, reason: "noValues" };
+        }
+        return locate({
+            values,
+            target,
+            numeric: numeric && target.isNumeric,
+        });
+    });
+}

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -365,9 +365,10 @@ export function returnListValueStateVariableDefinitions({
 
 /**
  * The comparable form of a value that did not come from a child component —
- * in practice, the `target` attribute of `<indexOf>` / `<searchSorted>`, which
- * is a `_componentWithSelectableType` and so can arrive as a number, a string,
- * a math-expression or a boolean.
+ * in practice, one value of the `target` attribute of `<indexOf>` /
+ * `<searchSorted>`, which is a `_componentListWithSelectableType` and so
+ * yields a list whose entries can each be a number, a string, a
+ * math-expression or a boolean.
  */
 export function comparableValueFromRaw(value) {
     if (value === null || value === undefined) {

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -39616,8 +39616,7 @@
                 "fixed": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
+                        "string"
                     ]
                 },
                 "fixLocation": {
@@ -39652,30 +39651,19 @@
                         "string"
                     ]
                 },
-                "format": {
+                "type": {
                     "optional": true,
                     "type": [
+                        "number",
+                        "math",
                         "text",
-                        "latex"
+                        "boolean"
                     ]
                 },
-                "simplify": {
+                "target": {
                     "optional": true,
                     "type": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ]
-                },
-                "expand": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
+                        "string"
                     ]
                 },
                 "displayDigits": {
@@ -39699,130 +39687,20 @@
                 "padZeros": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
+                        "string"
                     ]
                 },
                 "avoidScientificNotation": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "renderMode": {
-                    "optional": true,
-                    "type": [
-                        "inline",
-                        "display"
-                    ]
-                },
-                "unordered": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "createVectors": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "createIntervals": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "functionSymbols": {
-                    "optional": true,
-                    "type": [
                         "string"
                     ]
                 },
-                "referencesAreFunctionSymbols": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "splitSymbols": {
+                "asList": {
                     "optional": true,
                     "type": [
                         "true",
                         "false"
-                    ]
-                },
-                "parseScientificNotation": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "displayBlanks": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "assumptions": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "draggable": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "layer": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "anchor": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "positionFromAnchor": {
-                    "optional": true,
-                    "type": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ]
-                },
-                "type": {
-                    "optional": true,
-                    "type": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ]
-                },
-                "target": {
-                    "optional": true,
-                    "type": [
-                        "string"
                     ]
                 }
             },
@@ -40569,348 +40447,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
                     "name": "doenetML",
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph."
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "indexOf",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none."
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
                 }
             ]
         },
@@ -40941,8 +40481,7 @@
                 "fixed": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
+                        "string"
                     ]
                 },
                 "fixLocation": {
@@ -40977,30 +40516,19 @@
                         "string"
                     ]
                 },
-                "format": {
+                "type": {
                     "optional": true,
                     "type": [
+                        "number",
+                        "math",
                         "text",
-                        "latex"
+                        "boolean"
                     ]
                 },
-                "simplify": {
+                "target": {
                     "optional": true,
                     "type": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ]
-                },
-                "expand": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
+                        "string"
                     ]
                 },
                 "displayDigits": {
@@ -41024,130 +40552,20 @@
                 "padZeros": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
+                        "string"
                     ]
                 },
                 "avoidScientificNotation": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "renderMode": {
-                    "optional": true,
-                    "type": [
-                        "inline",
-                        "display"
-                    ]
-                },
-                "unordered": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "createVectors": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "createIntervals": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "functionSymbols": {
-                    "optional": true,
-                    "type": [
                         "string"
                     ]
                 },
-                "referencesAreFunctionSymbols": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "splitSymbols": {
+                "asList": {
                     "optional": true,
                     "type": [
                         "true",
                         "false"
-                    ]
-                },
-                "parseScientificNotation": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "displayBlanks": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "assumptions": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "draggable": {
-                    "optional": true,
-                    "type": [
-                        "true",
-                        "false"
-                    ]
-                },
-                "layer": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "anchor": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "positionFromAnchor": {
-                    "optional": true,
-                    "type": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ]
-                },
-                "type": {
-                    "optional": true,
-                    "type": [
-                        "number",
-                        "math",
-                        "text",
-                        "boolean"
-                    ]
-                },
-                "target": {
-                    "optional": true,
-                    "type": [
-                        "string"
                     ]
                 },
                 "side": {
@@ -41901,104 +41319,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "side",
                     "type": "text",
                     "isArray": false,
@@ -42006,250 +41326,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
                     "name": "doenetML",
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph."
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "searchSorted",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none."
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
                 }
             ]
         },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -158,7 +158,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_textOrInline",
                 "_inline",
@@ -403,7 +403,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -1322,7 +1322,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -1798,7 +1798,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -4229,7 +4229,7 @@
                 "ol",
                 "ul"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222211221111122200",
+            "childBuckets": "111111111111111111111111111111111111111111222221122111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222211221111122200",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -5102,7 +5102,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -5545,7 +5545,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -5988,7 +5988,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -7007,7 +7007,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -7419,7 +7419,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "122221111111111111111111111222221111222122222122020222212222201221222212222221112221211222221111111110212120",
+            "childBuckets": "122221111111111111111111111222221122222122222122020222212222201221222212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_booleanOperatorOneInput",
                 "_inline",
@@ -9828,7 +9828,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -10292,7 +10292,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -10756,7 +10756,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_booleanOperatorOfMath",
                 "_inline",
@@ -11250,7 +11250,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -12140,7 +12140,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -13030,7 +13030,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -13912,7 +13912,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -14794,7 +14794,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -15676,7 +15676,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -16545,7 +16545,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -17385,7 +17385,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -18241,7 +18241,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -19097,7 +19097,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -19953,7 +19953,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -20809,7 +20809,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -21699,7 +21699,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -22589,7 +22589,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -23496,7 +23496,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -24403,7 +24403,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -25293,7 +25293,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -26183,7 +26183,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -27073,7 +27073,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -27963,7 +27963,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -28853,7 +28853,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperator",
                 "_inline",
@@ -29743,7 +29743,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_mathOperatorOneInput",
                 "_inline",
@@ -30660,7 +30660,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathListOperator",
                 "_composite",
@@ -30933,7 +30933,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathListOperator",
                 "_composite",
@@ -31206,7 +31206,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathListOperator",
                 "_composite",
@@ -31479,7 +31479,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathListOperator",
                 "_composite",
@@ -31752,7 +31752,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222201221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222201221222212222221222221212222",
             "abstractAncestors": [
                 "_mathListOperator",
                 "_composite",
@@ -32549,7 +32549,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
+                    "description": "Component type to interpret bare string children as.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -33573,7 +33573,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
+                    "description": "Component type to interpret bare string children as.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -34224,8 +34224,8 @@
             ],
             "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
-                "_listIndexOperator",
-                "_inline",
+                "_listIndexListOperator",
+                "_composite",
                 "_base"
             ],
             "attributes": [
@@ -34257,12 +34257,7 @@
                 {
                     "name": "fixed",
                     "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
+                    "defaultValue": false
                 },
                 {
                     "name": "fixLocation",
@@ -34301,304 +34296,10 @@
                     "type": "reference"
                 },
                 {
-                    "name": "format",
-                    "description": "Input format.",
-                    "defaultValue": "text",
-                    "values": [
-                        "text",
-                        "latex"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "text",
-                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
-                        },
-                        {
-                            "value": "latex",
-                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "simplify",
-                    "description": "Level of simplification applied to the expression.",
-                    "defaultValue": "none",
-                    "values": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "none",
-                            "description": "No simplification is applied."
-                        },
-                        {
-                            "value": "full",
-                            "description": "Fully simplify the expression."
-                        },
-                        {
-                            "value": "numbers",
-                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
-                        },
-                        {
-                            "value": "numbersPreserveOrder",
-                            "description": "Like `numbers`, but does not reorder commutative operands."
-                        },
-                        {
-                            "value": "normalizeOrder",
-                            "description": "Reorder commutative operands into a canonical form without simplifying values."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "expand",
-                    "description": "Whether to expand the expression.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 3,
-                    "type": "integer"
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 2,
-                    "type": "integer"
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero.",
-                    "groupName": "number-display",
-                    "defaultValue": 1e-14,
-                    "type": "number"
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "renderMode",
-                    "description": "How the math is rendered.",
-                    "defaultValue": "inline",
-                    "values": [
-                        "inline",
-                        "display"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "inline",
-                            "description": "Render inline with the surrounding text."
-                        },
-                        {
-                            "value": "display",
-                            "description": "Render as a centered equation on its own line."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "unordered",
-                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createVectors",
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createIntervals",
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "functionSymbols",
-                    "description": "Symbols treated as function names when parsing.",
-                    "defaultValue": [
-                        "f",
-                        "g"
-                    ],
-                    "type": "textList"
-                },
-                {
-                    "name": "referencesAreFunctionSymbols",
-                    "description": "References whose names should be treated as function symbols when parsing.",
-                    "defaultValue": [],
-                    "type": "reference"
-                },
-                {
-                    "name": "splitSymbols",
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayBlanks",
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumptions",
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "＿"
-                    },
-                    "type": "math"
-                },
-                {
-                    "name": "draggable",
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "layer",
-                    "description": "Z-order layer index when shown on a graph.",
-                    "defaultValue": 0,
-                    "type": "number"
-                },
-                {
-                    "name": "anchor",
-                    "description": "Coordinates of the anchor point used to position this component on a graph.",
-                    "groupName": "positioning",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "\\left( 0, 0 \\right)"
-                    },
-                    "type": "point"
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "description": "Where this component sits relative to its anchor point.",
-                    "groupName": "positioning",
-                    "defaultValue": "center",
-                    "values": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "upperRight",
-                            "description": "Place the component above and to the right of the anchor point."
-                        },
-                        {
-                            "value": "upperLeft",
-                            "description": "Place the component above and to the left of the anchor point."
-                        },
-                        {
-                            "value": "lowerRight",
-                            "description": "Place the component below and to the right of the anchor point."
-                        },
-                        {
-                            "value": "lowerLeft",
-                            "description": "Place the component below and to the left of the anchor point."
-                        },
-                        {
-                            "value": "top",
-                            "description": "Place the component directly above the anchor point."
-                        },
-                        {
-                            "value": "bottom",
-                            "description": "Place the component directly below the anchor point."
-                        },
-                        {
-                            "value": "left",
-                            "description": "Place the component directly to the left of the anchor point."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Place the component directly to the right of the anchor point."
-                        },
-                        {
-                            "value": "center",
-                            "description": "Center the component on the anchor point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
                     "name": "type",
                     "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
                     "highlighted": true,
+                    "defaultValue": null,
                     "values": [
                         "number",
                         "math",
@@ -34627,10 +34328,40 @@
                 },
                 {
                     "name": "target",
-                    "description": "The value to look for.",
+                    "description": "The value, or list of values, to look for.",
                     "highlighted": true,
-                    "defaultValue": null,
-                    "type": "_componentWithSelectableType"
+                    "type": "_componentListWithSelectableType"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
                 }
             ],
             "properties": [
@@ -34656,359 +34387,18 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true,
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
                     "name": "doenetML",
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph.",
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "indexOf",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none.",
-                    "highlighted": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
                 }
             ],
             "top": true,
             "acceptsStringChildren": true,
-            "takesIndex": false,
+            "takesIndex": true,
             "docsSlug": "indexOf",
-            "summary": "The index of the first value in a list equal to a target, or 0 if there is none",
-            "layoutCategory": "inline"
+            "summary": "The index of the first value in a list equal to each target, or 0 where there is none",
+            "layoutCategory": "other"
         },
         {
             "name": "searchSorted",
@@ -35255,8 +34645,8 @@
             ],
             "childBuckets": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
-                "_listIndexOperator",
-                "_inline",
+                "_listIndexListOperator",
+                "_composite",
                 "_base"
             ],
             "attributes": [
@@ -35288,12 +34678,7 @@
                 {
                     "name": "fixed",
                     "description": "Whether this component's value is fixed and cannot be modified.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
+                    "defaultValue": false
                 },
                 {
                     "name": "fixLocation",
@@ -35332,304 +34717,10 @@
                     "type": "reference"
                 },
                 {
-                    "name": "format",
-                    "description": "Input format.",
-                    "defaultValue": "text",
-                    "values": [
-                        "text",
-                        "latex"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "text",
-                            "description": "Plain-text math notation (e.g., `x^2 + 1`)."
-                        },
-                        {
-                            "value": "latex",
-                            "description": "LaTeX-formatted math (e.g., `x^{2} + 1`)."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "simplify",
-                    "description": "Level of simplification applied to the expression.",
-                    "defaultValue": "none",
-                    "values": [
-                        "none",
-                        "full",
-                        "numbers",
-                        "numbersPreserveOrder",
-                        "normalizeOrder",
-                        "true",
-                        "false"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "none",
-                            "description": "No simplification is applied."
-                        },
-                        {
-                            "value": "full",
-                            "description": "Fully simplify the expression."
-                        },
-                        {
-                            "value": "numbers",
-                            "description": "Simplify numeric subexpressions only, leaving symbolic structure intact."
-                        },
-                        {
-                            "value": "numbersPreserveOrder",
-                            "description": "Like `numbers`, but does not reorder commutative operands."
-                        },
-                        {
-                            "value": "normalizeOrder",
-                            "description": "Reorder commutative operands into a canonical form without simplifying values."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "expand",
-                    "description": "Whether to expand the expression.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayDigits",
-                    "description": "Number of significant digits to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 3,
-                    "type": "integer"
-                },
-                {
-                    "name": "displayDecimals",
-                    "description": "Number of decimal places to display when rendering this number.",
-                    "groupName": "number-display",
-                    "defaultValue": 2,
-                    "type": "integer"
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "description": "Threshold below which numbers are displayed as zero.",
-                    "groupName": "number-display",
-                    "defaultValue": 1e-14,
-                    "type": "number"
-                },
-                {
-                    "name": "padZeros",
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation.",
-                    "groupName": "number-display",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "renderMode",
-                    "description": "How the math is rendered.",
-                    "defaultValue": "inline",
-                    "values": [
-                        "inline",
-                        "display"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "inline",
-                            "description": "Render inline with the surrounding text."
-                        },
-                        {
-                            "value": "display",
-                            "description": "Render as a centered equation on its own line."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
-                    "name": "unordered",
-                    "description": "Whether tuple- or list-like math expressions should be treated as unordered for comparison.",
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createVectors",
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "createIntervals",
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "functionSymbols",
-                    "description": "Symbols treated as function names when parsing.",
-                    "defaultValue": [
-                        "f",
-                        "g"
-                    ],
-                    "type": "textList"
-                },
-                {
-                    "name": "referencesAreFunctionSymbols",
-                    "description": "References whose names should be treated as function symbols when parsing.",
-                    "defaultValue": [],
-                    "type": "reference"
-                },
-                {
-                    "name": "splitSymbols",
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "defaultValue": false,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "displayBlanks",
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumptions",
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "＿"
-                    },
-                    "type": "math"
-                },
-                {
-                    "name": "draggable",
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "defaultValue": true,
-                    "values": [
-                        "true",
-                        "false"
-                    ],
-                    "type": "boolean"
-                },
-                {
-                    "name": "layer",
-                    "description": "Z-order layer index when shown on a graph.",
-                    "defaultValue": 0,
-                    "type": "number"
-                },
-                {
-                    "name": "anchor",
-                    "description": "Coordinates of the anchor point used to position this component on a graph.",
-                    "groupName": "positioning",
-                    "defaultValue": {
-                        "type": "math",
-                        "latex": "\\left( 0, 0 \\right)"
-                    },
-                    "type": "point"
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "description": "Where this component sits relative to its anchor point.",
-                    "groupName": "positioning",
-                    "defaultValue": "center",
-                    "values": [
-                        "upperRight",
-                        "upperLeft",
-                        "lowerRight",
-                        "lowerLeft",
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "center"
-                    ],
-                    "autocompleteValues": [
-                        {
-                            "value": "upperRight",
-                            "description": "Place the component above and to the right of the anchor point."
-                        },
-                        {
-                            "value": "upperLeft",
-                            "description": "Place the component above and to the left of the anchor point."
-                        },
-                        {
-                            "value": "lowerRight",
-                            "description": "Place the component below and to the right of the anchor point."
-                        },
-                        {
-                            "value": "lowerLeft",
-                            "description": "Place the component below and to the left of the anchor point."
-                        },
-                        {
-                            "value": "top",
-                            "description": "Place the component directly above the anchor point."
-                        },
-                        {
-                            "value": "bottom",
-                            "description": "Place the component directly below the anchor point."
-                        },
-                        {
-                            "value": "left",
-                            "description": "Place the component directly to the left of the anchor point."
-                        },
-                        {
-                            "value": "right",
-                            "description": "Place the component directly to the right of the anchor point."
-                        },
-                        {
-                            "value": "center",
-                            "description": "Center the component on the anchor point."
-                        }
-                    ],
-                    "type": "keyword"
-                },
-                {
                     "name": "type",
                     "description": "Component type to interpret bare string children as. Also decides how a `target` is read, since it has no type of its own.",
                     "highlighted": true,
+                    "defaultValue": null,
                     "values": [
                         "number",
                         "math",
@@ -35658,10 +34749,40 @@
                 },
                 {
                     "name": "target",
-                    "description": "The value to locate within the sorted list.",
+                    "description": "The value, or list of values, to locate within the sorted list.",
                     "highlighted": true,
-                    "defaultValue": null,
-                    "type": "_componentWithSelectableType"
+                    "type": "_componentListWithSelectableType"
+                },
+                {
+                    "name": "displayDigits",
+                    "description": "Number of significant digits to display when rendering this number."
+                },
+                {
+                    "name": "displayDecimals",
+                    "description": "Number of decimal places to display when rendering this number."
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "description": "Threshold below which numbers are displayed as zero."
+                },
+                {
+                    "name": "padZeros",
+                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
+                },
+                {
+                    "name": "avoidScientificNotation",
+                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
+                },
+                {
+                    "name": "asList",
+                    "description": "Whether to render the items separated by commas (true) or with no separator (false).",
+                    "highlighted": true,
+                    "defaultValue": true,
+                    "values": [
+                        "true",
+                        "false"
+                    ],
+                    "type": "boolean"
                 },
                 {
                     "name": "side",
@@ -35708,105 +34829,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "format",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Input format.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "simplify",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Level of simplification applied to the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "expand",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to expand the expression.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How the math is rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createVectors",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether tuple-like expressions are interpreted as vectors.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "createIntervals",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether range expressions are interpreted as intervals.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "functionSymbols",
-                    "type": "textList",
-                    "isArray": false,
-                    "description": "Symbols treated as function names when parsing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "splitSymbols",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether multi-character symbols are split into a product of variables.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "parseScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to parse expressions like 1e3 as scientific notation.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "displayBlanks",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether blanks (placeholders) are visibly rendered.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "assumptions",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "Assumptions applied when simplifying or comparing.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "draggable",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the math component can be dragged on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "layer",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Z-order layer index when shown on a graph.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "positionFromAnchor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Where this component sits relative to its anchor point.",
-                    "fromAttribute": true,
-                    "groupName": "positioning"
-                },
-                {
                     "name": "side",
                     "type": "text",
                     "isArray": false,
@@ -35815,260 +34837,18 @@
                     "highlighted": true
                 },
                 {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is hidden from the rendered output."
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component is disabled and cannot be interacted with."
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's value is fixed and cannot be modified."
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component's location is fixed (preventing it from being moved while still allowing other modifications)."
-                },
-                {
                     "name": "doenetML",
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
-                },
-                {
-                    "name": "textColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's text color, derived from the active style and theme."
-                },
-                {
-                    "name": "backgroundColor",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable name for this component's background color, derived from the active style and theme."
-                },
-                {
-                    "name": "textStyleDescription",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Human-readable description of this component's text styling (color and any background color)."
-                },
-                {
-                    "name": "anchor",
-                    "type": "point",
-                    "isArray": false,
-                    "description": "The coordinates where this component is anchored on the graph.",
-                    "groupName": "positioning"
-                },
-                {
-                    "name": "displayDigits",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of significant digits to display when rendering this number."
-                },
-                {
-                    "name": "displayDecimals",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "Number of decimal places to display when rendering this number."
-                },
-                {
-                    "name": "displaySmallAsZero",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "Threshold below which numbers are displayed as zero."
-                },
-                {
-                    "name": "padZeros",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals."
-                },
-                {
-                    "name": "avoidScientificNotation",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether to render numbers in full decimal form rather than scientific notation."
-                },
-                {
-                    "name": "value",
-                    "type": "searchSorted",
-                    "isArray": false,
-                    "description": "The 1-based index the operator found, or 0 if there is none.",
-                    "highlighted": true
-                },
-                {
-                    "name": "number",
-                    "type": "number",
-                    "isArray": false,
-                    "description": "The numeric value of the expression (NaN if not a number)."
-                },
-                {
-                    "name": "isNumber",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to a finite number."
-                },
-                {
-                    "name": "isNumeric",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether the expression evaluates to any number (including infinities)."
-                },
-                {
-                    "name": "latex",
-                    "type": "latex",
-                    "isArray": false,
-                    "description": "The expression rendered as a LaTeX string."
-                },
-                {
-                    "name": "text",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "The expression rendered as a plain text string."
-                },
-                {
-                    "name": "numDimensions",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of dimensions if the math expression is interpreted as a vector or matrix."
-                },
-                {
-                    "name": "vector",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a vector (its components).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "vector"
-                        }
-                    ]
-                },
-                {
-                    "name": "list",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a list (its elements).",
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "matrixSize",
-                    "type": "numberList",
-                    "isArray": false,
-                    "description": "The size of the math expression as a matrix, as a [numRows, numColumns] list."
-                },
-                {
-                    "name": "numRows",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of rows when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "numColumns",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of columns when the math expression is interpreted as a matrix."
-                },
-                {
-                    "name": "matrix",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The math expression interpreted as a matrix (its entries by row and column).",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "rows",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by row.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "columns",
-                    "type": "math",
-                    "isArray": true,
-                    "description": "The matrix's entries grouped by column.",
-                    "numDimensions": 2,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        },
-                        {
-                            "isArray": false,
-                            "type": "matrix"
-                        }
-                    ]
-                },
-                {
-                    "name": "x",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The first component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "y",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The second component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "z",
-                    "type": "math",
-                    "isArray": false,
-                    "description": "The third component of the math expression when interpreted as a vector."
-                },
-                {
-                    "name": "numListItems",
-                    "type": "integer",
-                    "isArray": false,
-                    "description": "The number of items when the math expression is interpreted as a list."
                 }
             ],
             "top": true,
             "acceptsStringChildren": true,
-            "takesIndex": false,
+            "takesIndex": true,
             "docsSlug": "searchSorted",
-            "summary": "The position at which a target would be inserted to keep a sorted list sorted",
-            "layoutCategory": "inline"
+            "summary": "The position at which each target would be inserted to keep a sorted list sorted",
+            "layoutCategory": "other"
         },
         {
             "name": "clampFunction",
@@ -36167,7 +34947,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
+            "childBuckets": "122221111111111111111111111222221122111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -37114,7 +35894,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
+            "childBuckets": "122221111111111111111111111222221122111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -38061,7 +36841,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
+            "childBuckets": "122221111111111111111111111222221122111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_functionOperator",
                 "_inline",
@@ -39009,7 +37789,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_textOperatorOfMath",
                 "_inline",
@@ -39536,7 +38316,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -39839,7 +38619,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -40142,7 +38922,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -40445,7 +39225,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -40748,7 +39528,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41051,7 +39831,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41354,7 +40134,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41657,7 +40437,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -41960,7 +40740,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -42263,7 +41043,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inlineRenderInlineChildren",
                 "_inline",
@@ -61387,7 +60167,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "11201111111111111111111111122222111111022010122121111222111111112222012222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111122222112211022010122121111222111111112222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -62143,7 +60923,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
+            "childBuckets": "112012222111111111111111111111122222112222222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -62803,7 +61583,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120111010122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
+            "childBuckets": "1120111010122221111111111111111111111222221122222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -64562,7 +63342,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -65418,7 +64198,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "0201222211111111111111111111112222211112222222221222202221222220122122212222221222221212222",
+            "childBuckets": "0201222211111111111111111111112222211222222222221222202221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -70633,7 +69413,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11200012222111111111111111111111122222111122222222212222022221222222222122212222221222221212222",
+            "childBuckets": "11200012222111111111111111111111122222112222222222212222022221222222222122212222221222221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -71304,7 +70084,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111122222112211111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -71657,7 +70437,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111122222112211111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -74558,7 +73338,7 @@
                 "ol",
                 "ul"
             ],
-            "childBuckets": "111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222211221111122200",
+            "childBuckets": "111111111111111111111111111111111111111111222221122111111111111111111111112211111111121212222121212211111111111222222122212222221112111121222211221111122200",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -74990,7 +73770,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "122221111111111111111111111222221111222122222122020222212222201221222212222221112221211222221111111110212120",
+            "childBuckets": "122221111111111111111111111222221122222122222122020222212222201221222212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -75620,7 +74400,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -76475,7 +75255,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -76807,7 +75587,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -77139,7 +75919,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "111111111111111111111112222211112122022210112222122222212222112222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211222122022210112222122222212222112222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -77921,7 +76701,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "11201111111111111111111111122222111111022010122121111222111111112222012222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111122222112211022010122121111222111111112222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -78659,7 +77439,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -79506,7 +78286,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
+            "childBuckets": "112012222111111111111111111111122222112222222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -84858,7 +83638,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
+            "childBuckets": "112012222111111111111111111111122222112222222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -85749,7 +84529,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "112012222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
+            "childBuckets": "112012222111111111111111111111122222112222222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -86472,7 +85252,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120111010122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
+            "childBuckets": "1120111010122221111111111111111111111222221122222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -87415,7 +86195,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "0212222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
+            "childBuckets": "0212222111111111111111111111122222112222222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -87664,7 +86444,7 @@
                 "latex",
                 "pointList"
             ],
-            "childBuckets": "111111111111111111111112222211111022101222121112222222222222222222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211221022101222121112222222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -87983,7 +86763,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "112011111111111111111111111222221111110220101221211112222222012222222222222222222222222222222",
+            "childBuckets": "112011111111111111111111111222221122110220101221211112222222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -88754,7 +87534,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "112011111111111111111111111222221111212202221011222122222212222112222222222222222222222222222",
+            "childBuckets": "112011111111111111111111111222221122212202221011222122222212222112222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -89335,7 +88115,7 @@
                 "hasSameFactoring",
                 "matchesPattern"
             ],
-            "childBuckets": "02111111011000122221111111111111111111111222221111222122222100001021222001221222122222211122212112221111111110011",
+            "childBuckets": "02111111011000122221111111111111111111111222221122222122222100001021222001221222122222211122212112221111111110011",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -90384,7 +89164,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "0212222111111111111111111111122222111122212222212202022221222220122122212222221112221211222221111111110212120",
+            "childBuckets": "0212222111111111111111111111122222112222212222212202022221222220122122212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_base"
             ],
@@ -91003,7 +89783,7 @@
                 "booleanInput",
                 "orbitalDiagram"
             ],
-            "childBuckets": "122221111111111111111111111222221111222122222122020222212222201221222212222221112221211222221111111110212120",
+            "childBuckets": "122221111111111111111111111222221122222122222122020222212222201221222212222221112221211222221111111110212120",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -91500,7 +90280,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "11200012222111111111111111111111122222111122222222212222022221222222222122212222221222221212222",
+            "childBuckets": "11200012222111111111111111111111122222112222222222212222022221222222222122212222221222221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -92932,7 +91712,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1120001111111110221112222111111111111111111111122222111122222222212222022221222220122122212222221222221212222",
+            "childBuckets": "1120001111111110221112222111111111111111111111122222112222222222212222022221222220122122212222221222221212222",
             "abstractAncestors": [
                 "_input",
                 "_inline",
@@ -94315,7 +93095,7 @@
                 "matchesPattern",
                 "booleanInput"
             ],
-            "childBuckets": "11111111111111111111111222221111110202221011222212222221112211122222222222222222222222222222111111111021212",
+            "childBuckets": "11111111111111111111111222221122110202221011222212222221112211122222222222222222222222222222111111111021212",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -94823,7 +93603,7 @@
                 "matchesPattern",
                 "booleanInput"
             ],
-            "childBuckets": "11111111111111111111111222221111110202221011222212222221112211122222222222222222222222222222111111111021212",
+            "childBuckets": "11111111111111111111111222221122110202221011222212222221112211122222222222222222222222222222111111111021212",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -95372,7 +94152,7 @@
                 "graph",
                 "annotations"
             ],
-            "childBuckets": "0200011111111111111111111111222221111222111110222111111111111111221222122221212122121111111112220011122222222212202222201222222112220212220010000000",
+            "childBuckets": "0200011111111111111111111111222221122222111110222111111111111111221222122221212122121111111112220011122222222212202222201222222112220212220010000000",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -96694,7 +95474,7 @@
                 "yLabel",
                 "label"
             ],
-            "childBuckets": "122221111111111111111111111222221111111222222122220222212222222011222212222221222221212222110",
+            "childBuckets": "122221111111111111111111111222221122111222222122220222212222222011222212222221222221212222110",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -98402,7 +97182,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -102593,7 +101373,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "02111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "02111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -102979,7 +101759,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "20111111111111111111111111111111111111111111222221111111111111111111111111112211111111121212222121212211111111111222221222122222211121111212222112211111222111111111111111111111111111111111111111111111111111",
+            "childBuckets": "20111111111111111111111111111111111111111111222221122111111111111111111111112211111111121212222121212211111111111222221222122222211121111212222112211111222111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -106541,7 +105321,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -118116,7 +116896,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -118476,7 +117256,7 @@
                 "pretzel",
                 "cascade"
             ],
-            "childBuckets": "11111111111111111111111111111111111111111122222111111111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
+            "childBuckets": "11111111111111111111111111111111111111111122222112211111111111111111111111221111111112121222212121221111111111122222212221222222111211112122221122111112221111111111111111111111111111111111111111111111111111",
             "abstractAncestors": [
                 "_block",
                 "_base"
@@ -118725,7 +117505,7 @@
                 "piecewiseFunction",
                 "bestFitLine"
             ],
-            "childBuckets": "11201111111111111111111111122222111111022010122121111222111111112222012222222222222222222222222222222",
+            "childBuckets": "11201111111111111111111111122222112211022010122121111222111111112222012222222222222222222222222222222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -120774,7 +119554,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -121340,7 +120120,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -123879,7 +122659,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111012122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
+            "childBuckets": "111012122221111111111111111111111222221122222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -124248,7 +123028,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "111012122221111111111111111111111222221111222222122220222212222201122212222221222221212222",
+            "childBuckets": "111012122221111111111111111111111222221122222222122220222212222201122212222221222221212222",
             "abstractAncestors": [
                 "_graphical",
                 "_base"
@@ -125516,7 +124296,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -126372,7 +125152,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -126784,7 +125564,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -128182,7 +126962,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_base"
             ],
@@ -128568,7 +127348,7 @@
                 "md",
                 "mdn"
             ],
-            "childBuckets": "122011122222222211111111111111111111112222211111221022202221222122221222222111221222112111111111111111111222222222222222222201",
+            "childBuckets": "122011122222222211111111111111111111112222211221221022202221222122221222222111221222112111111111111111111222222222222222222201",
             "abstractAncestors": [
                 "_inline",
                 "_base"
@@ -131479,7 +130259,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "1111111111111111111111111111111111111111112222211111111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
+            "childBuckets": "1111111111111111111111111111111111111111112222211221111111111111111111111122111111111212122221212122111111111112222221222122222211121111212222112211111222",
             "abstractAncestors": [
                 "_textOrInline",
                 "_inline",
@@ -131724,7 +130504,7 @@
                 "bestFitLine",
                 "latex"
             ],
-            "childBuckets": "111111111111111111111112222211111102201212221211112222222222222222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211221102201212221211112222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -131985,7 +130765,7 @@
                 "pointList",
                 "vectorList"
             ],
-            "childBuckets": "022122221111111111111111111111222221111222222222122220222212222222222221222222122222121222",
+            "childBuckets": "022122221111111111111111111111222221122222222222122220222212222222222221222222122222121222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -132246,7 +131026,7 @@
                 "latex",
                 "pointList"
             ],
-            "childBuckets": "111111111111111111111112222211111022101222121112222222222222222222222222222222222222222222",
+            "childBuckets": "111111111111111111111112222211221022101222121112222222222222222222222222222222222222222222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -132737,7 +131517,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"
@@ -133068,7 +131848,7 @@
                 "intervalList",
                 "vectorList"
             ],
-            "childBuckets": "122221111111111111111111111222221111222222222122220222212222222221222212222221222221212222",
+            "childBuckets": "122221111111111111111111111222221122222222222122220222212222222221222212222221222221212222",
             "abstractAncestors": [
                 "_composite",
                 "_base"


### PR DESCRIPTION
## Why

`<searchSorted>` and `<indexOf>` (from #1817) took a single `target` and reported a single position. Mapping M sampled values onto their positions therefore cost M components — a `<repeat>` wrapping one operator per draw — which stops being practical long before a sample is large enough to be interesting. That is the one thing the weighted-sampling pattern these operators were added for actually wants to do.

## What

`target` is now a list, and the result has one index per target, in the manner of `np.searchsorted(a, v)` with an array `v` and R's `match()`.

```xml
<numberList name="pop">30 45 12 60</numberList>
<cumulativeSum name="cum">$pop</cumulativeSum>
<number name="total"><sum>$pop</sum></number>

<sampleRandomNumbers name="draws" type="discreteUniform"
                     from="1" to="$total" numSamples="500" />

<searchSorted name="which" target="$draws">$cum</searchSorted>
```

Raising `numSamples` still adds a component per draw: `<searchSorted>` is a composite and creates one `<math>` for each result. What it no longer adds is an *operator* per draw — one `<searchSorted>` searches on behalf of the whole list, where the `<repeat>` route built a complete operator component, with its own dependencies and its own replacement, for every draw, inside `<repeat>`'s own per-iteration structure.

A single target still reads as a single index — it renders inline, aggregates under `<sum>`, and indexes another list — so `$pop[$which]`, the whole reason an operator returns a position rather than a value, is unchanged.

`<indexOf>` moves for the same reason: it has the same `target` attribute and the same argument, and R's `match()` (vectorized `indexOf`) is vectorized by default. Vectorizing one of the pair and not the other is the inconsistency authors would trip over. `<argMin>` and `<argMax>` take no target, so there is nothing to vectorize and their behavior is unchanged; the one thing that moves for them is the description of their `type` attribute, which used to explain how a `target` is read and so named an attribute they do not have.

## Breaking, and why there is no second changeset

This changes the shape of components that are merged but **unreleased**, so `.changeset/list-operators-scans-and-indices.md` is amended in place rather than contradicted by a second entry. It needs to land before the next release.

## Structure

Returning a list makes these composites rather than `<math>` components, so they move to a new `ListIndexBaseListOperator`, built on the value extraction in `utils/listValues` and the fresh-value replacement machinery in `utils/valueListReplacements` — the same pair `<cumulativeSum>` already uses. `<argMin>`/`<argMax>` stay scalar on `ListIndexBaseOperator`, and what the two bases share moved to `utils/listIndexOperators`, mirroring how `utils/mathOperatorChildren` serves both math-operator bases.

Four details worth a reviewer's eye:

- The operators now declare a **`type` state variable**. The `target` attribute is a `_componentListWithSelectableType`, whose own `type` resolves through a `parentStateVariable` — without one, `<indexOf type="text" target="Cal">` converted its target with the default numeric reading and compared `NaN`.
- Replacements are `<math>`, not `<number>` as `<sortIndices>` creates. An index is an integer either way, but these operators rendered as `<math>` before they returned a list and their `<argMin>`/`<argMax>`/`<count>` siblings still do, so `<math>` keeps one family rendering one way — and a `<math>` replacement resolves as a path index just as `<cumulativeSum>`'s does.
- Being composites changes their **attribute and property surface**, to exactly `<cumulativeSum>`'s: they gain `asList` and forward `displayDigits` and its neighbors onto each result, and they lose `<math>`'s parsing attributes (`format`, `simplify`, …) and `<math>`'s own properties (`$which.latex`, `$which.value`). None of that ever applied to an integer index — `ListIndexBaseOperator` already un-highlighted `format`, `simplify` and `displayDigits` for that reason.
- The `target` description is per-operator rather than shared by the base, because the two targets mean different things: `<indexOf>` looks its target **up in** the list, while `<searchSorted>` places one that need not be in the list at all — which is exactly the distinction its reference page draws.

## Diagnostics

An **empty list** of targets produces no indices and is not reported — that is the honest answer to a question about nothing. Omitting `target` altogether still gives a single `0` and a warning, since no document written that way can ever produce an answer. A target simply absent from the list is still unreported, as before. The two reasons that *are* reported are properties of the document rather than of an individual target, so a run of many targets raises each message once, not once per target.

## Testing

- `listoperators.test.ts` is at 52 tests, 8 of them new: a list of targets, a single target still reading as one index (including `$pop[$i]`), text targets, an empty target list, a target list whose length changes as it is grown, emptied and refilled — the replacement add / withhold / reveal path — a `<searchSorted>` with no targets still declaring the `math` renderer, and two diagnostics tests, that many targets with nothing to look through report once and that an empty target list reports nothing at all.
- 135 pass across `listoperators` / `sort` / `shuffle` / `sequence`; `docs-nextra`'s 12 pass.
- Schema regenerated; `lint:i18n` passes with its baseline untouched (232/233 codes, 1 retired).
- Checked in the browser against a freshly built worker: 12 draws map to correct subpopulations, Resample updates them, `<sum>$which</sum>` and `$which[3]` work, `$pop[$i]` resolves, and the document raises no diagnostics.

Closes #1831. Part of #1815, and amends the behavior added in #1817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdEWccVoUPCJoDYxKmHRo

