### PR TITLE
fix: keep a repeat's valueName from capturing an index reference in the items it repeats over

### DIFF
--- a/.changeset/repeat-value-name-captures-index-reference.md
+++ b/.changeset/repeat-value-name-captures-index-reference.md
@@ -1,0 +1,27 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop a repeat's `valueName` from capturing a same-named reference inside an index of the items it repeats over.
+
+Repeating over iterations that index something by the iteration value, as in
+
+```xml
+<mathList name="popSizes">1163 1164 292 290</mathList>
+
+<repeatForSequence from="1" to="4" valueName="i" name="countByPop">
+  <round>$popSizes[$i]</round>
+</repeatForSequence>
+
+<repeat for="$countByPop" valueName="i">$i</repeat>
+```
+
+took the whole document down with "Something went wrong as path index is not an integer". A repeat names each item it creates after its `valueName`, so the `<round>` copies here are named `i`; the `$i` inside `$popSizes[$i]` that each copy carried then found the copy it sits inside rather than the iteration value it was written to mean. Indexing by the component the index belongs to is circular, so the index came out an error rather than an integer, which is a state the reference machinery treats as impossible.
+
+A reference copied inside a path index now shadows the one it was copied from, the way a copied child does, and a reference that resolves onto a component containing it now prefers a candidate origin that resolves elsewhere. Together those keep the copied `$i` pointing at the iteration value it named in the original.
+
+A reference that means its own container and has nowhere else to resolve from, such as the `$P` in `P`'s own label, still resolves the way it did.

--- a/.changeset/repeat-value-name-captures-index-reference.md
+++ b/.changeset/repeat-value-name-captures-index-reference.md
@@ -25,3 +25,5 @@ took the whole document down with "Something went wrong as path index is not an 
 A reference copied inside a path index now shadows the one it was copied from, the way a copied child does, and a reference that resolves onto a component containing it now prefers a candidate origin that resolves elsewhere. Together those keep the copied `$i` pointing at the iteration value it named in the original.
 
 A reference that means its own container and has nowhere else to resolve from, such as the `$P` in `P`'s own label, still resolves the way it did.
+
+An index written inside an attribute rather than inside the content — the `$i` of `<updateValue target="$m[$i]" />` — is not covered. Copying content that holds one still loses the index, as it did before.

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -246,6 +246,29 @@ export class RefResolutionDependency extends Dependency {
         }
     }
 
