### PR TITLE
Say that the PreFigure publish needs approving

### DIFF
--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -169,6 +169,24 @@ npm run build -w @doenet/prefigure
 npm run browser-runtime -w @doenet/prefigure
 ```
 
+10. **Approve the publish.** Merging is not enough on its own. `publish-prefigure.yml`
+    triggers automatically once CI succeeds on `main` and works out that
+    `packages/prefigure/package.json` carries a version npm does not have — but its
+    publishing job declares `environment: production`, so it stops at `status=waiting`
+    until a reviewer for that environment approves it. Until then the version is
+    absent from npm and the CDN URL bumped in step 3 returns 404, so
+    `prefigure.tsx` logs `warmup failed … Failed to fetch dynamically imported
+    module` and every diagram falls back to the build service. Find the waiting run
+    under [Actions → Publish Prefigure](https://github.com/Doenet/DoenetML/actions/workflows/publish-prefigure.yml)
+    and approve it; check what it is waiting on with:
+
+    ```bash
+    gh api repos/Doenet/DoenetML/actions/runs/<run_id>/pending_deployments
+    ```
+
+    Publishing then purges the jsDelivr cache, which takes minutes rather than
+    seconds — the URL can 404 for a short while after approval.
+
 ### Upgrade Pyodide runtime packages
 
 1. Bump `pyodide` in `packages/prefigure/package.json`.


### PR DESCRIPTION
The PreFigure upgrade procedure in `packages/prefigure/README.md` ends at the browser runtime check, which reads as though merging finishes the job. It does not.

`publish-prefigure.yml` triggers on its own once CI succeeds on `main`, and its first job correctly works out that `packages/prefigure/package.json` carries a version npm does not have. But the job that actually publishes declares `environment: production`, so it stops at `status=waiting` until a reviewer for that environment approves it.

Nothing in the procedure said so, and the gap is quiet in the wrong way: the version never reaches npm, the CDN URL bumped in step 3 keeps returning 404, and the only symptom is a console line —

```
[prefigure] warmup failed TypeError: Failed to fetch dynamically imported module:
https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.7.6/prefigure.js
```

— with every diagram falling back to the build service. That is a working page with the local WASM path silently switched off: easy to miss, and hard to attribute to a missing approval three steps earlier.

This is exactly what happened on the 0.7.6 upgrade (#1889). `npm view @doenet/prefigure` still showed `latest: 0.6.7` while the run sat waiting.

Adds step 10 with the approval, the command for finding what a given run is blocked on:

```bash
gh api repos/Doenet/DoenetML/actions/runs/<run_id>/pending_deployments
```

and a note that publishing then purges the jsDelivr cache over minutes rather than seconds, so a brief 404 after approval is expected rather than a second problem.

Documentation only — no code, no workflow change. The approval gate itself is deliberate and worth keeping; it just needs to be written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
