### PR TITLE
Add <chart type="box">

### DIFF
--- a/.changeset/chart-box.md
+++ b/.changeset/chart-box.md
@@ -1,0 +1,32 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Add `<chart type="box">`.
+
+```xml
+<chart type="box">
+  <shortDescription>Scores by section</shortDescription>
+  <yLabel>score</yLabel>
+  <series><label>9am</label>52 61 63 68 70 71 75 78 84 91</series>
+  <series><label>1pm</label>44 55 58 60 62 65 66 70 72 96</series>
+</chart>
+```
+
+A box plot per series, side by side. This is the first chart type whose `<series>` holds **raw observations** rather than one value per category, and that turns the axis around: a whole series is now one position on it, which is what every plotting package means by `aes(x = group, y = value)`. So a box chart has no categories — its positions are its series, named under each box by that series' own `<label>` — and writing `categories` on one is reported rather than dropped in silence, since the names are text an author wrote for a reader. `$chart.categories` reports nothing for a box plot for the same reason.
+
+The box runs from the first quartile to the third with the median drawn across it; the whiskers reach the furthest observation within one and a half interquartile ranges of the box, with a cap across each end; and an observation beyond that is drawn as a point of its own. A whisker ends on a datum that is in the data rather than on the fence, and a side whose quartile is already the extreme gets no whisker, since the box's own edge is the mark. A series of one observation, or of one value repeated, draws as a line at that value — every one of the five numbers is there.
+
+The vertical axis is the data's and is not anchored to zero, as a line or scatter chart's is not: a box plot's numbers are positions on a scale rather than lengths measured from a baseline. A box chart draws no legend whichever way `legend` is written, because the names are already under the boxes and a legend would spend width to repeat the axis; `$chart.showLegend` reports that.
+
+Every `<series>` now reports its own summary — `minimum`, `quartile1`, `median`, `quartile3`, `maximum` and `outliers` — whatever chart was drawn from it, so a sentence or an `<answer>` beside the picture can say what the picture shows. These come from the same definition `<summaryStatistics>` uses, extracted so that a table of quartiles and a box plot of the same column cannot disagree on the page. They are interpolated percentiles, not Tukey's hinges, which differ on some sample sizes.
+
+Each box carries its five-number summary as an annotation and each outlier its own, so a box plot is navigable by screen reader like every other chart. Those are the one chart annotation that needs words to be read at all — five numbers at one position have nothing but their naming to tell them apart — so the wording is a translatable message rather than English built in the worker.
+
+An observation that is not a finite number is left out of the summary rather than read as zero, and the chart says so: a dropped observation moves every quartile of the box drawn from it and leaves nothing on the page to notice.
+
+Closes #1880.

--- a/.changeset/chart-box.md
+++ b/.changeset/chart-box.md
@@ -29,4 +29,6 @@ Each box carries its five-number summary as an annotation and each outlier its o
 
 An observation that is not a finite number is left out of the summary rather than read as zero, and the chart says so: a dropped observation moves every quartile of the box drawn from it and leaves nothing on the page to notice.
 
+`<summaryStatistics>` now takes the median as the 50th percentile rather than as the average of the two middle values, which overflowed before it halved: the median of a column of `1e308` and `1.5e308` was reported as infinite and is now reported as `1.25e308`. Every column whose two middle values sum to a number a double can hold reports the median it always did.
+
 Closes #1880.

--- a/.changeset/chart-box.md
+++ b/.changeset/chart-box.md
@@ -29,6 +29,9 @@ Each box carries its five-number summary as an annotation and each outlier its o
 
 An observation that is not a finite number is left out of the summary rather than read as zero, and the chart says so: a dropped observation moves every quartile of the box drawn from it and leaves nothing on the page to notice.
 
-`<summaryStatistics>` now takes the median as the 50th percentile rather than as the average of the two middle values, which overflowed before it halved: the median of a column of `1e308` and `1.5e308` was reported as infinite and is now reported as `1.25e308`. Every column whose two middle values sum to a number a double can hold reports the median it always did.
+`<summaryStatistics>` reports the same median it always did on any column of ordinary numbers, and a different one at two edges of the range a number can hold. Its median is now computed by ordering the values and taking the middle one, or the midpoint of the two middle ones — the same value the 50th percentile interpolates to, and unchanged for every column whose values are ordinary. Two things change:
+
+- A column near the top of the range no longer overflows before it halves. The median of a column of `1e308` and `1.5e308` was reported as infinite and is now reported as `1.25e308`.
+- Values are ordered by size rather than by a comparison that reads values agreeing to twelve significant digits as equal, so a column of readings that close reports its middle value rather than whichever of them happened to be written first: the median of `1 1.0000000000001 1.00000000000005` was reported as `1` and is now reported as `1.00000000000005`. `quartile1` and `quartile3` still order such a column by that comparison and are as unreliable on it as they were before.
 
 Closes #1880.

--- a/.changeset/chart-box.md
+++ b/.changeset/chart-box.md
@@ -25,7 +25,7 @@ The vertical axis is the data's and is not anchored to zero, as a line or scatte
 
 Every `<series>` now reports its own summary — `minimum`, `quartile1`, `median`, `quartile3`, `maximum` and `outliers` — whatever chart was drawn from it, so a sentence or an `<answer>` beside the picture can say what the picture shows. These come from the same definition `<summaryStatistics>` uses, extracted so that a table of quartiles and a box plot of the same column cannot disagree on the page. They are interpolated percentiles, not Tukey's hinges, which differ on some sample sizes.
 
-Each box carries its five-number summary as an annotation and each outlier its own, so a box plot is navigable by screen reader like every other chart. Those are the one chart annotation that needs words to be read at all — five numbers at one position have nothing but their naming to tell them apart — so the wording is a translatable message rather than English built in the worker.
+Each box carries its five-number summary as an annotation and each outlier its own, so a box plot is navigable by screen reader like every other chart. They are the only chart annotations that need words to be read at all — five numbers at one position have nothing but their naming to tell them apart — so the wording is a translatable message rather than English built in the worker.
 
 An observation that is not a finite number is left out of the summary rather than read as zero, and the chart says so: a dropped observation moves every quartile of the box drawn from it and leaves nothing on the page to notice.
 

--- a/packages/docs-nextra/pages/reference/chart.mdx
+++ b/packages/docs-nextra/pages/reference/chart.mdx
@@ -118,6 +118,41 @@ where every other type colors by series.
 
 
 
+### `type="box"`
+
+A box plot per series, side by side. A series holds raw observations — a column of
+measurements — rather than one value per category, and the box drawn from it runs from the
+first quartile to the third with the median across it.
+
+
+```doenet-editor-horiz
+<chart type="box" size="small">
+  <shortDescription>Scores in one section</shortDescription>
+  <yLabel>score</yLabel>
+  52 61 63 68 70 71 75 78 84 91
+</chart>
+
+<chart type="box" size="small">
+  <shortDescription>Scores in two sections</shortDescription>
+  <yLabel>score</yLabel>
+  <series><label>9am</label>52 61 63 68 70 71 75 78 84 91</series>
+  <series><label>1pm</label>44 55 58 60 62 65 66 70 72 96</series>
+</chart>
+```
+
+
+
+Each series is one position on the axis, named under its box by its own `<label>{:dn}`. The
+whiskers reach the furthest observation within one and a half interquartile ranges of the
+box, and an observation past that is drawn as a point of its own — the 96 in the second
+section. The vertical axis is the data's, so it need not include zero.
+
+Each `<series>{:dn}` also reports its own summary — `minimum`, `quartile1`, `median`,
+`quartile3`, `maximum` and `outliers` — computed the same way `<summaryStatistics>{:dn}`
+computes them, so a table beside the picture agrees with it.
+
+
+
 ## Examples
 
 ### Example: a bar chart of counts
@@ -213,6 +248,34 @@ there if the chart is printed or exported.
 draws them; [`<tally>{:dn}`](tally) does the same for named categories. Building a whole
 sampling simulation this way is walked through in
 [Charting a Simulation](../guides/charting-a-simulation).
+
+---
+
+### Example: a box plot beside the numbers behind it
+
+
+```doenet-editor-horiz
+<setup>
+  <numberList name="scores">52 61 63 68 70 71 75 78 84 91</numberList>
+</setup>
+
+<chart type="box" size="small">
+  <shortDescription>Scores in one section</shortDescription>
+  <yLabel>score</yLabel>
+  <series name="section">$scores</series>
+</chart>
+
+<summaryStatistics statisticsToDisplay="fiveNumberSummary">$scores</summaryStatistics>
+
+<p>The middle half of the section scored between $section.quartile1 and
+$section.quartile3.</p>
+```
+
+
+
+A box plot and a [`<summaryStatistics>{:dn}`](summaryStatistics) of the same numbers report
+the same five, so the table and the picture can stand side by side. Naming the
+`<series>{:dn}` is what makes each of them readable into a sentence.
 
 ---
 
@@ -537,3 +600,27 @@ drawn with rather than what was asked for, so `$counts.yMax` is the top of the a
 see even though nothing above set one. `xMin` and `xMax` report nothing for a chart whose
 horizontal axis carries category names rather than numbers, and a pie reports nothing for
 any of the four: it has no axes to read a value off.
+
+### Property Example: a series' own summary
+
+
+```doenet-editor-horiz
+<chart type="box" size="small">
+  <shortDescription>Two sections' scores</shortDescription>
+  <yLabel>score</yLabel>
+  <series name="morning"><label>9am</label>52 61 63 68 70 71 75 78 84 91</series>
+  <series name="afternoon"><label>1pm</label>44 55 58 60 62 65 66 70 72 96</series>
+</chart>
+
+<p>Morning median: $morning.median, afternoon median: $afternoon.median.</p>
+<p>The afternoon section's middle half ran from $afternoon.quartile1 to
+$afternoon.quartile3.</p>
+<p>Drawn apart from the rest: $afternoon.outliers</p>
+```
+
+
+
+Every `<series>{:dn}` reports `minimum`, `quartile1`, `median`, `quartile3`, `maximum` and
+`outliers` about the values it holds, whichever chart was drawn from them, so a sentence
+beside the picture can say what the picture shows. `outliers` is the observations a box plot
+draws as points beyond its whiskers.

--- a/packages/docs-nextra/pages/reference/chart.mdx
+++ b/packages/docs-nextra/pages/reference/chart.mdx
@@ -142,7 +142,8 @@ first quartile to the third with the median across it.
 
 
 
-Each series is one position on the axis, named under its box by its own `<label>{:dn}`. The
+Each series is one position on the axis, named under its box by its own `<label>{:dn}` — or
+by its position, as the single box above is, where there is no label to name it. The
 whiskers reach the furthest observation within one and a half interquartile ranges of the
 box, and an observation past that is drawn as a point of its own — the 96 in the second
 section. The vertical axis is the data's, so it need not include zero.

--- a/packages/doenetml-worker-javascript/src/components/Chart.js
+++ b/packages/doenetml-worker-javascript/src/components/Chart.js
@@ -16,9 +16,11 @@ import {
 import {
     chartLegendHasItems,
     computeBarChartGeometry,
+    computeBoxChartGeometry,
     computePieChartGeometry,
     computePointChartGeometry,
     createBarChartPrefigureXML,
+    createBoxChartPrefigureXML,
     createPieChartPrefigureXML,
     createPointChartPrefigureXML,
 } from "../utils/prefigure/chart";
@@ -49,7 +51,7 @@ const DEFAULT_BAR_WIDTH = 0.8;
  * the schema before its geometry lands — the chart draws nothing and says so
  * rather than falling through a branch that is not there yet.
  */
-const DRAWABLE_TYPES = new Set(["bar", "line", "scatter", "pie"]);
+const DRAWABLE_TYPES = new Set(["bar", "line", "scatter", "pie", "box"]);
 
 /**
  * A chart of its data. `type` picks which chart is drawn: one bar per value, a
@@ -152,6 +154,11 @@ export default class Chart extends BlockComponent {
                     description:
                         "A pie chart: one slice per value, each a share of the total, named by the category names. Draws one series and has no axes.",
                 },
+                {
+                    value: "box",
+                    description:
+                        "A box plot per series, side by side under an axis of the series' names. A series holds raw observations rather than one value per category.",
+                },
             ],
         };
 
@@ -187,7 +194,7 @@ export default class Chart extends BlockComponent {
             groupName: "axes",
             createComponentOfType: "textList",
             description:
-                "The name of each position in the data: the label under each position on the horizontal axis, or the name of each slice of a pie. Defaults to the position itself, 1, 2, 3 and so on. A line or scatter chart whose series carry an `x` is placed by measurement instead and has no positions to name; a bar chart and a pie name theirs whatever else the series carry.",
+                "The name of each position in the data: the label under each position on the horizontal axis, or the name of each slice of a pie. Defaults to the position itself, 1, 2, 3 and so on. A line or scatter chart whose series carry an `x` is placed by measurement instead and has no positions to name; a bar chart and a pie name theirs whatever else the series carry. A box plot's positions are its series, each named by its own `<label>`.",
             highlighted: true,
         };
 
@@ -243,7 +250,7 @@ export default class Chart extends BlockComponent {
         attributes.legend = {
             groupName: "legend",
             description:
-                'Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend="false"` suppresses it, and a pie then writes its slice names around the rim instead.',
+                'Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend="false"` suppresses it, and a pie then writes its slice names around the rim instead. A box plot names each series under the box drawn from it and never draws a legend.',
             createComponentOfType: "boolean",
             createStateVariable: "legend",
             defaultValue: true,
@@ -325,7 +332,7 @@ export default class Chart extends BlockComponent {
         attributes.yMin = {
             groupName: "axes",
             description:
-                "Lowest value shown on the vertical axis. Defaults to 0 for a bar chart, whose bars are measured from it, or to the first tick past the smallest value — which is what a bar chart with negative values gets, and what a line or scatter chart always gets. If `yMin` and `yMax` do not describe a box — both finite, with `yMin` below `yMax` — the axis is chosen from the data instead. A pie has no axes and reads neither.",
+                "Lowest value shown on the vertical axis. Defaults to 0 for a bar chart, whose bars are measured from it, or to the first tick past the smallest value — which is what a bar chart with negative values gets, and what a line, scatter or box chart always gets. If `yMin` and `yMax` do not describe a box — both finite, with `yMin` below `yMax` — the axis is chosen from the data instead. A pie has no axes and reads neither.",
             createComponentOfType: "number",
             createStateVariable: "yMinAttr",
             defaultValue: null,
@@ -343,7 +350,7 @@ export default class Chart extends BlockComponent {
         attributes.displayValues = {
             groupName: "marks",
             description:
-                "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice.",
+                "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice. A box plot reports five numbers at each position rather than one, and does not draw with it.",
             createComponentOfType: "boolean",
             createStateVariable: "displayValues",
             defaultValue: false,
@@ -870,7 +877,7 @@ export default class Chart extends BlockComponent {
         stateVariableDefinitions.categories = {
             groupName: "axes",
             description:
-                "The name of each position in the data, in order: the label under each bar, or the name of each slice of a pie.",
+                "The name of each position in the data, in order: the label under each bar, or the name of each slice of a pie. Empty on a box plot, whose positions are its series.",
             public: true,
             isArray: true,
             entryPrefixes: ["category"],
@@ -880,13 +887,27 @@ export default class Chart extends BlockComponent {
             // As many as the longest series: every series is drawn against the
             // same categories, so a series that runs short leaves the later
             // slots empty rather than shortening the axis under the others.
+            //
+            // None at all on a box plot, which has no categories: each of its
+            // series is one position on the axis, so the positions are named by
+            // the series' own labels and the values within a series are
+            // observations rather than positions. Reporting one category per
+            // observation would name a hundred positions on a chart that has
+            // three.
             returnArraySizeDependencies: () => ({
+                type: {
+                    dependencyType: "stateVariable",
+                    variableName: "type",
+                },
                 seriesData: {
                     dependencyType: "stateVariable",
                     variableName: "seriesData",
                 },
             }),
             returnArraySize({ dependencyValues }) {
+                if (dependencyValues.type === "box") {
+                    return [0];
+                }
                 return [
                     dependencyValues.seriesData.reduce(
                         (longest, oneSeries) =>
@@ -1034,6 +1055,15 @@ export default class Chart extends BlockComponent {
                     dependencyType: "stateVariable",
                     variableName: "categories",
                 },
+                // The attribute rather than the state variable, which fills in
+                // the positions where the author named nothing: what the box
+                // branch below has to know is whether they wrote any, not what
+                // the axis would have been labeled.
+                categoriesAttr: {
+                    dependencyType: "attributeComponent",
+                    attributeName: "categories",
+                    variableNames: ["texts"],
+                },
                 barWidth: {
                     dependencyType: "stateVariable",
                     variableName: "barWidth",
@@ -1159,6 +1189,51 @@ export default class Chart extends BlockComponent {
                             codedDiagnostic({
                                 type: "warning",
                                 code: "doenet-w0152",
+                            }),
+                        );
+                    }
+
+                    return {
+                        setValue: { chartGeometry: geometry },
+                        sendDiagnostics,
+                    };
+                }
+
+                if (type === "box") {
+                    const geometry = computeBoxChartGeometry({
+                        series: dependencyValues.seriesData.map(
+                            ({ label, values }) => ({ label, values }),
+                        ),
+                        yMinAttr: dependencyValues.yMinAttr,
+                        yMaxAttr: dependencyValues.yMaxAttr,
+                    });
+
+                    const sendDiagnostics = [];
+                    // An observation that is not a finite number is left out of
+                    // the summary. Saying so matters more here than on a bar
+                    // chart, where the reader can see the empty slot: a
+                    // dropped observation moves every quartile of the box drawn
+                    // from it and leaves nothing on the page to notice.
+                    if (geometry.undrawnValues > 0) {
+                        sendDiagnostics.push(
+                            codedDiagnostic({
+                                type: "warning",
+                                code: "doenet-w0154",
+                            }),
+                        );
+                    }
+                    // The names in `categories` are text an author wrote
+                    // for a reader, and a box plot has no positions for them
+                    // to name — the same reason an `<xLabel>` on a pie is
+                    // reported rather than dropped in silence.
+                    if (
+                        dependencyValues.categoriesAttr?.stateValues.texts
+                            ?.length > 0
+                    ) {
+                        sendDiagnostics.push(
+                            codedDiagnostic({
+                                type: "warning",
+                                code: "doenet-w0155",
                             }),
                         );
                     }
@@ -1324,8 +1399,8 @@ export default class Chart extends BlockComponent {
                 // series carried an `x`, and to nothing else: `slots` is the
                 // categorical axis' positions, so a point chart that has them
                 // is one whose axis carries names instead, a bar chart's
-                // positions are always categories, and a pie has no axes at
-                // all.
+                // positions are always categories, a box plot's are always its
+                // series, and a pie has no axes at all.
                 if (geometry?.kind !== "point" || geometry.slots) {
                     return { setValue: { xMin: null, xMax: null } };
                 }
@@ -1445,6 +1520,13 @@ export default class Chart extends BlockComponent {
                     dependencyType: "stateVariable",
                     variableName: "sliceStyles",
                 },
+                // For the words a box plot's annotations need. A bar is
+                // announced as its category and its value and a point as its
+                // coordinates, because there the position says which number is
+                // which; five numbers at one position have nothing but their
+                // naming to tell them apart, and a name built here would be
+                // English in a document that may be in any language.
+                ...returnContentLocaleDependencies(),
                 document: {
                     dependencyType: "ancestor",
                     componentType: "document",
@@ -1509,28 +1591,63 @@ export default class Chart extends BlockComponent {
                     };
                 }
 
+                // Resolved once, for the box branch below and the shared
+                // path after it.
+                const seriesRendering = dependencyValues.seriesData.map(
+                    ({
+                        label,
+                        labelHasLatex,
+                        selectedStyle,
+                        unlabeledName,
+                    }) => ({
+                        label,
+                        labelHasLatex,
+                        unlabeledName,
+                        // Resolved here rather than in the geometry, which is
+                        // renderer-neutral and has no view of the page's
+                        // theme: what a series is drawn in depends on which
+                        // theme the reader is in, where what it is drawn as
+                        // does not.
+                        selectedStyle: resolveSelectedStyleForTheme(
+                            selectedStyle,
+                            darkMode,
+                        ),
+                    }),
+                );
+
+                if (dependencyValues.type === "box") {
+                    const t = contentTranslator(dependencyValues);
+
+                    const { xml, diagnostics } = createBoxChartPrefigureXML({
+                        geometry: dependencyValues.chartGeometry,
+                        seriesRendering,
+                        // Named the way a bar's annotation is — the label on
+                        // the axis, then what is drawn there — so that a box
+                        // read on its own says which group it summarizes.
+                        boxAnnotationText: ({ label, ...summary }) =>
+                            `${label}: ${t("chart-box-summary", summary)}`,
+                        outlierAnnotationText: ({ label, value }) =>
+                            `${label}: ${t("chart-box-outlier", { value })}`,
+                        widthPx,
+                        heightPx,
+                        xLabel: dependencyValues.xLabel,
+                        xLabelHasLatex: dependencyValues.xLabelHasLatex,
+                        yLabel: dependencyValues.yLabel,
+                        yLabelHasLatex: dependencyValues.yLabelHasLatex,
+                        title: dependencyValues.title,
+                        shortDescription: dependencyValues.shortDescription,
+                        darkMode,
+                    });
+
+                    return {
+                        setValue: { prefigureXML: xml },
+                        sendDiagnostics: diagnostics,
+                    };
+                }
+
                 const shared = {
                     geometry: dependencyValues.chartGeometry,
-                    // Resolved here rather than in the geometry, which is
-                    // renderer-neutral and has no view of the page's theme:
-                    // what a series is drawn in depends on which theme the
-                    // reader is in, where what it is drawn as does not.
-                    seriesRendering: dependencyValues.seriesData.map(
-                        ({
-                            label,
-                            labelHasLatex,
-                            selectedStyle,
-                            unlabeledName,
-                        }) => ({
-                            label,
-                            labelHasLatex,
-                            unlabeledName,
-                            selectedStyle: resolveSelectedStyleForTheme(
-                                selectedStyle,
-                                darkMode,
-                            ),
-                        }),
-                    ),
+                    seriesRendering,
                     widthPx,
                     heightPx,
                     xLabel: dependencyValues.xLabel,

--- a/packages/doenetml-worker-javascript/src/components/Series.js
+++ b/packages/doenetml-worker-javascript/src/components/Series.js
@@ -8,6 +8,7 @@ import {
     numericValuesFromValueChildren,
     returnBreakStringsIntoMathsBySpacesSugarInstruction,
 } from "../utils/mathOperatorChildren";
+import { boxPlotSummary } from "../utils/summaryStatistics";
 
 /**
  * One group of data within a `<chart>`: the values, a label to name them by,
@@ -259,6 +260,121 @@ export default class Series extends BaseComponent {
                     values[arrayKey] = numericValues[arrayKey];
                 }
                 return { setValue: { values } };
+            },
+        };
+
+        // Everything a box plot draws from this series, computed once. The
+        // definition is shared with `<summaryStatistics>`, so a table of
+        // quartiles and a box plot of the same numbers cannot disagree on the
+        // page.
+        //
+        // Defined on the series rather than on the chart, and whatever the
+        // chart's `type`: these are statistics of a column of numbers, and a
+        // column does not stop having a median because it was drawn as bars.
+        // What the chart decides is which of them get a mark, not which of them
+        // exist. A named series is then readable into a sentence or an
+        // `<answer>` beside the picture — the argument #1833 made for binning
+        // in the worker rather than in scipy.
+        //
+        // Anything that is not a finite number is missing data and is left out,
+        // which is what `<summaryStatistics>` does with the same column: a
+        // symbolic `<math>` has no place in an order statistic, and reading it
+        // as zero would move every one of these.
+        stateVariableDefinitions.summaryOfValues = {
+            description:
+                "The five-number summary of this series' values, with the whisker ends and outliers a box plot draws, or null when it has no finite values.",
+            returnDependencies: () => ({
+                values: {
+                    dependencyType: "stateVariable",
+                    variableName: "values",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        summaryOfValues: boxPlotSummary(
+                            dependencyValues.values.filter((value) =>
+                                Number.isFinite(value),
+                            ),
+                        ),
+                    },
+                };
+            },
+        };
+
+        // Each of the five, plus the outliers, read off that one summary.
+        //
+        // Null for a series with no finite values, which is what
+        // `<summaryStatistics>` reports for an empty column: there is no
+        // smallest value in no values, and reporting 0 would be a number the
+        // data does not contain. `outliers` is the exception — an empty list is
+        // the honest answer there, since "which values lie beyond the fences"
+        // has one whether or not there are any values to ask it of.
+        for (const [name, description] of [
+            ["minimum", "The smallest value in this series."],
+            ["quartile1", "The first quartile (25th percentile)."],
+            ["median", "The median value."],
+            ["quartile3", "The third quartile (75th percentile)."],
+            ["maximum", "The largest value in this series."],
+        ]) {
+            stateVariableDefinitions[name] = {
+                description,
+                public: true,
+                shadowingInstructions: {
+                    createComponentOfType: "number",
+                },
+                returnDependencies: () => ({
+                    summaryOfValues: {
+                        dependencyType: "stateVariable",
+                        variableName: "summaryOfValues",
+                    },
+                }),
+                definition({ dependencyValues }) {
+                    return {
+                        setValue: {
+                            [name]:
+                                dependencyValues.summaryOfValues?.[name] ??
+                                null,
+                        },
+                    };
+                },
+            };
+        }
+
+        stateVariableDefinitions.outliers = {
+            description:
+                "The values more than one and a half interquartile ranges beyond the nearer quartile, in the order they were given — the ones a box plot draws as points beyond its whiskers.",
+            public: true,
+            isArray: true,
+            entryPrefixes: ["outlier"],
+            shadowingInstructions: {
+                createComponentOfType: "number",
+            },
+            returnArraySizeDependencies: () => ({
+                summaryOfValues: {
+                    dependencyType: "stateVariable",
+                    variableName: "summaryOfValues",
+                },
+            }),
+            returnArraySize({ dependencyValues }) {
+                return [dependencyValues.summaryOfValues?.outliers.length ?? 0];
+            },
+            returnArrayDependenciesByKey: () => ({
+                globalDependencies: {
+                    summaryOfValues: {
+                        dependencyType: "stateVariable",
+                        variableName: "summaryOfValues",
+                    },
+                },
+            }),
+            arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
+                const found =
+                    globalDependencyValues.summaryOfValues?.outliers ?? [];
+                const outliers = {};
+                for (const arrayKey of arrayKeys) {
+                    outliers[arrayKey] = found[arrayKey];
+                }
+                return { setValue: { outliers } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -1,7 +1,17 @@
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
-const { mean, std, variance, median, quantileSeq } = me.math;
+const { mean, std, variance } = me.math;
 import { numberToMathExpression, roundForDisplay } from "../utils/math";
+// The five that a box plot also draws come from one shared definition, so that
+// a table of quartiles and a `<chart type="box">` of the same column cannot
+// disagree on the page.
+import {
+    largest,
+    median,
+    quartile1,
+    quartile3,
+    smallest,
+} from "../utils/summaryStatistics";
 import { returnBreakStringsIntoMathsBySpacesSugarInstruction } from "../utils/mathOperatorChildren";
 import {
     buildNumberDisplayParameters,
@@ -44,27 +54,23 @@ const STATISTICS = [
     {
         value: "minimum",
         description: "The smallest value.",
-        // Reduced rather than spread, as `<chart>` reduces for the same
-        // reason: `Math.min(...column)` throws once the column is longer than
-        // the engine's argument limit, and a column that long is exactly what
-        // summarizing a simulation produces.
-        compute: (column) => column.reduce((a, c) => (c < a ? c : a)),
+        compute: smallest,
     },
     {
         value: "quartile1",
         description: "The first quartile (25th percentile).",
-        compute: (column) => quantileSeq(column, 0.25),
+        compute: quartile1,
     },
     { value: "median", description: "The median value.", compute: median },
     {
         value: "quartile3",
         description: "The third quartile (75th percentile).",
-        compute: (column) => quantileSeq(column, 0.75),
+        compute: quartile3,
     },
     {
         value: "maximum",
         description: "The largest value.",
-        compute: (column) => column.reduce((a, c) => (c > a ? c : a)),
+        compute: largest,
     },
     { value: "range", description: "The maximum minus the minimum." },
     {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
@@ -1,0 +1,642 @@
+import { describe, expect, it, vi } from "vitest";
+import { getWarnings } from "./graph-prefigure.helpers";
+import { chartXML } from "./chart.helpers";
+import { createTestCore } from "../utils/test-core";
+import { getDiagnosticsByType } from "../utils/diagnostics";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+describe("chart box prefigure tests @group4", async () => {
+    /**
+     * Six observations, chosen because they are the sample size where
+     * interpolated percentiles and Tukey's hinges disagree: the quartiles here
+     * are 2.25 and 4.75, where hinges would give 2 and 5.
+     */
+    const ONE_BOX = `
+    <chart type="box" name="c">
+      <shortDescription>Six observations</shortDescription>
+      <series><label>A</label>1 2 3 4 5 6</series>
+    </chart>
+    `;
+
+    describe("the box", async () => {
+        it("draws the box from the first quartile to the third", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            // The one box sits at x = 1, half a slot wide, so it spans 0.75 to
+            // 1.25; from the first quartile up to the third, which for these
+            // six observations is 2.25 to 4.75.
+            expect(xml).toContain(
+                '<rectangle at="box-1" lower-left="(0.75,2.25)" dimensions="(0.5,2.5)"',
+            );
+            expect(xml.match(/<rectangle /g)?.length).eq(1);
+        });
+
+        it("draws the median across the box", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            // Across the whole width of the box, at 3.5 — and after the
+            // rectangle in document order, so the fill cannot cover it.
+            expect(xml).toContain('<line p1="(0.75,3.5)" p2="(1.25,3.5)"');
+            expect(xml.indexOf('p1="(0.75,3.5)"')).greaterThan(
+                xml.indexOf('at="box-1"'),
+            );
+        });
+
+        it("draws a whisker to each end of the data, with a cap across it", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            // Up the middle of the slot, from each quartile to the furthest
+            // observation the fence allows — which here is the whole range,
+            // since an interquartile range of 2.5 puts the fences at -1.5 and
+            // 8.5.
+            expect(xml).toContain('<line p1="(1,2.25)" p2="(1,1)"');
+            expect(xml).toContain('<line p1="(1,4.75)" p2="(1,6)"');
+
+            // The cap is half the box's width, centered on the slot.
+            expect(xml).toContain('<line p1="(0.875,1)" p2="(1.125,1)"');
+            expect(xml).toContain('<line p1="(0.875,6)" p2="(1.125,6)"');
+
+            // A median, two whiskers and two caps.
+            expect(xml.match(/<line /g)?.length).eq(5);
+        });
+
+        it("draws no point where nothing lies beyond a whisker", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            expect(xml).not.toContain("<point ");
+        });
+
+        it("draws the whiskers as strokes, with no fill", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            // A `<line>` reads only the stroke attributes, so a fill on one
+            // would say nothing — but the box it hangs from is a shape and
+            // keeps its own.
+            const median = xml.slice(xml.indexOf('<line p1="(0.75,3.5)"'));
+            expect(median.slice(0, median.indexOf("/>"))).not.toContain("fill");
+            expect(xml).toContain('at="box-1"');
+            expect(xml.slice(xml.indexOf('at="box-1"'))).toContain("fill=");
+        });
+
+        it("clips the box and its whiskers to the frame", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            // A box is an extent and a whisker is a length, so a bound
+            // genuinely truncates both: PreFigure draws neither clipped unless
+            // asked, and the part outside would be painted over the names
+            // below the frame.
+            expect(xml.match(/cliptobbox="yes"/g)?.length).eq(6);
+        });
+    });
+
+    describe("the whiskers and what lies beyond them", async () => {
+        it("stops each whisker at an observation rather than at the fence", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Ten observations with one far out</shortDescription>
+      <series><label>A</label>44 55 58 60 62 65 66 70 72 96</series>
+    </chart>
+    `);
+
+            // The quartiles are 58.5 and 69, so the interquartile range is
+            // 10.5 and the upper fence is at 84.75. The whisker stops at 72 —
+            // the furthest observation inside it — and not at the fence, which
+            // is a number the data does not contain.
+            expect(xml).toContain('<line p1="(1,69)" p2="(1,72)"');
+            expect(xml).not.toContain("84.75");
+        });
+
+        it("draws an observation past the fence as a point of its own", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Ten observations with one far out</shortDescription>
+      <series><label>A</label>44 55 58 60 62 65 66 70 72 96</series>
+    </chart>
+    `);
+
+            // A point, so that it is one element a screen reader can reach, and
+            // so that it reads as an observation apart from the distribution
+            // rather than as the end of the whisker.
+            expect(xml).toContain('<point at="outlier-1-1" p="(1,96)"');
+            expect(xml.match(/<point /g)?.length).eq(1);
+        });
+
+        it("reports the outliers on the series that holds them", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c">
+      <series name="s">44 55 58 60 62 65 66 70 72 96</series>
+    </chart>
+    <p name="out">$s.outliers</p>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            expect(
+                sv[await resolvePathToNodeIdx("s")].stateValues.outliers,
+            ).eqls([96]);
+            expect(sv[await resolvePathToNodeIdx("out")].stateValues.text).eq(
+                "96",
+            );
+        });
+
+        it("reports no outliers where nothing lies beyond a fence", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c"><series name="s">1 2 3 4 5 6</series></chart>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            // An empty list rather than nothing: "which values lie beyond the
+            // fences" has an answer here, and it is none of them.
+            expect(
+                sv[await resolvePathToNodeIdx("s")].stateValues.outliers,
+            ).eqls([]);
+        });
+
+        it("spends no margin on an outlier's marker", async () => {
+            const withOutlier = await chartXML(`
+    <chart type="box" name="c"><series>44 55 58 60 62 65 66 70 72 96</series></chart>
+    `);
+            const without = await chartXML(`
+    <chart type="box" name="c"><series>55 58 60 62 65 66 70 72</series></chart>
+    `);
+
+            // A marker is a symbol around a datum rather than a shape a clip
+            // may cut, so a scatter plot reserves seven pixels of margin for
+            // one. An outlier is at the center of its slot, half a slot from
+            // either side of it, and vertically the sixteen pixels above the
+            // box and the thirty below already hold it — so the margins here
+            // are the ones any box chart gets, and the left one is the axis
+            // numbers' alone.
+            expect(withOutlier).toContain('margins="[41,30,12,16]"');
+            expect(without).toContain('margins="[32,30,12,16]"');
+        });
+    });
+
+    describe("several series", async () => {
+        const THREE_BOXES = `
+    <chart type="box" name="c">
+      <shortDescription>Scores by section</shortDescription>
+      <series><label>morning</label>52 61 63 68 70 71 75 78 84 91</series>
+      <series><label>afternoon</label>44 55 58 60 62 65 66 70 72 96</series>
+      <series><label>evening</label>60 62 64 65 66 68 70</series>
+    </chart>
+    `;
+
+        it("puts one box per series, side by side", async () => {
+            const xml = await chartXML(THREE_BOXES);
+
+            expect(xml.match(/<rectangle /g)?.length).eq(3);
+            expect(xml).toContain('lower-left="(0.75,64.25)"');
+            expect(xml).toContain('lower-left="(1.75,58.5)"');
+            expect(xml).toContain('lower-left="(2.75,63)"');
+        });
+
+        it("names each position after the series drawn there", async () => {
+            const xml = await chartXML(THREE_BOXES);
+
+            // A box chart's positions are its series, so the names on the axis
+            // are the series' own labels rather than `categories`.
+            expect(xml).toContain('<tick-mark axis="horizontal" location="1"');
+            expect(xml).toContain(">morning</tick-mark>");
+            expect(xml).toContain(">afternoon</tick-mark>");
+            expect(xml).toContain(">evening</tick-mark>");
+        });
+
+        it("falls back to the position where a series has no label", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Two unnamed groups</shortDescription>
+      <series>1 2 3</series>
+      <series>4 5 6</series>
+    </chart>
+    `);
+
+            // The same fallback `categories` makes on every other type: the
+            // position itself, 1, 2, 3.
+            expect(xml).toContain(">1</tick-mark>");
+            expect(xml).toContain(">2</tick-mark>");
+        });
+
+        it("keeps the position of a series with no observations", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>One group with nothing in it</shortDescription>
+      <series><label>A</label>1 2 3</series>
+      <series><label>B</label></series>
+      <series><label>C</label>4 5 6</series>
+    </chart>
+    `);
+
+            // Its name stays on the axis over an empty position: a gap reads as
+            // a group with no data, which is what it is, where a missing
+            // position would read as a group that was never given.
+            expect(xml.match(/<tick-mark /g)?.length).eq(3);
+            expect(xml).toContain(">B</tick-mark>");
+            expect(xml.match(/<rectangle /g)?.length).eq(2);
+            expect(xml).toContain('at="box-1"');
+            expect(xml).toContain('at="box-3"');
+            expect(xml).not.toContain('at="box-2"');
+        });
+
+        it("keeps the horizontal extent a bar chart of the same positions gets", async () => {
+            const xml = await chartXML(THREE_BOXES);
+
+            // Zero to one past the last position, so the gap before the first
+            // box and the gap after the last are equal.
+            expect(xml).toContain('bbox="(0,40,4,100)"');
+        });
+
+        it("draws each series in its own style", async () => {
+            const xml = await chartXML(THREE_BOXES);
+
+            // The categorical color scale every other type gives its series:
+            // the chart's own number, then one more for each series after the
+            // first.
+            const boxes = xml.match(/<rectangle [^>]*>/g) ?? [];
+            const strokes = boxes.map(
+                (box) => box.match(/stroke="([^"]*)"/)?.[1],
+            );
+            expect(new Set(strokes).size).eq(3);
+        });
+    });
+
+    describe("degenerate columns", async () => {
+        it("draws a single observation as a line at its value", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>One observation</shortDescription>
+      <series><label>A</label>5</series>
+    </chart>
+    `);
+
+            // Every one of the five numbers is 5, so the box has no height and
+            // neither whisker has any length. Drawn rather than skipped: a
+            // rectangle of no height paints as a line at the value, which is
+            // exactly what the summary says.
+            expect(xml).toContain(
+                '<rectangle at="box-1" lower-left="(0.75,5)" dimensions="(0.5,0)"',
+            );
+            expect(xml).toContain('<line p1="(0.75,5)" p2="(1.25,5)"');
+            // The median alone: a whisker of no length, and a cap lying along
+            // the edge of the box, would be two marks saying what the box's own
+            // edge already says.
+            expect(xml.match(/<line /g)?.length).eq(1);
+        });
+
+        it("draws a column of one repeated value the same way", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>No spread at all</shortDescription>
+      <series><label>A</label>7 7 7 7</series>
+    </chart>
+    `);
+
+            expect(xml).toContain('dimensions="(0.5,0)"');
+            expect(xml.match(/<line /g)?.length).eq(1);
+            expect(xml).not.toContain("<point ");
+        });
+
+        it("draws no whisker on the side where the quartile is the extreme", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>A lower quarter of one repeated value</shortDescription>
+      <series><label>A</label>2 2 2 2 2 2 2 6 9 12</series>
+    </chart>
+    `);
+
+            // The first quartile is 2, which is also the smallest observation,
+            // so the lower whisker would have no length and its cap would lie
+            // along the bottom edge of the box.
+            expect(xml).toContain('<line p1="(1,5)" p2="(1,9)"');
+            expect(xml).not.toContain('p2="(1,2)"');
+            // The median and the one whisker with its cap.
+            expect(xml.match(/<line /g)?.length).eq(3);
+        });
+
+        it("draws nothing but the frame for a chart with no observations", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Nothing yet</shortDescription>
+    </chart>
+    `);
+
+            // A chart being written rather than one that is wrong, so no
+            // message either. One position, since a chart of bare values is one
+            // series whatever it holds.
+            expect(xml).not.toContain("<rectangle ");
+            expect(xml).not.toContain("<line ");
+            expect(xml).toContain("<axes ");
+        });
+
+        it("leaves out an observation that is not a finite number, and says so", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c">
+      <series><label>A</label>1 2 3 4 5 6 x</series>
+    </chart>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+            const xml =
+                sv[await resolvePathToNodeIdx("c")].stateValues.prefigureXML;
+
+            // Left out of the summary rather than read as zero, which would
+            // move all three quartiles: the box is the one six observations
+            // give.
+            expect(xml).toContain('lower-left="(0.75,2.25)"');
+            expect(
+                getDiagnosticsByType(core).warnings.map((w) => w.code),
+            ).toContain("doenet-w0154");
+        });
+    });
+
+    describe("the axis", async () => {
+        it("is not anchored to zero", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Heights</shortDescription>
+      <series><label>A</label>158 162 165 168 170 172 175 178 181</series>
+    </chart>
+    `);
+
+            // A box plot's numbers are positions on a scale rather than lengths
+            // measured from a baseline, so forcing zero in would push every box
+            // into the top of the picture.
+            expect(xml).toContain('bbox="(0,150,2,190)"');
+        });
+
+        it("honors the author's bounds and clips to them", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c" yMin="0" yMax="10">
+      <shortDescription>Bounded</shortDescription>
+      <series><label>A</label>44 55 58 60 62 65 66 70 72 96</series>
+    </chart>
+    `);
+
+            expect(xml).toContain('bbox="(0,0,2,10)"');
+            // The box is outside the frame and is cut off at it, and the
+            // outlier's marker — which cannot be cut without cutting the
+            // symbol — is left out entirely.
+            expect(xml).toContain('cliptobbox="yes"');
+            expect(xml).not.toContain("<point ");
+        });
+
+        it("reports the axis it was drawn with, and no horizontal one", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c"><series>1 2 3 4 5 6</series></chart>
+    <p name="bounds">$c.xMin, $c.xMax, $c.yMin, $c.yMax</p>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            // The positions on a box plot's horizontal axis are its series, so
+            // there is no measured extent to report there; the vertical axis is
+            // the data's and is reported. `NaN` is how a null number reads in
+            // prose.
+            expect(
+                sv[await resolvePathToNodeIdx("bounds")].stateValues.text,
+            ).eq("NaN, NaN, 0, 8");
+        });
+    });
+
+    describe("categories", async () => {
+        it("reports none, and says so when the author writes some", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c" categories="North South">
+      <series><label>A</label>1 2 3</series>
+    </chart>
+    <p name="cats">$c.categories</p>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            // A box plot has no categories: each of its series is one position,
+            // named by its own label. Reporting one category per observation
+            // would name three positions on a chart that has one.
+            expect(
+                sv[await resolvePathToNodeIdx("c")].stateValues.categories,
+            ).eqls([]);
+            expect(sv[await resolvePathToNodeIdx("cats")].stateValues.text).eq(
+                "",
+            );
+
+            // Reported rather than dropped in silence, because the names are
+            // something the author wrote for a reader to see — the same reason
+            // an `<xLabel>` on a pie is reported.
+            expect(
+                getDiagnosticsByType(core).warnings.map((w) => w.code),
+            ).toContain("doenet-w0155");
+        });
+
+        it("says nothing where the author wrote none", async () => {
+            const { warnings } = await getWarnings(`
+    <chart type="box" name="c">
+      <shortDescription>x</shortDescription>
+      <series><label>A</label>1 2 3</series>
+    </chart>
+    `);
+
+            expect(warnings.map((w) => w.code)).not.toContain("doenet-w0155");
+        });
+
+        it("does not name the boxes from them", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c" categories="North South">
+      <shortDescription>x</shortDescription>
+      <series><label>A</label>1 2 3</series>
+      <series><label>B</label>4 5 6</series>
+    </chart>
+    `);
+
+            expect(xml).toContain(">A</tick-mark>");
+            expect(xml).not.toContain("North");
+        });
+    });
+
+    describe("the legend", async () => {
+        it("draws none, and costs nothing for one", async () => {
+            const labeled = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>x</shortDescription>
+      <series><label>morning</label>1 2 3</series>
+      <series><label>afternoon</label>4 5 6</series>
+    </chart>
+    `);
+
+            // The names are already under the boxes, so a legend would spend
+            // width to repeat the axis.
+            expect(labeled).not.toContain("<legend");
+            expect(labeled).toContain('margins="[23,30,12,16]"');
+        });
+
+        it("reports that none is drawn, however it was asked for", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c" legend legendPosition="outsideRight">
+      <series><label>morning</label>1 2 3</series>
+    </chart>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            expect(
+                sv[await resolvePathToNodeIdx("c")].stateValues.showLegend,
+            ).eq(false);
+        });
+    });
+
+    describe("the annotation tree", async () => {
+        it("announces the five-number summary on each box", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            // Words rather than five bare numbers: a bar is announced as its
+            // category and its value because the position says which number it
+            // is, and five numbers at one position have nothing but their
+            // naming to tell them apart.
+            expect(xml).toContain(
+                '<annotation ref="box-1" text="A: minimum 1, first quartile 2.25, median 3.5, third quartile 4.75, maximum 6" />',
+            );
+        });
+
+        it("names an outlier rather than announcing a bare number", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>x</shortDescription>
+      <series><label>A</label>44 55 58 60 62 65 66 70 72 96</series>
+    </chart>
+    `);
+
+            expect(xml).toContain(
+                '<annotation ref="outlier-1-1" text="A: outlier 96" />',
+            );
+        });
+
+        it("hangs one series' annotations straight under the figure", async () => {
+            const xml = await chartXML(ONE_BOX);
+
+            expect(xml).toContain(
+                '<annotation ref="figure" text="Six observations"><annotation ref="box-1"',
+            );
+            expect(xml).not.toContain("<group ");
+        });
+
+        it("wraps several series in a level of their own", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Two groups</shortDescription>
+      <series><label>morning</label>1 2 3</series>
+      <series><label>afternoon</label>44 55 58 60 62 65 66 70 72 96</series>
+    </chart>
+    `);
+
+            // The level a screen reader stops at between the chart and its
+            // marks, named by the series — with the box and anything drawn
+            // beyond its whiskers under it.
+            expect(xml).toContain('<group at="series-1">');
+            expect(xml).toContain(
+                '<annotation ref="series-2" text="afternoon"><annotation ref="box-2"',
+            );
+            expect(xml).toContain('/><annotation ref="outlier-2-1"');
+        });
+
+        it("uses the localized fallback name for an unlabeled series", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Two groups</shortDescription>
+      <series>1 2 3</series>
+      <series>4 5 6</series>
+    </chart>
+    `);
+
+            expect(xml).toContain('<annotation ref="series-1" text="series 1"');
+        });
+
+        it("writes the numbers the way the picture writes them", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>x</shortDescription>
+      <series><label>A</label>0.1 0.2 0.3 0.4</series>
+    </chart>
+    `);
+
+            // Interpolating a quartile leaves floating-point dust —
+            // `0.17500000000000002` — which would be written into the picture
+            // and read out by a screen reader alike. Snapped, so that what a
+            // reader hears and what a reader sees are one rounding of one
+            // value.
+            expect(xml).toContain("first quartile 0.175");
+            expect(xml).toContain("third quartile 0.325");
+            expect(xml).toContain('lower-left="(0.75,0.175)"');
+            expect(xml).not.toContain("0.17500000000000002");
+        });
+    });
+
+    describe("the summary a series reports", async () => {
+        it("agrees with <summaryStatistics> on the same data", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c"><series name="s">1 2 3 4 5 6</series></chart>
+    <summaryStatistics name="ss" statisticsToDisplay="fiveNumberSummary">
+      1 2 3 4 5 6
+    </summaryStatistics>
+    <p name="fromSeries">$s.minimum, $s.quartile1, $s.median, $s.quartile3, $s.maximum</p>
+    <p name="fromStats">$ss.minimum, $ss.quartile1, $ss.median, $ss.quartile3, $ss.maximum</p>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            // Interpolated percentiles, not Tukey's hinges, which would give 2
+            // and 5 on this sample size. One shared definition is what keeps a
+            // table of quartiles and a box plot of the same column from
+            // disagreeing on the page.
+            expect(
+                sv[await resolvePathToNodeIdx("fromSeries")].stateValues.text,
+            ).eq("1, 2.25, 3.5, 4.75, 6");
+            expect(
+                sv[await resolvePathToNodeIdx("fromStats")].stateValues.text,
+            ).eq(sv[await resolvePathToNodeIdx("fromSeries")].stateValues.text);
+        });
+
+        it("reports nothing for a series with no finite values", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="box" name="c"><series name="s"></series></chart>
+    <p name="summary">$s.minimum, $s.median, $s.maximum</p>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            // There is no smallest value in no values, and reporting 0 would be
+            // a number the data does not contain. `NaN` is how a null number
+            // reads in prose.
+            expect(
+                sv[await resolvePathToNodeIdx("summary")].stateValues.text,
+            ).eq("NaN, NaN, NaN");
+        });
+
+        it("summarizes a series whatever the chart drew it as", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+    <chart type="bar" name="c"><series name="s">1 2 3 4 5 6</series></chart>
+    <p name="median">$s.median</p>
+    `,
+            });
+            const sv = await core.returnAllStateVariables(false, true);
+
+            // A column does not stop having a median because it was drawn as
+            // bars. What the chart decides is which of these get a mark, not
+            // which of them exist.
+            expect(
+                sv[await resolvePathToNodeIdx("median")].stateValues.text,
+            ).eq("3.5");
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
@@ -368,6 +368,49 @@ describe("chart box prefigure tests @group4", async () => {
             expect(xml.match(/<point /g)?.length).eq(1);
         });
 
+        it("writes the box from its lower corner even where the quartiles came out inverted", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>A column narrower than the comparison tolerance</shortDescription>
+      <series><label>A</label>1E-16 2E-16 3E-16 4E-16</series>
+    </chart>
+    `);
+
+            // `quantileSeq` answers with a first quartile of 3.5e-16 above its
+            // third of 2.5e-16 on this column, and a rectangle written from
+            // that pair as it stands has its corner at the top and a negative
+            // height. Taken in order, so `lower-left` is the corner it says it
+            // is, over the same interval either way.
+            expect(xml).toContain(
+                '<rectangle at="box-1" lower-left="(0.75,2.5e-16)" dimensions="(0.5,1e-16)"',
+            );
+
+            // The annotation still reports the pair as it came out: it is
+            // saying what the statistic answered, not describing the shape.
+            expect(xml).toContain(
+                "first quartile 3.5e-16, median 2.5e-16, third quartile 2.5e-16",
+            );
+        });
+
+        it("draws no whisker where no observation lies inside the fences", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>A column whose quartiles it has no observation near</shortDescription>
+      <series><label>A</label>3E-16 2E-16 2E-16</series>
+    </chart>
+    `);
+
+            // Both quartiles come back as 2.5e-16, which this column does not
+            // contain, so the interquartile range is zero and every one of the
+            // three observations is outside the fences. Each whisker then falls
+            // back to its quartile and has no length to draw: the box's own
+            // edge is the mark, and all three observations are drawn as points.
+            expect(xml).toContain('dimensions="(0.5,0)"');
+            expect(xml.match(/<point /g)?.length).eq(3);
+            // The median alone — no whisker, and so no cap either.
+            expect(xml.match(/<line /g)?.length).eq(1);
+        });
+
         it("draws nothing but the frame for a chart with no observations", async () => {
             const xml = await chartXML(`
     <chart type="box" name="c">

--- a/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
@@ -319,6 +319,55 @@ describe("chart box prefigure tests @group4", async () => {
             expect(xml.match(/<line /g)?.length).eq(3);
         });
 
+        it("keeps a box drawable at the top of the double range", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>A column a double can barely hold</shortDescription>
+      <series><label>A</label>1E308 1.5E308</series>
+    </chart>
+    `);
+
+            // Averaging the two middle observations to find the median
+            // overflows before it halves, and `formatNumber` writes anything
+            // non-finite as `null` — which is not a coordinate PreFigure can
+            // read. Interpolated as halves instead, so the median line is
+            // drawn where the summary says it is.
+            expect(xml).toContain('<line p1="(0.75,1.25e+308)"');
+            expect(xml).toContain("median 1.25e+308");
+            expect(xml).not.toContain("null");
+        });
+
+        it("keeps a box drawable across the whole double range", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>A column spanning the double range</shortDescription>
+      <series><label>A</label>-1.7976931348623157E308 -1.7976931348623157E308 -1.7976931348623157E308 1.7976931348623157E308 1.7976931348623157E308 1.7976931348623157E308</series>
+    </chart>
+    `);
+
+            // A rectangle is written as a corner and a size, and the distance
+            // between these two quartiles is not a number: the box is drawn as
+            // tall as a double goes rather than with a `null` for its height.
+            expect(xml).toContain('dimensions="(0.5,1.7976931348623157e+308)"');
+            expect(xml).not.toContain("null");
+        });
+
+        it("draws a box for a column whose values agree to twelve digits", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Three readings that barely differ</shortDescription>
+      <series><label>A</label>1 1.0000000000001 1.00000000000005</series>
+    </chart>
+    `);
+
+            // The quartiles of a column this narrow can come back out of
+            // order, and fences taken in that order would lie the wrong way
+            // round and put every observation outside them — a chart of three
+            // loose points saying that none of the three is typical.
+            expect(xml).toContain('<rectangle at="box-1"');
+            expect(xml.match(/<point /g)?.length).eq(1);
+        });
+
         it("draws nothing but the frame for a chart with no observations", async () => {
             const xml = await chartXML(`
     <chart type="box" name="c">

--- a/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/chart-box.test.ts
@@ -208,6 +208,34 @@ describe("chart box prefigure tests @group4", async () => {
             expect(xml).toContain(">evening</tick-mark>");
         });
 
+        it("typesets a name that carries math", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>Two groups</shortDescription>
+      <series><label>Group <m>x</m></label>1 2 3</series>
+      <series><label>plain</label>4 5 6</series>
+    </chart>
+    `);
+
+            // A tick mark's content goes through PreFigure's own label
+            // machinery, so an `<m>` in it is typeset the way one in a legend
+            // entry is. A box chart is the only type that can reach this: every
+            // other names its positions from `categories`, which is a
+            // `textList` and so is text and nothing else — and those names are
+            // still written as they always were.
+            expect(xml).toContain(">Group <m>x</m></tick-mark>");
+            expect(xml).toContain(">plain</tick-mark>");
+            // The drawn names, and only those. The annotation still carries
+            // the label as it arrived, `\\(x\\)` and all — a bar chart's group
+            // annotation does the same on `main`, because what a screen reader
+            // should hear for a name written as math is a question for every
+            // type at once rather than one this can answer alone.
+            for (const tick of xml.match(/<tick-mark[^>]*>.*?<\/tick-mark>/g) ??
+                []) {
+                expect(tick).not.toContain("\\(");
+            }
+        });
+
         it("falls back to the position where a series has no label", async () => {
             const xml = await chartXML(`
     <chart type="box" name="c">
@@ -409,6 +437,26 @@ describe("chart box prefigure tests @group4", async () => {
             expect(xml.match(/<point /g)?.length).eq(3);
             // The median alone — no whisker, and so no cap either.
             expect(xml.match(/<line /g)?.length).eq(1);
+        });
+
+        it("draws both whiskers outward from a box whose quartiles inverted", async () => {
+            const xml = await chartXML(`
+    <chart type="box" name="c">
+      <shortDescription>A spread inside the comparison tolerance</shortDescription>
+      <series>1E-16 2E-16 3E-16 4E-16</series>
+    </chart>
+    `);
+
+            // `quantileSeq` compares with a tolerance, so this column's
+            // quartiles come back the wrong way round. The rectangle takes them
+            // in order, and so must the whiskers: paired with the quartiles as
+            // they came out, the lower one would start at the top of the box
+            // and run down past the bottom, and the upper one back up through
+            // it — two lines drawn through the box rather than out of it.
+            expect(xml).toContain('lower-left="(0.75,2.5e-16)"');
+            expect(xml).toContain('dimensions="(0.5,1e-16)"');
+            expect(xml).toContain('<line p1="(1,2.5e-16)" p2="(1,2e-16)"');
+            expect(xml).toContain('<line p1="(1,3.5e-16)" p2="(1,4e-16)"');
         });
 
         it("draws nothing but the frame for a chart with no observations", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/chart-prefigure-live-validation.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/chart-prefigure-live-validation.test.ts
@@ -102,6 +102,46 @@ describe("Chart prefigure renderer live validation @group4", () => {
     </chart>`,
                     expectText: "pie (one value, a full turn)",
                 },
+                {
+                    doenetML: `
+    <chart type="box" name="c">
+      <shortDescription>Scores in one section</shortDescription>
+      <yLabel>score</yLabel>
+      52 61 63 68 70 71 75 78 84 91
+    </chart>`,
+                    expectText: "box (one implicit series)",
+                },
+                {
+                    doenetML: `
+    <chart type="box" name="c">
+      <title>Scores by section</title>
+      <shortDescription>Scores by section</shortDescription>
+      <yLabel>score</yLabel>
+      <series><label>morning</label>52 61 63 68 70 71 75 78 84 91</series>
+      <series><label>afternoon</label>44 55 58 60 62 65 66 70 72 96</series>
+      <series><label>evening</label>60 62 64 65 66 68 70</series>
+    </chart>`,
+                    expectText: "box (three series, titled, one outlier)",
+                },
+                {
+                    doenetML: `
+    <chart type="box" name="c">
+      <shortDescription>One observation, and a group with none</shortDescription>
+      <series><label>A</label>5</series>
+      <series><label>B</label></series>
+    </chart>`,
+                    expectText:
+                        "box (a box of no height, and an empty position)",
+                },
+                {
+                    doenetML: `
+    <chart type="box" name="c" yMin="60" yMax="70">
+      <shortDescription>Bounded below the data</shortDescription>
+      <series><label>A</label>44 55 58 60 62 65 66 70 72 96</series>
+    </chart>`,
+                    expectText:
+                        "box (bounds that cut the box and its whiskers)",
+                },
             ];
 
             for (const c of cases) {
@@ -327,6 +367,10 @@ describe("Chart prefigure renderer live validation @group4", () => {
                 [
                     "below zero",
                     `<chart type="scatter" name="c"><series x="1 2 3">-400 -900 -200</series></chart>`,
+                ],
+                [
+                    "box below zero",
+                    `<chart type="box" name="c"><series><label>A</label>-400 -900 -200 -350 -500</series></chart>`,
                 ],
                 [
                     "below zero, titled",
@@ -883,6 +927,187 @@ describe("Chart prefigure renderer live validation @group4", () => {
                         label.baseline + 3,
                         `${what}: "${label.text}" sits below the picture`,
                     ).toBeLessThan(pictureHeight + 0.5);
+                }
+            }
+        },
+    );
+    it.skipIf(!RUN_LIVE_PREFIGURE_VALIDATION)(
+        "optional: a box plot's parts are drawn where the geometry puts them",
+        async () => {
+            // A box plot is six marks that only mean something in relation to
+            // one another — the median inside the box, the whiskers on the
+            // box's own center line, the caps across their ends — and the XML
+            // says where each was *asked* for, in data coordinates, not where
+            // any of them came out. What turns those into pixels is the
+            // bounding box and the margins, and a chart whose vertical scale
+            // came out inverted, or whose box was placed off its slot, would
+            // pass every assertion in `chart-box.test.ts` and draw nonsense.
+            //
+            // The rectangle reaches the SVG as a `<path>` carrying the handle,
+            // so its four corners are readable; the lines that follow it in
+            // document order are its median, whiskers and caps.
+            for (const [what, doenetML] of [
+                [
+                    "default shape",
+                    `<chart type="box" name="c"><series><label>A</label>52 61 63 68 70 71 75 78 84 91</series></chart>`,
+                ],
+                [
+                    "wide",
+                    `<chart type="box" name="c" aspectRatio="4"><series><label>A</label>52 61 63 68 70 71 75 78 84 91</series></chart>`,
+                ],
+                [
+                    "tall",
+                    `<chart type="box" name="c" aspectRatio="0.5"><series><label>A</label>52 61 63 68 70 71 75 78 84 91</series></chart>`,
+                ],
+                [
+                    "three series on a small chart",
+                    `<chart type="box" name="c" size="small"><series><label>A</label>52 61 63 68 70 71 75 78 84 91</series><series><label>B</label>44 55 58 60 62 65 66 70 72 96</series><series><label>C</label>60 62 64 65 66 68 70</series></chart>`,
+                ],
+                [
+                    "a title above it",
+                    `<chart type="box" name="c"><title>Scores</title><yLabel>score</yLabel><series><label>A</label>52 61 63 68 70 71 75 78 84 91</series></chart>`,
+                ],
+            ] as [string, string][]) {
+                const prefigureXML = await getPrefigureXML(doenetML, "c");
+                const result =
+                    await validatePrefigureXMLAgainstBuildService(prefigureXML);
+                expect(result.ok, `${what}: build failed`).toBe(true);
+
+                const svg: string = result.body?.svg ?? "";
+                const pictureWidth = Number(
+                    svg.match(/<svg[^>]*width="([\d.]+)"/)?.[1],
+                );
+                const pictureHeight = Number(
+                    svg.match(/<svg[^>]*height="([\d.]+)"/)?.[1],
+                );
+
+                const boxes = [
+                    ...svg.matchAll(
+                        /<path id="[^"]*?box-(\d+)" d="M ([\d.-]+) ([\d.-]+) L ([\d.-]+) ([\d.-]+) L ([\d.-]+) ([\d.-]+) L ([\d.-]+) ([\d.-]+) Z"[^>]*stroke-width="([\d.]+)"/g,
+                    ),
+                ];
+                expect(
+                    boxes.length,
+                    `${what}: no box was drawn`,
+                ).toBeGreaterThan(0);
+
+                // Every line drawn after each box and before the next one: its
+                // median, its whiskers and their caps.
+                const lines = [
+                    ...svg.matchAll(
+                        /<(?:path id="[^"]*?box-(\d+)"|line id="[^"]*?__line-\d+" x1="([\d.-]+)" y1="([\d.-]+)" x2="([\d.-]+)" y2="([\d.-]+)")/g,
+                    ),
+                ];
+
+                let currentBox: RegExpMatchArray | null = null;
+                let linesInBox = 0;
+                for (const mark of lines) {
+                    if (mark[1] !== undefined) {
+                        currentBox =
+                            boxes.find((box) => box[1] === mark[1]) ?? null;
+                        linesInBox = 0;
+                        continue;
+                    }
+                    if (currentBox === null) {
+                        // The axes and their tick marks, drawn before any box.
+                        continue;
+                    }
+
+                    const left = Math.min(
+                        Number(currentBox[2]),
+                        Number(currentBox[4]),
+                    );
+                    const right = Math.max(
+                        Number(currentBox[2]),
+                        Number(currentBox[4]),
+                    );
+                    // `M x0 y0 L x1 y0 L x1 y1 L x0 y1 Z`, so the two
+                    // distinct coordinates are the first and third pairs.
+                    const top = Math.min(
+                        Number(currentBox[3]),
+                        Number(currentBox[7]),
+                    );
+                    const bottom = Math.max(
+                        Number(currentBox[3]),
+                        Number(currentBox[7]),
+                    );
+                    const center = (left + right) / 2;
+                    const stroke = Number(currentBox[10]);
+
+                    const [x1, y1, x2, y2] = [
+                        Number(mark[2]),
+                        Number(mark[3]),
+                        Number(mark[4]),
+                        Number(mark[5]),
+                    ];
+                    linesInBox++;
+
+                    if (linesInBox === 1) {
+                        // The median, across the whole width of the box and
+                        // between its two edges — the assertion a chart drawn
+                        // upside down would fail.
+                        expect(
+                            [x1, x2, y1, y2],
+                            `${what}: box ${currentBox[1]}'s median is not drawn across it`,
+                        ).eqls([left, right, y1, y1]);
+                        expect(
+                            y1,
+                            `${what}: box ${currentBox[1]}'s median is outside it`,
+                        ).toBeGreaterThanOrEqual(top - 0.05);
+                        expect(y1).toBeLessThanOrEqual(bottom + 0.05);
+                    } else if (linesInBox % 2 === 0) {
+                        // A whisker: up the box's own center line, from one of
+                        // its edges outward.
+                        expect(
+                            x1,
+                            `${what}: box ${currentBox[1]}'s whisker is off center`,
+                        ).closeTo(center, 0.05);
+                        expect(x2).closeTo(center, 0.05);
+                        expect(
+                            Math.min(Math.abs(y1 - top), Math.abs(y1 - bottom)),
+                            `${what}: box ${currentBox[1]}'s whisker does not start at an edge`,
+                        ).toBeLessThan(0.05);
+                        // Outward: a whisker from the top edge goes up the
+                        // picture, one from the bottom edge goes down it.
+                        expect(
+                            Math.abs(y1 - top) < Math.abs(y1 - bottom)
+                                ? y2 - y1
+                                : y1 - y2,
+                            `${what}: box ${currentBox[1]}'s whisker points back into it`,
+                        ).toBeLessThanOrEqual(0);
+                    } else {
+                        // The cap across that whisker's end: centered on the
+                        // box, and narrower than it, so it does not read as a
+                        // second box edge.
+                        expect(
+                            (x1 + x2) / 2,
+                            `${what}: box ${currentBox[1]}'s cap is off center`,
+                        ).closeTo(center, 0.05);
+                        expect(
+                            Math.abs(x2 - x1),
+                            `${what}: box ${currentBox[1]}'s cap is not narrower than the box`,
+                        ).toBeLessThan(right - left);
+                        expect(Math.abs(x2 - x1)).toBeGreaterThan(0);
+                    }
+
+                    // And all of it inside the picture, stroke included.
+                    for (const [x, y] of [
+                        [x1, y1],
+                        [x2, y2],
+                    ]) {
+                        expect(
+                            x - stroke / 2,
+                            `${what}: box ${currentBox[1]} reaches past the left edge`,
+                        ).toBeGreaterThan(-0.5);
+                        expect(x + stroke / 2).toBeLessThan(pictureWidth + 0.5);
+                        expect(
+                            y - stroke / 2,
+                            `${what}: box ${currentBox[1]} reaches past the top edge`,
+                        ).toBeGreaterThan(-0.5);
+                        expect(y + stroke / 2).toBeLessThan(
+                            pictureHeight + 0.5,
+                        );
+                    }
                 }
             }
         },

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/summarystatistics.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/summarystatistics.test.ts
@@ -270,6 +270,18 @@ describe("summaryStatistics tag tests @group4", async () => {
             expect(sv.quartile3).eq(4);
         });
 
