### PR TITLE
Sort the reference sidebar, and drop an auto-import that crept in

### DIFF
--- a/packages/docs-nextra/pages/reference/_meta.ts
+++ b/packages/docs-nextra/pages/reference/_meta.ts
@@ -1,5 +1,3 @@
-import { split } from "postcss/lib/list";
-
 export default {
     componentIndex: "Alphabetical Index",
     componentTypes: "Index by Component Type",
@@ -18,8 +16,8 @@ export default {
     answer4: { title: "answer (Advanced Use)" },
     argMax: { title: "argMax" },
     argMin: { title: "argMin" },
-    asList: { title: "asList" },
     aside: { title: "aside" },
+    asList: { title: "asList" },
     atom: { title: "atom" },
     attr: { title: "attr" },
     attractTo: { title: "attractTo" },
@@ -258,10 +256,10 @@ export default {
     summaryStatistics: { title: "summaryStatistics" },
     table: { title: "table" },
     tabular: { title: "tabular" },
-    tally: { title: "tally" },
     tag: { title: "tag" },
     tagc: { title: "tagc" },
     tage: { title: "tage" },
+    tally: { title: "tally" },
     task: { title: "task" },
     term: { title: "term" },
     text: { title: "text" },


### PR DESCRIPTION
Three entries in `pages/reference/_meta.ts` sat out of alphabetical order, and the file opened with an import nothing uses.

## Ordering

Checked mechanically across all 282 entries rather than by eye:

| Was | Should be |
| --- | --- |
| `asList`, `aside` | `aside`, `asList` |
| `tabular`, `tally`, `tag`, `tagc`, `tage` | `tabular`, `tag`, `tagc`, `tage`, `tally` |

The `tally` one is why this was worth checking with a script: the obvious repair is to swap it with `tag`, which still leaves it ahead of `tagc` and `tage`. I made exactly that mistake first, and the checker caught it.

The sidebar is the one index where a reader scans rather than searches, so an entry a few lines from where it belongs is an entry they conclude is missing.

`Sample_Component` stays last. It is the hidden in-tree template rather than a component page, so it is not part of the ordering.

## The import

```ts
import { split } from "postcss/lib/list";
```

Nothing uses it. There is a `split:` key further down the object, so an editor offered the import while someone typed that key and it was accepted — a key of that name is not a use of the binding. Removing it stops the reference sidebar's metadata pulling a postcss module into the docs build for no reason.

Documentation metadata only — no package source, so no changeset. Docs coverage passes: 264 components, 284 pages, 0 unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YdEWccVoUPCJoDYxKmHRo
