### PR TITLE
Upgrade the bundled PreFigure runtime to 0.7.6

### DIFF
--- a/.changeset/prefigure-0-7-6.md
+++ b/.changeset/prefigure-0-7-6.md
@@ -1,0 +1,38 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Upgrade the bundled PreFigure runtime from 0.6.7 to 0.7.6.
+
+Nothing a Doenet author writes behaves differently. The upgrade was checked
+against the parts of PreFigure the renderers actually depend on, and they are
+unchanged: every element and attribute the graph and chart renderers emit is
+still accepted, `alignment_displacement` — which fixes where a label or legend
+sits relative to its anchor — is byte-identical, and the legend's geometry
+(`outer_padding`, `vertical-skip`, the key width and the box width formula) is
+the same. The `fill-pattern` vocabulary is unchanged, so patterned fills keep
+their meaning.
+
+What is new upstream is mostly elsewhere: circuit diagrams, an adapter schema,
+and `hticks`/`vticks` for controlling tick marks, none of which Doenet emits
+yet. Two changes are worth having. `annotations.py` now skips comments and
+processing instructions rather than trying to annotate them, which is a class
+of crash rather than a cosmetic fix. And the MathJax label extraction now
+resolves its XPath in the XHTML namespace, which is how labels are found at
+all when the label tree carries one.
+
+Two schema definitions were also relaxed: `coordinates` and `group` moved from
+an interleave of element groups to a free choice of them, which permits the
+mixed ordering our diagrams already emit.
+
+The chart and graph renderers reserve their margins from measurements taken
+against a real PreFigure render — how wide a legend's key is drawn, how wide a
+character is at 14px. Those measurements were taken at 0.6.7 and none of the
+constants behind them moved in 0.7.6, so no margin needed recalibrating. The
+opt-in live suites (`RUN_LIVE_PREFIGURE_VALIDATION=1`) measure the drawn
+geometry rather than predicting it, and are the check to run against the build
+service once it is upgraded to match.

--- a/packages/doenetml-print/src/ptx-compiler.ts
+++ b/packages/doenetml-print/src/ptx-compiler.ts
@@ -18,7 +18,7 @@ const rawLxml = rawLxmlImport as Uint8Array;
 
 // Keep this wheel path in sync with PREFIG_VERSION in packages/prefigure/src/worker/compiler-metadata.ts
 // @ts-ignore
-import rawPrefigImport from "../../prefigure/pyodide_packages/prefig-0.6.7-py3-none-any.whl?uint8array&base64";
+import rawPrefigImport from "../../prefigure/pyodide_packages/prefig-0.7.6-py3-none-any.whl?uint8array&base64";
 const rawPrefig = rawPrefigImport as Uint8Array;
 
 type PyodideAPI = Awaited<ReturnType<typeof loadPyodide>>;

--- a/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
@@ -5,7 +5,7 @@ const DEFAULT_PREFIGURE_DIAGCESS_SCRIPT_URL =
 // It is configured here (not auto-derived from prefigure package metadata),
 // but should still be manually kept aligned with runtime version bumps.
 const DEFAULT_PREFIGURE_MODULE_URL =
-    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.6.7/prefigure.js";
+    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.7.6/prefigure.js";
 
 const env = (
     import.meta as ImportMeta & {

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -29,7 +29,7 @@ Or load from CDN:
 
 ```html
 <script type="module">
-  import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.6.7/prefigure.js';
+  import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.7.6/prefigure.js';
   await prefigure.initPrefigure();
   const result = await prefigure.compilePrefigure(diagramXml, { mode: 'svg' });
 </script>

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/prefigure",
     "type": "module",
     "description": "Standalone PreFigure WASM compiler for browser and CDN usage",
-    "version": "0.6.7",
+    "version": "0.7.6",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/prefigure/src/worker/compiler-metadata.ts
+++ b/packages/prefigure/src/worker/compiler-metadata.ts
@@ -13,5 +13,5 @@
  *
  * Keep this file free of imports so it tree-shakes to a tiny constant.
  */
-export const PREFIG_VERSION = "0.6.7";
+export const PREFIG_VERSION = "0.7.6";
 export const PREFIG_WHEEL_FILENAME = `prefig-${PREFIG_VERSION}-py3-none-any.whl`;


### PR DESCRIPTION
Upgrades the bundled PreFigure runtime from **0.6.7** to **0.7.6**, following the procedure in `packages/prefigure/README.md`.

Kept separate from the chart work (#1884) deliberately: 54 files changed upstream, including a refactor running through `annotations.py` and the outline path, and a regression there should not be attributed to a chart PR.

## What changed here

The five pins the procedure lists: `PREFIG_VERSION`, the npm version that tracks it, the default CDN module URL, the README's example pin, and the literal wheel path in `ptx-compiler.ts` — which a Vite `?uint8array&base64` import cannot derive from a constant.

## Why it is safe to take

Checked against the parts the renderers actually depend on, rather than against the release as a whole.

| Checked | Result |
| --- | --- |
| Every element and attribute the graph and chart renderers emit | still accepted |
| `alignment_displacement` (the 4px legend/label offset) | byte-identical |
| Legend geometry — `outer_padding`, `vertical-skip`, key width, box width formula | unchanged |
| `label_tools.py` text measurement | only XPath namespace fixes |
| `fill-pattern` vocabulary | unchanged (only its quoting) |
| `coordinates` / `group` content models | **relaxed** — interleave to free choice |

`axes` looks like it loses `stroke` and `thickness`; it does not. It gains `StrokeAttributes`, the shared group that declares them, so an inline declaration became a reference.

The group outline refactor that accounts for most of the upstream diff does not reach us: `outline` defaults to none and no renderer sets it.

This matters more than a routine bump because the chart and graph renderers reserve their margins from measurements taken against a real PreFigure render — how wide a legend key is drawn, how wide a character is at 14px. Those were measured at 0.6.7. None of the constants behind them moved, so nothing needed recalibrating.

## What is new upstream

Mostly elsewhere: circuit diagrams, an adapter schema, and `hticks`/`vticks` for controlling tick marks, none of which Doenet emits yet. Two changes are worth having — `annotations.py` now skips comments and processing instructions rather than trying to annotate them, and MathJax label extraction resolves its XPath in the XHTML namespace.

Also worth knowing for anyone reading the upstream diff: the id-prefix collision filed as [prefigure#91](https://github.com/davidaustinm/prefigure/issues/91) is **still unfixed** in 0.7.6, so the build service's per-request filename workaround remains necessary.

## Verified by running

- The browser runtime check compiles a diagram in-browser on the new wheel.
- `verify-wheel-sync` passes.
- `@doenet/doenetml-print` builds; since the fetch script deletes the old wheel, a stale reference would have failed the import.
- 275 worker-side prefigure tests pass.

## Not verified here — the deploy has to follow

`prefigure.doenet.org` is still 0.6.7. Charts render through a local WASM compile when warm and the build service when cold, so until the service is upgraded to match (step 5 of the README procedure) the two paths run different runtimes. The constants above say that skew changes no geometry, but it should not be left standing.

Once the service moves, run the opt-in live suites — they measure the drawn geometry rather than predicting it:

```bash
RUN_LIVE_PREFIGURE_VALIDATION=1 npx vitest run \
  --root packages/doenetml-worker-javascript \
  src/test/prefigure/chart-prefigure-live-validation.test.ts
```

The npm side is automatic **except for one approval**, which I got wrong when I first wrote this. `publish-prefigure.yml` triggers on CI succeeding on `main` and correctly works out that `packages/prefigure/package.json` carries a version npm does not have — but the job that publishes declares `environment: production` and stops at `status=waiting` for a reviewer of that environment.

Until it is approved, `@doenet/prefigure@0.7.6` is absent from npm and the CDN pin bumped here returns 404, so `prefigure.tsx` logs `warmup failed … Failed to fetch dynamically imported module` and every diagram falls back to the build service — a working page with the local WASM path silently switched off. That is what happened after this PR merged.

Find the waiting run under Actions → Publish Prefigure and approve it; `gh api repos/Doenet/DoenetML/actions/runs/<run_id>/pending_deployments` says what it is blocked on. Publishing then purges the jsDelivr cache over minutes, so a brief 404 after approval is expected. #1890 adds this to the procedure in `packages/prefigure/README.md`, which did not mention it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