+        it("takes the median of a column at the top of the double range", async () => {
+            const sv = await statisticsOf(`
+    <summaryStatistics name="s">
+      <number>1E308</number><number>1.5E308</number>
+    </summaryStatistics>
+    `);
+
+            // Halfway between the two middle values, which is a number a
+            // double holds even though their sum is not.
+            expect(sv.median).eq(1.25e308);
+        });
+
         it("does not depend on the order the values are given in", async () => {
             const sv = await statisticsOf(`
     <summaryStatistics name="s">

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/summarystatistics.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/summarystatistics.test.ts
@@ -282,6 +282,33 @@ describe("summaryStatistics tag tests @group4", async () => {
             expect(sv.median).eq(1.25e308);
         });
 
+        it("takes the median of a column at the bottom of the double range", async () => {
+            const sv = await statisticsOf(`
+    <summaryStatistics name="s">
+      <number>5E-324</number><number>5E-324</number>
+    </summaryStatistics>
+    `);
+
+            // Halving each of the two middle values before adding them would
+            // round both to zero, reporting a median the column does not
+            // contain. Two copies of one value have that value as their
+            // median, wherever in the range it sits.
+            expect(sv.median).eq(5e-324);
+        });
+
+        it("takes the median of readings that agree to twelve digits", async () => {
+            const sv = await statisticsOf(`
+    <summaryStatistics name="s">
+      <number>1</number><number>1.0000000000001</number><number>1.00000000000005</number>
+    </summaryStatistics>
+    `);
+
+            // The middle of the three by value. Ordering them by a relative
+            // tolerance instead reads all three as equal and answers with
+            // whichever was written first.
+            expect(sv.median).eq(1.00000000000005);
+        });
+
         it("does not depend on the order the values are given in", async () => {
             const sv = await statisticsOf(`
     <summaryStatistics name="s">

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
@@ -217,9 +217,39 @@ export function computeBoxChartGeometry({
     };
 }
 
-/** A pair of coordinates as PreFigure writes one, `(x,y)`. */
+/**
+ * A pair of coordinates as PreFigure writes one, `(x,y)`.
+ *
+ * The horizontal coordinate is computed from a slot and a width, so it is
+ * snapped; the vertical one is either an observation as the author wrote it or
+ * a statistic snapped already, so it is written as it stands. `point.ts` writes
+ * a datum the same way.
+ */
 function coordinates(x: number, y: number) {
     return `(${formatNumber(snapNumber(x))},${formatNumber(y)})`;
+}
+
+/**
+ * How tall the box between the two quartiles is drawn.
+ *
+ * A rectangle is written as a corner and a size, so PreFigure adds the two back
+ * together to find the far corner: both the height and that sum have to stay
+ * inside the double range. The distance between quartiles a quarter of the
+ * range apart on either side of zero does not — `-3.8e307` to `1.5e308` is
+ * already too far — and `formatNumber` answers `null` for anything non-finite,
+ * which is not a size PreFigure can read.
+ *
+ * So the box is drawn as tall as a double allows and stops short of its third
+ * quartile, on a chart whose axis spans most of the range a double holds. That
+ * is a smaller wrong than a box with no height to draw it by, which is the
+ * trade `scale.ts` makes at the same edge for the same reason.
+ */
+function boxHeight(quartile1: number, quartile3: number): number {
+    const snapped = snapNumber(quartile3 - quartile1);
+    if (Number.isFinite(quartile1 + snapped)) {
+        return snapped;
+    }
+    return quartile1 > 0 ? Number.MAX_VALUE - quartile1 : Number.MAX_VALUE;
 }
 
 /**
@@ -356,7 +386,7 @@ export function createBoxChartPrefigureXML({
                 coordinates(slot - halfWidth, summary.quartile1),
             )}" dimensions="${escapeXml(
                 `(${formatNumber(snapNumber(halfWidth * 2))},${formatNumber(
-                    snapNumber(summary.quartile3 - summary.quartile1),
+                    boxHeight(summary.quartile1, summary.quartile3),
                 )})`,
             )}" cliptobbox="yes"${withSpace(style.box)} />`,
         );

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
@@ -12,11 +12,11 @@
  * per series, named by the series' own `<label>`, and `categories` has nothing
  * to name.
  *
- * `<line>` is the one PreFigure element this folder had no use for until now —
- * the median across each box, the two whiskers and the cap at each of their
- * ends. Written with `p1`/`p2` rather than the `endpoints` pair
- * `components/line.ts` uses; `line.py` reads either, and a segment with no
- * `infinite` to declare is shorter said as two points.
+ * `<line>` is drawn here and nowhere else in this folder — the median across
+ * each box, the two whiskers and the cap at each of their ends. Written with
+ * `p1`/`p2` rather than the `endpoints` pair `components/line.ts` uses;
+ * `line.py` reads `endpoints` when it is there and `p1`/`p2` otherwise, and a
+ * segment with no `infinite` to declare is shorter said as two points.
  */
 
 import { escapeXml, formatNumber } from "../common";
@@ -42,8 +42,8 @@ import {
  * Narrower than a bar's default, and not for looks: a bar is read by its
  * length, so filling the slot makes it easier to compare, while a box is read
  * by where its edges sit against the axis, and a wide box only makes the
- * vertical distances harder to see. Half a slot is where R's `boxplot` and
- * ggplot2 both land.
+ * vertical distances harder to see. Half a slot leaves as much gap between two
+ * boxes as each of them takes.
  *
  * Not an attribute: `barWidth` is one because bars of several series share a
  * slot and dividing it is a real choice, where each box has a slot to itself.
@@ -53,8 +53,8 @@ const BOX_WIDTH = 0.5;
 /**
  * How wide the cap at the end of a whisker is drawn, as a fraction of the box.
  *
- * Half, which is what every drawing of a box plot does: a cap as wide as the
- * box reads as a second box edge, and one much narrower disappears.
+ * Half: a cap as wide as the box reads as a second box edge, and one much
+ * narrower disappears.
  */
 const CAP_WIDTH_FRACTION = 0.5;
 
@@ -232,6 +232,9 @@ function coordinates(x: number, y: number) {
 /**
  * How tall the box between the two quartiles is drawn.
  *
+ * `bottom` and `top` are taken in order, so the height is never negative and
+ * the fallback below never has to guess which way the box goes.
+ *
  * A rectangle is written as a corner and a size, so PreFigure adds the two back
  * together to find the far corner: both the height and that sum have to stay
  * inside the double range. The distance between quartiles a quarter of the
@@ -244,12 +247,12 @@ function coordinates(x: number, y: number) {
  * is a smaller wrong than a box with no height to draw it by, which is the
  * trade `scale.ts` makes at the same edge for the same reason.
  */
-function boxHeight(quartile1: number, quartile3: number): number {
-    const snapped = snapNumber(quartile3 - quartile1);
-    if (Number.isFinite(quartile1 + snapped)) {
+function boxHeight(bottom: number, top: number): number {
+    const snapped = snapNumber(top - bottom);
+    if (Number.isFinite(bottom + snapped)) {
         return snapped;
     }
-    return quartile1 > 0 ? Number.MAX_VALUE - quartile1 : Number.MAX_VALUE;
+    return bottom > 0 ? Number.MAX_VALUE - bottom : Number.MAX_VALUE;
 }
 
 /**
@@ -381,12 +384,25 @@ export function createBoxChartPrefigureXML({
         // Drawn rather than skipped: it paints as a line at the value, which is
         // exactly what the summary says — every one of the five numbers is
         // there.
+        //
+        // The two quartiles are taken in order, so `lower-left` is the corner
+        // it says it is. `quantileSeq` compares with a tolerance and can answer
+        // with a first quartile above its third on a column whose whole spread
+        // falls inside it, and a rectangle written from that pair as it stands
+        // has a negative height and its corner at the top. PreFigure reads such
+        // a shape from the other corner and draws the same interval, so this is
+        // the XML saying what it means rather than a fix to the picture — and
+        // it is what lets `boxHeight` fall back to an unsigned height. The
+        // annotation below goes on reporting the pair as it came out, which is
+        // the honest thing for it to say.
+        const boxBottom = Math.min(summary.quartile1, summary.quartile3);
+        const boxTop = Math.max(summary.quartile1, summary.quartile3);
         elements.push(
             `<rectangle at="${escapeXml(handle)}" lower-left="${escapeXml(
-                coordinates(slot - halfWidth, summary.quartile1),
+                coordinates(slot - halfWidth, boxBottom),
             )}" dimensions="${escapeXml(
                 `(${formatNumber(snapNumber(halfWidth * 2))},${formatNumber(
-                    boxHeight(summary.quartile1, summary.quartile3),
+                    boxHeight(boxBottom, boxTop),
                 )})`,
             )}" cliptobbox="yes"${withSpace(style.box)} />`,
         );

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
@@ -1,0 +1,497 @@
+/**
+ * `<chart type="box">`: one box plot per series, side by side on an axis of
+ * series names.
+ *
+ * The first type whose series holds raw observations rather than one value per
+ * category. That is what turns the axis around: every other type reads a series
+ * position by position against shared categories, and here a whole series
+ * becomes one position — which is `aes(x = group, y = value)`, the standard
+ * reading rather than a Doenet-specific one.
+ *
+ * So a box chart has no categories. Its horizontal axis carries one tick mark
+ * per series, named by the series' own `<label>`, and `categories` has nothing
+ * to name.
+ *
+ * `<line>` is the one PreFigure element this folder had no use for until now —
+ * the median across each box, the two whiskers and the cap at each of their
+ * ends. Written with `p1`/`p2` rather than the `endpoints` pair
+ * `components/line.ts` uses; `line.py` reads either, and a segment with no
+ * `infinite` to declare is shorter said as two points.
+ */
+
+import { escapeXml, formatNumber } from "../common";
+import { pointStyleAttributes, styleAttributes } from "../style";
+import type { DiagnosticRecord } from "@doenet/utils";
+import { boxPlotSummary, type BoxPlotSummary } from "../../summaryStatistics";
+import {
+    autoAxisBounds,
+    reconcileBounds,
+    snapNumber,
+    tickStepForBounds,
+    type ChartSeriesValues,
+} from "./scale";
+import {
+    assembleChartDiagram,
+    axisTicks,
+    type ChartSeriesRendering,
+} from "./frame";
+
+/**
+ * How much of its one-unit slot a box fills.
+ *
+ * Narrower than a bar's default, and not for looks: a bar is read by its
+ * length, so filling the slot makes it easier to compare, while a box is read
+ * by where its edges sit against the axis, and a wide box only makes the
+ * vertical distances harder to see. Half a slot is where R's `boxplot` and
+ * ggplot2 both land.
+ *
+ * Not an attribute: `barWidth` is one because bars of several series share a
+ * slot and dividing it is a real choice, where each box has a slot to itself.
+ */
+const BOX_WIDTH = 0.5;
+
+/**
+ * How wide the cap at the end of a whisker is drawn, as a fraction of the box.
+ *
+ * Half, which is what every drawing of a box plot does: a cap as wide as the
+ * box reads as a second box edge, and one much narrower disappears.
+ */
+const CAP_WIDTH_FRACTION = 0.5;
+
+/** One box plot, in data coordinates. */
+export type BoxGeometry = {
+    /** Which series the box is drawn from, 0-based. */
+    seriesIndex: number;
+    /** 1-based position along the axis of series names. */
+    slot: number;
+    /** The name under the box: the series' label, or its position. */
+    label: string;
+    /**
+     * The summary as it is drawn and spoken.
+     *
+     * The quartiles are interpolated, so two of the three arrive with the dust
+     * a floating-point interpolation leaves — the quartiles of
+     * `0.1 0.2 0.3 0.4` come out as `0.17500000000000002` and
+     * `0.32499999999999996`. Snapped here, for the same reason every other
+     * computed coordinate in this folder is snapped: the number is written into
+     * the XML and read out by a screen reader, and twelve significant digits is
+     * far more than either needs. `<series>`'s own `quartile1` is the
+     * unsnapped statistic, which is what `<summaryStatistics>` reports as well.
+     */
+    summary: BoxPlotSummary;
+    /** How far each side of the box reaches from the slot's center. */
+    halfWidth: number;
+};
+
+export type BoxChartGeometry = {
+    kind: "box";
+    /**
+     * The series drawn, in order, whether or not any of them had observations
+     * to summarize. One with none keeps its place, and its name stays on the
+     * axis over an empty position, for the reason a bar chart keeps the slot of
+     * a value it could not draw: a gap reads as missing data, which is what it
+     * is, where a missing position reads as a group that was never given.
+     */
+    series: { label: string }[];
+    boxes: BoxGeometry[];
+    /** Every position on the axis, drawn or not, with the name under it. */
+    slots: { center: number; label: string }[];
+    /** `[xMin, yMin, xMax, yMax]` in data coordinates. */
+    bounds: [number, number, number, number];
+    /** The spacing between labeled values on the vertical axis. */
+    tickStep: number;
+    /** How many observations were not finite numbers, and so not summarized. */
+    undrawnValues: number;
+};
+
+/**
+ * The box plots and bounding box for one or more columns of observations.
+ *
+ * One box per series at x = 1, 2, … n, each filling `BOX_WIDTH` of its
+ * one-unit slot. The box runs from the first to the third quartile with the
+ * median across it, the whiskers reach the furthest observation within one and
+ * a half interquartile ranges of the box, and anything past that is drawn as a
+ * point of its own.
+ *
+ * The vertical axis is the data's, not anchored to zero: a box plot's numbers
+ * are positions on a scale rather than lengths measured from a baseline, so
+ * forcing zero into the axis of a chart of adult heights would push every box
+ * into the top of the picture. Both bounds are rounded outward to the next
+ * tick, so no whisker end or outlier is drawn on the frame.
+ *
+ * The horizontal extent is the one a bar chart of the same number of positions
+ * gets — zero to one past the last slot — so the gap before the first box and
+ * after the last are equal, and a chart switched from `bar` to `box` does not
+ * move its positions sideways.
+ */
+export function computeBoxChartGeometry({
+    series,
+    yMinAttr,
+    yMaxAttr,
+}: {
+    series: ChartSeriesValues[];
+    yMinAttr: number | null;
+    yMaxAttr: number | null;
+}): BoxChartGeometry {
+    const halfWidth = BOX_WIDTH / 2;
+
+    let undrawnValues = 0;
+    const boxes: BoxGeometry[] = [];
+    const slots: BoxChartGeometry["slots"] = [];
+
+    /** Every observation that was summarized, for the axis to be sized by. */
+    let low = 0;
+    let high = 0;
+    let anyObservations = false;
+    let wholeValues = true;
+
+    series.forEach((oneSeries, seriesIndex) => {
+        const slot = seriesIndex + 1;
+        const label = oneSeries.label || String(slot);
+        slots.push({ center: slot, label });
+
+        // An observation that is not a finite number is missing data. Left out
+        // of the summary rather than read as a zero, which would move every
+        // quartile of the box drawn from it; counted, because a reader cannot
+        // see the difference between an observation that was dropped and one
+        // that was never given.
+        const observations: number[] = [];
+        for (const value of oneSeries.values) {
+            if (Number.isFinite(value)) {
+                observations.push(value);
+            } else {
+                undrawnValues++;
+            }
+        }
+
+        const exact = boxPlotSummary(observations);
+        if (exact === null) {
+            return;
+        }
+
+        for (const observation of observations) {
+            low = anyObservations ? Math.min(low, observation) : observation;
+            high = anyObservations ? Math.max(high, observation) : observation;
+            anyObservations = true;
+            wholeValues = wholeValues && Number.isInteger(observation);
+        }
+
+        boxes.push({
+            seriesIndex,
+            slot,
+            label,
+            summary: {
+                ...exact,
+                quartile1: snapNumber(exact.quartile1),
+                median: snapNumber(exact.median),
+                quartile3: snapNumber(exact.quartile3),
+            },
+            halfWidth,
+        });
+    });
+
+    const [autoYMin, autoYMax] = autoAxisBounds({
+        low,
+        high,
+        // Whole observations get whole ticks, but the quartiles between them
+        // need not be whole — the median of `1 2` is 1.5 — so this decides the
+        // labels on the axis and not what may be drawn against them.
+        minStep: wholeValues ? 1 : 0,
+        baseline: null,
+    });
+    const [yMin, yMax] = reconcileBounds(
+        yMinAttr,
+        yMaxAttr,
+        autoYMin,
+        autoYMax,
+    );
+
+    return {
+        kind: "box",
+        series: series.map(({ label }) => ({ label })),
+        boxes,
+        slots,
+        bounds: [0, yMin, slots.length + 1, yMax],
+        tickStep: tickStepForBounds(yMin, yMax, wholeValues),
+        undrawnValues,
+    };
+}
+
+/** A pair of coordinates as PreFigure writes one, `(x,y)`. */
+function coordinates(x: number, y: number) {
+    return `(${formatNumber(snapNumber(x))},${formatNumber(y)})`;
+}
+
+/**
+ * Whether a value lies in the box the chart is drawn in.
+ *
+ * Applied to an outlier's coordinates rather than to its marker, for the reason
+ * `point.ts` gives: a marker is a symbol standing for a location rather than a
+ * shape with an extent, so clipping it cuts the symbol instead of the datum.
+ * The boxes and whiskers keep `cliptobbox`, where cutting is right — a whisker
+ * is a length, and a bound genuinely truncates it.
+ */
+function inBounds(value: number, yMin: number, yMax: number): boolean {
+    return value >= yMin && value <= yMax;
+}
+
+/**
+ * Builds the PreFigure XML for a box chart.
+ *
+ * The vertical axis keeps numeric labels via an explicit `vlabels`; the
+ * horizontal axis has its automatic labels suppressed and gets one
+ * `<tick-mark>` per series instead.
+ *
+ * No legend, whichever way `legend` was written. A legend names what a color
+ * stands for, and on a box chart the name is already under the box: every other
+ * type puts several series in the same space and needs the key to tell them
+ * apart, where this one gives each series a position of its own and labels it
+ * on the axis. A legend here would spend width to repeat the axis.
+ *
+ * `boxAnnotationText` and `outlierAnnotationText` are handed in rather than
+ * built here. The five numbers of a summary cannot be told apart without words
+ * naming them, and a word built in the worker would be English in a document
+ * that may be in any language — so the phrasing is assembled where the
+ * document's locale is known. The numbers themselves are written here, by the
+ * same `formatNumber` that writes them into the picture, so that what a reader
+ * hears and what a reader sees cannot be two different roundings of one value.
+ */
+export function createBoxChartPrefigureXML({
+    geometry,
+    seriesRendering,
+    boxAnnotationText,
+    outlierAnnotationText,
+    widthPx,
+    heightPx,
+    xLabel,
+    xLabelHasLatex,
+    yLabel,
+    yLabelHasLatex,
+    title,
+    shortDescription,
+    darkMode = false,
+}: {
+    geometry: BoxChartGeometry;
+    seriesRendering: ChartSeriesRendering[];
+    /** What a screen reader hears on each box: its five-number summary. */
+    boxAnnotationText: (parts: {
+        label: string;
+        minimum: string;
+        quartile1: string;
+        median: string;
+        quartile3: string;
+        maximum: string;
+    }) => string;
+    /** The same for one observation drawn beyond a whisker. */
+    outlierAnnotationText: (parts: { label: string; value: string }) => string;
+    widthPx: number;
+    heightPx: number;
+    xLabel?: string;
+    xLabelHasLatex?: boolean;
+    yLabel?: string;
+    yLabelHasLatex?: boolean;
+    title?: string;
+    shortDescription?: string;
+    darkMode?: boolean;
+}): { xml: string; diagnostics: DiagnosticRecord[] } {
+    const diagnostics: DiagnosticRecord[] = [];
+
+    const [, yMin, , yMax] = geometry.bounds;
+
+    // Once per series rather than once per element: every part of a box is
+    // drawn from the same `selectedStyle`, so the attribute strings are
+    // identical across them, and `styleAttributes` also reports an unsupported
+    // fill or line style through `diagnostics` — which the queue deduplicates
+    // by message, but there is no reason to hand it the same one six times.
+    //
+    // The whiskers, the caps and the median are strokes rather than shapes:
+    // `<line>` reads only the stroke attributes (`get_1d_attr`, `line.py`), and
+    // a fill on one would say nothing.
+    const styleForSeries = geometry.series.map((_unused, seriesIndex) => {
+        const selectedStyle = seriesRendering[seriesIndex]?.selectedStyle;
+        return {
+            box: styleAttributes({
+                selectedStyle,
+                diagnostics,
+                warningPrefix: "<chart>",
+            }).join(" "),
+            stroke: styleAttributes({
+                selectedStyle,
+                diagnostics,
+                warningPrefix: "<chart>",
+                includeFill: false,
+            }).join(" "),
+            outlier: pointStyleAttributes({
+                selectedStyle,
+                diagnostics,
+                warningPrefix: "<chart>",
+            }).join(" "),
+        };
+    });
+
+    const seriesElements: string[][] = geometry.series.map(() => []);
+    const seriesAnnotations: string[][] = geometry.series.map(() => []);
+
+    for (const box of geometry.boxes) {
+        const { seriesIndex, slot, halfWidth, summary } = box;
+        const style = styleForSeries[seriesIndex];
+        const withSpace = (attrs: string) => (attrs ? ` ${attrs}` : "");
+
+        const elements = seriesElements[seriesIndex];
+        const handle = `box-${seriesIndex + 1}`;
+
+        // Quartile to quartile. Clipped to the box it is drawn in, since a
+        // `yMin` above the first quartile or a `yMax` below the third leaves
+        // part of the rectangle outside the axes — and PreFigure draws a
+        // rectangle unclipped unless asked, so that part would be painted over
+        // the names below the frame or off the edge of the picture.
+        //
+        // A rectangle of no height where the two quartiles coincide, which is
+        // what a series of one observation, or of one value repeated, comes to.
+        // Drawn rather than skipped: it paints as a line at the value, which is
+        // exactly what the summary says — every one of the five numbers is
+        // there.
+        elements.push(
+            `<rectangle at="${escapeXml(handle)}" lower-left="${escapeXml(
+                coordinates(slot - halfWidth, summary.quartile1),
+            )}" dimensions="${escapeXml(
+                `(${formatNumber(snapNumber(halfWidth * 2))},${formatNumber(
+                    snapNumber(summary.quartile3 - summary.quartile1),
+                )})`,
+            )}" cliptobbox="yes"${withSpace(style.box)} />`,
+        );
+
+        // Across the box, at the median. Drawn after the rectangle so the fill
+        // cannot cover it.
+        elements.push(
+            `<line p1="${escapeXml(
+                coordinates(slot - halfWidth, summary.median),
+            )}" p2="${escapeXml(
+                coordinates(slot + halfWidth, summary.median),
+            )}" cliptobbox="yes"${withSpace(style.stroke)} />`,
+        );
+
+        // A whisker from each quartile to the furthest observation still inside
+        // the fence, with a cap across its end.
+        //
+        // Neither is drawn where the observation is the quartile itself — the
+        // minimum of a column whose lower quarter is one repeated value, say.
+        // The whisker would have no length, and the cap would be a short line
+        // lying along the edge of the box: two marks saying what the box's own
+        // edge already says, in a drawing whose whole subject is which mark is
+        // where.
+        const whiskers: [number, number][] = [
+            [summary.quartile1, summary.lowerWhisker],
+            [summary.quartile3, summary.upperWhisker],
+        ];
+        const capHalfWidth = halfWidth * CAP_WIDTH_FRACTION;
+        for (const [fromQuartile, toObservation] of whiskers) {
+            if (toObservation === fromQuartile) {
+                continue;
+            }
+            elements.push(
+                `<line p1="${escapeXml(
+                    coordinates(slot, fromQuartile),
+                )}" p2="${escapeXml(
+                    coordinates(slot, toObservation),
+                )}" cliptobbox="yes"${withSpace(style.stroke)} />`,
+                `<line p1="${escapeXml(
+                    coordinates(slot - capHalfWidth, toObservation),
+                )}" p2="${escapeXml(
+                    coordinates(slot + capHalfWidth, toObservation),
+                )}" cliptobbox="yes"${withSpace(style.stroke)} />`,
+            );
+        }
+
+        // The box carries the whole summary, because the five numbers it
+        // reports are not five elements: two of them are the rectangle's own
+        // edges, and there is nothing separate to annotate. A reader stopping
+        // here hears the distribution in one phrase, which is what a box plot
+        // is read for.
+        seriesAnnotations[seriesIndex].push(
+            `<annotation ref="${escapeXml(handle)}" text="${escapeXml(
+                boxAnnotationText({
+                    label: box.label,
+                    minimum: formatNumber(summary.minimum) ?? "",
+                    quartile1: formatNumber(summary.quartile1) ?? "",
+                    median: formatNumber(summary.median) ?? "",
+                    quartile3: formatNumber(summary.quartile3) ?? "",
+                    maximum: formatNumber(summary.maximum) ?? "",
+                }),
+            )}" />`,
+        );
+
+        // Each observation beyond a fence, as a point of its own — which is
+        // what makes it reachable in the tree a screen reader walks, and is why
+        // they are not drawn as part of the whisker.
+        summary.outliers.forEach((outlier, ind) => {
+            if (!inBounds(outlier, yMin, yMax)) {
+                return;
+            }
+            const outlierHandle = `outlier-${seriesIndex + 1}-${ind + 1}`;
+            elements.push(
+                `<point at="${escapeXml(outlierHandle)}" p="${escapeXml(
+                    coordinates(slot, outlier),
+                )}"${withSpace(style.outlier)} />`,
+            );
+            seriesAnnotations[seriesIndex].push(
+                `<annotation ref="${escapeXml(
+                    outlierHandle,
+                )}" text="${escapeXml(
+                    outlierAnnotationText({
+                        label: box.label,
+                        value: formatNumber(outlier) ?? "",
+                    }),
+                )}" />`,
+            );
+        });
+    }
+
+    const xml = assembleChartDiagram({
+        bounds: geometry.bounds,
+        yTicks: axisTicks(yMin, yMax, geometry.tickStep),
+        xTicks: null,
+        slots: geometry.slots,
+        widthPx,
+        heightPx,
+        xLabel,
+        xLabelHasLatex,
+        yLabel,
+        yLabelHasLatex,
+        title,
+        // Never a legend, and so nothing for one to be keyed off or placed by.
+        // With no handles to point at there is no entry to write, whatever the
+        // author asked for — the same absence a series whose every value was
+        // undrawable leaves.
+        showLegend: false,
+        legendPosition: "outsideright",
+        seriesRendering,
+        seriesLabels: geometry.series.map(({ label }) => label),
+        seriesElements,
+        seriesAnnotations,
+        seriesKeyHandles: geometry.series.map(() => null),
+        legendKeyWidth: 0,
+        // Nothing reaches past the frame. A box and its whiskers are drawn
+        // inside it and clipped to it, and an outlier's marker — which is a
+        // symbol around a datum rather than a shape a clip may cut — is at the
+        // center of its slot, half a slot from either side of it, so it never
+        // approaches the left or right frame the way a scatter plot's points
+        // do.
+        //
+        // Vertically it can reach the frame, on an authored bound sitting
+        // exactly on the outlier, and the base margins already hold it: the
+        // seven pixels it reaches against the sixteen above the box and thirty
+        // below. Reserving them again was measured and moved nothing — a
+        // marker at `yMax` came out one pixel inside a `size="tiny"` picture
+        // with the reservation and one pixel inside without it, because
+        // `fitMargins` scales what it grants and a crowded frame does not
+        // honor the extra. All it did was take seven pixels of drawing area
+        // from every chart that had room to spare.
+        markOverhang: 0,
+        overlayElements: [],
+        shortDescription,
+        darkMode,
+    });
+
+    return { xml, diagnostics };
+}

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/chart/box.ts
@@ -417,22 +417,35 @@ export function createBoxChartPrefigureXML({
             )}" cliptobbox="yes"${withSpace(style.stroke)} />`,
         );
 
-        // A whisker from each quartile to the furthest observation still inside
-        // the fence, with a cap across its end.
+        // A whisker from each edge of the box to the furthest observation
+        // still inside the fence, with a cap across its end.
         //
-        // Neither is drawn where the observation is the quartile itself — the
-        // minimum of a column whose lower quarter is one repeated value, say.
-        // The whisker would have no length, and the cap would be a short line
-        // lying along the edge of the box: two marks saying what the box's own
-        // edge already says, in a drawing whose whole subject is which mark is
-        // where.
-        const whiskers: [number, number][] = [
-            [summary.quartile1, summary.lowerWhisker],
-            [summary.quartile3, summary.upperWhisker],
+        // From the *ordered* edges rather than from `quartile1` and
+        // `quartile3` as they came out: on a column whose quartiles
+        // `quantileSeq` inverted, pairing the first quartile with the lower
+        // whisker starts that whisker at the top of the box and runs it down
+        // past the bottom, and the other one back up through it — two lines
+        // drawn through the box rather than out of it.
+        //
+        // Each is drawn only where it would point away from the box.
+        // `Math.sign` is zero when the observation is the edge itself — the
+        // minimum of a column whose lower quarter is one repeated value, say —
+        // so that case is skipped as it always was: the whisker would have no
+        // length and the cap would lie along the edge of the box, two marks
+        // saying what the box's own edge already says. It is also skipped in
+        // the case that rule now covers, where the furthest observation inside
+        // the fence is on the wrong side of the edge to be reached outward.
+        const whiskers = [
+            { from: boxBottom, to: summary.lowerWhisker, outward: -1 },
+            { from: boxTop, to: summary.upperWhisker, outward: 1 },
         ];
         const capHalfWidth = halfWidth * CAP_WIDTH_FRACTION;
-        for (const [fromQuartile, toObservation] of whiskers) {
-            if (toObservation === fromQuartile) {
+        for (const {
+            from: fromQuartile,
+            to: toObservation,
+            outward,
+        } of whiskers) {
+            if (Math.sign(toObservation - fromQuartile) !== outward) {
                 continue;
             }
             elements.push(
@@ -497,7 +510,16 @@ export function createBoxChartPrefigureXML({
         bounds: geometry.bounds,
         yTicks: axisTicks(yMin, yMax, geometry.tickStep),
         xTicks: null,
-        slots: geometry.slots,
+        // A box chart's positions are named by the series' own `<label>`, which
+        // may hold an `<m>` — the one type whose axis names can carry math,
+        // since every other type names its positions from `categories`, a
+        // `textList`. Read off the rendering rather than the geometry, which is
+        // renderer-neutral and has no business knowing how a name is typeset.
+        // One slot per series, in the same order, so the indices line up.
+        slots: geometry.slots.map((slot, seriesIndex) => ({
+            ...slot,
+            labelHasLatex: Boolean(seriesRendering[seriesIndex]?.labelHasLatex),
+        })),
         widthPx,
         heightPx,
         xLabel,

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/chart/frame.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/chart/frame.ts
@@ -758,7 +758,14 @@ export function assembleChartDiagram({
     /** Null when the horizontal axis carries category names instead of numbers. */
     xTicks: AxisTicks | null;
     /** Null when the horizontal axis is numeric. */
-    slots: { center: number; label: string }[] | null;
+    /**
+     * Null when the horizontal axis is numeric. `labelHasLatex` says the name
+     * carries math to typeset rather than characters to print — true only of a
+     * box chart, whose positions are named by a `<label>` that may hold an
+     * `<m>`, where every other type names them from `categories`, which is a
+     * `textList` and so is text and nothing else.
+     */
+    slots: { center: number; label: string; labelHasLatex?: boolean }[] | null;
     widthPx: number;
     heightPx: number;
     xLabel?: string;
@@ -1016,8 +1023,20 @@ export function assembleChartDiagram({
     // otherwise the gap would read as a missing category rather than as a
     // missing value.
     for (const slot of slots ?? []) {
+        // A tick mark's content goes through PreFigure's own label machinery
+        // (`tick_mark`, `axes.py`), so an `<m>` in it is typeset the way one in
+        // a legend entry is — and a name that arrives as `\(x\)` without being
+        // marked up is drawn as those six characters. Only asked of a name that
+        // carries math: without the flag this is the plain `escapeXml` it has
+        // always been, which is what every other type still gets.
+        const name = slot.labelHasLatex
+            ? (labelMarkup({
+                  label: slot.label,
+                  labelHasLatex: true,
+              }) ?? escapeXml(slot.label))
+            : escapeXml(slot.label);
         elements.push(
-            `<tick-mark axis="horizontal" location="${formatNumber(slot.center)}"${strokeAttr} ${THEME_AWARE_LABEL_COLOR_ATTR}>${escapeXml(slot.label)}</tick-mark>`,
+            `<tick-mark axis="horizontal" location="${formatNumber(slot.center)}"${strokeAttr} ${THEME_AWARE_LABEL_COLOR_ATTR}>${name}</tick-mark>`,
         );
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/chart/index.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/chart/index.ts
@@ -1,6 +1,6 @@
 /**
  * PreFigure assembly for `<chart>` — bars, points and the lines through them,
- * and pies.
+ * pies, and box plots.
  *
  * Kept apart from `graph.ts` because a chart is not a graph with data in it: it
  * owns its own bounding box, it sizes its own axes from the data, and it has no
@@ -13,18 +13,19 @@
  * - `scale.ts` — the arithmetic behind an axis: rounding, tick steps, bounds.
  * - `frame.ts` — what a chart is drawn *in*: the margins, the axes and their
  *   labels, the legend, the title and the annotation tree.
- * - `bar.ts`, `point.ts`, `pie.ts` — one chart type each: the geometry its
- *   values come to, and the marks drawn from it.
+ * - `bar.ts`, `point.ts`, `pie.ts`, `box.ts` — one chart type each: the
+ *   geometry its values come to, and the marks drawn from it.
  *
  * This file is what the rest of the worker imports. It holds the union of the
- * three geometries and the one question `<chart>` asks about a legend before
- * any XML is built, and re-exports each type's own two functions.
+ * geometries and the one question `<chart>` asks about a legend before any XML
+ * is built, and re-exports each type's own two functions.
  */
 
 import { labelMarkup } from "../label";
 import type { BarChartGeometry } from "./bar";
 import type { PointChartGeometry } from "./point";
 import type { PieChartGeometry } from "./pie";
+import type { BoxChartGeometry } from "./box";
 
 export type { BarChartGeometry, BarGeometry, BarLayout } from "./bar";
 export { computeBarChartGeometry, createBarChartPrefigureXML } from "./bar";
@@ -43,12 +44,15 @@ export {
 export type { PieChartGeometry, PieSliceGeometry } from "./pie";
 export { computePieChartGeometry, createPieChartPrefigureXML } from "./pie";
 
+export type { BoxChartGeometry, BoxGeometry } from "./box";
+export { computeBoxChartGeometry, createBoxChartPrefigureXML } from "./box";
+
 export type { ChartSeriesValues } from "./scale";
 export type { ChartSeriesRendering } from "./frame";
 
 /** Any of the geometries a `<chart>` produces, whichever type was named. */
 export type ChartGeometry =
-    BarChartGeometry | PointChartGeometry | PieChartGeometry;
+    BarChartGeometry | PointChartGeometry | PieChartGeometry | BoxChartGeometry;
 
 /**
  * Whether the legend this chart would draw has anything to put in it.
@@ -57,9 +61,9 @@ export type ChartGeometry =
  * element the item points at, so whatever the legend names needs both a name
  * and something drawn: a series whose every value is undrawable is named but
  * has nothing to point at, and one drawn from an unnamed series would be a
- * swatch beside a blank line. What is named is the series on every type but
- * one — a pie names its slices, since that is the level its colors are chosen
- * at.
+ * swatch beside a blank line. What is named is usually the series: a pie names
+ * its slices, since that is the level its colors are chosen at, and a box chart
+ * names nothing, having already named each series on its axis.
  *
  * Exported so that `<chart>`'s `showLegend` asks the same question the XML
  * builders ask, rather than restating it somewhere it could drift.
@@ -68,6 +72,13 @@ export type ChartGeometry =
  */
 export function chartLegendHasItems(geometry: ChartGeometry | null): boolean {
     if (geometry === null) {
+        return false;
+    }
+
+    // A box chart names each series on the axis, under the box drawn from it,
+    // so it has nothing left for a legend to say. Every other type draws
+    // several series into the same space and needs a key to tell them apart.
+    if (geometry.kind === "box") {
         return false;
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
+++ b/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
@@ -9,10 +9,11 @@
  * tell which was wrong.
  *
  * The quartiles are math-expressions' `quantileSeq` — interpolated percentiles,
- * not Tukey's hinges, which differ on some sample sizes. `SummaryStatistics.js`
- * carries the note on why the term "five-number summary" is used unattributed;
- * nothing here needs to repeat it, but nothing here may change the calculation
- * either.
+ * not Tukey's hinges, which differ on some sample sizes. The median is the same
+ * value the 50th percentile interpolates to, arrived at here rather than asked
+ * for, for the reason its own note gives. `SummaryStatistics.js` carries the
+ * note on why the term "five-number summary" is used unattributed; nothing here
+ * needs to repeat it, but nothing here may change the calculation either.
  */
 
 import me from "math-expressions";
@@ -54,17 +55,42 @@ export function quartile1(column: number[]): number {
 }
 
 /**
- * The median: the 50th percentile, by the same interpolation as the quartiles.
+ * The median: the middle observation, or the midpoint of the two middle ones.
  *
- * `me.math.median` averages the two middle values of an even column as
- * `(a + b) / 2`, which overflows before it halves: the median of
- * `1e308 1.5e308` came back `Infinity`, and a box plot of that column drew its
- * median line at a coordinate PreFigure cannot read. `quantileSeq` interpolates
- * as `a * 0.5 + b * 0.5`, where neither half can overflow, and halving a normal
- * double is exact — so the two agree wherever their sum is representable.
+ * The same value the 50th percentile interpolates to, computed here rather than
+ * asked of math-expressions, because both of the ways math-expressions can
+ * answer it are wrong at one end of the double range.
+ * `me.math.median` averages the two middle values as `(a + b) / 2`, which
+ * overflows before it halves: the median of `1e308 1.5e308` came back
+ * `Infinity`, and a box plot of that column drew its median line at a
+ * coordinate PreFigure cannot read. `quantileSeq(column, 0.5)` interpolates as
+ * `a * 0.5 + b * 0.5` instead, which cannot overflow but underflows at the
+ * other end: the median of two copies of `Number.MIN_VALUE` halves each of
+ * them to zero and reports `0`, a number the column does not contain.
+ *
+ * Summing and halving is exact for a normal double, so the sum is taken first
+ * and only a sum too large to hold falls back to halving each side — the guard
+ * `scale.ts` and `bar.ts` use at the same edge. Measured against an exact
+ * reference (each double as a BigInt ratio, rounded to nearest at the end),
+ * this is the correctly rounded midpoint on all of 56,000 random columns across
+ * seven magnitude bands, where each of the two math-expressions forms is wrong
+ * on some of them.
+ *
+ * Sorting a copy, and by value: the input belongs to the caller, and
+ * math-expressions compares with a relative and absolute tolerance, which puts
+ * the middle values of a column whose spread is below the tolerance in an order
+ * that is not the column's own.
  */
 export function median(column: number[]): number {
-    return quantileSeq(column, 0.5);
+    const sorted = [...column].sort((a, b) => a - b);
+    const middle = sorted.length >> 1;
+    if (sorted.length % 2 === 1) {
+        return sorted[middle];
+    }
+    const below = sorted[middle - 1];
+    const above = sorted[middle];
+    const sum = below + above;
+    return Number.isFinite(sum) ? sum / 2 : below / 2 + above / 2;
 }
 
 /** The 75th percentile, interpolated. */

--- a/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
+++ b/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
@@ -9,11 +9,11 @@
  * tell which was wrong.
  *
  * The quartiles are math-expressions' `quantileSeq` — interpolated percentiles,
- * not Tukey's hinges, which differ on some sample sizes. The median is the same
- * value the 50th percentile interpolates to, arrived at here rather than asked
- * for, for the reason its own note gives. `SummaryStatistics.js` carries the
- * note on why the term "five-number summary" is used unattributed; nothing here
- * needs to repeat it, but nothing here may change the calculation either.
+ * not Tukey's hinges, which differ on some sample sizes. The median is the 50th
+ * percentile, arrived at here rather than asked for, for the reason its own
+ * note gives. `SummaryStatistics.js` carries the note on why the term
+ * "five-number summary" is used unattributed; nothing here needs to repeat it,
+ * but nothing here may change the calculation either.
  */
 
 import me from "math-expressions";
@@ -57,9 +57,9 @@ export function quartile1(column: number[]): number {
 /**
  * The median: the middle observation, or the midpoint of the two middle ones.
  *
- * The same value the 50th percentile interpolates to, computed here rather than
- * asked of math-expressions, because both of the ways math-expressions can
- * answer it are wrong at one end of the double range.
+ * The 50th percentile, computed here rather than asked of math-expressions,
+ * because both of the ways math-expressions can answer it are wrong at one end
+ * of the double range.
  * `me.math.median` averages the two middle values as `(a + b) / 2`, which
  * overflows before it halves: the median of `1e308 1.5e308` came back
  * `Infinity`, and a box plot of that column drew its median line at a
@@ -110,9 +110,13 @@ export type BoxPlotSummary = {
     maximum: number;
     /**
      * The furthest observation within the fence at each end — where the whisker
-     * stops. An observation, never the fence itself: a whisker is drawn to a
-     * datum that is there, so that its end is a value in the data rather than
-     * an arithmetic consequence of the quartiles.
+     * stops. An observation rather than the fence itself, so that a whisker
+     * ends on a value the data holds rather than on an arithmetic consequence
+     * of the quartiles.
+     *
+     * A column with no such observation reports its quartile here instead —
+     * see the note on the fallback in `boxPlotSummary`. A box plot then draws
+     * no whisker on that side, the quartile being the box's own edge.
      */
     lowerWhisker: number;
     upperWhisker: number;
@@ -126,9 +130,10 @@ export type BoxPlotSummary = {
  *
  * Null rather than a summary of nothing, which is what `<summaryStatistics>`
  * reports for an empty column and what a box plot needs to know in order to
- * leave its position on the axis empty. Every statistic here throws on an empty
+ * leave its position on the axis empty. Four of the five throw on an empty
  * array — a `reduce` without an initial value, and math-expressions' own
- * statistics alike — so the check is not merely for tidiness.
+ * quantile alike — and the median answers `NaN`, so the check is not merely for
+ * tidiness.
  *
  * The column must hold finite numbers only. Anything else is missing data, and
  * whether missing data is worth a message is a question for the component that

--- a/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
+++ b/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
@@ -1,0 +1,155 @@
+/**
+ * The five-number summary, and the box-plot rules built on top of it.
+ *
+ * Here rather than in either component that needs it, because
+ * `<summaryStatistics>` and `<chart type="box">` report the same numbers about
+ * the same data and a document may show both: a table of quartiles beside a box
+ * plot of the column it summarizes. Two implementations of "the first quartile"
+ * would eventually disagree on the page, and the reader would have no way to
+ * tell which was wrong.
+ *
+ * The quartiles are math-expressions' `quantileSeq` — interpolated percentiles,
+ * not Tukey's hinges, which differ on some sample sizes. `SummaryStatistics.js`
+ * carries the note on why the term "five-number summary" is used unattributed;
+ * nothing here needs to repeat it, but nothing here may change the calculation
+ * either.
+ */
+
+import me from "math-expressions";
+
+const { median: medianOf, quantileSeq } = me.math;
+
+/**
+ * How far past the quartiles an observation may lie and still be drawn as part
+ * of the distribution rather than apart from it.
+ *
+ * Tukey's rule, and the only rule implemented: an observation more than one and
+ * a half interquartile ranges beyond the near quartile is an outlier, and the
+ * whisker stops at the furthest one that is not. A `whiskers` attribute — a
+ * plain minimum-to-maximum pair, or a multiplier of the author's — would slot
+ * in here without changing anything about how a box is drawn.
+ */
+const OUTLIER_FENCE_IQRS = 1.5;
+
+/**
+ * The smallest of a column.
+ *
+ * Reduced rather than spread, as `<chart>` and `<summaryStatistics>` both
+ * reduce for the same reason: `Math.min(...column)` throws once the column is
+ * longer than the engine's argument limit, and a column that long is exactly
+ * what summarizing a simulation produces.
+ */
+export function smallest(column: number[]): number {
+    return column.reduce((a, c) => (c < a ? c : a));
+}
+
+/** The largest of a column, reduced for the reason `smallest` is. */
+export function largest(column: number[]): number {
+    return column.reduce((a, c) => (c > a ? c : a));
+}
+
+/** The 25th percentile, interpolated. */
+export function quartile1(column: number[]): number {
+    return quantileSeq(column, 0.25);
+}
+
+/** The median. */
+export function median(column: number[]): number {
+    return medianOf(column);
+}
+
+/** The 75th percentile, interpolated. */
+export function quartile3(column: number[]): number {
+    return quantileSeq(column, 0.75);
+}
+
+/**
+ * The five-number summary of a column, with everything a box plot draws from
+ * it: where each whisker stops, and which observations lie beyond them.
+ */
+export type BoxPlotSummary = {
+    minimum: number;
+    quartile1: number;
+    median: number;
+    quartile3: number;
+    maximum: number;
+    /**
+     * The furthest observation within the fence at each end — where the whisker
+     * stops. An observation, never the fence itself: a whisker is drawn to a
+     * datum that is there, so that its end is a value in the data rather than
+     * an arithmetic consequence of the quartiles.
+     */
+    lowerWhisker: number;
+    upperWhisker: number;
+    /** The observations beyond the fences, in the order they were given. */
+    outliers: number[];
+};
+
+/**
+ * Everything a box plot needs about one column of observations, or `null` for
+ * an empty one.
+ *
+ * Null rather than a summary of nothing, which is what `<summaryStatistics>`
+ * reports for an empty column and what a box plot needs to know in order to
+ * leave its position on the axis empty. Every statistic here throws on an empty
+ * array — a `reduce` without an initial value, and math-expressions' own
+ * statistics alike — so the check is not merely for tidiness.
+ *
+ * The column must hold finite numbers only. Anything else is missing data, and
+ * whether missing data is worth a message is a question for the component that
+ * read it: `<summaryStatistics>` counts non-missing values and says nothing,
+ * while a chart says so, because a reader cannot see the difference between an
+ * observation that was dropped and one that was never given.
+ */
+export function boxPlotSummary(column: number[]): BoxPlotSummary | null {
+    if (column.length === 0) {
+        return null;
+    }
+
+    const lowerQuartile = quartile1(column);
+    const upperQuartile = quartile3(column);
+    const interquartileRange = upperQuartile - lowerQuartile;
+
+    // Computed from the quartiles as they came out, before anything rounds them
+    // for a picture: an observation sitting exactly on a fence is on a knife
+    // edge already, and moving the fence by a twelfth-digit rounding would
+    // decide the question by accident rather than by the rule.
+    //
+    // A column spanning the whole double range has an infinite interquartile
+    // range, which puts both fences at infinity and leaves every observation
+    // inside them. That is the right answer as well as the drawable one: a
+    // spread that large has no outliers to speak of.
+    const lowerFence = lowerQuartile - OUTLIER_FENCE_IQRS * interquartileRange;
+    const upperFence = upperQuartile + OUTLIER_FENCE_IQRS * interquartileRange;
+
+    const outliers: number[] = [];
+    let lowerWhisker = Infinity;
+    let upperWhisker = -Infinity;
+    for (const observation of column) {
+        if (observation < lowerFence || observation > upperFence) {
+            outliers.push(observation);
+            continue;
+        }
+        lowerWhisker = Math.min(lowerWhisker, observation);
+        upperWhisker = Math.max(upperWhisker, observation);
+    }
+
+    // Both quartiles lie between the fences by construction, so at least one
+    // observation is always inside them and the two whiskers are always
+    // observations. The fallback is there for the reader rather than for the
+    // arithmetic.
+    return {
+        minimum: smallest(column),
+        quartile1: lowerQuartile,
+        median: median(column),
+        quartile3: upperQuartile,
+        maximum: largest(column),
+        lowerWhisker: Number.isFinite(lowerWhisker)
+            ? lowerWhisker
+            : lowerQuartile,
+        upperWhisker: Number.isFinite(upperWhisker)
+            ? upperWhisker
+            : upperQuartile,
+        outliers,
+    };
+}

--- a/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
+++ b/packages/doenetml-worker-javascript/src/utils/summaryStatistics.ts
@@ -17,7 +17,7 @@
 
 import me from "math-expressions";
 
-const { median: medianOf, quantileSeq } = me.math;
+const { quantileSeq } = me.math;
 
 /**
  * How far past the quartiles an observation may lie and still be drawn as part
@@ -53,9 +53,18 @@ export function quartile1(column: number[]): number {
     return quantileSeq(column, 0.25);
 }
 
-/** The median. */
+/**
+ * The median: the 50th percentile, by the same interpolation as the quartiles.
+ *
+ * `me.math.median` averages the two middle values of an even column as
+ * `(a + b) / 2`, which overflows before it halves: the median of
+ * `1e308 1.5e308` came back `Infinity`, and a box plot of that column drew its
+ * median line at a coordinate PreFigure cannot read. `quantileSeq` interpolates
+ * as `a * 0.5 + b * 0.5`, where neither half can overflow, and halving a normal
+ * double is exact — so the two agree wherever their sum is representable.
+ */
 export function median(column: number[]): number {
-    return medianOf(column);
+    return quantileSeq(column, 0.5);
 }
 
 /** The 75th percentile, interpolated. */
@@ -108,19 +117,28 @@ export function boxPlotSummary(column: number[]): BoxPlotSummary | null {
 
     const lowerQuartile = quartile1(column);
     const upperQuartile = quartile3(column);
-    const interquartileRange = upperQuartile - lowerQuartile;
 
     // Computed from the quartiles as they came out, before anything rounds them
     // for a picture: an observation sitting exactly on a fence is on a knife
     // edge already, and moving the fence by a twelfth-digit rounding would
     // decide the question by accident rather than by the rule.
     //
+    // Taken in order, so that the lower fence is never the higher of the two.
+    // `quantileSeq` compares with a tolerance, and a column whose values all
+    // fall within it — three readings agreeing to twelve significant digits,
+    // say — can come back with a first quartile above its third. Ordering them
+    // costs nothing on a column that is already in order and keeps that one
+    // from having every observation of it declared an outlier.
+    //
     // A column spanning the whole double range has an infinite interquartile
     // range, which puts both fences at infinity and leaves every observation
     // inside them. That is the right answer as well as the drawable one: a
     // spread that large has no outliers to speak of.
-    const lowerFence = lowerQuartile - OUTLIER_FENCE_IQRS * interquartileRange;
-    const upperFence = upperQuartile + OUTLIER_FENCE_IQRS * interquartileRange;
+    const boxBottom = Math.min(lowerQuartile, upperQuartile);
+    const boxTop = Math.max(lowerQuartile, upperQuartile);
+    const interquartileRange = boxTop - boxBottom;
+    const lowerFence = boxBottom - OUTLIER_FENCE_IQRS * interquartileRange;
+    const upperFence = boxTop + OUTLIER_FENCE_IQRS * interquartileRange;
 
     const outliers: number[] = [];
     let lowerWhisker = Infinity;
@@ -134,10 +152,11 @@ export function boxPlotSummary(column: number[]): BoxPlotSummary | null {
         upperWhisker = Math.max(upperWhisker, observation);
     }
 
-    // Both quartiles lie between the fences by construction, so at least one
-    // observation is always inside them and the two whiskers are always
-    // observations. The fallback is there for the reader rather than for the
-    // arithmetic.
+    // Both quartiles lie between the fences by construction, so a column whose
+    // observations bracket its own quartiles has one inside them and the two
+    // whiskers are observations. The fallback is for the column that does not:
+    // a spread narrow enough that `quantileSeq`'s tolerance answers with
+    // quartiles the column has no observation near.
     return {
         minimum: smallest(column),
         quartile1: lowerQuartile,

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -249,5 +249,7 @@
     "doenet-w0150": "chart-pie-negative-values",
     "doenet-w0151": "chart-pie-total-not-positive",
     "doenet-w0152": "chart-pie-one-series",
-    "doenet-w0153": "chart-pie-axis-name-ignored"
+    "doenet-w0153": "chart-pie-axis-name-ignored",
+    "doenet-w0154": "chart-box-values-not-drawable",
+    "doenet-w0155": "chart-box-categories-ignored"
 }

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -602,3 +602,27 @@ math-embedded-input-blank = blank
 # The same, when one expression has more than one gap, so that a reader can tell
 # which one they have reached.
 math-embedded-input-blank-ordinal = blank { $ordinal } of { $total }
+
+# The five-number summary a `<chart type="box">` gives a screen reader on each
+# box it draws.
+#
+# Words rather than five bare numbers, which is the one annotation in a chart
+# that cannot do without them: a bar is announced as its category and its
+# value, and a point as its coordinates, because in both the position says
+# which number it is. A box reports five numbers at one position, and nothing
+# but the naming tells them apart.
+#
+# Each number arrives as text, already written the way the chart writes the
+# numbers on its own axis. Passed as a number instead, a translation would
+# format it a second time — grouping it, and rounding it to three fraction
+# digits — so a reader would hear a different figure from the one drawn.
+chart-box-summary =
+    minimum { $minimum }, first quartile { $quartile1 }, median { $median }, third quartile { $quartile3 }, maximum { $maximum }
+
+# The name a `<chart type="box">` gives one observation drawn beyond a whisker.
+#
+# Named rather than announced as a bare number, for the reason the summary
+# above is worded: after the five numbers of the box, a further number on its
+# own says nothing about why it is drawn apart from them.
+chart-box-outlier =
+    outlier { $value }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -1199,3 +1199,20 @@ chart-pie-one-series =
 # because what was dropped is something the author wrote for a reader to see.
 chart-pie-axis-name-ignored =
     A pie chart has no axes, so an `<xLabel>` or `<yLabel>` was not drawn. Put the text in a `<title>` instead, or in prose beside the chart.
+
+# Raised by `<chart type="box">` for an observation that is not a finite
+# number. Left out of the summary rather than read as zero, which would move
+# every quartile of the box drawn from it. No count, for the reason the others
+# give: the queue deduplicates by message, and the number changes as an input is
+# typed into.
+chart-box-values-not-drawable =
+    A box plot summarizes finite numbers, so an observation that is not one was left out of its summary.
+
+# Raised by `<chart type="box">` carrying a `categories` attribute. A box chart
+# has no categories: each of its series is one position on the axis and is named
+# by its own `<label>`, so the names in `categories` are authored text with
+# nowhere on the page to go — which is worth a message where an ignored
+# *attribute* is not, because what was dropped is something the author wrote for
+# a reader to see.
+chart-box-categories-ignored =
+    A box plot names each of its boxes after the series it was drawn from, so `categories` was not used. Give each `<series>` a `<label>` instead.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -241,6 +241,8 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0151": "chart-pie-total-not-positive",
     "doenet-w0152": "chart-pie-one-series",
     "doenet-w0153": "chart-pie-axis-name-ignored",
+    "doenet-w0154": "chart-box-values-not-drawable",
+    "doenet-w0155": "chart-box-categories-ignored",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -299,6 +299,8 @@ export type MessageKey =
     | "chemistry-invalid-ionic-compound"
     | "math-embedded-input-blank"
     | "math-embedded-input-blank-ordinal"
+    | "chart-box-summary"
+    | "chart-box-outlier"
     | "line-segment-attributes-ignored-with-endpoints"
     | "line-segment-attributes-ignored-with-endpoint-and-midpoint"
     | "line-segment-midpoint-offset-without-midpoint"
@@ -550,6 +552,8 @@ export type MessageKey =
     | "chart-pie-total-not-positive"
     | "chart-pie-one-series"
     | "chart-pie-axis-name-ignored"
+    | "chart-box-values-not-drawable"
+    | "chart-box-categories-ignored"
     | "editor-update-viewer"
     | "editor-update-viewer-title"
     | "editor-variant"
@@ -915,6 +919,8 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "chemistry-invalid-ionic-compound",
     "math-embedded-input-blank",
     "math-embedded-input-blank-ordinal",
+    "chart-box-summary",
+    "chart-box-outlier",
     "line-segment-attributes-ignored-with-endpoints",
     "line-segment-attributes-ignored-with-endpoint-and-midpoint",
     "line-segment-midpoint-offset-without-midpoint",
@@ -1166,6 +1172,8 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "chart-pie-total-not-positive",
     "chart-pie-one-series",
     "chart-pie-axis-name-ignored",
+    "chart-box-values-not-drawable",
+    "chart-box-categories-ignored",
     "editor-update-viewer",
     "editor-update-viewer-title",
     "editor-variant",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -44812,7 +44812,8 @@
                         "bar",
                         "line",
                         "scatter",
-                        "pie"
+                        "pie",
+                        "box"
                     ]
                 },
                 "aspectRatio": {
@@ -45293,7 +45294,7 @@
                     "name": "legend",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend=\"false\"` suppresses it, and a pie then writes its slice names around the rim instead.",
+                    "description": "Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend=\"false\"` suppresses it, and a pie then writes its slice names around the rim instead. A box plot names each series under the box drawn from it and never draws a legend.",
                     "fromAttribute": true
                 },
                 {
@@ -45307,7 +45308,7 @@
                     "name": "displayValues",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice.",
+                    "description": "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice. A box plot reports five numbers at each position rather than one, and does not draw with it.",
                     "fromAttribute": true
                 },
                 {
@@ -45447,7 +45448,7 @@
                     "name": "categories",
                     "type": "text",
                     "isArray": true,
-                    "description": "The name of each position in the data, in order: the label under each bar, or the name of each slice of a pie.",
+                    "description": "The name of each position in the data, in order: the label under each bar, or the name of each slice of a pie. Empty on a box plot, whose positions are its series.",
                     "numDimensions": 1,
                     "indexedArrayDescription": [
                         {
@@ -45974,6 +45975,50 @@
                     "type": "number",
                     "isArray": true,
                     "description": "The values in this series, in order.",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "number",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "minimum",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The smallest value in this series."
+                },
+                {
+                    "name": "quartile1",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The first quartile (25th percentile)."
+                },
+                {
+                    "name": "median",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The median value."
+                },
+                {
+                    "name": "quartile3",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The third quartile (75th percentile)."
+                },
+                {
+                    "name": "maximum",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The largest value in this series."
+                },
+                {
+                    "name": "outliers",
+                    "type": "number",
+                    "isArray": true,
+                    "description": "The values more than one and a half interquartile ranges beyond the nearer quartile, in the order they were given — the ones a box plot draws as points beyond its whiskers.",
                     "numDimensions": 1,
                     "indexedArrayDescription": [
                         {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -36497,7 +36497,8 @@
                         "bar",
                         "line",
                         "scatter",
-                        "pie"
+                        "pie",
+                        "box"
                     ],
                     "autocompleteValues": [
                         {
@@ -36515,6 +36516,10 @@
                         {
                             "value": "pie",
                             "description": "A pie chart: one slice per value, each a share of the total, named by the category names. Draws one series and has no axes."
+                        },
+                        {
+                            "value": "box",
+                            "description": "A box plot per series, side by side under an axis of the series' names. A series holds raw observations rather than one value per category."
                         }
                     ],
                     "type": "keyword"
@@ -36527,7 +36532,7 @@
                 },
                 {
                     "name": "categories",
-                    "description": "The name of each position in the data: the label under each position on the horizontal axis, or the name of each slice of a pie. Defaults to the position itself, 1, 2, 3 and so on. A line or scatter chart whose series carry an `x` is placed by measurement instead and has no positions to name; a bar chart and a pie name theirs whatever else the series carry.",
+                    "description": "The name of each position in the data: the label under each position on the horizontal axis, or the name of each slice of a pie. Defaults to the position itself, 1, 2, 3 and so on. A line or scatter chart whose series carry an `x` is placed by measurement instead and has no positions to name; a bar chart and a pie name theirs whatever else the series carry. A box plot's positions are its series, each named by its own `<label>`.",
                     "groupName": "axes",
                     "highlighted": true,
                     "type": "textList"
@@ -36563,7 +36568,7 @@
                 },
                 {
                     "name": "legend",
-                    "description": "Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend=\"false\"` suppresses it, and a pie then writes its slice names around the rim instead.",
+                    "description": "Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend=\"false\"` suppresses it, and a pie then writes its slice names around the rim instead. A box plot names each series under the box drawn from it and never draws a legend.",
                     "groupName": "legend",
                     "defaultValue": true,
                     "values": [
@@ -36629,7 +36634,7 @@
                 },
                 {
                     "name": "yMin",
-                    "description": "Lowest value shown on the vertical axis. Defaults to 0 for a bar chart, whose bars are measured from it, or to the first tick past the smallest value — which is what a bar chart with negative values gets, and what a line or scatter chart always gets. If `yMin` and `yMax` do not describe a box — both finite, with `yMin` below `yMax` — the axis is chosen from the data instead. A pie has no axes and reads neither.",
+                    "description": "Lowest value shown on the vertical axis. Defaults to 0 for a bar chart, whose bars are measured from it, or to the first tick past the smallest value — which is what a bar chart with negative values gets, and what a line, scatter or box chart always gets. If `yMin` and `yMax` do not describe a box — both finite, with `yMin` below `yMax` — the axis is chosen from the data instead. A pie has no axes and reads neither.",
                     "groupName": "axes",
                     "defaultValue": null,
                     "type": "number"
@@ -36643,7 +36648,7 @@
                 },
                 {
                     "name": "displayValues",
-                    "description": "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice.",
+                    "description": "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice. A box plot reports five numbers at each position rather than one, and does not draw with it.",
                     "groupName": "marks",
                     "defaultValue": false,
                     "values": [
@@ -36774,7 +36779,7 @@
                     "name": "legend",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend=\"false\"` suppresses it, and a pie then writes its slice names around the rim instead.",
+                    "description": "Whether to draw a legend naming the series — or, on a pie, naming the slices. A legend is drawn when a series carries a `<label>`, and on a pie whenever there is a slice to name; `legend=\"false\"` suppresses it, and a pie then writes its slice names around the rim instead. A box plot names each series under the box drawn from it and never draws a legend.",
                     "fromAttribute": true,
                     "groupName": "legend"
                 },
@@ -36790,7 +36795,7 @@
                     "name": "displayValues",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice.",
+                    "description": "Whether to print each value beside its mark: at a bar's far end — above one that rises, below one that falls — above a line or scatter chart's point, and beyond the rim of a pie's slice. A box plot reports five numbers at each position rather than one, and does not draw with it.",
                     "fromAttribute": true,
                     "groupName": "marks"
                 },
@@ -36938,7 +36943,7 @@
                     "name": "categories",
                     "type": "text",
                     "isArray": true,
-                    "description": "The name of each position in the data, in order: the label under each bar, or the name of each slice of a pie.",
+                    "description": "The name of each position in the data, in order: the label under each bar, or the name of each slice of a pie. Empty on a box plot, whose positions are its series.",
                     "groupName": "axes",
                     "numDimensions": 1,
                     "indexedArrayDescription": [
@@ -37286,6 +37291,50 @@
                     "type": "number",
                     "isArray": true,
                     "description": "The values in this series, in order.",
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "number",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "minimum",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The smallest value in this series."
+                },
+                {
+                    "name": "quartile1",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The first quartile (25th percentile)."
+                },
+                {
+                    "name": "median",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The median value."
+                },
+                {
+                    "name": "quartile3",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The third quartile (75th percentile)."
+                },
+                {
+                    "name": "maximum",
+                    "type": "number",
+                    "isArray": false,
+                    "description": "The largest value in this series."
+                },
+                {
+                    "name": "outliers",
+                    "type": "number",
+                    "isArray": true,
+                    "description": "The values more than one and a half interquartile ranges beyond the nearer quartile, in the order they were given — the ones a box plot draws as points beyond its whiskers.",
                     "numDimensions": 1,
                     "indexedArrayDescription": [
                         {

--- a/packages/test-cypress/cypress/e2e/prefigure/chartLive.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/chartLive.cy.js
@@ -360,6 +360,158 @@ liveDescribe("Live chart rendering @group4", { tags: ["@group4"] }, () => {
             .and("contain.text", "Population by region");
     });
 
+    it("draws a box plot with its parts in place and its groups navigable", () => {
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<text name="ready">ready</text>
+<chart name="b" type="box">
+  <title>Scores by section</title>
+  <shortDescription>Scores in two sections</shortDescription>
+  <yLabel>score</yLabel>
+  <series><label>9am</label>52 61 63 68 70 71 75 78 84 91</series>
+  <series><label>1pm</label>44 55 58 60 62 65 66 70 72 96</series>
+</chart>
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get("#b .svg svg", { timeout: 30000 }).should("exist");
+
+        // The names of a box chart's positions are its series' own labels,
+        // drawn as tick marks under the boxes — so the legend's job is done by
+        // the axis, and no legend is drawn at all.
+        cy.get("#b .svg svg").should(($svg) => {
+            const text = $svg.text();
+            for (const expected of [
+                "9am",
+                "1pm",
+                "Scores by section",
+                "score",
+            ]) {
+                expect(
+                    text,
+                    `drawn text should include ${expected}`,
+                ).to.include(expected);
+            }
+            expect(
+                $svg[0].querySelectorAll('rect[fill="white"]').length,
+                "a box chart should draw no legend box",
+            ).to.equal(0);
+        });
+
+        // Measured by the browser rather than read off the path data: a box
+        // plot is six marks that mean something only in relation to one
+        // another, and what turns the data coordinates into pixels is the
+        // bounding box and the margins.
+        cy.get("#b .svg svg").then(($svg) => {
+            const svg = $svg[0];
+            for (const index of [1, 2]) {
+                const box = svg.querySelector(`[id$="box-${index}"]`);
+                expect(box, `box ${index}`).to.exist;
+                const boxRect = box.getBoundingClientRect();
+
+                // The whisker caps reach above and below the box, and stay
+                // inside its width — a cap as wide as the box would read as a
+                // second box edge.
+                const lines = [...svg.querySelectorAll("line")].filter(
+                    (line) => {
+                        const rect = line.getBoundingClientRect();
+                        return (
+                            rect.left >= boxRect.left - 1 &&
+                            rect.right <= boxRect.right + 1 &&
+                            rect.width > 0
+                        );
+                    },
+                );
+                const caps = lines.filter(
+                    (line) =>
+                        line.getBoundingClientRect().width < boxRect.width - 1,
+                );
+                expect(
+                    caps.length,
+                    `box ${index} should have a cap at each whisker`,
+                ).to.equal(2);
+                const capTops = caps.map(
+                    (cap) => cap.getBoundingClientRect().top,
+                );
+                expect(Math.min(...capTops)).to.be.at.most(boxRect.top);
+                expect(Math.max(...capTops)).to.be.at.least(boxRect.bottom);
+
+                // And the median lies inside the box, across its full width.
+                const median = lines.find(
+                    (line) =>
+                        Math.abs(
+                            line.getBoundingClientRect().width - boxRect.width,
+                        ) <= 1,
+                );
+                expect(median, `box ${index}'s median`).to.exist;
+                const medianRect = median.getBoundingClientRect();
+                expect(medianRect.top).to.be.at.least(boxRect.top - 1);
+                expect(medianRect.bottom).to.be.at.most(boxRect.bottom + 1);
+            }
+
+            expectNothingClipped(svg, "#b");
+        });
+
+        // The tree diagcess walks: figure, a level per series, then the box
+        // drawn from it and anything lying beyond its whiskers. The second
+        // section has an observation past the fence, so its level holds two
+        // marks where the first holds one.
+        cy.get("#b .cml", { timeout: 30000 }).should(($cml) => {
+            const annotations = [...$cml[0].querySelectorAll("annotation")];
+            const byIdSuffix = (suffix) =>
+                annotations.find((el) =>
+                    (el.getAttribute("id") ?? "").endsWith(suffix),
+                );
+
+            const figure = byIdSuffix("figure");
+            expect(figure, "figure annotation").to.exist;
+
+            for (const [seriesSuffix, marks] of [
+                ["series-1", ["box-1"]],
+                ["series-2", ["box-2", "outlier-2-1"]],
+            ]) {
+                const series = byIdSuffix(seriesSuffix);
+                expect(series, `${seriesSuffix} annotation`).to.exist;
+
+                const parents = [...series.querySelectorAll("parents > *")].map(
+                    (el) => el.textContent.trim(),
+                );
+                expect(parents.some((id) => id.endsWith("figure"))).to.be.true;
+
+                const children = [
+                    ...series.querySelectorAll("children > *"),
+                ].map((el) => el.textContent.trim());
+                expect(children).to.have.length(marks.length);
+                for (const [ind, markId] of children.entries()) {
+                    expect(markId.endsWith(marks[ind])).to.be.true;
+                    expect(
+                        annotations.find(
+                            (el) => el.getAttribute("id") === markId,
+                        ),
+                        `annotation for ${markId}`,
+                    ).to.exist;
+                }
+            }
+        });
+
+        cy.get("#b .ChemAccess-element", { timeout: 30000 })
+            .should("have.attr", "has-svg", "true")
+            .and("have.attr", "has-cml", "true")
+            .and("have.attr", "tabindex", "0")
+            .and("have.attr", "role", "application");
+
+        cy.get("#b .ChemAccess-element").click({ force: true });
+        cy.get("#b .cacc-message", { timeout: 30000 })
+            .should("exist")
+            .and("contain.text", "Scores in two sections");
+    });
+
     it("navigates the bars through their series", () => {
         cy.window().then((win) => {
             win.postMessage(


### PR DESCRIPTION
Phase 4 of #437. Adds `<chart type="box">`.

```xml
<chart type="box">
  <shortDescription>Scores by section</shortDescription>
  <yLabel>score</yLabel>
  <series><label>9am</label>52 61 63 68 70 71 75 78 84 91</series>
  <series><label>1pm</label>44 55 58 60 62 65 66 70 72 96</series>
</chart>
```

## The axis turns around

This is the first type whose `<series>` holds **raw observations** rather than one value per category, and that is not a detail about the data: it changes what a position on the horizontal axis *is*. Every other type reads its series position by position against shared categories — four series and four categories are sixteen marks. Here a whole series becomes one position, which is what every plotting package means by `aes(x = group, y = value)`.

So a box chart has no categories. Its axis carries one `<tick-mark>` per series, named by that series' own `<label>` and falling back to the position — 1, 2, 3 — where the author gave none, which is what `boxplot(x)` labels a single box in R too. `categories` has nothing left to name, so `$chart.categories` reports nothing for a box plot rather than one entry per observation, and writing the attribute on one is reported. That last part is the `<xLabel>`-on-a-pie rule rather than the `barWidth`-on-a-scatter one: an ignored attribute is documented and silent, but `categories` is names an author wrote for a reader, and dropping them leaves nothing on the page and nothing said.

`legend` and `legendPosition` are the ignored-and-silent kind. A legend names what a color stands for, and here the name is already under the box: no legend is drawn whichever way they are written, and `$chart.showLegend` says so. `displayValues` is the same — a box reports five numbers at one position, not one.

## What is drawn

- `<rectangle>` from the first quartile to the third, filled from the series' `styleNumber`.
- `<line>` across it at the median, after the rectangle so the fill cannot cover it.
- `<line>` from each quartile to the furthest observation within 1.5 interquartile ranges of the box, with a `<line>` cap across each end at half the box's width.
- `<point>` for each observation beyond that.

`<line>` is drawn here and nowhere else in this folder. Written with `p1`/`p2` rather than the `endpoints` pair `components/line.ts` uses — `line.py` reads `endpoints` when it is there and `p1`/`p2` otherwise, and a segment with no `infinite` to declare is shorter said as two points.

A whisker ends on an observation rather than on the fence, so its end is a number the data contains — with one exception, below, where the column has no observation between its own fences. Where a quartile is already the extreme — a column whose lower quarter is one repeated value — there is no whisker and no cap: both would be marks saying what the box's own edge already says, in a drawing whose whole subject is which mark is where. A series of one observation, or of one value repeated, has all five numbers in one place; the rectangle of no height that follows paints as a line at the value, which is exactly right, and is checked against a real render rather than assumed.

The vertical axis is the data's and is not anchored to zero, as a line or scatter chart's is not: these are positions on a scale, not lengths measured from a baseline, so forcing zero into the axis of a chart of adult heights would push every box into the top of the picture. The horizontal extent is the one a bar chart of the same number of positions gets, so switching a chart's `type` between them does not move the data sideways.

Nothing is reserved for an outlier's marker, unlike a scatter plot, and that is measured rather than assumed. An outlier sits at the center of its slot, half a slot from either side, so it never approaches the left or right frame; vertically the sixteen pixels above the box and thirty below already hold the seven it reaches. Reserving them again moved nothing — a marker at an authored `yMax` came out one pixel inside a `size="tiny"` picture with the reservation and one pixel inside without it, because `fitMargins` scales what it grants and a crowded frame does not honor the extra — and cost seven pixels of drawing area on every chart that had room to spare.

## One definition of a quartile

`<summaryStatistics>` already computes the five-number summary, and a document may well show both: a table of quartiles beside a box plot of the column it summarizes. Two implementations would eventually disagree on the page and a reader would have no way to tell which was wrong, so the computation is extracted to `utils/summaryStatistics.ts` and `SummaryStatistics.js` now reads it from there. Interpolated percentiles, not Tukey's hinges — they differ on some sample sizes, which is why the tests use `1 2 3 4 5 6`, where these give 2.25 and 4.75 and hinges would give 2 and 5.

Every `<series>` reports `minimum`, `quartile1`, `median`, `quartile3`, `maximum` and `outliers` off that summary, and reports them whatever chart was drawn from it: a column does not stop having a median because it was drawn as bars. What the chart decides is which of them get a mark. Null for a series with no finite values, which is what `<summaryStatistics>` reports for an empty column; `outliers` is the exception, since "which values lie beyond the fences" has an answer there and it is none of them.

The fences are computed from the quartiles as they came out — and taken in order. `quantileSeq` compares with a tolerance, so a column whose values all fall inside it (three readings agreeing to twelve significant digits) can answer with a first quartile above its third; unordered fences would then lie the wrong way round and declare every observation of that column an outlier. Ordering them costs nothing on a column already in order. Otherwise they are read before anything rounds them for a picture: an observation sitting exactly on one is on a knife edge already, and moving the fence by a twelfth-digit rounding would decide the question by accident. What the *geometry* carries is snapped, because an interpolated quartile arrives with the dust interpolation leaves — the quartiles of `0.1 0.2 0.3 0.4` are `0.17500000000000002` and `0.32499999999999996` — and that number is both written into the XML and read out by a screen reader.

That tolerance leaves two more marks to settle, both on the same kind of column. One whose whole spread falls inside it can have **no observation between its own fences** at all — every one of them is an outlier — and each whisker then falls back to its quartile, which is the box's own edge: no whisker and no cap is drawn, and all the observations are points. And the rectangle takes the two quartiles in order, so the corner it is written from is the one `lower-left` names. PreFigure reads a negative `dimensions` from the other corner and draws the same interval either way — checked against the build service, which returns the same four corners wound the other way — so that is the XML saying what it means rather than a change to the picture. The annotation goes on reporting the pair the statistic answered, inverted or not, which is what it is there to say.

The median is the one statistic of the five that math-expressions cannot be asked for, because both of the ways it can answer are wrong at one end of the range a double holds. `me.math.median` averages the two middle values of an even column as `(a + b) / 2` and overflows before it halves: the median of `1e308 1.5e308` came back `Infinity`, which `formatNumber` writes as `null` — so the box plot of that column drew `p1="(0.75,null)"`, a coordinate PreFigure cannot read. `quantileSeq(column, 0.5)` interpolates as `a * 0.5 + b * 0.5`, which cannot overflow but underflows at the other end: the median of two copies of `Number.MIN_VALUE` halves each of them to zero and answers `0`, a number the column does not contain.

So it is summed and halved here, with the guard `scale.ts` and `bar.ts` use at the same edge — only a sum too large to hold falls back to halving each side — and the values are ordered by size rather than by math-expressions' tolerant comparison. Measured against an exact reference (each double as a BigInt ratio, rounded to nearest at the end), that is the correctly rounded midpoint on all of 56,000 random columns across seven magnitude bands, where each of the two math-expressions forms is wrong on some of them; and it agrees with `me.math.median` on every one of 200,000 integer and one-decimal columns, and in both bands (1 and 1e307) where `me.math.median` is exact.

`<summaryStatistics>` reads the same function, so its median changes in exactly those two places: a column at the top of the range that reported `Infinity` now reports its midpoint, and a column of readings agreeing to twelve significant digits now reports its middle value by size rather than whichever was written first. `quartile1` and `quartile3` are still `quantileSeq` — #1880 pins them there — and are as unreliable on that second column as they were before, which is #1895 rather than a change here.

The box's own height is guarded the way `scale.ts` and `bar.ts` guard theirs. A rectangle is written as a corner and a size, so the distance between the quartiles has to be representable, and quartiles a quarter of the double range apart on either side of zero are already too far: `-3.8e307` to `1.5e308` overflows, and `dimensions="(0.5,null)"` is not a size PreFigure can read. Such a box is drawn as tall as a double allows, which stops it short of its third quartile on a chart whose axis spans most of the range a double holds — a smaller wrong than a box with no height to draw it by.

## Words in an annotation

Every other chart annotates a mark with data alone: a bar is `North: 41`, a point is `1.5, 55`. In both, the position says which number it is. A box reports five numbers at one position and nothing but the naming tells them apart — so this is the one chart annotation that needs words, and they are a translatable message (`chart-box-summary`, `chart-box-outlier`) assembled where the document's locale is known rather than English built in the worker. The numbers are written by the same `formatNumber` that writes them into the picture, and passed in as text: passed as numbers, a translation would format them a second time — grouping them, and rounding to three fraction digits — so a reader would hear a different figure from the one drawn.

The tree is figure → a level per series → the box drawn from it and anything beyond its whiskers. The box carries the whole summary rather than five annotations, because two of the five numbers *are* the rectangle's edges and there is nothing separate to point at.

## What a box chart says it cannot draw

| | |
| --- | --- |
| `doenet-w0154` | an observation that is not a finite number |
| `doenet-w0155` | a `categories` attribute, which a box plot has no positions for |

The first matters more here than on a bar chart, where an empty slot is visible: a dropped observation moves every quartile of the box drawn from it and leaves nothing on the page to notice.

## Verification

The 44 unit tests assert on generated XML, which cannot show a box drawn upside down or a cap that reads as a second box edge, so the geometry was checked against real renders:

- **In place**: a new live test reads each box's four corners off the `<path>` PreFigure emits for it, then walks the lines that follow — asserting the median lies inside the box and spans its width, each whisker runs up the box's own center line and outward from an edge, and each cap is centered and narrower than the box. Both mutations were checked: widening the cap to the box's width fails it, and swapping the two whiskers so they point back into the box fails it.
- **Accepted**: box cases added to the build-service acceptance test, including the box of no height, an empty position, and bounds that cut the box and its whiskers; and a box chart drawn below zero added to the axis-label containment test, where PreFigure moves the horizontal axis to the top of the box.
- **Navigable**: the Cypress live spec builds a two-series box plot in a browser, measures the caps and the median against the box the browser drew, walks the annotation tree — figure, a level per series, the box and its outlier under it — and clicks the chart to wait for the description diagcess speaks. Gated behind `RUN_LIVE_PREFIGURE_ACCESSIBILITY`, which CI never sets, so it was run by hand against the preview build.
- **Drawable at the edges**: three unit tests pin the numbers that used to come out non-finite — the median of a column near the top of the double range, a box spanning the whole of it, and a column whose values agree to twelve significant digits — each of which fails without its fix, plus three on `<summaryStatistics>`' median: the column at the top of the range, a column at the bottom of it, and the one whose readings agree to twelve digits. Two more pin what the tolerance-band column draws — the rectangle written from its lower corner, and the box whose whiskers have no observation to end on — and both fail without the code that makes them true. A fuzz over six thousand random box charts, including columns at `Number.MAX_VALUE`, subnormal columns, non-finite observations and random authored bounds, found no `null` left in the XML.
- **Agreeing**: a unit test puts `$series.quartile1` and `<summaryStatistics>`' beside each other on the sample size where hinges and interpolated percentiles differ.
- **Unchanged elsewhere**: the four types that already shipped emit byte-identical XML. 57 configurations of `bar`, `line`, `scatter` and `pie` — with and without `categories`, one and three series, labeled and unlabeled, `legend` off, every `legendPosition`, `displayValues`, authored bounds, `barWidth`, `layout="stacked"`, dark theme, a numeric `x` axis and a categorical one, symbolic and empty series — were dumped with their `prefigureXML`, `categories`, `showLegend`, `xMin`/`xMax`/`yMin`/`yMax` and every diagnostic, and compared against the same dump taken from a worktree of `upstream/main`: 110,560 bytes, identical hash. The same harness run on `type="box"` gives `null` and `doenet-w0146` on `upstream/main` and a box here, so it was reading each branch's own sources.

The live suite is opt-in (`RUN_LIVE_PREFIGURE_VALIDATION`) and CI never sets it, so what it alone protected is pinned at the XML level too: the box's corners, the median's span, each whisker's endpoints and each cap's width, the margins a box chart takes, and the absence of a legend.

## Known limits, not introduced here

- Long series names on adjacent positions crowd each other, exactly as long `categories` do on a bar chart: `morning` and `afternoon` touch at `size="small"`, which is why the reference page's own example names its sections `9am` and `1pm`.
- A frame too small to hold its own margins clips what is in them, box plots included — `size="tiny"` is a 65px picture.
- Where the data crosses zero, PreFigure puts the horizontal axis at zero and the position names against it, so they land over the boxes rather than under them. A bar chart of mixed-sign values writes its category names inside its bars in exactly the same place — both were rendered and compared — so this is the categorical axis, not the box.
- A multi-word series name is expressible here, unlike a bar category: a `<label>` is content rather than a `textList`. A name written as math is drawn as math on the axis — the tick mark goes through PreFigure's own label machinery, so an `<m>` in one is typeset the way one in a legend entry is — but the *annotation* a screen reader hears carries it as the LaTeX it arrived as, `\(x\)` and all. A bar chart's group annotation does the same on `main`; what a reader should hear for a name written as math is a question for every type at once rather than one this can answer alone, and is now #1899.

Closes #1880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)