+    /**
+     * Whether `resolution` landed on a component that contains the reference itself.
+     *
+     * A reference can legitimately point at its own container — `$P` inside `P`'s label
+     * is how a label says "my own value" — so such a resolution is used when it is the
+     * only one on offer. It is not what a *copy* wants, though. A composite that names
+     * the item it creates, as `<repeat valueName="i">` does, hands that name to the copy
+     * itself, so a `$i` that the copied content already carried now finds the copy rather
+     * than what it named in the original. Preferring a candidate origin that resolves
+     * outside the reference keeps the copied `$i` pointing where the original one did.
+     */
+    resolvesIntoOwnAncestry(composite: any, resolution: any) {
+        const nodeIdx = resolution.nodeIdx;
+
+        return (
+            nodeIdx === composite.componentIdx ||
+            (composite.ancestors?.some(
+                (ancestor: any) => ancestor.componentIdx === nodeIdx,
+            ) ??
+                false)
+        );
+    }
+
     async determineDownstreamComponents({ force = false } = {}) {
         this.compositeReplacementDependencies = [];
 
@@ -394,6 +417,10 @@ export class RefResolutionDependency extends Dependency {
         // `undefined` if every candidate failed (or if there was no candidate to try).
         let refResolution;
 
+        // A resolution that landed on a component containing the reference, kept aside
+        // in case no candidate origin does better. See `resolvesIntoOwnAncestry`.
+        let selfReferentialResolution;
+
         // The failure reported if no candidate origin resolves. It is the failure of the
         // first candidate — the reference's own position — since that is the one that
         // describes the document the author wrote; later candidates are only fallbacks.
@@ -402,11 +429,21 @@ export class RefResolutionDependency extends Dependency {
 
         for (const origin of this.originsToResolveFrom(composite)) {
             try {
-                refResolution = this.dependencyHandler.core.resolvePath!(
+                const candidateResolution = this.dependencyHandler.core
+                    .resolvePath!(
                     { path: resolveComponentResult.path },
                     origin,
                     skip_parent_search,
                 );
+
+                if (
+                    this.resolvesIntoOwnAncestry(composite, candidateResolution)
+                ) {
+                    selfReferentialResolution ??= candidateResolution;
+                    continue;
+                }
+
+                refResolution = candidateResolution;
                 break;
             } catch (e) {
                 // console.log("resolve error", e);
@@ -417,6 +454,8 @@ export class RefResolutionDependency extends Dependency {
                 }
             }
         }
+
+        refResolution ??= selfReferentialResolution;
 
         if (refResolution === undefined) {
             const referenceText = getDoenetMLStringForReference();

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -247,7 +247,7 @@ export class RefResolutionDependency extends Dependency {
     }
 
     /**
-     * Whether `resolution` landed on a component that contains the reference itself.
+     * Whether `resolution` landed on the reference itself or on a component containing it.
      *
      * A reference can legitimately point at its own container — `$P` inside `P`'s label
      * is how a label says "my own value" — so such a resolution is used when it is the
@@ -417,8 +417,9 @@ export class RefResolutionDependency extends Dependency {
         // `undefined` if every candidate failed (or if there was no candidate to try).
         let refResolution;
 
-        // A resolution that landed on a component containing the reference, kept aside
-        // in case no candidate origin does better. See `resolvesIntoOwnAncestry`.
+        // A resolution that landed on the reference itself or on a component containing
+        // it, kept aside in case no candidate origin does better.
+        // See `resolvesIntoOwnAncestry`.
         let selfReferentialResolution;
 
         // The failure reported if no candidate origin resolves. It is the failure of the

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeat.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeat.test.ts
@@ -2242,8 +2242,8 @@ describe("Repeat tag tests @group1", async () => {
         // The repeat names each item after its `valueName`, and the items here are copies
         // of iterations that carry a `$i` of their own inside the index of `$m[$i]`. That
         // copied `$i` still means the iteration's `i`, not the item the repeat just named
-        // `i` — which is the item the index sits inside, so reading it that way would be
-        // circular and would leave the reference with no index at all.
+        // `i` — which is the item the index sits inside, so reading it that way is circular
+        // and puts an `_error` where the index belongs, taking the whole document down.
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <mathList name="m">11 22 33 44</mathList>

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/repeat.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/repeat.test.ts
@@ -2237,4 +2237,28 @@ describe("Repeat tag tests @group1", async () => {
 
         await check_items(2, answers);
     });
+
+    it("valueName matching a name inside an index of the items does not capture it", async () => {
+        // The repeat names each item after its `valueName`, and the items here are copies
+        // of iterations that carry a `$i` of their own inside the index of `$m[$i]`. That
+        // copied `$i` still means the iteration's `i`, not the item the repeat just named
+        // `i` — which is the item the index sits inside, so reading it that way would be
+        // circular and would leave the reference with no index at all.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <mathList name="m">11 22 33 44</mathList>
+    <repeatForSequence from="2" to="3" valueName="i" name="rounded">
+      <round>$m[$i]</round>
+    </repeatForSequence>
+
+    <p name="p"><repeat for="$rounded" valueName="i">$i</repeat></p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
+        ).eq("22, 33");
+    });
 });

--- a/packages/doenetml-worker-javascript/src/utils/copy.js
+++ b/packages/doenetml-worker-javascript/src/utils/copy.js
@@ -130,6 +130,28 @@ export function postProcessCopy({
                 init: false,
             });
         }
+
+        // The components inside a reference's path indices, such as the `$i` of
+        // `$m[$i]`, were copied along with the reference, so they shadow their
+        // originals just as a copied child does.
+        if (component.extending) {
+            for (const pathPart of unwrapSource(component.extending)
+                .originalPath ?? []) {
+                for (const index of pathPart.index) {
+                    postProcessCopy({
+                        serializedComponents: index.value,
+                        componentIdx,
+                        addShadowDependencies,
+                        markAsPrimaryShadow,
+                        identifierPrefix,
+                        unlinkExternalCopies,
+                        copiesByRefIdx,
+                        componentIndicesFound,
+                        init: false,
+                    });
+                }
+            }
+        }
     }
 
     if (init && unlinkExternalCopies) {

--- a/packages/doenetml-worker-javascript/src/utils/copy.js
+++ b/packages/doenetml-worker-javascript/src/utils/copy.js
@@ -82,14 +82,10 @@ export function postProcessCopy({
     // recurse after processing all components
     // so that first gather all active aliases
 
-    for (let ind in serializedComponents) {
-        let component = serializedComponents[ind];
-        if (typeof component !== "object") {
-            continue;
-        }
-
-        postProcessCopy({
-            serializedComponents: component.children,
+    /** Recurse into components nested one level below this one. */
+    function recurse(nestedComponents) {
+        return postProcessCopy({
+            serializedComponents: nestedComponents,
             componentIdx,
             addShadowDependencies,
             markAsPrimaryShadow,
@@ -99,36 +95,25 @@ export function postProcessCopy({
             componentIndicesFound,
             init: false,
         });
+    }
+
+    for (let ind in serializedComponents) {
+        let component = serializedComponents[ind];
+        if (typeof component !== "object") {
+            continue;
+        }
+
+        recurse(component.children);
 
         for (let attrName in component.attributes) {
             let attribute = component.attributes[attrName];
             if (attribute.component) {
-                attribute.component = postProcessCopy({
-                    serializedComponents: [attribute.component],
-                    componentIdx,
-                    addShadowDependencies,
-                    markAsPrimaryShadow,
-                    identifierPrefix,
-                    unlinkExternalCopies,
-                    copiesByRefIdx,
-                    componentIndicesFound,
-                    init: false,
-                })[0];
+                attribute.component = recurse([attribute.component])[0];
             }
         }
 
         if (component.replacements) {
-            postProcessCopy({
-                serializedComponents: component.replacements,
-                componentIdx,
-                addShadowDependencies,
-                markAsPrimaryShadow,
-                identifierPrefix,
-                unlinkExternalCopies,
-                copiesByRefIdx,
-                componentIndicesFound,
-                init: false,
-            });
+            recurse(component.replacements);
         }
 
         // The components inside a reference's path indices, such as the `$i` of
@@ -138,17 +123,7 @@ export function postProcessCopy({
             for (const pathPart of unwrapSource(component.extending)
                 .originalPath ?? []) {
                 for (const index of pathPart.index) {
-                    postProcessCopy({
-                        serializedComponents: index.value,
-                        componentIdx,
-                        addShadowDependencies,
-                        markAsPrimaryShadow,
-                        identifierPrefix,
-                        unlinkExternalCopies,
-                        copiesByRefIdx,
-                        componentIndicesFound,
-                        init: false,
-                    });
+                    recurse(index.value);
                 }
             }
         }


### PR DESCRIPTION
## The bug

```xml
<mathList name="popSizes">1163 1164 292 290</mathList>

<repeatForSequence from="1" to="4" valueName="i" name="countByPop">
  <round>$popSizes[$i]</round>
</repeatForSequence>

<repeat for="$countByPop" valueName="i">$i</repeat>
```

takes the whole document down with **"Something went wrong as path index is not an integer"**, thrown out of `RefResolutionIndexDependencies.gatherComponentsInPath` (`refResolutionDependencies.ts:120` on `upstream/main`). Nothing renders. Renaming either `valueName` — or reaching the same items through `indexName`, a plain `$countByPop`, or a nested `repeatForSequence` — works fine, which is what made the collision hard to see from the markup.

## Cause

A repeat names each item it creates after its `valueName`: `addAndLinkAliasComponents` (`Repeat.js:809`) gives the alias `_copy` a `createComponentName`, and `adjustForCreateComponentIdxName` (`CompositeExpander.ts:756`) puts that name on the item itself. The items here are copies of the `<round>` iterations, and each copy carries a `$i` of its own inside the index of `$popSizes[$i]`.

That copied `$i` is re-resolved from where the copy now sits, so it finds the item the repeat just named `i` — which is the very `<round>` the index sits inside. Copying it therefore walks into itself: `serialize` raises its `Encountered <componentIdx>` self-reference error, `Copy.createReplacementForSource` turns that into an `_error` in the index's place, and an index component that is not an `<integer>` is a state the reference machinery treats as impossible, so it throws rather than reporting anything.

Two things had to line up for that to happen:

1. `postProcessCopy` recursed into a copy's children, attributes and replacements, but never into the components inside `extending.originalPath`'s indices. A `$i` copied inside an index therefore had no `shadows` link, so `originsToResolveFrom` had no second candidate origin to offer — unlike every other copied reference.
2. `RefResolutionDependency` accepted the first candidate origin that resolved, even when the resolution landed on a component containing the reference. For an index that is always circular: the index is part of what brings that component into being.

## The fix

`postProcessCopy` now also walks the components inside a reference's path indices, so a reference copied inside an index shadows the one it was copied from, exactly as a copied child does. That gives the resolution somewhere else to look. The three recursive calls it already made — children, attributes, replacements — passed the same nine arguments as the new one does, so all four now go through one local `recurse` helper.

A `<repeat>` never calls `postProcessCopy` for its own replacements: the call in `CompositeExpander.ts:584` sits inside `expandShadowingComposite`, which runs only for a composite that shadows another. What carries the fix for the document above is the level below — `Copy.createReplacementForSource` (`components/abstract/Copy.js:1586`) calls `postProcessCopy` while expanding the `_copy` that stands for each repeat item, and the recursion reaches the copied `$i` two levels of children down.

`RefResolutionDependency` now sets aside a candidate resolution that lands on the reference itself or on one of its ancestors (`resolvesIntoOwnAncestry`) and tries the next candidate origin. The copied `$i` falls through to the origin of the reference it shadows and points back at the iteration value it named in the original, which is what it meant all along.

The set-aside resolution is still used when no candidate does better, so a reference that means its own container and has no other origin — the `$P` in `P`'s own label — resolves the way it did. That path is what `Copy.js`'s `getSelfReferentialFallbackPropName` exists to serve, and it is unchanged.

## Testing

One regression test in `repeat.test.ts` for the reported shape, asserting `22, 33` rather than a dead document. It throws on `upstream/main`.

The other half — that a self-referential reference with nowhere else to go still resolves — is covered by tests already in the tree: deleting the `refResolution ??= selfReferentialResolution` fallback makes two tests in `label.test.ts` fail.

The full `@doenet/doenetml-worker-javascript` suite passes on this branch: 3797 passed, 1 expected fail, 38 skipped, 1 todo, on six of seven runs. The seventh had a flaky failure in `selectsamplerandomnumbers.test.ts > copying parameters` (a variance assertion, `expected 4.07 to be close to 3 +/- 1`) that passes when that file is re-run. It is unrelated to this change: `sampleRandomNumbers` seeds itself from the clock unless `variantDeterminesSeed` is set (`SampleRandomNumbers.js:1207`), and instrumentation shows neither half of this change fires in that document — no copied reference there sits in a path index, and no candidate origin is ever set aside.

These variants were also checked by hand, before and after: the reported document verbatim; the same items reached through `indexName="i"`, through a plain `$countByPop`, and through a nested `repeatForSequence` that reuses `i`; a `<point>` whose label references its own `x`; and a copy of that point made with `extend`. All resolve as they did, and the ones that were fatal now aren't.

So were these edge cases, each run both ways: an index naming nothing that exists; an index that is `NaN`, negative, zero, fractional, or past the end of the list it indexes; a repeat whose `for` is empty, and one with a single item; nested repeats whose `valueName`s collide at two levels, and a chain of three repeats all using `i`; an index driven by a `<mathInput>` that happens to be named `i`, including while it is being typed into; and repeat bounds moved to and from empty. Each is either unchanged or no longer fatal, and where one renders something it renders what the same document renders with a non-colliding `valueName`.

A copied reference that names the `valueName` outside an index — `<p>i is $i</p>` in the repeated content, or a `<label>` doing the same — already resolved correctly and still does, as does a `<sort>` over content carrying an index reference.

### Where the origin preference fires, and why only the index case is observable

`resolvesIntoOwnAncestry` is not index-aware, and the preference does change which origin wins outside indices. Instrumented over the whole suite — recording every resolution where a candidate was set aside *and* a later one succeeded — it fires at exactly eight places: the two index references of the new test, and six self-referential prop references sitting inside a copy that kept the referenced name. Those six are `$l.slope` in a line's own label, copied into a second graph that names the copy `l` again (`line.test.ts`'s `setupScene`, twice); `$f.formula` in a function's own label (`functionTag.test.ts`, in "function determined by formula via sugar, label with math" and in "function determined by math formula, label with math"); and `$c.controlVectors[…]` written as one of a curve's own `<controlVectors>` children inside `<bezierControls>` (`curve.bezier.test.ts:1900` and `:1922`).

The preference can fire only where the *name* part of a path resolves to the reference's own ancestor. Props and indices stay in `unresolvedPath`, since the resolver stops at the last named component, so `$s.title` written inside `s` reaches the test while `$s.f` written inside `s` does not — the latter resolves to `f`, which contains nothing. That is what keeps the set this small: each of the eight has a bare ancestor name at the head of its path.

None of the six non-index sites is observable, and the reason is structural. A copy has a second candidate origin only when it has a `shadows` chain, and `expandCompositeComponent` sends a composite that shadows another to `expandShadowingComposite` (`CompositeExpander.ts:332-337`), which builds the replacements by serializing the *shadowed* composite's replacements and never reads `extendIdx` (`CompositeExpander.ts:430-545`). The resolution the preference changes therefore cannot change what the copy produces.

Measured rather than argued: eleven documents of exactly that shape — a linked copy that keeps the referenced name and overrides the very thing the self-reference reads — had their whole `returnAllStateVariables` dump compared against `upstream/main`. They were a `<section extend>` overriding its own title; a `<point extend>` overriding `x`, and the same document after the copy is dragged somewhere else again; a `<point extend>` overriding `displayDigits` with a list-valued `$P.xs` in its label; a `<line extend>` overriding `through` under a `$l.slope` label; a `<function extend>` overriding its formula under a `$f.formula` label; a `<curve extend>` overriding `through` under a `$c.controlVectors[1]` label; a `<graph extend>` overriding `xmax` that a point inside reads back; an `<updateValue target="$s.hide">` inside a section copied under its own name, both before and after the button is pressed; and a copy of a copy that keeps the name at every level. The only difference anywhere in any of them is the `_copy`'s own `extendIdx` state variable, which is not public. Everything downstream — labels, values, rounding, `unordered`, `hide`, the dependency graph — is byte-identical. A copy made with `copy=` has no shadow chain at all, so `originsToResolveFrom` offers it a single candidate, the set-aside resolution is used, and it renders its own overridden value (`x is 7`, `slope = 3`, `t: Second`) exactly as before.

### Where the fix does not reach: references inside an attribute

`postProcessCopy` walks a component's children, the attributes that became components, and its replacements. It does not walk `attribute.references` — the reference list an attribute declared `createReferences: true` carries (`BaseComponent.js:1621-1632`), which is what `target=`, `from=`, `bindValueTo=`, `referencesAreResponses=` and the rest resolve through (`AttributeRefResolutions`, `refResolutionDependencies.ts:764`). This PR does not change that, so two failures survive it — one visible, one latent. Both behave identically on `upstream/main`; neither is a regression. They are filed as #1841.

Copying content that holds an index inside such an attribute loses the index. In

```xml
<mathList name="m">11 22 33 44</mathList>
<repeatForSequence from="2" to="3" valueName="i" name="rounded">
  <updateValue name="uv" target="$m[$i]" newValue="99" type="math" />
</repeatForSequence>
<p name="p">$rounded</p>
```

the two iterations resolve their targets, and the two copies of them inside `<p>` resolve none (`targetComponentIdx: -1`, the index value having come out `NaN`). The copies render as buttons that do nothing; the document does report `No referent found for reference: $m[$i]` and `Invalid target for <updateValue>: cannot find target.` Give the outer composite a colliding `valueName`, the way the bug this PR fixes does —

```xml
<p name="p"><repeat for="$rounded" valueName="i">$i</repeat></p>
```

— and the copy's `targetComponentIdx`, `targetIdentities` and `targets` raise the same `Something went wrong as path index is not an integer`, still, with this PR applied. That one is latent rather than fatal: the document builds and renders and the written-out buttons work, because nothing the renderer asks for reaches those state variables. It surfaces where something walks every state variable, as `core.returnAllStateVariables` does in the test harness — checked in the dev app, where both documents render and `m` reaches `11, 99, 99, 44`.

Walking each attribute reference's path indices the way the fix walks a component's does repair both — the copies then resolve distinct, correct per-iteration targets, and the whole suite stays green. But it also changes documents with no name collision anywhere in them, since the first failure above has nothing to do with `valueName`. That is a second fix, needing its own test and its own changeset, so it is left for its own change rather than smuggled into this one.

### Why only `originalPath` is walked

`unresolvedPath` carries index components too, and three distinct shapes of them reach `postProcessCopy` over the course of the suite — but nothing ever builds one. `ComponentBuilder` instantiates only `originalPath`'s index values and passes `unresolvedPath` through untouched (`ComponentBuilder.ts:551-590`); `BaseComponent.serialize` runs `serializePath` over `originalPath` and merely deep-clones `unresolvedPath` (`BaseComponent.js:1755-1768`); and both dependency classes read `originalPath` (`refResolutionDependencies.ts:45` and `:336`). No reader anywhere treats an `unresolvedPath` index value as a live component, so a reference copied there has nothing to capture. `RefResolutionIndexDependencies` needs no origin preference for the same kind of reason: it resolves nothing, only collecting the indices of the index components, each of which is a `_copy` that `RefResolutionDependency` resolves on its own.

### What the new recursion changes for other composites

`postProcessCopy` is shared machinery — fourteen call sites reach it — so the path-index recursion runs wherever content is copied, not only on the `Copy` expansion that carries this fix. The structural change, measured by comparing `core._components`' shadow bookkeeping and the dependency count before and after: a copied index component now gets a `shadows` link to the one it was copied from (never `firstLevelReplacement`, since the recursion always passes `init: false`), the mediating composite gets the matching `mediatesShadows` entry, and the copy's replacements shadow the source's replacements rather than resolving to the original target on their own. Under `link="false"` the component gets `unlinkedCopySource` instead, the same as a copied child.

Rendered output is identical, before and after, in every document I could build where that fires: `extend` of a `<p>` holding `$m[$k]`, the same with `link="false"`, `<sort>`, `<shuffle>`, `<collect>`, a repeat extending another repeat, a copy of a copy, an index inside an attribute, `$M.matrix[$k][$k]`, an index nested inside another index, an index reference that names the copy itself or an ancestor of the reference, and two mutually referential copies (which fails the same way on both sides). It stays identical while a `<mathInput>` drives the index in and out of range, and while a repeat's bounds move to and from empty — the paths where replacements are updated rather than first expanded.

The cost is small and proportional to how many copied references carry an index. Counting entries in `DependencyHandler.downstreamDependencies` and keys in `core._components`, a single copied index reference costs +2 dependencies and +0 components — `extend` of a `<p>` holding `$m[$k]`, and the same content under `<sort>`, `<shuffle>` and `<collect>`, each measured at exactly +2 and +0. It is larger only when the copy is itself a composite whose replacements get copied again: an `extend` of a `<p>` holding `<repeatForSequence from="1" to="4" valueName="k"><math>$m[$k]</math></repeatForSequence>` goes from 112 to 116 components and from 12,824 to 13,416 dependencies — one extra copied index component per iteration, and the state-variable dependencies each of those brings. A document whose copied content holds no path index is untouched — the new loop finds nothing to recurse into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtLBioQmDs848sYUVbhrhw




