### PR TITLE
Read a list operator's bare string children as what they look like

### DIFF
--- a/.changeset/infer-list-value-type.md
+++ b/.changeset/infer-list-value-type.md
@@ -21,10 +21,15 @@ They are now read by their content: every whitespace-separated piece naming a nu
 
 This is the rule the values already followed when they arrived as components: `allAreNumeric` is true only when every value is numeric, and a single text among numbers sends the whole list to a text comparison. Applying it to bare strings means an author who writes `1 10 3` and an author who references a `<numberList>` get the same answer.
 
+A piece names a number whenever a `<number>` around it would be one, so `1/2`, `2^3`, `1e5`, `0x10`, `pi` and `min(1,2)` all count, and `x`, `2x`, `true` and `NaN` do not.
+
 `type` is now an override rather than a requirement, for when the look is misleading — `007 008` counts the numbers 7 and 8, and `type="text"` keeps the leading zeros. It still governs only bare strings; a referenced component keeps the type it already has.
 
 A `type` naming something that is not one of the four is now reported and then **dropped**, so it behaves exactly as if it had not been written. It used to be replaced with `math`, which is how `<tally type="txt" categories="apple fig">` came to make every category `NaN` and then report that a category had been named twice.
 
 Two diagnostics are retired in place and one is added: `doenet-w0013` asked for a type nothing needs any more, and `doenet-w0014` named a `math` fallback that no longer happens. `doenet-w0145` replaces the second and says what now occurs.
 
-Affects `<sort>`, `<shuffle>`, `<sortIndices>`, `<tally>`, `<argMin>`, `<argMax>`, `<indexOf>` and `<searchSorted>`. Of those, only `<sort>` and `<shuffle>` have shipped, and for them the change reaches only markup that produced nothing before.
+Affects `<sort>`, `<shuffle>`, `<sortIndices>`, `<tally>`, `<argMin>`, `<argMax>`, `<indexOf>` and `<searchSorted>`. Only `<sort>` and `<shuffle>` have shipped, and two existing documents change:
+
+- One that mixes a reference with a bare string. `<sort>$mi 3</sort>` used to sort the reference alone and drop the `3`; it now sorts both.
+- One with a `type` that is not one of the four. Those strings used to be read as maths, so `<sort type="txt">1/2 2 1</sort>` rendered `1/2, 1, 2` and now renders `0.5, 1, 2`, and `<sort type="letters">d a b</sort>` produces text rather than maths, so `.latex` on an item no longer resolves. Both already reported the type as invalid.

--- a/.changeset/infer-list-value-type.md
+++ b/.changeset/infer-list-value-type.md
@@ -21,11 +21,11 @@ They are now read by their content: every whitespace-separated piece naming a nu
 
 This is the rule the values already followed when they arrived as components: `allAreNumeric` is true only when every value is numeric, and a single text among numbers sends the whole list to a text comparison. Applying it to bare strings means an author who writes `1 10 3` and an author who references a `<numberList>` get the same answer.
 
-A piece names a number whenever a `<number>` around it would be one, so `1/2`, `2^3`, `1e5`, `0x10`, `pi` and `min(1,2)` all count, and `x`, `2x`, `true` and `NaN` do not.
+A piece names a number when Doenet's own math parser works one out of it, so `1/2`, `2^3`, `sqrt(4)`, `pi` and `min(1,2)` all count, and `x`, `2x`, `true` and `NaN` do not. JavaScript's numeric literals are not consulted, so `1e5` and `0x10` are words here: scientific notation has to be asked for and is spelled with a capital `E`, and hexadecimal is not DoenetML notation at all. An author who wants an exponent read writes `<mathList parseScientificNotation="true">1E3 2 5E2</mathList>` and references it.
 
 `type` is now an override rather than a requirement, for when the look is misleading — `007 008` counts the numbers 7 and 8, and `type="text"` keeps the leading zeros. It still governs only bare strings; a referenced component keeps the type it already has.
 
-A `type` naming something that is not one of the four is now reported and then **dropped**, so it behaves exactly as if it had not been written. It used to be replaced with `math`, which is how `<tally type="txt" categories="apple fig">` came to make every category `NaN` and then report that a category had been named twice.
+A `type` naming something that is not one of the four is now reported and then **dropped**, so the string children are read exactly as they would be with no `type` at all. It used to be replaced with `math`, so `<tally type="txt">apple fig apple</tally>` read its three words as maths and reported its categories as `a p p l e` and `f i g`. This covers the string children only: `categories` and `target` resolve an invalid `type` separately and still replace it, so `<tally type="txt" categories="apple fig">` counts nothing either way.
 
 Two diagnostics are retired in place and one is added: `doenet-w0013` asked for a type nothing needs any more, and `doenet-w0014` named a `math` fallback that no longer happens. `doenet-w0145` replaces the second and says what now occurs.
 

--- a/.changeset/infer-list-value-type.md
+++ b/.changeset/infer-list-value-type.md
@@ -1,0 +1,30 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Read a list operator's bare string children as what they look like, instead of refusing them.
+
+`<sort>d a b</sort>` rendered nothing at all. So did `<tally>apple fig apple</tally>`, `<shuffle>d a b</shuffle>`, and every other component that reads its children as a list of comparable values. Each reported that a `type` attribute was required, ignored the string, and produced an empty result — for markup that says exactly what it means.
+
+They are now read by their content: every whitespace-separated piece naming a number makes the list numeric, and anything else makes it text.
+
+```xml
+<sort>10 2 1</sort>          <!-- 1, 2, 10   — ordered by value -->
+<sort>d a b</sort>           <!-- a, b, d    — ordered alphabetically -->
+<sort>10 2 x</sort>          <!-- 10, 2, x   — one word, so all text -->
+<tally>apple fig apple</tally>
+```
+
+This is the rule the values already followed when they arrived as components: `allAreNumeric` is true only when every value is numeric, and a single text among numbers sends the whole list to a text comparison. Applying it to bare strings means an author who writes `1 10 3` and an author who references a `<numberList>` get the same answer.
+
+`type` is now an override rather than a requirement, for when the look is misleading — `007 008` counts the numbers 7 and 8, and `type="text"` keeps the leading zeros. It still governs only bare strings; a referenced component keeps the type it already has.
+
+A `type` naming something that is not one of the four is now reported and then **dropped**, so it behaves exactly as if it had not been written. It used to be replaced with `math`, which is how `<tally type="txt" categories="apple fig">` came to make every category `NaN` and then report that a category had been named twice.
+
+Two diagnostics are retired in place and one is added: `doenet-w0013` asked for a type nothing needs any more, and `doenet-w0014` named a `math` fallback that no longer happens. `doenet-w0145` replaces the second and says what now occurs.
+
+Affects `<sort>`, `<shuffle>`, `<sortIndices>`, `<tally>`, `<argMin>`, `<argMax>`, `<indexOf>` and `<searchSorted>`. Of those, only `<sort>` and `<shuffle>` have shipped, and for them the change reaches only markup that produced nothing before.

--- a/packages/docs-nextra/pages/reference/sort.mdx
+++ b/packages/docs-nextra/pages/reference/sort.mdx
@@ -107,40 +107,55 @@ using the `<sort>{:dn}` component.
 ### Attribute Example: type
 
 
+Bare string children are read as what they look like: if every whitespace-separated piece
+names a number the list is numeric, and otherwise it is text. So `<sort>10 2 1</sort>{:dn}`
+sorts by value and `<sort>d a b</sort>{:dn}` sorts alphabetically with nothing declared
+either way, and most documents never need `type` at all. Write it for the cases where the
+look is misleading.
+
+
+**Numerals that are labels rather than quantities.** Zip codes, course numbers and
+rankings are written with digits but are not amounts.
+
+
 ```doenet-editor-horiz
-<p>Numbers: <sort type="number">101 542 51 234</sort></p>
-<p>Text: <sort type="text">orange apple banana</sort></p>
-<p>Booleans: <sort type="boolean">true false true</sort></p>
+<p>Read as numbers: <sort>02134 55455 07094</sort></p>
+<p>Read as text: <sort type="text">02134 55455 07094</sort></p>
 ```
 
 
+The first line drops the leading zeros that make a zip code a zip code. `type="text"` is
+also what puts `10` before `9`, which is the order a list of labels usually wants.
 
