### PR TITLE
Trim the introductions on the index-operator reference pages

### DIFF
--- a/packages/docs-nextra/pages/reference/argMax.mdx
+++ b/packages/docs-nextra/pages/reference/argMax.mdx
@@ -8,17 +8,10 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 <ComponentDisplay name='argMax'/>
 
 `<argMax>{:dn}` is a [General Operator](../concepts/essentialConcepts#component-types)
-component that renders the **index** of the largest of its arguments, rather than the
-value itself. Indices start at 1, ties resolve to the first occurrence, and an empty
-list gives 0. Since 0 is not the index of any item, an empty list also reports an
-info message saying there was nothing to look through.
-
-Because DoenetML lists can be indexed by a reference, the index that `<argMax>{:dn}`
-produces can be used to look up the matching entry of a *different* list — which is
-what makes it more useful than [`<max>{:dn}`](max) alone.
-
-Values are compared numerically when they are all numeric, and alphabetically
-otherwise, exactly as in [`<sort>{:dn}`](sort).
+component that renders the **index** of the largest of its arguments rather than the value
+itself, so the position can be used to look up the matching entry of a *different* list —
+which is what makes it more useful than [`<max>{:dn}`](max) alone. Indices start at 1, ties
+resolve to the first occurrence, and an empty list gives 0.
 
 <AttrPropDisplay name='argMax'/>
 
@@ -78,3 +71,23 @@ The index from `<argMax>{:dn}` indexes into the parallel list of names.
 
 
 The index updates as the values change.
+
+
+
+---
+
+### Example: alphabetically last
+
+
+```doenet-editor-horiz
+<textList name="fruit">pear apple fig banana</textList>
+
+<argMax name="last">$fruit</argMax>
+
+<p>Fruit: $fruit</p>
+<p>The alphabetically last is $fruit[$last].</p>
+```
+
+
+
+On text, "largest" means alphabetically last.

--- a/packages/docs-nextra/pages/reference/argMin.mdx
+++ b/packages/docs-nextra/pages/reference/argMin.mdx
@@ -8,18 +8,10 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 <ComponentDisplay name='argMin'/>
 
 `<argMin>{:dn}` is a [General Operator](../concepts/essentialConcepts#component-types)
-component that renders the **index** of the smallest of its arguments, rather than the
-value itself. Indices start at 1, ties resolve to the first occurrence, and an empty
-list gives 0. Since 0 is not the index of any item, an empty list also reports an
-info message saying there was nothing to look through.
-
-Because DoenetML lists can be indexed by a reference, the index that `<argMin>{:dn}`
-produces can be used to look up the matching entry of a *different* list — which is
-what makes it more useful than [`<min>{:dn}`](min) alone.
-
-Values are compared numerically when they are all numeric, and alphabetically
-otherwise, exactly as in [`<sort>{:dn}`](sort). So `<argMin>{:dn}` works on a
-`<textList>{:dn}` as readily as on a `<numberList>{:dn}`.
+component that renders the **index** of the smallest of its arguments rather than the value
+itself, so the position can be used to look up the matching entry of a *different* list —
+which is what makes it more useful than [`<min>{:dn}`](min) alone. Indices start at 1, ties
+resolve to the first occurrence, and an empty list gives 0.
 
 <AttrPropDisplay name='argMin'/>
 

--- a/packages/docs-nextra/pages/reference/indexOf.mdx
+++ b/packages/docs-nextra/pages/reference/indexOf.mdx
@@ -8,23 +8,10 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 <ComponentDisplay name='indexOf'/>
 
 `<indexOf>{:dn}` is a [General Operator](../concepts/essentialConcepts#component-types)
-component that renders, for each value given by the `target` attribute, the position of
-the first of its arguments equal to that value. Indices start at 1, and a target that
-does not occur in the list gives 0.
-
-`target` may be a single value or a whole list of them, and the result has one position
-per target — so looking up twenty names against a roster takes one `<indexOf>{:dn}`
-rather than twenty. Each of the twenty positions is still a component of its own; what
-one operator replaces is the twenty operators.
-
-A 0 for a target that is not in the list is the answer, not a problem, so nothing is
-reported for it. Omitting `target` altogether is a warning, since nothing about that
-document could ever produce an answer, and a list with no values at all is an info
-message. (An empty *list of targets* is neither: it simply produces no positions.)
-
-Values are compared numerically when they are all numeric, and as text otherwise, so
-`<indexOf>{:dn}` searches a `<textList>{:dn}` as readily as a `<numberList>{:dn}`.
-When searching text, set `type="text"` so that the target is read as text too.
+component that renders, for each value given by the `target` attribute, the position of the
+first of its arguments equal to that value. Indices start at 1, and a target that does not
+occur in the list gives 0. To find where a value *belongs* in a sorted list rather than
+whether it is there at all, use [`<searchSorted>{:dn}`](searchSorted).
 
 <AttrPropDisplay name='indexOf'/>
 

--- a/packages/docs-nextra/pages/reference/searchSorted.mdx
+++ b/packages/docs-nextra/pages/reference/searchSorted.mdx
@@ -8,27 +8,10 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 <ComponentDisplay name='searchSorted'/>
 
 `<searchSorted>{:dn}` is a [General Operator](../concepts/essentialConcepts#component-types)
-component that locates values within an **already sorted** list. It renders the
-position at which each `target` would have to be inserted for the list to stay sorted.
-
-With the default `side="left"`, that position is the index of the first entry greater
-than or equal to the target. A target larger than every entry gives one past the end of
-the list.
-
-`target` may be a single value or a whole list of them, and the result has one position
-per target. One component maps a thousand samples onto their positions, which is what
-makes it usable on the output of `<sampleRandomNumbers>{:dn}` — see the sampling example
-below.
-
-Unlike [`<indexOf>{:dn}`](indexOf), the target need not appear in the list; this
-answers "where does it belong?", not "is it there?". Ordering is numeric when the list
-is all numeric and alphabetical otherwise, so a sorted `<textList>{:dn}` works too.
-
-Every position in a list is at least 1, so the result is 1 or more whenever there is a
-target to place and something to place it among. The two cases that give 0 instead are
-both reported: omitting `target` is a warning, since nothing about that document could
-ever produce an answer, and an empty list is an info message. (An empty *list of
-targets* is neither: it simply produces no positions.)
+component that locates values within an **already sorted** list: it renders the position at
+which each `target` would have to be inserted for the list to stay sorted. Unlike
+[`<indexOf>{:dn}`](indexOf), the target need not appear in the list — this answers "where
+does it belong?", not "is it there?".
 
 <AttrPropDisplay name='searchSorted'/>
 


### PR DESCRIPTION
The reference pages for `<searchSorted>`, `<indexOf>`, `<argMin>` and `<argMax>` each opened with three to five paragraphs before the attribute table. In every case the paragraphs after the first restated an example that already appears further down the same page.

| Page | Intro before | after |
| --- | --- | --- |
| `searchSorted` | 225 words, 5 paragraphs | 54 words |
| `indexOf` | 199 words, 4 paragraphs | 64 words |
| `argMin` | 127 words, 3 paragraphs | 64 words |
| `argMax` | 115 words, 3 paragraphs | 64 words |

The docs-authoring skill asks for a one- to three-sentence introduction naming the component's category, its required attributes, and what it produces. That is what these now are; no example was removed, and each surviving introduction still links its related component.

What moved out of the prose, and where the reader meets it instead:

- `side` on `<searchSorted>` — *Example: `side` and repeated values*.
- The vectorized `target` on `<searchSorted>` and `<indexOf>`, including the aside about one component replacing twenty — *Example: many draws at once*, *Example: looking up several targets at once*.
- The "numeric when all numeric, alphabetical otherwise" rule, which appeared on all four pages — *Example: a sorted list of words*, *Example: alphabetically first*.
- `type="text"` on `<indexOf>` — *Example: finding a name*, which already demonstrates it and says what it does.

Two deliberate exceptions:

- **The diagnostics paragraphs are dropped, not relocated.** Which condition raises a warning and which raises an information message is not what an author needs before reading a single example, and it has no example of its own on any of the four pages. The observable half is kept: an empty list gives 0, and a target that does not occur gives 0.
- **`<argMax>` gains an example.** It was the only page that lost a point nothing else covered — that on text, "largest" means alphabetically last. Rather than keep the sentence, it gets the alphabetical example `<argMin>` already had. Verified: on `pear apple fig banana` it returns index 1, and the page renders "The alphabetically last is pear."

Documentation only. No published package's source changes, so there is no changeset — `docs-nextra` is internal and nothing bundles these files.

Follow-up to the documentation written in #1824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdEWccVoUPCJoDYxKmHRo