### PR TITLE
Say that a written-out target splits on whitespace, and pin it

### DIFF
--- a/packages/docs-nextra/pages/reference/indexOf.mdx
+++ b/packages/docs-nextra/pages/reference/indexOf.mdx
@@ -96,3 +96,31 @@ roster, so her slot is 0 while the others keep their positions.
 
 Finding a position in one list and reading it out of another is the usual reason to
 want `<indexOf>{:dn}` rather than a test for membership.
+
+
+
+---
+
+## Attribute Examples
+
+### Attribute Example: target
+
+
+```doenet-editor-horiz
+<textList name="cities">
+  <text>Boston</text><text>New York</text><text>Chicago</text>
+</textList>
+
+<text name="wanted">New York</text>
+
+<p>Written out: <indexOf type="text" target="New York">$cities</indexOf></p>
+<p>Referenced: <indexOf type="text" target="$wanted">$cities</indexOf></p>
+```
+
+
+
+`target` is read the way bare children are: whitespace separates one target from the
+next, so `target="New York"` asks for two of them and neither is on the list. A value
+with a space in it is written as a `<text>{:dn}` of its own and referenced — which is
+also how the list holding it is built, since `<textList>Boston New York</textList>{:dn}`
+is three cities and not two.

--- a/packages/docs-nextra/pages/reference/searchSorted.mdx
+++ b/packages/docs-nextra/pages/reference/searchSorted.mdx
@@ -138,3 +138,31 @@ When the target equals several entries, `side` chooses which end of that run to 
 
 
 Only an ordering is needed, not arithmetic, so a sorted text list works the same way.
+
+
+
+---
+
+## Attribute Examples
+
+### Attribute Example: target
+
+
+```doenet-editor-horiz
+<textList name="cities">
+  <text>Boston</text><text>Chicago</text><text>New York</text>
+</textList>
+
+<text name="wanted">New York</text>
+
+<p>Written out: <searchSorted type="text" target="New York">$cities</searchSorted></p>
+<p>Referenced: <searchSorted type="text" target="$wanted">$cities</searchSorted></p>
+```
+
+
+
+`target` is read the way bare children are: whitespace separates one target from the
+next, so `target="New York"` asks where two separate words belong and gets two answers.
+A value with a space in it is written as a `<text>{:dn}` of its own and referenced —
+which is also how the sorted list is built, since
+`<textList>Boston Chicago New York</textList>{:dn}` is four entries and not three.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/listoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/listoperators.test.ts
@@ -608,6 +608,71 @@ describe("List operator tag tests @group4", async () => {
             });
         });
 
+        it("splits a written-out target on whitespace, so a value with a space is referenced instead", async () => {
+            // Vectorizing `target` made it a list, and a list reads a bare
+            // string by splitting it: `target="New York"` is two targets, not
+            // one, so a city that is on the list is found at neither. The way
+            // to ask for a value containing a space is to build it outside and
+            // reference it -- which is also how the list itself is built, since
+            // a bare `<textList>` would split the same way.
+            //
+            // Untested when the vectorization landed, which is how the change
+            // reached `main` without anyone noticing it. Both reference pages
+            // now document it; this keeps the documented behavior honest.
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <textList name="cities">
+      <text>Boston</text><text>New York</text><text>Chicago</text>
+    </textList>
+    <text name="wanted">New York</text>
+    <p name="pSplit"><indexOf type="text" target="New York">$cities</indexOf></p>
+    <p name="pReferenced"><indexOf type="text" target="$wanted">$cities</indexOf></p>
+    `,
+            });
+
+            // Two targets, "New" and "York", neither of which is a city here.
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pSplit",
+                text: "0, 0",
+            });
+            // One target, found where it actually sits.
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pReferenced",
+                text: "2",
+            });
+        });
+
+        it("splits a written-out searchSorted target the same way", async () => {
+            let { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <textList name="cities">
+      <text>Boston</text><text>Chicago</text><text>New York</text>
+    </textList>
+    <text name="wanted">New York</text>
+    <p name="pSplit"><searchSorted type="text" target="New York">$cities</searchSorted></p>
+    <p name="pReferenced"><searchSorted type="text" target="$wanted">$cities</searchSorted></p>
+    `,
+            });
+
+            // "New" belongs at 3 and "York" after everything, at 4.
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pSplit",
+                text: "3, 4",
+            });
+            await expectText({
+                core,
+                resolvePathToNodeIdx,
+                name: "pReferenced",
+                text: "3",
+            });
+        });
+
         it("indexOf a text", async () => {
             let { core, resolvePathToNodeIdx } = await createTestCore({
                 doenetML: `


### PR DESCRIPTION
Vectorizing `target` on `<indexOf>` and `<searchSorted>` in #1827 turned it into a list, and a list reads a bare string by splitting it on whitespace. So a written-out `target` containing a space became several targets rather than one:

| Document | Result |
| --- | --- |
| `<indexOf type="text" target="New York">$cities</indexOf>` | `0, 0` |
| `<text name="wanted">New York</text>` … `target="$wanted"` | `2` |
| `<searchSorted type="text" target="New York">$cities</searchSorted>` | `3, 4` |
| the same, referenced | `3` |

The first row is the one worth seeing: `New York` **is** on the list, and asking for it by writing it out finds it at neither position, because the question asked was "where are `New` and `York`".

## Paying off a promise from #1827

Copilot raised exactly this on that PR, and I said it would be documented and pinned. It merged without either, and nothing has said so since:

- **No test anywhere passed a literal multi-value `target`** — every existing test uses a single word or a reference.
- **The multi-target example on each page uses a reference** (`target="$wanted"`), so the written-out form appeared nowhere in the docs.

Between them, the behavior was neither described nor protected, which is how it changed unnoticed in the first place.

## What this adds

An `### Attribute Example: target` on both pages, showing the split beside the way to avoid it: build the value as a `<text>` and reference it. That also gives the generated attribute table a link for `target`, which was already highlighted but had no worked example of its own.

Both examples build the list from `<text>` children too, because a bare `<textList>Boston New York Chicago</textList>` splits identically — three cities where an author meant two. That is the part they are most likely to meet first, so the example shows it rather than leaving it to be discovered.

Plus two regression tests in `listoperators.test.ts`, one per component, asserting both the split and the referenced form.

No behavior change — documentation and tests only, so no changeset. 54 tests pass in `listoperators.test.ts`; docs coverage clean at 264 components, 0 unresolved.

Every number in the prose was run rather than reasoned about, including using a genuinely sorted list for the `<searchSorted>` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdEWccVoUPCJoDYxKmHRo