### PR TITLE
Put writing space in a printout that can hold it, and stop inventing titles

### DIFF
--- a/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
+++ b/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
@@ -140,7 +140,9 @@ const BLOCK_ELEMENTS = new Set([
  * Which printout that is, is decided for the document as a whole: either every input sits
  * in a division that can become one, and each of those divisions is retagged a `<handout>`,
  * or a single `<handout>` is wrapped around the whole document. Either way a printout
- * stands above every input, so none is left a `<fillin>` blank for want of one.
+ * stands above every input, so none is left a `<fillin>` blank for want of one, and a
+ * printout that has no title of its own is given an empty one rather than PreTeXt's
+ * default heading for a handout.
  */
 export function addWritingSpace(flatDast: FlatDastRoot) {
     const expandedInputs = flatDast.elements.filter(isExpandedTextInput);
@@ -192,8 +194,13 @@ export function addWritingSpace(flatDast: FlatDastRoot) {
 
     if (perDivision) {
         for (const division of new Set(divisions)) {
+            const props = mutableProps(division);
             // `divisionType` is the name of the tag a division exports as.
-            mutableProps(division).divisionType = "handout";
+            props.divisionType = "handout";
+            // `title` is the id of the division's title, or null where it has none.
+            if (props.title == null) {
+                props.title = emptyTitle(flatDast).data.id;
+            }
         }
     } else {
         makeDocumentPrintout(documentElement(flatDast) ?? flatDast, flatDast);
@@ -331,16 +338,30 @@ function setWorkspace(paragraph: FlatDastElement, inches: number) {
 }
 
 /**
+ * A `<title>` with nothing in it, which heads a printout with nothing at all.
+ *
+ * PreTeXt heads an untitled division with the default title for its kind, and `handout` is
+ * one of the kinds that has one (`has-default-title` in `pretext-common.xsl`), so a printout
+ * left untitled is headed by the bare word "Handout". A `<section>` has no default title, so
+ * a division that is retagged a printout would gain a heading it did not have, and a
+ * document handout would gain one the document never had. An empty title suppresses it:
+ * `title-xref` tests for a title element rather than for its text, so an empty one is used
+ * as written and the default is never reached.
+ */
+function emptyTitle(flatDast: FlatDastRoot) {
+    return addElement(flatDast, "title", []);
+}
+
+/**
  * Put a `<handout>` around the whole document. PreTeXt honors `@workspace` only under a
  * `<worksheet>` or a `<handout>` (`sanitize-workspace` in `pretext-common.xsl`), and a
  * handout may hold divisions, so one around everything serves every input at once and
  * leaves the sections inside it as they were written.
  *
  * The document's own title stays where it is, since the `<article>` PreTeXt builds around
- * it needs one. The handout is given an *empty* title rather than a copy of it: an
- * untitled printout is headed by PreTeXt's default title for the division — the bare word
- * "Handout" — and a copy would print the activity's title a second time. Neither is a
- * title the author wrote, and an empty one leaves the heading blank.
+ * it needs one. The handout is given an empty title rather than a copy of it, since a copy
+ * would print the activity's title a second time — a heading the author did not write, as
+ * much as the default "Handout" an untitled printout is given.
  */
 function makeDocumentPrintout(
     container: FlatDastElement | FlatDastRoot,
@@ -353,7 +374,7 @@ function makeDocumentPrintout(
     const handoutChildren = container.children.filter(
         (child) => child !== titleRef,
     );
-    handoutChildren.unshift(refTo(addElement(flatDast, "title", [])));
+    handoutChildren.unshift(refTo(emptyTitle(flatDast)));
 
     const handout = addElement(flatDast, "handout", handoutChildren);
     container.children = titleRef

--- a/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
+++ b/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
@@ -144,19 +144,35 @@ export function addWritingSpace(flatDast: FlatDastRoot) {
         return;
     }
 
+    // Decided once for the document as a whole, so that the printouts never nest: either
+    // every input sits in a division that can become one, or a single handout goes around
+    // the whole document.
+    const parents = buildParentMap(flatDast);
+    const divisions: FlatDastElement[] = [];
+    let perDivision = true;
+    for (const input of expandedInputs) {
+        const division = findAncestor(
+            input,
+            parents,
+            (element) => element.name === "division",
+        );
+        if (division && !containsDivision(division, flatDast)) {
+            divisions.push(division);
+        } else {
+            perDivision = false;
+            break;
+        }
+    }
+
     /** How much space each paragraph has been asked for, in inches. */
     const requested = new Map<FlatDastElement, number>();
-    /** The containers whose contents need to end up inside a printout. */
-    const containers = new Set<FlatDastElement | FlatDastRoot>();
-
     for (const input of expandedInputs) {
         // Rebuilt each time around, since placing one input's space moves content.
-        const parents = buildParentMap(flatDast);
-        const container = findPrintoutContainer(input, parents, flatDast);
-        if (!container) {
-            continue;
-        }
-        const paragraph = paragraphForSpace(input, parents, flatDast);
+        const paragraph = paragraphForSpace(
+            input,
+            buildParentMap(flatDast),
+            flatDast,
+        );
         if (!paragraph) {
             continue;
         }
@@ -165,14 +181,18 @@ export function addWritingSpace(flatDast: FlatDastRoot) {
             paragraph,
             (requested.get(paragraph) ?? 0) + heightInInches(input),
         );
-        containers.add(container);
     }
-
     for (const [paragraph, inches] of requested) {
         setWorkspace(paragraph, inches);
     }
-    for (const container of containers) {
-        makePrintout(container, flatDast);
+
+    if (perDivision) {
+        for (const division of new Set(divisions)) {
+            // `divisionType` is the name of the tag a division exports as.
+            mutableProps(division).divisionType = "handout";
+        }
+    } else {
+        makeDocumentPrintout(documentElement(flatDast) ?? flatDast, flatDast);
     }
 }
 
@@ -307,42 +327,21 @@ function setWorkspace(paragraph: FlatDastElement, inches: number) {
 }
 
 /**
- * The element whose contents must become a printout for the workspace to be rendered:
- * the innermost division containing `node`, or the document as a whole if there is none.
+ * Put a `<handout>` around the whole document. PreTeXt honors `@workspace` only under a
+ * `<worksheet>` or a `<handout>` (`sanitize-workspace` in `pretext-common.xsl`), and a
+ * handout may hold divisions, so one around everything serves every input at once and
+ * leaves the sections inside it as they were written.
  *
- * Returns `undefined` when no printout can hold the workspace, which happens when that
- * container also holds divisions — no PreTeXt printout can contain a division.
+ * The document's own title stays where it is, since the `<article>` PreTeXt builds around
+ * it needs one. The handout is given an *empty* title rather than a copy of it: an
+ * untitled printout is headed by PreTeXt's default title for the division — the bare word
+ * "Handout" — and a copy would print the activity's title a second time. Neither is a
+ * title the author wrote, and an empty one leaves the heading blank.
  */
-function findPrintoutContainer(
-    node: FlatDastElement,
-    parents: Map<number, FlatDastElement>,
-    flatDast: FlatDastRoot,
-): FlatDastElement | FlatDastRoot | undefined {
-    const container =
-        findAncestor(node, parents, (element) => element.name === "division") ??
-        documentElement(flatDast) ??
-        flatDast;
-    return containsDivision(container, flatDast) ? undefined : container;
-}
-
-/**
- * Turn `container` into a printout: a division is retagged as a `<handout>`, and the
- * document as a whole gets a `<handout>` wrapped around its contents.
- */
-function makePrintout(
+function makeDocumentPrintout(
     container: FlatDastElement | FlatDastRoot,
     flatDast: FlatDastRoot,
 ) {
-    if (container.type === "element" && container.name === "division") {
-        // `divisionType` is the name of the tag a division exports as.
-        mutableProps(container).divisionType = "handout";
-        return;
-    }
-
-    // The document itself. Its title stays where it is, since the `<article>` built around
-    // the document needs one, and is rendered a second time on the handout so that the
-    // printed page is headed by the activity's title. That second rendering is annotated a
-    // duplicate, so it claims none of the `xml:id`s the first one already owns.
     const titleRef = container.children.find(
         (child): child is AnnotatedElementRef =>
             elementOf(child, flatDast)?.name === "title",
@@ -350,9 +349,7 @@ function makePrintout(
     const handoutChildren = container.children.filter(
         (child) => child !== titleRef,
     );
-    if (titleRef) {
-        handoutChildren.unshift({ id: titleRef.id, annotation: "duplicate" });
-    }
+    handoutChildren.unshift(refTo(addElement(flatDast, "title", [])));
 
     const handout = addElement(flatDast, "handout", handoutChildren);
     container.children = titleRef

--- a/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
+++ b/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
@@ -139,8 +139,8 @@ const BLOCK_ELEMENTS = new Set([
  *
  * Which printout that is, is decided for the document as a whole: either every input sits
  * in a division that can become one, and each of those divisions is retagged a `<handout>`,
- * or a single `<handout>` is wrapped around the whole document. Either way every input is
- * served, so none is left to export as the short `<fillin>` blank.
+ * or a single `<handout>` is wrapped around the whole document. Either way a printout
+ * stands above every input, so none is left a `<fillin>` blank for want of one.
  */
 export function addWritingSpace(flatDast: FlatDastRoot) {
     const expandedInputs = flatDast.elements.filter(isExpandedTextInput);

--- a/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
+++ b/packages/doenetml-to-pretext/src/utils/pretext/writing-space.ts
@@ -1,8 +1,10 @@
 /**
  * An expanded `<textInput>` is a text area where a reader writes a long answer. On paper
  * that is blank space, which PreTeXt spells as a `workspace` attribute on the block the
- * space follows. PreTeXt only honors `workspace` inside a printout division, so the
- * division holding the block becomes a `<handout>`.
+ * space follows. PreTeXt only honors `workspace` inside a printout division, so a printout
+ * is put above every such block: the division holding it becomes a `<handout>`, or, where
+ * the inputs are not all in divisions that can become one, a `<handout>` is wrapped around
+ * the whole document.
  *
  * A document with no expanded input is left exactly as it was: wrapping it in a printout
  * would add a heading, a print-preview bar, and (in LaTeX) its own page geometry.
@@ -132,11 +134,13 @@ const BLOCK_ELEMENTS = new Set([
 ]);
 
 /**
- * Give every expanded `<textInput>` in `flatDast` room to write in, and turn the divisions
- * holding them into printouts. `flatDast` is mutated in place.
+ * Give every expanded `<textInput>` in `flatDast` room to write in, inside a printout that
+ * can hold it. `flatDast` is mutated in place.
  *
- * An input whose space cannot be placed — because its division cannot become a printout —
- * is left alone, so it still exports as the short `<fillin>` blank.
+ * Which printout that is, is decided for the document as a whole: either every input sits
+ * in a division that can become one, and each of those divisions is retagged a `<handout>`,
+ * or a single `<handout>` is wrapped around the whole document. Either way every input is
+ * served, so none is left to export as the short `<fillin>` blank.
  */
 export function addWritingSpace(flatDast: FlatDastRoot) {
     const expandedInputs = flatDast.elements.filter(isExpandedTextInput);

--- a/packages/doenetml-to-pretext/test/pretext-export.test.ts
+++ b/packages/doenetml-to-pretext/test/pretext-export.test.ts
@@ -303,6 +303,26 @@ describe("Pretext export", async () => {
         expect(exported).toContain(`<section xml:id="doenet-id-6">`);
     });
 
+    it("a section with no title of its own is not given one when it becomes a handout", async () => {
+        // PreTeXt heads an untitled `<handout>` with its default title for the division,
+        // the bare word "Handout", where the same section left alone would have carried
+        // no heading text at all. The empty title suppresses it, so becoming a printout
+        // does not invent a heading the author never wrote.
+        source = `<section><p>Why? <textInput expanded /></p></section>`;
+        const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported).toContain(`<handout xml:id="doenet-id-1">`);
+        expect(exported).toContain(`<title></title>`);
+        expect(exported.match(/<title>/g)).toHaveLength(1);
+    });
+
+    it("a section's own title is kept when it becomes a handout", async () => {
+        // Only a division with no title of its own is given the empty one.
+        source = `<section><title>A</title><p>Why? <textInput expanded /></p></section>`;
+        const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported).toContain(`<title>A</title>`);
+        expect(exported.match(/<title>/g)).toHaveLength(1);
+    });
+
     it("a section holding sections of its own is served by the document handout", async () => {
         // The section cannot become the handout itself, since it would then hold a
         // division. The handout goes around the whole document instead, which serves the

--- a/packages/doenetml-to-pretext/test/pretext-export.test.ts
+++ b/packages/doenetml-to-pretext/test/pretext-export.test.ts
@@ -301,6 +301,17 @@ describe("Pretext export", async () => {
         expect(exported).not.toContain(`<fillin`);
     });
 
+    it("a section that could have held the space is left a section when another input cannot use it", async () => {
+        // The choice is made for the document as a whole, so a section that would have
+        // become the handout on its own is left alone once a second input is found
+        // outside it. One handout around the document serves both.
+        source = `<section><title>A</title><p>Q1 <textInput expanded /></p></section><p>Q2 <textInput expanded /></p>`;
+        const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported.match(/<handout/g)).toHaveLength(1);
+        expect(exported).toContain(`<section xml:id="doenet-id-1">`);
+        expect(exported.match(/workspace="1.25in"/g)).toHaveLength(2);
+    });
+
     it("a problem written beside a section gets room to write", async () => {
         // A `<problem>` is not a division and so cannot become a handout itself. The
         // handout goes around the whole document, which serves it.

--- a/packages/doenetml-to-pretext/test/pretext-export.test.ts
+++ b/packages/doenetml-to-pretext/test/pretext-export.test.ts
@@ -156,6 +156,19 @@ describe("Pretext export", async () => {
             `);
     });
 
+    it("an answer written with the response it expects gets room to write too", async () => {
+        // Content asks the answer for an input as much as `handGraded` does, so an
+        // answer written with the response it expects sugars in the same expanded input
+        // and gets the same room. The expected response itself is not printed.
+        source = `<answer type="text" expanded>The correct answer</answer>`;
+        expect(await coreRunner.processToFlatDastAsFragment(source))
+            .toMatchInlineSnapshot(`
+              "<handout>
+              <title></title><p workspace="1.25in"></p>
+              </handout>"
+            `);
+    });
+
     it("a hand-graded answer keeps its label alongside the room to write", async () => {
         // Only the input is replaced by the space; the answer wrapping it still
         // renders the label that asks the question.
@@ -297,7 +310,11 @@ describe("Pretext export", async () => {
         source = `<section><title>A</title><p>Why? <textInput expanded /></p><section><title>B</title><p>Inner</p></section></section>`;
         const exported = await coreRunner.processToFlatDastAsFragment(source);
         expect(exported).toContain(`<p workspace="1.25in">Why? </p>`);
-        expect(exported).toContain(`<section`);
+        // The handout around the document carries no `xml:id`, where a section retagged
+        // as one would; both sections are still written as sections.
+        expect(exported).toContain(`<handout>`);
+        expect(exported).toContain(`<section xml:id="doenet-id-1">`);
+        expect(exported).toContain(`<section xml:id="doenet-id-5">`);
         expect(exported).not.toContain(`<fillin`);
     });
 
@@ -317,6 +334,7 @@ describe("Pretext export", async () => {
         // handout goes around the whole document, which serves it.
         source = `<section><title>S</title><p>x</p></section><problem><p>Q <textInput expanded /></p></problem>`;
         const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported).toContain(`<handout>`);
         expect(exported).toContain(`<p workspace="1.25in">Q </p>`);
         expect(exported).not.toContain(`<fillin`);
     });
@@ -335,6 +353,7 @@ describe("Pretext export", async () => {
         // input, the one around the document reaches it.
         source = `<problem><p>Q <textInput expanded /></p><section><title>B</title><p>x</p></section></problem><section><title>C</title><p>y</p></section>`;
         const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported).toContain(`<handout>`);
         expect(exported).toContain(`<p workspace="1.25in">Q </p>`);
         expect(exported).not.toContain(`<fillin`);
     });

--- a/packages/doenetml-to-pretext/test/pretext-export.test.ts
+++ b/packages/doenetml-to-pretext/test/pretext-export.test.ts
@@ -125,7 +125,7 @@ describe("Pretext export", async () => {
         expect(await coreRunner.processToFlatDastAsFragment(source))
             .toMatchInlineSnapshot(`
               "<handout>
-              <p workspace="1.25in">Explain your reasoning: </p>
+              <title></title><p workspace="1.25in">Explain your reasoning: </p>
               </handout>"
             `);
     });
@@ -151,7 +151,7 @@ describe("Pretext export", async () => {
         expect(await coreRunner.processToFlatDastAsFragment(source))
             .toMatchInlineSnapshot(`
               "<handout>
-              <p workspace="1.25in"></p>
+              <title></title><p workspace="1.25in"></p>
               </handout>"
             `);
     });
@@ -162,10 +162,10 @@ describe("Pretext export", async () => {
         source = `<answer type="text" handGraded expanded><label>Explain</label></answer>`;
         expect(await coreRunner.processToFlatDastAsFragment(source))
             .toMatchInlineSnapshot(`
-          "<handout>
-          <p workspace="1.25in">Explain</p>
-          </handout>"
-        `);
+              "<handout>
+              <title></title><p workspace="1.25in">Explain</p>
+              </handout>"
+            `);
     });
 
     it("a hand-graded answer in a list item keeps the item's text in the paragraph", async () => {
@@ -290,30 +290,61 @@ describe("Pretext export", async () => {
         expect(exported).toContain(`<section xml:id="doenet-id-6">`);
     });
 
-    it("an expanded input stays a blank where no printout can hold the space", async () => {
-        // No PreTeXt printout may contain a division, so a section that also holds
-        // sections of its own cannot become a handout, and the input keeps its blank.
+    it("a section holding sections of its own is served by the document handout", async () => {
+        // The section cannot become the handout itself, since it would then hold a
+        // division. The handout goes around the whole document instead, which serves the
+        // input and leaves both sections standing where they were written.
         source = `<section><title>A</title><p>Why? <textInput expanded /></p><section><title>B</title><p>Inner</p></section></section>`;
         const exported = await coreRunner.processToFlatDastAsFragment(source);
-        expect(exported).not.toContain(`handout`);
-        expect(exported).toContain(`<fillin characters="8"></fillin>`);
+        expect(exported).toContain(`<p workspace="1.25in">Why? </p>`);
+        expect(exported).toContain(`<section`);
+        expect(exported).not.toContain(`<fillin`);
     });
 
-    it("the handout wrapped around a whole document repeats its title", async () => {
-        // The `<article>` PreTeXt builds around the document has to keep the title,
-        // so the handout renders it a second time to head the printed page.
+    it("a problem written beside a section gets room to write", async () => {
+        // A `<problem>` is not a division and so cannot become a handout itself. The
+        // handout goes around the whole document, which serves it.
+        source = `<section><title>S</title><p>x</p></section><problem><p>Q <textInput expanded /></p></problem>`;
+        const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported).toContain(`<p workspace="1.25in">Q </p>`);
+        expect(exported).not.toContain(`<fillin`);
+    });
+
+    it("a run of problems beside a section shares a single handout", async () => {
+        // One handout for the document, rather than one apiece, so the printed page is
+        // not broken up by a heading before every problem.
+        source = `<section><title>S</title><p>x</p></section><problem><p>Q1 <textInput expanded /></p></problem><problem><p>Q2 <textInput expanded /></p></problem>`;
+        const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported.match(/<handout/g)).toHaveLength(1);
+        expect(exported.match(/workspace="1.25in"/g)).toHaveLength(2);
+    });
+
+    it("a division nested inside a block is still served by the document handout", async () => {
+        // A handout may hold divisions, so however the sections are arranged around the
+        // input, the one around the document reaches it.
+        source = `<problem><p>Q <textInput expanded /></p><section><title>B</title><p>x</p></section></problem><section><title>C</title><p>y</p></section>`;
+        const exported = await coreRunner.processToFlatDastAsFragment(source);
+        expect(exported).toContain(`<p workspace="1.25in">Q </p>`);
+        expect(exported).not.toContain(`<fillin`);
+    });
+
+    it("the handout wrapped around a whole document is left untitled", async () => {
+        // The document's title stays on the `<article>`, which needs one. The handout is
+        // given an empty title rather than a copy: untitled, PreTeXt would head it with
+        // its default title for the division — the bare word "Handout" — and a copy
+        // would print the activity's title twice. Neither is a title the author wrote.
         source = `<title>My activity</title><p>Why? <textInput expanded /></p>`;
         expect(await coreRunner.processToFlatDast(source))
             .toMatchInlineSnapshot(`
-          "<?xml version="1.0" encoding="UTF-8"?>
-          <pretext>
-          <article>
-          <title>My activity</title><handout>
-          <title>My activity</title><p workspace="1.25in">Why? </p>
-          </handout>
-          </article>
-          </pretext>"
-        `);
+              "<?xml version="1.0" encoding="UTF-8"?>
+              <pretext>
+              <article>
+              <title>My activity</title><handout>
+              <title></title><p workspace="1.25in">Why? </p>
+              </handout>
+              </article>
+              </pretext>"
+            `);
     });
 
     it("an unfilled input inside an <m> becomes a fillin", async () => {


### PR DESCRIPTION
An expanded `<textInput>` — and the `<answer type="text" expanded>` that sugars into one — becomes blank space for a reader to write in. PreTeXt spells that as a `@workspace` attribute, and honors it only under a `<worksheet>` or a `<handout>` (`sanitize-workspace`, `pretext-common.xsl`), so the converter has to put a printout above every such input.

## The bug

`findPrintoutContainer` looked for an ancestor named `division`, fell back to the document, and gave up if that container held a division of its own — on the grounds that no PreTeXt printout may contain one.

That premise is wrong. PreTeXt renders a `<section>` inside a `<handout>` and `sanitize-workspace` reaches the input through the handout ancestor; `handout` appears throughout the numbering templates as `section/handout` and `chapter/handout`, beside `section/exercises`. The restriction was the converter's own.

It cost every document whose inputs sit outside a section its room to write. A `<problem>` written beside a `<section>` is not itself a division, so the search fell through to the document, which was then refused because the section is one — and all six answers in a document shaped like this exported as 8-character `<fillin>` blanks:

```
<title>Sample exploration activity</title>
<section boxed><title>About this activity</title>… <textInput expanded height="0.5in" />…</section>
<problem><title>Warm up</title>… <answer type="text" handGraded expanded /></problem>
<problem><title>Sampling exploration</title>… <answer type="text" handGraded expanded /></problem>
```

## The fix

The choice is now made once for the document as a whole, which also keeps printouts from nesting: either every input sits in a division that can become the handout — unchanged behavior — or a single handout goes around the whole document, and the sections inside it stand as they were written.

**A printout that has no title of its own is given an empty one.** Left untitled, PreTeXt heads a division with the default title for its kind, and `handout` is one of the kinds that has one (`has-default-title`, `pretext-common.xsl:2486`) — the bare word "Handout". That bites both paths, and it is a heading the author never wrote:

- The document handout previously copied the document's title into itself, printing the activity's title a second time.
- A retagged `<section>` had no title added at all. `section` is *not* in `has-default-title`, so an untitled section carries no heading text — but the same section retagged a `<handout>` gained one.

Run through PreTeXt's own `pretext-html.xsl`, an untitled handout gives `<span class="title">Handout</span>`, a copied title `<span class="title">My activity</span>`, and an empty `<title/>` `<span class="title"></span>` — while the untitled `<section>` it was made from gives `<span class="title"></span>`. A division that has a title of its own keeps it.

On the document above: 7 workspaces (six answers at `1.25in` and the section's own input at `0.5in`), 0 `fillin`s, no invented headings, and `Problem 1./2.` numbering preserved.

## Notes

- **No changeset.** `@doenet/doenetml-to-pretext` is `private` and no published npm package bundles it — its consumers are `doenetml-print`, `demos`, `doenetml-prototype` and the separately-published Python wrapper, which builds against its `dist` rather than depending on a version of it and is released to PyPI by its own workflow.
- Two artifacts of the empty title remain and are left alone here, both of them what PreTeXt does for any division whose author wrote `<title></title>`: it leaves a blank heading rule where the printout begins, and it makes the permalink and `<xref>` tooltip on that division read `Handout: ` rather than `Handout`. PreTeXt has no way to ask for a division with no heading, so removing the rule means dropping the empty heading in `PtxCompiler`'s HTML post-processing — a change in a different package.
- An input written *outside* a paragraph and beside a block leaves the prose around it unwrapped (`<problem>Q <p workspace="1.25in"/>…`), and PreTeXt drops that bare text. Pre-existing behavior of `paragraphForSpace`, unchanged here, and no more reachable than before: `main` exports the same document as `<problem>Q <fillin characters="8"/><section>…`, and PreTeXt drops loose text inside a `<problem>` whether a workspace paragraph or a `<fillin>` follows it. The remedy — taking the adjacent inline run into the new paragraph — belongs in a PR of its own.
- `<problems>` and `<exercises>` drop their body content entirely on export. Pre-existing, unrelated, not touched here.

## Tests

`test/pretext-export.test.ts`: 77 passed, 5 skipped. Five tests changed, all intentionally — four snapshots gain the empty `<title></title>`, one of them `repeats its title`, renamed `is left untitled`; and the test asserting an input *stays a blank* no longer holds, because with a document-wide handout there is no arrangement of sections that cannot be served.

Seven tests were added: a problem beside a section, a run of problems sharing one handout, a division nested inside a block, a section left standing because a second input sits outside it, an answer that sugars its input from the response it expects rather than from `handGraded`, a section with no title of its own that is not given one when it becomes a handout, and a section whose own title survives becoming one.

Against `upstream/main`, 11 of those twelve fail and the other 66 tests pass unchanged. The twelfth — the section that keeps its own title — passes there too: it is the guard against giving *every* retagged division an empty title, not a discriminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