-When the children are written as plain text rather than as components, `type` says how
-to read each whitespace-separated piece: as a `number`, a `math`, a `text`, or a
-`boolean`. Numbers and maths are ordered by value when every value is numeric;
-otherwise everything is ordered alphabetically, which puts `false` before `true`.
 
-Without `type`, each piece is read as what it looks like: every piece naming a number
-makes the list numeric, and anything else makes it text. So `<sort>10 2 1</sort>{:dn}`
-sorts by value and `<sort>d a b</sort>{:dn}` sorts alphabetically, with nothing to
-declare either way — the same rule the values follow when they arrive as components,
-where one text among numbers sends the whole list to an alphabetical ordering.
+**Expressions that should be compared as maths.** Two spellings of one expression are two
+different values as text and a single value as maths.
 
-A piece names a number when it works out to one, so `<sort>1/2 2^3 pi sqrt(4)</sort>{:dn}`
-orders four numbers, not four words.
-
-`type` applies only to those bare strings. A referenced component already has a type of
-its own and is left as it is, so a referenced list keeps its individual items:
 
 ```doenet-editor-horiz
-<setup>
-  <textList name="names">Ann Cal Bob</textList>
-</setup>
-
-<p>Sorted: <sort type="text">$names Zoe</sort></p>
+<p>Read as text: <sort>2x 2*x x</sort></p>
+<p>Read as maths: <sort type="math">2x 2*x x</sort></p>
 ```
 
-This sorts four names, not the two values `Ann, Cal, Bob` and `Zoe`.
+
+`type="math"` also keeps an expression in the form it was written while still ordering it
+by value: `<sort type="math">1/2 2^3 pi sqrt(4)</sort>{:dn}` puts the four expressions in
+order as they were typed, where without `type` the same four arrive as `0.5, 2, 3.14, 8`.
+
+
+**Booleans.** Without `type` these are just words, and alphabetical order happens to put
+`false` first — so it looks right until the capitalization varies.
+
+
+```doenet-editor-horiz
+<p>Read as text: <sort>True false TRUE</sort></p>
+<p>Read as booleans: <sort type="boolean">True false TRUE</sort></p>
+```
+
+
+There is no case for writing `type="number"`: a piece that names a number is already read
+as one, and one that does not becomes `NaN`. `type` applies only to bare strings — a
+referenced component carries a type of its own and keeps it.
 
 
 

--- a/packages/docs-nextra/pages/reference/sort.mdx
+++ b/packages/docs-nextra/pages/reference/sort.mdx
@@ -126,6 +126,9 @@ sorts by value and `<sort>d a b</sort>{:dn}` sorts alphabetically, with nothing 
 declare either way — the same rule the values follow when they arrive as components,
 where one text among numbers sends the whole list to an alphabetical ordering.
 
+A piece names a number when it works out to one, so `<sort>1/2 2^3 pi sqrt(4)</sort>{:dn}`
+orders four numbers, not four words.
+
 `type` applies only to those bare strings. A referenced component already has a type of
 its own and is left as it is, so a referenced list keeps its individual items:
 

--- a/packages/docs-nextra/pages/reference/sort.mdx
+++ b/packages/docs-nextra/pages/reference/sort.mdx
@@ -120,10 +120,11 @@ to read each whitespace-separated piece: as a `number`, a `math`, a `text`, or a
 `boolean`. Numbers and maths are ordered by value when every value is numeric;
 otherwise everything is ordered alphabetically, which puts `false` before `true`.
 
-Without `type`, there is nothing to say what each piece should become, so the text is
-left out of the result entirely: `<sort>d a b</sort>{:dn}` renders nothing at all, and
-two warnings report it — one that a `type` is needed, one naming the string that was
-ignored.
+Without `type`, each piece is read as what it looks like: every piece naming a number
+makes the list numeric, and anything else makes it text. So `<sort>10 2 1</sort>{:dn}`
+sorts by value and `<sort>d a b</sort>{:dn}` sorts alphabetically, with nothing to
+declare either way — the same rule the values follow when they arrive as components,
+where one text among numbers sends the whole list to an alphabetical ordering.
 
 `type` applies only to those bare strings. A referenced component already has a type of
 its own and is left as it is, so a referenced list keeps its individual items:

--- a/packages/docs-nextra/pages/reference/tally.mdx
+++ b/packages/docs-nextra/pages/reference/tally.mdx
@@ -15,10 +15,10 @@ are in total, `<tally>{:dn}` reports how many there are of each kind.
 Name the categories with `categories` to fix which ones are counted and in what order;
 omit it and they are the distinct values present, in sorted order.
 
-`type` says how bare *string children* are read, and they are the only children that need
-it: values arriving as a list, a reference or a [`<searchSorted>{:dn}`](searchSorted) are
-read as what they already are. Written out, it also decides how `categories` is read,
-which is otherwise text.
+Bare string children are read as what they look like: all numbers makes the list numeric,
+anything else makes it text. `type` overrides that when the look is misleading — numerals
+that are labels rather than quantities. Values arriving as a list or a reference are read
+as what they already are.
 
 <AttrPropDisplay name='tally'/>
 
@@ -129,18 +129,20 @@ categories, `<tally>{:dn}` would report only the four values that actually appea
 
 
 ```doenet-editor-horiz
-<p>Without: <tally>apple fig apple</tally></p>
-<p>With: <tally type="text">apple fig apple</tally></p>
+<tally name="inferred">007 008 007</tally>
+<p>Inferred: $inferred.categories</p>
 
-<textList name="fruit">apple fig apple</textList>
-<p>Children of their own type: <tally>$fruit</tally></p>
+<tally name="asText" type="text">007 008 007</tally>
+<p>With `type="text"`: $asText.categories</p>
 ```
 
 
 
-Bare strings have no type of their own, so `<tally>{:dn}` asks for one before it will
-read them. Children that arrive as components already have one, and need no `type` at
-all.
+Bare strings are read as what they look like, so these count as the numbers 7 and 8 and
+the leading zeros go with them. `type` is for when the look is misleading — a jersey
+number, a ZIP code or a room number is a label rather than a quantity, and reading it as
+text keeps it whole. The counts are the same either way; it is the categories that
+change.
 
 
 

--- a/packages/docs-nextra/pages/reference/tally.mdx
+++ b/packages/docs-nextra/pages/reference/tally.mdx
@@ -12,16 +12,6 @@ component that renders how many times each category appears among its arguments:
 of counts, one per category. Where [`<count>{:dn}`](count) reports how many values there
 are in total, `<tally>{:dn}` reports how many there are of each kind.
 
-Name the categories with `categories` to fix which ones are counted and in what order;
-omit it and they are the distinct values present, in sorted order.
-
-Bare string children are read as what they look like: every one of them naming a number
-makes the list numeric, and anything else makes it text. `type` overrides that when the
-look is misleading — numerals that are labels rather than quantities, or expressions that
-should be compared as maths rather than as the characters they were typed with. Written
-out, it also decides how `categories` is read, which is otherwise text. Values arriving as
-a list or a reference are read as what they already are.
-
 <AttrPropDisplay name='tally'/>
 
 ## Examples

--- a/packages/docs-nextra/pages/reference/tally.mdx
+++ b/packages/docs-nextra/pages/reference/tally.mdx
@@ -17,8 +17,9 @@ omit it and they are the distinct values present, in sorted order.
 
 Bare string children are read as what they look like: all numbers makes the list numeric,
 anything else makes it text. `type` overrides that when the look is misleading — numerals
-that are labels rather than quantities. Values arriving as a list or a reference are read
-as what they already are.
+that are labels rather than quantities, or expressions that should be compared as maths
+rather than as the characters they were typed with. Values arriving as a list or a
+reference are read as what they already are.
 
 <AttrPropDisplay name='tally'/>
 
@@ -134,15 +135,24 @@ categories, `<tally>{:dn}` would report only the four values that actually appea
 
 <tally name="asText" type="text">007 008 007</tally>
 <p>With `type="text"`: $asText.categories</p>
+
+<tally name="inferredMath">2x 2*x 2x</tally>
+<p>Inferred: $inferredMath.categories — $inferredMath</p>
+
+<tally name="asMath" type="math">2x 2*x 2x</tally>
+<p>With `type="math"`: $asMath.categories — $asMath</p>
 ```
 
 
 
-Bare strings are read as what they look like, so these count as the numbers 7 and 8 and
-the leading zeros go with them. `type` is for when the look is misleading — a jersey
-number, a ZIP code or a room number is a label rather than a quantity, and reading it as
-text keeps it whole. The counts are the same either way; it is the categories that
-change.
+Bare strings are read as what they look like, so `007` and `008` count as the numbers 7
+and 8 and the leading zeros go with them. `type="text"` keeps a numeral that is a label
+rather than a quantity — a jersey number, a ZIP code, a room number — whole.
+
+`type="math"` is for the other direction. Neither `2x` nor `2*x` is a number, so both are
+read as text and compared letter by letter, which makes them two categories. Read as
+maths they are the same expression, and the three values are one category counted three
+times.
 
 
 

--- a/packages/docs-nextra/pages/reference/tally.mdx
+++ b/packages/docs-nextra/pages/reference/tally.mdx
@@ -15,8 +15,9 @@ are in total, `<tally>{:dn}` reports how many there are of each kind.
 Name the categories with `categories` to fix which ones are counted and in what order;
 omit it and they are the distinct values present, in sorted order.
 
-Bare string children are read as what they look like: all numbers makes the list numeric,
-anything else makes it text. `type` overrides that when the look is misleading — numerals
+Bare string children are read as what they look like: every one of them naming a number
+makes the list numeric, and anything else makes it text. `type` overrides that when the
+look is misleading — numerals
 that are labels rather than quantities, or expressions that should be compared as maths
 rather than as the characters they were typed with. Values arriving as a list or a
 reference are read as what they already are.

--- a/packages/docs-nextra/pages/reference/tally.mdx
+++ b/packages/docs-nextra/pages/reference/tally.mdx
@@ -17,10 +17,10 @@ omit it and they are the distinct values present, in sorted order.
 
 Bare string children are read as what they look like: every one of them naming a number
 makes the list numeric, and anything else makes it text. `type` overrides that when the
-look is misleading — numerals
-that are labels rather than quantities, or expressions that should be compared as maths
-rather than as the characters they were typed with. Values arriving as a list or a
-reference are read as what they already are.
+look is misleading — numerals that are labels rather than quantities, or expressions that
+should be compared as maths rather than as the characters they were typed with. Written
+out, it also decides how `categories` is read, which is otherwise text. Values arriving as
+a list or a reference are read as what they already are.
 
 <AttrPropDisplay name='tally'/>
 
@@ -147,8 +147,9 @@ categories, `<tally>{:dn}` would report only the four values that actually appea
 
 
 Bare strings are read as what they look like, so `007` and `008` count as the numbers 7
-and 8 and the leading zeros go with them. `type="text"` keeps a numeral that is a label
-rather than a quantity — a jersey number, a ZIP code, a room number — whole.
+and 8, and the leading zeros are gone from the categories. `type="text"` keeps a numeral
+that is a label rather than a quantity — a jersey number, a ZIP code, a room number —
+whole.
 
 `type="math"` is for the other direction. Neither `2x` nor `2*x` is a number, so both are
 read as text and compared letter by letter, which makes them two categories. Read as

--- a/packages/doenetml-worker-javascript/src/components/CountOperators.js
+++ b/packages/doenetml-worker-javascript/src/components/CountOperators.js
@@ -160,7 +160,7 @@ export class Tally extends CountingBaseListOperator {
         attributes.type = {
             ...returnListTypeAttribute(),
             description:
-                "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also overrides how `categories` is read, which is otherwise text.",
+                "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text. Also overrides how `categories` is read, which is otherwise text.",
         };
 
         attributes.categories = {
@@ -200,13 +200,14 @@ export class Tally extends CountingBaseListOperator {
         // of them may be advertised. `categories` resolves this variable
         // through `parentStateVariable`, and falls back to text — the reading
         // that survives comparison against values of any type. Bare string
-        // children resolve the *attribute*, in sugar, and have no fallback at
-        // all: read as text by default, `<tally>1 2 10</tally>` would order its
-        // categories `1, 10, 2`, so the author is asked which type they meant.
+        // children resolve the *attribute*, in sugar, and fall back to what
+        // their content looks like, so `<tally>1 2 10</tally>` counts three
+        // numbers while `<tally>a b</tally>` counts two words, neither of them
+        // needing a `type`.
         //
-        // Declaring the default on the attribute would publish it to the
-        // schema, and the generated reference would then promise a default that
-        // bare children reject.
+        // Declaring text as the attribute's default would publish it to the
+        // schema, and the generated reference would then promise bare children
+        // a default they do not take.
         stateVariableDefinitions.type = {
             returnDependencies: () => ({
                 typeAttr: {

--- a/packages/doenetml-worker-javascript/src/components/CountOperators.js
+++ b/packages/doenetml-worker-javascript/src/components/CountOperators.js
@@ -155,12 +155,12 @@ export class Tally extends CountingBaseListOperator {
         //
         // Bare string children are a separate question with a separate answer:
         // they are read by the sugar below, from the attribute rather than
-        // from this state variable, and still require the author to say which
-        // type they meant.
+        // from this state variable, and when it is absent they are read as
+        // whatever their content is. Writing `type` overrides that.
         attributes.type = {
             ...returnListTypeAttribute(),
             description:
-                "Component type to interpret bare string children as, which they require. Also overrides how `categories` is read, which is otherwise text.",
+                "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also overrides how `categories` is read, which is otherwise text.",
         };
 
         attributes.categories = {

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -28,7 +28,7 @@ export default class Shuffle extends CompositeComponent {
             highlighted: true,
             createPrimitiveOfType: "string",
             description:
-                "Component type to read bare string children as. Omit it and they are read as what they look like: all numbers makes them numbers, anything else makes them text.",
+                "Component type to read bare string children as. Omit it and they are read as what they look like: every piece naming a number makes them numbers, anything else makes them text.",
             validValues: [
                 {
                     value: "number",

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -27,7 +27,8 @@ export default class Shuffle extends CompositeComponent {
         attributes.type = {
             highlighted: true,
             createPrimitiveOfType: "string",
-            description: "Component type to shuffle children as.",
+            description:
+                "Component type to read bare string children as. Omit it and they are read as what they look like: all numbers makes them numbers, anything else makes them text.",
             validValues: [
                 {
                     value: "number",

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -67,7 +67,8 @@ export default class Sort extends CompositeComponent {
         attributes.type = {
             createPrimitiveOfType: "string",
             highlighted: true,
-            description: "Component type to sort children as.",
+            description:
+                "Component type to sort bare string children as. Omit it and they are read as what they look like: all numbers sorts by value, anything else sorts alphabetically.",
             validValues: [
                 {
                     value: "number",

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -68,7 +68,7 @@ export default class Sort extends CompositeComponent {
             createPrimitiveOfType: "string",
             highlighted: true,
             description:
-                "Component type to sort bare string children as. Omit it and they are read as what they look like: all numbers sorts by value, anything else sorts alphabetically.",
+                "Component type to sort bare string children as. Omit it and they are read as what they look like: every piece naming a number sorts by value, anything else sorts alphabetically.",
             validValues: [
                 {
                     value: "number",

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -159,12 +159,19 @@ describe("coded diagnostics reach the record @group4", () => {
     });
 
     it("gives every warning either a registered code or an English message", async () => {
+        // The warning has to come from something that will keep warning. This
+        // used to be `<sort name="s">a b c</sort>`, which warned only because
+        // bare strings needed a `type`; once they were read by their content
+        // the document became correct and the test had no warning left to
+        // check. An index that cannot be applied is a mistake in the markup
+        // itself, so it stays one — and the code it emits is pinned
+        // independently, by the `doenet-w0100` test below.
         const { core } = await createTestCore({
             doenetML: `
 <graph>
   <point name="p" />
 </graph>
-<sort name="s">a b c</sort>
+<text extend="$p.styleDescription[1]" />
 `,
         });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/countoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/countoperators.test.ts
@@ -291,21 +291,37 @@ describe("Counting operator tag tests @group4", async () => {
             expect(infos.length).eq(0);
         });
 
-        it("bare string children still ask which type was meant", async () => {
-            // The default that `categories` follows is not extended to the
-            // children. Read as text, `<tally>1 2 10</tally>` would order its
-            // categories `1, 10, 2` and count `2/2` apart from `1`, so a
-            // `<tally>` whose values are written as bare strings still has to
-            // be told what they are.
+        it("bare string children are read as what they look like", async () => {
+            // Words count as words and numbers as numbers, with nothing to
+            // declare. Both of these used to warn and count nothing.
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <tally name="words">apple fig apple</tally>
+    <p name="pWords">$words.categories | $words</p>
+
+    <tally name="nums">10 2 10</tally>
+    <p name="pNums">$nums.categories | $nums</p>
+    `,
+            });
+
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pWords",
+                text: "apple, fig | 2, 1",
+            });
+            // Sorted as numbers, so 2 comes before 10 rather than after it.
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pNums",
+                text: "2, 10 | 1, 2",
+            });
+
             const { warnings } = await messagesFor(`
     <p><tally>apple fig apple</tally></p>
     `);
-
-            expect(
-                warnings.some((m) =>
-                    m.includes("a `type` attribute must be specified"),
-                ),
-            ).eq(true);
+            expect(warnings.length).eq(0);
         });
 
         it("a category written as an expression names the number it evaluates to", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
@@ -696,7 +696,8 @@ describe("Shuffle tag tests @group1", async () => {
         expect(result.sort()).eqls(options.sort());
     });
 
-    it("string children without type emit warning", async () => {
+    it("string children with no type are read as what they look like", async () => {
+        // These used to warn and shuffle nothing at all.
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="pList"><shuffle name="sh">d a b</shuffle></p>
@@ -704,27 +705,15 @@ describe("Shuffle tag tests @group1", async () => {
         });
 
         const stateVariables = await core.returnAllStateVariables(false, true);
-        let diagnosticsByType = getDiagnosticsByType(core);
-        expect(diagnosticsByType.warnings.length).gte(1);
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
         expect(
-            diagnosticsByType.warnings.some((w) =>
-                w.message.includes("a `type` attribute must be specified"),
-            ),
-        ).eq(true);
-        expect(
-            diagnosticsByType.warnings.some((w) =>
-                w.message.includes(
-                    'String "d a b" is not a valid component to shuffle.',
-                ),
-            ),
-        ).eq(true);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("pList")].stateValues
-                .text,
-        ).eq("");
+            stateVariables[await resolvePathToNodeIdx("pList")].stateValues.text
+                .split(", ")
+                .sort(),
+        ).eqls(["a", "b", "d"]);
     });
 
-    it("sugar with invalid type specified defaults to math type with warning", async () => {
+    it("sugar with invalid type reports it and reads the children anyway", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="pList"><shuffle name="sh" type="bad">d a b</shuffle></p>
@@ -738,7 +727,7 @@ describe("Shuffle tag tests @group1", async () => {
             resolvePathToNodeIdx,
             options,
             must_be_reordered: [],
-            replacements_all_of_type: "math",
+            replacements_all_of_type: "text",
         });
 
         let diagnosticsByType = getDiagnosticsByType(core);
@@ -747,7 +736,7 @@ describe("Shuffle tag tests @group1", async () => {
             "Invalid type bad for shuffle component",
         );
         expect(diagnosticsByType.warnings[0].message).contain(
-            "Defaulting to math",
+            "reading the values as though no type had been given",
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -846,12 +846,16 @@ describe("Sort tag tests @group4", async () => {
             ["10 2 1", "1, 2, 10"],
             // Read as numbers, so the half sorts by value and renders as one.
             ["1/2 2 1", "0.5, 1, 2"],
-            // A `<number>` converts its content with `Number` before it tries
-            // the math parser, so scientific and hexadecimal notation name
-            // numbers too. Read only by the math parser, these would be three
-            // words, and `1e3` would sort before `5e2`.
-            ["1e3 5e2 2e4", "500, 1000, 20000"],
-            ["0x10 9", "9, 16"],
+            // Read the way DoenetML reads a number, which is not the way
+            // JavaScript reads one. `parseScientificNotation` is declared on 42
+            // components and defaults to false, and it recognizes an uppercase
+            // exponent only, so `1e3` is never scientific notation and these
+            // are words. `0x10` and `0b101` are not a DoenetML notation at all;
+            // `<number>` accepts them only because it asks `Number()` first,
+            // which is #1849. An author who wants an exponent read can say so
+            // with `<math parseScientificNotation="true">`.
+            ["1e3 5e2 2e4", "1e3, 2e4, 5e2"],
+            ["0x10 9", "0x10, 9"],
             // The math pass has to be Doenet's own reading of a function name,
             // not just any math parser's. `nCr` is a function to both; `min`
             // and `mean` are functions only to Doenet, so read by the other

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -838,35 +838,48 @@ describe("Sort tag tests @group4", async () => {
         expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(1);
     });
 
-    it("string children without type emit warning", async () => {
+    it("string children with no type are read as what they look like", async () => {
+        // Words are text and numbers are numbers, so neither needs saying.
+        // These used to warn and sort nothing at all.
+        for (const [children, sorted] of [
+            ["d a b", "a, b, d"],
+            ["10 2 1", "1, 2, 10"],
+            // Read as numbers, so the half sorts by value and renders as one.
+            ["1/2 2 1", "0.5, 1, 2"],
+        ] as [string, string][]) {
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `<p name="pList"><sort>${children}</sort></p>`,
+            });
+
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("pList")].stateValues
+                    .text,
+            ).eq(sorted);
+            expect(getDiagnosticsByType(core).warnings.length).eq(0);
+        }
+    });
+
+    it("one non-numeric string sends the whole list to text", async () => {
+        // The same rule the values follow when they arrive as components: a
+        // list is numeric only if every one of them is, so `10` sorts before
+        // `2` here exactly as it would in a `<textList>`.
         let { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
-    <p name="pList"><sort>d a b</sort></p>
-  `,
+            doenetML: `<p name="pList"><sort>10 2 x</sort></p>`,
         });
 
         const stateVariables = await core.returnAllStateVariables(false, true);
-        let diagnosticsByType = getDiagnosticsByType(core);
-        expect(diagnosticsByType.warnings.length).gte(1);
-        expect(
-            diagnosticsByType.warnings.some((w) =>
-                w.message.includes("a `type` attribute must be specified"),
-            ),
-        ).eq(true);
-        expect(
-            diagnosticsByType.warnings.some((w) =>
-                w.message.includes(
-                    'String "d a b" is not a valid component to sort.',
-                ),
-            ),
-        ).eq(true);
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
-        ).eq("");
+        ).eq("10, 2, x");
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
     });
 
-    it("sugar with invalid type specified defaults to math type with warning", async () => {
+    it("sugar with invalid type reports it and reads the children anyway", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="pList"><sort type="bad">d a b</sort></p>
@@ -875,11 +888,14 @@ describe("Sort tag tests @group4", async () => {
 
         const sorted_result = ["a", "b", "d"];
 
+        // Read as text, which is what three words are — the invalid value is
+        // dropped rather than replaced by a guess, so the children are read as
+        // though no type had been written.
         await test_sort({
             core,
             resolvePathToNodeIdx,
             sorted_result,
-            replacements_all_of_type: "math",
+            replacements_all_of_type: "text",
         });
 
         let diagnosticsByType = getDiagnosticsByType(core);
@@ -888,7 +904,7 @@ describe("Sort tag tests @group4", async () => {
             "Invalid type bad for sort component",
         );
         expect(diagnosticsByType.warnings[0].message).contain(
-            "Defaulting to math",
+            "reading the values as though no type had been given",
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -852,6 +852,13 @@ describe("Sort tag tests @group4", async () => {
             // words, and `1e3` would sort before `5e2`.
             ["1e3 5e2 2e4", "500, 1000, 20000"],
             ["0x10 9", "9, 16"],
+            // The math pass has to be Doenet's own reading of a function name,
+            // not just any math parser's. `nCr` is a function to both; `min`
+            // and `mean` are functions only to Doenet, so read by the other
+            // one these sorted as the words `min(1,2)` and `mean(1,2,3)`.
+            ["nCr(4,2) 3", "3, 6"],
+            ["min(1,2) 3", "1, 3"],
+            ["mean(1,2,3) 1", "1, 2"],
         ] as [string, string][]) {
             let { core, resolvePathToNodeIdx } = await createTestCore({
                 doenetML: `<p name="pList"><sort>${children}</sort></p>`,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -846,6 +846,12 @@ describe("Sort tag tests @group4", async () => {
             ["10 2 1", "1, 2, 10"],
             // Read as numbers, so the half sorts by value and renders as one.
             ["1/2 2 1", "0.5, 1, 2"],
+            // A `<number>` converts its content with `Number` before it tries
+            // the math parser, so scientific and hexadecimal notation name
+            // numbers too. Read only by the math parser, these would be three
+            // words, and `1e3` would sort before `5e2`.
+            ["1e3 5e2 2e4", "500, 1000, 20000"],
+            ["0x10 9", "9, 16"],
         ] as [string, string][]) {
             let { core, resolvePathToNodeIdx } = await createTestCore({
                 doenetML: `<p name="pList"><sort>${children}</sort></p>`,

--- a/packages/doenetml-worker-javascript/src/utils/listIndexOperators.js
+++ b/packages/doenetml-worker-javascript/src/utils/listIndexOperators.js
@@ -23,7 +23,8 @@ import { comparableValueFromRaw } from "./listValues";
  * would point the author at an attribute the component does not have.
  */
 export function returnListTypeAttribute({ readsTarget = false } = {}) {
-    const base = "Component type to interpret bare string children as.";
+    const base =
+        "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text.";
     return {
         createPrimitiveOfType: "string",
         description: readsTarget

--- a/packages/doenetml-worker-javascript/src/utils/listIndexOperators.js
+++ b/packages/doenetml-worker-javascript/src/utils/listIndexOperators.js
@@ -24,7 +24,7 @@ import { comparableValueFromRaw } from "./listValues";
  */
 export function returnListTypeAttribute({ readsTarget = false } = {}) {
     const base =
-        "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text.";
+        "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text.";
     return {
         createPrimitiveOfType: "string",
         description: readsTarget

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -1,4 +1,5 @@
 import me from "math-expressions";
+import { textToAst } from "./math";
 import { codedDiagnostic } from "./diagnostics";
 import { returnGroupIntoComponentTypeSeparatedBySpacesOutsideParens } from "../components/commonsugar/lists";
 
@@ -429,6 +430,15 @@ export function comparableValueFromRaw(value) {
  * `<sort>1e5 2</sort>` text while the `<number>` the inference goes on to
  * create reads `1e5` as 100000.
  *
+ * The math pass has to be the same parser too, not merely a math parser.
+ * `Number.js` reads its content with `textToAst`, which is configured with
+ * Doenet's own list of applied functions; `me.fromText` uses the parser
+ * library's shorter default list, which has `abs` and `nCr` but not `min`,
+ * `max`, `mean`, `median`, `sum`, `prod`, `count`, `std` or `variance`. Read by
+ * that one, `<sort>min(1,2) 3</sort>` called itself text and rendered
+ * `3, min(1,2)`, while the `<number>` it goes on to create reads `min(1,2)` as
+ * 1 — and `<sort>nCr(4,2) 3</sort>` next to it read as numbers.
+ *
  * The math pass tests `typeof` together with `NaN`, and neither half is
  * redundant. `Number.isFinite` alone would rule out an infinity, which *is* a
  * number the comparison handles — it tests equality before subtracting. A bare
@@ -442,7 +452,7 @@ function tokenIsRealNumber(token) {
     }
     let value;
     try {
-        value = me.fromText(token).evaluate_to_constant();
+        value = me.fromAst(textToAst.convert(token)).evaluate_to_constant();
     } catch (e) {
         return false;
     }

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -1,3 +1,4 @@
+import me from "math-expressions";
 import { codedDiagnostic } from "./diagnostics";
 import { returnGroupIntoComponentTypeSeparatedBySpacesOutsideParens } from "../components/commonsugar/lists";
 
@@ -417,6 +418,59 @@ export function comparableValueFromRaw(value) {
 }
 
 /**
+ * Whether a bare token names a real number, read the way `<number>` reads its
+ * own content — so `1/2` and `2^3` are numbers and `x` and `apple` are not.
+ *
+ * The test is `typeof` together with `NaN`, and neither half is redundant.
+ * `Number.isFinite` alone would rule out an infinity, which *is* a number the
+ * comparison handles — it tests equality before subtracting. A bare
+ * `!Number.isNaN` alone would let through the complex object that `i`
+ * evaluates to, on which every comparison is `NaN`, so such a value would be
+ * called numeric and then never equal anything, not even itself.
+ */
+function tokenIsRealNumber(token) {
+    let value;
+    try {
+        value = me.fromText(token).evaluate_to_constant();
+    } catch (e) {
+        return false;
+    }
+    return typeof value === "number" && !Number.isNaN(value);
+}
+
+/**
+ * The type to read bare strings as when the author did not say.
+ *
+ * Every token being a number makes the list numeric; anything else makes it
+ * text. That is the rule the values already follow when they arrive as
+ * components — `allAreNumeric` is true only if every one of them is numeric,
+ * and a single text among numbers sends the whole list to a text comparison —
+ * so inferring it here means an author writing `1 10 3` and an author
+ * referencing a `<numberList>` get the same answer, and `1 10 x` reads as text
+ * either way.
+ *
+ * Tokens are split on whitespace alone, while the wrapping below splits on
+ * whitespace *outside parens*. The two can only disagree about a token
+ * containing a paren, which does not evaluate to a number under either
+ * splitting, so both readings call it text.
+ *
+ * Returns `null` when there is nothing to read — no bare strings at all — so
+ * the caller can leave a list of references alone.
+ */
+function inferTypeFromStrings(matchedChildren) {
+    const tokens = matchedChildren
+        .filter((child) => typeof child === "string")
+        .flatMap((child) => child.split(/\s+/))
+        .filter((token) => token !== "");
+
+    if (tokens.length === 0) {
+        return null;
+    }
+
+    return tokens.every(tokenIsRealNumber) ? "number" : "text";
+}
+
+/**
  * Sugar shared by the components that read their children as a list of typed
  * values — `<sort>`, `<sortIndices>`, `<shuffle>` and the index-returning and
  * counting operators: bare strings are split on whitespace and wrapped in the
@@ -446,32 +500,30 @@ export function returnBreakStringsIntoTypeSugarInstruction(componentName) {
             return { success: false };
         }
 
-        let type;
-        if (componentAttributes.type?.value) {
-            type = componentAttributes.type.value;
-        } else {
-            if (matchedChildren.some((child) => typeof child === "string")) {
-                diagnostics.push(
-                    codedDiagnostic({
-                        type: "warning",
-                        code: "doenet-w0013",
-                        args: { component: componentName },
-                    }),
-                );
-            }
-            return { success: false, diagnostics };
-        }
+        let type = componentAttributes.type?.value;
 
-        if (!["math", "text", "number", "boolean"].includes(type)) {
-            console.warn(`Invalid type ${type}`);
+        // A type that is not one of the four is reported and then dropped, so
+        // that it behaves exactly as if it had not been written. Reading it as
+        // something arbitrary instead is how `<tally type="txt">` came to make
+        // every category `NaN`.
+        if (type && !["math", "text", "number", "boolean"].includes(type)) {
             diagnostics.push(
                 codedDiagnostic({
                     type: "warning",
-                    code: "doenet-w0014",
+                    code: "doenet-w0145",
                     args: { type, component: componentName },
                 }),
             );
-            type = "math";
+            type = undefined;
+        }
+
+        if (!type) {
+            type = inferTypeFromStrings(matchedChildren);
+
+            // Nothing but references, so there is nothing for a type to say.
+            if (type === null) {
+                return { success: false, diagnostics };
+            }
         }
 
         // Break any string by white space and wrap the pieces with `type`.

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -419,18 +419,25 @@ export function comparableValueFromRaw(value) {
 }
 
 /**
- * Whether a bare token names a real number, read in the two passes `<number>`
- * reads its own content in — so `1e5` and `0x10` are numbers just as `1/2` and
- * `2^3` are, while `x` and `apple` are not.
+ * Whether a bare token names a real number, read with Doenet's own math
+ * parser — so `1/2`, `2^3`, `sqrt(4)`, `pi` and `min(1,2)` are numbers, while
+ * `x`, `2x` and `apple` are not.
  *
- * The order of the two passes is what `<number>` does, not a shortcut:
- * `Number.js` converts its string child with `Number` and reaches for the math
- * parser only when that yields `NaN`. The math parser has no scientific
- * notation and no hexadecimal, so reading a token by it alone would call
- * `<sort>1e5 2</sort>` text while the `<number>` the inference goes on to
- * create reads `1e5` as 100000.
+ * The parser decides alone; `Number` is deliberately not consulted, even
+ * though `<number>` consults it first. The tokens the two disagree about are
+ * JavaScript numeric literals, and none of them is DoenetML notation.
+ * `Number("1e3")` is 1000, but `parseScientificNotation` is off by default
+ * wherever it is offered and recognizes an *uppercase* exponent only, so `1e3`
+ * is not scientific notation in DoenetML under any setting. `Number("0x10")`
+ * is 16 and `Number("0b101")` is 5, and neither notation exists in DoenetML at
+ * all. `<number>` reads all three only because `Number.js` converts its string
+ * child with `Number` before reaching for the parser — issue #1849, which has
+ * to wait for a breaking release — and inferring "this list is numeric" from a
+ * JavaScript literal would entrench it. An author who wants an exponent read
+ * says so, and references the result:
+ * `<mathList parseScientificNotation="true">1E3 2 5E2</mathList>`.
  *
- * The math pass has to be the same parser too, not merely a math parser.
+ * The parser does have to be Doenet's own, though, not merely a math parser.
  * `Number.js` reads its content with `textToAst`, which is configured with
  * Doenet's own list of applied functions; `me.fromText` uses the parser
  * library's shorter default list, which has `abs` and `nCr` but not `min`,
@@ -439,7 +446,7 @@ export function comparableValueFromRaw(value) {
  * `3, min(1,2)`, while the `<number>` it goes on to create reads `min(1,2)` as
  * 1 — and `<sort>nCr(4,2) 3</sort>` next to it read as numbers.
  *
- * The math pass tests `typeof` together with `NaN`, and neither half is
+ * The result is tested with `typeof` together with `NaN`, and neither half is
  * redundant. `Number.isFinite` alone would rule out an infinity, which *is* a
  * number the comparison handles — it tests equality before subtracting. A bare
  * `!Number.isNaN` alone would let through the complex object that `i`
@@ -528,9 +535,16 @@ export function returnBreakStringsIntoTypeSugarInstruction(componentName) {
         let type = componentAttributes.type?.value;
 
         // A type that is not one of the four is reported and then dropped, so
-        // that it behaves exactly as if it had not been written. Reading it as
-        // something arbitrary instead is how `<tally type="txt">` came to make
-        // every category `NaN`.
+        // the children are read exactly as they would be with no `type` at
+        // all. Replacing it with `math` instead read them as maths, which is
+        // how `<tally type="txt">apple fig apple</tally>` came to report its
+        // categories as `a p p l e` and `f i g`.
+        //
+        // Only the children. An invalid `type` still reaches `categories` and
+        // `target`, which resolve it separately and do replace it — the
+        // deferred `_componentWithSelectableType` half of #1825 — so
+        // `<tally type="txt" categories="apple fig">` is unaffected by the
+        // drop and still counts nothing.
         if (type && !["math", "text", "number", "boolean"].includes(type)) {
             diagnostics.push(
                 codedDiagnostic({

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -418,17 +418,28 @@ export function comparableValueFromRaw(value) {
 }
 
 /**
- * Whether a bare token names a real number, read the way `<number>` reads its
- * own content — so `1/2` and `2^3` are numbers and `x` and `apple` are not.
+ * Whether a bare token names a real number, read in the two passes `<number>`
+ * reads its own content in — so `1e5` and `0x10` are numbers just as `1/2` and
+ * `2^3` are, while `x` and `apple` are not.
  *
- * The test is `typeof` together with `NaN`, and neither half is redundant.
- * `Number.isFinite` alone would rule out an infinity, which *is* a number the
- * comparison handles — it tests equality before subtracting. A bare
+ * The order of the two passes is what `<number>` does, not a shortcut:
+ * `Number.js` converts its string child with `Number` and reaches for the math
+ * parser only when that yields `NaN`. The math parser has no scientific
+ * notation and no hexadecimal, so reading a token by it alone would call
+ * `<sort>1e5 2</sort>` text while the `<number>` the inference goes on to
+ * create reads `1e5` as 100000.
+ *
+ * The math pass tests `typeof` together with `NaN`, and neither half is
+ * redundant. `Number.isFinite` alone would rule out an infinity, which *is* a
+ * number the comparison handles — it tests equality before subtracting. A bare
  * `!Number.isNaN` alone would let through the complex object that `i`
  * evaluates to, on which every comparison is `NaN`, so such a value would be
  * called numeric and then never equal anything, not even itself.
  */
 function tokenIsRealNumber(token) {
+    if (!Number.isNaN(Number(token))) {
+        return true;
+    }
     let value;
     try {
         value = me.fromText(token).evaluate_to_constant();
@@ -450,9 +461,13 @@ function tokenIsRealNumber(token) {
  * either way.
  *
  * Tokens are split on whitespace alone, while the wrapping below splits on
- * whitespace *outside parens*. The two can only disagree about a token
- * containing a paren, which does not evaluate to a number under either
- * splitting, so both readings call it text.
+ * whitespace *outside parens*. They part company only where whitespace falls
+ * inside parens, and then only in the safe direction: the piece holding the
+ * unmatched `(` is not a number under any reading, so the list is called text
+ * where the wrapping would have accepted a number. `<sort>(1+2) 4</sort>`
+ * orders by value; `<sort>(1 + 2) 4</sort>` orders the same two pieces as
+ * text. Inference never calls a list numeric that the wrapping would then fill
+ * with something unreadable.
  *
  * Returns `null` when there is nothing to read — no bare strings at all — so
  * the caller can leave a list of references alone.
@@ -477,9 +492,12 @@ function inferTypeFromStrings(matchedChildren) {
  * component type named by the `type` attribute.
  *
  * Unlike the math-only operators, these components accept text as readily as
- * numbers, so there is no sensible default: without an explicit `type` the
- * strings are left alone and a warning is issued, naming `componentName` so the
- * author sees the tag they actually wrote.
+ * numbers, so there is no one type to fall back on. Without a `type` the
+ * strings are read as what they look like, by `inferTypeFromStrings` above. A
+ * `type` naming something that is not one of the four readings is reported —
+ * naming `componentName`, so the author sees the tag they actually wrote — and
+ * then dropped, leaving the children to be read as though it had not been
+ * written.
  */
 export function returnBreakStringsIntoTypeSugarInstruction(componentName) {
     function breakStringsMacrosIntoTypeBySpaces({

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -419,6 +419,29 @@ export function comparableValueFromRaw(value) {
 }
 
 /**
+ * Whether every bracket in a token is closed by its own kind, in order.
+ *
+ * Only a rejection is meaningful: balanced delimiters say nothing about
+ * whether the token names a number, which the parser still decides.
+ */
+function delimitersBalanced(token) {
+    const closerFor = { ")": "(", "]": "[", "}": "{" };
+    const open = [];
+
+    for (const character of token) {
+        if (character === "(" || character === "[" || character === "{") {
+            open.push(character);
+        } else if (character in closerFor) {
+            if (open.pop() !== closerFor[character]) {
+                return false;
+            }
+        }
+    }
+
+    return open.length === 0;
+}
+
+/**
  * Whether a bare token names a real number, read with Doenet's own math
  * parser — so `1/2`, `2^3`, `sqrt(4)`, `pi` and `min(1,2)` are numbers, while
  * `x`, `2x` and `apple` are not.
@@ -454,6 +477,18 @@ export function comparableValueFromRaw(value) {
  * called numeric and then never equal anything, not even itself.
  */
 function tokenIsRealNumber(token) {
+    // A token whose delimiters do not close cannot name a number, and asking
+    // is expensive: parsing a run of unmatched openers is exponential, so
+    // `((((((((((((((((1+2` takes about nine seconds and two more of them take
+    // a minute. Before this file inferred anything, a bare string with no
+    // `type` never reached the parser at all, so answering here without
+    // calling it keeps a typo from stalling the document. The parser's own
+    // cost is #1852; this is not a fix for it, it is not asking a question
+    // whose answer is already known.
+    if (!delimitersBalanced(token)) {
+        return false;
+    }
+
     let value;
     try {
         value = me.fromAst(textToAst.convert(token)).evaluate_to_constant();

--- a/packages/doenetml-worker-javascript/src/utils/listValues.js
+++ b/packages/doenetml-worker-javascript/src/utils/listValues.js
@@ -447,9 +447,6 @@ export function comparableValueFromRaw(value) {
  * called numeric and then never equal anything, not even itself.
  */
 function tokenIsRealNumber(token) {
-    if (!Number.isNaN(Number(token))) {
-        return true;
-    }
     let value;
     try {
         value = me.fromAst(textToAst.convert(token)).evaluate_to_constant();

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -239,5 +239,6 @@
     "doenet-w0141": "bin-counts-cut-points-decreasing",
     "doenet-w0142": "tally-repeated-category",
     "doenet-w0143": "bar-chart-bar-width-invalid",
-    "doenet-w0144": "bar-chart-values-not-drawable"
+    "doenet-w0144": "bar-chart-values-not-drawable",
+    "doenet-w0145": "invalid-type-ignored"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -99,6 +99,12 @@ string-children-need-type = For `<{ $component }>` to work with string children,
 # values and stay in English.
 invalid-type-defaulting-to-math = Invalid type { $type } for { $component } component. Must be one of math, text, number, or boolean. Defaulting to math.
 
+# Raised when `type` names something that is not one of the four readings. The
+# value is dropped rather than replaced by a guess, so the children are read as
+# though no type had been written. $type is what the author wrote.
+invalid-type-ignored =
+    Invalid type { $type } for { $component } component. Must be one of math, text, number, or boolean. Ignoring it and reading the values as though no type had been given.
+
 # $value is the string child that could not be used.
 string-not-valid-component-to-arrange = String "{ $value }" is not a valid component to { $component }. Ignoring.
 

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -231,6 +231,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0142": "tally-repeated-category",
     "doenet-w0143": "bar-chart-bar-width-invalid",
     "doenet-w0144": "bar-chart-values-not-drawable",
+    "doenet-w0145": "invalid-type-ignored",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",
@@ -320,7 +321,15 @@ export type DiagnosticCode = keyof typeof DIAGNOSTIC_CODES;
  * stopped arising.
  */
 export const RETIRED_DIAGNOSTIC_CODES: ReadonlySet<DiagnosticCode> =
-    new Set<DiagnosticCode>(["doenet-w0123"]);
+    new Set<DiagnosticCode>([
+        "doenet-w0123",
+        // Both named a remedy that no longer happens. Bare strings are read as
+        // the type their content implies when none is written, so there is no
+        // longer a reading to demand (`w0013`) nor a `math` to fall back to
+        // (`w0014`, replaced by `w0145`, which says the value was ignored).
+        "doenet-w0013",
+        "doenet-w0014",
+    ]);
 
 /**
  * The shape every code has to match: `doenet-` + severity letter + 4 digits.

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -321,6 +321,7 @@ export type MessageKey =
     | "pretzel-circuit-first-index"
     | "string-children-need-type"
     | "invalid-type-defaulting-to-math"
+    | "invalid-type-ignored"
     | "string-not-valid-component-to-arrange"
     | "invalid-type-defaulting-to-number"
     | "invalid-variable-value"
@@ -926,6 +927,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "pretzel-circuit-first-index",
     "string-children-need-type",
     "invalid-type-defaulting-to-math",
+    "invalid-type-ignored",
     "string-not-valid-component-to-arrange",
     "invalid-type-defaulting-to-number",
     "invalid-variable-value",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -32644,7 +32644,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -33671,7 +33671,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -34398,7 +34398,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how `target` is read, since it has no type of its own.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also decides how `target` is read, since it has no type of its own.",
                     "highlighted": true,
                     "defaultValue": null,
                     "values": [
@@ -34822,7 +34822,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Also decides how `target` is read, since it has no type of its own.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also decides how `target` is read, since it has no type of its own.",
                     "highlighted": true,
                     "defaultValue": null,
                     "values": [
@@ -35306,7 +35306,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as, which they require. Also overrides how `categories` is read, which is otherwise text.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also overrides how `categories` is read, which is otherwise text.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -120268,7 +120268,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to sort children as.",
+                    "description": "Component type to sort bare string children as. Omit it and they are read as what they look like: all numbers sorts by value, anything else sorts alphabetically.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -120720,7 +120720,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to sort children as.",
+                    "description": "Component type to sort bare string children as. Omit it and they are read as what they look like: all numbers sorts by value, anything else sorts alphabetically.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -121137,7 +121137,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to shuffle children as.",
+                    "description": "Component type to read bare string children as. Omit it and they are read as what they look like: all numbers makes them numbers, anything else makes them text.",
                     "highlighted": true,
                     "values": [
                         "number",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -32644,7 +32644,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -33671,7 +33671,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -34398,7 +34398,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also decides how `target` is read, since it has no type of its own.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text. Also decides how `target` is read, since it has no type of its own.",
                     "highlighted": true,
                     "defaultValue": null,
                     "values": [
@@ -34822,7 +34822,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also decides how `target` is read, since it has no type of its own.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text. Also decides how `target` is read, since it has no type of its own.",
                     "highlighted": true,
                     "defaultValue": null,
                     "values": [
@@ -35306,7 +35306,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: all numbers makes the list numeric, anything else makes it text. Also overrides how `categories` is read, which is otherwise text.",
+                    "description": "Component type to interpret bare string children as. Omit it and they are read as what they look like: every piece naming a number makes the list numeric, anything else makes it text. Also overrides how `categories` is read, which is otherwise text.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -120268,7 +120268,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to sort bare string children as. Omit it and they are read as what they look like: all numbers sorts by value, anything else sorts alphabetically.",
+                    "description": "Component type to sort bare string children as. Omit it and they are read as what they look like: every piece naming a number sorts by value, anything else sorts alphabetically.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -120720,7 +120720,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to sort bare string children as. Omit it and they are read as what they look like: all numbers sorts by value, anything else sorts alphabetically.",
+                    "description": "Component type to sort bare string children as. Omit it and they are read as what they look like: every piece naming a number sorts by value, anything else sorts alphabetically.",
                     "highlighted": true,
                     "values": [
                         "number",
@@ -121137,7 +121137,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Component type to read bare string children as. Omit it and they are read as what they look like: all numbers makes them numbers, anything else makes them text.",
+                    "description": "Component type to read bare string children as. Omit it and they are read as what they look like: every piece naming a number makes them numbers, anything else makes them text.",
                     "highlighted": true,
                     "values": [
                         "number",


### PR DESCRIPTION
## The problem

Markup that says exactly what it means produced nothing:

```xml
<sort>d a b</sort>              <!-- rendered "" -->
<tally>apple fig apple</tally>  <!-- counted nothing -->
<shuffle>d a b</shuffle>        <!-- rendered "" -->
```

Each reported that a `type` attribute was required, then ignored the string entirely. Every component reading its children as a list of comparable values behaved this way — `<sort>`, `<shuffle>`, `<sortIndices>`, `<tally>`, `<argMin>`, `<argMax>`, `<indexOf>`, `<searchSorted>`.

Requiring the attribute was a real choice, not an oversight: read as text by default, `<tally>1 2 10</tally>` would order its categories `1, 10, 2`. But the price was that the most natural thing a beginner writes returns an empty result.

## What changed

Bare strings are read by their content. Every whitespace-separated piece naming a number makes the list numeric; anything else makes it text.

| markup | before | now |
| --- | --- | --- |
| `<sort>10 2 1</sort>` | `` + warning | `1, 2, 10` |
| `<sort>d a b</sort>` | `` + warning | `a, b, d` |
| `<sort>10 2 x</sort>` | `` + warning | `10, 2, x` |
| `<sort>1/2 2 1</sort>` | `` + warning | `0.5, 1, 2` |
| `<tally>apple fig apple</tally>` | nothing | `apple, fig` -> `2, 1` |

**This is the rule the values already followed.** When they arrive as components, `allAreNumeric` is true only if every one of them is numeric, and a single text among numbers sends the whole list to a text comparison. Inferring the same way for strings means an author who writes `1 10 3` and an author who references a `<numberList>` get the same answer, and `1 10 x` reads as text either way. It is one rule now, not two.

`type` survives as an override for when the look is misleading: `007 008` counts the numbers 7 and 8, and `type="text"` keeps the leading zeros. It still governs bare strings only — a referenced component keeps the type it already has.

## An invalid type is dropped, not replaced

`type="bad"` used to become `math`. It is now reported and discarded, so the string children are read exactly as they would be with no `type` at all.

Replacing it read them as maths, which is visible wherever the values are not maths: `<tally type="txt">apple fig apple</tally>` reported its categories as `a p p l e` and `f i g`, and now reports `apple` and `fig`.

**The drop reaches the string children only.** `categories` and `target` resolve an invalid `type` by their own route, which still replaces it (`Invalid type txt, setting type to number`), so `<tally type="txt" categories="apple fig">apple fig apple</tally>` still reads every category as `NaN`, matches nothing, counts `0, 0` and reports that a category was named twice — one `NaN` reads like another. That is unchanged by this PR: the same document produces the same counts and the same set of diagnostics on the base, with only the first warning's wording different. It is the deferred `_componentWithSelectableType` half of #1825, below.

## The numeric test

A token is read with **Doenet's math parser** — `textToAst`, the one `<math>` and `<number>` both use, carrying Doenet's applied function symbols. Not with JavaScript's `Number()`.

That distinction is deliberate, and it is why `<sort>1e5 2</sort>` is text while `<sort type="number">1e5 2</sort>` renders `2, 100000`. `parseScientificNotation` is declared on 42 components, defaults to `False`, and recognizes an **uppercase** exponent only — so `1e3` is never scientific notation in DoenetML, under any setting. `0x10` and `0b101` are not a DoenetML notation at all; `<number>` accepts them only because it asks `Number()` before the parser, which is #1849. Inference declines to guess from a JavaScript literal what an instructor did not write. An author who wants an exponent read says so: `<mathList parseScientificNotation="true">1E3 2 5E2</mathList>` into a `<sort>` gives `2, 500, 1000`.

**Which math parser.** `Number.js` reads its content with `textToAst`, configured with Doenet's own list of applied function names; `me.fromText` uses the parser library's shorter default, which has `abs` and `nCr` but not `min`, `max`, `mean`, `median`, `sum`, `prod`, `count`, `std` or `variance`. Read by that one, `<sort>min(1,2) 3</sort>` rendered `3, min(1,2)` as text while `<number>min(1,2)</number>` is 1 and `<sort>nCr(4,2) 3</sort>` next to it read as numbers.

The result is tested with `typeof v === "number" && !Number.isNaN(v)`, and neither half is spare:

- `Number.isFinite` alone would rule out an infinity, which *is* a number the comparison handles — `compareExtractedValues` tests equality before subtracting, precisely so `Infinity` equals itself.
- `!Number.isNaN` alone would admit the **complex object** that `i` evaluates to, on which every comparison is `NaN`. Such a value is called numeric and then never equals anything, not even itself. That exact mistake shipped in #1829 and was caught by review; this is the same trap one layer down.

Tokens are split on whitespace, while the wrapping splits on whitespace *outside parens*. They part company only where whitespace falls inside parens, and only in the safe direction — the piece holding the unmatched `(` is not a number under any reading, so `<sort>(1 + 2) 4</sort>` is read as text where `<sort>(1+2) 4</sort>` is read as numbers. The inference never calls a list numeric that the wrapping would then fill with something unreadable.

## Diagnostics

Both affected codes are in the v0.7.26 lock and `string-children-need-type` is translated into 347 locales, so neither could be edited in place. `packages/i18n/README.md` describes the path, and `lint:i18n` names it directly when the last call site goes:

- `doenet-w0013` — retired. Nothing needs a type declared any more.
- `doenet-w0014` — retired. Its message *id* was `invalid-type-defaulting-to-math`, so repointing the code would have orphaned 347 translations of a key naming behavior that no longer exists.
- `doenet-w0145` — new, English only: *"Invalid type X … Ignoring it and reading the values as though no type had been given."*

Retiring keeps each code's entry and message, so no other locale file is touched. `lint:i18n` passes: 603 keys across 348 locales, 242 codes, 3 retired.

## Compatibility

Of the eight components, only `<sort>` and `<shuffle>` have shipped in 0.7.26 — the rest are unreleased. Two shapes of released markup produced a non-empty result before and produce a different one now. Both were run on this branch and on its base to establish the before.

**A reference next to a bare string.** The string used to be dropped, so the document rendered the reference alone:

| markup | before | now |
| --- | --- | --- |
| `<sort>$mi 3</sort>` (`<mathInput prefill="5"/>`) | `5` + 2 warnings | `3, 5` |
| `<sort>$nl x</sort>` (`<numberList>3 1</numberList>`) | `1, 3` + 2 warnings | `1, 3, x` |

**A `type` that is not one of the four.** It used to be replaced with `math`, so the strings were read — as maths. Dropping it instead reads them as what they look like, which changes both the rendered value and the replacement component type. Every one of these already reported the type as invalid:

| markup | before | now |
| --- | --- | --- |
| `<sort type="txt">1/2 2 1</sort>` | `1/2, 1, 2` (`math`) | `0.5, 1, 2` (`number`) |
| `<shuffle type="txt">1/2 2 1</shuffle>` | `2, 1, 1/2` | `2, 1, 0.5` |
| `<sort type="txt">sqrt(4) 3</sort>` | `sqrt(4), 3` | `2, 3` |
| `<sort type="txt">pi 3</sort>` | `3, π` | `3, 3.14` |
| `<sort type="letters">d a b</sort>` | `a, b, d` (`math`) | `a, b, d` (`text`) |

The changed replacement type is visible downstream: with `<sort name="s" type="txt">1/2 2 1</sort>`, `$s[1].latex` was `\frac{1}{2}` and is now `0.5`, and `<sum>$s</sum>` was `1/2 + 1 + 2` and is now `3.5`. With `type="letters"` the items become `<text>`, and `$s[1].latex` resolves to nothing at all where it used to render `a`.

Nothing changes for a released document that writes no `type` and has no bare strings, or that writes one of the four valid types.

## Tests

Four tests asserted the replaced behavior and now assert the rule: the two "string children without type emit warning" tests, and the two "invalid type defaults to math" tests. New coverage for numeric inference, textual inference, one word sending a numeric-looking list to text, scientific and hexadecimal notation staying text, Doenet's applied function names (`min`, `mean`, `nCr`), and the `007` override. 140 pass across `sort`, `shuffle`, `countoperators` and `listoperators`.

`src/test/diagnostics/diagnosticCodes.test.ts` is also in the diff. It used `<sort name="s">a b c</sort>` as a source guaranteed to raise a warning, and that document is now correct, so the file failed on this branch — a suite outside the four above, which is why it was missed until a review cycle widened the net. It now takes its warning from a component this PR does not touch. With it, 159 pass across five files.

Verified by running rather than reading: which tokens evaluate to numbers (`1/2` -> 0.5, `2^3` -> 8, `007` -> 7, `pi` -> 3.14159, `i` -> a complex object, `x` -> `NaN`, and `1e5` -> `NaN` from the math parser but 100000 from `Number`, which is why the parser is the one consulted), every example added to the reference pages, both before/after tables above, and a fuzz of 60 000 random tokens finding none that the inference calls a number and `<number>` then reads as `NaN`, and none carrying an unmatched `(` that the inference calls a number.

## Not in this PR

How `categories` and `target` resolve their own type — the `_componentWithSelectableType` half of #1825. This is also why an invalid `type` is only half dropped: the children stop being read as maths, but `categories` and `target` still turn `txt` into `number`. `categories` reaches the right answer by a different route (`comparableCategory` rereads a textual category against numeric values), so `<tally categories="apple fig">apple fig apple</tally>` counts correctly with no type written. `target` does not: `<indexOf target="b">a b c</indexOf>` reports 0 while `<indexOf type="text" target="b">a b c</indexOf>` reports 2, and `<searchSorted target="b">a b c</searchSorted>` reports 1 rather than 2. That is not a change here — the children produced nothing before, so the answers were the same — but inferring the children's type makes it the remaining half of the inconsistency, and the plumbing behind `target` wants its own change.

Nor a guard on the math parser: 18 or more consecutive unmatched opening delimiters in one token take the parser exponentially long — `<math>((((((((((((((((((1+2</math>` already takes 23 seconds on `main`, without any of this. Inference now reaches that parser from markup with no `type` attribute, so the same input freezes `<sort>` too, but the defect is in the parser and belongs there.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdEWccVoUPCJoDYxKmHRo




