### PR TITLE
Put correctness first in the PR review guidelines

### DIFF
--- a/docs/PR_REVIEW_GUIDELINES.md
+++ b/docs/PR_REVIEW_GUIDELINES.md
@@ -125,7 +125,22 @@ Review whether the PR includes adequate tests:
 
 ## Documentation
 
-Review whether the PR updates or adds documentation as needed:
+These pages are written for **authors writing DoenetML activities**, not for developers
+working on the implementation. That distinction is the first thing to check in any docs
+change, because a PR's own author has just been reading the implementation and it leaks
+into the prose easily.
+
+Nothing should appear in a page that an author could not observe from the DoenetML side:
+no source files, function names or internal state-variable identifiers; no walking through
+what the runtime does internally; no componentTypes an author never writes. Attribute
+names, child tags and properties are fine — those *are* the author-facing surface. The test
+is whether an author could discover the statement by experimenting. Where a behavior does
+come from something internal, describe the behavior, not the mechanism. The
+[`doenetml-docs-authoring`](../.github/skills/doenetml-docs-authoring/SKILL.md) skill is the
+authority here and covers the specific cases; consult it rather than working from this
+paragraph.
+
+Then review whether the PR updates or adds documentation as needed:
 
 - If the PR changes user-visible behavior (new features, changed defaults, renamed
   attributes, etc.), check whether the corresponding page(s) in `packages/docs-nextra/`

--- a/docs/PR_REVIEW_GUIDELINES.md
+++ b/docs/PR_REVIEW_GUIDELINES.md
@@ -4,6 +4,12 @@ Review this PR. The first question is whether the code is **correct** — whethe
 what the PR, its documentation, and its own comments say it does. Everything else in this
 document is secondary to that.
 
+Look for the case that breaks the change, not the case that confirms it: a review that
+sets out to agree will find agreement. Report only what you can substantiate, and say what
+each finding rests on. A review that finds nothing real is a legitimate result and should
+be reported as one — findings offered to look thorough cost more to disprove than they
+were worth.
+
 ## Correctness
 
 Trace the main path of the change by hand and satisfy yourself that it produces the
@@ -13,14 +19,16 @@ what the code does.
 Work the edge cases deliberately. The ones that have actually shipped bugs in this
 codebase are:
 
-- **Empty input** — an empty list, or one whose only children were references that
-  produced nothing.
-- **`NaN` and non-numeric values**, including a `<number>` whose content does not parse
-  and so is numeric by type but `NaN` by value. Remember that *every* comparison against
-  `NaN` is false, so a guard phrased as "no element is out of order" passes a `NaN` that a
-  guard phrased as "every element is in order" would catch. A `NaN` also equals nothing —
-  not even another `NaN` — so anything that groups by equality will give each one a group
-  of its own.
+- **Empty input** — not just an empty literal, but input that looks non-empty in the
+  source and produces nothing: a reference that resolves to no components, a composite
+  with no replacements, a filter that removes everything.
+- **`NaN` and non-numeric values** — a value can satisfy a type check and still be
+  meaningless, as a `<number>` whose content does not parse is numeric by type and `NaN` by
+  value. Two properties of `NaN` break guards that look sound: every comparison against it
+  is false, so a condition written as a negation ("nothing is out of order") admits a `NaN`
+  that the positive form ("everything is in order") would reject; and it is equal to
+  nothing, not even to itself, so anything that groups, deduplicates or caches by equality
+  treats each occurrence as new.
 - **Boundary values** — the first and last element, a value lying exactly on a cut point,
   equal or duplicate values, and collections of one and of zero elements.
 - **Values that change over time**, especially anything driven by an input while a student
@@ -35,7 +43,9 @@ and establish the "before" by reading the code that used to run, not by assuming
 
 Reading is not verification. Where a finding can be settled by executing a document — which
 is most of them — write the smallest one that decides it, and report what it actually
-rendered. Delete any scratch file before you finish.
+rendered. Choose the input most likely to break the change rather than the one most likely
+to show it working; a passing example proves less than a failing one. Delete any scratch
+file before you finish.
 
 Say how you established each claim: **ran it**, **read the code**, or **assumed**. A review
 that does not distinguish these is hard to act on, because the reader cannot tell which
@@ -53,10 +63,12 @@ rather than against the code, so one error propagates and every later reader fin
 reassuringly consistent with everything around it. Go back to the code each time,
 including for the copy you have already read somewhere else.
 
-Claims about cost deserve particular suspicion. "One component rather than a thousand" is
-easy to write and rarely true: a composite creates one replacement per result, so a change
-that removes a thousand *operators* usually still creates a thousand *components*. State
-what is saved and what is not.
+Claims about cost deserve particular suspicion, because they are easy to write and
+expensive to check. A claim that a change reduces how much a document creates has to
+account for how components actually come into being: a composite creates one replacement
+per result, so removing N *operators* from the markup generally still creates N
+*components*. Establish the count by running a document and measuring it, and say what is
+saved and what is not.
 
 ## Scope
 

--- a/docs/PR_REVIEW_GUIDELINES.md
+++ b/docs/PR_REVIEW_GUIDELINES.md
@@ -16,15 +16,17 @@ Trace the main path of the change by hand and satisfy yourself that it produces 
 claimed result. Do not accept a comment, a test name, or a variable name as evidence of
 what the code does.
 
-Work the edge cases deliberately. The ones that have actually shipped bugs in this
-codebase are:
+Work the edge cases deliberately. These four recur in this codebase and are worth
+checking every time:
 
 - **Empty input** — not just an empty literal, but input that looks non-empty in the
   source and produces nothing: a reference that resolves to no components, a composite
   with no replacements, a filter that removes everything.
 - **`NaN` and non-numeric values** — a value can satisfy a type check and still be
   meaningless, as a `<number>` whose content does not parse is numeric by type and `NaN` by
-  value. Two properties of `NaN` break guards that look sound: every comparison against it
+  value. Do not assume the converse either: `<number>` takes a `valueOnNaN` attribute
+  (`Number.js`), so unparseable content yields whatever the author set, `NaN` only by
+  default. Two properties of `NaN` break guards that look sound: every comparison against it
   is false, so a condition written as a negation ("nothing is out of order") admits a `NaN`
   that the positive form ("everything is in order") would reject; and it is equal to
   nothing, not even to itself, so anything that groups, deduplicates or caches by equality
@@ -142,6 +144,6 @@ Review whether the PR updates or adds documentation as needed:
 
 - The changeset must describe the user-visible behavior in the diff, and only behavior that
   is actually in it. Consult the `changesets` skill rather than copying a sibling changeset.
-- The PR description must still describe everything in the diff. A stale PR description is
-  the single most common oversight in this procedure, so check it explicitly rather than
-  assuming an earlier pass left it accurate.
+- The PR description must still describe everything in the diff. Check it explicitly
+  rather than assuming an earlier pass left it accurate: it is the one surface that no
+  test, no CI job and no reader of the code will catch when it goes stale.

--- a/docs/PR_REVIEW_GUIDELINES.md
+++ b/docs/PR_REVIEW_GUIDELINES.md
@@ -1,31 +1,135 @@
-Perform a thorough review of this PR. Look for ways in which the code can be made more concise, redundancy can be eliminated, and the codebase can be made easier to maintain. Look for simplifications of the code that could perform the same functions. Abstract repeated code to helper functions if that will increase readability. Prefer conventions established in AGENTS.md.
+# PR Review Guidelines
 
-Review all the documentation and comments for consistency, clarity of intent, and accuracy. Add additional doc strings to functions or code blocks if they would help clarify the intent and make the code easier to maintain.
+Review this PR. The first question is whether the code is **correct** — whether it does
+what the PR, its documentation, and its own comments say it does. Everything else in this
+document is secondary to that.
+
+## Correctness
+
+Trace the main path of the change by hand and satisfy yourself that it produces the
+claimed result. Do not accept a comment, a test name, or a variable name as evidence of
+what the code does.
+
+Work the edge cases deliberately. The ones that have actually shipped bugs in this
+codebase are:
+
+- **Empty input** — an empty list, or one whose only children were references that
+  produced nothing.
+- **`NaN` and non-numeric values**, including a `<number>` whose content does not parse
+  and so is numeric by type but `NaN` by value. Remember that *every* comparison against
+  `NaN` is false, so a guard phrased as "no element is out of order" passes a `NaN` that a
+  guard phrased as "every element is in order" would catch. A `NaN` also equals nothing —
+  not even another `NaN` — so anything that groups by equality will give each one a group
+  of its own.
+- **Boundary values** — the first and last element, a value lying exactly on a cut point,
+  equal or duplicate values, and collections of one and of zero elements.
+- **Values that change over time**, especially anything driven by an input while a student
+  is still typing.
+
+Then ask what the change breaks that **is not in the diff**. Swapping a base class,
+changing an attribute's `createComponentOfType`, or editing a shared utility can change
+behavior entirely inside files the PR never touches. Name the behavior before and after,
+and establish the "before" by reading the code that used to run, not by assuming.
+
+## Run the code
+
+Reading is not verification. Where a finding can be settled by executing a document — which
+is most of them — write the smallest one that decides it, and report what it actually
+rendered. Delete any scratch file before you finish.
+
+Say how you established each claim: **ran it**, **read the code**, or **assumed**. A review
+that does not distinguish these is hard to act on, because the reader cannot tell which
+parts to re-check.
+
+## Check prose against code, not against other prose
+
+Every factual or quantitative claim — in the changeset, the PR description, the reference
+documentation, the code comments, and the commit message — must be traceable to the code
+that makes it true. Cite the file and line, or delete the claim.
+
+This matters most when a claim appears on several surfaces. A sentence written once and
+then paraphrased into each new place tends to get checked against the earlier wording
+rather than against the code, so one error propagates and every later reader finds it
+reassuringly consistent with everything around it. Go back to the code each time,
+including for the copy you have already read somewhere else.
+
+Claims about cost deserve particular suspicion. "One component rather than a thousand" is
+easy to write and rarely true: a composite creates one replacement per result, so a change
+that removes a thousand *operators* usually still creates a thousand *components*. State
+what is saved and what is not.
+
+## Scope
+
+Prefer changes that live inside the PR's own diff. If you find a worthwhile refactor that
+would mean editing files this PR does not touch — extracting shared machinery, folding
+duplicated helpers together — **report it rather than performing it**. It probably belongs
+in a PR of its own, and if this PR is part of a stack, editing a lower layer forces every
+branch above it to be replayed.
+
+## Simplification and maintainability
+
+Once correctness is settled: look for code that can be made more concise, redundancy that
+can be eliminated, and simplifications that would perform the same function. Abstract
+repeated code into helper functions where that increases readability and where it stays in
+scope as described above. Prefer conventions established in `AGENTS.md`.
+
+Review the documentation and comments for consistency, clarity of intent, and accuracy.
+Add doc strings to functions or code blocks where they would clarify intent and make the
+code easier to maintain — and correct or remove any comment that no longer describes what
+the code does.
 
 ## Schema freshness
 
-If the PR adds or modifies any component class (files under `packages/doenetml-worker-javascript/src/components/`) — including new state variables, attributes, or component types — regenerate the schema and commit the result:
+If the PR adds or modifies any component class (files under
+`packages/doenetml-worker-javascript/src/components/`) — including new state variables,
+attributes, or component types — regenerate the schema and commit the result:
 
 ```bash
 npm run build:schema -w packages/static-assets
 git add packages/static-assets/src/generated/
 ```
 
-The CI job `schema-freshness` will fail if the committed schema files are out of date with the component source. Running `build:schema` locally and staging any changed files in `packages/static-assets/src/generated/` prevents that failure.
+The CI job `schema-freshness` will fail if the committed schema files are out of date with
+the component source. Running `build:schema` locally and staging any changed files in
+`packages/static-assets/src/generated/` prevents that failure.
 
 ## Test coverage
 
 Review whether the PR includes adequate tests:
 
-- New behavior or bug fixes should have at least one Vitest unit test (in `*.test.ts`), a Cypress e2e test (in `cypress/e2e/**/*.cy.js`), or a Cypress component test (in `test/cypress/component/**/*.cy.tsx` — present in `@doenet/codemirror`, `@doenet/doenetml`, and `@doenet/doenetml-iframe`), as appropriate for the change.
-- If the PR modifies existing behavior, confirm that any existing tests covering that behavior have been updated to reflect the new expected behavior.
-- Check that the tests actually exercise the scenario described in the PR — not just adjacent or unrelated scenarios.
+- New behavior or bug fixes should have at least one Vitest unit test (in `*.test.ts`), a
+  Cypress e2e test (in `cypress/e2e/**/*.cy.js`), or a Cypress component test (in
+  `test/cypress/component/**/*.cy.tsx` — present in `@doenet/codemirror`,
+  `@doenet/doenetml`, and `@doenet/doenetml-iframe`), as appropriate for the change.
+- If the PR modifies existing behavior, confirm that any existing tests covering that
+  behavior have been updated to reflect the new expected behavior.
+- Check that the tests actually exercise the scenario described in the PR — not just
+  adjacent or unrelated scenarios.
+- A test written for a bug fix should **fail without the fix**. Where it is cheap to do so,
+  confirm that by reverting the fix and watching the test fail; a test that passes either
+  way documents nothing.
 
 ## Documentation
 
 Review whether the PR updates or adds documentation as needed:
 
-- If the PR changes user-visible behavior (new features, changed defaults, renamed attributes, etc.), check whether the corresponding page(s) in `packages/docs-nextra/` need updating.
-- If the PR adds a new component, ensure a reference page exists or is created under `packages/docs-nextra/pages/reference/`.
-- If the PR changes how an existing component behaves (e.g. new attribute, changed default, fixed edge case), update the relevant reference or guide page.
-- Documentation changes are not required for purely internal refactors or fixes with no user-visible effect.
+- If the PR changes user-visible behavior (new features, changed defaults, renamed
+  attributes, etc.), check whether the corresponding page(s) in `packages/docs-nextra/`
+  need updating.
+- If the PR adds a new component, ensure a reference page exists or is created under
+  `packages/docs-nextra/pages/reference/`.
+- If the PR changes how an existing component behaves (e.g. new attribute, changed
+  default, fixed edge case), update the relevant reference or guide page.
+- Every DoenetML example on a page is a claim about what that markup renders. Run the ones
+  the PR adds or changes, and confirm the surrounding prose describes what actually
+  happens.
+- Documentation changes are not required for purely internal refactors or fixes with no
+  user-visible effect.
+
+## Changeset and PR description
+
+- The changeset must describe the user-visible behavior in the diff, and only behavior that
+  is actually in it. Consult the `changesets` skill rather than copying a sibling changeset.
+- The PR description must still describe everything in the diff. A stale PR description is
+  the single most common oversight in this procedure, so check it explicitly rather than
+  assuming an earlier pass left it accurate.

--- a/docs/REPEATED_REVIEW_OF_PR.md
+++ b/docs/REPEATED_REVIEW_OF_PR.md
@@ -9,8 +9,8 @@ cycle left it.
 Put these in every subagent's brief, not just the first:
 
 - **The working directory, as an absolute path**, and an instruction to verify it before
-  starting. A review agent has previously wandered into a second checkout of the same
-  repository and committed there.
+  starting. More than one checkout of this repository may exist on the machine, and a
+  review agent that starts in the wrong one will commit to the wrong one.
 - **What to review.** If the PR is part of a stack, its GitHub diff includes every PR
   beneath it. Point the reviewer at `git diff <parent-branch>...HEAD`, name the branches it
   must not touch, and say plainly that a finding in a lower PR is to be **reported, not
@@ -23,13 +23,21 @@ Put these in every subagent's brief, not just the first:
 
 Give the subagent these instructions:
 
-1. Review the PR according to `docs/PR_REVIEW_GUIDELINES.md`, through this cycle's lens.
-2. Address all issues identified during the review.
-3. Verify the changeset still describes the user-visible behavior in the diff; update if not.
-4. Verify the PR description still describes everything in the diff; update if not. Don't
+1. Verify the previous cycle's changes (skip on the first cycle). Take its ledger entry as
+   a set of claims, not as settled fact, and check the ones it recorded as *assumed* or
+   *read* rather than *ran*. Confirming a change was unnecessary, or wrong, is as useful an
+   outcome as a new finding — say so and revert it.
+2. Review the PR according to `docs/PR_REVIEW_GUIDELINES.md`, through this cycle's lens.
+3. Address the issues identified during the review — but **confirm a finding before
+   changing code for it**. If the guidelines' test says you established it by *assuming*,
+   either settle it by running something or report it without acting on it. A wrong
+   correctness fix is worse here than a wrong report, because it is committed, pushed, and
+   inherited by every later cycle as a decision already taken.
+4. Verify the changeset still describes the user-visible behavior in the diff; update if not.
+5. Verify the PR description still describes everything in the diff; update if not. Don't
    skip this — a stale PR description is the most common review-cycle oversight.
-5. Commit and push the results.
-6. Append to the ledger, and report back a short summary of what was changed (or "no
+6. Commit and push the results.
+7. Append to the ledger, and report back a short summary of what was changed (or "no
    changes" if nothing needed updating).
 
 Run cycles **sequentially** — each new subagent must see the prior subagent's commits, so
@@ -39,7 +47,8 @@ between.
 ## Lenses
 
 Repeating one prompt has steep diminishing returns; asking a different question does not.
-Give each cycle a lens of its own:
+Give each cycle a lens of its own. The first three lenses are different questions, not
+three attempts at the same one, and each covers a class of defect the others do not:
 
 | Cycle | Lens |
 | --- | --- |
@@ -57,14 +66,39 @@ Each cycle appends a short entry recording what it verified and how, what it fou
 what it deliberately did not do and why. The next cycle reads the ledger first, so settled
 ground is not re-derived and deferred items are reconsidered rather than forgotten.
 
+Keep two kinds of entry apart, because the next cycle must treat them differently:
+
+- **Decisions** — a refactor declined as out of scope, an approach chosen, a trap already
+  hit. These are closed. Do not re-litigate them.
+- **Findings and the changes made for them**, each recorded with how it was established:
+  **ran it**, **read the code**, or **assumed**. These are open. They are the previous
+  agent's conclusions about code it was editing at the time, and the next cycle is the only
+  independent reader they will get.
+
+A ledger that blurs the two suppresses the loop's own check: fresh eyes on the last cycle's
+work are what a sequential loop has instead of a separate verification stage, and an entry
+written as "fixed, verified" spends that for nothing.
+
 ## When to stop
 
-- Run at least **two** cycles.
-- Stop when a cycle finds **no correctness issue** — no bug, no inaccurate claim, no
-  missing coverage for behavior that is in the diff. Documentation polish, wording changes
-  and typo fixes do not by themselves justify another cycle.
+- Run at least **three** cycles — one for each lens. The minimum is three because there
+  are three lenses, not because three passes are better than two: stopping at two skips the
+  claims-against-code pass entirely, which is the one that catches a false statement
+  repeated across the changeset, the PR description and the reference pages. A quiet cycle
+  under one lens says nothing about what the next lens would find.
+- From the fourth cycle on, stop when a cycle finds **no correctness issue** — no bug, no
+  inaccurate claim, no missing coverage for behavior that is in the diff. Documentation
+  polish, wording changes and typo fixes do not by themselves justify another cycle.
 - The orchestrator judges this against the ledger. Do not leave it to the agent that made
   the changes to decide whether its own changes were significant.
+- A cycle that reports "no changes" is a real result and is how this loop is meant to end.
+  A cycle that produces a finding in order to look productive costs the next cycle the time
+  to disprove it, so the brief should say so.
+
+When the loop ends on a cycle that *made* changes — at the cap, or because the user
+called it — those changes are the only ones no other cycle has seen. Run one more agent
+that reviews and reports without committing, rather than treating the last cycle's own
+account of its work as verification.
 
 **Five cycles is a soft cap, not a hard one.** If a fifth cycle is still turning up real
 problems, do not simply keep going, and do not stop merely because a number was reached.

--- a/docs/REPEATED_REVIEW_OF_PR.md
+++ b/docs/REPEATED_REVIEW_OF_PR.md
@@ -35,7 +35,7 @@ Give the subagent these instructions:
    inherited by every later cycle as a decision already taken.
 4. Verify the changeset still describes the user-visible behavior in the diff; update if not.
 5. Verify the PR description still describes everything in the diff; update if not. Don't
-   skip this — a stale PR description is the most common review-cycle oversight.
+   skip this — nothing else in the pipeline checks it.
 6. Commit and push the results.
 7. Append to the ledger, and report back a short summary of what was changed (or "no
    changes" if nothing needed updating).

--- a/docs/REPEATED_REVIEW_OF_PR.md
+++ b/docs/REPEATED_REVIEW_OF_PR.md
@@ -1,37 +1,83 @@
 # Repeated Review of a PR
 
-After creating a PR, use this procedure to iteratively improve it via subagent reviews.
+After creating a PR, use this procedure to iteratively improve it through a series of
+subagent reviews. Each cycle spawns one subagent, which reviews the PR as the previous
+cycle left it.
 
-## Procedure
+## Before the first cycle
 
-Run the **review cycle** below at least three times in sequence. Each cycle operates on the PR as left by the previous cycle (i.e. pull the latest branch state before spawning the next subagent).
+Put these in every subagent's brief, not just the first:
 
-### Review cycle
+- **The working directory, as an absolute path**, and an instruction to verify it before
+  starting. A review agent has previously wandered into a second checkout of the same
+  repository and committed there.
+- **What to review.** If the PR is part of a stack, its GitHub diff includes every PR
+  beneath it. Point the reviewer at `git diff <parent-branch>...HEAD`, name the branches it
+  must not touch, and say plainly that a finding in a lower PR is to be **reported, not
+  fixed**.
+- **What is already settled** — decisions taken, refactors deliberately deferred, traps
+  already hit. Without this each cycle re-derives the same conclusions and re-proposes the
+  same declined changes.
 
-Spawn one subagent and give it the following instructions:
+## The review cycle
 
-1. Review the PR according to `@./PR_REVIEW_GUIDELINES.md`.
+Give the subagent these instructions:
+
+1. Review the PR according to `docs/PR_REVIEW_GUIDELINES.md`, through this cycle's lens.
 2. Address all issues identified during the review.
 3. Verify the changeset still describes the user-visible behavior in the diff; update if not.
-4. Verify the PR description still describes everything in the diff; update if not. Don't skip this — a stale PR description is the most common review-cycle oversight.
+4. Verify the PR description still describes everything in the diff; update if not. Don't
+   skip this — a stale PR description is the most common review-cycle oversight.
 5. Commit and push the results.
-6. Report back a short summary of what was changed (or report "no changes" if nothing needed updating).
+6. Append to the ledger, and report back a short summary of what was changed (or "no
+   changes" if nothing needed updating).
 
-Run cycles sequentially — each new subagent must see the prior subagent's commits, so wait for one to finish before spawning the next.
+Run cycles **sequentially** — each new subagent must see the prior subagent's commits, so
+wait for one to finish before spawning the next, and pull the latest branch state in
+between.
 
-## Stopping criterion
+## Lenses
 
-- **Cycles 1–3:** always run.
-- **After cycle 3:** if cycle 3 produced *significant* changes, run cycle 4. Otherwise stop.
-- **After cycle 4:** if cycle 4 produced *significant* changes, run cycle 5. Otherwise stop.
-- **Maximum:** 5 cycles total.
+Repeating one prompt has steep diminishing returns; asking a different question does not.
+Give each cycle a lens of its own:
 
-A change counts as *significant* if it modifies behavior, refactors non-trivially, or alters more than minor wording in docs/comments. Pure typo fixes, formatting tweaks, or a "no changes" report do not count.
+| Cycle | Lens |
+| --- | --- |
+| 1 | **Correctness and edge cases.** Does it do what it claims, on empty, `NaN`, boundary and degenerate input? |
+| 2 | **Behavior delta.** What changed that is not visible in the diff — base classes, shared utilities, attribute types? What regressed? |
+| 3 | **Claims against code.** Every statement in the changeset, PR description, reference pages, comments and commit message, traced to the code that makes it true. Plus test and documentation coverage. |
+| 4+ | The reviewer's own judgment, informed by the ledger. |
+
+A lens is a starting point, not a restriction: a cycle that notices a bug outside its lens
+should still fix it.
+
+## The ledger
+
+Each cycle appends a short entry recording what it verified and how, what it found, and
+what it deliberately did not do and why. The next cycle reads the ledger first, so settled
+ground is not re-derived and deferred items are reconsidered rather than forgotten.
+
+## When to stop
+
+- Run at least **two** cycles.
+- Stop when a cycle finds **no correctness issue** — no bug, no inaccurate claim, no
+  missing coverage for behavior that is in the diff. Documentation polish, wording changes
+  and typo fixes do not by themselves justify another cycle.
+- The orchestrator judges this against the ledger. Do not leave it to the agent that made
+  the changes to decide whether its own changes were significant.
+
+**Five cycles is a soft cap, not a hard one.** If a fifth cycle is still turning up real
+problems, do not simply keep going, and do not stop merely because a number was reached.
+Put it to the user: report what the last two cycles found, say why the evidence suggests
+more remain, and let them decide whether to continue. A PR still yielding defects at cycle
+five may need something other than another cycle — it may need to be split, or its approach
+reconsidered — and that is a judgment for a person to make.
 
 ## Final report
 
 After the last cycle, summarize for the user:
 
-- How many cycles ran and why you stopped.
+- How many cycles ran and why they stopped.
 - The most important changes made across all cycles.
+- Anything reported but deliberately not fixed, and why.
 - A link to the PR.


### PR DESCRIPTION
## Why

Reviewing a four-PR stack under the current guidelines produced a clear picture of what they do and do not catch. The subagent cycles found **six real correctness bugs** in one PR, so the procedure works. But an external reviewer caught two whole classes the cycles missed: a false claim about component counts that three separate cycles read in six places without questioning, and a behavior regression that was invisible in the diff.

Both misses trace back to the same thing: `PR_REVIEW_GUIDELINES.md` never asked the reviewer to determine whether the code is **correct**. Its opening paragraph asked for concision, redundancy elimination, simplification and helper extraction; the rest covered schema freshness, test coverage and documentation. The word "correct" did not appear. A reviewer following it literally would tidy a component and never ask whether it computes the right answer — the bugs that were found were found *despite* the document.

## What

**`docs/PR_REVIEW_GUIDELINES.md`** — correctness now leads, and the rest is explicitly secondary to it.

- **Correctness**, with the edge cases that have actually shipped bugs in this repo named rather than left implicit: empty input, `NaN` and non-numeric values, boundaries and degenerate collections, and values that change while a student types. The `NaN` entry records the specific trap that every comparison against `NaN` is false, so a guard phrased as "no element is out of order" admits a value that "every element is in order" would reject — which is exactly how one bug survived.
- **Behavior delta** — ask what the change breaks that is *not* in the diff. Swapping a base class or editing a shared utility changes behavior entirely inside untouched files, which is where the missed regression lived.
- **Check prose against code, not against other prose.** A claim written once and paraphrased onto each new surface gets checked against the earlier wording, so one error propagates and reads as consistent with everything around it. Cost claims get a specific caution: a composite creates one replacement per result, so "one component rather than a thousand" is rarely true.
- **Run the code.** Reading is not verification, and a report should state whether each claim was established by running it, reading it, or assuming it. In practice the reviews that found real bugs quoted rendered output; the ones that missed things said "checked and it's correct".
- **Scope** — new, and it deliberately restrains the existing advice to abstract repeated code. A refactor that would edit files outside the PR is to be reported rather than performed: it may belong in its own PR, and in a stack it forces every branch above to be replayed.

Kept as they were: schema freshness, test coverage and documentation. They are concrete, repo-specific, and they earned it — one cycle caught a stale committed schema that would have failed CI. Test coverage gains one line (a bug-fix test should fail without the fix) and documentation gains one (a DoenetML example is a claim about what that markup renders, so run it).

**`docs/REPEATED_REVIEW_OF_PR.md`** — the loop itself.

- **A lens per cycle** rather than the same pass repeated. Cycles 1 and 2 were consistently productive and both third cycles were thin; that is repetition, not fatigue. Correctness → behavior delta → claims against code, then the reviewer's judgment.
- **A ledger** carried between cycles, recording what was verified, what was found, and what was deliberately not done. Without it each cycle re-derives the same conclusions and re-proposes the same declined refactors.
- **A stopping rule keyed to evidence** — stop when a cycle finds no correctness issue — replacing "significant changes", which was vague and was self-assessed by the agent that had just made them.
- **Five cycles as a soft cap.** If a fifth cycle is still finding real problems, the orchestrator reports what the last two found and asks, rather than either halting at a number or continuing on its own. A PR still yielding defects at cycle five may need to be split or rethought, and that is a judgment for a person.
- **Setup guidance**: pin the working directory as an absolute path (a review agent once wandered into a second checkout of this repository and committed there), and, for stacked PRs, point the reviewer at `git diff <parent-branch>...HEAD` and tell it to report rather than fix findings that belong to a lower PR.

## Second pass

A later review of the guidelines themselves changed three things.

**Generality.** Four passages carried the specifics of the review that prompted them rather than the lesson: the `NaN` entry quoted one bug's guard ("no element is out of order"), the cost caution used that PR's arithmetic ("one component rather than a thousand"), the empty-input entry described a single past occurrence, and the working-directory rule rested on an anecdote about an agent that wandered into another checkout. Each now states the general shape. The DoenetML-specific mechanisms stay — `createComponentOfType`, one replacement per composite result, an input changing while a student types — because those recur; it was the incident detail that did not.

**The minimum is three cycles again.** The first pass replaced a repeated prompt with three distinct lenses and then set the floor at two, so a two-cycle run never ran the claims-against-code lens — the class this PR was written to catch. The evidence for lowering it ("both third cycles were thin") was about a third *identical* pass, which the lenses had already eliminated. The floor is now stated as one cycle per lens so it is not re-lowered, and the evidence-keyed stopping rule governs cycle four onward.

**"Adversarial" as behavior, not as a label.** The useful part is disconfirmation: pick the input that breaks the change, do not accept a comment or a test name as evidence, and establish the "before" by reading the code that used to run. Those are checkable. "Be adversarial" is a tone instruction, and a reviewer that also commits fixes answers a tone instruction with volume — inflated severity and findings produced to look diligent. So the stance is written as behavior, with the counterweight it needs: a review that finds nothing real is a legitimate result and should be reported as one.

**A verification step, inside the cycle.** The reviewer here is also the fixer, so an unconfirmed finding is not noise a reader skims past — it is a pushed commit that every later cycle inherits as a decision already taken. That is a stronger case for verification than a report-only review has, but not a case for a separate verify stage: this loop is sequential and narrow, and it already contains an independent verifier, since cycle N+1 is a fresh agent with no attachment to cycle N's work.

The ledger was disarming it. Its stated job was that "settled ground is not re-derived", which told each cycle to treat the previous cycle's fixes as closed — and a fix recorded as "found it, fixed it, verified" is the claim most worth challenging. So: a cycle now opens by verifying the previous cycle's changes, must confirm a finding before changing code for it (the guidelines' *ran it / read the code / assumed* test now gates the commit, not just the report), and the ledger separates closed decisions from open claims. The normal path costs no extra agents. One case is left over — the loop stopping at the cap or by the user's call, on a cycle that did make changes — and only that case gets a final read-and-report pass.

## Claims audit

A prompt cannot be verified by re-reading it, but the factual claims inside one can be checked against the repository. Everything the guidelines name as a path, script or mechanism holds: the schema script and its generated directory, the `schema-freshness` CI job, the three packages that carry Cypress component tests (and they are the only three), `createComponentOfType`, and the composite claim — `SampleRandomNumbers.js` pushes exactly one `number` replacement per sampled value.

Three claims did not survive, and were corrected.

**A frequency claim that propagated.** "A stale PR description is *the most common* review-cycle oversight" was asserted without evidence in an earlier commit, copied into the second file, and strengthened in the copy to "*the single most common* oversight in this procedure". That is the failure these guidelines describe — a sentence checked against its own earlier wording rather than against anything real — occurring inside the document that warns about it. The step now rests on something checkable: nothing else in the pipeline checks the PR description.

**An unsupported appeal to history.** The edge-case list was introduced as "the ones that have actually shipped bugs in this codebase". Those cases are demonstrably live — forty test files exercise `NaN`, fifteen exercise empty input — but the history does not record what the sentence claimed, and the guidelines' own rule is to cite a claim or drop it.

**An incomplete `NaN` entry.** `Number.js` carries a `valueOnNaN` attribute, so unparseable content yields whatever the author set and is `NaN` only by default. The reviewer's inference is unsafe in both directions, and the entry now says so.

## Author-facing documentation

The documentation section asked whether pages were updated. It never asked whether what was written belongs on an author-facing page at all — a different question, and one that a docs change can fail while satisfying every other bullet.

`packages/docs-nextra/` is written for people authoring DoenetML activities, not for developers working on the implementation, and nothing should appear there that an author could not observe from the DoenetML side. The failure has a specific cause worth telling the reviewer: whoever wrote the page has just spent hours in the implementation, so its vocabulary is the nearest to hand, and source files, internal state-variable names and walkthroughs of what the runtime does internally arrive in the prose without anyone deciding to put them there.

The check now leads the section and gives the observable test — could an author discover this by experimenting? — then defers to the [`doenetml-docs-authoring`](.github/skills/doenetml-docs-authoring/SKILL.md) skill for the specific cases, the way the changeset bullet defers to the `changesets` skill. Copying that skill's list into the guidelines would create a second copy to drift out of sync, which is the defect the claims audit above had just removed from this same document.

## Notes

Documentation only — no package changes, so no changeset.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdEWccVoUPCJoDYxKmHRo



